### PR TITLE
fix: drain_and_apply returns only successfully applied commands

### DIFF
--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -128,19 +128,19 @@ class CommandService:
             return []
 
         world = self._world_service.get_world(UUID(str(world_id)))
-        applied_ids = []
+        applied: list[Command] = []
 
         for cmd in commands:
             try:
                 await self.apply(world, cmd)
-                applied_ids.append(cmd.id)
+                applied.append(cmd)
             except Exception:
                 logger.exception(f"Failed to apply command {cmd.id} ({cmd.type.value})")
 
-        if applied_ids:
-            await self._broker.ack(applied_ids)
+        if applied:
+            await self._broker.ack([cmd.id for cmd in applied])
 
-        return commands
+        return applied
 
     @staticmethod
     def _hydrate_components(raw: list) -> list:

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -459,3 +459,94 @@ async def test_player_can_spawn_but_not_add_processor(tmp_path):
             await container.command_service.submit(str(world.world_id), proc_cmd, player_ctx)
     finally:
         await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_drain_and_apply_returns_only_applied_commands(tmp_path):
+    """drain_and_apply must return only successfully applied commands.
+
+    When a command fails during apply, it should be excluded from the
+    returned list so callers (e.g. SimulationService.step) report an
+    accurate count and audit trail.
+    """
+    from archetype.core.component import Component
+
+    class GoodComp(Component):
+        value: int = 0
+
+    class BadComp(Component):
+        count: int = 0
+
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await container.world_service.create_world(
+            WorldConfig(name="drain-filter"), storage
+        )
+
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+
+        valid_cmd = Command(
+            type=CommandType.SPAWN,
+            tick=0,
+            payload={"components": [GoodComp(value=42)]},
+        )
+        invalid_cmd = Command(
+            type=CommandType.SPAWN,
+            tick=0,
+            payload={"components": [BadComp(count=1).model_dump()]},
+        )
+        await container.command_service.submit(str(world.world_id), valid_cmd, ctx)
+        await container.command_service.submit(str(world.world_id), invalid_cmd, ctx)
+
+        pending = await container.broker.get_pending_count(str(world.world_id))
+        assert pending == 2
+
+        applied = await container.command_service.drain_and_apply(str(world.world_id), tick=0)
+
+        assert len(applied) == 1
+        assert applied[0].id == valid_cmd.id
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_step_reports_accurate_applied_count(tmp_path):
+    """SimulationService.step must report only successfully applied commands.
+
+    When one of several queued commands fails, the step count should
+    reflect successful applications, not total dequeued commands.
+    """
+    from archetype.core.component import Component
+
+    class StepGood(Component):
+        v: int = 0
+
+    class StepBad(Component):
+        v: int = 0
+
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await container.world_service.create_world(WorldConfig(name="step-count"), storage)
+
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+
+        good = Command(
+            type=CommandType.SPAWN,
+            tick=0,
+            payload={"components": [StepGood(v=1)]},
+        )
+        bad = Command(
+            type=CommandType.SPAWN,
+            tick=0,
+            payload={"components": [StepBad(v=1).model_dump()]},
+        )
+        await container.command_service.submit(str(world.world_id), good, ctx)
+        await container.command_service.submit(str(world.world_id), bad, ctx)
+
+        count = await container.simulation_service.step(world.world_id)
+
+        assert count == 1
+    finally:
+        await container.shutdown()


### PR DESCRIPTION
## Summary

- **Bug:** `CommandService.drain_and_apply()` documented "Returns applied commands for audit" but returned **all** dequeued commands — including ones that failed during `apply()`. This caused `SimulationService.step()` (and the `/step` API route) to over-report `commands_applied` whenever any command in the batch failed.
- **Fix:** Track successfully applied commands directly and return only those. Failed commands are still logged but excluded from the returned list and never acked.
- **Two regression tests** verify the fix at both the `drain_and_apply` level and the `SimulationService.step` level, using a mixed batch of one valid SPAWN and one malformed SPAWN (missing `type` discriminator) that fails during hydration.

## Changed files

| File | What changed |
|------|-------------|
| `src/archetype/app/command_service.py` | `drain_and_apply` now collects applied `Command` objects instead of separate IDs, returns only the applied list |
| `tests/integration/test_command_flow.py` | Two new tests: `test_drain_and_apply_returns_only_applied_commands`, `test_step_reports_accurate_applied_count` |

## Test plan

- [x] `make ci` — 461 passed, 1 skipped, 86.37% coverage, eval-reg 10/10 green
- [x] Both new tests fail against the pre-fix code (`return commands` returns 2 instead of 1)
- [x] Both new tests pass after the fix
- [x] Existing command flow integration tests unaffected

https://claude.ai/code/session_01VYDqU8pbwfbKgB69qSfmjK