### PR TITLE
fix: enqueue_bulk no longer debits quota when RBAC fails mid-bulk

### DIFF
--- a/src/archetype/app/auth/guard.py
+++ b/src/archetype/app/auth/guard.py
@@ -79,19 +79,26 @@ def estimate_token_cost(cmd: Command) -> int:
     return _TOKEN_COSTS.get(cmd.type.value, 10)
 
 
-def guardrail_allow(cmd: Command, ctx: ActorCtx) -> None:
-    """
-    Check RBAC permissions and quotas. Raises PermissionError if denied.
+def guardrail_check(
+    cmd: Command,
+    ctx: ActorCtx,
+    projected_count: int = 0,
+    projected_tokens: int = 0,
+) -> int:
+    """Pure RBAC + quota check.
 
-    Checks:
-    1. Role permissions — does any of the actor's roles grant the command type?
-    2. Per-tick quota — has the actor exceeded MAX_CMDS_PER_TICK?
-    3. Daily token budget — has the actor exceeded MAX_TOKENS_PER_DAY?
+    Returns the token cost of ``cmd`` if allowed; raises ``PermissionError``
+    otherwise. Does NOT mutate ``_tick_counters`` or ``_daily_tokens`` — use
+    :func:`guardrail_commit` to apply the debit after the caller is certain
+    the command will actually be enqueued.
+
+    ``projected_count`` / ``projected_tokens`` let bulk callers stack
+    pre-check quota usage across a bulk without committing anything to the
+    global state until every command in the bulk passes.
 
     The daily-token budget is rolled over lazily: before running the quota
     check, :func:`maybe_reset_daily_tokens` clears ``_daily_tokens`` if the
-    UTC date has advanced since the last reset. This makes the "daily" in
-    ``MAX_TOKENS_PER_DAY`` real without relying on a background scheduler.
+    UTC date has advanced since the last reset.
     """
     # Roll the daily budget forward if the UTC date has changed. Without
     # this, ``_daily_tokens`` accumulates monotonically for the lifetime
@@ -113,20 +120,46 @@ def guardrail_allow(cmd: Command, ctx: ActorCtx) -> None:
 
     # 2. Per-tick quota
     current_count = _tick_counters.get(ctx.id, 0)
-    if current_count >= MAX_CMDS_PER_TICK:
+    if current_count + projected_count >= MAX_CMDS_PER_TICK:
         raise PermissionError(
             f"Actor {ctx.id} exceeded per-tick quota ({MAX_CMDS_PER_TICK} commands)"
         )
-    _tick_counters[ctx.id] = current_count + 1
 
     # 3. Daily token budget
     cost = estimate_token_cost(cmd)
     current_tokens = _daily_tokens.get(ctx.id, 0)
-    if current_tokens + cost > MAX_TOKENS_PER_DAY:
+    if current_tokens + projected_tokens + cost > MAX_TOKENS_PER_DAY:
         raise PermissionError(
             f"Actor {ctx.id} exceeded daily token budget ({MAX_TOKENS_PER_DAY} tokens)"
         )
-    _daily_tokens[ctx.id] = current_tokens + cost
+
+    return cost
+
+
+def guardrail_commit(ctx: ActorCtx, count: int, tokens: int) -> None:
+    """Apply the quota debit computed by previous :func:`guardrail_check` calls.
+
+    Callers MUST only invoke this after they have ensured the associated
+    commands will actually be enqueued. Bulk callers should compute the
+    projected totals via :func:`guardrail_check` and commit once at the end,
+    so a partial validation failure leaves counters untouched.
+    """
+    if count:
+        _tick_counters[ctx.id] = _tick_counters.get(ctx.id, 0) + count
+    if tokens:
+        _daily_tokens[ctx.id] = _daily_tokens.get(ctx.id, 0) + tokens
+
+
+def guardrail_allow(cmd: Command, ctx: ActorCtx) -> None:
+    """
+    Check RBAC permissions and quotas and debit the actor's counters.
+
+    Thin wrapper over :func:`guardrail_check` + :func:`guardrail_commit`
+    for single-command callers. Raises ``PermissionError`` if denied (in
+    which case no counters are mutated).
+    """
+    cost = guardrail_check(cmd, ctx)
+    guardrail_commit(ctx, count=1, tokens=cost)
 
 
 def reset_tick_counters() -> None:

--- a/src/archetype/app/broker.py
+++ b/src/archetype/app/broker.py
@@ -36,7 +36,7 @@ import heapq
 import logging
 from uuid import UUID
 
-from archetype.app.auth.guard import guardrail_allow
+from archetype.app.auth.guard import guardrail_allow, guardrail_check, guardrail_commit
 from archetype.app.auth.models import ActorCtx
 from archetype.app.models import Command
 
@@ -94,11 +94,26 @@ class CommandBroker:
     ) -> None:
         """
         Enqueue multiple commands for a specific world.
-        All-or-nothing: validates all commands before enqueueing any.
+        All-or-nothing: validates all commands before enqueueing any, and
+        debits quota only once the entire bulk has passed validation. A
+        partial RBAC or quota failure leaves the actor's counters untouched.
         """
         if ctx is not None:
-            for cmd in cmds:
-                guardrail_allow(cmd, ctx)
+            # Pure validation pass: stacks projected debits across the bulk
+            # without mutating global counters so a mid-bulk failure does
+            # not burn quota on commands that never get enqueued.
+            projected_tokens = 0
+            for i, cmd in enumerate(cmds):
+                projected_tokens += guardrail_check(
+                    cmd,
+                    ctx,
+                    projected_count=i,
+                    projected_tokens=projected_tokens,
+                )
+            # All commands allowed — commit the debit before acquiring the
+            # queue lock so subsequent guardrail_check calls observe the
+            # updated counters.
+            guardrail_commit(ctx, count=len(cmds), tokens=projected_tokens)
 
         async with self._lock:
             key = str(world_id)

--- a/tests/app/test_broker_extended.py
+++ b/tests/app/test_broker_extended.py
@@ -10,9 +10,25 @@ Tests cover edge cases, ActorCtx RBAC, and additional functionality.
 import pytest
 from uuid_utils import uuid7
 
+from archetype.app.auth.guard import (
+    _daily_tokens,
+    _tick_counters,
+    reset_daily_tokens,
+    reset_tick_counters,
+)
 from archetype.app.auth.models import ActorCtx
 from archetype.app.broker import CommandBroker
 from archetype.app.models import Command, CommandType
+
+
+@pytest.fixture
+def _reset_quotas():
+    """Snapshot + restore guard counters so broker tests don't leak into auth tests."""
+    reset_tick_counters()
+    reset_daily_tokens()
+    yield
+    reset_tick_counters()
+    reset_daily_tokens()
 
 
 class TestBrokerEdgeCases:
@@ -198,6 +214,79 @@ class TestBrokerConcurrency:
         assert await broker.get_pending_count("world_0") == 0
         assert await broker.get_pending_count("world_1") == 1
         assert await broker.get_pending_count("world_2") == 1
+
+
+class TestEnqueueBulkQuotaAccounting:
+    """Regression tests for enqueue_bulk's all-or-nothing quota guarantee.
+
+    Prior to the fix, guardrail_allow mutated the per-tick counter and
+    daily token budget during the validation phase, so a bulk that failed
+    RBAC mid-loop would silently burn quota for the earlier commands even
+    though zero commands were enqueued.
+    """
+
+    @pytest.mark.asyncio
+    async def test_partial_rbac_failure_does_not_debit_quota(self, _reset_quotas):
+        broker = CommandBroker()
+        actor_id = uuid7()
+        # player role: can spawn/despawn/update/message/custom; CANNOT add_processor
+        ctx = ActorCtx(id=actor_id, roles={"player"})
+
+        bulk = [
+            Command(type=CommandType.SPAWN, payload={"components": []}),
+            Command(type=CommandType.SPAWN, payload={"components": []}),
+            Command(type=CommandType.ADD_PROCESSOR, payload={}),  # forbidden
+            Command(type=CommandType.SPAWN, payload={"components": []}),
+        ]
+
+        with pytest.raises(PermissionError, match="add_processor"):
+            await broker.enqueue_bulk("w1", bulk, ctx)
+
+        # All-or-nothing: no commands enqueued, so no quota debited.
+        assert _tick_counters.get(actor_id, 0) == 0
+        assert _daily_tokens.get(actor_id, 0) == 0
+        assert len(broker._queues.get("w1", [])) == 0
+        assert await broker.get_pending_count("w1") == 0
+
+    @pytest.mark.asyncio
+    async def test_successful_bulk_debits_exactly_once_per_command(self, _reset_quotas):
+        broker = CommandBroker()
+        actor_id = uuid7()
+        ctx = ActorCtx(id=actor_id, roles={"player"})
+
+        bulk = [
+            Command(type=CommandType.SPAWN, payload={"components": []}),
+            Command(type=CommandType.SPAWN, payload={"components": []}),
+            Command(type=CommandType.SPAWN, payload={"components": []}),
+        ]
+        await broker.enqueue_bulk("w1", bulk, ctx)
+
+        # 3 SPAWNs × 10 tokens each = 30 tokens.
+        assert _tick_counters[actor_id] == 3
+        assert _daily_tokens[actor_id] == 30
+        assert len(broker._queues["w1"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_bulk_detects_projected_tick_quota_before_mutating(self, _reset_quotas):
+        """A bulk that would overflow the per-tick quota fails up-front and
+        leaves the actor's counters untouched."""
+        from archetype.app.auth.guard import MAX_CMDS_PER_TICK
+
+        broker = CommandBroker()
+        actor_id = uuid7()
+        ctx = ActorCtx(id=actor_id, roles={"admin"})
+
+        # A bulk larger than the per-tick quota must be rejected atomically.
+        oversized = [
+            Command(type=CommandType.CUSTOM, payload={}) for _ in range(MAX_CMDS_PER_TICK + 1)
+        ]
+
+        with pytest.raises(PermissionError, match="per-tick quota"):
+            await broker.enqueue_bulk("w1", oversized, ctx)
+
+        assert _tick_counters.get(actor_id, 0) == 0
+        assert _daily_tokens.get(actor_id, 0) == 0
+        assert len(broker._queues.get("w1", [])) == 0
 
 
 class TestBrokerWithoutCtx:


### PR DESCRIPTION
## Summary

Fixes the `enqueue-bulk-quota-debit-on-failure` bug documented in PR #123 (`docs/reports/2026-04-11-bug-enqueue-bulk-quota-debit-on-failure.md`). `CommandBroker.enqueue_bulk` advertised an **all-or-nothing** guarantee, but `guardrail_allow` mutated `_tick_counters` and `_daily_tokens` as a side effect of validation. A bulk that passed RBAC for the first N commands and then failed on command N+1 raised `PermissionError`, enqueued **zero** commands, and silently consumed N quota slots plus the associated token budget.

Visible fallout:

- Audit history showed "no commands applied" while the actor's fair-share quota was drained.
- Trivial quota-exhaustion attack: any caller who can submit a bulk with a forbidden trailing command can burn through `MAX_CMDS_PER_TICK` (500) and `MAX_TOKENS_PER_DAY` (200k) without ever enqueueing a single command.
- Race window where a tick boundary during the validation loop would zero the counter and lose the prior debits permanently.

## Root cause

`guardrail_allow` (`src/archetype/app/auth/guard.py:77`) was named like a pure predicate ("allow?") but had side effects — it debited counters *inside* the check. `enqueue_bulk`'s (`src/archetype/app/broker.py:89`) validation loop therefore mutated global quota state *before* the queue mutations ran, and the two phases diverged on failure: the queue respected all-or-nothing, the counters did not.

## Fix

- Split `guardrail_allow` into a **pure** `guardrail_check(cmd, ctx, projected_count, projected_tokens)` (returns the command's token cost if allowed, raises otherwise, **no mutation**) and a separate `guardrail_commit(ctx, count, tokens)` that applies the debit.
- `enqueue_bulk` now stacks projected debits across the bulk via `guardrail_check` with no global mutation, and commits once at the end — so a partial validation failure leaves counters untouched.
- `guardrail_allow` stays as a thin `check`+`commit` wrapper so single-command callers (`enqueue`, `CommandService.submit`) keep their exact prior behavior.

All changes live in `src/archetype/app/` — no `core/` modifications.

## Regression tests

`tests/app/test_broker_extended.py::TestEnqueueBulkQuotaAccounting` adds three tests:

- `test_partial_rbac_failure_does_not_debit_quota` — exact MRE from the bug report: `[SPAWN, SPAWN, ADD_PROCESSOR(forbidden), SPAWN]` as `player`. Asserts `_tick_counters == 0`, `_daily_tokens == 0`, queue empty after the `PermissionError`. **Fails on `main`** (counter is 2, tokens are 20).
- `test_successful_bulk_debits_exactly_once_per_command` — sanity check that a successful 3-cmd bulk debits exactly 3 tick slots and 30 tokens and enqueues all 3.
- `test_bulk_detects_projected_tick_quota_before_mutating` — a bulk of `MAX_CMDS_PER_TICK + 1` commands is rejected atomically, leaving counters at 0.

## Test plan

- [x] `uv run pytest tests/app/test_broker_extended.py tests/app/test_auth.py -x -q` → 29 passed
- [x] `make ci` → 423 passed, 85.6% coverage, gate passed
- [x] Ran the bug report's MRE against the fix — `tick_counter=0 tokens=0 queue=0` after the rejected bulk (was `tick_counter=2 tokens=20` on main).

Closes the `enqueue-bulk-quota-debit-on-failure` bug report.