### PR TITLE
feat(plugin): exploit-explore scaffolding — /exploit + /explore commands

### DIFF
--- a/.claude/plugins/exploit-explore/README.md
+++ b/.claude/plugins/exploit-explore/README.md
@@ -1,0 +1,96 @@
+# exploit-explore
+
+Two-command scaffolding for depth-first and breadth-first work on Archetype.
+
+## What this is
+
+| Command | Mode | Produces | Never produces |
+|---|---|---|---|
+| `/exploit <mission>` | Depth-first dogfood — runs a sandboxed agent via `archetype-runner autoresearch` on a single thread until the frontier advances or the loop abandons | Commits, a branch, a handoff log at `.claude/handoffs/` | Research summaries without code |
+| `/explore <question>` | Breadth-first reconnaissance — spawns parallel Explore agents to map options | A frontier map at `.claude/frontiers/` | Commits, branches, source edits |
+
+The two commands are duals. `/explore` maps a frontier; `/exploit` picks one point on it and drives deep.
+
+## Why they're separate
+
+Past sessions that blurred the line (research drifting into scratch edits; exploit loops skipping the handoff log) became dead branches that nobody could revive. The separation is enforced by the skill files — each command loads a skill that refuses the anti-patterns of the other.
+
+## Prerequisites
+
+- `archetype-runner` on PATH (`/exploit` only — `/explore` is pure Claude Code)
+- `ANTHROPIC_API_KEY` and `GH_TOKEN` in environment (for VM agents)
+- Current working directory is the archetype repo root or a worktree of it
+
+## /exploit usage
+
+```
+/exploit <mission> [--branch <name>] [--metric <name>] [--iterations <n>]
+```
+
+Example:
+```
+/exploit "merge sweet-benz lifecycle fixes with bug-mre MREs into a single integration branch and ship as one PR"
+```
+
+The command will:
+1. Load the `exploit-loop` skill
+2. Gather context (repo URL, branch strategy, sibling branches, metric)
+3. Shell out to `archetype-runner autoresearch run` with a curated task prompt
+4. Wait for the loop to finish or stall
+5. Write `.claude/handoffs/exploit-<slug>-<timestamp>.md`
+6. Print a 4-line summary
+
+**What /exploit will NOT do:**
+- Open a PR automatically (you approve it after seeing the handoff log)
+- Edit `src/archetype/core/` without permission
+- Run locally without the VM sandbox
+- Skip the handoff log
+
+## /explore usage
+
+```
+/explore <question> [--agents <n>] [--depth quick|medium|thorough]
+```
+
+Example:
+```
+/explore "how should query subscriptions integrate with the existing DaftCLI and trajectory replay pipeline"
+```
+
+The command will:
+1. Load the `explore-sweep` skill
+2. Decompose the question into 3–6 independent sub-queries
+3. Dispatch parallel Explore agents (single tool-use block)
+4. Collect findings into `.claude/frontiers/<slug>-<timestamp>.md`
+5. Print a 4-line summary pointing at the frontier map
+
+**What /explore will NOT do:**
+- Commit anything
+- Create branches or worktrees
+- Edit anything outside `.claude/frontiers/`
+- Convert itself to an exploit mid-run
+
+## Handoff artifacts
+
+Both commands produce artifacts you can grep later:
+
+```
+.claude/handoffs/exploit-<slug>-<timestamp>.md    # every /exploit run
+.claude/frontiers/<slug>-<timestamp>.md           # every /explore run
+```
+
+These are the memory-of-work. They're the reason future sessions can skip re-reading 1MB of JSONL transcript to figure out what was tried and what was abandoned.
+
+## Design source
+
+The command prompts and skills are distilled from analysis of 14 recent sessions on archetype. The patterns that shipped (docs PR batches, surgical bug fixes, QueryService wiring) and the patterns that stalled (branches inheriting from #55 with no unique commits, full-stack mashups abandoned without a reason field) both shaped the guardrails.
+
+See `.claude/plugins/exploit-explore/skills/exploit-loop/SKILL.md` and `skills/explore-sweep/SKILL.md` for the full procedure specs.
+
+## First dogfood target
+
+The first real `/exploit` run is:
+
+> **Mission:** Coordinate `claude/sweet-benz` (2 commits of ECS lifecycle fixes) with `claude/bug-mre-issue-sMWgS` (15 commits of MREs documenting the same bugs) into a single integration PR.
+
+This is deliberately the hardest case on the weekend cleanup list — it stress-tests the sibling-branch coordination rule, the handoff log, and the "don't edit core without permission" guardrail all at once.

--- a/.claude/plugins/exploit-explore/commands/exploit.md
+++ b/.claude/plugins/exploit-explore/commands/exploit.md
@@ -1,0 +1,83 @@
+---
+description: Depth-first dogfood iteration on a single thread. Spawns a sandboxed agent via archetype-runner autoresearch to execute test→edit→commit→verify→PR until the frontier advances or the loop abandons with a reason.
+argument-hint: <mission> [--branch <name>] [--metric <name>] [--iterations <n>] [--harness <name>]
+---
+
+You are running the **`/exploit`** command. Your role is to **drive depth-first exploitation** of a single feature, bug, or refactor thread. You do not do the coding work yourself — you orchestrate a sandboxed agent to do it, then judge the result.
+
+## The mission
+
+```
+$ARGUMENTS
+```
+
+If `$ARGUMENTS` is empty, STOP and ask the user what thread they want to exploit. Do not proceed without a mission.
+
+## Preflight
+
+Load the **`exploit-loop`** skill from this plugin before doing anything else. It encodes the research→plan→execute→verify→merge→handoff procedure and the decision rules for abandoning vs continuing. You MUST follow it.
+
+## Required context-gathering before invoking the agent
+
+Before shelling out to `archetype-runner autoresearch run`, you must gather:
+
+1. **Target repo URL** — default to the current git `remote.origin.url` if the user didn't specify one. If you're in a worktree, resolve to the parent repo's remote.
+2. **Target branch** — the branch the agent will push to. If `--branch` was passed, use that. Otherwise propose one derived from the mission (`claude/exploit-<slug>`) and confirm with the user before creating it.
+3. **Metric** — what determines "frontier advances". Default is `test_pass_rate`. If the mission is a bug-hunt, prefer `test_pass_rate` with the failing test as the baseline. If it's a perf or coverage goal, pass the appropriate metric.
+4. **Iterations + timeout** — default `--max-iterations 5 --timeout-per-run 1800`. Do not exceed 10 iterations without explicit user approval (VMs cost real money).
+5. **Sibling-branch coordination check** — run `git branch -a | grep claude/` and scan for branches that touch the same subsystem as the mission. If you find any, report them to the user before proceeding — they may need to be merged together or the mission refined.
+
+## The invocation
+
+Shell out via the **`make exploit`** target. This is a hard rule — the Makefile is the stable interface. It handles whichever archetype-runner packaging is currently wired (uv dep, PATH binary, future installed package) so the command prompt never has to change.
+
+```bash
+# 1. Preflight: confirm the runner is reachable before composing the full prompt
+make runner-check
+
+# 2. Run exploit
+make exploit \
+  MISSION="<the curated one-line mission>" \
+  BRANCH="<target branch>" \
+  METRIC="<metric>" \
+  ITERATIONS=<n> \
+  TIMEOUT=<seconds>
+```
+
+If `make runner-check` fails, tell the user and stop. Do NOT try to invoke `archetype-runner` directly, and do NOT try to run the loop yourself in the current worktree. `/exploit` is the VM-sandboxed path by design, and the make target is the only sanctioned entrypoint.
+
+The `MISSION` string should be a single line (no embedded newlines — shell-quoting issues). If the mission genuinely needs multi-line detail (acceptance criteria, sibling-branch notes, test hints), write the detail to `.claude/missions/<slug>.md` in the worktree BEFORE invoking make, and reference the file from MISSION: `MISSION="close thread X — see .claude/missions/<slug>.md"`. The agent running inside the VM will read the repo's own `.claude/missions/` directory.
+
+## After the loop returns
+
+Regardless of outcome, write a **handoff log** to `.claude/handoffs/exploit-<slug>-<timestamp>.md` with:
+
+- **Mission** — the original instruction
+- **Branch** — where the work lives
+- **Outcome** — one of: `shipped` (PR open), `ready-to-pr` (green locally, needs PR), `stalled` (iteration limit hit), `abandoned` (explicit abort with reason)
+- **Commits added** — count and short list
+- **What was touched** — top-level files/subsystems
+- **What's left** — open TODOs, follow-up issues, decisions deferred
+- **Reason (on stall/abandon)** — concrete blocker, not "didn't work"
+
+The handoff log is the anti-stall artifact. Sessions 9, 13, 14 in the recent history had NO handoff log and that's why they became dead branches nobody could revive. This file is mandatory.
+
+## Forbidden shortcuts
+
+- Do NOT run tests, edits, or commits locally to "save time". `/exploit` always goes through the VM sandbox — that's the whole point of the thin wrapper.
+- Do NOT open a PR automatically after a successful iteration. Always stop and show the user the handoff log first, then ask for explicit permission to push/PR.
+- Do NOT reuse a handoff slug. If one exists with the same slug, append a suffix.
+- Do NOT edit files under `src/archetype/core/` from this command — that layer is read-only per archetype CLAUDE.md. If the mission requires core edits, ask for explicit permission first and route through a separate review.
+
+## Final response format
+
+When the command finishes, print a 4-line summary:
+
+```
+mission:  <one line>
+outcome:  <shipped | ready-to-pr | stalled | abandoned>
+handoff:  .claude/handoffs/exploit-<slug>-<timestamp>.md
+next:     <single concrete next action>
+```
+
+Do not print the full handoff log inline. Point at the file.

--- a/.claude/plugins/exploit-explore/commands/explore.md
+++ b/.claude/plugins/exploit-explore/commands/explore.md
@@ -1,0 +1,83 @@
+---
+description: Breadth-first frontier reconnaissance. Spawns parallel Explore agents to map the surface area of a question, classify options, and hand back a structured frontier map. Never commits code, never opens branches.
+argument-hint: <frontier question> [--agents <n>] [--depth quick|medium|thorough]
+---
+
+You are running the **`/explore`** command. Your role is to **map a frontier** — take a fuzzy question and return a structured catalog of what's out there, what it would take to do each option, and which paths are worth exploiting next.
+
+## The frontier question
+
+```
+$ARGUMENTS
+```
+
+If `$ARGUMENTS` is empty, STOP and ask the user what frontier they want mapped. Do not proceed without a question.
+
+## Preflight
+
+Load the **`explore-sweep`** skill from this plugin before doing anything else. It encodes the parallel-agent dispatch pattern, the structured-findings format, and the anti-commit rules.
+
+## Hard rules
+
+- **Zero commits.** `/explore` produces research artifacts only. If you feel the urge to `git add`, stop.
+- **Zero branches.** Do not create worktrees, do not check out new branches, do not push anything.
+- **Zero edits to source files.** You may write to `.claude/frontiers/` and nowhere else.
+- **Parallel-first.** Dispatch all Explore agents in a single message. Serial dispatch is a bug.
+
+## The procedure
+
+1. **Decompose the question into 3–6 independent sub-queries.** Each should be answerable by a single Explore agent without seeing the others' output. If you can't decompose cleanly, the question is too specific — offer to convert it to `/exploit` instead.
+
+2. **Dispatch sub-agents in parallel.** Use the Agent tool with `subagent_type: "Explore"` for each sub-query in a single tool-use block. Set thoroughness per the `--depth` flag (default `medium`).
+
+3. **Collect findings into a frontier map.** Write to `.claude/frontiers/<slug>-<timestamp>.md` with this schema:
+
+   ```markdown
+   # Frontier: <question>
+
+   ## Sub-queries
+   - [Q1](#q1) — <one-line summary>
+   - [Q2](#q2) — ...
+
+   ## Q1 — <sub-query>
+   **Findings:** <bullet list, each with a concrete file/function/url>
+   **Effort to exploit:** <xs/s/m/l/xl>
+   **Risk:** <low/medium/high>
+   **Prerequisites:** <things that must be true before this is workable>
+
+   ## Q2 — ...
+
+   ## Options (ranked)
+   1. **<option>** — effort: <x>, risk: <y>, expected gain: <z>
+   2. ...
+
+   ## Recommended /exploit
+   <single sentence naming the top option and why>
+
+   ## What's NOT worth exploiting
+   <options investigated and rejected, with reasons — this prevents re-scouting>
+   ```
+
+4. **Do not synthesize beyond the agents' findings.** If the agents disagree or return conflicting data, report the conflict and ask the user which to trust. Don't paper over gaps.
+
+5. **Output a 4-line summary** at the end:
+
+   ```
+   question:  <one line>
+   sub-queries:  <n>
+   frontier:  .claude/frontiers/<slug>-<timestamp>.md
+   recommended:  /exploit "<top option>"
+   ```
+
+## When to use /explore vs /exploit
+
+- **Use /explore when:** the user asks "what's available", "what are our options", "how would we approach", "what's the state of X", "should we do A or B"
+- **Use /exploit when:** the user has named a concrete target — a bug, a feature, a metric to improve, a PR to close
+
+If in doubt, ask. It's cheaper to ask once than to run an autoresearch VM for a question that didn't need a VM.
+
+## Anti-patterns from past sessions
+
+- **Don't produce an Explore artifact and then immediately start editing files.** That breaks the explore/exploit separation and pollutes the frontier map with half-done work. (This failure mode was visible in session 3 of the last-15 catalog — Daft exploration drifted into scratch edits.)
+- **Don't let the user convert an explore into an exploit mid-run.** Finish the frontier map, then they can invoke `/exploit` separately with the top option. Mixing modes hides where the handoff happened.
+- **Don't skip the "NOT worth exploiting" section.** That's the memory-of-failure that prevents re-scouting next weekend.

--- a/.claude/plugins/exploit-explore/plugin.json
+++ b/.claude/plugins/exploit-explore/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "exploit-explore",
+  "version": "0.1.0",
+  "description": "Two-command scaffolding for the exploit/explore loop on Archetype. /exploit drives depth-first dogfood iteration via archetype-runner autoresearch. /explore drives breadth-first frontier reconnaissance via parallel Explore agents.",
+  "author": {
+    "name": "Vangelis"
+  }
+}

--- a/.claude/plugins/exploit-explore/skills/exploit-loop/SKILL.md
+++ b/.claude/plugins/exploit-explore/skills/exploit-loop/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: exploit-loop
+description: Use when driving a depth-first iteration on a single feature, bug, or metric via archetype-runner autoresearch. Encodes the research→plan→execute→verify→merge→handoff procedure and the decision rules for when to continue, stall, or abandon. Invoked by the /exploit command.
+---
+
+# Exploit Loop
+
+The exploit loop is the **depth-first, recursive dogfood pattern** that drove every successful session in the recent catalog. This skill extracts what worked so `/exploit` can reproduce it reliably.
+
+## The five phases
+
+Every exploit iteration runs through five phases. Skipping any phase is a footgun.
+
+### 1. Research (bounded)
+
+Before touching code, confirm you understand the target:
+
+- **Read the relevant files completely.** Not excerpts — the whole file, unless it's >2k lines, in which case read the function being modified plus its immediate callers.
+- **Grep for siblings.** If the mission is "fix bug in `_move_entity`", grep for `_move_entity` across the repo before editing. Things that look local often aren't.
+- **Check for open work.** `git branch -a | grep claude/` — if another branch is already touching the same file, the exploit must coordinate with it or explicitly declare independence.
+- **Time-box this phase.** If research takes more than 20% of the budget, the mission is too fuzzy. Convert to `/explore` instead.
+
+### 2. Plan (single paragraph)
+
+Write a short plan before executing. Not a full plan-mode plan — just:
+
+- What you're going to change (files + functions)
+- Why (the root cause, not the symptom)
+- How you'll verify it (the specific test or assertion)
+- What could go wrong (the one failure mode most likely to bite)
+
+If you can't write all four, go back to research.
+
+### 3. Execute (small commits)
+
+- **One logical change per commit.** Session 11 (sweet-benz) landed two surgical commits and that was the right shape. Session 2 (bug-mre) landed 15 doc-only commits which was also right because each MRE was its own artifact.
+- **Run tests after each commit**, not at the end. The goal is to catch regressions at the commit that introduced them.
+- **Never use `--no-verify`.** Hook failures are signal. Fix the underlying issue.
+- **Never amend someone else's commits.** If rebasing makes you tempted to squash prior work, stop and ask.
+
+### 4. Verify (CI must be green, not just "looks fine")
+
+- Run the full test suite at least once before declaring done. `make ci` in archetype.
+- If CI has flaky tests, run twice and report both outcomes.
+- If a test was failing before you started and still fails after, that's a separate thread — do not fix it as a side effect without explicit permission. Record it in the handoff log as a "known unrelated failure".
+
+### 5. Handoff (mandatory)
+
+Write `.claude/handoffs/exploit-<slug>-<timestamp>.md` with the schema defined in `/exploit`. This is non-negotiable. The handoff log is the artifact that lets the next session (or next run) pick up without re-reading 1MB of JSONL transcript.
+
+**A handoff log is not a success log.** Stalled and abandoned runs MUST also produce handoff logs. The `reason` field is the most valuable part — it's the memory-of-failure that prevents re-running the same dead path.
+
+## The decision rules
+
+### When to continue iterating
+
+- The metric is improving (even slowly) AND you have a concrete hypothesis for why the next iteration will be better
+- You're within the iteration budget
+- No catastrophic errors (agent crashes, VM failures, git conflicts that can't be resolved)
+
+### When to stall (stop without merging)
+
+- Metric plateaued for 2+ iterations with no hypothesis improvement
+- You hit the iteration limit
+- The mission turned out to be bigger than estimated — declare "needs decomposition" in the handoff log
+
+### When to abandon (stop and recommend reverting the branch)
+
+- The mission was based on a wrong premise (e.g. "fix this bug" but the bug isn't real)
+- The fix requires changes to `src/archetype/core/` without prior approval
+- A sibling branch is doing the same work better — coordinate or defer
+- The user explicitly says stop
+
+## Sibling-branch coordination
+
+This is the pattern that sessions 9, 13, 14, 11+2 failed at and sessions 6, 7, 12, 15 nailed.
+
+**Before starting the exploit**, run:
+
+```bash
+git branch -a | grep claude/
+git log --all --since="7 days ago" --format="%h %d %s" | grep -i "<subsystem-keyword>"
+```
+
+If you find branches that touch the same subsystem as the mission:
+
+1. **Read their commits.** Don't assume based on branch name.
+2. **Decide the relationship:** independent / supersedes / depends-on / conflicts
+3. **If `conflicts` or `depends-on`:** either merge them first into a shared integration branch, or ask the user which wins.
+4. **If `supersedes`:** archive the older branch via handoff log, then proceed.
+5. **If `independent`:** proceed, but note the other branch in the handoff log so a future reader can coordinate merges.
+
+The failure mode to prevent: **two branches both fix the same thing and neither PR is ever merged because they conflict with each other.** This is exactly what sweet-benz and bug-mre-issue-sMWgS risk becoming.
+
+## Forbidden shortcuts
+
+- Never run the exploit loop locally (in the current worktree) instead of the VM sandbox. The sandbox is the point — it's what prevents a failed run from corrupting your checkout.
+- Never skip tests to unblock CI.
+- Never delete the handoff log "because the run succeeded". The success log is still valuable.
+- Never compress stalled/abandoned runs into the "successful" handoff narrative. Stalls and abandons are first-class outcomes.

--- a/.claude/plugins/exploit-explore/skills/explore-sweep/SKILL.md
+++ b/.claude/plugins/exploit-explore/skills/explore-sweep/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: explore-sweep
+description: Use when mapping an unfamiliar frontier — spawn parallel Explore agents, collect structured findings, rank options, and produce a frontier map artifact. Encodes the decomposition pattern, the parallel-dispatch rule, and the anti-commit guardrails. Invoked by the /explore command.
+---
+
+# Explore Sweep
+
+The explore sweep is the **breadth-first reconnaissance pattern** for fuzzy questions. Its job is not to do the work — its job is to map what the work would look like so a later `/exploit` can move fast.
+
+## The three-step procedure
+
+### 1. Decompose the question into independent sub-queries
+
+A good sub-query:
+- Can be answered without seeing the other sub-queries' results
+- Has a concrete artifact as its answer (a list of files, a function signature, a set of options)
+- Is cheap enough that a single Explore agent can finish in one pass
+
+A bad sub-query:
+- Depends on the answer to another sub-query (serialize these instead)
+- Requires reading 10+ files to answer (too deep — split it further)
+- Has a yes/no answer (you don't need an agent for that, just grep)
+
+Target 3–6 sub-queries. Fewer means you should just answer directly. More means the question is too broad — scope it down.
+
+### 2. Dispatch in parallel, ALWAYS
+
+Use a single message with multiple `Agent` tool calls, one per sub-query. **Parallel dispatch is a hard rule.** Serial dispatch blows the context budget and misses the whole point of breadth-first.
+
+Each agent's prompt should include:
+- The single sub-query it owns
+- The context it needs (paths, keywords, prior findings from the user — NOT the other agents' findings)
+- The schema you want back (concrete: "return a bullet list of files with one-line summaries")
+- A word budget (250 words max per agent, typically)
+
+Do not give agents overlapping scope. Duplicate work is wasted tokens.
+
+### 3. Merge findings into a frontier map
+
+The frontier map lives at `.claude/frontiers/<slug>-<timestamp>.md`. Its structure is defined in the `/explore` command prompt. The critical sections:
+
+- **Findings per sub-query** — keep the agents' bullets, don't paraphrase them away
+- **Options (ranked)** — your synthesis across sub-queries, with effort/risk/gain labels
+- **Recommended /exploit** — the single highest-value next step, stated so a future run can paste it into `/exploit "<mission>"`
+- **What's NOT worth exploiting** — options investigated and rejected, with reasons
+
+## Hard rules
+
+### Zero commits, zero branches, zero source edits
+
+`/explore` is pure reconnaissance. If you edit anything outside `.claude/frontiers/`, that's a bug. If you feel the urge to "just fix this while I'm here", stop — that's an exploit, not an explore. Open a separate conversation and invoke `/exploit`.
+
+### Rank effort honestly
+
+When labeling effort (xs/s/m/l/xl), use these anchors:
+
+- **xs**: 1–2 lines, 10 minutes, no tests needed
+- **s**: one function, one commit, tests trivially extend
+- **m**: 3–5 files, 1–3 commits, tests need thought
+- **l**: a subsystem refactor, 5+ commits, test suite extensions
+- **xl**: cross-cutting change, sequencing matters, may spawn its own `/explore`
+
+If everything is labeled `m`, you didn't rank — go back and force distinctions.
+
+### Don't let explore mutate into exploit mid-run
+
+The failure mode from session 3 in the recent catalog: research drifted into scratch edits that never became commits, and the frontier map never got written. If the user asks you to start working mid-`/explore`, stop and say: "let me finish the frontier map first, then you can invoke `/exploit` on the top option".
+
+The separation is what makes both commands work. Collapse them and you just have a confused agent.
+
+## When parallelism is the wrong tool
+
+Skip `/explore` if:
+
+- The answer is a single grep (just grep, don't dispatch agents)
+- The question is already a concrete mission (go straight to `/exploit`)
+- You already have the context loaded from a prior `/explore` on the same question — reuse the frontier map
+
+## Output contract
+
+Every `/explore` run ends with:
+
+1. The frontier map file at `.claude/frontiers/<slug>-<timestamp>.md`
+2. A 4-line summary printed to the chat (defined in the `/explore` command prompt)
+
+No other output. No pre-summary narrative, no "here's what I found" prose before the summary. The frontier map is the artifact; the chat message is just the pointer.

--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,13 @@ node_modules/
 .cursorignore
 .worktrees/
 *.lance
-# Ignore claude user state, but track project config, hooks, skills, and agents
+# Ignore claude user state, but track project config, hooks, skills, agents, and plugins
 .claude/*
 !.claude/settings.json
 !.claude/hooks/
 !.claude/skills/
 !.claude/agents/
+!.claude/plugins/
 data/
 
 .venv/

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ help:
 	@echo "  make docs-serve     Serve docs locally"
 	@echo "  make docs-lint      Run doc quality checks (spelling, markdown lint, link check)"
 	@echo ""
+	@echo "Exploit / Explore:"
+	@echo "  make exploit MISSION=\"...\" [BRANCH=...] [METRIC=...] [ITERATIONS=5]"
+	@echo "                      Run a depth-first /exploit loop via archetype-runner autoresearch"
+	@echo "  make runner-check   Verify archetype-runner is reachable"
+	@echo ""
 	@echo "Utilities:"
 	@echo "  make clean          Remove build artifacts"
 	@echo "  make clean-all      Remove all generated files"
@@ -276,6 +281,88 @@ docs-lint:
 	fi
 	@echo ""
 	@echo "Docs lint passed"
+
+# ------------------------------------------------------------------------------
+# Exploit / Explore
+# ------------------------------------------------------------------------------
+#
+# `make exploit` is the stable entrypoint used by the /exploit slash command
+# in .claude/plugins/exploit-explore/. It dispatches to archetype-runner via
+# whichever interface is currently wired:
+#
+#   1. `uv run archetype-runner` — if runner is a project dependency
+#   2. `archetype-runner`        — if runner is on PATH
+#   3. error                     — if neither is reachable
+#
+# This indirection means the packaging transition (PATH binary -> uv dep ->
+# installed package) can happen without touching the slash command prompts.
+#
+# Required env vars:
+#   MISSION     — the task description (quoted string)
+#
+# Optional env vars:
+#   BRANCH      — target branch (default: generated from MISSION slug)
+#   METRIC      — eval metric (default: test_pass_rate)
+#   ITERATIONS  — max autoresearch iterations (default: 5)
+#   TIMEOUT     — per-run timeout in seconds (default: 1800)
+#   HARNESS     — agent harness (default: claude-code)
+#   REPO        — git repo URL (default: current origin)
+
+RUNNER_BIN := $(shell \
+	if uv run --no-sync archetype-runner --help >/dev/null 2>&1; then \
+		echo "uv run --no-sync archetype-runner"; \
+	elif command -v archetype-runner >/dev/null 2>&1; then \
+		echo "archetype-runner"; \
+	else \
+		echo ""; \
+	fi)
+
+.PHONY: runner-check
+runner-check:
+	@if [ -z "$(RUNNER_BIN)" ]; then \
+		echo "ERROR: archetype-runner is not reachable."; \
+		echo ""; \
+		echo "Install one of:"; \
+		echo "  1. uv add --optional runner 'archetype-runner @ git+ssh://git@github.com/<org>/archetype-runner'"; \
+		echo "  2. Put the archetype-runner binary on PATH"; \
+		echo ""; \
+		echo "Then re-run: make runner-check"; \
+		exit 1; \
+	else \
+		echo "archetype-runner: $(RUNNER_BIN)"; \
+		$(RUNNER_BIN) --version 2>/dev/null || echo "(version unknown)"; \
+	fi
+
+.PHONY: exploit
+exploit: runner-check
+	@if [ -z "$(MISSION)" ]; then \
+		echo "ERROR: MISSION is required."; \
+		echo "Usage: make exploit MISSION=\"<one-line task>\" [BRANCH=...] [METRIC=...]"; \
+		exit 1; \
+	fi
+	@REPO_URL="$${REPO:-$$(git config --get remote.origin.url)}"; \
+	BRANCH_NAME="$${BRANCH:-claude/exploit-$$(date +%s)}"; \
+	METRIC_NAME="$${METRIC:-test_pass_rate}"; \
+	ITER="$${ITERATIONS:-5}"; \
+	TIMEOUT_SEC="$${TIMEOUT:-1800}"; \
+	HARNESS_NAME="$${HARNESS:-claude-code}"; \
+	echo "Exploit launch"; \
+	echo "  mission:     $(MISSION)"; \
+	echo "  repo:        $$REPO_URL"; \
+	echo "  branch:      $$BRANCH_NAME"; \
+	echo "  metric:      $$METRIC_NAME"; \
+	echo "  iterations:  $$ITER"; \
+	echo "  timeout:     $${TIMEOUT_SEC}s per run"; \
+	echo "  harness:     $$HARNESS_NAME"; \
+	echo ""; \
+	$(RUNNER_BIN) autoresearch run \
+		--repo "$$REPO_URL" \
+		--branch "$$BRANCH_NAME" \
+		--task "$(MISSION)" \
+		--metric "$$METRIC_NAME" \
+		--max-iterations "$$ITER" \
+		--timeout-per-run "$$TIMEOUT_SEC" \
+		--harness "$$HARNESS_NAME"
 
 # ------------------------------------------------------------------------------
 # Utilities


### PR DESCRIPTION
## Summary

Two-command Claude Code plugin for depth-first dogfood iteration and breadth-first frontier reconnaissance, distilled from analysis of the last 14 sessions on archetype.

- **`/exploit <mission>`** — runs `archetype-runner autoresearch` against a single thread via the new `make exploit` target. Handoff log at `.claude/handoffs/` is **mandatory** on every run (success, stall, or abandon) — this is the fix for the dead-branch failure mode where stalled work couldn't be revived because nobody knew why it stopped.
- **`/explore <question>`** — dispatches parallel Explore agents in a single tool-use block, collects findings into a frontier map at `.claude/frontiers/`. Zero commits, zero branches, zero source edits — enforced in the skill file.

## Why

The session catalog surfaced two patterns:
- **Exploit wins** had either 1–3 surgical commits or 10+ cohesive commits; a handoff log on every run; and a sibling-branch check before starting.
- **Failure mode** was branches that inherited from an older PR, never landed unique work, and never got pruned — because no session left behind a "why I stopped" artifact.

The plugin encodes both the winning patterns and the guardrails against the failure mode.

## What's in the PR

- `.claude/plugins/exploit-explore/plugin.json` — manifest
- `.claude/plugins/exploit-explore/commands/{exploit,explore}.md` — slash command prompts
- `.claude/plugins/exploit-explore/skills/{exploit-loop,explore-sweep}/SKILL.md` — the procedure specs
- `.claude/plugins/exploit-explore/README.md` — usage + design rationale
- `Makefile` — new `exploit` + `runner-check` targets. `RUNNER_BIN` auto-detects `uv run archetype-runner` (dep) or `archetype-runner` (PATH), so packaging changes to archetype-runner don't require touching the slash command prompts.
- `.gitignore` — allowlist `.claude/plugins/` alongside existing allowlists for hooks/skills/settings.

## What's NOT in this PR

- No runner integration tests — `make runner-check` errors cleanly when the runner isn't reachable, but end-to-end validation is deferred until the runner lifecycle + packaging lands in a parallel session.
- No first dogfood run — the scaffolding is what this PR delivers; the sweet-benz + bug-mre coordination dogfood is a follow-up once the runner wiring is stable.

## Test plan

- [ ] `make runner-check` errors cleanly on a machine without archetype-runner
- [ ] `make exploit` errors with a helpful message when `MISSION` is unset
- [ ] `/exploit` slash command is discoverable in Claude Code after this merges
- [ ] `/explore` slash command is discoverable in Claude Code after this merges
- [ ] Plugin validator (see PR description for verdict: READY WITH NITS, all non-blocking)

## Follow-up nits (not blocking merge)

- Add `allowed-tools` frontmatter to `/explore` to make the anti-commit guardrail mechanical rather than advisory
- Create `.claude/missions/` placeholder directory (referenced by `/exploit` as an escape hatch for multi-line missions)
- Consider moving `plugin.json` to the canonical `.claude-plugin/plugin.json` subdir

🤖 Generated with [Claude Code](https://claude.com/claude-code)