### PR TITLE
fix: UPDATE command mutates existing component values

### DIFF
--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -179,6 +179,46 @@ class CommandService:
             world._next_entity_id = entity_id
 
     @staticmethod
+    async def _apply_update(world: AsyncWorld, entity_id: int, components: list) -> None:
+        """Apply an UPDATE: overlay component values on an existing entity.
+
+        Unlike ``ADD_COMPONENT``, UPDATE must mutate component values even when
+        the entity already has those component types (same archetype signature).
+        ``AsyncWorld.add_components`` early-returns in that case, which made
+        UPDATE a silent no-op for the natural use case. Here we detect the
+        same-signature path and push an overlaid row through the spawn cache
+        directly; type-widening updates still delegate to ``add_components``.
+        """
+        from archetype.core.archetype import Archetype
+
+        old_sig = world._entity2sig.get(entity_id)
+        if old_sig is None:
+            logger.warning("UPDATE: entity %s not found", entity_id)
+            return
+
+        if not components:
+            return
+
+        new_sig = Archetype.add_components(old_sig, [type(c) for c in components])
+        if new_sig != old_sig:
+            # New component types introduced — archetype move already handles
+            # overlaying the supplied values via _move_entity.
+            await world.add_components(entity_id, components)
+            return
+
+        row = await world._move_entity(entity_id, old_sig, new_sig, components)
+        if not row:
+            logger.warning("UPDATE: entity %s has no prior row to update", entity_id)
+            return
+
+        # Mark the prior row for this entity inactive and append the overlaid
+        # row under the same signature. Mirrors the archetype-move bookkeeping
+        # in ``AsyncWorld.add_components`` so that queries latched onto "latest
+        # active row" return the updated values, not the original.
+        world._despawn_cache.setdefault(old_sig, []).append(entity_id)
+        world._spawn_cache.setdefault(new_sig, []).append(row)
+
+    @staticmethod
     def _apply_reserved_spawn(world: AsyncWorld, entity_id: int, components: list) -> None:
         from archetype.core.archetype import Archetype
 
@@ -250,7 +290,12 @@ class CommandService:
                 entity_id = payload["entity_id"]
                 await world.remove_entity(entity_id)
 
-            case CommandType.UPDATE | CommandType.ADD_COMPONENT:
+            case CommandType.UPDATE:
+                entity_id = payload["entity_id"]
+                components = self._hydrate_components(payload.get("components", []))
+                await self._apply_update(world, int(entity_id), components)
+
+            case CommandType.ADD_COMPONENT:
                 entity_id = payload["entity_id"]
                 components = self._hydrate_components(payload.get("components", []))
                 await world.add_components(entity_id, components)

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -206,6 +206,106 @@ async def test_spawn_with_bare_model_dump_raises(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_update_command_mutates_existing_component_values(tmp_path):
+    """UPDATE must change component values even when the entity already has
+    that component type (same archetype signature).
+
+    Regression for the ``update-command-silently-noops`` bug: the UPDATE and
+    ADD_COMPONENT dispatch arms in ``CommandService.apply`` both routed to
+    ``AsyncWorld.add_components``, which early-returns when the signature is
+    unchanged. The user's "update Position to (99, 99)" looked like it
+    succeeded end-to-end — the command acked, audit history recorded it — but
+    the entity values never moved.
+    """
+    from archetype.core.component import Component
+    from archetype.core.config import RunConfig
+
+    class UpdateRegressionPos(Component):
+        x: int = 0
+        y: int = 0
+
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await container.world_service.create_world(
+            WorldConfig(name="update-regression"), storage
+        )
+
+        eid = await world.create_entity([UpdateRegressionPos(x=1, y=2)])
+        await world.run(RunConfig(num_steps=1))
+
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        cmd = Command(
+            type=CommandType.UPDATE,
+            tick=0,
+            payload={
+                "entity_id": eid,
+                "components": [UpdateRegressionPos(x=99, y=99).to_payload()],
+            },
+        )
+        await container.command_service.submit(str(world.world_id), cmd, ctx)
+        await container.simulation_service.step(world.world_id)
+
+        df = await world.get_components([UpdateRegressionPos], entity_ids=[eid])
+        rows = df.collect().to_pylist()
+        assert rows, "UPDATE produced no rows for entity"
+        latest = max(rows, key=lambda r: r["tick"])
+        assert latest["updateregressionpos__x"] == 99 and latest["updateregressionpos__y"] == 99, (
+            f"UPDATE silently dropped — latest row is "
+            f"({latest['updateregressionpos__x']}, {latest['updateregressionpos__y']}), "
+            f"expected (99, 99)."
+        )
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_update_command_widens_archetype_with_new_component(tmp_path):
+    """UPDATE that introduces a brand-new component type should behave like
+    ADD_COMPONENT — the entity moves to a wider archetype and picks up the
+    new values."""
+    from archetype.core.component import Component
+    from archetype.core.config import RunConfig
+
+    class UpdateWidenPos(Component):
+        x: int = 0
+
+    class UpdateWidenVel(Component):
+        vx: int = 0
+
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await container.world_service.create_world(
+            WorldConfig(name="update-widen"), storage
+        )
+
+        eid = await world.create_entity([UpdateWidenPos(x=1)])
+        await world.run(RunConfig(num_steps=1))
+
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        cmd = Command(
+            type=CommandType.UPDATE,
+            tick=0,
+            payload={
+                "entity_id": eid,
+                "components": [UpdateWidenVel(vx=7).to_payload()],
+            },
+        )
+        await container.command_service.submit(str(world.world_id), cmd, ctx)
+        await container.simulation_service.step(world.world_id)
+
+        df = await world.get_components([UpdateWidenPos, UpdateWidenVel], entity_ids=[eid])
+        rows = df.collect().to_pylist()
+        assert rows, "UPDATE-widen produced no rows in (UpdateWidenPos, UpdateWidenVel) archetype"
+        latest = max(rows, key=lambda r: r["tick"])
+        assert latest["updatewidenpos__x"] == 1
+        assert latest["updatewidenvel__vx"] == 7
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_rbac_denies_viewer_spawn(tmp_path):
     """A viewer should not be able to submit a SPAWN command."""
     container = ServiceContainer()


### PR DESCRIPTION
## Summary

Fixes the `update-command-silently-noops` bug documented in PR #123 (`docs/reports/2026-04-11-bug-update-command-silently-noops.md`). `CommandService.apply` routed `CommandType.UPDATE` through the same dispatch arm as `ADD_COMPONENT`, forwarding both to `AsyncWorld.add_components`. `add_components` early-returns when the new signature matches the old — the natural UPDATE case where the entity already has the component types being written.

Visible fallout:

- REST/CLI `update` requests returned 200s, the broker acked the commands, audit history recorded them applied — and the entity values never changed.
- The `player` role's only write path to existing component state (UPDATE) was silently broken; no per-tick component mutations could land.
- Quota was burned by no-op updates; audit history lied about what had been applied.

## Root cause

`command_service.py` collapsed `UPDATE | ADD_COMPONENT` into one `case` that delegated to `world.add_components(entity_id, components)`. The two operations have fundamentally different semantics: `ADD_COMPONENT` only needs to act when new types widen the archetype, but `UPDATE` must overlay component values whether or not the signature changes. When the signature was unchanged, `add_components` hit its "no-op" early return at `async_world.py:356-358` and the command silently dropped.

## Fix

- Split the two dispatch arms. `ADD_COMPONENT` keeps calling `world.add_components` (still correct — and still a no-op when the component type is already present, which is defensible for "add").
- Route `UPDATE` through a new `CommandService._apply_update` helper:
  - If the supplied components introduce new types, delegate to `world.add_components` (archetype-widening path — `_move_entity` already overlays supplied values).
  - Otherwise, call `AsyncWorld._move_entity(entity_id, sig, sig, components)` directly to build an overlaid row, mark the prior row inactive via `_despawn_cache`, and push the new row through `_spawn_cache`. Mirrors the bookkeeping `add_components` does on an archetype move, but against the same signature.

Entity lookup misses still log a warning and drop (matching the existing `add_components` behaviour); empty component lists short-circuit without touching state.

## Test plan

Two regression tests in `tests/integration/test_command_flow.py`, both driven through the full `submit -> broker -> drain_and_apply -> step` pipeline:

- [x] `test_update_command_mutates_existing_component_values` — spawn `Pos(1, 2)`, submit `UPDATE` to `(99, 99)`, assert the latest row reflects the new values. Fails on `main` (assertion fires with `(1, 2)`), passes with the fix.
- [x] `test_update_command_widens_archetype_with_new_component` — spawn with one component, submit `UPDATE` that introduces a brand-new type, assert the entity now lives in the wider archetype with both values.
- [x] `make ci` passes end-to-end (422 tests, coverage 85.55%).
