### PR TITLE
fix: detect Component prefix collisions at schema and row-build time

### DIFF
--- a/src/archetype/core/archetype.py
+++ b/src/archetype/core/archetype.py
@@ -93,6 +93,20 @@ class Archetype:
         Get the schema for an archetype from a list of component types.
         Combines the base archetype schema with prefixed component schemas.
         """
+        seen: dict[str, type[Component]] = {}
+        for component_type in sig:
+            prefix = component_type.get_prefix()
+            existing = seen.get(prefix)
+            if existing is not None and existing is not component_type:
+                raise ValueError(
+                    f"Archetype prefix collision: "
+                    f"{existing.__module__}.{existing.__qualname__} and "
+                    f"{component_type.__module__}.{component_type.__qualname__} "
+                    f"both produce prefix {prefix!r}. Rename one of the classes "
+                    f"so their field prefixes do not collide."
+                )
+            seen[prefix] = component_type
+
         archetype_schema = Archetype.BASE_SCHEMA
         for component_type in sig:
             component_schema = component_type.get_prefixed_schema()
@@ -125,8 +139,20 @@ class Archetype:
             "is_active": True,
         }
 
+        seen_prefixes: dict[str, type[Component]] = {}
         for c in components:
+            component_type = type(c)
             prefix = c.get_prefix()
+            existing = seen_prefixes.get(prefix)
+            if existing is not None and existing is not component_type:
+                raise ValueError(
+                    f"Component prefix collision in to_row_dict: "
+                    f"{existing.__module__}.{existing.__qualname__} and "
+                    f"{component_type.__module__}.{component_type.__qualname__} "
+                    f"both produce prefix {prefix!r}. Rename one of the classes "
+                    f"so their field prefixes do not collide."
+                )
+            seen_prefixes[prefix] = component_type
             row_dict.update({prefix + key: value for key, value in c.model_dump().items()})
 
         return row_dict

--- a/tests/core/test_archetype_core_signatures.py
+++ b/tests/core/test_archetype_core_signatures.py
@@ -1,3 +1,5 @@
+import pytest
+
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 
@@ -8,6 +10,14 @@ class A(Component):
 
 class B(Component):
     y: int
+
+
+class PrefixCollisionA(Component):
+    value: int = 0
+
+
+class prefixcollisiona(Component):  # noqa: N801 — intentional name collision
+    value: int = 0
 
 
 def test_sig_from_components_is_sorted_by_type_name():
@@ -58,3 +68,47 @@ def test_get_name_is_order_invariant_and_hash_suffixed():
     n2 = Archetype.get_name(sig2)
     assert n1 == n2
     assert n1.startswith("a_2c_s")
+
+
+def test_get_archetype_schema_raises_on_prefix_collision():
+    """Two distinct components with the same lowercased class name must not be
+    silently merged into a single set of fields — the schema builder must raise
+    a clear ValueError instead of corrupting the row layout."""
+    assert PrefixCollisionA.get_prefix() == prefixcollisiona.get_prefix()
+    with pytest.raises(ValueError, match="prefix collision"):
+        Archetype.get_archetype_schema((PrefixCollisionA, prefixcollisiona))
+
+
+def test_to_row_dict_raises_on_prefix_collision_between_distinct_classes():
+    """Combining two same-prefix components on one entity must raise instead of
+    letting the second silently overwrite the first under the shared key."""
+    with pytest.raises(ValueError, match="prefix collision"):
+        Archetype.to_row_dict(
+            entity_id=1,
+            tick=0,
+            components=[PrefixCollisionA(value=1), prefixcollisiona(value=99)],
+            world_id="w",
+            run_id="r",
+        )
+
+
+def test_to_row_dict_allows_duplicate_instances_of_same_class():
+    """The collision check must only fire for *distinct* classes that share a
+    prefix; passing two instances of the same class is the existing
+    "last-write-wins" dedupe path and must continue to work."""
+    row = Archetype.to_row_dict(
+        entity_id=1,
+        tick=0,
+        components=[PrefixCollisionA(value=1), PrefixCollisionA(value=2)],
+        world_id="w",
+        run_id="r",
+    )
+    assert row["prefixcollisiona__value"] == 2
+
+
+def test_get_archetype_schema_allows_repeated_same_type_in_sig():
+    """A signature that lists the same component class more than once must not
+    trigger the collision check — only distinct classes with colliding prefixes
+    should fail."""
+    schema = Archetype.get_archetype_schema((PrefixCollisionA,))
+    assert "prefixcollisiona__value" in set(schema.names)


### PR DESCRIPTION
## Summary

Fixes the `component-prefix-collision` bug documented in PR #123 (`docs/reports/2026-04-11-bug-component-prefix-collision.md`). `Component.get_prefix` returns `cls.__name__.lower() + "__"`, so two `Component` subclasses with names that differ only in case (e.g. `Position` vs `position`), or two same-named classes imported from different modules, produce the same prefix. When both ended up on the same entity, `Archetype.to_row_dict` overwrote the first component's values under the shared key and `pa.unify_schemas` silently collapsed the two schemas into one. The failure mode was silent data corruption — no exception, no log line, and no test coverage.

## Root cause

- `Archetype.to_row_dict` (`src/archetype/core/archetype.py`) iterates components and calls `row_dict.update({prefix + key: value for ...})`. A second component under the same prefix overwrites the first.
- `Archetype.get_archetype_schema` then calls `pa.unify_schemas([...])` over the per-component prefixed schemas. Identical-named identical-typed fields merge without error, so the corruption reaches the store with a "healthy" schema.

Neither layer caught the collision. The implicit "all Component class names are globally unique" invariant was documented nowhere and enforced nowhere.

## Fix

Both `Archetype.get_archetype_schema` and `Archetype.to_row_dict` now track seen prefixes during their loop and raise a `ValueError` naming both offending classes as soon as two **distinct** types produce the same prefix. Two instances of the same class still follow the existing last-write-wins dedupe path (the archetype signature and the spawn cache both rely on that).

## Regression tests

`tests/core/test_archetype_core_signatures.py`:

- `test_get_archetype_schema_raises_on_prefix_collision` — schema builder rejects a sig containing two distinct classes with the same lowercased name.
- `test_to_row_dict_raises_on_prefix_collision_between_distinct_classes` — row builder rejects a component list that would otherwise silently overwrite a key.
- `test_to_row_dict_allows_duplicate_instances_of_same_class` — same-class duplicates keep the last-write-wins behavior.
- `test_get_archetype_schema_allows_repeated_same_type_in_sig` — single component sigs still build their schema unchanged.

Verified that the two "raises" tests fail on `main` (DID NOT RAISE) and pass with the fix.

## Test plan

- [x] `make ci` — 463 passed, 1 skipped, coverage 86.44%, eval regression 10/10, gate passed
- [x] New regression tests fail on pre-fix code and pass post-fix
- [x] Existing `test_get_archetype_schema_unifies_base_and_components` still passes (distinct-prefix path is untouched)

Closes the `component-prefix-collision` item from #123.
