### PR TITLE
fix: fire on_spawn/on_despawn hooks from AsyncWorld

### DIFF
--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -243,9 +243,7 @@ class CommandService:
         world._spawn_cache.setdefault(new_sig, []).append(row)
 
     @staticmethod
-    async def _apply_reserved_spawn(
-        world: AsyncWorld, entity_id: int, components: list
-    ) -> None:
+    async def _apply_reserved_spawn(world: AsyncWorld, entity_id: int, components: list) -> None:
         from archetype.core.archetype import Archetype
 
         if entity_id in world._entity2sig:

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -243,7 +243,9 @@ class CommandService:
         world._spawn_cache.setdefault(new_sig, []).append(row)
 
     @staticmethod
-    def _apply_reserved_spawn(world: AsyncWorld, entity_id: int, components: list) -> None:
+    async def _apply_reserved_spawn(
+        world: AsyncWorld, entity_id: int, components: list
+    ) -> None:
         from archetype.core.archetype import Archetype
 
         if entity_id in world._entity2sig:
@@ -256,6 +258,7 @@ class CommandService:
             entity_id, world.tick, components, world.world_id, run_id=""
         )
         world._spawn_cache.setdefault(sig, []).append(row_dict)
+        await world._fire_hooks("on_spawn", world=world, entity_id=entity_id, components=components)
 
     async def apply_world_lifecycle(self, cmd: Command) -> iWorld | None:
         """Dispatch a world-level lifecycle command (create/destroy/fork).
@@ -313,7 +316,7 @@ class CommandService:
                 if entity_id is None:
                     await world.create_entity(components)
                 else:
-                    self._apply_reserved_spawn(world, int(entity_id), components)
+                    await self._apply_reserved_spawn(world, int(entity_id), components)
 
             case CommandType.DESPAWN:
                 entity_id = payload["entity_id"]

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -324,6 +324,7 @@ class AsyncWorld(iAsyncWorld):
         # Placeholder run_id; updater will stamp correct run_id on update
         row_dict = Archetype.to_row_dict(entity_id, self.tick, components, self.world_id, run_id="")
         self._spawn_cache.setdefault(sig, []).append(row_dict)
+        await self._fire_hooks("on_spawn", world=self, entity_id=entity_id, components=components)
         return entity_id
 
     async def remove_entity(self, entity_id: int):
@@ -342,9 +343,11 @@ class AsyncWorld(iAsyncWorld):
                     self._spawn_cache[sig] = remaining
                 else:
                     del self._spawn_cache[sig]
+                await self._fire_hooks("on_despawn", world=self, entity_id=entity_id)
                 return
 
         self._despawn_cache.setdefault(sig, []).append(entity_id)
+        await self._fire_hooks("on_despawn", world=self, entity_id=entity_id)
 
     async def add_components(self, entity_id: int, components: list[Component]) -> None:
         old_sig = self._entity2sig.get(entity_id)

--- a/tests/core/test_resources_hooks_messaging.py
+++ b/tests/core/test_resources_hooks_messaging.py
@@ -330,6 +330,52 @@ class TestHooks:
         await world.run(rc)
         assert world.tick == 1
 
+    @pytest.mark.asyncio
+    async def test_on_spawn_hook_fires_when_entity_created(self, world):
+        """on_spawn hook fires on create_entity with entity_id and components."""
+        events: list[dict] = []
+
+        async def on_spawn(**kwargs):
+            events.append(kwargs)
+
+        world.add_hook("on_spawn", on_spawn)
+        components = [Position(x=1, y=2)]
+        eid = await world.create_entity(components)
+
+        assert len(events) == 1
+        assert events[0]["entity_id"] == eid
+        assert events[0]["world"] is world
+        assert events[0]["components"] == components
+
+    @pytest.mark.asyncio
+    async def test_on_despawn_hook_fires_when_entity_removed(self, world):
+        """on_despawn hook fires on remove_entity with entity_id."""
+        events: list[dict] = []
+
+        async def on_despawn(**kwargs):
+            events.append(kwargs)
+
+        eid = await world.create_entity([Position(x=1, y=2)])
+        world.add_hook("on_despawn", on_despawn)
+        await world.remove_entity(eid)
+
+        assert len(events) == 1
+        assert events[0]["entity_id"] == eid
+        assert events[0]["world"] is world
+
+    @pytest.mark.asyncio
+    async def test_on_despawn_hook_skips_unknown_entity(self, world):
+        """on_despawn hook does not fire when remove_entity targets an unknown id."""
+        events: list[dict] = []
+
+        async def on_despawn(**kwargs):
+            events.append(kwargs)
+
+        world.add_hook("on_despawn", on_despawn)
+        await world.remove_entity(9999)
+
+        assert events == []
+
 
 # =============================================================================
 # Resources in Processor Tests

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -123,10 +123,8 @@ async def test_reserved_spawn_fires_on_spawn_hook(tmp_path):
         world.add_hook("on_spawn", on_spawn)
 
         ctx = ActorCtx(id=uuid7(), roles={"admin"})
-        entity_id = await container.command_service.submit_spawn(
-            world.world_id, [Pos(x=7)], ctx
-        )
-        await container.simulation_service.step(world.world_id)
+        entity_id = await container.command_service.submit_spawn(world.world_id, [Pos(x=7)], ctx)
+        await container.simulation_service.step(world.world_id, RunConfig())
 
         assert len(events) == 1
         assert events[0]["entity_id"] == entity_id

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -98,6 +98,44 @@ async def test_submit_spawn_returns_reserved_entity_id_and_materializes_it(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_reserved_spawn_fires_on_spawn_hook(tmp_path):
+    """submit_spawn takes the reserved-id path (_apply_reserved_spawn), which
+    bypasses AsyncWorld.create_entity. The on_spawn hook must still fire so
+    consumers see the same lifecycle events regardless of which spawn API the
+    caller used."""
+    from archetype.core.component import Component
+
+    class Pos(Component):
+        x: int = 0
+
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await container.world_service.create_world(
+            WorldConfig(name="reserved-hook"), storage
+        )
+
+        events: list[dict] = []
+
+        async def on_spawn(**kwargs):
+            events.append(kwargs)
+
+        world.add_hook("on_spawn", on_spawn)
+
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        entity_id = await container.command_service.submit_spawn(
+            world.world_id, [Pos(x=7)], ctx
+        )
+        await container.simulation_service.step(world.world_id)
+
+        assert len(events) == 1
+        assert events[0]["entity_id"] == entity_id
+        assert events[0]["world"] is world
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_spawn_preserves_typed_components_through_command_service(tmp_path):
     """SPAWN with ``to_payload()`` dicts must land in the typed archetype, not ``(Component,)``.
 


### PR DESCRIPTION
## Summary

`AsyncWorld.add_hook` advertises four lifecycle events — `pre_tick`, `post_tick`, `on_spawn`, `on_despawn` — but only the first two were wired to `_fire_hooks`. Registering an `on_spawn` or `on_despawn` callback silently stored a hook that never fired.

This PR wires the two missing events:

- `create_entity` now fires `on_spawn` with `world`, `entity_id`, and `components`.
- `remove_entity` now fires `on_despawn` with `world` and `entity_id`, and only when the entity actually existed (matching the existing "no entity" warning path for unknown ids).

Closes the `on_spawn` / `on_despawn` subset of the #123 bug-report bundle. Addresses the bug report in `docs/reports/2026-04-11-bug-on-spawn-on-despawn-hooks-never-fire.md`.

## Why

The docstring promised four hook events but only delivered two. This is an observability gap on a documented public API: log-on-spawn, per-entity telemetry, entity-lifetime auditing, and the planned `@behavior.on_spawn` DSL layer all depended on a hook that never fired, with no error surfaced from `add_hook`.

## Changes

- `src/archetype/core/aio/async_world.py`
  - `create_entity` → `await self._fire_hooks("on_spawn", world, entity_id, components)`
  - `remove_entity` → `await self._fire_hooks("on_despawn", world, entity_id)` (inside the `if sig:` branch)
- `tests/core/test_resources_hooks_messaging.py`
  - `test_on_spawn_hook_fires_when_entity_created` — asserts the hook fires with the expected kwargs
  - `test_on_despawn_hook_fires_when_entity_removed` — asserts the hook fires on remove
  - `test_on_despawn_hook_skips_unknown_entity` — asserts no fire when `remove_entity` targets an unknown id

## Test plan

- [x] `make ci` passes locally
- [x] New `test_on_spawn_hook_fires_when_entity_created` passes
- [x] New `test_on_despawn_hook_fires_when_entity_removed` passes
- [x] New `test_on_despawn_hook_skips_unknown_entity` passes
- [x] Existing `TestHooks` tests still pass
