### PR TITLE
chore: drop dead SyncStore._cache annotation

### DIFF
--- a/src/archetype/core/sync/store.py
+++ b/src/archetype/core/sync/store.py
@@ -15,8 +15,6 @@
 # Standard Python Libraries
 from logging import getLogger
 
-import pyarrow as pa
-
 # Technologies
 from daft import DataFrame, Schema
 from daft.catalog import Table
@@ -54,8 +52,6 @@ class SyncStore(iStore):
         self.uri = uri
         self.debug = debug
         self.sess = session
-
-        self._cache: dict[ArchetypeSignature, pa.Table]  # Omniscient, Multi-World
         self.flush_interval = None
 
     def _ensure_table(self, sig: ArchetypeSignature) -> Table:


### PR DESCRIPTION
## Summary
- Remove the bare PEP 526 annotation `self._cache: dict[...]` from `SyncStore.__init__` and the `pyarrow` import it was the only consumer of.
- This is a dead-code cleanup, **not** a behavior fix: function-local annotations don't initialize attributes, and no caller references `._cache`. The original #164 framing (and test) was wrong.

Supersedes #164.

## Test plan
- [x] `make ci` green