### PR TITLE
fix: SyncWorld.remove_entity cancels pending same-tick spawns

### DIFF
--- a/src/archetype/core/sync/world.py
+++ b/src/archetype/core/sync/world.py
@@ -261,12 +261,23 @@ class SyncWorld(iWorld):
 
     def remove_entity(self, entity_id: int):
         sig = self._entity2sig.pop(entity_id, None)
-        if sig:
-            self._despawn_cache.setdefault(sig, []).append(entity_id)
-        else:
+        if sig is None:
             logger.warning(
                 f"World {self.name} ({self.world_id}): Entity Removal Failed: No entity: {entity_id}"
             )
+            return
+
+        pending = self._spawn_cache.get(sig)
+        if pending:
+            remaining = [row for row in pending if row["entity_id"] != entity_id]
+            if len(remaining) != len(pending):
+                if remaining:
+                    self._spawn_cache[sig] = remaining
+                else:
+                    del self._spawn_cache[sig]
+                return
+
+        self._despawn_cache.setdefault(sig, []).append(entity_id)
 
     def add_components(self, entity_id: int, components: list[Component]) -> None:
         old_sig = self._entity2sig.get(entity_id)

--- a/tests/sync/test_sync_world.py
+++ b/tests/sync/test_sync_world.py
@@ -155,7 +155,10 @@ class TestSyncSystem:
 
 
 def _make_sync_world(tmp_path, name="test"):
-    """Helper to construct a SyncWorld with in-memory Daft session."""
+    """Helper to construct a SyncWorld with an in-memory Daft session.
+
+    Used by the lightweight tests that never call ``world.step``.
+    """
     session = Session()
     uri = str(tmp_path / "sync_store")
     store = SyncStore(uri=uri, session=session)
@@ -164,6 +167,23 @@ def _make_sync_world(tmp_path, name="test"):
     system = SyncSystem()
     config = WorldConfig(name=name)
     return SyncWorld(world_config=config, querier=querier, updater=updater, system=system)
+
+
+def _make_sync_world_with_catalog(tmp_path, name="test"):
+    """Helper to construct a SyncWorld backed by a real catalog so
+    ``world.step`` can actually persist rows."""
+    from archetype.core.config import StorageConfig
+    from archetype.core.runtime.storage import StorageContextFactory
+
+    cfg = StorageConfig(uri=str(tmp_path / f"{name}_store"), namespace=f"{name}_ns")
+    ctx = StorageContextFactory.build(cfg)
+    store = SyncStore(uri=ctx.uri, session=ctx.session)
+    querier = QueryManager(store=store)
+    updater = UpdateManager(store=store)
+    system = SyncSystem()
+    return SyncWorld(
+        world_config=WorldConfig(name=name), querier=querier, updater=updater, system=system
+    )
 
 
 class TestSyncWorld:
@@ -189,14 +209,30 @@ class TestSyncWorld:
         assert sig in world._spawn_cache
         assert len(world._spawn_cache[sig]) == 1
 
-    def test_remove_entity_populates_despawn_cache(self, tmp_path):
-        world = _make_sync_world(tmp_path)
+    def test_remove_entity_cancels_pending_spawn_in_same_tick(self, tmp_path):
         from archetype.core.archetype import Archetype
 
+        world = _make_sync_world(tmp_path)
         sig = Archetype.sig_from_components([Position(x=0, y=0)])
         e1 = world.create_entity([Position(x=1, y=2)])
 
         world.remove_entity(e1)
+
+        assert sig not in world._spawn_cache
+        assert e1 not in world._entity2sig
+        assert e1 not in world._despawn_cache.get(sig, [])
+
+    def test_remove_entity_schedules_despawn_after_spawn_materialized(self, tmp_path):
+        from archetype.core.archetype import Archetype
+        from archetype.core.config import RunConfig
+
+        world = _make_sync_world_with_catalog(tmp_path, "despawn_after_step")
+        sig = Archetype.sig_from_components([Position(x=0, y=0)])
+        e1 = world.create_entity([Position(x=1, y=2)])
+        world.step(RunConfig(num_steps=1))
+
+        world.remove_entity(e1)
+
         assert sig in world._despawn_cache
         assert e1 in world._despawn_cache[sig]
 
@@ -239,3 +275,59 @@ class TestSyncWorld:
         world.create_entity([Position(x=1, y=2)])
         world.create_entity([Position(x=3, y=4)])
         assert world._next_entity_id == 3
+
+    def test_step_after_same_tick_spawn_remove_leaves_no_active_row(self, tmp_path):
+        from archetype.core.archetype import Archetype
+        from archetype.core.config import RunConfig
+
+        world = _make_sync_world_with_catalog(tmp_path, "cancel_active")
+        sig = Archetype.sig_from_components([Position(x=0, y=0)])
+        rc = RunConfig(num_steps=1)
+
+        eid = world.create_entity([Position(x=1, y=2)])
+        world.remove_entity(eid)
+        world.step(rc)
+
+        df = world.querier.query_archetype(
+            sig=sig,
+            run_config=rc,
+            ticks=None,
+            entity_ids=[eid],
+            components=None,
+            world_id=str(world.world_id),
+        )
+        rows = df.to_pylist()
+        assert all(not r["is_active"] for r in rows), (
+            f"cancelled entity persisted as active: {rows}"
+        )
+
+        for s, live_df in world._live.items():
+            active_eids = [r["entity_id"] for r in live_df.to_pylist() if r["is_active"]]
+            assert eid not in active_eids, f"_live[{s}] kept cancelled entity {eid}"
+
+    def test_step_after_same_tick_spawn_remove_preserves_sibling_entity(self, tmp_path):
+        from archetype.core.archetype import Archetype
+        from archetype.core.config import RunConfig
+
+        world = _make_sync_world_with_catalog(tmp_path, "cancel_sibling")
+        sig = Archetype.sig_from_components([Position(x=0, y=0)])
+        rc = RunConfig(num_steps=1)
+
+        survivor = world.create_entity([Position(x=10, y=20)])
+        cancelled = world.create_entity([Position(x=1, y=2)])
+        world.remove_entity(cancelled)
+        world.step(rc)
+
+        df = world.querier.query_archetype(
+            sig=sig,
+            run_config=rc,
+            ticks=None,
+            entity_ids=None,
+            components=None,
+            world_id=str(world.world_id),
+        )
+        rows = df.to_pylist()
+        active_ids = sorted(r["entity_id"] for r in rows if r["is_active"])
+        assert active_ids == [survivor], (
+            f"expected only survivor {survivor} active, got {active_ids}"
+        )


### PR DESCRIPTION
## Summary

`SyncWorld.remove_entity` unconditionally scheduled a despawn and popped `_entity2sig`. When the matching spawn was still in `_spawn_cache` (i.e. `step()` had not run yet), `_materialize_mutations` applied the despawn mask **before** the spawn concat, so the mask saw no row to flip and the spawn row was appended as-is — persisting an `is_active=True` row for an entity the caller explicitly removed, and poisoning the `_live` snapshot with the same row.

This is the sync sibling of the bug described in `docs/reports/2026-04-11-bug-sync-spawn-despawn-same-tick.md`.

## Changes

- `src/archetype/core/sync/world.py` — `remove_entity` now checks `_spawn_cache` for a pending row with the same `entity_id` and cancels it in place. It only schedules a despawn when the spawn has already been materialised. This keeps the store and `_live` tombstone-free for cancelled entities.
- `tests/sync/test_sync_world.py`:
  - Replaced `test_remove_entity_populates_despawn_cache` (which encoded the buggy behaviour) with two tests that describe the two branches: `test_remove_entity_cancels_pending_spawn_in_same_tick` and `test_remove_entity_schedules_despawn_after_spawn_materialized`.
  - Added `test_step_after_same_tick_spawn_remove_leaves_no_active_row` — exercises the store + `_live` snapshot end-to-end after a cancelled spawn.
  - Added `test_step_after_same_tick_spawn_remove_preserves_sibling_entity` — a sibling entity in the same archetype must still be active after the step.
  - Added `_make_sync_world_with_catalog` helper so the step-driven tests run against a real catalog (the existing in-memory `Session()` helper cannot `create_table_if_not_exists`).

## Verification

- `make ci` — 462 passed, coverage 86.40%, eval-reg 10/10.
- Reverted the `src/archetype/core/sync/world.py` change and re-ran the three new tests — all three fail against pre-fix code, confirming the regression suite reproduces the original bug.

## Test plan

- [x] `make ci` passes locally
- [x] New regression tests fail against pre-fix code
- [x] Existing `SyncWorld` tests still pass

https://claude.ai/code/session_01EA4QRJ7LNLZErqedGbzR77