### PR TITLE
feat: query CLI subcommand with DataFrame expressions

### DIFF
--- a/src/archetype/api/routes/query.py
+++ b/src/archetype/api/routes/query.py
@@ -46,11 +46,21 @@ async def get_components(
     world_id: str,
     types: str = "",
     tick: int | None = None,
+    show: int | None = None,
+    count: bool = False,
+    where: str | None = None,
     qs: QueryService = Depends(get_query_service),
 ):
     try:
         component_types = [t.strip() for t in types.split(",") if t.strip()]
-        result = await qs.get_components(UUID(world_id), component_types, tick=tick)
+        result = await qs.get_components(
+            UUID(world_id),
+            component_types,
+            tick=tick,
+            limit=show,
+            count_only=count,
+            where=where,
+        )
         return result
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from None

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -79,6 +79,40 @@ def _resolve_component_types(world: Any, type_names: list[str]) -> list[type]:
     return resolved
 
 
+def _apply_where(df: DataFrame, expr: str) -> DataFrame:
+    """Apply a simple filter expression to a DataFrame.
+
+    Supports: ``column > value``, ``column == value``, etc.
+    Operators: ``>``, ``<``, ``>=``, ``<=``, ``==``, ``!=``
+    """
+    import re
+
+    match = re.match(r"^\s*(\S+)\s*(>=|<=|!=|==|>|<)\s*(.+?)\s*$", expr)
+    if not match:
+        raise ValueError(f"Invalid where expression: {expr!r}. Expected: column op value")
+
+    column, op, raw_value = match.groups()
+
+    # Parse value: try float, then int, then bare string
+    value: float | int | str
+    try:
+        value = float(raw_value)
+        if value == int(value) and "." not in raw_value:
+            value = int(value)
+    except ValueError:
+        value = raw_value.strip("'\"")
+
+    ops = {
+        ">": col(column) > value,
+        "<": col(column) < value,
+        ">=": col(column) >= value,
+        "<=": col(column) <= value,
+        "==": col(column) == value,
+        "!=": col(column) != value,
+    }
+    return df.where(ops[op])
+
+
 class QueryService:
     """
     Read path facade. Time-travel queries, entity state, cross-world reads.
@@ -205,18 +239,28 @@ class QueryService:
         component_types: list[str],
         entity_ids: list[int] | None = None,
         tick: int | None = None,
+        limit: int | None = None,
+        count_only: bool = False,
+        where: str | None = None,
     ) -> dict:
-        """Query specific component types across entities."""
+        """Query specific component types across entities.
+
+        Args:
+            limit: Maximum rows to return (``--show``).
+            count_only: Return only the row count (``--count``).
+            where: Simple filter expression, e.g. ``"score__val > 0.5"``.
+                   Supports ``>``, ``<``, ``>=``, ``<=``, ``==``, ``!=``.
+        """
         world = self._get_async_world(world_id)
         effective_tick = max(world.tick - 1, 0) if tick is None else tick
 
         if not component_types:
-            return {
+            base: dict = {
                 "world_id": str(world_id),
                 "tick": effective_tick,
                 "component_types": [],
-                "rows": [],
             }
+            return {**base, "count": 0} if count_only else {**base, "rows": []}
 
         resolved = _resolve_component_types(world, component_types)
 
@@ -239,6 +283,21 @@ class QueryService:
                 )
                 proj_cols = schema.names
                 df = df.concat(sig_df.select(*proj_cols))
+
+        # Apply where filter before count/limit
+        if where:
+            df = _apply_where(df, where)
+
+        if count_only:
+            return {
+                "world_id": str(world_id),
+                "tick": effective_tick,
+                "component_types": component_types,
+                "count": df.count_rows(),
+            }
+
+        if limit is not None:
+            df = df.limit(limit)
 
         rows = _df_to_rows(df)
         return {

--- a/src/archetype/cli/main.py
+++ b/src/archetype/cli/main.py
@@ -189,14 +189,61 @@ def step(world_id: str = typer.Argument(..., help="World ID")):
 @app.command()
 def query(
     world_id: str = typer.Argument(..., help="World ID"),
-    tick: int | None = typer.Option(None, "--tick", "-t", help="Tick to query"),
+    component_types: str = typer.Argument(
+        "",
+        help="Comma-separated component types (e.g. Agent,Score). "
+        "Omit to get world state overview.",
+    ),
+    tick: int | None = typer.Option(None, "--tick", "-t", help="Query at this tick"),
+    show: int | None = typer.Option(None, "--show", "-s", help="Limit to N rows"),
+    count: bool = typer.Option(False, "--count", "-c", help="Return row count only"),
+    where: str | None = typer.Option(None, "--where", "-w", help='Filter: "col op val"'),
 ):
-    """Query world state at a tick."""
-    params = {}
+    """Query world state or specific components.
+
+    \b
+    Without component types, returns a world state overview.
+    With component types, queries entities matching those components.
+
+    \b
+    Examples:
+        archetype query <wid> Agent,Score --show 5
+        archetype query <wid> Agent --tick 3 --show 10
+        archetype query <wid> Trajectory,Label --count
+        archetype query <wid> Score --where "score__val > 0.5"
+    """
+    if not component_types:
+        # World state overview (original behavior)
+        params: dict = {}
+        if tick is not None:
+            params["tick"] = tick
+        data = _request("get", f"/worlds/{world_id}/state", params=params)
+        typer.echo(json.dumps(data, indent=2))
+        return
+
+    # Component query
+    params = {"types": component_types}
     if tick is not None:
         params["tick"] = tick
-    data = _request("get", f"/worlds/{world_id}/state", params=params)
-    typer.echo(json.dumps(data, indent=2))
+    if show is not None:
+        params["show"] = show
+    if count:
+        params["count"] = "true"
+    if where:
+        params["where"] = where
+
+    data = _request("get", f"/worlds/{world_id}/components", params=params)
+
+    if count:
+        typer.echo(f"Count: {data.get('count', 0)}")
+        return
+
+    rows = data.get("rows", [])
+    if not rows:
+        typer.echo("No matching entities.")
+        return
+
+    typer.echo(json.dumps(rows, indent=2, default=str))
 
 
 @app.command()

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -259,6 +259,82 @@ class TestQueryService:
             await container.shutdown()
 
     @pytest.mark.asyncio
+    async def test_get_components_with_limit(self, tmp_path):
+        """--show limits the number of returned rows."""
+        from archetype.core.component import Component
+
+        class Metric(Component):
+            val: float = 0.0
+
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            for i in range(5):
+                await world.create_entity([Metric(val=float(i))])
+            await world.step(RunConfig())
+
+            result = await container.query_service.get_components(
+                world.world_id, ["Metric"], limit=2
+            )
+            assert len(result["rows"]) == 2
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_get_components_count_only(self, tmp_path):
+        """--count returns count without rows."""
+        from archetype.core.component import Component
+
+        class Tally(Component):
+            n: int = 0
+
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            for i in range(3):
+                await world.create_entity([Tally(n=i)])
+            await world.step(RunConfig())
+
+            result = await container.query_service.get_components(
+                world.world_id, ["Tally"], count_only=True
+            )
+            assert result["count"] == 3
+            assert "rows" not in result
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_get_components_where_filter(self, tmp_path):
+        """--where filters rows by column expression."""
+        from archetype.core.component import Component
+
+        class Rating(Component):
+            val: float = 0.0
+
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            await world.create_entity([Rating(val=0.3)])
+            await world.create_entity([Rating(val=0.7)])
+            await world.create_entity([Rating(val=0.9)])
+            await world.step(RunConfig())
+
+            result = await container.query_service.get_components(
+                world.world_id, ["Rating"], where="rating__val > 0.5"
+            )
+            assert len(result["rows"]) == 2
+            for row in result["rows"]:
+                assert row["components"]["rating"]["val"] > 0.5
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
     async def test_get_command_history_empty(self, tmp_path):
         container = ServiceContainer()
         try:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -158,6 +158,25 @@ class TestCLIIntegration:
         assert listing.exit_code == 0
         assert "No worlds found" in listing.output
 
+    @pytest.mark.usefixtures("_patch_request")
+    def test_query_no_components_returns_state(self, tmp_path):
+        """query without component types returns world state overview."""
+        uri = str(tmp_path / "store")
+        create = runner.invoke(app, ["world", "create", "q2-test", "--uri", uri])
+        world_id = create.output.split("Created world: ")[1].split()[0]
+
+        result = runner.invoke(app, ["query", world_id])
+        assert result.exit_code == 0, result.output
+        assert "world_id" in result.output
+
+    def test_query_help_shows_options(self):
+        """query --help shows --show, --count, --where options."""
+        result = runner.invoke(app, ["query", "--help"])
+        assert result.exit_code == 0
+        assert "--show" in result.output
+        assert "--count" in result.output
+        assert "--where" in result.output
+
     def test_no_server_gives_clear_error(self):
         """When the server is down, the CLI should exit with a useful message."""
         result = runner.invoke(app, ["status"])


### PR DESCRIPTION
## Summary
- Extends `archetype query` to accept positional component types with `--show`, `--count`, and `--where` options
- `--show N`: limits returned rows (lazy — only materializes N)
- `--count`: returns row count without collecting data
- `--where "col op val"`: applies simple column filter expressions (`>`, `<`, `>=`, `<=`, `==`, `!=`)
- Without component types, still returns world state overview (backwards compatible)
- Server-side: QueryService builds lazy DataFrame chain, materializes only at terminal operation

## Test plan
- [x] 3 new service tests: limit, count_only, where filter
- [x] 2 new CLI tests: overview mode, help flags
- [x] All 290 tests pass
- [x] `make ci` green (78.5% coverage)

Depends on #79
Closes #104

@everettVT

🤖 Generated with [Claude Code](https://claude.com/claude-code)