### PR TITLE
fix: wire QueryService, add LabelingProcessor tests, harden OpenAPI generator

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -4,116 +4,39 @@
 
 This reference is auto-generated from the FastAPI application's OpenAPI schema. Start the server with `archetype serve` (default: `http://localhost:8000`).
 
-## Worlds
+## Other
 
-### List Worlds
-
-```text
-GET /worlds
-```
-
----
-
-### Create World
+### Root
 
 ```text
-POST /worlds
+GET /
 ```
-
-**Request body:**
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `name` | string \| null | No | — | Name |
-| `storage_uri` | string | No | `"./archetype_data"` | Storage Uri |
-| `namespace` | string | No | `"archetypes"` | Namespace |
-
-**Response** (`200`):
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `world_id` | string | Yes | — | World Id |
-| `name` | string \| null | No | — | Name |
-| `tick` | integer | No | `0` | Tick |
-| `entity_count` | integer | No | `0` | Entity Count |
-
-**Error codes:** `422`
-
----
-
-### Get World
-
-```text
-GET /worlds/{world_id}
-```
-
-**Path parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `world_id` | string |  |
-
-**Response** (`200`):
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `world_id` | string | Yes | — | World Id |
-| `name` | string \| null | No | — | Name |
-| `tick` | integer | No | `0` | Tick |
-| `entity_count` | integer | No | `0` | Entity Count |
-
-**Error codes:** `422`
-
----
-
-### Remove World
-
-```text
-DELETE /worlds/{world_id}
-```
-
-**Path parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `world_id` | string |  |
-
-**Error codes:** `422`
-
----
-
-### Fork World
-
-```text
-POST /worlds/{world_id}/fork
-```
-
-**Path parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `world_id` | string |  |
-
-**Request body:**
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `name` | string \| null | No | — | Name |
-
-**Response** (`200`):
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `world_id` | string | Yes | — | World Id |
-| `name` | string \| null | No | — | Name |
-| `tick` | integer | No | `0` | Tick |
-| `entity_count` | integer | No | `0` | Entity Count |
-
-**Error codes:** `422`
 
 ---
 
 ## Commands
+
+### Get Command History
+
+```text
+GET /worlds/{world_id}/commands
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `world_id` | string |  |
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | `100` |  |
+
+**Error codes:** `422`
+
+---
 
 ### Submit Command
 
@@ -144,28 +67,6 @@ POST /worlds/{world_id}/commands
 | `type` | string | Yes | — | Type |
 | `tick` | integer | Yes | — | Tick |
 | `priority` | integer | Yes | — | Priority |
-
-**Error codes:** `422`
-
----
-
-### Get Command History
-
-```text
-GET /worlds/{world_id}/commands
-```
-
-**Path parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `world_id` | string |  |
-
-**Query parameters:**
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `limit` | integer | `100` |  |
 
 **Error codes:** `422`
 
@@ -209,12 +110,12 @@ GET /worlds/{world_id}/commands/pending
 
 ---
 
-## Simulation
+## Query
 
-### Step World
+### Get Components
 
 ```text
-POST /worlds/{world_id}/step
+GET /worlds/{world_id}/components
 ```
 
 **Path parameters:**
@@ -223,7 +124,96 @@ POST /worlds/{world_id}/step
 |-----------|------|-------------|
 | `world_id` | string |  |
 
-**Request body:**
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `types` | string | `""` |  |
+
+**Error codes:** `422`
+
+---
+
+### Get Entity
+
+```text
+GET /worlds/{world_id}/entities/{entity_id}
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `world_id` | string |  |
+| `entity_id` | integer |  |
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tick` | integer \| null | — |  |
+
+**Error codes:** `422`
+
+---
+
+### Get Command History
+
+```text
+GET /worlds/{world_id}/history
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `world_id` | string |  |
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | `100` |  |
+
+**Error codes:** `422`
+
+---
+
+### Get World State
+
+```text
+GET /worlds/{world_id}/state
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `world_id` | string |  |
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tick` | integer \| null | — |  |
+
+**Error codes:** `422`
+
+---
+
+## Simulation
+
+### List Processors
+
+```text
+GET /worlds/{world_id}/processors
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `world_id` | string |  |
 
 **Error codes:** `422`
 
@@ -262,10 +252,70 @@ POST /worlds/{world_id}/run
 
 ---
 
-### List Processors
+### Step World
 
 ```text
-GET /worlds/{world_id}/processors
+POST /worlds/{world_id}/step
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `world_id` | string |  |
+
+**Request body:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `num_steps` | integer | No | `1` | Num Steps |
+| `debug` | boolean | No | `false` | Debug |
+
+**Error codes:** `422`
+
+---
+
+## Worlds
+
+### List Worlds
+
+```text
+GET /worlds
+```
+
+---
+
+### Create World
+
+```text
+POST /worlds
+```
+
+**Request body:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string \| null | No | — | Name |
+| `storage_uri` | string | No | `"./archetype_data"` | Storage Uri |
+| `namespace` | string | No | `"archetypes"` | Namespace |
+
+**Response** (`200`):
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `world_id` | string | Yes | — | World Id |
+| `name` | string \| null | No | — | Name |
+| `tick` | integer | No | `0` | Tick |
+| `entity_count` | integer | No | `0` | Entity Count |
+
+**Error codes:** `422`
+
+---
+
+### Remove World
+
+```text
+DELETE /worlds/{world_id}
 ```
 
 **Path parameters:**
@@ -278,12 +328,10 @@ GET /worlds/{world_id}/processors
 
 ---
 
-## Query
-
-### Get World State
+### Get World
 
 ```text
-GET /worlds/{world_id}/state
+GET /worlds/{world_id}
 ```
 
 **Path parameters:**
@@ -292,43 +340,23 @@ GET /worlds/{world_id}/state
 |-----------|------|-------------|
 | `world_id` | string |  |
 
-**Query parameters:**
+**Response** (`200`):
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `tick` | string | — |  |
-
-**Error codes:** `422`
-
----
-
-### Get Entity
-
-```text
-GET /worlds/{world_id}/entities/{entity_id}
-```
-
-**Path parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `world_id` | string |  |
-| `entity_id` | integer |  |
-
-**Query parameters:**
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `tick` | string | — |  |
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `world_id` | string | Yes | — | World Id |
+| `name` | string \| null | No | — | Name |
+| `tick` | integer | No | `0` | Tick |
+| `entity_count` | integer | No | `0` | Entity Count |
 
 **Error codes:** `422`
 
 ---
 
-### Get Components
+### Fork World
 
 ```text
-GET /worlds/{world_id}/components
+POST /worlds/{world_id}/fork
 ```
 
 **Path parameters:**
@@ -337,44 +365,21 @@ GET /worlds/{world_id}/components
 |-----------|------|-------------|
 | `world_id` | string |  |
 
-**Query parameters:**
+**Request body:**
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `types` | string | `""` |  |
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string \| null | No | — | Name |
 
-**Error codes:** `422`
+**Response** (`200`):
 
----
-
-### Get Command History
-
-```text
-GET /worlds/{world_id}/history
-```
-
-**Path parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `world_id` | string |  |
-
-**Query parameters:**
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `limit` | integer | `100` |  |
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `world_id` | string | Yes | — | World Id |
+| `name` | string \| null | No | — | Name |
+| `tick` | integer | No | `0` | Tick |
+| `entity_count` | integer | No | `0` | Entity Count |
 
 **Error codes:** `422`
-
----
-
-## Other
-
-### Root
-
-```text
-GET /
-```
 
 ---

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -40,6 +40,28 @@ def resolve_ref(schema: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
     return node
 
 
+def unwrap_optional(
+    schema: dict[str, Any], root: dict[str, Any]
+) -> dict[str, Any]:
+    """Unwrap top-level anyOf/oneOf: pick the non-null option and resolve $ref.
+
+    Optional Pydantic models like ``StepRequest | None`` produce a top-level
+    ``anyOf: [{$ref}, {type: null}]``. For rendering tables we want the
+    underlying object schema.
+    """
+    schema = resolve_ref(schema, root)
+    for key in ("anyOf", "oneOf"):
+        options = schema.get(key)
+        if not options:
+            continue
+        non_null = [
+            opt for opt in options if opt.get("type") != "null"
+        ]
+        if len(non_null) == 1:
+            return unwrap_optional(non_null[0], root)
+    return schema
+
+
 def schema_to_table(
     schema: dict[str, Any], root: dict[str, Any], indent: int = 0
 ) -> list[str]:
@@ -128,7 +150,7 @@ def render_operation(
         lines.append("|-----------|------|-------------|")
         for p in path_params:
             schema = p.get("schema", {})
-            typ = schema.get("type", "string")
+            typ = _type_label(schema, root)
             desc = p.get("description", "")
             lines.append(f"| `{p['name']}` | {typ} | {desc} |")
         lines.append("")
@@ -140,7 +162,7 @@ def render_operation(
         lines.append("|-----------|------|---------|-------------|")
         for p in query_params:
             schema = p.get("schema", {})
-            typ = schema.get("type", "string")
+            typ = _type_label(schema, root)
             default = schema.get("default", "—")
             if default != "—":
                 default = f"`{json.dumps(default)}`"
@@ -155,29 +177,31 @@ def render_operation(
         json_content = content.get("application/json", {})
         body_schema = json_content.get("schema", {})
         if body_schema:
-            resolved = resolve_ref(body_schema, root)
-            lines.append("**Request body:**")
-            lines.append("")
+            resolved = unwrap_optional(body_schema, root)
             table = schema_to_table(resolved, root)
             if table:
+                lines.append("**Request body:**")
+                lines.append("")
                 lines.extend(table)
                 lines.append("")
 
-    # Responses — prefer 200, else lowest numeric 2xx for deterministic output
+    # Responses — prefer the lowest numeric 2xx for deterministic output
     responses = operation.get("responses", {})
-    success_codes = sorted(c for c in responses if c.startswith("2"))
-    if success_codes:
-        code = "200" if "200" in success_codes else success_codes[0]
+    numeric_2xx = sorted(
+        c for c in responses if c.isdigit() and 200 <= int(c) < 300
+    )
+    if numeric_2xx:
+        code = numeric_2xx[0]
         resp = responses[code]
         resp_content = resp.get("content", {})
         json_resp = resp_content.get("application/json", {})
         resp_schema = json_resp.get("schema", {})
         if resp_schema:
-            resolved = resolve_ref(resp_schema, root)
-            lines.append(f"**Response** (`{code}`):")
-            lines.append("")
+            resolved = unwrap_optional(resp_schema, root)
             table = schema_to_table(resolved, root)
             if table:
+                lines.append(f"**Response** (`{code}`):")
+                lines.append("")
                 lines.extend(table)
                 lines.append("")
 
@@ -217,10 +241,12 @@ def generate() -> str:
                 tag = tags[0] if tags else "Other"
                 tag_groups.setdefault(tag, []).append((method, path, operation))
 
-    for tag, operations in tag_groups.items():
+    for tag, operations in sorted(tag_groups.items(), key=lambda kv: kv[0]):
         lines.append(f"## {tag.title()}")
         lines.append("")
-        for method, path, operation in operations:
+        for method, path, operation in sorted(
+            operations, key=lambda op: (op[1], op[0])
+        ):
             lines.extend(render_operation(method, path, operation, schema))
 
     return "\n".join(lines)

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -10,11 +10,14 @@ All external reads go through here.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from uuid_utils import UUID
 
 from archetype.app.models import Command, WorldSnapshot
+from archetype.core.aio.async_world import AsyncWorld
+from archetype.core.archetype import Archetype
+from archetype.core.component import Component
 
 if TYPE_CHECKING:
     from archetype.app.broker import CommandBroker
@@ -24,24 +27,115 @@ if TYPE_CHECKING:
 class QueryService:
     """
     Read path facade. Time-travel queries, entity state, cross-world reads.
+
+    Time-travel policy (mirrors ``prefer_live_reads``):
+        - ``tick is None`` or ``tick == world.tick``: read from the world's
+          live snapshots (``AsyncWorld.get_components``).
+        - Otherwise: read from the store via ``AsyncWorld.query_archetype(ticks=[tick])``.
     """
 
     def __init__(self, world_service: WorldService, broker: CommandBroker | None = None):
         self._world_service = world_service
         self._broker = broker
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_current_tick(world: Any, tick: int | None) -> bool:
+        """True if the requested tick is the current (live) tick of the world."""
+        if tick is None:
+            return True
+        current = getattr(world, "tick", 0)
+        return tick == current
+
+    def _archetype_name(self, sig) -> str:
+        return Archetype.get_name(sig)
+
+    async def _collect_archetype_rows(
+        self,
+        world: AsyncWorld,
+        sig,
+        tick: int | None,
+        entity_ids: list[int] | None = None,
+    ) -> list[dict]:
+        """Return list of row dicts for a single archetype signature at the given tick.
+
+        Uses live snapshot when tick is current; otherwise falls back to the store.
+        """
+        if self._is_current_tick(world, tick):
+            df = world._live.get(sig)
+            if df is None:
+                return []
+            if entity_ids is not None:
+                from daft import col
+
+                df = df.where(col("entity_id").is_in(entity_ids))
+            return df.collect().to_pylist()
+
+        # Historical: query the store for this archetype at the given tick.
+        df = await world.query_archetype(
+            sig=sig,
+            ticks=[tick],
+            entity_ids=entity_ids,
+            components=None,
+        )
+        return df.collect().to_pylist()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
     async def get_world_state(
         self,
         world_id: UUID,
         tick: int | None = None,
     ) -> WorldSnapshot:
-        """Get the current (or historical) world state snapshot."""
+        """Get the current (or historical) world state snapshot.
+
+        Returns per-entity component-type lists and per-archetype active counts.
+        """
         world = self._world_service.get_world(world_id)
+        current_tick = getattr(world, "tick", 0)
+        effective_tick = current_tick if tick is None else tick
+
+        entities: dict[int, list[str]] = {}
+        archetype_counts: dict[str, int] = {}
+
+        if not isinstance(world, AsyncWorld):
+            # Non-AsyncWorld instances have no introspectable live state here.
+            return WorldSnapshot(
+                world_id=world_id,
+                tick=effective_tick,
+                entities={},
+                archetype_counts={},
+            )
+
+        # Enumerate all known signatures for this world. For current-tick
+        # reads _live is authoritative; for historical reads we scan the same
+        # set of signatures (the archetype catalog) against the store.
+        known_sigs = set(world._live.keys()) | set(world._entity2sig.values())
+
+        for sig in known_sigs:
+            rows = await self._collect_archetype_rows(world, sig, tick=tick)
+            # Only count active rows (live snapshots already filter, but be defensive).
+            active_rows = [r for r in rows if r.get("is_active", True)]
+            if not active_rows:
+                continue
+            name = self._archetype_name(sig)
+            archetype_counts[name] = archetype_counts.get(name, 0) + len(active_rows)
+            component_names = [c.__name__ for c in sig]
+            for row in active_rows:
+                eid = row.get("entity_id")
+                if eid is not None:
+                    entities[int(eid)] = component_names
+
         return WorldSnapshot(
             world_id=world_id,
-            tick=tick if tick is not None else getattr(world, "tick", 0),
-            entities={},
-            archetype_counts={},
+            tick=effective_tick,
+            entities=entities,
+            archetype_counts=archetype_counts,
         )
 
     async def get_entity(
@@ -50,27 +144,127 @@ class QueryService:
         entity_id: int,
         tick: int | None = None,
     ) -> dict:
-        """Get entity state, optionally at a specific tick."""
+        """Get entity state, optionally at a specific tick.
+
+        Returns a dict containing identity, tick, archetype, and a
+        ``components`` map of ``{ComponentName: {field: value, ...}}``.
+        Returns an empty ``components`` map if the entity is not present
+        at the requested tick.
+        """
         world = self._world_service.get_world(world_id)
-        return {
+        current_tick = getattr(world, "tick", 0)
+        effective_tick = current_tick if tick is None else tick
+
+        result: dict[str, Any] = {
             "world_id": str(world_id),
             "entity_id": entity_id,
-            "tick": tick if tick is not None else getattr(world, "tick", 0),
+            "tick": effective_tick,
+            "archetype": None,
+            "components": {},
         }
+
+        if not isinstance(world, AsyncWorld):
+            return result
+
+        # Determine which signature(s) to search. For current tick, consult
+        # _entity2sig directly; for historical tick we may need to scan all
+        # known signatures since the entity's archetype may have changed.
+        candidate_sigs = []
+        if self._is_current_tick(world, tick):
+            sig = world._entity2sig.get(entity_id)
+            if sig is not None:
+                candidate_sigs = [sig]
+        else:
+            candidate_sigs = list(set(world._live.keys()) | set(world._entity2sig.values()))
+
+        for sig in candidate_sigs:
+            rows = await self._collect_archetype_rows(world, sig, tick=tick, entity_ids=[entity_id])
+            active = [r for r in rows if r.get("is_active", True)]
+            if not active:
+                continue
+            # Prefer latest tick if multiple rows returned (historical scans).
+            row = max(active, key=lambda r: r.get("tick", 0))
+            result["archetype"] = self._archetype_name(sig)
+            components: dict[str, dict[str, Any]] = {}
+            for ctype in sig:
+                prefix = ctype.get_prefix()
+                fields = {k[len(prefix) :]: v for k, v in row.items() if k.startswith(prefix)}
+                components[ctype.__name__] = fields
+            result["components"] = components
+            break
+
+        return result
 
     async def get_components(
         self,
         world_id: UUID,
         component_types: list[str],
         entity_ids: list[int] | None = None,
+        tick: int | None = None,
     ) -> dict:
-        """Query specific component types across entities."""
-        self._world_service.get_world(world_id)  # validate world exists
-        return {
+        """Query specific component types across entities.
+
+        Returns a dict with ``rows``: a list of per-entity dicts with
+        ``entity_id``, ``tick``, and each requested component's fields
+        nested under the component's class name.
+        """
+        world = self._world_service.get_world(world_id)
+        current_tick = getattr(world, "tick", 0)
+        effective_tick = current_tick if tick is None else tick
+
+        response: dict[str, Any] = {
             "world_id": str(world_id),
             "component_types": component_types,
             "entity_ids": entity_ids,
+            "tick": effective_tick,
+            "rows": [],
         }
+
+        if not isinstance(world, AsyncWorld):
+            return response
+
+        # Resolve component type names to classes.
+        try:
+            ctypes = [Component.get_type_by_name(name) for name in component_types]
+        except ValueError:
+            # Unknown component name => empty projection, not an error.
+            return response
+
+        required = set(ctypes)
+
+        if self._is_current_tick(world, tick):
+            # Fast path: AsyncWorld.get_components handles union + projection.
+            df = await world.get_components(ctypes, entity_ids=entity_ids)
+            rows = df.collect().to_pylist()
+        else:
+            # Historical path: union query_archetype across matching sigs.
+            rows = []
+            matching = [
+                sig
+                for sig in (set(world._live.keys()) | set(world._entity2sig.values()))
+                if required.issubset(set(sig))
+            ]
+            for sig in matching:
+                sig_rows = await self._collect_archetype_rows(
+                    world, sig, tick=tick, entity_ids=entity_ids
+                )
+                rows.extend(r for r in sig_rows if r.get("is_active", True))
+
+        # Shape into a stable, component-centric response.
+        shaped = []
+        for row in rows:
+            entry: dict[str, Any] = {
+                "entity_id": row.get("entity_id"),
+                "tick": row.get("tick"),
+            }
+            for ctype in ctypes:
+                prefix = ctype.get_prefix()
+                entry[ctype.__name__] = {
+                    k[len(prefix) :]: v for k, v in row.items() if k.startswith(prefix)
+                }
+            shaped.append(entry)
+        response["rows"] = shaped
+        return response
 
     async def get_command_history(
         self,

--- a/src/archetype/trajectories/processors.py
+++ b/src/archetype/trajectories/processors.py
@@ -89,6 +89,51 @@ def _make_outcome_matcher(substring: str):
     return _outcome_matches
 
 
+# ── Response parsers (module-level, pure functions) ──
+#
+# Extracted from LabelingProcessor.process() so they can be unit tested
+# without constructing a DataFrame or invoking the LLM. Wrapped as row-wise
+# UDFs at the call site with `daft.func`.
+
+
+def _parse_value(response: str) -> str:
+    """Extract the VALUE line from a structured LLM response.
+
+    Falls back to the first 100 characters of the response if no VALUE
+    line is present (so an unparseable response still yields something
+    useful for debugging).
+    """
+    if not response:
+        return ""
+    for line in response.split("\n"):
+        if line.startswith("VALUE:"):
+            return line[6:].strip()
+    return response[:100]
+
+
+def _parse_score(response: str) -> float:
+    """Extract the SCORE line as a float. Returns 0.0 on missing/malformed."""
+    if not response:
+        return 0.0
+    for line in response.split("\n"):
+        if line.startswith("SCORE:"):
+            try:
+                return float(line[6:].strip())
+            except ValueError:
+                return 0.0
+    return 0.0
+
+
+def _parse_rationale(response: str) -> str:
+    """Extract the RATIONALE line. Returns empty string on missing."""
+    if not response:
+        return ""
+    for line in response.split("\n"):
+        if line.startswith("RATIONALE:"):
+            return line[10:].strip()
+    return ""
+
+
 # ── Processors ──
 
 
@@ -202,37 +247,21 @@ class LabelingProcessor(AsyncProcessor):
             max_output_tokens=config.max_output_tokens,
         )
 
-        # Row-wise extractors — @daft.func with auto type inference (LEARNINGS.md §4)
+        # Row-wise extractors — @daft.func with auto type inference (LEARNINGS.md §4).
+        # Thin wrappers that delegate to module-level pure functions so the
+        # parsing logic is unit-testable without a DataFrame.
 
         @daft.func
         def extract_value(response: str) -> str:
-            if not response:
-                return ""
-            for line in response.split("\n"):
-                if line.startswith("VALUE:"):
-                    return line[6:].strip()
-            return response[:100]
+            return _parse_value(response)
 
         @daft.func
         def extract_score(response: str) -> float:
-            if not response:
-                return 0.0
-            for line in response.split("\n"):
-                if line.startswith("SCORE:"):
-                    try:
-                        return float(line[6:].strip())
-                    except ValueError:
-                        return 0.0
-            return 0.0
+            return _parse_score(response)
 
         @daft.func
         def extract_rationale(response: str) -> str:
-            if not response:
-                return ""
-            for line in response.split("\n"):
-                if line.startswith("RATIONALE:"):
-                    return line[10:].strip()
-            return ""
+            return _parse_rationale(response)
 
         llm_col = llm_output
 

--- a/tests/app/test_query_service.py
+++ b/tests/app/test_query_service.py
@@ -1,0 +1,243 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for QueryService wired to real AsyncWorld data (issue #75)."""
+
+import pytest
+import pytest_asyncio
+
+from archetype.app.container import ServiceContainer
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+
+# --- Test components (unique names to avoid clashes with other tests) ---
+
+
+class QSPosition(Component):
+    x: int
+    y: int
+
+
+class QSVelocity(Component):
+    dx: int
+    dy: int
+
+
+class QSTag(Component):
+    label: str
+
+
+@pytest_asyncio.fixture
+async def container():
+    c = ServiceContainer()
+    try:
+        yield c
+    finally:
+        await c.shutdown()
+
+
+@pytest_asyncio.fixture
+async def populated_world(container, tmp_path):
+    """Create a world, spawn a few entities, step twice so we have history."""
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+    world = await container.world_service.create_world(WorldConfig(name="qs-world"), storage)
+
+    # Spawn: 2 entities with (QSPosition, QSVelocity), 1 with just (QSPosition),
+    # 1 with (QSTag).
+    e1 = await world.create_entity([QSPosition(x=1, y=2), QSVelocity(dx=10, dy=20)])
+    e2 = await world.create_entity([QSPosition(x=3, y=4), QSVelocity(dx=30, dy=40)])
+    e3 = await world.create_entity([QSPosition(x=5, y=6)])
+    e4 = await world.create_entity([QSTag(label="hello")])
+
+    # Tick 0 -> tick 1: materializes spawns. world.tick is now 1.
+    await world.run(RunConfig(num_steps=1, prefer_live_reads=True))
+
+    return {
+        "world": world,
+        "e_pos_vel": [e1, e2],
+        "e_pos_only": e3,
+        "e_tag": e4,
+        "tick_after_spawn": world.tick,  # 1
+    }
+
+
+# -----------------------------------------------------------------------------
+# get_world_state
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_world_state_current_tick_returns_real_entities(container, populated_world):
+    world = populated_world["world"]
+    qs = container.query_service
+
+    snap = await qs.get_world_state(world.world_id)
+
+    assert snap.world_id == world.world_id
+    assert snap.tick == world.tick
+    # Four entities across three archetypes.
+    assert len(snap.entities) == 4
+    for eid in [
+        *populated_world["e_pos_vel"],
+        populated_world["e_pos_only"],
+        populated_world["e_tag"],
+    ]:
+        assert eid in snap.entities
+    # One archetype per signature; counts should be 2, 1, 1.
+    assert sorted(snap.archetype_counts.values()) == [1, 1, 2]
+
+    # Entity -> component-type names mapping is correct.
+    pos_vel_components = sorted(snap.entities[populated_world["e_pos_vel"][0]])
+    assert pos_vel_components == ["QSPosition", "QSVelocity"]
+    assert snap.entities[populated_world["e_pos_only"]] == ["QSPosition"]
+    assert snap.entities[populated_world["e_tag"]] == ["QSTag"]
+
+
+@pytest.mark.asyncio
+async def test_get_world_state_echoes_tick_for_no_data_case(container, tmp_path):
+    """An empty world: tick echoes, entities/archetype_counts empty."""
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+    world = await container.world_service.create_world(WorldConfig(name="empty"), storage)
+    snap = await container.query_service.get_world_state(world.world_id, tick=5)
+    assert snap.tick == 5
+    assert snap.entities == {}
+    assert snap.archetype_counts == {}
+
+
+# -----------------------------------------------------------------------------
+# get_entity
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_entity_current_tick_returns_real_components(container, populated_world):
+    world = populated_world["world"]
+    e1 = populated_world["e_pos_vel"][0]
+
+    entity = await container.query_service.get_entity(world.world_id, entity_id=e1)
+
+    assert entity["entity_id"] == e1
+    assert entity["world_id"] == str(world.world_id)
+    assert entity["tick"] == world.tick
+    assert entity["archetype"] is not None
+    # Real component values present.
+    assert entity["components"]["QSPosition"] == {"x": 1, "y": 2}
+    assert entity["components"]["QSVelocity"] == {"dx": 10, "dy": 20}
+
+
+@pytest.mark.asyncio
+async def test_get_entity_missing_entity_returns_empty_components(container, populated_world):
+    world = populated_world["world"]
+    entity = await container.query_service.get_entity(world.world_id, entity_id=9999)
+    assert entity["components"] == {}
+    assert entity["archetype"] is None
+
+
+# -----------------------------------------------------------------------------
+# get_components
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_components_projects_real_data(container, populated_world):
+    world = populated_world["world"]
+
+    result = await container.query_service.get_components(world.world_id, ["QSPosition"])
+
+    # Three entities have QSPosition (two with Velocity, one standalone).
+    assert len(result["rows"]) == 3
+    eids = {r["entity_id"] for r in result["rows"]}
+    expected = {
+        populated_world["e_pos_only"],
+        *populated_world["e_pos_vel"],
+    }
+    assert eids == expected
+    # Each row has a nested QSPosition dict with real fields.
+    for row in result["rows"]:
+        assert set(row["QSPosition"].keys()) == {"x", "y"}
+
+
+@pytest.mark.asyncio
+async def test_get_components_entity_id_filter(container, populated_world):
+    world = populated_world["world"]
+    e1 = populated_world["e_pos_vel"][0]
+
+    result = await container.query_service.get_components(
+        world.world_id, ["QSPosition"], entity_ids=[e1]
+    )
+    assert len(result["rows"]) == 1
+    assert result["rows"][0]["entity_id"] == e1
+
+
+@pytest.mark.asyncio
+async def test_get_components_union_across_archetypes(container, populated_world):
+    """QSPosition projects across both archetypes containing it."""
+    world = populated_world["world"]
+    # QSPosition+QSVelocity archetype has 2 entities; stand-alone has 1.
+    result = await container.query_service.get_components(
+        world.world_id, ["QSPosition", "QSVelocity"]
+    )
+    # Only the (QSPosition, QSVelocity) archetype satisfies both.
+    assert len(result["rows"]) == 2
+    for row in result["rows"]:
+        assert "QSPosition" in row and "QSVelocity" in row
+
+
+@pytest.mark.asyncio
+async def test_get_components_unknown_type_returns_empty(container, populated_world):
+    world = populated_world["world"]
+    result = await container.query_service.get_components(
+        world.world_id, ["ThisComponentDoesNotExist"]
+    )
+    assert result["rows"] == []
+
+
+# -----------------------------------------------------------------------------
+# Time-travel
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_time_travel_historical_tick_reads_from_store(container, tmp_path):
+    """Snapshot at an older tick should read from the store, not the live cache.
+
+    Uses a single ``RunConfig`` for multiple ticks so all ticks share a
+    ``run_id`` (store reads filter by run_id — mirrors the comment in
+    ``AsyncWorld._run_archetype``)."""
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+    world = await container.world_service.create_world(WorldConfig(name="tt"), storage)
+
+    await world.create_entity([QSPosition(x=1, y=1)])
+    await world.create_entity([QSPosition(x=2, y=2)])
+
+    # Run 3 ticks under a single run_id so historical store reads can find
+    # rows stamped with earlier ticks.
+    await world.run(RunConfig(num_steps=3, prefer_live_reads=True))
+    assert world.tick == 3
+
+    qs = container.query_service
+
+    # Current tick: live read — 2 entities present.
+    snap_now = await qs.get_world_state(world.world_id)
+    assert snap_now.tick == 3
+    assert len(snap_now.entities) == 2
+
+    # Historical: tick 0 is the first persisted tick under this run_id.
+    snap_t0 = await qs.get_world_state(world.world_id, tick=0)
+    assert snap_t0.tick == 0
+    assert len(snap_t0.entities) == 2
+
+
+@pytest.mark.asyncio
+async def test_time_travel_get_components_historical_tick(container, tmp_path):
+    """Historical-tick get_components returns data from the store."""
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+    world = await container.world_service.create_world(WorldConfig(name="tt2"), storage)
+
+    e1 = await world.create_entity([QSPosition(x=1, y=1)])
+    # Single run_id spanning both ticks so tick=0 rows are accessible.
+    await world.run(RunConfig(num_steps=2, prefer_live_reads=True))
+
+    result = await container.query_service.get_components(world.world_id, ["QSPosition"], tick=0)
+    assert result["tick"] == 0
+    assert any(r["entity_id"] == e1 for r in result["rows"])

--- a/tests/trajectories/test_labeling_processor.py
+++ b/tests/trajectories/test_labeling_processor.py
@@ -132,8 +132,10 @@ def _make_df(trajectories, labels):
     return daft.from_pylist(rows)
 
 
-def _make_fake_prompt(response_by_technique: dict[str, str] | None = None,
-                     default: str = "VALUE: fake\nSCORE: 0.5\nRATIONALE: fake reason"):
+def _make_fake_prompt(
+    response_by_technique: dict[str, str] | None = None,
+    default: str = "VALUE: fake\nSCORE: 0.5\nRATIONALE: fake reason",
+):
     """Return a drop-in replacement for daft.functions.prompt that doesn't hit the network.
 
     Ignores the model/max_output_tokens kwargs and returns a string expression
@@ -205,9 +207,7 @@ async def test_labeling_only_sampled_rows_updated():
 async def test_labeling_all_unsampled_no_llm_calls():
     """When no rows are sampled, all labels stay untouched and the row count is preserved."""
     trajs = [
-        Trajectory.from_turns(
-            f"t-{i}", turns=[Turn(role="user", content="x")], source="test"
-        )
+        Trajectory.from_turns(f"t-{i}", turns=[Turn(role="user", content="x")], source="test")
         for i in range(3)
     ]
     labels = [
@@ -237,14 +237,10 @@ async def test_labeling_all_unsampled_no_llm_calls():
 async def test_labeling_all_sampled_all_updated():
     """When every row is sampled, every row gets fresh LLM-derived values."""
     trajs = [
-        Trajectory.from_turns(
-            f"t-{i}", turns=[Turn(role="user", content="x")], source="test"
-        )
+        Trajectory.from_turns(f"t-{i}", turns=[Turn(role="user", content="x")], source="test")
         for i in range(3)
     ]
-    labels = [
-        Label(technique="t", description="d", sampled=True) for _ in range(3)
-    ]
+    labels = [Label(technique="t", description="d", sampled=True) for _ in range(3)]
     df = _make_df(trajs, labels)
 
     fake = _make_fake_prompt(default="VALUE: v\nSCORE: 0.5\nRATIONALE: r")

--- a/tests/trajectories/test_labeling_processor.py
+++ b/tests/trajectories/test_labeling_processor.py
@@ -1,0 +1,304 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for LabelingProcessor — response parsing + sampled/unsampled gating.
+
+The LLM-powered parsing logic is exercised through the module-level pure
+functions (`_parse_value`, `_parse_score`, `_parse_rationale`). The gating
+behavior is exercised via the full processor with `daft.functions.prompt`
+replaced by a small fake that does not touch any network.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import daft
+import pytest
+
+from archetype.core.resources import Resources
+from archetype.trajectories.components import Label, Trajectory, Turn
+from archetype.trajectories.processors import (
+    LabelingConfig,
+    LabelingProcessor,
+    _parse_rationale,
+    _parse_score,
+    _parse_value,
+)
+
+# ── Response parsing: module-level pure functions ──
+
+
+class TestParseValue:
+    def test_clean_response(self):
+        response = "VALUE: efficient\nSCORE: 0.85\nRATIONALE: Agent solved it quickly."
+        assert _parse_value(response) == "efficient"
+
+    def test_missing_value_line_falls_back_to_first_100_chars(self):
+        response = "SCORE: 0.5\nRATIONALE: no value line here"
+        out = _parse_value(response)
+        assert out == response[:100]
+        assert len(out) <= 100
+
+    def test_missing_value_truncates_long_response(self):
+        response = "x" * 500
+        out = _parse_value(response)
+        assert len(out) == 100
+        assert out == "x" * 100
+
+    def test_empty_response(self):
+        assert _parse_value("") == ""
+
+    def test_extra_whitespace_stripped(self):
+        response = "VALUE:    efficient    \nSCORE: 0.9"
+        assert _parse_value(response) == "efficient"
+
+    def test_multiline_only_first_value_line_used(self):
+        response = "VALUE: first\nOther: x\nVALUE: second"
+        # The implementation returns the first matching line
+        assert _parse_value(response) == "first"
+
+
+class TestParseScore:
+    def test_clean_response(self):
+        response = "VALUE: x\nSCORE: 0.85\nRATIONALE: y"
+        assert _parse_score(response) == 0.85
+
+    def test_malformed_score_returns_zero(self):
+        response = "SCORE: not_a_number"
+        assert _parse_score(response) == 0.0
+
+    def test_missing_score_returns_zero(self):
+        assert _parse_score("VALUE: x\nRATIONALE: y") == 0.0
+
+    def test_empty_response(self):
+        assert _parse_score("") == 0.0
+
+    def test_extra_whitespace_stripped(self):
+        response = "SCORE:    0.42   "
+        assert _parse_score(response) == 0.42
+
+    def test_integer_score_parsed_as_float(self):
+        assert _parse_score("SCORE: 1") == 1.0
+
+
+class TestParseRationale:
+    def test_clean_response(self):
+        response = "VALUE: x\nSCORE: 0.5\nRATIONALE: Agent solved the task quickly."
+        assert _parse_rationale(response) == "Agent solved the task quickly."
+
+    def test_missing_rationale_returns_empty(self):
+        assert _parse_rationale("VALUE: x\nSCORE: 0.5") == ""
+
+    def test_empty_response(self):
+        assert _parse_rationale("") == ""
+
+    def test_extra_whitespace_stripped(self):
+        response = "RATIONALE:    Because reasons.    "
+        assert _parse_rationale(response) == "Because reasons."
+
+
+def test_empty_response_all_defaults():
+    """An empty LLM response should yield empty value, 0.0 score, empty rationale."""
+    assert _parse_value("") == ""
+    assert _parse_score("") == 0.0
+    assert _parse_rationale("") == ""
+
+
+def test_clean_response_all_three_populated():
+    """The canonical happy-path response populates all three fields."""
+    response = "VALUE: efficient\nSCORE: 0.85\nRATIONALE: Agent solved it in 3 turns."
+    assert _parse_value(response) == "efficient"
+    assert _parse_score(response) == 0.85
+    assert _parse_rationale(response) == "Agent solved it in 3 turns."
+
+
+# ── Sampled/unsampled gating ──
+
+
+def _make_df(trajectories, labels):
+    """Mirror of tests/trajectories/test_processors.py::_make_df."""
+    rows = []
+    for traj, lab in zip(trajectories, labels, strict=True):
+        row = {}
+        for field, val in traj.model_dump().items():
+            row[f"trajectory__{field}"] = val
+        for field, val in lab.model_dump().items():
+            row[f"label__{field}"] = val
+        row["entity_id"] = len(rows)
+        row["is_active"] = True
+        rows.append(row)
+    return daft.from_pylist(rows)
+
+
+def _make_fake_prompt(response_by_technique: dict[str, str] | None = None,
+                     default: str = "VALUE: fake\nSCORE: 0.5\nRATIONALE: fake reason"):
+    """Return a drop-in replacement for daft.functions.prompt that doesn't hit the network.
+
+    Ignores the model/max_output_tokens kwargs and returns a string expression
+    — a constant by default, so no API key is needed.
+    """
+
+    def fake_prompt(_expr, model=None, max_output_tokens=None, **_kwargs):
+        # Return a literal string column — Daft treats this like any other expr.
+        return daft.lit(default)
+
+    return fake_prompt
+
+
+@pytest.mark.asyncio
+async def test_labeling_only_sampled_rows_updated():
+    """Unsampled rows must retain their prior label__value/score/rationale."""
+    trajs = [
+        Trajectory.from_turns(
+            f"t-{i}",
+            turns=[Turn(role="user", content="hi")],
+            source="test",
+            outcome="ok",
+        )
+        for i in range(4)
+    ]
+    # Pre-seed label values so we can detect whether they got overwritten.
+    labels = []
+    for i in range(4):
+        labels.append(
+            Label(
+                technique="eff",
+                description="efficiency",
+                value=f"prior-{i}",
+                score=0.11 * (i + 1),
+                rationale=f"prior-rationale-{i}",
+                sampled=(i % 2 == 0),  # entities 0, 2 sampled; 1, 3 unsampled
+            )
+        )
+    df = _make_df(trajs, labels)
+
+    fake = _make_fake_prompt(default="VALUE: fresh\nSCORE: 0.77\nRATIONALE: updated")
+
+    with patch("daft.functions.prompt", fake):
+        resources = Resources()
+        resources.insert(LabelingConfig())
+        proc = LabelingProcessor()
+        result = await proc.process(df, resources=resources)
+        collected = result.collect().to_pylist()
+
+    # No row count change
+    assert len(collected) == 4
+
+    by_id = {r["entity_id"]: r for r in collected}
+
+    # Sampled rows: overwritten with fake LLM output
+    for eid in (0, 2):
+        assert by_id[eid]["label__value"] == "fresh"
+        assert by_id[eid]["label__score"] == 0.77
+        assert by_id[eid]["label__rationale"] == "updated"
+
+    # Unsampled rows: prior values preserved
+    for eid in (1, 3):
+        assert by_id[eid]["label__value"] == f"prior-{eid}"
+        assert by_id[eid]["label__score"] == pytest.approx(0.11 * (eid + 1))
+        assert by_id[eid]["label__rationale"] == f"prior-rationale-{eid}"
+
+
+@pytest.mark.asyncio
+async def test_labeling_all_unsampled_no_llm_calls():
+    """When no rows are sampled, all labels stay untouched and the row count is preserved."""
+    trajs = [
+        Trajectory.from_turns(
+            f"t-{i}", turns=[Turn(role="user", content="x")], source="test"
+        )
+        for i in range(3)
+    ]
+    labels = [
+        Label(technique="t", description="d", value=f"keep-{i}", score=0.3, sampled=False)
+        for i in range(3)
+    ]
+    df = _make_df(trajs, labels)
+
+    # If fake_prompt is called, return sentinel so we can detect it.
+    fake = _make_fake_prompt(default="VALUE: SHOULD_NOT_APPEAR\nSCORE: 1.0\nRATIONALE: x")
+
+    with patch("daft.functions.prompt", fake):
+        resources = Resources()
+        resources.insert(LabelingConfig())
+        proc = LabelingProcessor()
+        result = await proc.process(df, resources=resources)
+        collected = result.collect().to_pylist()
+
+    assert len(collected) == 3
+    for row in collected:
+        assert row["label__value"].startswith("keep-")
+        assert row["label__score"] == 0.3
+        assert "SHOULD_NOT_APPEAR" not in row["label__value"]
+
+
+@pytest.mark.asyncio
+async def test_labeling_all_sampled_all_updated():
+    """When every row is sampled, every row gets fresh LLM-derived values."""
+    trajs = [
+        Trajectory.from_turns(
+            f"t-{i}", turns=[Turn(role="user", content="x")], source="test"
+        )
+        for i in range(3)
+    ]
+    labels = [
+        Label(technique="t", description="d", sampled=True) for _ in range(3)
+    ]
+    df = _make_df(trajs, labels)
+
+    fake = _make_fake_prompt(default="VALUE: v\nSCORE: 0.5\nRATIONALE: r")
+
+    with patch("daft.functions.prompt", fake):
+        resources = Resources()
+        resources.insert(LabelingConfig())
+        proc = LabelingProcessor()
+        result = await proc.process(df, resources=resources)
+        collected = result.collect().to_pylist()
+
+    assert len(collected) == 3
+    for row in collected:
+        assert row["label__value"] == "v"
+        assert row["label__score"] == 0.5
+        assert row["label__rationale"] == "r"
+
+
+# ── End-to-end LLM integration (guarded) ──
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set; skipping live LLM integration test",
+)
+@pytest.mark.asyncio
+async def test_labeling_end_to_end_with_real_llm():
+    """Smoke test against the real LLM. Only runs when OPENAI_API_KEY is present."""
+    traj = Trajectory.from_turns(
+        "t-live",
+        turns=[
+            Turn(role="user", content="What's 2+2?"),
+            Turn(role="assistant", content="4"),
+        ],
+        source="test",
+        outcome="success",
+    )
+    label = Label(
+        technique="correctness",
+        description="Did the assistant answer correctly?",
+        sampled=True,
+    )
+    df = _make_df([traj], [label])
+
+    resources = Resources()
+    resources.insert(LabelingConfig(model="gpt-4o-mini", max_output_tokens=128))
+    proc = LabelingProcessor()
+    result = await proc.process(df, resources=resources)
+    collected = result.collect().to_pylist()
+
+    assert len(collected) == 1
+    row = collected[0]
+    # Parsed fields should be populated (though exact content is model-dependent).
+    assert isinstance(row["label__value"], str)
+    assert isinstance(row["label__score"], float)
+    assert isinstance(row["label__rationale"], str)
+    assert 0.0 <= row["label__score"] <= 1.0 or row["label__score"] == 0.0


### PR DESCRIPTION
## Summary
- **#75**: Wire `QueryService` to `AsyncWorld` with time-travel query support
- **#78**: Add `LabelingProcessor` response parsing and sampled/unsampled gating tests
- **#115**: Fix OpenAPI doc generator edge cases (anyOf unwrap, param type labels, deterministic output)

## Test plan
- [x] CI passes (`make ci`)
- [ ] Verify QueryService wiring against real data
- [ ] Confirm OpenAPI docs render correctly

Closes #75, closes #78, closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)