### PR TITLE
docs: add tiered auto-merge policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           version: "latest"
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --group dev
 
       - name: Run tests
         run: uv run pytest tests/ -v --tb=short

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,9 @@ make check          # Auto-format + lint (ruff, writes files)
 make lint-fix       # Auto-fix lint issues
 ```
 
+For the full dev workflow reference — all Make targets, CI job mappings,
+pre-commit hooks, and contribution process — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ### Dependencies
 
 Use **`uv sync --group dev`** (dependency-groups), not `uv sync --dev` (optional-deps).
@@ -166,6 +169,7 @@ Use **`uv sync --group dev`** (dependency-groups), not `uv sync --dev` (optional
 | `src/archetype/app/chat_graph.py` | (PLANNED, not yet implemented) ChatGraph DAG, ChatGraphRegistry |
 | `src/archetype/app/broker.py` | CommandBroker (governance only) |
 | `src/archetype/app/models.py` | Command model (append_history, parent_id, channel) |
+| `CONTRIBUTING.md` | Dev workflow, Make targets, CI mappings, contribution process |
 | `LEARNINGS.md` | Extended architectural knowledge — read before major changes |
 
 ## Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,244 @@
+# Contributing to Archetype
+
+This is the single reference for development workflow, CI, and contribution
+process. CLAUDE.md links here; LEARNINGS.md covers architecture.
+
+## Prerequisites
+
+- **Python 3.12+**
+- **[uv](https://docs.astral.sh/uv/)** (package manager)
+- **Node.js or Bun** (docs only)
+
+## Setup
+
+```bash
+git clone https://github.com/VangelisTech/archetype.git
+cd archetype
+make sync-dev          # Install runtime + dev dependencies
+make precommit-install # Set up pre-commit hooks
+```
+
+**Important:** Always use `uv sync --group dev` (dependency-groups), never
+`uv sync --dev` (optional-deps). They are different commands with different
+behavior. The Makefile handles this correctly.
+
+## Make Targets
+
+Every target below is a `.PHONY` rule. Run `make help` for the quick version.
+
+### Setup
+
+| Target | Command | Purpose |
+|--------|---------|---------|
+| `make sync` | `uv sync` | Install runtime deps only |
+| `make sync-dev` | `uv sync --group dev` | Install runtime + dev deps |
+| `make precommit-install` | `uv run pre-commit install` | Install git hooks |
+| `make precommit-run` | `uv run pre-commit run --all-files` | Run all hooks manually |
+
+### Quality
+
+| Target | Command | Purpose |
+|--------|---------|---------|
+| `make format` | `ruff format src tests` | Auto-format code (writes files) |
+| `make format-check` | `ruff format --check src tests` | Check formatting (read-only) |
+| `make lint` | `ruff check src tests` | Lint code (read-only) |
+| `make lint-fix` | `ruff check src tests --fix` | Lint + auto-fix |
+| `make check` | `format` + `lint` | Auto-format then lint (writes files) |
+
+### Tests
+
+| Target | Command | Purpose |
+|--------|---------|---------|
+| `make test` | `pytest -q` | Fast test run, no coverage |
+| `make test-cov` | `pytest --cov --cov-branch --cov-fail-under=70` | Tests with 70% branch coverage gate |
+| `make test-all` | `pytest -v --tb=short` | Verbose test run |
+
+### CI Gate
+
+| Target | Steps | Purpose |
+|--------|-------|---------|
+| `make ci` | `format-check` + `lint` + `lock-check` + `test-cov` | **The CI gate. Run before every push.** |
+
+`make ci` is the single command that must pass for any PR to merge. It runs
+exactly what the `ci` job in GitHub Actions runs.
+
+### Build & Release
+
+| Target | Command | Purpose |
+|--------|---------|---------|
+| `make version` | reads `pyproject.toml` | Print current version |
+| `make lock-check` | `uv lock --check` | Verify lockfile is in sync |
+| `make build` | `uv build` | Build sdist + wheel into `dist/` |
+| `make release-check` | `sync-dev` + `check` + `test-cov` + `lock-check` + `build` | Full pre-release validation |
+| `make publish-test` | `uv publish` to TestPyPI | Publish to TestPyPI |
+| `make publish` | `uv publish` to PyPI | Publish to PyPI |
+
+### Docs
+
+| Target | Command | Purpose |
+|--------|---------|---------|
+| `make docs` | `npx --yes mintlify build` | Build docs (requires Node.js or Bun) |
+| `make docs-serve` | `npx --yes mintlify dev` | Serve docs locally with hot reload |
+
+### Cleanup
+
+| Target | Purpose |
+|--------|---------|
+| `make clean` | Remove `dist/`, `build/`, `__pycache__`, egg-info |
+| `make clean-all` | Above + `.pytest_cache`, `.ruff_cache`, `.coverage`, `.venv` |
+
+## CI / GitHub Actions
+
+Four workflows live in `.github/workflows/`. Here is exactly what each one
+does and when it runs.
+
+### `python-tests.yml` (Tests) — on push to main + PRs
+
+The primary CI workflow. Contains three jobs:
+
+| Job | What it runs | Required to merge? |
+|-----|--------------|-------------------|
+| `ci (3.12)` | `make ci` (format-check + lint + lock-check + tests w/ 70% coverage) | **Yes** |
+| `format` | `ruff format --check src/ tests/` | **Yes** |
+| `typecheck` | `pyright src/archetype/` | No (`continue-on-error: true`) |
+
+The `ci` job also uploads coverage to Codecov (`fail_ci_if_error: false` — informational only).
+
+Concurrency: grouped by `ci-${{ github.ref }}`, cancels in-progress runs on
+the same branch.
+
+### `release.yml` (Release) — on `v*` tags
+
+Triggered by pushing a version tag (e.g. `git tag v0.5.0 && git push origin v0.5.0`).
+
+Pipeline: `test` → `build` → `publish-testpypi` → `publish-pypi` → `github-release`
+
+Uses trusted publishing (OIDC `id-token: write`) for both PyPI and TestPyPI.
+GitHub Release is auto-created with generated release notes.
+
+### `claude.yml` (Claude Code) — on issue/PR comments
+
+Runs Claude Code via `@claude` mentions in issues and PR comments. Restricted
+to the `everettVT` actor.
+
+### `daily-security-audit.yml` — daily at 09:00 UTC + manual
+
+Runs `pip-audit` against exported dependencies, then uses Claude Code to
+produce a security audit report. Creates/updates a GitHub issue with findings.
+
+Schedule-only — does not run on PRs. (See [#65](https://github.com/VangelisTech/archetype/issues/65)
+for planned PR-triggered doc/security checks.)
+
+## Make Targets vs CI Jobs
+
+This table maps local commands to what CI actually runs, so you know exactly
+what to run locally to reproduce a CI failure.
+
+| CI Job | Local equivalent | Notes |
+|--------|------------------|-------|
+| `ci (3.12)` | `make ci` | Exact match — same Makefile target |
+| `format` | `make format-check` | Read-only check; use `make format` to fix |
+| `typecheck` | `uv run pyright src/archetype/` | No Makefile target yet; non-blocking in CI |
+| Release `test` | `make test-all` | Uses `pytest -v --tb=short` |
+| Release `build` | `make build` | Builds sdist + wheel |
+
+## Pre-commit Hooks
+
+Installed via `make precommit-install`. Runs automatically on `git commit`:
+
+| Hook | Source | What it checks |
+|------|--------|----------------|
+| `ruff` | `ruff-pre-commit` | Lint + auto-fix (`--fix`) on `src/` and `tests/` |
+| `ruff-format` | `ruff-pre-commit` | Format check on `src/` and `tests/` |
+| `uv-lock-check` | local | `uv lock --check` — lockfile in sync |
+| `check-license-headers` | local | Apache 2.0 headers on `src/**/*.py` |
+| `trailing-whitespace` | `pre-commit-hooks` | No trailing whitespace |
+| `end-of-file-fixer` | `pre-commit-hooks` | Files end with newline |
+| `check-yaml` | `pre-commit-hooks` | Valid YAML syntax |
+| `check-added-large-files` | `pre-commit-hooks` | No accidentally committed binaries |
+| `check-merge-conflict` | `pre-commit-hooks` | No unresolved conflict markers |
+
+## Code Quality Rules
+
+- **Formatter + linter:** ruff (not black, not flake8)
+- **Config:** `[tool.ruff]` in `pyproject.toml`
+- **Line length:** 100
+- **Target:** Python 3.12
+- **Lint rules:** E, F, I, UP, B (E501 ignored — formatter handles line length)
+- **Import sorting:** ruff `I` rules (isort-compatible)
+
+## Project Structure & Modification Zones
+
+```
+src/archetype/
+  core/     # ECS engine — READ-ONLY. Do not modify without explicit approval.
+  app/      # Service layer — extend carefully, always add tests.
+  api/      # REST API — safe to modify freely.
+  cli/      # CLI — safe to modify freely.
+
+tests/
+  core/     app/     api/     cli/
+  integration/   aio/   storage/   sync/
+
+examples/   # Load-bearing documentation — must run against current API.
+bench/      # Benchmarks.
+docs/       # Mintlify docs — deployed to archetype.vangelis.tech
+```
+
+## Testing
+
+- **Coverage threshold:** 70% branch coverage (enforced by `make test-cov`)
+- **Test layout:** mirrors `src/` structure under `tests/`
+- **Every new feature needs tests.** Every bug fix needs a regression test.
+- `make ci` is the single gate — always run it before pushing
+
+## Commit Conventions
+
+Use [conventional commits](https://www.conventionalcommits.org/):
+
+```
+feat:      New feature
+fix:       Bug fix
+docs:      Documentation only
+refactor:  Code change that neither fixes a bug nor adds a feature
+test:      Adding or updating tests
+chore:     Build process, CI, deps
+```
+
+## Pull Request Process
+
+1. Create a feature branch from `main`
+2. Make changes, ensure `make ci` passes locally
+3. Push and open a PR targeting `main`
+4. CI runs `ci` + `format` + `typecheck` (typecheck is non-blocking)
+5. PRs require `ci` and `format` to pass before merge
+
+For auto-merge tiers based on what files you changed, see
+[Auto-Merge Policy](docs/guide/auto-merge.md).
+
+## Dependencies
+
+- Add runtime deps to `[project.dependencies]` in `pyproject.toml`
+- Add dev deps to `[dependency-groups.dev]` in `pyproject.toml`
+- After changing deps: `uv lock` then verify with `uv lock --check`
+- **Never** commit a lockfile that fails `uv lock --check`
+
+## Docs
+
+Docs use [Mintlify](https://mintlify.com/) and deploy to
+`archetype.vangelis.tech`.
+
+```bash
+make docs-serve  # Local preview with hot reload
+make docs        # Build (validates pages compile)
+```
+
+Config lives in `docs/mint.json`. Navigation is defined there.
+
+## Related Documents
+
+| Document | Purpose |
+|----------|---------|
+| [CLAUDE.md](CLAUDE.md) | Hard constraints for AI agents — architectural rules |
+| [LEARNINGS.md](LEARNINGS.md) | Extended architectural knowledge — Daft patterns, ECS design |
+| [docs/guide/auto-merge.md](docs/guide/auto-merge.md) | Tiered auto-merge policy by change scope |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,15 @@ behavior. The Makefile handles this correctly.
 
 Every target below is a `.PHONY` rule. Run `make help` for the quick version.
 
+> **Always use `make <target>`**, not the underlying commands directly.
+> The Makefile runs everything through `uv run` with the correct `PYTHONPATH`.
+> The "Command" column below is shorthand for readability — the Makefile is the
+> source of truth.
+
 ### Setup
 
-| Target | Command | Purpose |
-|--------|---------|---------|
+| Target | What it does | Purpose |
+|--------|-------------|---------|
 | `make sync` | `uv sync` | Install runtime deps only |
 | `make sync-dev` | `uv sync --group dev` | Install runtime + dev deps |
 | `make precommit-install` | `uv run pre-commit install` | Install git hooks |
@@ -37,21 +42,21 @@ Every target below is a `.PHONY` rule. Run `make help` for the quick version.
 
 ### Quality
 
-| Target | Command | Purpose |
-|--------|---------|---------|
-| `make format` | `ruff format src tests` | Auto-format code (writes files) |
-| `make format-check` | `ruff format --check src tests` | Check formatting (read-only) |
-| `make lint` | `ruff check src tests` | Lint code (read-only) |
-| `make lint-fix` | `ruff check src tests --fix` | Lint + auto-fix |
+| Target | What it does | Purpose |
+|--------|-------------|---------|
+| `make format` | `uv run ruff format src tests` | Auto-format code (writes files) |
+| `make format-check` | `uv run ruff format --check src tests` | Check formatting (read-only) |
+| `make lint` | `uv run ruff check src tests` | Lint code (read-only) |
+| `make lint-fix` | `uv run ruff check src tests --fix` | Lint + auto-fix |
 | `make check` | `format` + `lint` | Auto-format then lint (writes files) |
 
 ### Tests
 
-| Target | Command | Purpose |
-|--------|---------|---------|
-| `make test` | `pytest -q` | Fast test run, no coverage |
-| `make test-cov` | `pytest --cov --cov-branch --cov-fail-under=70` | Tests with 70% branch coverage gate |
-| `make test-all` | `pytest -v --tb=short` | Verbose test run |
+| Target | What it does | Purpose |
+|--------|-------------|---------|
+| `make test` | `PYTHONPATH=src uv run pytest -q` | Fast test run, no coverage |
+| `make test-cov` | `PYTHONPATH=src uv run pytest --cov --cov-branch --cov-fail-under=70` | Tests with 70% branch coverage gate |
+| `make test-all` | `PYTHONPATH=src uv run pytest -v --tb=short` | Verbose test run |
 
 ### CI Gate
 

--- a/docs/guide/auto-merge.md
+++ b/docs/guide/auto-merge.md
@@ -1,0 +1,149 @@
+# Auto-Merge Policy
+
+Auto-merge is gated by **tiered status checks**. The tier is determined by the
+paths a PR touches. A PR's tier is the *highest* tier any changed path falls
+into — touching `core/` once makes the whole PR Tier 1, regardless of what else
+it changes.
+
+The principle: **the blast radius of a change sets the bar for merging it.** A
+docs typo and a scheduler rewrite should not clear the same gate.
+
+## Tiers
+
+### Tier 0 — Docs & Meta
+
+**Paths:** `docs/**`, `*.md`, `LICENSE`, `assets/**`, `.github/ISSUE_TEMPLATE/**`
+
+**Required checks:**
+- `format` (ruff format --check, in case of embedded code blocks touched via
+  tooling)
+- Link-check on changed markdown (if/when added)
+
+**Rationale:** Zero runtime impact. Don't gate on `ci` — there's nothing to
+test. Auto-merge should be near-instant.
+
+---
+
+### Tier 1 — Examples & Benches
+
+**Paths:** `examples/**`, `bench/**`, `scripts/**`
+
+**Required checks:**
+- `format`
+- `ci` (the full gate — these import from `src/` and can break if APIs drift)
+
+**Rationale:** Examples are load-bearing documentation. They must run against
+the current API surface, but a broken example doesn't break user code. The
+existing `ci` gate is sufficient.
+
+---
+
+### Tier 2 — App / API / CLI (service layer)
+
+**Paths:** `src/archetype/app/**`, `src/archetype/api/**`, `src/archetype/cli/**`,
+`tests/app/**`, `tests/api/**`, `tests/cli/**`, `tests/integration/**`
+
+**Required checks:**
+- `format`
+- `ci`
+- **Coverage delta ≥ 0** (no net coverage regression on changed files)
+- At least one **integration test** added/modified if behavior changed
+  (enforced by review, not CI — but auto-merge should require a `has-tests`
+  label or a passing "changed files include tests" check)
+
+**Rationale:** Service-layer changes ship to users as library API. Regressions
+here surface as broken agents in the field. The 70% branch-coverage floor
+(already in `make ci`) is the backstop; the delta check prevents slow rot.
+
+---
+
+### Tier 3 — Core Engine
+
+**Paths:** `src/archetype/core/**`, `tests/core/**`, `tests/aio/**`,
+`tests/sync/**`, `tests/storage/**`
+
+**Required checks:**
+- `format`
+- `ci`
+- `typecheck` **promoted to required** (remove `continue-on-error` for core/)
+- **Coverage delta ≥ 0** on changed files
+- **Benchmark regression check** (`bench/` runs; >10% regression blocks)
+- **Human approval required** — auto-merge disabled or requires CODEOWNERS
+  approval from a core maintainer
+
+**Rationale:** Per `CLAUDE.md`: "Do not modify [core/] without explicit
+approval." The ECS engine is the invariant-holder of the whole framework.
+Pickling semantics, lazy-DAG preservation, Resources DI — all live here. A
+silent change in core can break every downstream processor.
+
+**This tier should rarely auto-merge.** Auto-merge is appropriate for
+dependency bumps and trivial refactors within core; architectural changes
+require synchronous human review.
+
+---
+
+### Tier D — Dependencies (special case)
+
+**Paths:** `pyproject.toml`, `uv.lock` only (Dependabot/Renovate PRs)
+
+**Required checks:**
+- `ci` (lock-check + full test suite)
+- **Security audit** (`daily-security-audit.yml` or equivalent on-PR run)
+- **Semver discrimination:**
+  - Patch bumps (`x.y.Z`): auto-merge if `ci` green
+  - Minor bumps (`x.Y.z`): auto-merge if `ci` green *and* no core/ imports
+    from the bumped package
+  - Major bumps (`X.y.z`): **never auto-merge** — human review required
+
+**Rationale:** Dependency updates are the most common auto-merge case and the
+most common source of supply-chain risk. Patch-level churn should not burn
+maintainer attention; major-version jumps should never land unseen.
+
+---
+
+## Determining a PR's Tier
+
+Enforced by a labeler workflow that reads changed paths:
+
+```yaml
+# .github/labeler.yml (sketch)
+tier-0-docs:
+  - docs/**
+  - "**/*.md"
+tier-1-examples:
+  - examples/**
+  - bench/**
+tier-2-app:
+  - src/archetype/app/**
+  - src/archetype/api/**
+  - src/archetype/cli/**
+tier-3-core:
+  - src/archetype/core/**
+tier-d-deps:
+  - pyproject.toml
+  - uv.lock
+```
+
+A workflow then picks the **highest-numbered** tier label present and
+configures the matching required-checks set via a status check named
+`auto-merge-gate`. Branch protection on `main` requires `auto-merge-gate` to
+pass; the gate resolves to the correct check matrix per tier.
+
+## Disabling Auto-Merge
+
+- **Tier 3 (core):** auto-merge disabled by default; re-enabled per-PR by a
+  maintainer with the `auto-merge-approved` label.
+- **Any PR with the `manual-review` label:** auto-merge disabled regardless
+  of tier.
+- **Any PR failing a non-required check twice:** auto-merge disabled, flagged
+  for review (likely flaky test or genuine regression).
+
+## What Auto-Merge Does NOT Replace
+
+- Architecture decisions (see `LEARNINGS.md`)
+- Breaking-change discussion
+- Release-note curation
+- Judgement about whether a feature belongs in the framework at all
+
+Auto-merge is for **keeping the main branch moving on work that has already
+been decided**. It is not a substitute for deciding.

--- a/docs/guide/auto-merge.md
+++ b/docs/guide/auto-merge.md
@@ -64,7 +64,8 @@ here surface as broken agents in the field. The 70% branch-coverage floor
 **Required checks:**
 - `format`
 - `ci`
-- `typecheck` **promoted to required** (remove `continue-on-error` for core/)
+- `typecheck` **(planned:** promote to required by removing
+  `continue-on-error` for core/; currently non-blocking)
 - **Coverage delta ≥ 0** on changed files
 - **Benchmark regression check** (if/when added; `bench/` runs and >10%
   regression blocks)
@@ -103,12 +104,16 @@ maintainer attention; major-version jumps should never land unseen.
 
 ---
 
-## Determining a PR's Tier
+## Determining a PR's Tier (proposed)
 
-Enforced by a labeler workflow that reads changed paths:
+> **Status:** This section describes the target implementation. The labeler
+> workflow and `auto-merge-gate` check do not exist yet. Today, `ci` and
+> `format` are the only required status checks.
+
+The plan is a labeler workflow that reads changed paths and assigns tier labels:
 
 ```yaml
-# .github/labeler.yml (sketch)
+# .github/labeler.yml (proposed)
 tier-0-docs:
   - docs/**
   - "**/*.md"
@@ -126,10 +131,10 @@ tier-d-deps:
   - uv.lock
 ```
 
-A workflow then picks the **highest** tier label present and configures the
-matching required-checks set via a status check named `auto-merge-gate`. Branch
-protection on `main` requires `auto-merge-gate` to pass; the gate resolves to
-the correct check matrix per tier.
+A companion workflow would pick the **highest** tier label present and configure
+the matching required-checks set via a status check named `auto-merge-gate`.
+Branch protection on `main` would require `auto-merge-gate` to pass; the gate
+resolves to the correct check matrix per tier.
 
 **Tier precedence** (highest to lowest): Tier 3 > Tier 2 > Tier 1 > Tier 0.
 Tier D is evaluated independently — if a PR touches *only* `pyproject.toml` /

--- a/docs/guide/auto-merge.md
+++ b/docs/guide/auto-merge.md
@@ -2,8 +2,8 @@
 
 Auto-merge is gated by **tiered status checks**. The tier is determined by the
 paths a PR touches. A PR's tier is the *highest* tier any changed path falls
-into — touching `core/` once makes the whole PR Tier 1, regardless of what else
-it changes.
+into — touching `src/archetype/core/` once makes the whole PR Tier 3,
+regardless of what else it changes.
 
 The principle: **the blast radius of a change sets the bar for merging it.** A
 docs typo and a scheduler rewrite should not clear the same gate.
@@ -12,12 +12,11 @@ docs typo and a scheduler rewrite should not clear the same gate.
 
 ### Tier 0 — Docs & Meta
 
-**Paths:** `docs/**`, `*.md`, `LICENSE`, `assets/**`, `.github/ISSUE_TEMPLATE/**`
+**Paths:** `docs/**`, `**/*.md`, `LICENSE`, `assets/**`, `.github/ISSUE_TEMPLATE/**`
 
 **Required checks:**
-- `format` (ruff format --check, in case of embedded code blocks touched via
-  tooling)
-- Link-check on changed markdown (if/when added)
+- `format` (`ruff format --check` on `src/` and `tests/`)
+- Link-check on changed markdown (if/when added as a docs-specific check)
 
 **Rationale:** Zero runtime impact. Don't gate on `ci` — there's nothing to
 test. Auto-merge should be near-instant.
@@ -67,7 +66,8 @@ here surface as broken agents in the field. The 70% branch-coverage floor
 - `ci`
 - `typecheck` **promoted to required** (remove `continue-on-error` for core/)
 - **Coverage delta ≥ 0** on changed files
-- **Benchmark regression check** (`bench/` runs; >10% regression blocks)
+- **Benchmark regression check** (if/when added; `bench/` runs and >10%
+  regression blocks)
 - **Human approval required** — auto-merge disabled or requires CODEOWNERS
   approval from a core maintainer
 
@@ -88,7 +88,9 @@ require synchronous human review.
 
 **Required checks:**
 - `ci` (lock-check + full test suite)
-- **Security audit** (`daily-security-audit.yml` or equivalent on-PR run)
+- **Security audit** (requires a PR-triggered variant of
+  `daily-security-audit.yml`; the current workflow is schedule-only and cannot
+  report PR status — see #65 for adding this)
 - **Semver discrimination:**
   - Patch bumps (`x.y.Z`): auto-merge if `ci` green
   - Minor bumps (`x.Y.z`): auto-merge if `ci` green *and* no core/ imports
@@ -124,10 +126,16 @@ tier-d-deps:
   - uv.lock
 ```
 
-A workflow then picks the **highest-numbered** tier label present and
-configures the matching required-checks set via a status check named
-`auto-merge-gate`. Branch protection on `main` requires `auto-merge-gate` to
-pass; the gate resolves to the correct check matrix per tier.
+A workflow then picks the **highest** tier label present and configures the
+matching required-checks set via a status check named `auto-merge-gate`. Branch
+protection on `main` requires `auto-merge-gate` to pass; the gate resolves to
+the correct check matrix per tier.
+
+**Tier precedence** (highest to lowest): Tier 3 > Tier 2 > Tier 1 > Tier 0.
+Tier D is evaluated independently — if a PR touches *only* `pyproject.toml` /
+`uv.lock`, Tier D applies. If it also touches source code, the numeric tier
+takes precedence and Tier D's semver rules are ignored (the full code-change
+gates apply instead).
 
 ## Disabling Auto-Merge
 

--- a/docs/guide/auto-merge.md
+++ b/docs/guide/auto-merge.md
@@ -14,9 +14,11 @@ docs typo and a scheduler rewrite should not clear the same gate.
 
 **Paths:** `docs/**`, `**/*.md`, `LICENSE`, `assets/**`, `.github/ISSUE_TEMPLATE/**`
 
-**Required checks:**
+**Required checks (today):**
 - `format` (`ruff format --check` on `src/` and `tests/`)
-- Link-check on changed markdown (if/when added as a docs-specific check)
+
+**Planned checks (not yet implemented):**
+- Link-check on changed markdown (see [#65](https://github.com/VangelisTech/archetype/issues/65))
 
 **Rationale:** Zero runtime impact. Don't gate on `ci` — there's nothing to
 test. Auto-merge should be near-instant.
@@ -25,7 +27,7 @@ test. Auto-merge should be near-instant.
 
 ### Tier 1 — Examples & Benches
 
-**Paths:** `examples/**`, `bench/**`, `scripts/**`
+**Paths:** `examples/**`, `bench/**`
 
 **Required checks:**
 - `format`

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -17,16 +17,16 @@
       "pages": [
         "index",
         "guide/quickstart",
-        "guide/architecture",
-        "guide/core-concepts"
+        "guide/architecture"
       ]
     },
     {
       "group": "Guides",
       "pages": [
-        "guide/dsl",
-        "guide/storage",
-        "guide/glossary"
+        "guide/processors",
+        "guide/examples",
+        "guide/api-reference",
+        "guide/cli-reference"
       ]
     },
     {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -28,6 +28,12 @@
         "guide/storage",
         "guide/glossary"
       ]
+    },
+    {
+      "group": "Contributing",
+      "pages": [
+        "guide/auto-merge"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `docs/guide/auto-merge.md` defining five tiers of auto-merge gating based on blast radius of changed paths
- Registers the new page under a "Contributing" group in `docs/mint.json`

### Tiers

| Tier | Scope | Key gate |
|------|-------|----------|
| **0** | Docs & meta | `format` only |
| **1** | Examples & benches | `format` + `ci` |
| **2** | App / API / CLI | `format` + `ci` + coverage delta ≥ 0 |
| **3** | Core engine | All above + `typecheck` required + bench regression + human approval |
| **D** | Dependencies | Semver-discriminated (patch auto-merges, major never) |

A PR's tier is the *highest* tier any changed path falls into.

## Related

- Doc quality checks (spelling, markdown lint, link check, build) scoped in #65

## Test plan

- [ ] `make docs` builds successfully with the new page
- [ ] mint.json navigation renders the Contributing group correctly in `make docs-serve`

https://claude.ai/code/session_01VKPFkbKaxWu9dHMw9RVXQh