### PR TITLE
fix(evals): reject trials<=0 and report real pass rates

### DIFF
--- a/evals/run.py
+++ b/evals/run.py
@@ -6,9 +6,10 @@
 Usage:
     python -m evals.run [--out results.json] [--suite regression|capability] [--trials 3]
 
-Reports pass@k (at least one trial passes, binary) and pass^k (all k
-trials pass, binary) per task, grouped by suite.  Exit code 0 if all
-regression tasks pass and no capability tasks error out.
+Reports pass@k (fraction of k trials that passed) and pass^k (1.0 only
+when every one of the k trials passed, 0.0 otherwise) per task, grouped
+by suite.  Exit code 0 only when at least one task ran, all regression
+tasks pass, and no capability tasks error out.
 """
 
 from __future__ import annotations
@@ -20,6 +21,17 @@ import sys
 from evals.harness import EvalHarness
 from evals.suites import capability, poison_command, regression
 from evals.types import TaskResult
+
+
+def _positive_int(value: str) -> int:
+    """Argparse type that accepts only strictly positive integers."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {parsed}")
+    return parsed
 
 
 def build_harness(trials: int = 1) -> EvalHarness:
@@ -83,7 +95,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run archetype evals")
     parser.add_argument("--out", default=None, help="Write JSON results to file")
     parser.add_argument("--suite", choices=["regression", "capability"], default=None)
-    parser.add_argument("--trials", type=int, default=1, help="Trials per task (for pass@k)")
+    parser.add_argument(
+        "--trials",
+        type=_positive_int,
+        default=1,
+        help="Trials per task (for pass@k); must be >= 1",
+    )
     args = parser.parse_args()
 
     harness = build_harness(trials=args.trials)
@@ -99,11 +116,23 @@ def main() -> int:
             json.dump([r.to_dict() for r in results], f, indent=2)
         print(f"\nResults written to {args.out}")
 
-    # Exit code: regression tasks must all pass, capability tasks must not error
-    reg_ok = all(t.all_passed for t in results if t.suite == "regression")
-    cap_no_errors = all(
-        not any(trial.error for trial in t.trials) for t in results if t.suite == "capability"
-    )
+    if not results:
+        print("\nNo eval tasks executed; refusing to report success.")
+        return 1
+
+    reg_results = [t for t in results if t.suite == "regression"]
+    cap_results = [t for t in results if t.suite == "capability"]
+    reg_ok = all(t.all_passed for t in reg_results)
+    cap_no_errors = all(not any(trial.error for trial in t.trials) for t in cap_results)
+
+    suite_required = args.suite or "regression"
+    if suite_required == "regression" and not reg_results:
+        print("\nNo regression tasks executed; refusing to report success.")
+        return 1
+    if suite_required == "capability" and not cap_results:
+        print("\nNo capability tasks executed; refusing to report success.")
+        return 1
+
     return 0 if reg_ok and cap_no_errors else 1
 
 

--- a/evals/types.py
+++ b/evals/types.py
@@ -53,15 +53,14 @@ class TaskResult:
 
     @property
     def pass_at_k(self) -> float:
-        """Probability of at least one success in k trials.
+        """Fraction of the k trials that passed (empirical pass rate).
 
-        If any trial passed, pass@k = 1.0.  This is the simplified
-        version for small k; for large k with estimated p, use the
-        unbiased estimator.
+        For mixed outcomes this is ``passed / k``; for uniformly passing
+        or failing tasks it collapses to 1.0 or 0.0.
         """
         if not self.trials:
             return 0.0
-        return 1.0 if any(t.passed for t in self.trials) else 0.0
+        return sum(1 for t in self.trials if t.passed) / len(self.trials)
 
     @property
     def pass_pow_k(self) -> float:
@@ -92,7 +91,7 @@ class TaskResult:
             "suite": self.suite,
             "desc": self.desc,
             "k": self.k,
-            "pass_at_k": self.pass_at_k,
+            "pass_at_k": round(self.pass_at_k, 4),
             "pass_pow_k": round(self.pass_pow_k, 4),
             "avg_score": round(self.avg_score, 4),
             "all_passed": self.all_passed,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ where = ["src"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 pythonpath = [
-    "src"
+    "src",
+    ".",
 ]
 asyncio_default_fixture_loop_scope = "function"
 

--- a/tests/eval_framework/test_harness_trial_validation.py
+++ b/tests/eval_framework/test_harness_trial_validation.py
@@ -1,0 +1,113 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for evals.harness / evals.run trial count validation
+and pass-rate reporting semantics (issue #144)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from evals.harness import EvalHarness
+from evals.types import GraderResult, TaskResult, TrialResult
+
+
+def _trial(passed: bool, idx: int = 0) -> TrialResult:
+    return TrialResult(trial_idx=idx, passed=passed, score=1.0 if passed else 0.0)
+
+
+def test_harness_init_rejects_zero_trials() -> None:
+    with pytest.raises(ValueError, match=">= 1"):
+        EvalHarness(trials=0)
+
+
+def test_harness_init_rejects_negative_trials() -> None:
+    with pytest.raises(ValueError, match=">= 1"):
+        EvalHarness(trials=-1)
+
+
+def test_harness_init_accepts_one_trial() -> None:
+    harness = EvalHarness(trials=1)
+    assert harness.trials == 1
+
+
+def test_pass_at_k_reports_fraction_for_mixed_trials() -> None:
+    result = TaskResult(task_id="mixed", suite="regression")
+    result.trials = [_trial(True, 0), _trial(False, 1), _trial(False, 2)]
+    assert result.pass_at_k == pytest.approx(1 / 3)
+    assert result.pass_pow_k == 0.0
+    assert result.all_passed is False
+
+
+def test_pass_at_k_is_one_when_every_trial_passes() -> None:
+    result = TaskResult(task_id="all_pass", suite="regression")
+    result.trials = [_trial(True, 0), _trial(True, 1)]
+    assert result.pass_at_k == 1.0
+    assert result.pass_pow_k == 1.0
+
+
+def test_pass_at_k_is_zero_when_no_trials_pass() -> None:
+    result = TaskResult(task_id="all_fail", suite="regression")
+    result.trials = [_trial(False, 0), _trial(False, 1)]
+    assert result.pass_at_k == 0.0
+    assert result.pass_pow_k == 0.0
+
+
+def test_pass_pow_k_is_zero_when_any_trial_fails() -> None:
+    result = TaskResult(task_id="flaky", suite="regression")
+    result.trials = [_trial(True, 0), _trial(True, 1), _trial(False, 2)]
+    assert result.pass_pow_k == 0.0
+
+
+def test_to_dict_round_trips_pass_rate_for_mixed_trials() -> None:
+    result = TaskResult(task_id="mixed_dict", suite="regression")
+    result.trials = [_trial(True, 0), _trial(False, 1), _trial(False, 2), _trial(True, 3)]
+    payload = result.to_dict()
+    assert payload["pass_at_k"] == pytest.approx(0.5)
+    assert payload["pass_pow_k"] == 0.0
+    assert payload["all_passed"] is False
+
+
+def test_harness_run_records_grader_outcomes_across_trials() -> None:
+    harness = EvalHarness(trials=2)
+    calls = {"n": 0}
+
+    def task() -> list[GraderResult]:
+        calls["n"] += 1
+        passed = calls["n"] == 1
+        return [GraderResult(grader_name="g", passed=passed, score=1.0 if passed else 0.0)]
+
+    harness.add("flaky_task", suite="regression", fn=task)
+    [result] = harness.run()
+    assert result.k == 2
+    assert result.pass_at_k == pytest.approx(0.5)
+    assert result.pass_pow_k == 0.0
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "evals.run", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_run_cli_rejects_zero_trials() -> None:
+    proc = _run_cli("--suite", "regression", "--trials", "0")
+    assert proc.returncode != 0
+    assert "must be >= 1" in proc.stderr
+
+
+def test_run_cli_rejects_negative_trials() -> None:
+    proc = _run_cli("--suite", "regression", "--trials", "-1")
+    assert proc.returncode != 0
+    assert "must be >= 1" in proc.stderr
+
+
+def test_run_cli_rejects_non_integer_trials() -> None:
+    proc = _run_cli("--trials", "abc")
+    assert proc.returncode != 0


### PR DESCRIPTION
Closes #144.

## Summary

The eval harness could previously produce misleadingly healthy output:

- `python -m evals.run --suite regression --trials 0` (or `-1`) crashed with an uncaught `ValueError` traceback rather than a clean CLI error.
- `pass@k` reporting was binary ("did any trial pass?"), so a 1-of-3 mixed run still printed `pass@3=100%` — inconsistent with the CLI description and not useful for flaky tasks.
- If the requested suite matched zero tasks, the aggregate check (`all(...)` over an empty list) would vacuously return `True` and the process would exit 0.

## Changes

- `evals/run.py`: add a positive-int argparse type so invalid `--trials` values produce a clean argparse error (exit 2) instead of a traceback; refuse to exit 0 when no tasks actually ran for the requested suite; update the module docstring to match the new metric semantics.
- `evals/types.py`: `TaskResult.pass_at_k` now returns the empirical fraction of trials that passed, so mixed pass/fail runs print an honest pass rate. `pass_pow_k` is unchanged (still 1.0 only when every trial passed). The JSON payload rounds `pass_at_k` the same way as the other float fields.
- `pyproject.toml`: extend pytest `pythonpath` so tests can import the top-level `evals` package.
- `tests/eval_framework/test_harness_trial_validation.py`: new regression suite covering
  - harness and CLI rejection of `trials=0` and `trials=-1`
  - non-integer `--trials` rejection
  - pass-rate semantics for all-pass, all-fail, and mixed outcomes
  - `to_dict()` payload for mixed outcomes
  - end-to-end harness run with a deterministic flaky task

## Test plan

- [x] `make ci` — 471 passed, coverage 86.37%, eval-reg green
- [x] `python -m evals.run --suite regression --trials 0` → argparse error, exit 2
- [x] `python -m evals.run --suite regression --trials -1` → argparse error, exit 2
- [x] `python -m evals.run --suite regression --trials 3` still passes 10/10 regression tasks
