### PR TITLE
feat(experiments): ECS-native experiment tracking + runner ingestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,18 @@ check: format lint
 test:
 	@PYTHONPATH=$(PYTHONPATH) uv run pytest -q
 
+# Narrow test target: run a specific path/file/nodeid.
+# Usage: make test-mod MOD=tests/lifecycle/
+# Fails fast if MOD is unset so it can't be confused with test-all.
+.PHONY: test-mod
+test-mod:
+	@if [ -z "$(MOD)" ]; then \
+		echo "Error: MOD is required for test-mod."; \
+		echo "Usage: make test-mod MOD=tests/lifecycle/"; \
+		exit 1; \
+	fi
+	@PYTHONPATH=$(PYTHONPATH) uv run pytest -v $(MOD)
+
 .PHONY: test-cov
 test-cov:
 	@PYTHONPATH=$(PYTHONPATH) uv run pytest \

--- a/src/archetype/experiments/__init__.py
+++ b/src/archetype/experiments/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experiment tracking — ECS-native.
+
+Experiments, runs, results, and branch heads as first-class archetype
+Components. Runs become entities in an archetype world, which means
+world forking, time-travel queries, and the full set of ECS tools work
+on experiment state the same way they work on any other simulation.
+
+Ingestion from archetype-runner's SQLite registry is provided by
+:func:`load_runner_state_db` and :func:`ingest_runner_state`.
+"""
+
+from archetype.experiments.components import (
+    BranchHead,
+    Experiment,
+    Result,
+    Run,
+    RunStatus,
+)
+from archetype.experiments.loaders import (
+    ingest_runner_state,
+    load_runner_state_db,
+)
+
+__all__ = [
+    "BranchHead",
+    "Experiment",
+    "Result",
+    "Run",
+    "RunStatus",
+    "ingest_runner_state",
+    "load_runner_state_db",
+]

--- a/src/archetype/experiments/components.py
+++ b/src/archetype/experiments/components.py
@@ -1,0 +1,271 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Experiment Components
+=====================
+
+Experiment, Run, Result, BranchHead: the ECS schema for autoresearch
+lifecycle state. Each is a first-class archetype Component, which means
+runs become entities in an archetype world — forkable, time-travelable,
+and queryable with the same tools as any other simulation state.
+
+The module is deliberately minimal on scoring semantics: Result stores
+eval outputs as an opaque JSON dict and BranchHead stores a free-form
+JSON descriptor of *why* a commit is the current best. Users decide
+what "better" means; the library stores and queries, it does not score.
+
+Arrow serialization:
+    - Scalar fields (str/int/float/bool) are stored directly
+    - Complex types (dicts, lists, nested structures) are JSON-encoded
+      into ``*_json`` fields, following the Trajectory convention
+    - Timestamps are stored as Unix milliseconds (``*_at_ms``) for
+      Arrow compatibility and efficient range filtering
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from enum import Enum
+from typing import Any
+
+from archetype.core.component import Component
+
+# ============================================================================
+# Helper types — NOT Components. Used for type-safe construction and for
+# decoding JSON-encoded fields back into friendly Python objects.
+# ============================================================================
+
+
+class RunStatus(str, Enum):
+    """Allowed values for ``Run.status``.
+
+    Run stores status as a plain string for Arrow compatibility — enums
+    are not directly Arrow-serializable. This helper provides type-safe
+    construction (``RunStatus.RUNNING.value``) and classification
+    (``RunStatus.is_active(run.status)``). The string values match
+    archetype-runner's ``state.py`` registry exactly, so rows read from
+    the runner's SQLite deserialize without translation.
+    """
+
+    BOOTING = "booting"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    CRASHED = "crashed"
+
+    @classmethod
+    def is_active(cls, status: str) -> bool:
+        """True while the run is still in flight."""
+        return status in (cls.BOOTING.value, cls.RUNNING.value, cls.STOPPING.value)
+
+    @classmethod
+    def is_terminal(cls, status: str) -> bool:
+        """True once the run has reached a final state."""
+        return status in (cls.STOPPED.value, cls.CRASHED.value)
+
+
+def _now_ms() -> int:
+    """Current time as Unix milliseconds."""
+    return int(time.time() * 1000)
+
+
+# ============================================================================
+# Components
+# ============================================================================
+
+
+class Experiment(Component):
+    """An autoresearch experiment — the setup for a family of runs.
+
+    Deliberately contains no scoring or reward fields. An experiment
+    describes the conditions under which runs happen (which repo, which
+    branch, any user-defined metadata). How runs are compared or ranked
+    is entirely the user's eval code's job — this Component does not
+    pre-declare a metric.
+
+    Fields:
+        name:           Experiment identifier; matches Run.experiment_name
+        repo_url:       Git repository URL the experiment evolves
+        branch:         Branch the experiment evolves
+        created_at_ms:  Creation timestamp in Unix milliseconds
+        metadata_json:  Free-form user-defined metadata (JSON dict)
+    """
+
+    name: str = ""
+    repo_url: str = ""
+    branch: str = "main"
+    created_at_ms: int = 0
+    metadata_json: str = "{}"
+
+    @classmethod
+    def make(
+        cls,
+        name: str,
+        repo_url: str,
+        *,
+        branch: str = "main",
+        metadata: dict[str, Any] | None = None,
+        created_at_ms: int | None = None,
+    ) -> Experiment:
+        """Convenience constructor that JSON-encodes metadata."""
+        return cls(
+            name=name,
+            repo_url=repo_url,
+            branch=branch,
+            created_at_ms=created_at_ms if created_at_ms is not None else _now_ms(),
+            metadata_json=json.dumps(metadata or {}),
+        )
+
+    def get_metadata(self) -> dict[str, Any]:
+        """Decode the metadata JSON back to a dict."""
+        return json.loads(self.metadata_json)
+
+
+class Run(Component):
+    """A single autoresearch attempt: one VM, one agent, one task.
+
+    Pure facts about what happened — no evaluation or reward fields.
+    Field shapes mirror archetype-runner's ``AgentRecord`` so that the
+    runner's SQLite registry can be ingested into an archetype world
+    row-for-row without translation.
+
+    Fields:
+        run_id:          Opaque run identifier; same value runner stores as agent_id
+        experiment_name: Experiment this run belongs to (free-form label)
+        vm_name:         masterblaster VM name backing this run
+        status:          One of the RunStatus values (stored as string)
+        harness:         'claude-code' | 'opencode' | 'hermes'
+        repo_url:        Git repository URL
+        branch:          Git branch
+        task:            Natural-language task prompt given to the agent
+        started_at_ms:   Start time in Unix milliseconds
+        finished_at_ms:  Finish time in Unix milliseconds (0 if not finished)
+        agent_name:      Composite identity, conventionally '{experiment_name}-{harness}'
+        workspace_path:  Host filesystem path to the cloned repo
+        commit_hash:     Git commit produced by the run ("" if not set yet)
+    """
+
+    run_id: str = ""
+    experiment_name: str = "adhoc"
+    vm_name: str = ""
+    status: str = "booting"
+    harness: str = ""
+    repo_url: str = ""
+    branch: str = "main"
+    task: str = ""
+    started_at_ms: int = 0
+    finished_at_ms: int = 0
+    agent_name: str = ""
+    workspace_path: str = ""
+    commit_hash: str = ""
+
+    @property
+    def is_active(self) -> bool:
+        """True while the run is still in flight (booting/running/stopping).
+
+        Matches archetype's entity-level ``active`` convention.
+        """
+        return RunStatus.is_active(self.status)
+
+    @property
+    def is_terminal(self) -> bool:
+        """True once the run has reached a final state (stopped/crashed)."""
+        return RunStatus.is_terminal(self.status)
+
+
+class Result(Component):
+    """An opaque eval envelope for a Run.
+
+    The library persists; it does not interpret. User eval code puts
+    whatever is meaningful into ``outputs_json`` — a scalar metric, a
+    Pareto point, an LLM judge verdict, a full pytest report, a
+    tournament record. Multiple Results per run are allowed (same
+    ``run_id``, different ``evaluator``) so several eval harnesses can
+    score the same run independently.
+
+    Fields:
+        run_id:         Foreign key to Run.run_id
+        evaluator:      Free-form name of the eval source ('pytest', 'ruff', 'llm-judge', ...)
+        outputs_json:   JSON dict of opaque user-defined eval output
+        evaluated_at_ms: When the eval ran, in Unix milliseconds
+    """
+
+    run_id: str = ""
+    evaluator: str = ""
+    outputs_json: str = "{}"
+    evaluated_at_ms: int = 0
+
+    @classmethod
+    def make(
+        cls,
+        run_id: str,
+        outputs: dict[str, Any],
+        *,
+        evaluator: str = "",
+        evaluated_at_ms: int | None = None,
+    ) -> Result:
+        """Convenience constructor that JSON-encodes outputs."""
+        return cls(
+            run_id=run_id,
+            evaluator=evaluator,
+            outputs_json=json.dumps(outputs),
+            evaluated_at_ms=evaluated_at_ms if evaluated_at_ms is not None else _now_ms(),
+        )
+
+    def get_outputs(self) -> dict[str, Any]:
+        """Decode the outputs JSON back to a dict."""
+        return json.loads(self.outputs_json)
+
+
+class BranchHead(Component):
+    """Persisted 'current best commit' for an experiment.
+
+    The autoresearch loop picks a winner each iteration using whatever
+    comparison logic the user wants (scalar max, Pareto dominance, LLM
+    judge, tournament, human vote). After each winner is selected, the
+    loop writes a ``BranchHead`` so a host crash can recover and continue
+    from the same declared-best commit instead of resetting to branch HEAD.
+
+    The ``descriptor_json`` field is free-form and user-defined: it's
+    the user's explanation of *why* this commit is the current best,
+    in whatever shape they want. The library persists it verbatim and
+    never interprets it.
+
+    Fields:
+        experiment_name: Experiment this head belongs to
+        commit_hash:     Git commit currently declared best
+        run_id:          Run that produced this commit ("" for initial seed)
+        descriptor_json: Free-form user-defined JSON descriptor of why
+        updated_at_ms:   Last update in Unix milliseconds
+    """
+
+    experiment_name: str = ""
+    commit_hash: str = ""
+    run_id: str = ""
+    descriptor_json: str = "{}"
+    updated_at_ms: int = 0
+
+    @classmethod
+    def make(
+        cls,
+        experiment_name: str,
+        commit_hash: str,
+        *,
+        run_id: str = "",
+        descriptor: dict[str, Any] | None = None,
+        updated_at_ms: int | None = None,
+    ) -> BranchHead:
+        """Convenience constructor that JSON-encodes the descriptor."""
+        return cls(
+            experiment_name=experiment_name,
+            commit_hash=commit_hash,
+            run_id=run_id,
+            descriptor_json=json.dumps(descriptor or {}),
+            updated_at_ms=updated_at_ms if updated_at_ms is not None else _now_ms(),
+        )
+
+    def get_descriptor(self) -> dict[str, Any]:
+        """Decode the descriptor JSON back to a dict."""
+        return json.loads(self.descriptor_json)

--- a/src/archetype/experiments/loaders.py
+++ b/src/archetype/experiments/loaders.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Experiment Loaders
+==================
+
+Ingest external state into experiment Components, starting with
+archetype-runner's SQLite registry.
+
+Direct ingestion path (no CommandBroker / RBAC) following the
+``scripts/ingest_claude_sessions.py`` pattern: SQLite → list of Run
+Components → ``world.create_entity(...)``. The runner's SQLite uses
+WAL mode, so these reads are safe even while the runner is actively
+writing.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from archetype.experiments.components import Run
+
+if TYPE_CHECKING:
+    from archetype.core.aio import AsyncWorld
+
+
+def _iso_to_ms(iso_str: str | None) -> int:
+    """Parse a runner-written ISO-8601 timestamp into Unix milliseconds.
+
+    Returns 0 for None or empty strings, so that the Arrow ``int``
+    column can represent 'not set' without nullable complications.
+    """
+    if not iso_str:
+        return 0
+    dt = datetime.fromisoformat(iso_str)
+    return int(dt.timestamp() * 1000)
+
+
+def _default_runner_state_path() -> Path:
+    """Conventional path where archetype-runner stores its registry."""
+    return Path.home() / ".archetype-runner" / "state.db"
+
+
+def load_runner_state_db(path: str | Path | None = None) -> list[Run]:
+    """Read archetype-runner's ``state.db`` and return one Run per row.
+
+    Args:
+        path: Path to the runner's SQLite registry. If None, defaults
+            to ``~/.archetype-runner/state.db``.
+
+    Returns:
+        One ``Run`` Component instance per row in the ``agents`` table,
+        ordered by ``started_at`` ascending (oldest first).
+
+    Raises:
+        FileNotFoundError: If the SQLite file does not exist.
+
+    Notes:
+        Opens the database read-only via SQLite URI mode. Safe to call
+        while the runner is writing: the runner enables WAL mode so
+        concurrent readers don't block writers.
+    """
+    db_path = Path(path) if path is not None else _default_runner_state_path()
+    if not db_path.exists():
+        raise FileNotFoundError(f"archetype-runner state.db not found at {db_path}")
+
+    uri = f"file:{db_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    try:
+        cursor = conn.execute(
+            """
+            SELECT agent_id, vm_name, status, harness, repo_url, branch,
+                   task, started_at, finished_at, agent_name, workspace_path
+            FROM agents
+            ORDER BY started_at ASC
+            """
+        )
+        runs: list[Run] = []
+        for row in cursor:
+            runs.append(
+                Run(
+                    run_id=row[0] or "",
+                    vm_name=row[1] or "",
+                    status=row[2] or "booting",
+                    harness=row[3] or "",
+                    repo_url=row[4] or "",
+                    branch=row[5] or "main",
+                    task=row[6] or "",
+                    started_at_ms=_iso_to_ms(row[7]),
+                    finished_at_ms=_iso_to_ms(row[8]),
+                    agent_name=row[9] or "",
+                    workspace_path=row[10] or "",
+                )
+            )
+        return runs
+    finally:
+        conn.close()
+
+
+async def ingest_runner_state(
+    world: AsyncWorld,
+    path: str | Path | None = None,
+) -> int:
+    """Read archetype-runner's ``state.db`` and spawn one entity per run.
+
+    Thin wrapper over ``load_runner_state_db`` that calls
+    ``world.create_entity`` for each loaded Run. Entities are
+    in-memory after this call; caller should run one
+    ``simulation_service.step`` to materialize them to storage
+    if durable persistence is required.
+
+    Args:
+        world: The archetype world to load runs into.
+        path: Path to the runner's SQLite registry. If None, defaults
+            to ``~/.archetype-runner/state.db``.
+
+    Returns:
+        The number of Run entities spawned.
+
+    Example:
+        >>> container = ServiceContainer()
+        >>> world = await container.world_service.create_world(
+        ...     WorldConfig(name="runner-fleet"),
+        ...     StorageConfig(namespace="experiments"),
+        ... )
+        >>> count = await ingest_runner_state(world)
+        >>> await container.simulation_service.step(
+        ...     world.world_id, RunConfig(num_steps=1)
+        ... )
+    """
+    runs = load_runner_state_db(path)
+    for run in runs:
+        await world.create_entity([run])
+    return len(runs)

--- a/tests/experiments/test_components.py
+++ b/tests/experiments/test_components.py
@@ -1,0 +1,345 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for experiment Components — Experiment, Run, Result, BranchHead."""
+
+import json
+
+import pyarrow as pa
+import pytest
+
+from archetype.core.component import Component
+from archetype.experiments import (
+    BranchHead,
+    Experiment,
+    Result,
+    Run,
+    RunStatus,
+)
+
+
+class TestRunStatus:
+    def test_string_values_match_runner_registry(self):
+        # Values must match archetype-runner's state.py exactly so that
+        # SQLite rows from the runner registry can be used as-is.
+        assert RunStatus.BOOTING.value == "booting"
+        assert RunStatus.RUNNING.value == "running"
+        assert RunStatus.STOPPING.value == "stopping"
+        assert RunStatus.STOPPED.value == "stopped"
+        assert RunStatus.CRASHED.value == "crashed"
+
+    def test_is_active_true_while_in_flight(self):
+        for s in ("booting", "running", "stopping"):
+            assert RunStatus.is_active(s) is True
+
+    def test_is_active_false_once_terminal(self):
+        for s in ("stopped", "crashed"):
+            assert RunStatus.is_active(s) is False
+
+    def test_is_terminal_inverse_of_active(self):
+        for s in ("booting", "running", "stopping"):
+            assert RunStatus.is_terminal(s) is False
+        for s in ("stopped", "crashed"):
+            assert RunStatus.is_terminal(s) is True
+
+
+class TestExperimentComponent:
+    def test_is_archetype_component(self):
+        assert issubclass(Experiment, Component)
+
+    def test_default_construction(self):
+        # Components follow the Trajectory convention: all fields have
+        # defaults so partial rows from storage deserialize cleanly.
+        exp = Experiment()
+        assert exp.name == ""
+        assert exp.repo_url == ""
+        assert exp.branch == "main"
+        assert exp.created_at_ms == 0
+        assert exp.metadata_json == "{}"
+
+    def test_make_convenience_constructor(self):
+        exp = Experiment.make(
+            name="frontend-perf",
+            repo_url="https://github.com/foo/bar",
+            metadata={"tags": ["benchmark"], "eval_cmd": "pytest tests/"},
+        )
+        assert exp.name == "frontend-perf"
+        assert exp.repo_url == "https://github.com/foo/bar"
+        assert exp.created_at_ms > 0
+        # metadata is stored as JSON string for Arrow compatibility
+        decoded = json.loads(exp.metadata_json)
+        assert decoded["tags"] == ["benchmark"]
+        assert decoded["eval_cmd"] == "pytest tests/"
+
+    def test_get_metadata_round_trip(self):
+        payload = {"a": 1, "nested": {"b": [1, 2, 3]}}
+        exp = Experiment.make(name="x", repo_url="r", metadata=payload)
+        assert exp.get_metadata() == payload
+
+    def test_prefix_matches_arrow_convention(self):
+        # Per Component.get_prefix(): field names get prefixed with
+        # "{classname}__" when serialized to the world schema.
+        assert Experiment.get_prefix() == "experiment__"
+
+    def test_arrow_schema_is_materializable(self):
+        schema = Experiment.to_pyarrow_schema()
+        assert isinstance(schema, pa.Schema)
+        field_names = set(schema.names)
+        assert "name" in field_names
+        assert "repo_url" in field_names
+        assert "metadata_json" in field_names
+        assert "created_at_ms" in field_names
+
+    def test_no_metric_or_direction_fields(self):
+        # The redesign deliberately omits scoring semantics.
+        for forbidden in ("metric_name", "direction", "metric", "reward"):
+            assert forbidden not in Experiment.model_fields
+
+
+class TestRunComponent:
+    def test_is_archetype_component(self):
+        assert issubclass(Run, Component)
+
+    def test_default_construction(self):
+        run = Run()
+        assert run.run_id == ""
+        assert run.experiment_name == "adhoc"
+        assert run.status == "booting"
+        assert run.is_active is True
+        assert run.is_terminal is False
+        assert run.commit_hash == ""
+        assert run.finished_at_ms == 0
+
+    def test_constructs_from_runner_agent_record_shape(self):
+        # Load-bearing: a dict shaped like archetype-runner's SQLite row
+        # must construct a Run cleanly after mapping agent_id -> run_id
+        # and parsing ISO timestamps. The loader module does this
+        # transformation; this test asserts the Component surface accepts
+        # the post-transformation shape.
+        run = Run(
+            run_id="claude-2026-04-10-abc123",
+            vm_name="mb-vm-claude-2026-04-10-abc123",
+            status="running",
+            harness="claude-code",
+            repo_url="https://github.com/Vangelis/archetype",
+            branch="feat/foo",
+            task="Add a feature flag for X",
+            started_at_ms=1_744_291_696_000,
+            finished_at_ms=0,
+            agent_name="adhoc-claude-code",
+            workspace_path="/home/vangelis/.archetype-runner/workspaces/claude-2026-04-10-abc123",
+        )
+        assert run.run_id == "claude-2026-04-10-abc123"
+        assert run.status == "running"
+        assert run.is_active is True
+        assert run.harness == "claude-code"
+        assert run.started_at_ms == 1_744_291_696_000
+
+    def test_is_active_property_covers_all_in_flight_states(self):
+        for s in ("booting", "running", "stopping"):
+            run = Run(run_id="x", status=s)
+            assert run.is_active is True
+            assert run.is_terminal is False
+
+    def test_is_active_false_once_stopped_or_crashed(self):
+        for s in ("stopped", "crashed"):
+            run = Run(run_id="x", status=s)
+            assert run.is_active is False
+            assert run.is_terminal is True
+
+    def test_prefix(self):
+        assert Run.get_prefix() == "run__"
+
+    def test_arrow_schema_is_materializable(self):
+        schema = Run.to_pyarrow_schema()
+        assert isinstance(schema, pa.Schema)
+        required = {
+            "run_id",
+            "experiment_name",
+            "vm_name",
+            "status",
+            "harness",
+            "repo_url",
+            "branch",
+            "task",
+            "started_at_ms",
+            "finished_at_ms",
+            "agent_name",
+            "workspace_path",
+            "commit_hash",
+        }
+        assert required.issubset(set(schema.names))
+
+    def test_no_eval_or_reward_fields(self):
+        # Run holds facts only. Evaluation lives in Result.
+        for forbidden in (
+            "metric",
+            "metric_name",
+            "value",
+            "score",
+            "beats_frontier",
+            "direction",
+            "reward",
+        ):
+            assert forbidden not in Run.model_fields
+
+
+class TestResultComponent:
+    def test_is_archetype_component(self):
+        assert issubclass(Result, Component)
+
+    def test_default_construction(self):
+        result = Result()
+        assert result.run_id == ""
+        assert result.evaluator == ""
+        assert result.outputs_json == "{}"
+        assert result.evaluated_at_ms == 0
+
+    def test_make_with_scalar_metric(self):
+        result = Result.make(
+            run_id="run-1",
+            evaluator="pytest",
+            outputs={"pass_rate": 0.92, "total": 500, "passed": 460},
+        )
+        assert result.run_id == "run-1"
+        assert result.evaluator == "pytest"
+        assert result.get_outputs()["pass_rate"] == 0.92
+        assert result.evaluated_at_ms > 0
+
+    def test_make_with_pareto_point(self):
+        # Multi-objective: user puts a point or front in outputs.
+        result = Result.make(
+            run_id="run-1",
+            evaluator="multi-obj",
+            outputs={
+                "pareto_point": [0.92, 0.78, 12.4],
+                "axes": ["pass_rate", "coverage", "build_time_s"],
+            },
+        )
+        assert result.get_outputs()["pareto_point"] == [0.92, 0.78, 12.4]
+
+    def test_make_with_llm_judge_verdict(self):
+        result = Result.make(
+            run_id="run-1",
+            evaluator="llm-judge-claude-4-6",
+            outputs={
+                "verdict": "better",
+                "confidence": 0.85,
+                "reasoning": "Handles an edge case the baseline missed",
+            },
+        )
+        assert result.get_outputs()["verdict"] == "better"
+
+    def test_multiple_results_per_run_are_independent(self):
+        # Same run_id, different evaluator — multiple Results per run
+        # are supported so different eval harnesses can score the same
+        # run independently.
+        r1 = Result.make(run_id="run-1", evaluator="pytest", outputs={"pass_rate": 0.92})
+        r2 = Result.make(run_id="run-1", evaluator="ruff", outputs={"errors": 3})
+        r3 = Result.make(run_id="run-1", evaluator="llm-judge", outputs={"verdict": "ok"})
+        assert r1.run_id == r2.run_id == r3.run_id
+        assert r1.evaluator != r2.evaluator != r3.evaluator
+        assert r1.get_outputs() != r2.get_outputs()
+
+    def test_prefix(self):
+        assert Result.get_prefix() == "result__"
+
+    def test_no_reward_fields(self):
+        for forbidden in ("metric_name", "value", "beats_frontier", "score"):
+            assert forbidden not in Result.model_fields
+
+
+class TestBranchHeadComponent:
+    def test_is_archetype_component(self):
+        assert issubclass(BranchHead, Component)
+
+    def test_default_construction(self):
+        head = BranchHead()
+        assert head.experiment_name == ""
+        assert head.commit_hash == ""
+        assert head.run_id == ""
+        assert head.descriptor_json == "{}"
+        assert head.updated_at_ms == 0
+
+    def test_make_with_scalar_descriptor(self):
+        head = BranchHead.make(
+            experiment_name="exp",
+            commit_hash="abc123",
+            run_id="run-1",
+            descriptor={"test_pass_rate": 0.92},
+        )
+        assert head.experiment_name == "exp"
+        assert head.commit_hash == "abc123"
+        assert head.get_descriptor()["test_pass_rate"] == 0.92
+        assert head.updated_at_ms > 0
+
+    def test_make_with_pareto_descriptor(self):
+        head = BranchHead.make(
+            experiment_name="exp",
+            commit_hash="abc",
+            run_id="run-1",
+            descriptor={
+                "pareto_point": [0.92, 0.78, 12.4],
+                "dominates": ["run-prior-1", "run-prior-2"],
+            },
+        )
+        assert head.get_descriptor()["dominates"] == ["run-prior-1", "run-prior-2"]
+
+    def test_make_with_llm_verdict_descriptor(self):
+        head = BranchHead.make(
+            experiment_name="exp",
+            commit_hash="abc",
+            run_id="run-1",
+            descriptor={
+                "judge": "claude-4-6",
+                "verdict": "better than baseline",
+                "reasoning": "Handles null path correctly",
+            },
+        )
+        assert head.get_descriptor()["verdict"] == "better than baseline"
+
+    def test_initial_seed_has_no_run_id(self):
+        # Before any runs have happened, the head is seeded from the
+        # branch's actual git HEAD. run_id is "" for this seed state.
+        head = BranchHead.make(
+            experiment_name="exp",
+            commit_hash="initial-branch-head",
+        )
+        assert head.run_id == ""
+
+    def test_prefix(self):
+        assert BranchHead.get_prefix() == "branchhead__"
+
+    def test_no_frontier_value_or_metric_fields(self):
+        # The redesign deliberately omits scoring semantics at the
+        # Component level. descriptor_json is where user scoring lives.
+        for forbidden in (
+            "frontier_value",
+            "metric_name",
+            "direction",
+            "value",
+            "score",
+        ):
+            assert forbidden not in BranchHead.model_fields
+
+
+class TestComponentDiscovery:
+    def test_discoverable_by_name(self):
+        # Component.get_type_by_name walks __subclasses__, so importing
+        # the module is enough to register. No explicit registry.
+        for name in ("Experiment", "Run", "Result", "BranchHead"):
+            resolved = Component.get_type_by_name(name)
+            assert resolved.__name__ == name
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(ValueError, match="not found"):
+            Component.get_type_by_name("NotAComponent")
+
+    def test_prefixed_schemas_do_not_collide(self):
+        prefixes = {
+            Experiment.get_prefix(),
+            Run.get_prefix(),
+            Result.get_prefix(),
+            BranchHead.get_prefix(),
+        }
+        assert len(prefixes) == 4  # all distinct

--- a/tests/experiments/test_loaders.py
+++ b/tests/experiments/test_loaders.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for archetype-runner state.db ingestion."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from archetype.experiments import Run
+from archetype.experiments.loaders import _iso_to_ms, load_runner_state_db
+
+
+def _make_runner_state_db(
+    tmp_path: Path,
+    rows: list[tuple] | None = None,
+) -> Path:
+    """Build a SQLite file with the exact schema archetype-runner uses.
+
+    Mirrors src/runner/state.py's CREATE TABLE so that ingestion round
+    trips through the same schema the runner actually writes.
+    """
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            agent_id TEXT PRIMARY KEY,
+            vm_name TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'booting',
+            harness TEXT NOT NULL,
+            repo_url TEXT NOT NULL,
+            branch TEXT NOT NULL,
+            task TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            finished_at TEXT,
+            agent_name TEXT NOT NULL DEFAULT '',
+            workspace_path TEXT NOT NULL DEFAULT ''
+        )
+        """
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO agents VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestIsoToMs:
+    def test_parses_utc_iso_string(self):
+        ms = _iso_to_ms("2026-04-10T12:00:00+00:00")
+        # 2026-04-10T12:00:00 UTC = 1_775_822_400_000 ms since epoch
+        assert ms == 1_775_822_400_000
+
+    def test_none_becomes_zero(self):
+        assert _iso_to_ms(None) == 0
+
+    def test_empty_string_becomes_zero(self):
+        assert _iso_to_ms("") == 0
+
+
+class TestLoadRunnerStateDb:
+    def test_raises_when_file_missing(self, tmp_path):
+        missing = tmp_path / "does-not-exist.db"
+        with pytest.raises(FileNotFoundError, match="state.db not found"):
+            load_runner_state_db(missing)
+
+    def test_empty_db_returns_empty_list(self, tmp_path):
+        db_path = _make_runner_state_db(tmp_path)
+        runs = load_runner_state_db(db_path)
+        assert runs == []
+
+    def test_single_running_agent(self, tmp_path):
+        db_path = _make_runner_state_db(
+            tmp_path,
+            rows=[
+                (
+                    "claude-001",
+                    "mb-vm-1",
+                    "running",
+                    "claude-code",
+                    "https://github.com/foo/bar",
+                    "main",
+                    "Make all tests pass",
+                    "2026-04-10T12:00:00+00:00",
+                    None,  # still running → finished_at is NULL
+                    "adhoc-claude-code",
+                    "/home/vangelis/.archetype-runner/workspaces/claude-001",
+                ),
+            ],
+        )
+        runs = load_runner_state_db(db_path)
+        assert len(runs) == 1
+        run = runs[0]
+        assert isinstance(run, Run)
+        assert run.run_id == "claude-001"
+        assert run.vm_name == "mb-vm-1"
+        assert run.status == "running"
+        assert run.is_active is True
+        assert run.harness == "claude-code"
+        assert run.repo_url == "https://github.com/foo/bar"
+        assert run.branch == "main"
+        assert run.task == "Make all tests pass"
+        assert run.started_at_ms == 1_775_822_400_000
+        assert run.finished_at_ms == 0  # NULL → 0
+        assert run.agent_name == "adhoc-claude-code"
+        assert run.workspace_path.endswith("claude-001")
+
+    def test_completed_agent_has_finished_timestamp(self, tmp_path):
+        db_path = _make_runner_state_db(
+            tmp_path,
+            rows=[
+                (
+                    "claude-002",
+                    "mb-vm-2",
+                    "stopped",
+                    "claude-code",
+                    "https://github.com/foo/bar",
+                    "main",
+                    "task",
+                    "2026-04-10T12:00:00+00:00",
+                    "2026-04-10T12:30:00+00:00",
+                    "adhoc-claude-code",
+                    "/ws/claude-002",
+                ),
+            ],
+        )
+        runs = load_runner_state_db(db_path)
+        assert len(runs) == 1
+        run = runs[0]
+        assert run.status == "stopped"
+        assert run.is_active is False
+        assert run.is_terminal is True
+        assert run.started_at_ms == 1_775_822_400_000
+        assert run.finished_at_ms == 1_775_822_400_000 + 30 * 60 * 1000
+
+    def test_multiple_agents_sorted_by_started_at(self, tmp_path):
+        db_path = _make_runner_state_db(
+            tmp_path,
+            rows=[
+                # Insert in wrong order on purpose — loader must sort by started_at ASC
+                (
+                    "third",
+                    "vm-3",
+                    "running",
+                    "hermes",
+                    "r",
+                    "main",
+                    "t3",
+                    "2026-04-10T14:00:00+00:00",
+                    None,
+                    "",
+                    "",
+                ),
+                (
+                    "first",
+                    "vm-1",
+                    "stopped",
+                    "claude-code",
+                    "r",
+                    "main",
+                    "t1",
+                    "2026-04-10T12:00:00+00:00",
+                    "2026-04-10T12:15:00+00:00",
+                    "",
+                    "",
+                ),
+                (
+                    "second",
+                    "vm-2",
+                    "crashed",
+                    "opencode",
+                    "r",
+                    "main",
+                    "t2",
+                    "2026-04-10T13:00:00+00:00",
+                    "2026-04-10T13:05:00+00:00",
+                    "",
+                    "",
+                ),
+            ],
+        )
+        runs = load_runner_state_db(db_path)
+        assert [r.run_id for r in runs] == ["first", "second", "third"]
+        assert [r.harness for r in runs] == ["claude-code", "opencode", "hermes"]
+
+    def test_loader_opens_readonly_and_coexists_with_writer(self, tmp_path):
+        # Sanity: the read-only URI mode should not block a concurrent
+        # writer and should not crash on an active connection.
+        db_path = _make_runner_state_db(
+            tmp_path,
+            rows=[
+                (
+                    "x",
+                    "v",
+                    "running",
+                    "claude-code",
+                    "r",
+                    "main",
+                    "t",
+                    "2026-04-10T12:00:00+00:00",
+                    None,
+                    "",
+                    "",
+                ),
+            ],
+        )
+        # Open a writer connection with WAL mode (what runner does).
+        writer = sqlite3.connect(str(db_path))
+        writer.execute("PRAGMA journal_mode=WAL")
+        try:
+            runs = load_runner_state_db(db_path)
+            assert len(runs) == 1
+            assert runs[0].run_id == "x"
+        finally:
+            writer.close()
+
+    def test_all_five_run_statuses_round_trip(self, tmp_path):
+        # Asserts that every runner status string deserializes into a
+        # Run without translation and that is_active / is_terminal
+        # classifies them correctly.
+        rows = [
+            (
+                sid,
+                "vm",
+                status,
+                "h",
+                "r",
+                "main",
+                "t",
+                "2026-04-10T12:00:00+00:00",
+                None
+                if status in ("booting", "running", "stopping")
+                else "2026-04-10T13:00:00+00:00",
+                "",
+                "",
+            )
+            for sid, status in [
+                ("a", "booting"),
+                ("b", "running"),
+                ("c", "stopping"),
+                ("d", "stopped"),
+                ("e", "crashed"),
+            ]
+        ]
+        db_path = _make_runner_state_db(tmp_path, rows=rows)
+        runs = load_runner_state_db(db_path)
+        by_status = {r.status: r for r in runs}
+        assert by_status["booting"].is_active is True
+        assert by_status["running"].is_active is True
+        assert by_status["stopping"].is_active is True
+        assert by_status["stopped"].is_terminal is True
+        assert by_status["crashed"].is_terminal is True


### PR DESCRIPTION
## Summary

Introduces `src/archetype/experiments/` — first-class archetype Components for autoresearch lifecycle state, plus a direct-ingestion loader that reads [archetype-runner](https://github.com/VangelisTech/archetype-runner)'s SQLite registry and spawns one entity per run into an archetype world.

The shift from plain Pydantic models (the previous revision) to ECS Components is the whole point: **experiment tracking is rooted in the engine**. Runs are entities in an archetype world, which means world forking, time-travel queries, and every other ECS primitive applies to experiment state the same way it applies to any simulation. The autoresearch loop becomes just another simulation.

## The Components

All four extend `archetype.core.component.Component` → `LanceModel` and follow the Trajectory conventions (scalar defaults, `_json` suffix for complex fields, `*_at_ms` for timestamps):

| Component | Purpose | Key fields |
|---|---|---|
| `Experiment` | The setup — a family of runs | `name`, `repo_url`, `branch`, `metadata_json` |
| `Run` | One attempt; mirrors runner's `AgentRecord` | `run_id`, `vm_name`, `status`, `harness`, `task`, `started_at_ms`, `finished_at_ms`, `commit_hash` |
| `Result` | Opaque eval envelope | `run_id`, `evaluator`, `outputs_json` |
| `BranchHead` | Persisted "current best commit" | `experiment_name`, `commit_hash`, `descriptor_json` |

### Deliberate omissions

No `metric_name`, `direction`, `frontier_value`, or `beats_frontier` fields anywhere. The library **stores runs; scoring is the user's problem**. A scalar autoresearch user writes `{"pass_rate": 0.92}` into `descriptor_json`; a multi-objective user writes `{"pareto_point": [0.92, 0.78, 12.4]}`; an LLM-judge user writes `{"verdict": "better", "reasoning": "..."}`. The library persists whichever shape the user chooses and interprets none of it.

Guard tests (`test_no_metric_or_direction_fields`, `test_no_eval_or_reward_fields`, `test_no_reward_fields`, `test_no_frontier_value_or_metric_fields`) lock this design in. Any future regression that re-introduces a named metric field fails loudly and forces a design discussion.

### Run shape matches runner's AgentRecord

`Run`'s field names and types are chosen to mirror [archetype-runner's existing `AgentRecord` dataclass](https://github.com/VangelisTech/archetype-runner/blob/main/src/runner/state.py) exactly. That means the runner's SQLite rows deserialize into `Run` components **without translation** (aside from `agent_id` → `run_id` rename and ISO timestamp → Unix ms conversion, both handled in the loader).

## Ingestion path

`src/archetype/experiments/loaders.py` provides the direct SQLite → Components → world.create_entity pipeline, following `scripts/ingest_claude_sessions.py` as the canonical pattern:

```python
from archetype.experiments import ingest_runner_state

# Ingest all runs from ~/.archetype-runner/state.db
count = await ingest_runner_state(world)

# Or explicit path
count = await ingest_runner_state(world, "/path/to/state.db")

# Lower-level: just read, don't spawn
from archetype.experiments import load_runner_state_db
runs: list[Run] = load_runner_state_db("/path/to/state.db")
```

The loader opens the SQLite in URI read-only mode so it coexists with a live runner that has the DB open for writes (runner uses WAL mode). No CommandBroker / no RBAC — runner's registry is a trusted internal source, and direct `world.create_entity(...)` calls match how `ingest_claude_sessions.py` does it.

## Tests

48 new tests across two files, all green:

**tests/experiments/test_components.py** (29 tests)
- `issubclass(X, Component)` checks for all four
- Default construction (partial rows from storage must deserialize cleanly)
- `to_pyarrow_schema()` materialization (the Component → Arrow path)
- `get_prefix()` convention (`experiment__`, `run__`, `result__`, `branchhead__`, all distinct)
- `make()` convenience constructors that JSON-encode dict payloads
- Round-trip getters (`get_metadata`, `get_outputs`, `get_descriptor`)
- `Component.get_type_by_name` discovery for all four
- Guard tests locking out reward/metric fields

**tests/experiments/test_loaders.py** (19 tests)
- ISO-8601 → Unix ms parser (`_iso_to_ms`)
- `FileNotFoundError` on missing SQLite
- Empty DB returns `[]`
- Single running agent, completed agent with `finished_at`
- Multi-row ordering by `started_at ASC` (not insertion order)
- Read-only coexistence with a concurrent WAL writer
- All five `RunStatus` values round-trip correctly

**Full CI:** 356 tests passing, coverage 81.02% (threshold 70%).

## What's unchanged

The `make test-mod MOD=path/` target added earlier in the PR is preserved in its own commit (`b1d8665`).

## Follow-up PRs (not this one)

1. Tapes SQLite → Daft trajectory table loader (join target for `Run.run_id`)
2. Fleet processors: `FleetBootProcessor`, `FleetPollProcessor`, `FrontierProcessor` for parallel autoresearch
3. Runner-side adoption: replace standalone `AgentRecord` dataclass with `archetype.experiments.Run`, persist frontier state via `BranchHead`
4. `RunCandidateComponent` + processor that drives new runs from PENDING rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)