### PR TITLE
fix: apply_world_lifecycle drains __global__ broker queue

### DIFF
--- a/src/archetype/app/broker.py
+++ b/src/archetype/app/broker.py
@@ -186,6 +186,32 @@ class CommandBroker:
             for cid in cmd_ids:
                 self._pending.pop(cid, None)
 
+    async def remove(self, world_id: str | UUID, cmd_id: UUID) -> None:
+        """Surgically remove a single command from both the per-world queue
+        and the global pending dict.
+
+        Used by callers that bypass ``dequeue_due`` (e.g. world-lifecycle
+        commands that are applied immediately rather than tick-scheduled),
+        so the command does not leak forever in ``_pending`` and
+        ``_queues``. ``_history`` is preserved as the audit trail.
+        Idempotent: if the command is not present, this is a no-op.
+        """
+        async with self._lock:
+            self._pending.pop(cmd_id, None)
+            key = str(world_id)
+            queue = self._queues.get(key)
+            if not queue:
+                return
+            for idx, cmd in enumerate(queue):
+                if cmd.id == cmd_id:
+                    # Replace with last and re-heapify; cheaper than rebuilding
+                    # except for the trivial single-element case.
+                    last = queue.pop()
+                    if idx < len(queue):
+                        queue[idx] = last
+                        heapq.heapify(queue)
+                    return
+
     async def peek(self, world_id: str | UUID, max_items: int | None = None) -> list[Command]:
         """Peek at commands without removing them."""
         max_items = min(max_items or self._max_dequeue, self._max_dequeue)

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -268,35 +268,46 @@ class CommandService:
         per-world ``apply()`` path.
 
         Returns the created/forked world for CREATE and FORK, None for DESTROY.
+
+        Lifecycle commands are not tick-scheduled, so the broker's
+        ``drain_and_apply`` loop never sees them. Drain the command from
+        ``__global__`` here (in a ``finally`` so failures don't leak either)
+        to keep ``broker._pending`` and ``broker._queues['__global__']`` from
+        growing without bound across the process lifetime.
         """
         payload = cmd.payload
 
-        match cmd.type:
-            case CommandType.CREATE_WORLD:
-                from archetype.core.config import StorageConfig, WorldConfig
+        try:
+            match cmd.type:
+                case CommandType.CREATE_WORLD:
+                    from archetype.core.config import StorageConfig, WorldConfig
 
-                cfg = payload.get("config", {})
-                world_config = WorldConfig(**cfg) if isinstance(cfg, dict) else cfg
-                storage_config = StorageConfig(
-                    uri=payload.get("storage_uri", "./archetype_data"),
-                    namespace=payload.get("namespace", "archetypes"),
-                )
-                return await self._world_service.create_world(world_config, storage_config)
+                    cfg = payload.get("config", {})
+                    world_config = WorldConfig(**cfg) if isinstance(cfg, dict) else cfg
+                    storage_config = StorageConfig(
+                        uri=payload.get("storage_uri", "./archetype_data"),
+                        namespace=payload.get("namespace", "archetypes"),
+                    )
+                    return await self._world_service.create_world(world_config, storage_config)
 
-            case CommandType.DESTROY_WORLD:
-                target_id = UUID(str(payload["world_id"]))
-                await self._world_service.remove_world(target_id)
-                return None
+                case CommandType.DESTROY_WORLD:
+                    target_id = UUID(str(payload["world_id"]))
+                    await self._world_service.remove_world(target_id)
+                    return None
 
-            case CommandType.FORK_WORLD:
-                from archetype.core.config import StorageConfig
+                case CommandType.FORK_WORLD:
+                    from archetype.core.config import StorageConfig
 
-                source_id = UUID(str(payload["source_world_id"]))
-                fork_name = payload.get("name") or payload.get("config", {}).get("name")
-                return await self._world_service.fork_world(source_id, fork_name, StorageConfig())
+                    source_id = UUID(str(payload["source_world_id"]))
+                    fork_name = payload.get("name") or payload.get("config", {}).get("name")
+                    return await self._world_service.fork_world(
+                        source_id, fork_name, StorageConfig()
+                    )
 
-            case _:
-                raise ValueError(f"apply_world_lifecycle does not handle {cmd.type.value}")
+                case _:
+                    raise ValueError(f"apply_world_lifecycle does not handle {cmd.type.value}")
+        finally:
+            await self._broker.remove("__global__", cmd.id)
 
     async def apply(self, world: AsyncWorld, cmd: Command) -> None:
         """

--- a/tests/app/test_broker_extended.py
+++ b/tests/app/test_broker_extended.py
@@ -191,6 +191,43 @@ class TestBrokerEdgeCases:
         count = await broker.get_pending_count("test")
         assert count == 0
 
+    @pytest.mark.asyncio
+    async def test_remove_clears_command_from_queue_and_pending(self):
+        """``remove`` surgically extracts a single command from both
+        ``_queues`` and ``_pending`` while leaving siblings intact."""
+        broker = CommandBroker()
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+
+        keep_a = Command(type=CommandType.MESSAGE, payload={"i": 0})
+        target = Command(type=CommandType.MESSAGE, payload={"i": 1})
+        keep_b = Command(type=CommandType.MESSAGE, payload={"i": 2})
+        await broker.enqueue("w", keep_a, ctx)
+        await broker.enqueue("w", target, ctx)
+        await broker.enqueue("w", keep_b, ctx)
+
+        await broker.remove("w", target.id)
+
+        assert target.id not in broker._pending
+        remaining_ids = {c.id for c in broker._queues["w"]}
+        assert target.id not in remaining_ids
+        assert keep_a.id in remaining_ids
+        assert keep_b.id in remaining_ids
+        # Heap invariant preserved.
+        sorted_remaining = sorted(broker._queues["w"])
+        assert list(broker._queues["w"]) == sorted_remaining or len(remaining_ids) <= 1
+
+    @pytest.mark.asyncio
+    async def test_remove_is_idempotent_on_missing_command(self):
+        """``remove`` must not raise when the command isn't queued."""
+        broker = CommandBroker()
+        # Empty broker — no queue, no pending entry.
+        await broker.remove("nope", uuid7())
+        # Queue exists but command isn't in it.
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        await broker.enqueue("w", Command(type=CommandType.MESSAGE, payload={}), ctx)
+        await broker.remove("w", uuid7())
+        assert len(broker._queues["w"]) == 1
+
 
 class TestBrokerConcurrency:
     @pytest.mark.asyncio

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -87,6 +87,122 @@ class TestCommandService:
         finally:
             await container.shutdown()
 
+    @pytest.mark.asyncio
+    async def test_apply_world_lifecycle_does_not_leak_broker_state(self, tmp_path):
+        """Regression: lifecycle commands (CREATE/DESTROY/FORK_WORLD) are
+        applied immediately rather than tick-scheduled, so the broker's
+        ``drain_and_apply`` loop never sees them. ``apply_world_lifecycle``
+        must drain ``__global__`` itself or every lifecycle op leaks one
+        zombie command into ``broker._pending`` and ``broker._queues``
+        forever.
+        """
+        container = ServiceContainer()
+        try:
+            ctx = ActorCtx(id=uuid7(), roles={"admin"})
+            broker = container.broker
+            assert len(broker._pending) == 0
+            assert len(broker._queues.get("__global__", [])) == 0
+
+            create_cmd = Command(
+                type=CommandType.CREATE_WORLD,
+                tick=0,
+                payload={
+                    "config": {"name": "leak_check"},
+                    "storage_uri": str(tmp_path / "store"),
+                    "namespace": "archetypes",
+                },
+            )
+            await container.command_service.submit("__global__", create_cmd, ctx)
+            world = await container.command_service.apply_world_lifecycle(create_cmd)
+
+            assert len(broker._pending) == 0, (
+                f"CREATE_WORLD leaked into broker._pending ({len(broker._pending)} zombies)"
+            )
+            assert len(broker._queues.get("__global__", [])) == 0, (
+                f"CREATE_WORLD leaked into broker._queues['__global__'] "
+                f"({len(broker._queues['__global__'])} zombies)"
+            )
+
+            destroy_cmd = Command(
+                type=CommandType.DESTROY_WORLD,
+                tick=0,
+                payload={"world_id": str(world.world_id)},
+            )
+            await container.command_service.submit("__global__", destroy_cmd, ctx)
+            await container.command_service.apply_world_lifecycle(destroy_cmd)
+
+            assert len(broker._pending) == 0, (
+                f"DESTROY_WORLD leaked into broker._pending ({len(broker._pending)} zombies)"
+            )
+            assert len(broker._queues.get("__global__", [])) == 0
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_round_trip_does_not_leak_at_volume(self, tmp_path):
+        """Regression: 50 CREATE/DESTROY pairs must leave zero zombies."""
+        container = ServiceContainer()
+        try:
+            ctx = ActorCtx(id=uuid7(), roles={"admin"})
+            broker = container.broker
+
+            for i in range(50):
+                create = Command(
+                    type=CommandType.CREATE_WORLD,
+                    tick=0,
+                    payload={
+                        "config": {"name": f"w{i}"},
+                        "storage_uri": str(tmp_path / "store"),
+                        "namespace": "archetypes",
+                    },
+                )
+                await container.command_service.submit("__global__", create, ctx)
+                world = await container.command_service.apply_world_lifecycle(create)
+
+                destroy = Command(
+                    type=CommandType.DESTROY_WORLD,
+                    tick=0,
+                    payload={"world_id": str(world.world_id)},
+                )
+                await container.command_service.submit("__global__", destroy, ctx)
+                await container.command_service.apply_world_lifecycle(destroy)
+
+            assert len(broker._pending) == 0, (
+                f"50 CREATE/DESTROY pairs leaked {len(broker._pending)} "
+                f"zombies into broker._pending"
+            )
+            assert len(broker._queues.get("__global__", [])) == 0
+            # History is the audit trail; it should still record everything.
+            history = await broker.get_history("__global__", limit=200)
+            assert len(history) == 100
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_apply_world_lifecycle_drains_on_failure(self, tmp_path):
+        """Regression: even if the side effect raises, the command must not
+        leak into the broker. The drain must happen in a finally block.
+        """
+        container = ServiceContainer()
+        try:
+            ctx = ActorCtx(id=uuid7(), roles={"admin"})
+            broker = container.broker
+
+            # Missing world_id triggers KeyError inside apply_world_lifecycle
+            bad_destroy = Command(
+                type=CommandType.DESTROY_WORLD,
+                tick=0,
+                payload={},  # missing "world_id"
+            )
+            await container.command_service.submit("__global__", bad_destroy, ctx)
+            with pytest.raises(KeyError):
+                await container.command_service.apply_world_lifecycle(bad_destroy)
+
+            assert len(broker._pending) == 0, "Failed lifecycle command leaked into broker._pending"
+            assert len(broker._queues.get("__global__", [])) == 0
+        finally:
+            await container.shutdown()
+
 
 class TestSimulationService:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes the broker leak documented in `docs/reports/2026-04-11-bug-lifecycle-commands-leak-broker.md` (PR #123). Every CREATE/DESTROY/FORK_WORLD call left one zombie `Command` in `broker._pending` and one in `broker._queues['__global__']` for the lifetime of the process.

### Root cause

The REST handlers in `api/routes/worlds.py` (and any caller of `submit + apply_world_lifecycle`) follow this pattern:

```python
await cs.submit("__global__", cmd, ctx)
await cs.apply_world_lifecycle(cmd)
```

`submit` enqueues into `broker._queues['__global__']` and `broker._pending`. `apply_world_lifecycle` runs the `WorldService` side effect directly — it never goes through `drain_and_apply`, so `dequeue_due` and `ack` are never called. Nothing else drains the `__global__` pseudo-world queue.

Result: every CREATE/DESTROY/FORK leaks one `Command` per call. `broker.get_pending_count()` (no world_id) over-reports indefinitely; the audit history at `broker.get_history('__global__')` shows nothing but zombies.

### Fix

1. **`CommandBroker.remove(world_id, cmd_id)`** — surgically removes a single command from both `_pending` and the per-world heap, preserving the heap invariant and leaving `_history` (the audit trail) intact. Idempotent for missing commands.
2. **`CommandService.apply_world_lifecycle`** — wraps the dispatch in `try/finally` and calls `await self._broker.remove("__global__", cmd.id)` after the side effect. The `finally` guarantees that failures (e.g. a missing `world_id` on DESTROY) don't leak either. When `apply()` dispatches to `apply_world_lifecycle` for a tick-scheduled lifecycle command, `drain_and_apply` has already removed the entry, so `remove` is a no-op.

### Regression tests

In `tests/app/test_services.py::TestCommandService`:
- `test_apply_world_lifecycle_does_not_leak_broker_state` — single CREATE then DESTROY; asserts `_pending` and `_queues['__global__']` are empty after each.
- `test_lifecycle_round_trip_does_not_leak_at_volume` — 50 CREATE/DESTROY pairs; asserts zero leaks and that `_history` correctly retains all 100 audit entries.
- `test_apply_world_lifecycle_drains_on_failure` — failing DESTROY (missing payload key) raises but still drains.

In `tests/app/test_broker_extended.py::TestBrokerEdgeCases`:
- `test_remove_clears_command_from_queue_and_pending` — surgical removal of one command among siblings.
- `test_remove_is_idempotent_on_missing_command` — no-op for missing commands.

All three lifecycle tests fail on `main` and pass with the fix. Full suite: 445 passed, coverage 86.13%.

## Test plan

- [x] `make ci` passes locally (445 passed, 1 skipped, 86.13% coverage)
- [x] Three new lifecycle regression tests fail without the fix
- [x] Two new broker.remove unit tests verify surgical removal + idempotence

🤖 Generated with [Claude Code](https://claude.com/claude-code)