### PR TITLE
fix: create_world no longer leaks orphan worlds on name collision

### DIFF
--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -69,6 +69,12 @@ class WorldService:
         if world_id in self._worlds:
             return self._worlds[world_id]
 
+        # Validate name uniqueness BEFORE allocating a storage backend or
+        # constructing a world. Otherwise, a duplicate-name attempt leaks a
+        # half-built world into _worlds while the validity check raises.
+        if config.name and config.name in self._world_names:
+            raise ValueError(f"World with name '{config.name}' already exists.")
+
         world = await self.factory.create_world(
             world_config=config,
             storage_config=storage_config,
@@ -83,8 +89,6 @@ class WorldService:
         self._worlds[world.world_id] = world
 
         if config.name:
-            if config.name in self._world_names:
-                raise ValueError(f"World with name '{config.name}' already exists.")
             self._world_names[config.name] = world.world_id
 
         self._persist_entry(world, storage_config)

--- a/tests/core/test_orchestrator_errors_and_instrumentation.py
+++ b/tests/core/test_orchestrator_errors_and_instrumentation.py
@@ -20,6 +20,50 @@ async def test_world_service_duplicate_name_raises(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_duplicate_name_create_does_not_leak_orphan_world(tmp_path):
+    """Regression: a failed duplicate-name create_world must NOT leave a
+    half-built world in _worlds (previously inserted before the name check)."""
+    ws = WorldService(StorageService())
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        await ws.create_world(WorldConfig(name="dup"), storage_config=storage)
+        baseline_worlds = len(ws._worlds)
+        baseline_names = len(ws._world_names)
+
+        with pytest.raises(ValueError):
+            await ws.create_world(WorldConfig(name="dup"), storage_config=storage)
+
+        assert len(ws._worlds) == baseline_worlds, (
+            f"create_world leaked an orphan world into _worlds: "
+            f"baseline={baseline_worlds}, after={len(ws._worlds)}"
+        )
+        assert len(ws._world_names) == baseline_names
+        # Every world in _worlds must be reachable via _world_names.
+        unreachable = [wid for wid in ws._worlds if wid not in ws._world_names.values()]
+        assert unreachable == [], f"orphaned worlds: {unreachable}"
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_repeated_duplicate_name_creates_do_not_grow_worlds(tmp_path):
+    """Regression: repeated failing duplicate-name create_world calls must
+    not accumulate worlds in the in-memory registry."""
+    ws = WorldService(StorageService())
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        await ws.create_world(WorldConfig(name="dup"), storage_config=storage)
+
+        for _ in range(10):
+            with pytest.raises(ValueError):
+                await ws.create_world(WorldConfig(name="dup"), storage_config=storage)
+
+        assert len(ws._worlds) == 1, f"10 failed retries leaked {len(ws._worlds) - 1} orphan worlds"
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_world_service_getters_missing_keys_raise(tmp_path):
     """Accessing non-existent worlds by name and id should raise KeyError with a clear message."""
     ws = WorldService(StorageService())

--- a/tests/core/test_orchestrator_errors_and_instrumentation.py
+++ b/tests/core/test_orchestrator_errors_and_instrumentation.py
@@ -20,7 +20,7 @@ async def test_world_service_duplicate_name_raises(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_duplicate_name_create_does_not_leak_orphan_world(tmp_path):
+async def test_world_service_duplicate_name_create_does_not_leak_orphan_world(tmp_path):
     """Regression: a failed duplicate-name create_world must NOT leave a
     half-built world in _worlds (previously inserted before the name check)."""
     ws = WorldService(StorageService())
@@ -46,7 +46,7 @@ async def test_duplicate_name_create_does_not_leak_orphan_world(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_repeated_duplicate_name_creates_do_not_grow_worlds(tmp_path):
+async def test_world_service_repeated_duplicate_name_creates_do_not_grow_worlds(tmp_path):
     """Regression: repeated failing duplicate-name create_world calls must
     not accumulate worlds in the in-memory registry."""
     ws = WorldService(StorageService())


### PR DESCRIPTION
## Summary

Fixes the `create-world-name-collision-orphan` bug documented in PR #123 (`docs/reports/2026-04-11-bug-create-world-name-collision-orphan.md`). `WorldService.create_world` inserted the newly-built world into `self._worlds` *before* checking whether `config.name` was already taken. The duplicate-name check then raised `ValueError`, but the half-built world stayed in `_worlds` — holding its storage handle, broker-injected `Resources`, `_entity2sig`, hooks, and Daft session — with no name mapping and no way for callers to reach it.

Visible fallout:

- Any REST client that retried `POST /worlds` after a 500/timeout with the same body leaked one orphan world per retry. `archetype serve` accumulated orphans for the lifetime of the process.
- `len(_worlds) - len(_world_names)` grew unboundedly on misconfigured workloads.
- Compounded with the already-filed `lifecycle-commands-leak-broker` report: each duplicate-name REST attempt also leaked a zombie command into the broker. Small misconfigurations cascaded.
- The existing `test_world_service_duplicate_name_raises` caught the `ValueError` and stopped — it never checked `len(_worlds)` afterwards, so the leak was invisible in CI.

## Fix

Move the `config.name in self._world_names` check to before `factory.create_world(...)`. On a duplicate name the function now fails fast without allocating a storage backend, constructing an `AsyncWorld`, or touching `_worlds` — so there is no half-built world to orphan.

## Regression tests

Two new tests in `tests/core/test_orchestrator_errors_and_instrumentation.py`:

- `test_duplicate_name_create_does_not_leak_orphan_world` — asserts `_worlds` and `_world_names` lengths are unchanged after a failed duplicate-name create, and that every world in `_worlds` is reachable via `_world_names`. Fails on `main` (`baseline=1, after=2`), passes after the fix.
- `test_repeated_duplicate_name_creates_do_not_grow_worlds` — 10 retries of a failing duplicate-name create must leave `_worlds` at size 1. Fails on `main` (`10 failed retries leaked 10 orphan worlds`), passes after the fix.

## Test plan

- [x] `make ci` passes (422 tests, 85.64% coverage)
- [x] Both new regression tests fail on `main` before the fix and pass after

Closes the `create-world-name-collision-orphan` item from #123.

https://claude.ai/code/session_012fXHCjvC19FWznJbMaguYf