### PR TITLE
fix: AsyncCachedStore.get_archetype_df unions memtable with disk

### DIFF
--- a/src/archetype/core/aio/async_cached_store.py
+++ b/src/archetype/core/aio/async_cached_store.py
@@ -24,6 +24,7 @@ import psutil
 import pyarrow as pa
 from daft import DataFrame
 
+from archetype.core.archetype import Archetype
 from archetype.core.config import CacheConfig
 
 # Internals
@@ -141,18 +142,24 @@ class AsyncCachedStore(iAsyncStore):
     ) -> DataFrame:
         """
         Get all archetypes that contain all of the specified component types.
+
+        Reads are a union of already-flushed rows on disk and unflushed rows
+        still in the memtable so that callers always see a coherent view of
+        the sig's full history regardless of flush state.
         """
-        # Get the memtable
+        disk_df = await self._inner.get_archetype_df(sig, world_id, run_id)
+
         mt = self._mem.get(sig)
+        if not (mt and mt.rows):
+            return disk_df
 
-        # Read the Archetype Table from Memtable or Disk
-        if mt and mt.rows:
-            df = daft.from_arrow(mt.to_table())
-
-            return df.where(df["world_id"] == str(world_id)).where(df["run_id"] == str(run_id))
-
-        # If no data in cache, grab from storage
-        return await self._inner.get_archetype_df(sig, world_id, run_id)
+        target_schema = Archetype.get_archetype_schema(sig)
+        mem_table = mt.to_table().select(target_schema.names).cast(target_schema)
+        mem_df = daft.from_arrow(mem_table)
+        mem_df = mem_df.where(mem_df["world_id"] == str(world_id)).where(
+            mem_df["run_id"] == str(run_id)
+        )
+        return disk_df.concat(mem_df)
 
     async def append(self, sig: ArchetypeSignature, df: DataFrame) -> None:
         """

--- a/tests/aio/test_async_cached_store_behavior.py
+++ b/tests/aio/test_async_cached_store_behavior.py
@@ -153,6 +153,105 @@ async def test_cached_store_idle_flush(inner_store):
 
 
 @pytest.mark.asyncio
+async def test_get_archetype_df_unions_memtable_with_disk(inner_store):
+    from archetype.core.config import CacheConfig
+
+    inner = inner_store
+    cache_cfg = CacheConfig(flush_rows=10_000_000, flush_mb=10_000, global_mb=10_000, idle_sec=3600)
+    cached = AsyncCachedStore(async_store=inner, cache_config=cache_cfg)
+    try:
+        sig = Archetype.sig_from_components([Position(x=0, y=0)])
+        world_id = "w_union"
+        run_id = "r_union"
+
+        _ = await inner.get_archetype_df(sig, world_id=world_id, run_id=run_id)
+
+        first = daft.from_pylist(
+            [
+                Archetype.to_row_dict(
+                    entity_id=1,
+                    tick=0,
+                    components=[Position(x=1, y=1)],
+                    world_id=world_id,
+                    run_id=run_id,
+                )
+            ]
+        ).collect()
+        await cached.append(sig, first)
+        await cached._background_flush_sig(sig)
+
+        second = daft.from_pylist(
+            [
+                Archetype.to_row_dict(
+                    entity_id=2,
+                    tick=1,
+                    components=[Position(x=2, y=2)],
+                    world_id=world_id,
+                    run_id=run_id,
+                )
+            ]
+        ).collect()
+        await cached.append(sig, second)
+
+        out = await cached.get_archetype_df(sig, world_id=world_id, run_id=run_id)
+        eids = sorted(r["entity_id"] for r in out.collect().to_pylist())
+        assert eids == [1, 2]
+    finally:
+        await cached.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_archetype_df_filters_memtable_by_run_id(inner_store):
+    from archetype.core.config import CacheConfig
+
+    inner = inner_store
+    cache_cfg = CacheConfig(flush_rows=10_000_000, flush_mb=10_000, global_mb=10_000, idle_sec=3600)
+    cached = AsyncCachedStore(async_store=inner, cache_config=cache_cfg)
+    try:
+        sig = Archetype.sig_from_components([Position(x=0, y=0)])
+        world_id = "w_filter"
+
+        _ = await inner.get_archetype_df(sig, world_id=world_id, run_id="r_a")
+
+        df_a = daft.from_pylist(
+            [
+                Archetype.to_row_dict(
+                    entity_id=10,
+                    tick=0,
+                    components=[Position(x=10, y=10)],
+                    world_id=world_id,
+                    run_id="r_a",
+                )
+            ]
+        ).collect()
+        await cached.append(sig, df_a)
+        await cached._background_flush_sig(sig)
+
+        df_b = daft.from_pylist(
+            [
+                Archetype.to_row_dict(
+                    entity_id=20,
+                    tick=0,
+                    components=[Position(x=20, y=20)],
+                    world_id=world_id,
+                    run_id="r_b",
+                )
+            ]
+        ).collect()
+        await cached.append(sig, df_b)
+
+        out_a = await cached.get_archetype_df(sig, world_id=world_id, run_id="r_a")
+        eids_a = sorted(r["entity_id"] for r in out_a.collect().to_pylist())
+        assert eids_a == [10]
+
+        out_b = await cached.get_archetype_df(sig, world_id=world_id, run_id="r_b")
+        eids_b = sorted(r["entity_id"] for r in out_b.collect().to_pylist())
+        assert eids_b == [20]
+    finally:
+        await cached.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_cached_store_concurrent_appends_are_safe(inner_store):
     from archetype.core.config import CacheConfig
 


### PR DESCRIPTION
## Summary

Fixes the `cached-store-read-shadows-disk` bug documented in #123 (`docs/reports/2026-04-11-bug-cached-store-read-shadows-disk.md`). `AsyncCachedStore.get_archetype_df` was an either-or read: if the memtable had any rows, it returned only the memtable and never consulted the inner store; otherwise it fell through to disk. After any flush the memtable refilled from fresh appends, and the next read silently shadowed every prior row on disk.

Visible fallout for any cache-wrapped world (`WorldFactory.create_world(..., cache_config=CacheConfig(...))`):

- Time-travel queries returned only the rows appended since the last flush — every prior tick was invisible.
- `prefer_live_reads=False` `world.step` reads saw a partial previous state, produced a partial next state, persisted it, and fed the partial view back into the following tick. The corruption compounded per-tick.
- No error, no warning — reads returned a "successful" DataFrame with a strict subset of the data.

## Root cause

`src/archetype/core/aio/async_cached_store.py` had mutually-exclusive branches:

```python
if mt and mt.rows:
    df = daft.from_arrow(mt.to_table())
    return df.where(...)  # memtable only, disk never read
return await self._inner.get_archetype_df(sig, world_id, run_id)
```

After a flush + fresh append, the memtable holds only the newest rows, so the read layer ignored everything on disk.

## Fix

Read from the inner store first, then concat the memtable's unflushed rows on top. The memtable's Arrow table is reordered and cast to the canonical `Archetype.get_archetype_schema(sig)` before the concat so disk (Int32 `entity_id`/`tick` from the Daft catalog table) and memtable (Int64 from `daft.from_pylist`) line up.

## Regression tests

`tests/aio/test_async_cached_store_behavior.py`:

- `test_get_archetype_df_unions_memtable_with_disk` — append+flush entity 1, then append entity 2 to the memtable; assert the read returns both. Fails on `main` (returns `[2]`), passes with the fix.
- `test_get_archetype_df_filters_memtable_by_run_id` — after a flush for `run_id="r_a"` and a memtable append for `run_id="r_b"`, each run_id must see only its own rows across the disk+memtable union.

## Test plan

- [x] `make ci` — 461 passed, 1 skipped, coverage 86.39%, evals 10/10, CI gate passed
- [x] New regression tests fail on `main` and pass with the fix
- [x] Existing `test_cached_store_*` tests still pass

Closes the `cached-store-read-shadows-disk` item from #123.