### PR TITLE
fix: SimulationService.run threads user's RunConfig into every step

### DIFF
--- a/src/archetype/app/simulation_service.py
+++ b/src/archetype/app/simulation_service.py
@@ -71,14 +71,28 @@ class SimulationService:
         """
         Execute run_config.num_steps ticks.
         Returns RunResult with run_id, ticks completed, final state.
+
+        The user's ``run_config`` is threaded into every per-tick step so that
+        ``run_id``, ``prefer_live_reads``, ``debug``, ``suite``, ``trial``,
+        ``metadata`` and other fields reach the world. Mirroring
+        ``AsyncWorld.run``, the world's ``run_id`` pointer is set once up-front
+        so default-run queries see the same identifier as ``RunResult.run_id``.
         """
+        world = self._world_service.get_world(world_id)
+
+        # Mirror AsyncWorld.run: pin the world's current run identifier so
+        # default-run queries resolve to the user's run_id.
+        if hasattr(world, "run_id"):
+            world.run_id = str(run_config.run_id)
+
         total_commands = 0
 
         for _ in range(run_config.num_steps):
-            cmds = await self.step(world_id, RunConfig(num_steps=1), **input_kwargs)
+            # Pass the user's run_config through unchanged so fields like
+            # prefer_live_reads, debug, run_id, suite, trial, metadata reach
+            # world.step. RunConfig is frozen, so sharing the instance is safe.
+            cmds = await self.step(world_id, run_config, **input_kwargs)
             total_commands += cmds
-
-        world = self._world_service.get_world(world_id)
 
         return RunResult(
             run_id=run_config.run_id,

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -162,7 +162,7 @@ class TestSimulationService:
     @pytest.mark.asyncio
     async def test_run_accumulates_commands_from_each_tick(self):
         world_id = uuid7()
-        world = Mock(tick=9)
+        world = Mock(tick=9, run_id=None)
         world_service = Mock()
         world_service.get_world.return_value = world
         command_service = Mock()
@@ -175,9 +175,63 @@ class TestSimulationService:
         assert result.ticks_completed == 3
         assert result.commands_applied == 6
         assert result.final_tick == 9
+        # Each per-tick step must receive the user's RunConfig unchanged so
+        # run_id / prefer_live_reads / debug / metadata reach world.step.
         assert sim.step.await_args_list[0].args[0] == world_id
-        assert sim.step.await_args_list[0].args[1].num_steps == 1
+        assert sim.step.await_args_list[0].args[1] is rc
         assert sim.step.await_args_list[0].kwargs == {"bonus": 7}
+        # World's run_id pointer must be pinned to the user's run_id up-front.
+        assert world.run_id == str(rc.run_id)
+
+    @pytest.mark.asyncio
+    async def test_run_threads_user_run_config_into_every_step(self, tmp_path):
+        """Regression for bug-simulation-service-run-discards-runconfig.
+
+        ``SimulationService.run`` used to construct ``RunConfig(num_steps=1)``
+        inside its loop, dropping the user's run_id, prefer_live_reads, debug,
+        suite, trial, metadata, etc. Every per-tick step must now receive the
+        same RunConfig the caller passed in, and the world's run_id pointer
+        must be set to the user's run_id.
+        """
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="t"), storage)
+            seen: list[RunConfig] = []
+            original_step = container.simulation_service.step
+
+            async def capturing_step(wid, rc=None, **kwargs):
+                seen.append(rc)
+                return await original_step(wid, rc, **kwargs)
+
+            container.simulation_service.step = capturing_step  # type: ignore[method-assign]
+
+            user_rc = RunConfig(
+                num_steps=3,
+                prefer_live_reads=True,
+                debug=True,
+                suite="regression",
+                trial=7,
+                metadata={"source": "test"},
+            )
+            result = await container.simulation_service.run(world.world_id, user_rc)
+
+            assert result.run_id == user_rc.run_id
+            assert result.ticks_completed == 3
+            # Every per-tick step received the user's RunConfig, not a fresh one.
+            assert len(seen) == 3
+            for rc in seen:
+                assert rc is user_rc
+                assert rc.run_id == user_rc.run_id
+                assert rc.prefer_live_reads is True
+                assert rc.debug is True
+                assert rc.suite == "regression"
+                assert rc.trial == 7
+                assert rc.metadata == {"source": "test"}
+            # World's run_id pointer is pinned to the user's run_id.
+            assert str(world.run_id) == str(user_rc.run_id)
+        finally:
+            await container.shutdown()
 
     @pytest.mark.asyncio
     async def test_step_skips_non_async_world_but_still_applies_commands(self):


### PR DESCRIPTION
## Summary

Fixes the `simulation-service-run-discards-runconfig` bug documented in PR #123. `SimulationService.run` was constructing a fresh `RunConfig(num_steps=1)` inside its loop, silently dropping `run_id`, `prefer_live_reads`, `debug`, `suite`, `trial`, `metadata`, and every other field from the caller's `RunConfig`. Visible fallout:

- Rows produced by the run were stamped with per-tick uuids the caller had no handle on — queries by `result.run_id` returned zero rows.
- `world.run_id` was never set, so default-run queries failed after a service-layer run.
- `prefer_live_reads=True` was silently ignored on every `simulation_service.run(...)` call (including ~9 call sites in `tests/integration/test_trajectory_pipeline.py`).
- `debug=True`, `enable_validation`, `suite`, `trial`, `metadata` were all reset to defaults before reaching the world.

## Root cause

`src/archetype/app/simulation_service.py:78` built a new `RunConfig(num_steps=1)` per iteration instead of forwarding the user's object. `AsyncWorld.run` (one layer down) handles `RunConfig` correctly — the bug was entirely in the service wrapper.

## Fix

- Thread the user's `run_config` straight into every `self.step(...)` call. `RunConfig` is frozen, so sharing the instance is safe and the `num_steps` field is unused inside `world.step`.
- Mirror `AsyncWorld.run` by pinning `world.run_id = str(run_config.run_id)` once up-front so default-run queries resolve to the user's run_id.

Changes live entirely in `src/archetype/app/simulation_service.py` — no `core/` modifications.

## Regression test

- New `tests/app/test_services.py::TestSimulationService::test_run_threads_user_run_config_into_every_step` spies on per-tick `step()` calls, submits a `RunConfig(prefer_live_reads=True, debug=True, suite="regression", trial=7, metadata=...)`, and asserts every tick receives the same `RunConfig` instance with all fields intact, plus `world.run_id == str(user_rc.run_id)`. Fails on `main`, passes with the fix.
- Updated `test_run_accumulates_commands_from_each_tick`, which previously asserted the buggy behavior (`num_steps == 1` per tick). Now asserts the user's `RunConfig` is passed through and the world's `run_id` is pinned.

## Test plan

- [x] `make ci` — 421 passed, coverage 85.91%
- [x] New regression test fails on pre-fix code and passes post-fix
