### PR TITLE
fix: remove_world clears broker state to prevent leak on world destroy

### DIFF
--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -285,7 +285,7 @@ class CommandService:
 
             case CommandType.DESTROY_WORLD:
                 target_id = UUID(str(payload["world_id"]))
-                self._world_service.remove_world(target_id)
+                await self._world_service.remove_world(target_id)
                 return None
 
             case CommandType.FORK_WORLD:

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -150,13 +150,23 @@ class WorldService:
             result.append(info)
         return result
 
-    def remove_world(self, world_id: UUID) -> None:
-        """Removes a world from management by its ID."""
+    async def remove_world(self, world_id: UUID) -> None:
+        """Removes a world from management by its ID.
+
+        Also evicts the world's broker state (pending queue, in-flight
+        command ids, and audit history) so destroying a world does not leak
+        broker bookkeeping for the lifetime of the process. Without this,
+        ``broker.get_pending_count()`` over-reports indefinitely and
+        ``broker.get_history(world_id)`` returns orphaned commands for a
+        world that no longer exists.
+        """
         if world_id in self._worlds:
             for name, uid in list(self._world_names.items()):
                 if uid == world_id:
                     del self._world_names[name]
             del self._worlds[world_id]
+        if self._broker is not None:
+            await self._broker.clear(world_id)
         if self._registry is not None:
             self._registry.delete(world_id)
 

--- a/src/archetype/sugar.py
+++ b/src/archetype/sugar.py
@@ -357,7 +357,7 @@ class RuntimeWorld:
                 and (from_runtime or not self._runtime._closed)
             ):
                 await self._runtime._container.broker.clear(self._world.world_id)
-                self._runtime._container.world_service.remove_world(self._world.world_id)
+                await self._runtime._container.world_service.remove_world(self._world.world_id)
             self._closed = True
             self._world = None
             self._initialized = False

--- a/tests/app/test_registry.py
+++ b/tests/app/test_registry.py
@@ -123,7 +123,7 @@ class TestCrossContainerDiscovery:
         try:
             world = await c1.world_service.create_world(WorldConfig(name="temp"), storage)
             wid = world.world_id
-            c1.world_service.remove_world(wid)
+            await c1.world_service.remove_world(wid)
         finally:
             await c1.shutdown()
 

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -468,7 +468,7 @@ class TestWorldService:
         try:
             storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
             world = await container.world_service.create_world(WorldConfig(name="w1"), storage)
-            container.world_service.remove_world(world.world_id)
+            await container.world_service.remove_world(world.world_id)
             assert len(container.world_service.list_worlds()) == 0
         finally:
             await container.shutdown()
@@ -481,6 +481,81 @@ class TestWorldService:
             world = await container.world_service.create_world(WorldConfig(name="alpha"), storage)
             found = container.world_service.get_world_by_name("alpha")
             assert found.world_id == world.world_id
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_remove_world_clears_broker_state(self, tmp_path):
+        """Regression: remove_world used to delete the world from _worlds
+        but leave every pending command, in-flight command id, and audit
+        history entry behind in the broker — an unbounded memory leak on
+        every world destroy.
+        """
+        container = ServiceContainer()
+        try:
+            ctx = ActorCtx(id=uuid7(), roles={"admin"})
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="doomed"), storage)
+            wid = world.world_id
+            wid_str = str(wid)
+
+            # Enqueue a few commands so the broker has non-trivial state.
+            for i in range(3):
+                cmd = Command(
+                    type=CommandType.SPAWN,
+                    tick=0,
+                    payload={"components": [_ListWorldsPos(x=i).to_payload()]},
+                )
+                await container.command_service.submit(wid, cmd, ctx)
+
+            broker = container.broker
+            assert len(broker._queues.get(wid_str, [])) == 3
+            assert len(broker._history.get(wid_str, [])) == 3
+            assert await broker.get_pending_count() >= 3
+
+            await container.world_service.remove_world(wid)
+
+            assert broker._queues.get(wid_str, []) == []
+            assert broker._history.get(wid_str, []) == []
+            assert await broker.get_pending_count() == 0
+            assert all(cmd_id not in broker._pending for cmd_id in list(broker._pending))
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_destroy_world_command_clears_broker_state(self, tmp_path):
+        """Regression: DESTROY_WORLD via CommandService must also evict the
+        destroyed world's broker state, not just the WorldService entry.
+        """
+        container = ServiceContainer()
+        try:
+            ctx = ActorCtx(id=uuid7(), roles={"admin"})
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(
+                WorldConfig(name="ephemeral"), storage
+            )
+            wid = world.world_id
+            wid_str = str(wid)
+
+            spawn_cmd = Command(
+                type=CommandType.SPAWN,
+                tick=0,
+                payload={"components": [_ListWorldsPos(x=0).to_payload()]},
+            )
+            await container.command_service.submit(wid, spawn_cmd, ctx)
+
+            broker = container.broker
+            assert len(broker._queues.get(wid_str, [])) == 1
+
+            destroy_cmd = Command(
+                type=CommandType.DESTROY_WORLD,
+                tick=0,
+                payload={"world_id": str(wid)},
+            )
+            await container.command_service.apply_world_lifecycle(destroy_cmd)
+
+            assert broker._queues.get(wid_str, []) == []
+            assert broker._history.get(wid_str, []) == []
         finally:
             await container.shutdown()
 

--- a/tests/core/test_factory_and_orchestrator.py
+++ b/tests/core/test_factory_and_orchestrator.py
@@ -47,7 +47,7 @@ async def test_world_service_lifecycle_and_name_lookup(tmp_path):
         assert len(worlds) == 1
 
         # remove by ID
-        ws.remove_world(w1.world_id)
+        await ws.remove_world(w1.world_id)
         assert len(ws.list_worlds()) == 0
     finally:
         await ws.shutdown()

--- a/tests/core/test_orchestrator_errors_and_instrumentation.py
+++ b/tests/core/test_orchestrator_errors_and_instrumentation.py
@@ -84,7 +84,7 @@ async def test_world_service_removal_clears_name_mapping_and_allows_reuse(tmp_pa
         storage = StorageConfig(uri=str(tmp_path / "store3"), namespace="ns")
         w = await ws.create_world(WorldConfig(name="cycle"), storage_config=storage)
         wid = w.world_id
-        ws.remove_world(wid)
+        await ws.remove_world(wid)
         with pytest.raises(KeyError):
             ws.get_world(wid)
         # name should be free again
@@ -99,7 +99,7 @@ async def test_world_service_remove_nonexistent_is_noop(tmp_path):
     """Removing a world that does not exist should be a no-op (no exception)."""
     ws = WorldService(StorageService())
     try:
-        ws.remove_world(uuid.uuid7())
+        await ws.remove_world(uuid.uuid7())
     finally:
         await ws.shutdown()
 


### PR DESCRIPTION
## Summary

`WorldService.remove_world` deleted the world from `_worlds`/`_world_names` but never called `broker.clear(world_id)`. Every destroyed world's pending queue, in-flight command ids, and audit history stayed in the broker forever — an unbounded memory leak on every `DESTROY_WORLD`. `broker.get_pending_count()` over-reported indefinitely and `broker.get_history(world_id)` kept returning orphaned commands for worlds that were already gone from `get_world`.

### Reproducer (on `main`)

```python
ws = container.world_service
broker = container.broker
info = await ws.create_world(WorldConfig(name="doomed"), StorageConfig(uri=tmp))

for _ in range(3):
    await container.command_service.submit(
        info.world_id, Command(type=CommandType.SPAWN, payload={"components": []}), ctx
    )

ws.remove_world(info.world_id)  # sync — no broker cleanup

# broker._queues[str(wid)]   -> still 3 commands
# broker._pending             -> still 3 entries
# broker._history[str(wid)]   -> still 3 entries
```

### Fix

- Convert `WorldService.remove_world` to **async** and call `await self._broker.clear(world_id)` inside.
- Update all callers (`CommandService.apply_world_lifecycle` DESTROY_WORLD arm, `sugar.WorldHandle._shutdown_internal`, and tests) to `await` it.

The sugar path already awaited `broker.clear` explicitly before removing the world; the duplicate clear inside `remove_world` is a safe no-op.

`broker.clear(world_id)` already existed and did exactly the right thing (`broker.py:215-223`); `remove_world` just didn't call it.

## Regression tests (`tests/app/test_services.py`)

- `test_remove_world_clears_broker_state` — enqueue 3 commands, call `remove_world`, assert `broker._queues`, `broker._pending`, and `broker._history` are empty for the destroyed world.
- `test_destroy_world_command_clears_broker_state` — `DESTROY_WORLD` through `CommandService.apply_world_lifecycle` also clears broker state, not just the `WorldService` entry.

Both fail on `main` (the first with `TypeError: object NoneType can't be used in 'await' expression` because `remove_world` used to be sync) and pass on this branch.

## Source

Bug documented in `docs/reports/2026-04-11-bug-remove-world-leaks-broker-state.md` (from PR #123).

## Test plan

- [x] `make ci` green — 442 passed, 1 skipped, coverage 86.11% (gate: 70%)
- [x] Two new regression tests pass; all pre-existing tests unaffected (existing `remove_world` call sites in `sugar.py`, `command_service.py`, and tests updated to `await`)
- [x] Only touches `app/` + `sugar.py` + tests; `core/` unchanged

https://claude.ai/code/session_01S1ADWYu8D9YF9A5H2CCRgD