### PR TITLE
fix: await async world methods in SimulationService.add/remove_processor

### DIFF
--- a/src/archetype/app/simulation_service.py
+++ b/src/archetype/app/simulation_service.py
@@ -105,15 +105,15 @@ class SimulationService:
             return list(await asyncio.gather(*tasks))
         return []
 
-    def add_processor(self, world_id: UUID, processor) -> None:
+    async def add_processor(self, world_id: UUID, processor) -> None:
         """Add a processor to a world's system."""
         world = self._world_service.get_world(world_id)
-        world.add_processor(processor)
+        await world.add_processor(processor)
 
-    def remove_processor(self, world_id: UUID, proc_type) -> None:
+    async def remove_processor(self, world_id: UUID, proc_type) -> None:
         """Remove a processor from a world."""
         world = self._world_service.get_world(world_id)
-        world.remove_processor(proc_type)
+        await world.remove_processor(proc_type)
 
     def list_processors(self, world_id: UUID) -> list[ProcessorInfo]:
         """List processors in a world."""

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -360,18 +360,67 @@ class TestSimulationService:
         assert count == 2
         world.step.assert_not_called()
 
-    def test_add_and_remove_processor_delegate_to_world(self):
-        world = Mock()
+    @pytest.mark.asyncio
+    async def test_add_and_remove_processor_delegate_to_world(self):
+        world = AsyncMock()
         world_service = Mock()
         world_service.get_world.return_value = world
         sim = SimulationService(world_service=world_service, command_service=Mock())
         proc = object()
 
-        sim.add_processor(uuid7(), proc)
-        sim.remove_processor(uuid7(), type(proc))
+        await sim.add_processor(uuid7(), proc)
+        await sim.remove_processor(uuid7(), type(proc))
 
         assert world.add_processor.call_count == 1
         assert world.remove_processor.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_add_processor_appends_to_world_system(self, tmp_path):
+        from archetype.core.aio.async_processor import AsyncProcessor
+
+        class _Marker(AsyncProcessor):
+            components = (_ListWorldsPos,)
+            priority = 99
+
+            async def process(self, df, **kwargs):
+                return df
+
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(
+                WorldConfig(name="add_proc_test"), storage
+            )
+            await container.simulation_service.add_processor(world.world_id, _Marker())
+            names = [type(p).__name__ for p in world.system.processors]
+            assert "_Marker" in names
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_remove_processor_deletes_from_world_system(self, tmp_path):
+        from archetype.core.aio.async_processor import AsyncProcessor
+
+        class _Removable(AsyncProcessor):
+            components = (_ListWorldsPos,)
+            priority = 99
+
+            async def process(self, df, **kwargs):
+                return df
+
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(
+                WorldConfig(name="rm_proc_test"), storage
+            )
+            await world.add_processor(_Removable())
+            assert any(type(p).__name__ == "_Removable" for p in world.system.processors)
+
+            await container.simulation_service.remove_processor(world.world_id, _Removable)
+            assert all(type(p).__name__ != "_Removable" for p in world.system.processors)
+        finally:
+            await container.shutdown()
 
     def test_list_processors_returns_metadata(self):
         class Position:


### PR DESCRIPTION
## Summary

- `SimulationService.add_processor` and `remove_processor` were sync `def` methods calling `AsyncWorld`'s async methods without `await`, silently discarding the coroutines — processors were never actually added or removed
- Made both methods `async def` and added `await` so the underlying world mutation executes
- Updated the existing mock-based test to use `AsyncMock` + `await` (the old `Mock` masked the bug by not returning a coroutine)
- Added two integration tests using a real `AsyncWorld` that verify the processor list is actually mutated

## Test plan

- [x] `test_add_and_remove_processor_delegate_to_world` — existing mock test updated to `async`/`AsyncMock`
- [x] `test_add_processor_appends_to_world_system` — creates a real world, calls `add_processor` via `SimulationService`, asserts the processor appears in `world.system.processors`
- [x] `test_remove_processor_deletes_from_world_system` — adds a processor directly, removes via `SimulationService`, asserts it's gone
- [x] `make ci` passes (461 passed, 1 skipped, 86.37% coverage, 10/10 evals)

Closes #168

https://claude.ai/code/session_01Xmxz5boQHV9kCnKhCvUQVq