### PR TITLE
feat: trajectory analysis pipeline with fork-based experiment comparison

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,16 +1,26 @@
 #!/bin/bash
 set -euo pipefail
 
-# Only run in remote (web) environments
+# Only run in remote (Claude Code on the web) environments
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Install dev tools (linter, test runner, HTTP client)
-pip install ruff pytest pytest-asyncio pytest-cov httpx
+cd "$CLAUDE_PROJECT_DIR"
 
-# Try editable install; may fail due to Python version or dep pins
-pip install --no-deps -e . 2>/dev/null || true
+# Bootstrap uv if the sandbox doesn't ship with it
+if ! command -v uv >/dev/null 2>&1; then
+  pip install --user uv
+  export PATH="$HOME/.local/bin:$PATH"
+fi
 
-# Ensure PYTHONPATH includes src/ for imports regardless
-echo 'export PYTHONPATH="${CLAUDE_PROJECT_DIR}/src:${PYTHONPATH:-}"' >> "$CLAUDE_ENV_FILE"
+# Project requires Python >=3.12 — uv fetches the interpreter if missing
+uv python install 3.12
+
+# Sync project + dev dependency-group from pyproject.toml / uv.lock
+# This mirrors `make sync-dev` and is the same env CI uses for `make ci`.
+uv sync --group dev
+
+# Expose the venv on PATH so `ruff`, `pytest`, `archetype` work without `uv run`
+echo "export PATH=\"${CLAUDE_PROJECT_DIR}/.venv/bin:\${PATH}\"" >> "$CLAUDE_ENV_FILE"
+echo "export VIRTUAL_ENV=\"${CLAUDE_PROJECT_DIR}/.venv\"" >> "$CLAUDE_ENV_FILE"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,8 +9,9 @@ fi
 cd "$CLAUDE_PROJECT_DIR"
 
 # Bootstrap uv if the sandbox doesn't ship with it
+UV_VERSION="0.8.17"
 if ! command -v uv >/dev/null 2>&1; then
-  pip install --user uv
+  pip install --user "uv==${UV_VERSION}"
   export PATH="$HOME/.local/bin:$PATH"
 fi
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install dev tools (linter, test runner, HTTP client)
+pip install ruff pytest pytest-asyncio pytest-cov httpx
+
+# Try editable install; may fail due to Python version or dep pins
+pip install --no-deps -e . 2>/dev/null || true
+
+# Ensure PYTHONPATH includes src/ for imports regardless
+echo 'export PYTHONPATH="${CLAUDE_PROJECT_DIR}/src:${PYTHONPATH:-}"' >> "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/archetype-components/SKILL.md
+++ b/.claude/skills/archetype-components/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: archetype-components
+description: Enforces correct Component definitions. Auto-triggers when creating or editing Component subclasses, ECS entities, or archetype schema code.
+paths: "src/**/*.py,tests/**/*.py,examples/**/*.py"
+---
+
+## Rules
+
+### 1. Components extend `Component`, which extends `LanceModel` (Pydantic)
+
+**Components are NOT dataclasses.** They are Pydantic models with Arrow serialization.
+
+```python
+from archetype.core.component import Component
+
+# RIGHT
+class Agent(Component):
+    name: str = ""
+    memory: str = "[]"
+
+# WRONG — dataclass, will not serialize to Arrow
+@dataclass
+class Agent:
+    name: str = ""
+```
+
+### 2. All fields must be Arrow-serializable
+
+| Type | Arrow? | What to do |
+|------|--------|------------|
+| `str`, `int`, `float`, `bool` | Yes | Use directly |
+| `list[str]`, `list[int]`, `list[float]` | Yes | Use directly |
+| `dict`, `list[dict]` | **No** | JSON-encode to `str` |
+| Custom objects | **No** | Serialize to JSON `str` |
+| `torch.Tensor` | **No** | Save to file, store path as `str` |
+
+### 3. JSON-encode complex types with `_json` suffix convention
+
+```python
+# WRONG — list[dict] is not Arrow-serializable
+class DebateState(Component):
+    history: list[dict] = []
+
+# RIGHT — JSON string
+class DebateState(Component):
+    history_json: str = "[]"
+```
+
+When working with JSON fields:
+```python
+# Writing
+history.append({"agent": name, "text": text})
+df = df.with_column("debatestate__history_json", daft.lit(json.dumps(history)))
+
+# Reading
+history = json.loads(row["debatestate__history_json"])
+```
+
+### 4. Prefix convention is automatic
+
+`Component.get_prefix()` returns `classname.lower() + "__"`. Fields become `{prefix}{field}` in the DataFrame.
+
+- `Agent.name` → `agent__name`
+- `EnvironmentComponent.gravity` → `environmentcomponent__gravity`
+
+Always use the prefixed name in processor column references:
+```python
+col("agent__name")  # not col("name")
+```
+
+### 5. Keep components small and focused
+
+One component = one concern. Prefer composition:
+
+```python
+# RIGHT — separate concerns
+class Position(Component):
+    x: float = 0.0
+    y: float = 0.0
+
+class Velocity(Component):
+    vx: float = 0.0
+    vy: float = 0.0
+
+# WRONG — kitchen sink
+class Entity(Component):
+    x: float = 0.0
+    y: float = 0.0
+    vx: float = 0.0
+    vy: float = 0.0
+    name: str = ""
+    health: int = 100
+```
+
+### 6. Helper types that are NOT Components
+
+Use plain dataclasses or Pydantic models for:
+- Turn-level data within a JSON field (e.g., `Turn` dataclass for building `Session.turns`)
+- Resource configs injected into `world.resources` (e.g., `SamplingConfig`)
+- API request/response models
+
+These never touch LanceDB and don't need Arrow serialization.

--- a/.claude/skills/archetype-processors/SKILL.md
+++ b/.claude/skills/archetype-processors/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: archetype-processors
+description: Enforces correct Processor implementation. Auto-triggers when creating or editing AsyncProcessor subclasses, process methods, or pipeline stages.
+paths: "src/**/*.py,tests/**/*.py,examples/**/*.py"
+---
+
+## Rules
+
+### 1. Extend `AsyncProcessor`, not raw classes
+
+```python
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.core.component import Component
+
+class MyProcessor(AsyncProcessor):
+    components = (ComponentA, ComponentB)  # tuple of Component TYPES
+    priority = 10                          # lower = runs first
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        # Transform and return. Never mutate in place.
+        return df.with_columns({...})
+```
+
+### 2. `components` declares dependencies
+
+The tuple contains Component **types** (not instances). The processor only runs on entities that have ALL listed components.
+
+```python
+components = (Agent, Position)  # runs on entities with both Agent AND Position
+```
+
+### 3. `process()` is a pure function: DataFrame in, DataFrame out
+
+- Never mutate `df` in place.
+- Never `.collect()` mid-pipeline (breaks the Daft DAG — see daft-patterns skill).
+- Always return the transformed DataFrame.
+
+### 4. Access shared state via Resources
+
+```python
+async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+    resources: Resources = kwargs.get("resources", Resources())
+    config = resources.require(MyConfig)    # raises if missing
+    broker = resources.get(CommandBroker)   # None if missing
+```
+
+Resources are injected into `world.resources` before running:
+```python
+world.resources.insert(MyConfig(...))
+world.resources.insert(CommandBroker())
+```
+
+### 5. Use `daft.functions.prompt()` for LLM calls
+
+```python
+from daft.functions import prompt
+
+async def process(self, df: DataFrame, tick: int = 0, **kwargs) -> DataFrame:
+    return df.with_columns({
+        "agent__response": prompt(
+            col("agent__role") + "\nTick: " + str(tick),
+            model="gpt-5-mini",
+            max_output_tokens=200,
+        ),
+    })
+```
+
+Daft batches all LLM calls across all entities automatically.
+
+### 6. Tick-gate expensive operations
+
+```python
+async def process(self, df: DataFrame, tick: int = 0, **kwargs) -> DataFrame:
+    if tick != 2:  # only run on tick 2
+        return df
+    # expensive work here
+```
+
+Use for: inner simulations, checkpoints, aggregation at sim end.
+
+### 7. Priority ordering
+
+Processors execute in priority order within a tick (lower first):
+
+| Priority | Use case |
+|----------|----------|
+| 0-9 | Setup, initialization |
+| 10-19 | Sampling, filtering |
+| 20-29 | Core logic, LLM calls, labeling |
+| 30-39 | Post-processing, scoring |
+| 40+ | Cleanup, persistence |
+
+### 8. Messages are tick-boundary consistent
+
+Messages enqueued at tick N are realized at tick N+1:
+
+```python
+cmd = Command(type=CommandType.MESSAGE, tick=tick, payload={...})
+await broker.enqueue(world_id, cmd)  # delivered NEXT tick
+```
+
+### 9. Column references use the component prefix
+
+```python
+# RIGHT
+col("agent__name")
+col("session__total_turns")
+
+# WRONG
+col("name")
+col("total_turns")
+```

--- a/.claude/skills/daft-patterns/SKILL.md
+++ b/.claude/skills/daft-patterns/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: daft-patterns
+description: Enforces correct Daft DataFrame patterns. Auto-triggers when writing or editing Python files that use Daft, DataFrames, UDFs, or column expressions.
+paths: "src/**/*.py,tests/**/*.py,examples/**/*.py"
+---
+
+## Rules
+
+These are non-negotiable. Violating them produces broken pipelines.
+
+### 1. DataFrames are lazy. Do not break the DAG.
+
+Never `.collect()` mid-pipeline. It materializes a separate plan and downstream columns may be empty.
+
+```python
+# WRONG — breaks the DAG
+df = df.with_column("response", prompt(col("input"), ...))
+debug = df.select("response").limit(1).collect()  # separate plan!
+df = df.with_column("next", col("response") + "...")  # response may be empty
+
+# RIGHT — single materialization
+df = df.with_column("response", prompt(col("input"), ...))
+df = df.with_column("next", col("response") + "...")
+result = df.collect()
+```
+
+Use `df.explain()` to debug, not intermediate collects.
+
+### 2. UDF selection
+
+| Decorator | When | Example |
+|-----------|------|---------|
+| DataFrame expressions | Always prefer this | `col("x") + col("y")` |
+| `@daft.func` | Row-wise transform, auto type inference | Simple string parsing, JSON encoding |
+| `@daft.func.batch` | Operation actually batches (NumPy, vLLM, PyTorch) | Vectorized math, batch inference |
+| `@daft.cls()` | Expensive init, once per worker | Model loading, DB connections |
+| `@daft.method.batch` | Stateful + actual batching | Model with batch predict |
+
+**`@daft.udf` is removed.** Deprecated 0.7.0, gone 0.8.0. Never use it. Use `@daft.func.batch` instead.
+
+**If you loop inside a batch UDF, you're not batching.** Use `@daft.func` row-wise instead.
+
+```python
+# WRONG — looping inside batch, no batching benefit
+@daft.func.batch(return_dtype=DataType.string())
+def process(values: Series) -> Series:
+    return Series.from_pylist([transform(v) for v in values.to_pylist()])
+
+# RIGHT — row-wise with auto type inference
+@daft.func
+def process(value: str) -> str:
+    return transform(value)
+```
+
+### 3. Struct access
+
+```python
+# WRONG — deprecated
+col("result").struct.get("field")
+
+# RIGHT
+col("result")["field"]
+```
+
+### 4. Column expressions first
+
+The DataFrame is already columnar. Most transforms are just expressions:
+
+```python
+df = df.with_column("score", col("reward") * 0.5 + col("bonus"))
+df = df.where(col("score") > 0.5)
+df = df.groupby("env_id").agg(col("reward").mean())
+```
+
+UDFs are the escape hatch, not the default.
+
+### 5. `with_columns` over chained `with_column`
+
+Use `with_columns(dict)` for multiple column updates. Chained `with_column` can cause Daft plan dependency issues.
+
+```python
+# Prefer
+df = df.with_columns({
+    "col_a": col("x") + 1,
+    "col_b": col("y") * 2,
+})
+```

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,11 @@ node_modules/
 .cursorignore
 .worktrees/
 *.lance
-.claude/
+# Ignore claude user state, but track project config, hooks, and skills
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/skills/
 data/
 
 .venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,12 @@
 
 Processors are pure functions: `DataFrame → DataFrame`. If the data looks right at the end of a tick, nothing else matters. Not how you called the LLM. Not whether it was async. Not how long it took.
 
+## What You're Building
+
+Archetype is an experiment harness disguised as an ECS engine. World state is DataFrames. Mutations are commands. Processors are transforms. Storage is append-only. **Storage is the version control** — no git ceremony for experimentation. Fork the world, tweak the processor, run again. Both versions coexist in LanceDB, queryable side by side.
+
+Current focus: **trajectory analysis** — evaluating agent session trajectories through configurable sampling regimes and labeling techniques described in natural language.
+
 ## Hard Constraints
 
 ### 1. Never break the lazy DAG unless you must
@@ -156,6 +162,7 @@ Use **`uv sync --group dev`** (dependency-groups), not `uv sync --dev` (optional
 - **`src/archetype/core/`** — ECS engine. **Read-only.** Do not modify without explicit approval.
 - **`src/archetype/app/`** — Service layer. Extend carefully.
 - **`src/archetype/api/`** + **`cli/`** — REST API and CLI. Safe to modify freely.
+- **`src/archetype/trajectories/`** — Trajectory analysis pipeline.
 - **`tests/`** — Every new feature needs tests.
 
 ## Key Files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,194 +1,24 @@
-# Archetype: Rules for AI Agents
+# Archetype
 
-> **This is not optional.** These are hard constraints, not suggestions.
-> Violating them produces code that compiles but breaks the architecture.
+Read these before doing anything:
 
-## The One Rule
+- `LEARNINGS.md` — Daft 0.7.x patterns, UDF rules, serialization. **Mandatory.**
+- `AGENTS.md` — Architecture, service layer, RBAC, conventions, dev workflow.
 
-**Archetype is data-centric. The DataFrame is the source of truth.**
+Skills in `.claude/skills/` enforce framework rules automatically. They fire based on file paths — you don't need to invoke them manually.
 
-Processors are pure functions: `DataFrame → DataFrame`. If the data looks right at the end of a tick, nothing else matters. Not how you called the LLM. Not whether it was async. Not how long it took.
+## Layers
 
-## What You're Building
+| Layer | Access |
+|-------|--------|
+| `src/archetype/core/` | **Read-only.** Do not modify without explicit permission. |
+| `src/archetype/app/` | Extend carefully. |
+| Everything else | Write freely. |
 
-Archetype is an experiment harness disguised as an ECS engine. World state is DataFrames. Mutations are commands. Processors are transforms. Storage is append-only. **Storage is the version control** — no git ceremony for experimentation. Fork the world, tweak the processor, run again. Both versions coexist in LanceDB, queryable side by side.
-
-Current focus: **trajectory analysis** — evaluating agent session trajectories through configurable sampling regimes and labeling techniques described in natural language.
-
-## Hard Constraints
-
-### 1. Never break the lazy DAG unless you must
-
-`.collect().to_pylist()` pulls data out of Daft's lazy execution engine. You lose plan optimization, automatic parallelism, and composability.
-
-**The ONLY justified `.collect()` is for cross-row context** — when you genuinely need global visibility across entities (name lookups, message routing). Document every `.collect()` with an inline comment explaining why.
-
-```python
-# ❌ WRONG — imperative loop over collected rows
-rows = df.select("entity_id", "agent__name").collect().to_pylist()
-for row in rows:
-    results.append(do_something(row))
-
-# ✅ RIGHT — row-wise UDF, Daft manages execution
-@daft.func
-def do_something(name: str) -> str:
-    return transform(name)
-
-df = df.with_column("result", do_something(col("agent__name")))
-```
-
-### 2. Use `@daft.func` by default, not `@daft.func.batch`
-
-If your batch UDF is just a for-loop over `Series.to_pylist()`, it must be `@daft.func` instead. `@daft.func` supports async natively.
-
-```python
-# ❌ WRONG — batch UDF that just loops
-@daft.func.batch(return_dtype=daft.DataType.list(daft.DataType.string()))
-def write_outbox(entity_ids: daft.Series) -> list:
-    return [messages.get(eid, []) for eid in entity_ids.to_pylist()]
-
-# ✅ RIGHT — row-wise
-@daft.func
-def write_outbox(entity_id: int) -> list[str]:
-    return messages.get(entity_id, [])
-```
-
-Use `@daft.func.batch` ONLY when the operation actually benefits from batching (vectorized NumPy, batch model inference, etc.).
-
-### 3. Use `@daft.cls()` for non-serializable state
-
-API clients (Anthropic, OpenAI), model weights, DB connections — anything that can't be pickled. The client lives in `__init__`, which runs once per worker and is never serialized.
-
-```python
-@daft.cls()
-class ClaudeAgent:
-    def __init__(self):
-        import anthropic
-        self.client = anthropic.AsyncAnthropic()
-
-    async def respond(self, name: str, role: str, inbox: list[str]) -> list[str]:
-        response = await self.client.messages.create(...)
-        return [json.dumps({...})]
-
-agent = ClaudeAgent()
-df = df.with_column("outbox__messages", agent.respond(col("agent__name"), ...))
-```
-
-**Never** capture non-serializable objects in `@daft.func` closures. Daft will raise a pickling error.
-
-### 4. No `asyncio.gather` over collected rows
-
-This pattern is always wrong in Archetype:
-
-```python
-# ❌ WRONG — actor pattern in a data-centric system
-rows = df.collect().to_pylist()
-results = await asyncio.gather(*[call_llm(row) for row in rows])
-response_by_id = {r["id"]: r["text"] for r in results}
-```
-
-Let Daft manage concurrency via async `@daft.func` or `@daft.cls()`.
-
-### 5. The broker is governance only
-
-The `CommandBroker` validates RBAC and quotas. It does NOT own message delivery or conversation structure. Those are processor responsibilities.
-
-- **Outbox/Inbox components** on entities handle message transport
-- **MessageDeliveryProcessor** (priority -100) routes Outbox → Inbox
-- **ChatGraphRegistry** (Resource) tracks conversation structure
-
-### 6. Tick boundaries are sacred
-
-Messages written to Outbox at tick N are delivered to Inbox at tick N+1. This enforces causal ordering. Do not circumvent this.
-
-### 7. Resources for shared state, not entity data
-
-`world.resources.insert(obj)` is for world-scoped services: `ChatGraphRegistry`, `CommandBroker`, simulation configs. Components are for entity data. Don't mix them.
-
-Processors opt into Resources via function signature: `async def process(self, df, resources: Resources, ...)`.
-
-## Architecture Quick Reference
-
-```
-Components (entity data, DataFrame columns):
-  Outbox(messages: list[str])     — agent writes here
-  Inbox(messages: list[str])      — messages land here after delivery
-  DeliveryReceipt(receipts: list[str]) — rejection feedback
-
-Resources (world-scoped, DI container):
-  ChatGraphRegistry  — conversation DAGs per (world, channel)
-  CommandBroker      — governance (RBAC, quotas, command queuing)
-
-Processors (DataFrame → DataFrame):
-  MessageDeliveryProcessor  priority=-100  routes Outbox → Inbox, updates ChatGraph
-  [Your processors]         priority=10+   read Inbox, call LLMs, write Outbox
-
-Column naming:  componentname__fieldname
-  outbox__messages, inbox__messages, agent__name, agent__role
-```
-
-## Dev Workflow
+## Commands
 
 ```bash
-make sync-dev       # Install all deps (uses uv dependency-groups, not optional-deps)
-make ci             # THE gate: lint + lock-check + tests w/ coverage (what CI runs)
-make test           # Fast tests, no coverage
-make check          # Auto-format + lint (ruff, writes files)
-make lint-fix       # Auto-fix lint issues
+make ci                         # Gate: lint + lock-check + tests with coverage
+make test                       # Fast tests, no coverage
+make check                      # Auto-format + lint
 ```
-
-For the full dev workflow reference — all Make targets, CI job mappings,
-pre-commit hooks, and contribution process — see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-### Dependencies
-
-Use **`uv sync --group dev`** (dependency-groups), not `uv sync --dev` (optional-deps).
-
-### Testing
-
-- `make ci` is the single CI gate — always run this before pushing
-- Coverage threshold: 70% with branch coverage
-- Tests live in `tests/` with subdirs: `core/`, `app/`, `api/`, `cli/`, `integration/`, `aio/`, `storage/`, `sync/`
-
-### Code Quality
-
-- **Formatter/linter:** ruff (not black, not flake8)
-- **Config:** `[tool.ruff]` in pyproject.toml — line-length 100, target py312
-- **Lint rules:** E, F, I, UP, B (with E501 ignored — formatter handles line length)
-- Pre-commit hooks enforce ruff, lock-check, license headers, and standard hygiene
-
-## Project Structure
-
-- **`src/archetype/core/`** — ECS engine. **Read-only.** Do not modify without explicit approval.
-- **`src/archetype/app/`** — Service layer. Extend carefully.
-- **`src/archetype/api/`** + **`cli/`** — REST API and CLI. Safe to modify freely.
-- **`src/archetype/trajectories/`** — Trajectory analysis pipeline.
-- **`tests/`** — Every new feature needs tests.
-
-## Key Files
-
-| File | Purpose |
-|------|---------|
-| `src/archetype/core/resources.py` | Type-safe DI container |
-| `src/archetype/core/aio/async_processor.py` | AsyncProcessor base class |
-| `src/archetype/core/aio/async_system.py` | Processor execution + Resources injection |
-| `src/archetype/app/messaging.py` | (PLANNED, not yet implemented) Outbox, Inbox, MessageDeliveryProcessor |
-| `src/archetype/app/chat_graph.py` | (PLANNED, not yet implemented) ChatGraph DAG, ChatGraphRegistry |
-| `src/archetype/app/broker.py` | CommandBroker (governance only) |
-| `src/archetype/app/models.py` | Command model (append_history, parent_id, channel) |
-| `CONTRIBUTING.md` | Dev workflow, Make targets, CI mappings, contribution process |
-| `LEARNINGS.md` | Extended architectural knowledge — read before major changes |
-
-## Conventions
-
-- **Commits:** conventional commits — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
-- **Components:** `_json` suffix for complex types serialized as strings
-- **Processors:** one concern each, use `priority` for ordering (lower = first)
-- **Imports:** ruff handles sorting (isort rules via `I` select)
-
-## What NOT to Do
-
-- Don't run `uv sync --dev` in CI — use `--group dev`
-- Don't bypass `make ci` with raw pytest invocations for validation
-- Don't modify `core/` without discussion
-- Don't add deps without checking `uv lock --check` passes

--- a/examples/trajectories/run.py
+++ b/examples/trajectories/run.py
@@ -5,7 +5,7 @@
 Trajectory Analysis Example
 ============================
 
-Demonstrates the full pipeline: ingest sessions, label them with
+Demonstrates the full pipeline: ingest trajectories, label them with
 natural language descriptions, compare techniques via world forking.
 
 Usage:
@@ -17,18 +17,18 @@ the pipeline structure (labeling will fail gracefully).
 
 import asyncio
 
-from archetype.trajectories import Session, TrajectoryPipeline
+from archetype.trajectories import Trajectory, TrajectoryPipeline
 from archetype.trajectories.components import Turn
 
-# ── Synthetic session data ──
+# ── Synthetic trajectory data ──
 
 
-def make_sessions() -> list[Session]:
-    """Build a few synthetic agent sessions for demonstration."""
+def make_trajectories() -> list[Trajectory]:
+    """Build a few synthetic agent trajectories for demonstration."""
 
-    # Session 1: Clean, efficient problem-solving
-    efficient = Session.from_turns(
-        session_id="session-001",
+    # Trajectory 1: Clean, efficient problem-solving
+    efficient = Trajectory.from_turns(
+        trajectory_id="traj-001",
         source="claude-code",
         outcome="success: implemented feature correctly on first attempt",
         tags=["feature", "python", "clean"],
@@ -65,9 +65,9 @@ def make_sessions() -> list[Session]:
         ],
     )
 
-    # Session 2: Backtracking, multiple attempts
-    backtracking = Session.from_turns(
-        session_id="session-002",
+    # Trajectory 2: Backtracking, multiple attempts
+    backtracking = Trajectory.from_turns(
+        trajectory_id="traj-002",
         source="claude-code",
         outcome="success: fixed bug after two wrong approaches",
         tags=["bugfix", "python", "backtracking"],
@@ -159,9 +159,9 @@ def make_sessions() -> list[Session]:
         ],
     )
 
-    # Session 3: Failed session
-    failed = Session.from_turns(
-        session_id="session-003",
+    # Trajectory 3: Failed trajectory
+    failed = Trajectory.from_turns(
+        trajectory_id="traj-003",
         source="claude-code",
         outcome="failure: could not resolve circular import",
         tags=["refactor", "python", "failed"],
@@ -214,8 +214,8 @@ def make_sessions() -> list[Session]:
 
 
 async def main():
-    sessions = make_sessions()
-    print(f"Created {len(sessions)} synthetic sessions\n")
+    trajectories = make_trajectories()
+    print(f"Created {len(trajectories)} synthetic trajectories\n")
 
     # Build pipeline with two labeling techniques
     pipeline = (
@@ -226,9 +226,9 @@ async def main():
     )
 
     # Ingest
-    print("Ingesting sessions...")
-    await pipeline.ingest(sessions)
-    print(f"  → {len(sessions)} sessions × {len(pipeline._labels)} techniques = {len(sessions) * len(pipeline._labels)} entities\n")
+    print("Ingesting trajectories...")
+    await pipeline.ingest(trajectories)
+    print(f"  → {len(trajectories)} trajectories × {len(pipeline._labels)} techniques = {len(trajectories) * len(pipeline._labels)} entities\n")
 
     # Run (this calls the LLM for labeling — skip if no API key)
     print("Running pipeline (sample → label → score)...")
@@ -242,7 +242,7 @@ async def main():
     print("Results:")
     results = await pipeline.results()
     for r in results:
-        print(f"  [{r['technique']}] {r['session_id']}: score={r['score']:.2f} value={r['value']!r}")
+        print(f"  [{r['technique']}] {r['trajectory_id']}: score={r['score']:.2f} value={r['value']!r}")
         if r["rationale"]:
             print(f"    rationale: {r['rationale']}")
     print()

--- a/examples/trajectories/run.py
+++ b/examples/trajectories/run.py
@@ -1,0 +1,261 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Trajectory Analysis Example
+============================
+
+Demonstrates the full pipeline: ingest sessions, label them with
+natural language descriptions, compare techniques via world forking.
+
+Usage:
+    uv run python examples/trajectories/run.py
+
+Set OPENAI_API_KEY for real LLM labeling, or run without it to see
+the pipeline structure (labeling will fail gracefully).
+"""
+
+import asyncio
+
+from archetype.trajectories import Session, TrajectoryPipeline
+from archetype.trajectories.components import Turn
+
+# ── Synthetic session data ──
+
+
+def make_sessions() -> list[Session]:
+    """Build a few synthetic agent sessions for demonstration."""
+
+    # Session 1: Clean, efficient problem-solving
+    efficient = Session.from_turns(
+        session_id="session-001",
+        source="claude-code",
+        outcome="success: implemented feature correctly on first attempt",
+        tags=["feature", "python", "clean"],
+        metadata={"repo": "acme/api", "model": "claude-sonnet-4-6"},
+        turns=[
+            Turn(role="user", content="Add a /health endpoint to the API", tokens=12),
+            Turn(role="assistant", content="I'll add a health endpoint to the FastAPI app.", tokens=8),
+            Turn(
+                role="tool_call",
+                content="Reading app/main.py",
+                tool_name="Read",
+                tool_input='{"path": "app/main.py"}',
+                tokens=5,
+                duration_ms=120,
+            ),
+            Turn(
+                role="tool_result",
+                content="from fastapi import FastAPI\napp = FastAPI()\n...",
+                tokens=50,
+            ),
+            Turn(
+                role="tool_call",
+                content="Editing app/main.py",
+                tool_name="Edit",
+                tool_input='{"path": "app/main.py", "new": "@app.get(\\"/health\\")..."}',
+                tokens=30,
+                duration_ms=85,
+            ),
+            Turn(
+                role="assistant",
+                content="Added the /health endpoint. It returns {\"status\": \"ok\"}.",
+                tokens=15,
+            ),
+        ],
+    )
+
+    # Session 2: Backtracking, multiple attempts
+    backtracking = Session.from_turns(
+        session_id="session-002",
+        source="claude-code",
+        outcome="success: fixed bug after two wrong approaches",
+        tags=["bugfix", "python", "backtracking"],
+        metadata={"repo": "acme/api", "model": "claude-sonnet-4-6"},
+        turns=[
+            Turn(role="user", content="Fix the 500 error on POST /users", tokens=10),
+            Turn(
+                role="assistant",
+                content="Let me investigate the error in the users endpoint.",
+                tokens=12,
+            ),
+            Turn(
+                role="tool_call",
+                content="Reading app/routes/users.py",
+                tool_name="Read",
+                tool_input='{"path": "app/routes/users.py"}',
+                tokens=5,
+                duration_ms=100,
+            ),
+            Turn(role="tool_result", content="async def create_user(...):\n    ...", tokens=80),
+            Turn(
+                role="assistant",
+                content="I think the issue is the missing validation. Let me add it.",
+                tokens=20,
+            ),
+            Turn(
+                role="tool_call",
+                content="Editing users.py — adding validation",
+                tool_name="Edit",
+                tool_input='{"path": "app/routes/users.py", "new": "...validation..."}',
+                tokens=25,
+                duration_ms=90,
+            ),
+            Turn(
+                role="tool_call",
+                content="Running tests",
+                tool_name="Bash",
+                tool_input='{"command": "pytest tests/"}',
+                tokens=5,
+                duration_ms=3000,
+            ),
+            Turn(
+                role="tool_result",
+                content="FAILED tests/test_users.py::test_create - TypeError",
+                tokens=30,
+                error="Tests failed",
+            ),
+            Turn(
+                role="assistant",
+                content="That wasn't it. Let me look at the database model instead.",
+                tokens=15,
+            ),
+            Turn(
+                role="tool_call",
+                content="Reading app/models/user.py",
+                tool_name="Read",
+                tool_input='{"path": "app/models/user.py"}',
+                tokens=5,
+                duration_ms=80,
+            ),
+            Turn(role="tool_result", content="class User(Base):\n    ...", tokens=60),
+            Turn(
+                role="assistant",
+                content="Found it — the email column is NOT NULL but the schema allows None.",
+                tokens=20,
+            ),
+            Turn(
+                role="tool_call",
+                content="Fixing the schema",
+                tool_name="Edit",
+                tool_input='{"path": "app/routes/users.py", "new": "...email required..."}',
+                tokens=20,
+                duration_ms=90,
+            ),
+            Turn(
+                role="tool_call",
+                content="Running tests again",
+                tool_name="Bash",
+                tool_input='{"command": "pytest tests/"}',
+                tokens=5,
+                duration_ms=2500,
+            ),
+            Turn(role="tool_result", content="All 12 tests passed", tokens=10),
+            Turn(
+                role="assistant",
+                content="Fixed. The email field was optional in the Pydantic schema but required in the DB.",
+                tokens=20,
+            ),
+        ],
+    )
+
+    # Session 3: Failed session
+    failed = Session.from_turns(
+        session_id="session-003",
+        source="claude-code",
+        outcome="failure: could not resolve circular import",
+        tags=["refactor", "python", "failed"],
+        metadata={"repo": "acme/api", "model": "claude-sonnet-4-6"},
+        turns=[
+            Turn(role="user", content="Refactor the circular import between models and utils", tokens=12),
+            Turn(
+                role="assistant",
+                content="I'll restructure the imports to break the cycle.",
+                tokens=10,
+            ),
+            Turn(
+                role="tool_call",
+                content="Reading models/__init__.py",
+                tool_name="Read",
+                tool_input='{"path": "app/models/__init__.py"}',
+                tokens=5,
+                duration_ms=100,
+            ),
+            Turn(role="tool_result", content="from .user import User\nfrom .utils import ...", tokens=40),
+            Turn(
+                role="tool_call",
+                content="Editing models/__init__.py",
+                tool_name="Edit",
+                tool_input='{"path": "app/models/__init__.py", "new": "...lazy imports..."}',
+                tokens=30,
+                duration_ms=90,
+            ),
+            Turn(
+                role="tool_call",
+                content="Running tests",
+                tool_name="Bash",
+                tool_input='{"command": "pytest tests/"}',
+                tokens=5,
+                duration_ms=2000,
+                error="ImportError: circular import detected",
+            ),
+            Turn(
+                role="assistant",
+                content="I'm stuck on this circular dependency. The issue runs deeper than I initially thought.",
+                tokens=25,
+            ),
+        ],
+    )
+
+    return [efficient, backtracking, failed]
+
+
+# ── Main ──
+
+
+async def main():
+    sessions = make_sessions()
+    print(f"Created {len(sessions)} synthetic sessions\n")
+
+    # Build pipeline with two labeling techniques
+    pipeline = (
+        TrajectoryPipeline(name="trajectory-eval", storage_uri="./trajectory_data")
+        .label("efficiency", "Rate how directly the agent reached the solution without unnecessary backtracking or wasted steps. A perfect score means the agent identified the correct approach immediately.")
+        .label("correctness", "Did the agent produce the correct final result? Score 1.0 for fully correct, 0.5 for partially correct, 0.0 for incorrect or unresolved.")
+        .sample(min_turns=3)
+    )
+
+    # Ingest
+    print("Ingesting sessions...")
+    await pipeline.ingest(sessions)
+    print(f"  → {len(sessions)} sessions × {len(pipeline._labels)} techniques = {len(sessions) * len(pipeline._labels)} entities\n")
+
+    # Run (this calls the LLM for labeling — skip if no API key)
+    print("Running pipeline (sample → label → score)...")
+    try:
+        await pipeline.run()
+        print("  → Pipeline completed\n")
+    except Exception as e:
+        print(f"  → Pipeline errored (expected without API key): {e}\n")
+
+    # Show results
+    print("Results:")
+    results = await pipeline.results()
+    for r in results:
+        print(f"  [{r['technique']}] {r['session_id']}: score={r['score']:.2f} value={r['value']!r}")
+        if r["rationale"]:
+            print(f"    rationale: {r['rationale']}")
+    print()
+
+    # Show what forking looks like
+    print("To compare a different labeling approach, fork the world:")
+    print('  fork = await pipeline.fork("strict-eval")')
+    print('  fork.label("correctness", "Binary only: 1.0 if output is exactly right, 0.0 otherwise")')
+    print("  await fork.run()")
+    print("  # Both worlds coexist in storage — query and compare")
+
+    await pipeline.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/trajectories/run.py
+++ b/examples/trajectories/run.py
@@ -218,17 +218,18 @@ async def main():
     print(f"Created {len(trajectories)} synthetic trajectories\n")
 
     # Build pipeline with two labeling techniques
-    pipeline = (
-        TrajectoryPipeline(name="trajectory-eval", storage_uri="./trajectory_data")
-        .label("efficiency", "Rate how directly the agent reached the solution without unnecessary backtracking or wasted steps. A perfect score means the agent identified the correct approach immediately.")
-        .label("correctness", "Did the agent produce the correct final result? Score 1.0 for fully correct, 0.5 for partially correct, 0.0 for incorrect or unresolved.")
-        .sample(min_turns=3)
-    )
+    label_specs = [
+        ("efficiency", "Rate how directly the agent reached the solution without unnecessary backtracking or wasted steps. A perfect score means the agent identified the correct approach immediately."),
+        ("correctness", "Did the agent produce the correct final result? Score 1.0 for fully correct, 0.5 for partially correct, 0.0 for incorrect or unresolved."),
+    ]
+    pipeline = TrajectoryPipeline(name="trajectory-eval", storage_uri="./trajectory_data").sample(min_turns=3)
+    for name, desc in label_specs:
+        pipeline = pipeline.label(name, desc)
 
     # Ingest
     print("Ingesting trajectories...")
     await pipeline.ingest(trajectories)
-    print(f"  → {len(trajectories)} trajectories × {len(pipeline._labels)} techniques = {len(trajectories) * len(pipeline._labels)} entities\n")
+    print(f"  → {len(trajectories)} trajectories × {len(label_specs)} techniques = {len(trajectories) * len(label_specs)} entities\n")
 
     # Run (this calls the LLM for labeling — skip if no API key)
     print("Running pipeline (sample → label → score)...")

--- a/src/archetype/app/auth/guard.py
+++ b/src/archetype/app/auth/guard.py
@@ -17,6 +17,15 @@ if TYPE_CHECKING:
 ROLE_PERMS: dict[str, set[str]] = {
     "viewer": {"get_state", "get_world", "get_run", "query_world"},
     "coder": {"add_component", "remove_component", "update"},
+    "operator": {
+        "spawn",
+        "despawn",
+        "update",
+        "get_state",
+        "get_world",
+        "get_run",
+        "query_world",
+    },
     "maintainer": {
         "spawn",
         "despawn",

--- a/src/archetype/trajectories/__init__.py
+++ b/src/archetype/trajectories/__init__.py
@@ -13,20 +13,20 @@ Fork a world to try a different labeling technique on the same data.
 Storage is the version control.
 
 Quick Start:
-    >>> from archetype.trajectories import Session, Label, TrajectoryPipeline
+    >>> from archetype.trajectories import Trajectory, Label, TrajectoryPipeline
     >>> pipeline = TrajectoryPipeline(name="my-experiment")
     >>> pipeline.label("efficiency", "Rate how directly the agent reached the solution without backtracking")
-    >>> await pipeline.ingest(sessions)
+    >>> await pipeline.ingest(trajectories)
     >>> await pipeline.run()
     >>> results = await pipeline.results()
 """
 
-from archetype.trajectories.components import Label, Session, Turn
+from archetype.trajectories.components import Label, Trajectory, Turn
 from archetype.trajectories.pipeline import TrajectoryPipeline
 from archetype.trajectories.processors import LabelingProcessor, SamplingProcessor, ScoringProcessor
 
 __all__ = [
-    "Session",
+    "Trajectory",
     "Turn",
     "Label",
     "TrajectoryPipeline",

--- a/src/archetype/trajectories/__init__.py
+++ b/src/archetype/trajectories/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Trajectory Analysis Pipeline
+=============================
+
+Components and processors for evaluating agent session trajectories
+through configurable sampling regimes and labeling techniques.
+
+Trajectories are entities. Processors are pipeline stages.
+Fork a world to try a different labeling technique on the same data.
+Storage is the version control.
+
+Quick Start:
+    >>> from archetype.trajectories import Session, Label, TrajectoryPipeline
+    >>> pipeline = TrajectoryPipeline(name="my-experiment")
+    >>> pipeline.label("efficiency", "Rate how directly the agent reached the solution without backtracking")
+    >>> await pipeline.ingest(sessions)
+    >>> await pipeline.run()
+    >>> results = await pipeline.results()
+"""
+
+from archetype.trajectories.components import Label, Session, Turn
+from archetype.trajectories.pipeline import TrajectoryPipeline
+from archetype.trajectories.processors import LabelingProcessor, SamplingProcessor, ScoringProcessor
+
+__all__ = [
+    "Session",
+    "Turn",
+    "Label",
+    "TrajectoryPipeline",
+    "SamplingProcessor",
+    "LabelingProcessor",
+    "ScoringProcessor",
+]

--- a/src/archetype/trajectories/components.py
+++ b/src/archetype/trajectories/components.py
@@ -5,11 +5,13 @@
 Trajectory Components
 =====================
 
-Session: The raw trajectory — every turn, tool call, output, and timing.
-Label:   An evaluation result attached to a session.
+Trajectory: The raw agent trajectory — every turn, tool call, output, and timing.
+Label:      An evaluation result attached to a trajectory.
 
 Both are Arrow-serializable. Complex nested data (turns, tool calls)
 is stored as JSON strings for LanceDB compatibility.
+
+Note: Named 'Trajectory' not 'Session' to avoid collision with daft.session.Session.
 """
 
 from __future__ import annotations
@@ -23,8 +25,8 @@ from archetype.core.component import Component
 
 @dataclass
 class Turn:
-    """A single turn in an agent session. Not a Component — just a data class
-    for building Session.turns JSON."""
+    """A single turn in an agent trajectory. Not a Component — just a data class
+    for building Trajectory.turns JSON."""
 
     role: str  # "user", "assistant", "tool_call", "tool_result", "system"
     content: str = ""
@@ -60,14 +62,14 @@ class Turn:
         return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
 
 
-class Session(Component):
-    """A complete agent session trajectory.
+class Trajectory(Component):
+    """A complete agent trajectory.
 
     Stores the full history of an agent session — every turn, tool call,
     reasoning step, output, error, and timing — as a JSON-encoded list of turns.
 
     Fields:
-        session_id:       External reference (e.g., Claude Code session ID)
+        trajectory_id:    External reference (e.g., Claude Code session ID)
         source:           Origin system ("claude-code", "api", "custom")
         turns:            JSON list of Turn dicts — the full trajectory
         total_turns:      Count of turns (denormalized for filtering)
@@ -78,7 +80,7 @@ class Session(Component):
         metadata:         JSON dict of arbitrary session metadata
     """
 
-    session_id: str = ""
+    trajectory_id: str = ""
     source: str = ""
     turns: str = "[]"
     total_turns: int = 0
@@ -91,19 +93,19 @@ class Session(Component):
     @classmethod
     def from_turns(
         cls,
-        session_id: str,
+        trajectory_id: str,
         turns: list[Turn],
         *,
         source: str = "",
         outcome: str = "",
         tags: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
-    ) -> Session:
-        """Build a Session from a list of Turn objects."""
+    ) -> Trajectory:
+        """Build a Trajectory from a list of Turn objects."""
         total_tokens = sum(t.tokens for t in turns)
         duration = sum(t.duration_ms for t in turns) / 1000.0
         return cls(
-            session_id=session_id,
+            trajectory_id=trajectory_id,
             source=source,
             turns=json.dumps([t.to_dict() for t in turns]),
             total_turns=len(turns),
@@ -120,10 +122,10 @@ class Session(Component):
 
 
 class Label(Component):
-    """An evaluation label attached to a session trajectory.
+    """An evaluation label attached to a trajectory.
 
-    Each (Session, Label) entity represents one labeling technique
-    applied to one session. To compare techniques, fork the world
+    Each (Trajectory, Label) entity represents one labeling technique
+    applied to one trajectory. To compare techniques, fork the world
     and swap the LabelingProcessor's description.
 
     Fields:

--- a/src/archetype/trajectories/components.py
+++ b/src/archetype/trajectories/components.py
@@ -1,0 +1,144 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Trajectory Components
+=====================
+
+Session: The raw trajectory — every turn, tool call, output, and timing.
+Label:   An evaluation result attached to a session.
+
+Both are Arrow-serializable. Complex nested data (turns, tool calls)
+is stored as JSON strings for LanceDB compatibility.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from archetype.core.component import Component
+
+
+@dataclass
+class Turn:
+    """A single turn in an agent session. Not a Component — just a data class
+    for building Session.turns JSON."""
+
+    role: str  # "user", "assistant", "tool_call", "tool_result", "system"
+    content: str = ""
+    tool_name: str | None = None
+    tool_input: str | None = None  # JSON string
+    tool_output: str | None = None  # JSON string
+    tokens: int = 0
+    duration_ms: float = 0.0
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = {
+            "role": self.role,
+            "content": self.content,
+            "tokens": self.tokens,
+            "duration_ms": self.duration_ms,
+        }
+        if self.tool_name is not None:
+            d["tool_name"] = self.tool_name
+        if self.tool_input is not None:
+            d["tool_input"] = self.tool_input
+        if self.tool_output is not None:
+            d["tool_output"] = self.tool_output
+        if self.error is not None:
+            d["error"] = self.error
+        if self.metadata:
+            d["metadata"] = self.metadata
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Turn:
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+class Session(Component):
+    """A complete agent session trajectory.
+
+    Stores the full history of an agent session — every turn, tool call,
+    reasoning step, output, error, and timing — as a JSON-encoded list of turns.
+
+    Fields:
+        session_id:       External reference (e.g., Claude Code session ID)
+        source:           Origin system ("claude-code", "api", "custom")
+        turns:            JSON list of Turn dicts — the full trajectory
+        total_turns:      Count of turns (denormalized for filtering)
+        total_tokens:     Total token usage across all turns
+        duration_seconds: Wall-clock duration of the session
+        outcome:          Final outcome summary (success/failure/partial + description)
+        tags:             JSON list of string tags for categorization
+        metadata:         JSON dict of arbitrary session metadata
+    """
+
+    session_id: str = ""
+    source: str = ""
+    turns: str = "[]"
+    total_turns: int = 0
+    total_tokens: int = 0
+    duration_seconds: float = 0.0
+    outcome: str = ""
+    tags: str = "[]"
+    metadata: str = "{}"
+
+    @classmethod
+    def from_turns(
+        cls,
+        session_id: str,
+        turns: list[Turn],
+        *,
+        source: str = "",
+        outcome: str = "",
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Session:
+        """Build a Session from a list of Turn objects."""
+        total_tokens = sum(t.tokens for t in turns)
+        duration = sum(t.duration_ms for t in turns) / 1000.0
+        return cls(
+            session_id=session_id,
+            source=source,
+            turns=json.dumps([t.to_dict() for t in turns]),
+            total_turns=len(turns),
+            total_tokens=total_tokens,
+            duration_seconds=duration,
+            outcome=outcome,
+            tags=json.dumps(tags or []),
+            metadata=json.dumps(metadata or {}),
+        )
+
+    def get_turns(self) -> list[Turn]:
+        """Deserialize turns JSON back to Turn objects."""
+        return [Turn.from_dict(d) for d in json.loads(self.turns)]
+
+
+class Label(Component):
+    """An evaluation label attached to a session trajectory.
+
+    Each (Session, Label) entity represents one labeling technique
+    applied to one session. To compare techniques, fork the world
+    and swap the LabelingProcessor's description.
+
+    Fields:
+        technique:   Name of the labeling technique (e.g., "efficiency", "correctness")
+        description: Natural language description of what to evaluate.
+                     This is the prompt — describe it and the LLM applies it.
+        value:       The label result (filled by LabelingProcessor)
+        score:       Numeric score 0.0-1.0 (filled by LabelingProcessor)
+        rationale:   Why this label was assigned (filled by LabelingProcessor)
+        sampled:     Whether this entity was selected by the SamplingProcessor
+    """
+
+    technique: str = ""
+    description: str = ""
+    value: str = ""
+    score: float = 0.0
+    rationale: str = ""
+    sampled: bool = True

--- a/src/archetype/trajectories/components.py
+++ b/src/archetype/trajectories/components.py
@@ -71,24 +71,24 @@ class Trajectory(Component):
     Fields:
         trajectory_id:    External reference (e.g., Claude Code session ID)
         source:           Origin system ("claude-code", "api", "custom")
-        turns:            JSON list of Turn dicts — the full trajectory
+        turns_json:       JSON list of Turn dicts — the full trajectory
         total_turns:      Count of turns (denormalized for filtering)
         total_tokens:     Total token usage across all turns
         duration_seconds: Wall-clock duration of the session
         outcome:          Final outcome summary (success/failure/partial + description)
-        tags:             JSON list of string tags for categorization
-        metadata:         JSON dict of arbitrary session metadata
+        tags_json:        JSON list of string tags for categorization
+        metadata_json:    JSON dict of arbitrary session metadata
     """
 
     trajectory_id: str = ""
     source: str = ""
-    turns: str = "[]"
+    turns_json: str = "[]"
     total_turns: int = 0
     total_tokens: int = 0
     duration_seconds: float = 0.0
     outcome: str = ""
-    tags: str = "[]"
-    metadata: str = "{}"
+    tags_json: str = "[]"
+    metadata_json: str = "{}"
 
     @classmethod
     def from_turns(
@@ -107,18 +107,18 @@ class Trajectory(Component):
         return cls(
             trajectory_id=trajectory_id,
             source=source,
-            turns=json.dumps([t.to_dict() for t in turns]),
+            turns_json=json.dumps([t.to_dict() for t in turns]),
             total_turns=len(turns),
             total_tokens=total_tokens,
             duration_seconds=duration,
             outcome=outcome,
-            tags=json.dumps(tags or []),
-            metadata=json.dumps(metadata or {}),
+            tags_json=json.dumps(tags or []),
+            metadata_json=json.dumps(metadata or {}),
         )
 
     def get_turns(self) -> list[Turn]:
         """Deserialize turns JSON back to Turn objects."""
-        return [Turn.from_dict(d) for d in json.loads(self.turns)]
+        return [Turn.from_dict(d) for d in json.loads(self.turns_json)]
 
 
 class Label(Component):

--- a/src/archetype/trajectories/pipeline.py
+++ b/src/archetype/trajectories/pipeline.py
@@ -1,0 +1,213 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Trajectory Pipeline
+===================
+
+The high-level API. Describe what you want, it wires the world.
+
+    pipeline = TrajectoryPipeline(name="eval-backtracking")
+    pipeline.label("efficiency", "Rate how directly the agent solved the problem")
+    pipeline.label("correctness", "Did the agent produce the right final answer?")
+    pipeline.sample(min_turns=5, max_sessions=100)
+    await pipeline.ingest(sessions)
+    await pipeline.run()
+    results = await pipeline.results()
+
+Fork to compare techniques:
+
+    fork = await pipeline.fork("eval-strict-correctness")
+    fork.label("correctness", "Strictly binary: did the final output exactly match expected?")
+    await fork.run()
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from uuid_utils import uuid7
+
+from archetype.app.auth.models import ActorCtx
+from archetype.app.container import ServiceContainer
+from archetype.app.models import Command, CommandType
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.trajectories.components import Label, Session
+from archetype.trajectories.processors import (
+    LabelingConfig,
+    LabelingProcessor,
+    SamplingConfig,
+    SamplingProcessor,
+    ScoringProcessor,
+)
+
+
+class TrajectoryPipeline:
+    """Wires up a trajectory analysis experiment as an archetype world.
+
+    Each pipeline is a world. Each session is an entity with (Session, Label)
+    components — one entity per (session, technique) pair. Processors run
+    in priority order: sample → label → score.
+
+    All state lives in LanceDB. Fork to compare. Query to analyze.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        storage_uri: str = "./trajectory_data",
+        model: str = "gpt-5-mini",
+    ):
+        self.name = name
+        self._storage_uri = storage_uri
+        self._model = model
+        self._labels: list[tuple[str, str]] = []  # (technique, description)
+        self._sampling = SamplingConfig()
+        self._container: ServiceContainer | None = None
+        self._world: Any = None  # AsyncWorld, set after init
+        self._ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        self._initialized = False
+
+    def label(self, technique: str, description: str) -> TrajectoryPipeline:
+        """Add a labeling technique. Describe it in natural language."""
+        self._labels.append((technique, description))
+        return self
+
+    def sample(
+        self,
+        *,
+        max_sessions: int = 0,
+        min_turns: int = 0,
+        max_turns: int = 0,
+        require_tags: list[str] | None = None,
+        exclude_tags: list[str] | None = None,
+        outcome_filter: str | None = None,
+    ) -> TrajectoryPipeline:
+        """Configure sampling. Chainable."""
+        self._sampling = SamplingConfig(
+            max_sessions=max_sessions,
+            min_turns=min_turns,
+            max_turns=max_turns,
+            require_tags=require_tags,
+            exclude_tags=exclude_tags,
+            outcome_filter=outcome_filter,
+        )
+        return self
+
+    async def _ensure_init(self) -> None:
+        if self._initialized:
+            return
+        self._container = ServiceContainer()
+        self._world = await self._container.world_service.create_world(
+            WorldConfig(name=self.name),
+            StorageConfig(uri=self._storage_uri, namespace="trajectories"),
+        )
+        # Wire processors
+        await self._world.system.add_processor(SamplingProcessor())
+        await self._world.system.add_processor(LabelingProcessor())
+        await self._world.system.add_processor(ScoringProcessor())
+        # Inject resources
+        self._world.resources.insert(self._sampling)
+        self._world.resources.insert(LabelingConfig(model=self._model))
+        self._initialized = True
+
+    async def ingest(self, sessions: list[Session]) -> list[int]:
+        """Ingest sessions into the world. Creates one entity per (session, technique) pair."""
+        await self._ensure_init()
+        if not self._labels:
+            raise ValueError("No labeling techniques defined. Call .label() first.")
+
+        entity_ids = []
+        for session in sessions:
+            for technique, description in self._labels:
+                label = Label(technique=technique, description=description)
+                cmd = Command(
+                    type=CommandType.SPAWN,
+                    payload={
+                        "components": [
+                            session.model_dump(),
+                            label.model_dump(),
+                        ],
+                    },
+                )
+                await self._container.command_service.submit(
+                    self._world.world_id, cmd, self._ctx
+                )
+                entity_ids.append(len(entity_ids))
+        return entity_ids
+
+    async def run(self, steps: int = 1) -> None:
+        """Run the pipeline. One step = sample → label → score."""
+        await self._ensure_init()
+        await self._container.simulation_service.run(
+            self._world.world_id,
+            RunConfig(num_steps=steps, suite=self.name),
+        )
+
+    async def results(self) -> list[dict[str, Any]]:
+        """Collect results as a list of dicts."""
+        await self._ensure_init()
+        rows = []
+        for _sig, df in self._world._live.items():
+            collected = df.collect().to_pylist()
+            for row in collected:
+                if not row.get("is_active", True):
+                    continue
+                rows.append(
+                    {
+                        "session_id": row.get("session__session_id", ""),
+                        "technique": row.get("label__technique", ""),
+                        "description": row.get("label__description", ""),
+                        "value": row.get("label__value", ""),
+                        "score": row.get("label__score", 0.0),
+                        "rationale": row.get("label__rationale", ""),
+                        "sampled": row.get("label__sampled", True),
+                        "total_turns": row.get("session__total_turns", 0),
+                        "outcome": row.get("session__outcome", ""),
+                        "source": row.get("session__source", ""),
+                    }
+                )
+        return rows
+
+    async def results_df(self) -> Any:
+        """Return raw Daft DataFrame of live state (for advanced queries)."""
+        await self._ensure_init()
+        dfs = list(self._world._live.values())
+        if not dfs:
+            return None
+        return dfs[0] if len(dfs) == 1 else dfs
+
+    async def fork(self, new_name: str) -> TrajectoryPipeline:
+        """Fork this pipeline into a new world with the same data.
+
+        Use this to compare labeling techniques on identical sessions.
+        Modify the fork's labels, then run it.
+        """
+        await self._ensure_init()
+        forked = TrajectoryPipeline(
+            name=new_name,
+            storage_uri=self._storage_uri,
+            model=self._model,
+        )
+        forked._labels = list(self._labels)
+        forked._sampling = self._sampling
+        # Initialize with a fresh world (fork semantics via archetype)
+        forked._container = self._container
+        forked._world = await self._container.world_service.fork_world(
+            source_id=self._world.world_id,
+            new_config=WorldConfig(name=new_name),
+            storage_config=StorageConfig(uri=self._storage_uri, namespace="trajectories"),
+        )
+        await forked._world.system.add_processor(SamplingProcessor())
+        await forked._world.system.add_processor(LabelingProcessor())
+        await forked._world.system.add_processor(ScoringProcessor())
+        forked._world.resources.insert(forked._sampling)
+        forked._world.resources.insert(LabelingConfig(model=forked._model))
+        forked._initialized = True
+        return forked
+
+    async def shutdown(self) -> None:
+        """Clean up."""
+        if self._container:
+            await self._container.shutdown()

--- a/src/archetype/trajectories/pipeline.py
+++ b/src/archetype/trajectories/pipeline.py
@@ -10,8 +10,8 @@ The high-level API. Describe what you want, it wires the world.
     pipeline = TrajectoryPipeline(name="eval-backtracking")
     pipeline.label("efficiency", "Rate how directly the agent solved the problem")
     pipeline.label("correctness", "Did the agent produce the right final answer?")
-    pipeline.sample(min_turns=5, max_sessions=100)
-    await pipeline.ingest(sessions)
+    pipeline.sample(min_turns=5, max_trajectories=100)
+    await pipeline.ingest(trajectories)
     await pipeline.run()
     results = await pipeline.results()
 
@@ -32,7 +32,7 @@ from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
 from archetype.app.models import Command, CommandType
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
-from archetype.trajectories.components import Label, Session
+from archetype.trajectories.components import Label, Trajectory
 from archetype.trajectories.processors import (
     LabelingConfig,
     LabelingProcessor,
@@ -45,8 +45,8 @@ from archetype.trajectories.processors import (
 class TrajectoryPipeline:
     """Wires up a trajectory analysis experiment as an archetype world.
 
-    Each pipeline is a world. Each session is an entity with (Session, Label)
-    components — one entity per (session, technique) pair. Processors run
+    Each pipeline is a world. Each trajectory is an entity with (Trajectory, Label)
+    components — one entity per (trajectory, technique) pair. Processors run
     in priority order: sample → label → score.
 
     All state lives in LanceDB. Fork to compare. Query to analyze.
@@ -77,7 +77,7 @@ class TrajectoryPipeline:
     def sample(
         self,
         *,
-        max_sessions: int = 0,
+        max_trajectories: int = 0,
         min_turns: int = 0,
         max_turns: int = 0,
         require_tags: list[str] | None = None,
@@ -86,7 +86,7 @@ class TrajectoryPipeline:
     ) -> TrajectoryPipeline:
         """Configure sampling. Chainable."""
         self._sampling = SamplingConfig(
-            max_sessions=max_sessions,
+            max_trajectories=max_trajectories,
             min_turns=min_turns,
             max_turns=max_turns,
             require_tags=require_tags,
@@ -112,21 +112,21 @@ class TrajectoryPipeline:
         self._world.resources.insert(LabelingConfig(model=self._model))
         self._initialized = True
 
-    async def ingest(self, sessions: list[Session]) -> list[int]:
-        """Ingest sessions into the world. Creates one entity per (session, technique) pair."""
+    async def ingest(self, trajectories: list[Trajectory]) -> list[int]:
+        """Ingest trajectories into the world. Creates one entity per (trajectory, technique) pair."""
         await self._ensure_init()
         if not self._labels:
             raise ValueError("No labeling techniques defined. Call .label() first.")
 
         entity_ids = []
-        for session in sessions:
+        for trajectory in trajectories:
             for technique, description in self._labels:
                 label = Label(technique=technique, description=description)
                 cmd = Command(
                     type=CommandType.SPAWN,
                     payload={
                         "components": [
-                            session.model_dump(),
+                            trajectory.model_dump(),
                             label.model_dump(),
                         ],
                     },
@@ -156,16 +156,16 @@ class TrajectoryPipeline:
                     continue
                 rows.append(
                     {
-                        "session_id": row.get("session__session_id", ""),
+                        "trajectory_id": row.get("trajectory__trajectory_id", ""),
                         "technique": row.get("label__technique", ""),
                         "description": row.get("label__description", ""),
                         "value": row.get("label__value", ""),
                         "score": row.get("label__score", 0.0),
                         "rationale": row.get("label__rationale", ""),
                         "sampled": row.get("label__sampled", True),
-                        "total_turns": row.get("session__total_turns", 0),
-                        "outcome": row.get("session__outcome", ""),
-                        "source": row.get("session__source", ""),
+                        "total_turns": row.get("trajectory__total_turns", 0),
+                        "outcome": row.get("trajectory__outcome", ""),
+                        "source": row.get("trajectory__source", ""),
                     }
                 )
         return rows
@@ -181,7 +181,7 @@ class TrajectoryPipeline:
     async def fork(self, new_name: str) -> TrajectoryPipeline:
         """Fork this pipeline into a new world with the same data.
 
-        Use this to compare labeling techniques on identical sessions.
+        Use this to compare labeling techniques on identical trajectories.
         Modify the fork's labels, then run it.
         """
         await self._ensure_init()

--- a/src/archetype/trajectories/pipeline.py
+++ b/src/archetype/trajectories/pipeline.py
@@ -68,7 +68,7 @@ class TrajectoryPipeline:
         self._sampling = SamplingConfig()
         self._container: ServiceContainer | None = None
         self._world: Any = None  # AsyncWorld, set after init
-        self._ctx = ctx or ActorCtx(id=uuid7(), roles={"pipeline"})
+        self._ctx = ctx or ActorCtx(id=uuid7(), roles={"operator"})
         self._initialized = False
         self._owns_container = False  # tracks whether we created the container
 

--- a/src/archetype/trajectories/pipeline.py
+++ b/src/archetype/trajectories/pipeline.py
@@ -215,7 +215,7 @@ class TrajectoryPipeline:
         forked._owns_container = True
         forked._world = await forked._container.world_service.fork_world(
             source_world_id=self._world.world_id,
-            config=WorldConfig(name=new_name),
+            name=new_name,
             storage_config=StorageConfig(uri=self._storage_uri, namespace="trajectories"),
         )
         await forked._setup_processors()

--- a/src/archetype/trajectories/pipeline.py
+++ b/src/archetype/trajectories/pipeline.py
@@ -25,6 +25,7 @@ Fork to compare techniques:
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
 
 from uuid_utils import uuid7
 
@@ -58,6 +59,7 @@ class TrajectoryPipeline:
         *,
         storage_uri: str = "./trajectory_data",
         model: str = "gpt-5-mini",
+        ctx: ActorCtx | None = None,
     ):
         self.name = name
         self._storage_uri = storage_uri
@@ -66,8 +68,14 @@ class TrajectoryPipeline:
         self._sampling = SamplingConfig()
         self._container: ServiceContainer | None = None
         self._world: Any = None  # AsyncWorld, set after init
-        self._ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        self._ctx = ctx or ActorCtx(id=uuid7(), roles={"pipeline"})
         self._initialized = False
+        self._owns_container = False  # tracks whether we created the container
+
+    @property
+    def label_specs(self) -> list[tuple[str, str]]:
+        """Public accessor for (technique, description) pairs."""
+        return list(self._labels)
 
     def label(self, technique: str, description: str) -> TrajectoryPipeline:
         """Add a labeling technique. Describe it in natural language."""
@@ -93,32 +101,42 @@ class TrajectoryPipeline:
             exclude_tags=exclude_tags,
             outcome_filter=outcome_filter,
         )
+        # If already initialized, update the live resource
+        if self._initialized and self._world is not None:
+            self._world.resources.insert(self._sampling)
         return self
 
     async def _ensure_init(self) -> None:
         if self._initialized:
             return
         self._container = ServiceContainer()
+        self._owns_container = True
         self._world = await self._container.world_service.create_world(
             WorldConfig(name=self.name),
             StorageConfig(uri=self._storage_uri, namespace="trajectories"),
         )
-        # Wire processors
+        await self._setup_processors()
+        self._initialized = True
+
+    async def _setup_processors(self) -> None:
+        """Wire processors and resources into the world."""
         await self._world.system.add_processor(SamplingProcessor())
         await self._world.system.add_processor(LabelingProcessor())
         await self._world.system.add_processor(ScoringProcessor())
-        # Inject resources
         self._world.resources.insert(self._sampling)
         self._world.resources.insert(LabelingConfig(model=self._model))
-        self._initialized = True
 
-    async def ingest(self, trajectories: list[Trajectory]) -> list[int]:
-        """Ingest trajectories into the world. Creates one entity per (trajectory, technique) pair."""
+    async def ingest(self, trajectories: list[Trajectory]) -> list[UUID]:
+        """Ingest trajectories into the world.
+
+        Creates one entity per (trajectory, technique) pair.
+        Returns the command UUIDs from submission.
+        """
         await self._ensure_init()
         if not self._labels:
             raise ValueError("No labeling techniques defined. Call .label() first.")
 
-        entity_ids = []
+        command_ids = []
         for trajectory in trajectories:
             for technique, description in self._labels:
                 label = Label(technique=technique, description=description)
@@ -126,62 +144,63 @@ class TrajectoryPipeline:
                     type=CommandType.SPAWN,
                     payload={
                         "components": [
-                            trajectory.model_dump(),
-                            label.model_dump(),
+                            {"type": "Trajectory", **trajectory.model_dump()},
+                            {"type": "Label", **label.model_dump()},
                         ],
                     },
                 )
-                await self._container.command_service.submit(
+                cmd_id = await self._container.command_service.submit(
                     self._world.world_id, cmd, self._ctx
                 )
-                entity_ids.append(len(entity_ids))
-        return entity_ids
+                command_ids.append(cmd_id)
+        return command_ids
 
     async def run(self, steps: int = 1) -> None:
         """Run the pipeline. One step = sample → label → score."""
         await self._ensure_init()
-        await self._container.simulation_service.run(
-            self._world.world_id,
-            RunConfig(num_steps=steps, suite=self.name),
-        )
+        for _ in range(steps):
+            await self._container.simulation_service.step(
+                self._world.world_id,
+                RunConfig(num_steps=1),
+            )
 
     async def results(self) -> list[dict[str, Any]]:
         """Collect results as a list of dicts."""
         await self._ensure_init()
+        df = await self._world.get_components([Trajectory, Label])
+        if df is None:
+            return []
+
         rows = []
-        for _sig, df in self._world._live.items():
-            collected = df.collect().to_pylist()
-            for row in collected:
-                if not row.get("is_active", True):
-                    continue
-                rows.append(
-                    {
-                        "trajectory_id": row.get("trajectory__trajectory_id", ""),
-                        "technique": row.get("label__technique", ""),
-                        "description": row.get("label__description", ""),
-                        "value": row.get("label__value", ""),
-                        "score": row.get("label__score", 0.0),
-                        "rationale": row.get("label__rationale", ""),
-                        "sampled": row.get("label__sampled", True),
-                        "total_turns": row.get("trajectory__total_turns", 0),
-                        "outcome": row.get("trajectory__outcome", ""),
-                        "source": row.get("trajectory__source", ""),
-                    }
-                )
+        collected = df.collect().to_pylist()
+        for row in collected:
+            if not row.get("is_active", True):
+                continue
+            rows.append(
+                {
+                    "trajectory_id": row.get("trajectory__trajectory_id", ""),
+                    "technique": row.get("label__technique", ""),
+                    "description": row.get("label__description", ""),
+                    "value": row.get("label__value", ""),
+                    "score": row.get("label__score", 0.0),
+                    "rationale": row.get("label__rationale", ""),
+                    "sampled": row.get("label__sampled", True),
+                    "total_turns": row.get("trajectory__total_turns", 0),
+                    "outcome": row.get("trajectory__outcome", ""),
+                    "source": row.get("trajectory__source", ""),
+                }
+            )
         return rows
 
     async def results_df(self) -> Any:
         """Return raw Daft DataFrame of live state (for advanced queries)."""
         await self._ensure_init()
-        dfs = list(self._world._live.values())
-        if not dfs:
-            return None
-        return dfs[0] if len(dfs) == 1 else dfs
+        return await self._world.get_components([Trajectory, Label])
 
     async def fork(self, new_name: str) -> TrajectoryPipeline:
-        """Fork this pipeline into a new world with the same data.
+        """Fork this pipeline into a new world.
 
-        Use this to compare labeling techniques on identical trajectories.
+        The forked pipeline gets its own container and world.
         Modify the fork's labels, then run it.
         """
         await self._ensure_init()
@@ -192,22 +211,18 @@ class TrajectoryPipeline:
         )
         forked._labels = list(self._labels)
         forked._sampling = self._sampling
-        # Initialize with a fresh world (fork semantics via archetype)
-        forked._container = self._container
-        forked._world = await self._container.world_service.fork_world(
-            source_id=self._world.world_id,
-            new_config=WorldConfig(name=new_name),
+        forked._container = ServiceContainer()
+        forked._owns_container = True
+        forked._world = await forked._container.world_service.fork_world(
+            source_world_id=self._world.world_id,
+            config=WorldConfig(name=new_name),
             storage_config=StorageConfig(uri=self._storage_uri, namespace="trajectories"),
         )
-        await forked._world.system.add_processor(SamplingProcessor())
-        await forked._world.system.add_processor(LabelingProcessor())
-        await forked._world.system.add_processor(ScoringProcessor())
-        forked._world.resources.insert(forked._sampling)
-        forked._world.resources.insert(LabelingConfig(model=forked._model))
+        await forked._setup_processors()
         forked._initialized = True
         return forked
 
     async def shutdown(self) -> None:
-        """Clean up."""
-        if self._container:
+        """Clean up. Only shuts down the container if we created it."""
+        if self._container and self._owns_container:
             await self._container.shutdown()

--- a/src/archetype/trajectories/pipeline.py
+++ b/src/archetype/trajectories/pipeline.py
@@ -161,7 +161,7 @@ class TrajectoryPipeline:
         for _ in range(steps):
             await self._container.simulation_service.step(
                 self._world.world_id,
-                RunConfig(num_steps=1),
+                RunConfig(num_steps=1, prefer_live_reads=True),
             )
 
     async def results(self) -> list[dict[str, Any]]:

--- a/src/archetype/trajectories/processors.py
+++ b/src/archetype/trajectories/processors.py
@@ -17,6 +17,7 @@ one tick = sample → label → score. Fork the world to try different configs.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -58,12 +59,22 @@ class LabelingConfig:
     Attributes:
         model:             LLM model to use for labeling
         max_output_tokens: Max tokens for LLM response
-        temperature:       Sampling temperature
     """
 
     model: str = "gpt-5-mini"
     max_output_tokens: int = 512
-    temperature: float = 0.0
+
+
+# ── Tag matching UDF ──
+
+
+@daft.func
+def _tags_contain(tags_json: str, tag: str) -> bool:
+    """Exact membership check against JSON-encoded tag list."""
+    try:
+        return tag in json.loads(tags_json)
+    except (json.JSONDecodeError, TypeError):
+        return False
 
 
 # ── Processors ──
@@ -73,7 +84,7 @@ class SamplingProcessor(AsyncProcessor):
     """Selects which trajectories to evaluate based on SamplingConfig.
 
     Sets label__sampled = True/False. Downstream processors skip
-    unsampled trajectories.
+    unsampled trajectories. Never drops rows — all entities are preserved.
     """
 
     components = (Trajectory, Label)
@@ -83,7 +94,8 @@ class SamplingProcessor(AsyncProcessor):
         resources: Resources = kwargs.get("resources", Resources())
         config = resources.get(SamplingConfig) or SamplingConfig()
 
-        sampled = col("label__sampled")
+        # Start fresh from True so sampling is recomputed each tick
+        sampled = daft.lit(True)
 
         if config.min_turns > 0:
             sampled = sampled & (col("trajectory__total_turns") >= config.min_turns)
@@ -96,16 +108,27 @@ class SamplingProcessor(AsyncProcessor):
 
         if config.require_tags:
             for tag in config.require_tags:
-                sampled = sampled & col("trajectory__tags").str.contains(f'"{tag}"')
+                sampled = sampled & _tags_contain(
+                    col("trajectory__tags_json"), daft.lit(tag)
+                )
 
         if config.exclude_tags:
             for tag in config.exclude_tags:
-                sampled = sampled & ~col("trajectory__tags").str.contains(f'"{tag}"')
+                sampled = sampled & ~_tags_contain(
+                    col("trajectory__tags_json"), daft.lit(tag)
+                )
 
         df = df.with_columns({"label__sampled": sampled})
 
+        # Enforce max_trajectories without dropping rows: mark excess as unsampled
         if config.max_trajectories > 0:
-            df = df.limit(config.max_trajectories)
+            df = df._add_monotonically_increasing_id("_sample_idx")
+            df = df.with_columns(
+                {
+                    "label__sampled": col("label__sampled")
+                    & (col("_sample_idx") < config.max_trajectories),
+                }
+            ).exclude("_sample_idx")
 
         return df
 
@@ -114,12 +137,12 @@ class LabelingProcessor(AsyncProcessor):
     """Applies a labeling technique to sampled trajectories via LLM.
 
     Reads label__description (the natural language labeling instruction)
-    and trajectory__turns (the full trajectory), then calls an LLM to produce:
+    and trajectory__turns_json (the full trajectory), then calls an LLM to produce:
         - label__value:     categorical or freeform label
         - label__score:     numeric 0.0-1.0
         - label__rationale: explanation
 
-    Only processes trajectories where label__sampled is True.
+    Only invokes the LLM for trajectories where label__sampled is True.
     """
 
     components = (Trajectory, Label)
@@ -130,6 +153,10 @@ class LabelingProcessor(AsyncProcessor):
         config = resources.get(LabelingConfig) or LabelingConfig()
 
         from daft.functions import prompt
+
+        # Split sampled vs unsampled to avoid LLM calls on unsampled rows
+        sampled_df = df.where(col("label__sampled"))
+        unsampled_df = df.where(~col("label__sampled"))
 
         eval_prompt = (
             "You are an expert evaluator of AI agent trajectories.\n\n"
@@ -147,7 +174,7 @@ class LabelingProcessor(AsyncProcessor):
             + "\nDuration: "
             + col("trajectory__duration_seconds").cast(daft.DataType.string())
             + "s\n\nTurns:\n"
-            + col("trajectory__turns")
+            + col("trajectory__turns_json")
             + "\n\n## Instructions\n"
             "Evaluate this trajectory according to the technique above.\n"
             "Respond in EXACTLY this format (no other text):\n"
@@ -163,11 +190,10 @@ class LabelingProcessor(AsyncProcessor):
         )
 
         # Row-wise extractors — @daft.func with auto type inference (LEARNINGS.md §4)
-        # No batching benefit here, just parsing strings.
 
         @daft.func
-        def extract_value(response: str, sampled: bool) -> str:
-            if not sampled or not response:
+        def extract_value(response: str) -> str:
+            if not response:
                 return ""
             for line in response.split("\n"):
                 if line.startswith("VALUE:"):
@@ -175,8 +201,8 @@ class LabelingProcessor(AsyncProcessor):
             return response[:100]
 
         @daft.func
-        def extract_score(response: str, sampled: bool) -> float:
-            if not sampled or not response:
+        def extract_score(response: str) -> float:
+            if not response:
                 return 0.0
             for line in response.split("\n"):
                 if line.startswith("SCORE:"):
@@ -187,8 +213,8 @@ class LabelingProcessor(AsyncProcessor):
             return 0.0
 
         @daft.func
-        def extract_rationale(response: str, sampled: bool) -> str:
-            if not sampled or not response:
+        def extract_rationale(response: str) -> str:
+            if not response:
                 return ""
             for line in response.split("\n"):
                 if line.startswith("RATIONALE:"):
@@ -196,15 +222,17 @@ class LabelingProcessor(AsyncProcessor):
             return ""
 
         llm_col = llm_output
-        sampled_col = col("label__sampled")
 
-        return df.with_columns(
+        sampled_df = sampled_df.with_columns(
             {
-                "label__value": extract_value(llm_col, sampled_col),
-                "label__score": extract_score(llm_col, sampled_col),
-                "label__rationale": extract_rationale(llm_col, sampled_col),
+                "label__value": extract_value(llm_col),
+                "label__score": extract_score(llm_col),
+                "label__rationale": extract_rationale(llm_col),
             }
         )
+
+        # Rejoin: unsampled rows keep their existing label values
+        return sampled_df.concat(unsampled_df)
 
 
 class ScoringProcessor(AsyncProcessor):
@@ -218,10 +246,8 @@ class ScoringProcessor(AsyncProcessor):
     priority = 30
 
     async def process(self, df: DataFrame, **kwargs: Any) -> DataFrame:
-        clamped = col("label__score").if_else(
-            col("label__score") > 1.0,
-            1.0,
-            col("label__score"),
-        )
-        clamped = clamped.if_else(clamped < 0.0, 0.0, clamped)
-        return df.with_columns({"label__score": clamped})
+        @daft.func
+        def clamp_score(score: float) -> float:
+            return max(0.0, min(1.0, score))
+
+        return df.with_columns({"label__score": clamp_score(col("label__score"))})

--- a/src/archetype/trajectories/processors.py
+++ b/src/archetype/trajectories/processors.py
@@ -1,0 +1,242 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Trajectory Processors
+=====================
+
+Three pipeline stages, priority-ordered:
+
+    SamplingProcessor  (priority=10)  — selects which sessions to evaluate
+    LabelingProcessor  (priority=20)  — applies a labeling technique via LLM
+    ScoringProcessor   (priority=30)  — normalizes and aggregates scores
+
+Each is a standard AsyncProcessor. They compose in a single tick:
+one tick = sample → label → score. Fork the world to try different configs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import daft
+from daft import DataFrame, col
+
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.core.resources import Resources
+from archetype.trajectories.components import Label, Session
+
+# ── Resources (injected into world.resources) ──
+
+
+@dataclass
+class SamplingConfig:
+    """Configures which sessions get evaluated.
+
+    Attributes:
+        max_sessions:  Maximum number of sessions to sample (0 = all)
+        min_turns:     Minimum turn count to include
+        max_turns:     Maximum turn count to include (0 = no limit)
+        require_tags:  Only include sessions with ALL of these tags
+        exclude_tags:  Exclude sessions with ANY of these tags
+        outcome_filter: If set, only include sessions matching this outcome substring
+    """
+
+    max_sessions: int = 0
+    min_turns: int = 0
+    max_turns: int = 0
+    require_tags: list[str] | None = None
+    exclude_tags: list[str] | None = None
+    outcome_filter: str | None = None
+
+
+@dataclass
+class LabelingConfig:
+    """Configures the LLM-based labeling.
+
+    Attributes:
+        model:             LLM model to use for labeling
+        max_output_tokens: Max tokens for LLM response
+        temperature:       Sampling temperature
+    """
+
+    model: str = "gpt-5-mini"
+    max_output_tokens: int = 512
+    temperature: float = 0.0
+
+
+# ── Processors ──
+
+
+class SamplingProcessor(AsyncProcessor):
+    """Selects which sessions to evaluate based on SamplingConfig.
+
+    Sets label__sampled = True/False. Downstream processors skip
+    unsampled sessions.
+    """
+
+    components = (Session, Label)
+    priority = 10
+
+    async def process(self, df: DataFrame, **kwargs: Any) -> DataFrame:
+        resources: Resources = kwargs.get("resources", Resources())
+        config = resources.get(SamplingConfig) or SamplingConfig()
+
+        sampled = col("label__sampled")
+
+        if config.min_turns > 0:
+            sampled = sampled & (col("session__total_turns") >= config.min_turns)
+
+        if config.max_turns > 0:
+            sampled = sampled & (col("session__total_turns") <= config.max_turns)
+
+        if config.outcome_filter:
+            sampled = sampled & col("session__outcome").str.contains(config.outcome_filter)
+
+        if config.require_tags:
+            for tag in config.require_tags:
+                sampled = sampled & col("session__tags").str.contains(f'"{tag}"')
+
+        if config.exclude_tags:
+            for tag in config.exclude_tags:
+                sampled = sampled & ~col("session__tags").str.contains(f'"{tag}"')
+
+        df = df.with_columns({"label__sampled": sampled})
+
+        if config.max_sessions > 0:
+            df = df.limit(config.max_sessions)
+
+        return df
+
+
+class LabelingProcessor(AsyncProcessor):
+    """Applies a labeling technique to sampled sessions via LLM.
+
+    Reads label__description (the natural language labeling instruction)
+    and session__turns (the full trajectory), then calls an LLM to produce:
+        - label__value:     categorical or freeform label
+        - label__score:     numeric 0.0-1.0
+        - label__rationale: explanation
+
+    Only processes sessions where label__sampled is True.
+    """
+
+    components = (Session, Label)
+    priority = 20
+
+    async def process(self, df: DataFrame, **kwargs: Any) -> DataFrame:
+        resources: Resources = kwargs.get("resources", Resources())
+        config = resources.get(LabelingConfig) or LabelingConfig()
+
+        from daft.functions import prompt
+
+        eval_prompt = (
+            "You are an expert evaluator of AI agent sessions.\n\n"
+            "## Evaluation Technique\n"
+            + col("label__technique")
+            + ": "
+            + col("label__description")
+            + "\n\n## Session Trajectory\n"
+            "Source: "
+            + col("session__source")
+            + "\nOutcome: "
+            + col("session__outcome")
+            + "\nTotal turns: "
+            + col("session__total_turns").cast(daft.DataType.string())
+            + "\nDuration: "
+            + col("session__duration_seconds").cast(daft.DataType.string())
+            + "s\n\nTurns:\n"
+            + col("session__turns")
+            + "\n\n## Instructions\n"
+            "Evaluate this session according to the technique above.\n"
+            "Respond in EXACTLY this format (no other text):\n"
+            "VALUE: <a short categorical label>\n"
+            "SCORE: <float 0.0 to 1.0>\n"
+            "RATIONALE: <1-2 sentence explanation>"
+        )
+
+        llm_output = prompt(
+            eval_prompt,
+            model=config.model,
+            max_output_tokens=config.max_output_tokens,
+        )
+
+        @daft.udf(return_dtype=daft.DataType.string())
+        def extract_value(responses, sampled):
+            results = []
+            for resp, is_sampled in zip(responses.to_pylist(), sampled.to_pylist(), strict=False):
+                if not is_sampled or not resp:
+                    results.append("")
+                    continue
+                for line in resp.split("\n"):
+                    if line.startswith("VALUE:"):
+                        results.append(line[6:].strip())
+                        break
+                else:
+                    results.append(resp[:100])
+            return results
+
+        @daft.udf(return_dtype=daft.DataType.float64())
+        def extract_score(responses, sampled):
+            results = []
+            for resp, is_sampled in zip(responses.to_pylist(), sampled.to_pylist(), strict=False):
+                if not is_sampled or not resp:
+                    results.append(0.0)
+                    continue
+                for line in resp.split("\n"):
+                    if line.startswith("SCORE:"):
+                        try:
+                            results.append(float(line[6:].strip()))
+                        except ValueError:
+                            results.append(0.0)
+                        break
+                else:
+                    results.append(0.0)
+            return results
+
+        @daft.udf(return_dtype=daft.DataType.string())
+        def extract_rationale(responses, sampled):
+            results = []
+            for resp, is_sampled in zip(responses.to_pylist(), sampled.to_pylist(), strict=False):
+                if not is_sampled or not resp:
+                    results.append("")
+                    continue
+                for line in resp.split("\n"):
+                    if line.startswith("RATIONALE:"):
+                        results.append(line[10:].strip())
+                        break
+                else:
+                    results.append("")
+            return results
+
+        llm_col = llm_output
+        sampled_col = col("label__sampled")
+
+        return df.with_columns(
+            {
+                "label__value": extract_value(llm_col, sampled_col),
+                "label__score": extract_score(llm_col, sampled_col),
+                "label__rationale": extract_rationale(llm_col, sampled_col),
+            }
+        )
+
+
+class ScoringProcessor(AsyncProcessor):
+    """Post-processes scores for normalization and summary stats.
+
+    Runs after labeling. Clamps scores to [0, 1] and could be extended
+    for cross-session normalization, percentile ranking, etc.
+    """
+
+    components = (Session, Label)
+    priority = 30
+
+    async def process(self, df: DataFrame, **kwargs: Any) -> DataFrame:
+        clamped = col("label__score").if_else(
+            col("label__score") > 1.0,
+            1.0,
+            col("label__score"),
+        )
+        clamped = clamped.if_else(clamped < 0.0, 0.0, clamped)
+        return df.with_columns({"label__score": clamped})

--- a/src/archetype/trajectories/processors.py
+++ b/src/archetype/trajectories/processors.py
@@ -7,7 +7,7 @@ Trajectory Processors
 
 Three pipeline stages, priority-ordered:
 
-    SamplingProcessor  (priority=10)  — selects which sessions to evaluate
+    SamplingProcessor  (priority=10)  — selects which trajectories to evaluate
     LabelingProcessor  (priority=20)  — applies a labeling technique via LLM
     ScoringProcessor   (priority=30)  — normalizes and aggregates scores
 
@@ -25,25 +25,25 @@ from daft import DataFrame, col
 
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.resources import Resources
-from archetype.trajectories.components import Label, Session
+from archetype.trajectories.components import Label, Trajectory
 
 # ── Resources (injected into world.resources) ──
 
 
 @dataclass
 class SamplingConfig:
-    """Configures which sessions get evaluated.
+    """Configures which trajectories get evaluated.
 
     Attributes:
-        max_sessions:  Maximum number of sessions to sample (0 = all)
-        min_turns:     Minimum turn count to include
-        max_turns:     Maximum turn count to include (0 = no limit)
-        require_tags:  Only include sessions with ALL of these tags
-        exclude_tags:  Exclude sessions with ANY of these tags
-        outcome_filter: If set, only include sessions matching this outcome substring
+        max_trajectories: Maximum number of trajectories to sample (0 = all)
+        min_turns:        Minimum turn count to include
+        max_turns:        Maximum turn count to include (0 = no limit)
+        require_tags:     Only include trajectories with ALL of these tags
+        exclude_tags:     Exclude trajectories with ANY of these tags
+        outcome_filter:   If set, only include trajectories matching this outcome substring
     """
 
-    max_sessions: int = 0
+    max_trajectories: int = 0
     min_turns: int = 0
     max_turns: int = 0
     require_tags: list[str] | None = None
@@ -70,13 +70,13 @@ class LabelingConfig:
 
 
 class SamplingProcessor(AsyncProcessor):
-    """Selects which sessions to evaluate based on SamplingConfig.
+    """Selects which trajectories to evaluate based on SamplingConfig.
 
     Sets label__sampled = True/False. Downstream processors skip
-    unsampled sessions.
+    unsampled trajectories.
     """
 
-    components = (Session, Label)
+    components = (Trajectory, Label)
     priority = 10
 
     async def process(self, df: DataFrame, **kwargs: Any) -> DataFrame:
@@ -86,43 +86,43 @@ class SamplingProcessor(AsyncProcessor):
         sampled = col("label__sampled")
 
         if config.min_turns > 0:
-            sampled = sampled & (col("session__total_turns") >= config.min_turns)
+            sampled = sampled & (col("trajectory__total_turns") >= config.min_turns)
 
         if config.max_turns > 0:
-            sampled = sampled & (col("session__total_turns") <= config.max_turns)
+            sampled = sampled & (col("trajectory__total_turns") <= config.max_turns)
 
         if config.outcome_filter:
-            sampled = sampled & col("session__outcome").str.contains(config.outcome_filter)
+            sampled = sampled & col("trajectory__outcome").str.contains(config.outcome_filter)
 
         if config.require_tags:
             for tag in config.require_tags:
-                sampled = sampled & col("session__tags").str.contains(f'"{tag}"')
+                sampled = sampled & col("trajectory__tags").str.contains(f'"{tag}"')
 
         if config.exclude_tags:
             for tag in config.exclude_tags:
-                sampled = sampled & ~col("session__tags").str.contains(f'"{tag}"')
+                sampled = sampled & ~col("trajectory__tags").str.contains(f'"{tag}"')
 
         df = df.with_columns({"label__sampled": sampled})
 
-        if config.max_sessions > 0:
-            df = df.limit(config.max_sessions)
+        if config.max_trajectories > 0:
+            df = df.limit(config.max_trajectories)
 
         return df
 
 
 class LabelingProcessor(AsyncProcessor):
-    """Applies a labeling technique to sampled sessions via LLM.
+    """Applies a labeling technique to sampled trajectories via LLM.
 
     Reads label__description (the natural language labeling instruction)
-    and session__turns (the full trajectory), then calls an LLM to produce:
+    and trajectory__turns (the full trajectory), then calls an LLM to produce:
         - label__value:     categorical or freeform label
         - label__score:     numeric 0.0-1.0
         - label__rationale: explanation
 
-    Only processes sessions where label__sampled is True.
+    Only processes trajectories where label__sampled is True.
     """
 
-    components = (Session, Label)
+    components = (Trajectory, Label)
     priority = 20
 
     async def process(self, df: DataFrame, **kwargs: Any) -> DataFrame:
@@ -132,24 +132,24 @@ class LabelingProcessor(AsyncProcessor):
         from daft.functions import prompt
 
         eval_prompt = (
-            "You are an expert evaluator of AI agent sessions.\n\n"
+            "You are an expert evaluator of AI agent trajectories.\n\n"
             "## Evaluation Technique\n"
             + col("label__technique")
             + ": "
             + col("label__description")
-            + "\n\n## Session Trajectory\n"
+            + "\n\n## Trajectory\n"
             "Source: "
-            + col("session__source")
+            + col("trajectory__source")
             + "\nOutcome: "
-            + col("session__outcome")
+            + col("trajectory__outcome")
             + "\nTotal turns: "
-            + col("session__total_turns").cast(daft.DataType.string())
+            + col("trajectory__total_turns").cast(daft.DataType.string())
             + "\nDuration: "
-            + col("session__duration_seconds").cast(daft.DataType.string())
+            + col("trajectory__duration_seconds").cast(daft.DataType.string())
             + "s\n\nTurns:\n"
-            + col("session__turns")
+            + col("trajectory__turns")
             + "\n\n## Instructions\n"
-            "Evaluate this session according to the technique above.\n"
+            "Evaluate this trajectory according to the technique above.\n"
             "Respond in EXACTLY this format (no other text):\n"
             "VALUE: <a short categorical label>\n"
             "SCORE: <float 0.0 to 1.0>\n"
@@ -211,10 +211,10 @@ class ScoringProcessor(AsyncProcessor):
     """Post-processes scores for normalization and summary stats.
 
     Runs after labeling. Clamps scores to [0, 1] and could be extended
-    for cross-session normalization, percentile ranking, etc.
+    for cross-trajectory normalization, percentile ranking, etc.
     """
 
-    components = (Session, Label)
+    components = (Trajectory, Label)
     priority = 30
 
     async def process(self, df: DataFrame, **kwargs: Any) -> DataFrame:

--- a/src/archetype/trajectories/processors.py
+++ b/src/archetype/trajectories/processors.py
@@ -162,53 +162,38 @@ class LabelingProcessor(AsyncProcessor):
             max_output_tokens=config.max_output_tokens,
         )
 
-        @daft.udf(return_dtype=daft.DataType.string())
-        def extract_value(responses, sampled):
-            results = []
-            for resp, is_sampled in zip(responses.to_pylist(), sampled.to_pylist(), strict=False):
-                if not is_sampled or not resp:
-                    results.append("")
-                    continue
-                for line in resp.split("\n"):
-                    if line.startswith("VALUE:"):
-                        results.append(line[6:].strip())
-                        break
-                else:
-                    results.append(resp[:100])
-            return results
+        # Row-wise extractors — @daft.func with auto type inference (LEARNINGS.md §4)
+        # No batching benefit here, just parsing strings.
 
-        @daft.udf(return_dtype=daft.DataType.float64())
-        def extract_score(responses, sampled):
-            results = []
-            for resp, is_sampled in zip(responses.to_pylist(), sampled.to_pylist(), strict=False):
-                if not is_sampled or not resp:
-                    results.append(0.0)
-                    continue
-                for line in resp.split("\n"):
-                    if line.startswith("SCORE:"):
-                        try:
-                            results.append(float(line[6:].strip()))
-                        except ValueError:
-                            results.append(0.0)
-                        break
-                else:
-                    results.append(0.0)
-            return results
+        @daft.func
+        def extract_value(response: str, sampled: bool) -> str:
+            if not sampled or not response:
+                return ""
+            for line in response.split("\n"):
+                if line.startswith("VALUE:"):
+                    return line[6:].strip()
+            return response[:100]
 
-        @daft.udf(return_dtype=daft.DataType.string())
-        def extract_rationale(responses, sampled):
-            results = []
-            for resp, is_sampled in zip(responses.to_pylist(), sampled.to_pylist(), strict=False):
-                if not is_sampled or not resp:
-                    results.append("")
-                    continue
-                for line in resp.split("\n"):
-                    if line.startswith("RATIONALE:"):
-                        results.append(line[10:].strip())
-                        break
-                else:
-                    results.append("")
-            return results
+        @daft.func
+        def extract_score(response: str, sampled: bool) -> float:
+            if not sampled or not response:
+                return 0.0
+            for line in response.split("\n"):
+                if line.startswith("SCORE:"):
+                    try:
+                        return float(line[6:].strip())
+                    except ValueError:
+                        return 0.0
+            return 0.0
+
+        @daft.func
+        def extract_rationale(response: str, sampled: bool) -> str:
+            if not sampled or not response:
+                return ""
+            for line in response.split("\n"):
+                if line.startswith("RATIONALE:"):
+                    return line[10:].strip()
+            return ""
 
         llm_col = llm_output
         sampled_col = col("label__sampled")

--- a/tests/trajectories/test_components.py
+++ b/tests/trajectories/test_components.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for trajectory components."""
+
+import json
+
+from archetype.trajectories.components import Label, Trajectory, Turn
+
+
+def test_turn_round_trip():
+    turn = Turn(role="assistant", content="hello", tokens=10)
+    d = turn.to_dict()
+    assert d["role"] == "assistant"
+    assert d["content"] == "hello"
+    assert d["tokens"] == 10
+    restored = Turn.from_dict(d)
+    assert restored.role == "assistant"
+    assert restored.content == "hello"
+
+
+def test_trajectory_from_turns():
+    turns = [
+        Turn(role="user", content="fix the bug", tokens=5),
+        Turn(role="assistant", content="on it", tokens=3, duration_ms=100),
+    ]
+    traj = Trajectory.from_turns(
+        trajectory_id="t-1",
+        turns=turns,
+        source="test",
+        outcome="success",
+        tags=["python", "bugfix"],
+        metadata={"repo": "acme"},
+    )
+    assert traj.trajectory_id == "t-1"
+    assert traj.total_turns == 2
+    assert traj.total_tokens == 8
+    assert traj.source == "test"
+    assert "python" in json.loads(traj.tags_json)
+    assert json.loads(traj.metadata_json)["repo"] == "acme"
+
+
+def test_trajectory_get_turns():
+    turns = [Turn(role="user", content="hi")]
+    traj = Trajectory.from_turns("t-2", turns)
+    restored = traj.get_turns()
+    assert len(restored) == 1
+    assert restored[0].role == "user"
+
+
+def test_trajectory_json_suffix_fields():
+    """Verify JSON-encoded fields follow the _json suffix convention."""
+    traj = Trajectory()
+    assert hasattr(traj, "turns_json")
+    assert hasattr(traj, "tags_json")
+    assert hasattr(traj, "metadata_json")
+    # Should not have old names
+    assert not hasattr(traj, "turns") or traj.__class__.__name__ != "Trajectory"
+    assert not hasattr(traj, "tags") or traj.__class__.__name__ != "Trajectory"
+
+
+def test_label_defaults():
+    label = Label()
+    assert label.sampled is True
+    assert label.score == 0.0
+    assert label.technique == ""

--- a/tests/trajectories/test_processors.py
+++ b/tests/trajectories/test_processors.py
@@ -1,0 +1,168 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for trajectory processors — sampling, scoring."""
+
+import daft
+import pytest
+
+from archetype.core.resources import Resources
+from archetype.trajectories.components import Label, Trajectory, Turn
+from archetype.trajectories.processors import (
+    SamplingConfig,
+    SamplingProcessor,
+    ScoringProcessor,
+)
+
+
+def _make_df(trajectories: list[Trajectory], labels: list[Label]) -> daft.DataFrame:
+    """Build a DataFrame matching what the ECS would produce for (Trajectory, Label) entities."""
+    rows = []
+    for traj, lab in zip(trajectories, labels, strict=True):
+        row = {}
+        for field, val in traj.model_dump().items():
+            row[f"trajectory__{field}"] = val
+        for field, val in lab.model_dump().items():
+            row[f"label__{field}"] = val
+        row["entity_id"] = len(rows)
+        row["is_active"] = True
+        rows.append(row)
+    return daft.from_pylist(rows)
+
+
+def _make_trajectories(n: int) -> list[Trajectory]:
+    trajs = []
+    for i in range(n):
+        trajs.append(
+            Trajectory.from_turns(
+                trajectory_id=f"t-{i}",
+                turns=[Turn(role="user", content=f"turn {j}") for j in range(i + 2)],
+                source="test",
+                outcome="success" if i % 2 == 0 else "failure",
+                tags=["python"] if i < 2 else ["rust"],
+            )
+        )
+    return trajs
+
+
+@pytest.mark.asyncio
+async def test_sampling_preserves_all_rows():
+    """max_trajectories should mark excess rows as unsampled, not drop them."""
+    trajs = _make_trajectories(5)
+    labels = [Label(technique="test", description="test") for _ in trajs]
+    df = _make_df(trajs, labels)
+
+    resources = Resources()
+    resources.insert(SamplingConfig(max_trajectories=2))
+
+    proc = SamplingProcessor()
+    result = await proc.process(df, resources=resources)
+    collected = result.collect().to_pylist()
+
+    # All 5 rows preserved
+    assert len(collected) == 5
+    sampled_count = sum(1 for r in collected if r["label__sampled"])
+    assert sampled_count == 2
+
+
+@pytest.mark.asyncio
+async def test_sampling_starts_fresh():
+    """Sampling should start from True each tick, not be monotonic."""
+    trajs = _make_trajectories(3)
+    # Pre-set sampled to False — sampling should override
+    labels = [Label(technique="test", description="test", sampled=False) for _ in trajs]
+    df = _make_df(trajs, labels)
+
+    resources = Resources()
+    resources.insert(SamplingConfig())  # no filters = all sampled
+
+    proc = SamplingProcessor()
+    result = await proc.process(df, resources=resources)
+    collected = result.collect().to_pylist()
+
+    # All should be sampled (start from True, no filters)
+    assert all(r["label__sampled"] for r in collected)
+
+
+@pytest.mark.asyncio
+async def test_sampling_min_turns():
+    trajs = _make_trajectories(4)  # turns: 2, 3, 4, 5
+    labels = [Label(technique="t", description="d") for _ in trajs]
+    df = _make_df(trajs, labels)
+
+    resources = Resources()
+    resources.insert(SamplingConfig(min_turns=4))
+
+    proc = SamplingProcessor()
+    result = await proc.process(df, resources=resources)
+    collected = result.collect().to_pylist()
+
+    assert len(collected) == 4  # all rows kept
+    sampled = [r for r in collected if r["label__sampled"]]
+    # Only trajectories with >= 4 turns: t-2 (4 turns) and t-3 (5 turns)
+    assert len(sampled) == 2
+
+
+@pytest.mark.asyncio
+async def test_sampling_tag_exact_match():
+    """Tags should use exact match, not substring."""
+    trajs = [
+        Trajectory.from_turns("t-0", [Turn(role="user", content="x")], tags=["python"]),
+        Trajectory.from_turns("t-1", [Turn(role="user", content="x")], tags=["pythonic"]),
+        Trajectory.from_turns("t-2", [Turn(role="user", content="x")], tags=["py"]),
+    ]
+    labels = [Label(technique="t", description="d") for _ in trajs]
+    df = _make_df(trajs, labels)
+
+    resources = Resources()
+    resources.insert(SamplingConfig(require_tags=["python"]))
+
+    proc = SamplingProcessor()
+    result = await proc.process(df, resources=resources)
+    collected = result.collect().to_pylist()
+
+    sampled = [r for r in collected if r["label__sampled"]]
+    # Only exact match "python", not "pythonic" or "py"
+    assert len(sampled) == 1
+    assert sampled[0]["trajectory__trajectory_id"] == "t-0"
+
+
+@pytest.mark.asyncio
+async def test_sampling_exclude_tags():
+    trajs = [
+        Trajectory.from_turns("t-0", [Turn(role="user", content="x")], tags=["python", "clean"]),
+        Trajectory.from_turns("t-1", [Turn(role="user", content="x")], tags=["python", "failed"]),
+    ]
+    labels = [Label(technique="t", description="d") for _ in trajs]
+    df = _make_df(trajs, labels)
+
+    resources = Resources()
+    resources.insert(SamplingConfig(exclude_tags=["failed"]))
+
+    proc = SamplingProcessor()
+    result = await proc.process(df, resources=resources)
+    collected = result.collect().to_pylist()
+
+    sampled = [r for r in collected if r["label__sampled"]]
+    assert len(sampled) == 1
+    assert sampled[0]["trajectory__trajectory_id"] == "t-0"
+
+
+@pytest.mark.asyncio
+async def test_scoring_clamps():
+    """ScoringProcessor should clamp scores to [0, 1]."""
+    rows = [
+        {"label__score": 1.5, "label__sampled": True, "entity_id": 0},
+        {"label__score": -0.3, "label__sampled": True, "entity_id": 1},
+        {"label__score": 0.7, "label__sampled": True, "entity_id": 2},
+    ]
+    df = daft.from_pylist(rows)
+
+    proc = ScoringProcessor()
+    result = await proc.process(df)
+    collected = result.collect().to_pylist()
+
+    scores = {r["entity_id"]: r["label__score"] for r in collected}
+    assert scores[0] == 1.0
+    assert scores[1] == 0.0
+    assert scores[2] == 0.7


### PR DESCRIPTION
## Summary

- **Trajectory pipeline** — `TrajectoryPipeline` API for evaluating agent session trajectories through configurable sampling regimes and LLM-based labeling techniques described in natural language
- **Components** — `Trajectory` (full session history as JSON) and `Label` (evaluation result) following `_json` suffix convention for serialized fields
- **Processors** — `SamplingProcessor` (tag-exact-match filtering, row-preserving caps), `LabelingProcessor` (LLM via `daft.functions.prompt()`, only invoked on sampled rows), `ScoringProcessor` (score clamping via `@daft.func`)
- **Fork-based comparison** — `pipeline.fork()` uses semantic cloning from #64 to branch experiments with different configs on identical data
- **RBAC** — new `operator` role for pipeline use (spawn + read, less than admin); tracked in #69
- **Agent onboarding** — slim `CLAUDE.md` index pointing to `LEARNINGS.md`/`AGENTS.md`, three auto-triggering skills (daft-patterns, archetype-components, archetype-processors)
- **Session start hook** — `uv sync --group dev` with pinned uv version, bootstraps Python 3.12
- **11 tests** covering components, sampling (row preservation, tag exact match, min_turns), scoring

## Key files

| File | What |
|------|------|
| `src/archetype/trajectories/components.py` | `Trajectory`, `Label`, `Turn` |
| `src/archetype/trajectories/processors.py` | Sampling, Labeling, Scoring processors |
| `src/archetype/trajectories/pipeline.py` | `TrajectoryPipeline` — chainable API |
| `src/archetype/app/auth/guard.py` | `operator` RBAC role |
| `.claude/skills/` | Three framework-enforcement skills |
| `.claude/hooks/session-start.sh` | uv-based dev environment setup |
| `tests/trajectories/` | Component + processor tests |
| `examples/trajectories/run.py` | End-to-end demo |

## Review feedback addressed

All 30 review comments from the initial rounds have been fixed:
- `df.limit()` → monotonic ID cap (no row dropping)
- LLM `prompt()` gated on `label__sampled` (split/concat)
- SPAWN payload includes `type` key for hydration
- `fork()` uses correct `fork_world(name=)` signature, own `ServiceContainer`
- `results()` uses public `world.get_components()` API
- `sample()` updates live resources post-init
- Tag filtering via JSON-parsed UDF (exact match)
- `prefer_live_reads=True` so forked worlds don't lose state on step

## Test plan

- [x] `ruff check` — clean
- [x] `pytest tests/trajectories/` — 11 passed
- [x] Fork demo: spawn entities → step → fork → change config → step fork → both worlds intact with diverged sampling
- [ ] Integration test through full `ServiceContainer` (ingest → step → results)
- [ ] LLM labeling with real API key

https://claude.ai/code/session_01LbSYsJAn3hym94wmPZKwsy