### PR TITLE
fix: wire QueryService to real data with time-travel support

### DIFF
--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -6,19 +6,30 @@ Query Service
 
 The read path. Time-travel queries, entity state, command history.
 All external reads go through here.
+
+Strategy:
+  - Current tick (tick=None or tick==world.tick): read from live in-memory state
+  - Historical tick: query the store via AsyncWorld.querier
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from collections import Counter
+from typing import TYPE_CHECKING, Any
 
+from daft import col
 from uuid_utils import UUID
 
 from archetype.app.models import Command, WorldSnapshot
+from archetype.core.aio.async_world import AsyncWorld
+from archetype.core.component import Component
 
 if TYPE_CHECKING:
     from archetype.app.broker import CommandBroker
     from archetype.app.world_service import WorldService
+
+logger = logging.getLogger(__name__)
 
 
 class QueryService:
@@ -30,18 +41,80 @@ class QueryService:
         self._world_service = world_service
         self._broker = broker
 
+    def _get_async_world(self, world_id: UUID) -> AsyncWorld:
+        """Get the world, ensuring it's an AsyncWorld for query access."""
+        world = self._world_service.get_world(world_id)
+        if not isinstance(world, AsyncWorld):
+            raise TypeError(f"World {world_id} is not an AsyncWorld; queries require AsyncWorld.")
+        return world
+
     async def get_world_state(
         self,
         world_id: UUID,
         tick: int | None = None,
     ) -> WorldSnapshot:
-        """Get the current (or historical) world state snapshot."""
-        world = self._world_service.get_world(world_id)
+        """Get the current (or historical) world state snapshot.
+
+        Populates entities and archetype_counts from live state (current tick)
+        or from the store (historical tick).
+        """
+        world = self._get_async_world(world_id)
+        effective_tick = tick if tick is not None else world.tick
+
+        if tick is None or tick == world.tick:
+            # Current tick: read from live in-memory state
+            return self._snapshot_from_live(world, effective_tick)
+
+        # Historical tick: query the store
+        return await self._snapshot_from_store(world, effective_tick)
+
+    def _snapshot_from_live(self, world: AsyncWorld, tick: int) -> WorldSnapshot:
+        """Build a WorldSnapshot from the live in-memory state."""
+        entities: dict[int, list[str]] = {}
+        archetype_counts: Counter[str] = Counter()
+
+        for entity_id, sig in world._entity2sig.items():
+            component_names = [c.__name__ for c in sig]
+            entities[entity_id] = component_names
+            archetype_key = ",".join(sorted(component_names))
+            archetype_counts[archetype_key] += 1
+
         return WorldSnapshot(
-            world_id=world_id,
-            tick=tick if tick is not None else getattr(world, "tick", 0),
-            entities={},
-            archetype_counts={},
+            world_id=world.world_id,
+            tick=tick,
+            entities=entities,
+            archetype_counts=dict(archetype_counts),
+        )
+
+    async def _snapshot_from_store(self, world: AsyncWorld, tick: int) -> WorldSnapshot:
+        """Build a WorldSnapshot by querying the store at a historical tick."""
+        entities: dict[int, list[str]] = {}
+        archetype_counts: Counter[str] = Counter()
+
+        for sig in world._live.keys():
+            try:
+                df = await world.querier.query_archetype(
+                    sig=sig,
+                    world_id=str(world.world_id),
+                    run_id=world.run_id,
+                    ticks=[tick],
+                )
+                rows = df.select("entity_id").collect().to_pylist()
+                component_names = [c.__name__ for c in sig]
+                archetype_key = ",".join(sorted(component_names))
+
+                for row in rows:
+                    eid = row["entity_id"]
+                    entities[eid] = component_names
+                    archetype_counts[archetype_key] += 1
+            except Exception:
+                logger.debug("Failed to query archetype %s at tick %d", sig, tick, exc_info=True)
+
+        return WorldSnapshot(
+            world_id=world.world_id,
+            tick=tick,
+            entities=entities,
+            archetype_counts=dict(archetype_counts),
         )
 
     async def get_entity(
@@ -49,27 +122,145 @@ class QueryService:
         world_id: UUID,
         entity_id: int,
         tick: int | None = None,
-    ) -> dict:
-        """Get entity state, optionally at a specific tick."""
-        world = self._world_service.get_world(world_id)
+    ) -> dict[str, Any]:
+        """Get entity state, optionally at a specific tick.
+
+        Returns a dict with world_id, entity_id, tick, components (dict of
+        component_name -> field values), and component_types (list of names).
+        """
+        world = self._get_async_world(world_id)
+        effective_tick = tick if tick is not None else world.tick
+
+        if tick is None or tick == world.tick:
+            return await self._entity_from_live(world, entity_id, effective_tick)
+
+        return await self._entity_from_store(world, entity_id, effective_tick)
+
+    async def _entity_from_live(
+        self, world: AsyncWorld, entity_id: int, tick: int
+    ) -> dict[str, Any]:
+        """Read a single entity's component data from live state."""
+        sig = world._entity2sig.get(entity_id)
+        if sig is None:
+            raise KeyError(f"Entity {entity_id} not found in world {world.world_id}")
+
+        component_names = [c.__name__ for c in sig]
+        components_data = await self._extract_entity_components(world, sig, entity_id, tick=None)
+
         return {
-            "world_id": str(world_id),
+            "world_id": str(world.world_id),
             "entity_id": entity_id,
-            "tick": tick if tick is not None else getattr(world, "tick", 0),
+            "tick": tick,
+            "component_types": component_names,
+            "components": components_data,
         }
+
+    async def _entity_from_store(
+        self, world: AsyncWorld, entity_id: int, tick: int
+    ) -> dict[str, Any]:
+        """Read a single entity's component data from the store at a historical tick."""
+        # Try all known signatures to find this entity
+        for sig in world._live.keys():
+            try:
+                df = await world.querier.query_archetype(
+                    sig=sig,
+                    world_id=str(world.world_id),
+                    run_id=world.run_id,
+                    ticks=[tick],
+                    entity_ids=[entity_id],
+                )
+                rows = df.collect().to_pylist()
+                if rows:
+                    row = rows[0]
+                    component_names = [c.__name__ for c in sig]
+                    components_data = self._row_to_components(row, sig)
+                    return {
+                        "world_id": str(world.world_id),
+                        "entity_id": entity_id,
+                        "tick": tick,
+                        "component_types": component_names,
+                        "components": components_data,
+                    }
+            except Exception:
+                logger.debug(
+                    "Failed to query entity %d in archetype %s at tick %d",
+                    entity_id,
+                    sig,
+                    tick,
+                    exc_info=True,
+                )
+
+        raise KeyError(f"Entity {entity_id} not found at tick {tick} in world {world.world_id}")
+
+    async def _extract_entity_components(
+        self,
+        world: AsyncWorld,
+        sig: tuple,
+        entity_id: int,
+        tick: int | None,
+    ) -> dict[str, dict[str, Any]]:
+        """Extract component field values for a single entity from live state."""
+        live_df = world._live.get(sig)
+        if live_df is None:
+            return {}
+
+        filtered = live_df.where(col("entity_id") == entity_id)
+        rows = filtered.collect().to_pylist()
+        if not rows:
+            return {}
+
+        return self._row_to_components(rows[0], sig)
+
+    @staticmethod
+    def _row_to_components(row: dict[str, Any], sig: tuple) -> dict[str, dict[str, Any]]:
+        """Convert a raw DataFrame row to a component-name -> fields dict."""
+        components_data: dict[str, dict[str, Any]] = {}
+        for comp_type in sig:
+            prefix = comp_type.__name__.lower() + "__"
+            fields = {}
+            for key, val in row.items():
+                if key.startswith(prefix):
+                    field_name = key[len(prefix) :]
+                    fields[field_name] = val
+            if fields:
+                components_data[comp_type.__name__] = fields
+        return components_data
 
     async def get_components(
         self,
         world_id: UUID,
         component_types: list[str],
         entity_ids: list[int] | None = None,
-    ) -> dict:
-        """Query specific component types across entities."""
-        self._world_service.get_world(world_id)  # validate world exists
+    ) -> dict[str, Any]:
+        """Query specific component types across entities.
+
+        Resolves component type names to classes and delegates to
+        AsyncWorld.get_components().
+        """
+        world = self._get_async_world(world_id)
+
+        if not component_types:
+            return {
+                "world_id": str(world_id),
+                "component_types": [],
+                "entities": [],
+            }
+
+        # Resolve string names to Component subclasses
+        resolved: list[type[Component]] = []
+        for name in component_types:
+            try:
+                resolved.append(Component.get_type_by_name(name))
+            except ValueError:
+                raise KeyError(f"Unknown component type: {name}") from None
+
+        df = await world.get_components(resolved, entity_ids=entity_ids)
+        rows = df.collect().to_pylist()
+
         return {
             "world_id": str(world_id),
             "component_types": component_types,
-            "entity_ids": entity_ids,
+            "entities": rows,
         }
 
     async def get_command_history(

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -110,7 +110,7 @@ class TestSimulationService:
 
 class TestQueryService:
     @pytest.mark.asyncio
-    async def test_get_world_state(self, tmp_path):
+    async def test_get_world_state_empty_world(self, tmp_path):
         container = ServiceContainer()
         try:
             storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
@@ -118,6 +118,128 @@ class TestQueryService:
 
             snapshot = await container.query_service.get_world_state(world.world_id)
             assert snapshot.world_id == world.world_id
+            assert snapshot.entities == {}
+            assert snapshot.archetype_counts == {}
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_get_world_state_with_entities(self, tmp_path):
+        """After creating entities, get_world_state returns real entity data."""
+        from archetype.core.component import Component
+
+        class Agent(Component):
+            name: str = ""
+
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            await world.create_entity([Agent(name="Alice")])
+            await world.create_entity([Agent(name="Bob")])
+            # Step to materialize the entities into live state
+            await container.simulation_service.step(world.world_id)
+
+            snapshot = await container.query_service.get_world_state(world.world_id)
+            assert snapshot.world_id == world.world_id
+            assert len(snapshot.entities) == 2
+            # Each entity should list Agent as a component type
+            for _eid, comp_names in snapshot.entities.items():
+                assert "Agent" in comp_names
+            # Archetype counts should reflect 2 entities in the Agent archetype
+            assert sum(snapshot.archetype_counts.values()) == 2
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_get_entity_returns_component_data(self, tmp_path):
+        """get_entity returns actual component field values."""
+        from archetype.core.component import Component
+
+        class Position(Component):
+            x: float = 0.0
+            y: float = 0.0
+
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            eid = await world.create_entity([Position(x=10.0, y=20.0)])
+            await container.simulation_service.step(world.world_id)
+
+            result = await container.query_service.get_entity(world.world_id, eid)
+            assert result["entity_id"] == eid
+            assert result["world_id"] == str(world.world_id)
+            assert "Position" in result["component_types"]
+            assert "Position" in result["components"]
+            assert result["components"]["Position"]["x"] == 10.0
+            assert result["components"]["Position"]["y"] == 20.0
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_get_entity_not_found(self, tmp_path):
+        """get_entity raises KeyError for non-existent entity."""
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            with pytest.raises(KeyError):
+                await container.query_service.get_entity(world.world_id, 9999)
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_get_components_returns_rows(self, tmp_path):
+        """get_components resolves type names and returns real DataFrame rows."""
+        from archetype.core.component import Component
+
+        class Score(Component):
+            val: float = 0.0
+
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            await world.create_entity([Score(val=0.5)])
+            await world.create_entity([Score(val=0.9)])
+            await container.simulation_service.step(world.world_id)
+
+            result = await container.query_service.get_components(world.world_id, ["Score"])
+            assert result["component_types"] == ["Score"]
+            assert len(result["entities"]) == 2
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_get_components_unknown_type(self, tmp_path):
+        """get_components raises KeyError for unknown component type names."""
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            with pytest.raises(KeyError, match="Unknown component type"):
+                await container.query_service.get_components(
+                    world.world_id, ["NonExistentComponent"]
+                )
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_get_components_empty_types(self, tmp_path):
+        """get_components with empty type list returns empty entities."""
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            result = await container.query_service.get_components(world.world_id, [])
+            assert result["entities"] == []
         finally:
             await container.shutdown()
 


### PR DESCRIPTION
## Summary
- Replaces stub `QueryService` methods with real data reads from `AsyncWorld`
- `get_world_state`: populates `entities` and `archetype_counts` from live state or store (historical ticks)
- `get_entity`: returns actual component field values with time-travel via store queries
- `get_components`: resolves string type names to `Component` subclasses, delegates to `AsyncWorld.get_components()`
- Strategy: current tick reads from `_live` snapshots, historical ticks query the store

## Test plan
- [x] 6 new tests: empty world, entities populated, entity component data, entity not found, component type resolution, unknown type error
- [x] All 236 tests pass (no regressions)
- [x] `make ci` green (lint, format, tests with 74.9% coverage)

Closes #75

@everettVT

🤖 Generated with [Claude Code](https://claude.com/claude-code)