### PR TITLE
fix: require RunConfig on SimulationService.step

### DIFF
--- a/docs/guide/building-simulations.md
+++ b/docs/guide/building-simulations.md
@@ -159,7 +159,7 @@ await container.command_service.submit(wid, spawn_cmd, ctx)
 await container.command_service.submit(wid, spawn_cmd, ctx)
 
 # Now they materialize
-await container.simulation_service.step(wid)
+await container.simulation_service.step(wid, rc)
 ```
 
 ### Fork to Compare Strategies

--- a/docs/guide/run-config.md
+++ b/docs/guide/run-config.md
@@ -13,6 +13,12 @@ config = RunConfig(num_steps=10, debug=True)
 await world.run(config)
 ```
 
+### Contract
+
+- A `RunConfig` identifies a run — one `run_id` shared by every tick in the run.
+- `SimulationService.step()` and `world.step()` **require** an explicit `RunConfig`. They MUST NOT mint one per call. Callers driving a multi-tick run reuse the same `RunConfig` across every step so persisted rows stay addressable by `run_id`.
+- `SimulationService.run()` and `world.run()` thread the caller's `RunConfig` into every internal `step()` call.
+
 ### Fields
 
 | Field | Type | Default | Description |

--- a/docs/guide/services.md
+++ b/docs/guide/services.md
@@ -134,6 +134,8 @@ Each `step()` call:
 2. `broker.reset_tick_counters()` -- clear per-actor command counts
 3. `world.step(run_config)` -- execute processors via the core tick lifecycle
 
+`run_config` is **required**. `step()` MUST NOT mint a `RunConfig` internally: every tick in a multi-tick run shares the caller's `RunConfig` so the `run_id` stays stable across ticks. `run()` threads the caller's `RunConfig` into every internal `step()` call.
+
 ## QueryService
 
 Read-only access to world state. No `ActorCtx` required, no RBAC checks, no broker involvement.

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -401,14 +401,12 @@ CURRENT GAPS:
 
 - `step()` is the authoritative world execution boundary.
 - `step()` MUST apply due commands before world execution.
-- `run()` MUST preserve one logical `run_id` across all steps in the run.
+- `step()` MUST receive an explicit `RunConfig` from the caller; the service
+  MUST NOT mint a fresh `RunConfig` per call. Callers drive a multi-tick run
+  by reusing the same `RunConfig` across every step so the `run_id` is stable.
+- `run()` MUST preserve one logical `run_id` across all steps in the run by
+  threading the caller's `RunConfig` into every `step()` call.
 - `run_all()` MAY execute multiple worlds concurrently.
-
-CURRENT GAP:
-
-- `run()` currently loops through fresh one-step `RunConfig` instances, which
-  appears inconsistent with the `RunConfig` contract of a single run-scoped
-  `run_id`.
 
 ### QueryService
 
@@ -740,17 +738,16 @@ The following items should be treated as implementation requirements for a
 coherent engine contract:
 
 1. Make updater durability failures explicit instead of log-only.
-2. Preserve one `run_id` across `SimulationService.run()`.
-3. Define and implement world-lifecycle command ack semantics so API create,
+2. Define and implement world-lifecycle command ack semantics so API create,
    destroy, and fork are not left in ambiguous broker state.
-4. Decide whether command submission to an unknown world is allowed; if not,
+3. Decide whether command submission to an unknown world is allowed; if not,
    reject at submit time.
-5. Fix `WorldService.create_world()` duplicate-name failure ordering so failed
+4. Fix `WorldService.create_world()` duplicate-name failure ordering so failed
    creation does not cache a hidden world.
-6. Align hook documentation and implementation for spawn/despawn lifecycle
+5. Align hook documentation and implementation for spawn/despawn lifecycle
    events.
-7. Give `QueryService` a real read contract or clearly mark it as provisional.
-8. Define world-local teardown semantics that do not leak broker or shared
+6. Give `QueryService` a real read contract or clearly mark it as provisional.
+7. Define world-local teardown semantics that do not leak broker or shared
    runtime state.
 
 ## Acceptance Criteria

--- a/evals/suites/poison_command.py
+++ b/evals/suites/poison_command.py
@@ -21,7 +21,7 @@ from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
 from archetype.app.models import Command, CommandType
 from archetype.core.component import Component
-from archetype.core.config import StorageConfig, WorldConfig
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 from evals.graders import exact_match, state_check
 from evals.harness import EvalHarness
 from evals.types import GraderResult
@@ -66,6 +66,7 @@ async def _task_poison_in_batch() -> list[GraderResult]:
             )
             ctx = ActorCtx(id=uuid7(), roles={"admin"})
             wid = str(world.world_id)
+            rc = RunConfig()
 
             # Valid SPAWN
             await container.command_service.submit(
@@ -100,7 +101,7 @@ async def _task_poison_in_batch() -> list[GraderResult]:
                 ctx,
             )
 
-            await container.simulation_service.step(world.world_id)
+            await container.simulation_service.step(world.world_id, rc)
 
             entity_count = len(world._entity2sig)
             signatures = {frozenset(sig) for sig in world._live}
@@ -142,6 +143,7 @@ async def _task_missing_payload_keys() -> list[GraderResult]:
             )
             ctx = ActorCtx(id=uuid7(), roles={"admin"})
             wid = str(world.world_id)
+            rc = RunConfig()
 
             # DESPAWN with no entity_id
             await container.command_service.submit(
@@ -168,7 +170,7 @@ async def _task_missing_payload_keys() -> list[GraderResult]:
                 ctx,
             )
 
-            await container.simulation_service.step(world.world_id)
+            await container.simulation_service.step(world.world_id, rc)
 
             return [
                 state_check(
@@ -206,6 +208,7 @@ async def _task_unknown_component_type() -> list[GraderResult]:
             )
             ctx = ActorCtx(id=uuid7(), roles={"admin"})
             wid = str(world.world_id)
+            rc = RunConfig()
 
             # Spawn an entity with two components
             await container.command_service.submit(
@@ -222,7 +225,7 @@ async def _task_unknown_component_type() -> list[GraderResult]:
                 ),
                 ctx,
             )
-            await container.simulation_service.step(world.world_id)
+            await container.simulation_service.step(world.world_id, rc)
 
             entity_id = next(iter(world._entity2sig))
             original_sig = frozenset(world._entity2sig[entity_id])
@@ -242,7 +245,7 @@ async def _task_unknown_component_type() -> list[GraderResult]:
                 ),
                 ctx,
             )
-            await container.simulation_service.step(world.world_id)
+            await container.simulation_service.step(world.world_id, rc)
 
             current_sig = frozenset(world._entity2sig[entity_id])
 
@@ -282,6 +285,7 @@ async def _task_despawn_nonexistent_entity() -> list[GraderResult]:
             )
             ctx = ActorCtx(id=uuid7(), roles={"admin"})
             wid = str(world.world_id)
+            rc = RunConfig()
 
             # Spawn a real entity
             await container.command_service.submit(
@@ -293,7 +297,7 @@ async def _task_despawn_nonexistent_entity() -> list[GraderResult]:
                 ),
                 ctx,
             )
-            await container.simulation_service.step(world.world_id)
+            await container.simulation_service.step(world.world_id, rc)
 
             entity_count_before = len(world._entity2sig)
 
@@ -309,7 +313,7 @@ async def _task_despawn_nonexistent_entity() -> list[GraderResult]:
                 ),
                 ctx,
             )
-            await container.simulation_service.step(world.world_id)
+            await container.simulation_service.step(world.world_id, rc)
 
             return [
                 state_check(
@@ -349,6 +353,7 @@ async def _task_unhandled_command_noop() -> list[GraderResult]:
             )
             ctx = ActorCtx(id=uuid7(), roles={"admin"})
             wid = str(world.world_id)
+            rc = RunConfig()
 
             for cmd_type in (CommandType.MESSAGE, CommandType.QUERY_WORLD, CommandType.CUSTOM):
                 await container.command_service.submit(
@@ -357,7 +362,7 @@ async def _task_unhandled_command_noop() -> list[GraderResult]:
                     ctx,
                 )
 
-            await container.simulation_service.step(world.world_id)
+            await container.simulation_service.step(world.world_id, rc)
 
             pending = await container.broker.get_pending_count(wid)
 

--- a/evals/suites/regression.py
+++ b/evals/suites/regression.py
@@ -29,7 +29,7 @@ from archetype.app.container import ServiceContainer
 from archetype.app.models import Command, CommandType
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
-from archetype.core.config import StorageConfig, WorldConfig
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 from evals.graders import exact_match, state_check
 from evals.harness import EvalHarness
 from evals.types import GraderResult
@@ -266,7 +266,8 @@ async def _task_command_pipeline() -> list[GraderResult]:
             pending = await container.broker.get_pending_count(wid)
 
             # Step → drains
-            applied = await container.simulation_service.step(world.world_id)
+            rc = RunConfig()
+            applied = await container.simulation_service.step(world.world_id, rc)
             pending_after = await container.broker.get_pending_count(wid)
 
             # History

--- a/examples/01_world_mutations.py
+++ b/examples/01_world_mutations.py
@@ -75,6 +75,7 @@ async def main():
         WorldConfig(name="mutations-demo"), StorageConfig(),
     )
     wid = world.world_id
+    rc = RunConfig()
     print(f"Created world: {wid}\n")
 
     # ── 1. SPAWN: create entities with components ───────────────────────
@@ -106,7 +107,7 @@ async def main():
     await container.command_service.submit(wid, cmd, admin)
 
     # Step to materialize
-    await container.simulation_service.step(wid)
+    await container.simulation_service.step(wid, rc)
     print(f"   Spawned 2 entities (tick={world.tick})")
 
     # ── 2. ADD_PROCESSOR: inject behavior at runtime ────────────────────
@@ -164,7 +165,7 @@ async def main():
     print("\n5. FORK — branch the world")
 
     # Step to materialize any pending commands first
-    await container.simulation_service.step(wid)
+    await container.simulation_service.step(wid, rc)
 
     fork = await container.world_service.fork_world(
         source_world_id=wid,

--- a/src/archetype/app/simulation_service.py
+++ b/src/archetype/app/simulation_service.py
@@ -37,25 +37,15 @@ class SimulationService:
     async def step(
         self,
         world_id: UUID,
-        run_config: RunConfig | None = None,
+        run_config: RunConfig,
         **input_kwargs,
     ) -> int:
-        """
-        One tick:
-        1. drain_and_apply(world_id, world.tick)
-        2. reset_tick_counters()
-        3. world.step(run_config, **input_kwargs)
-
-        Returns number of commands applied.
-        """
+        """Drain queued commands, advance the world one tick. Returns applied count."""
         world = self._world_service.get_world(world_id)
         tick = getattr(world, "tick", 0)
 
         applied = await self._command_service.drain_and_apply(world_id, tick)
         reset_tick_counters()
-
-        if run_config is None:
-            run_config = RunConfig(num_steps=1)
 
         if isinstance(world, AsyncWorld):
             await world.step(run_config, **input_kwargs)
@@ -68,12 +58,7 @@ class SimulationService:
         run_config: RunConfig,
         **input_kwargs,
     ) -> RunResult:
-        """
-        Execute run_config.num_steps ticks.
-        Returns RunResult with run_id, ticks completed, final state.
-
-        Threads ``run_config`` into every step and pins ``world.run_id`` up-front.
-        """
+        """Execute ``run_config.num_steps`` ticks and return the RunResult."""
         world = self._world_service.get_world(world_id)
 
         if hasattr(world, "run_id"):

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -195,20 +195,9 @@ class AsyncWorld(iAsyncWorld):
     ) -> DataFrame:
         "Atomic sequence of a world step with a dedicated execution and materialization helper for future remote operators."
 
-        # 1. Fetch previous state for all entities and their components.
-        # ``_live`` is always the authoritative in-memory cache of the last
-        # completed tick. The store is the durability layer; reading from it
-        # between ticks is fragile because each SimulationService.step() emits
-        # a fresh ``run_id``, so store reads filtered by ``run_config.run_id``
-        # miss rows written by earlier ticks. Forks exhibit the same failure:
-        # the cloned snapshot is persisted under a placeholder run_id and
-        # the next step queries under a different one. Prefer ``_live`` when
-        # it is populated for this signature — this fixes archetype#72 and
-        # keeps consecutive steps correct under default run configs.
         if self.tick > 0 and sig in self._live:
             df = self._live[sig]
         else:
-            # Builds a clean df with the correct schema for the archetype if tick is 0
             df = await self.query_archetype(
                 sig=sig,
                 run_id=run_config.run_id,

--- a/src/archetype/core/sync/world.py
+++ b/src/archetype/core/sync/world.py
@@ -101,9 +101,6 @@ class SyncWorld(iWorld):
         """
         Process a single archetype through the full pipeline.
         """
-        # 1. Fetch previous state for all entities and their components.
-        # See AsyncWorld._run_archetype: ``_live`` is authoritative when
-        # populated, so always prefer it over the store on tick > 0.
         if self.tick > 0 and sig in self._live:
             df = self._live[sig]
         else:

--- a/tests/app/test_broker_extended.py
+++ b/tests/app/test_broker_extended.py
@@ -298,7 +298,7 @@ class TestEnqueueBulkQuotaAccounting:
         ]
         await broker.enqueue_bulk("w1", bulk, ctx)
 
-        # 3 SPAWNs × 10 tokens each = 30 tokens.
+        # 3 spawn commands × 10 tokens each = 30 tokens.
         assert _tick_counters[actor_id] == 3
         assert _daily_tokens[actor_id] == 30
         assert len(broker._queues["w1"]) == 3

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -204,7 +204,7 @@ class TestSimulationService:
             storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
             world = await container.world_service.create_world(WorldConfig(name="test"), storage)
 
-            cmds_applied = await container.simulation_service.step(world.world_id)
+            cmds_applied = await container.simulation_service.step(world.world_id, RunConfig())
             assert cmds_applied == 0  # no commands queued
         finally:
             await container.shutdown()
@@ -247,7 +247,19 @@ class TestSimulationService:
             await container.shutdown()
 
     @pytest.mark.asyncio
-    async def test_step_uses_default_run_config_when_missing(self, tmp_path, monkeypatch):
+    async def test_step_requires_run_config(self, tmp_path):
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(WorldConfig(name="test"), storage)
+
+            with pytest.raises(TypeError):
+                await container.simulation_service.step(world.world_id)  # type: ignore[call-arg]
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_step_forwards_caller_run_config(self, tmp_path, monkeypatch):
         container = ServiceContainer()
         try:
             storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
@@ -264,10 +276,11 @@ class TestSimulationService:
             )
             monkeypatch.setattr(world, "step", fake_step)
 
-            count = await container.simulation_service.step(world.world_id, bonus=3)
+            rc = RunConfig()
+            count = await container.simulation_service.step(world.world_id, rc, bonus=3)
 
             assert count == 1
-            assert seen["run_config"].num_steps == 1
+            assert seen["run_config"] is rc
             assert seen["kwargs"] == {"bonus": 3}
         finally:
             await container.shutdown()

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -10,7 +10,7 @@ from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
 from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
 from archetype.app.models import Command, CommandType
-from archetype.core.config import StorageConfig, WorldConfig
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 
 
 @pytest.fixture(autouse=True)
@@ -43,7 +43,8 @@ async def test_submit_spawn_step_verify(tmp_path):
         assert pending == 1
 
         # Step the simulation — should drain and apply the command
-        cmds_applied = await container.simulation_service.step(world.world_id)
+        rc = RunConfig()
+        cmds_applied = await container.simulation_service.step(world.world_id, rc)
         assert cmds_applied == 1
 
         # Command should no longer be pending
@@ -83,7 +84,8 @@ async def test_submit_spawn_returns_reserved_entity_id_and_materializes_it(tmp_p
         assert entity_id == 1
         assert world._next_entity_id == 2
 
-        await container.simulation_service.step(world.world_id)
+        rc = RunConfig()
+        await container.simulation_service.step(world.world_id, rc)
 
         assert entity_id in world._entity2sig
         df = await world.get_components([Pos], entity_ids=[entity_id])
@@ -131,7 +133,8 @@ async def test_spawn_preserves_typed_components_through_command_service(tmp_path
             },
         )
         await container.command_service.submit(str(world.world_id), cmd, ctx)
-        await container.simulation_service.step(world.world_id)
+        rc = RunConfig()
+        await container.simulation_service.step(world.world_id, rc)
 
         # Entity should live in the (Pose, Tag) archetype — not (Component,).
         signatures = {frozenset(sig) for sig in world._live}
@@ -162,7 +165,8 @@ async def test_spawn_with_component_instances_passes_through(tmp_path):
             payload={"components": [Foo(value=42)]},
         )
         await container.command_service.submit(str(world.world_id), cmd, ctx)
-        await container.simulation_service.step(world.world_id)
+        rc = RunConfig()
+        await container.simulation_service.step(world.world_id, rc)
 
         assert frozenset({Foo}) in {frozenset(sig) for sig in world._live}
     finally:
@@ -197,7 +201,8 @@ async def test_spawn_with_bare_model_dump_raises(tmp_path):
         # drain_and_apply catches per-command exceptions and logs them, so we
         # assert that the command was dequeued but no entity materialized in
         # any typed archetype.
-        await container.simulation_service.step(world.world_id)
+        rc = RunConfig()
+        await container.simulation_service.step(world.world_id, rc)
 
         signatures = {frozenset(sig) for sig in world._live}
         assert frozenset({Bar}) not in signatures
@@ -218,7 +223,6 @@ async def test_update_command_mutates_existing_component_values(tmp_path):
     the entity values never moved.
     """
     from archetype.core.component import Component
-    from archetype.core.config import RunConfig
 
     class UpdateRegressionPos(Component):
         x: int = 0
@@ -231,8 +235,9 @@ async def test_update_command_mutates_existing_component_values(tmp_path):
             WorldConfig(name="update-regression"), storage
         )
 
+        rc = RunConfig()
         eid = await world.create_entity([UpdateRegressionPos(x=1, y=2)])
-        await world.run(RunConfig(num_steps=1))
+        await world.run(rc)
 
         ctx = ActorCtx(id=uuid7(), roles={"admin"})
         cmd = Command(
@@ -244,7 +249,7 @@ async def test_update_command_mutates_existing_component_values(tmp_path):
             },
         )
         await container.command_service.submit(str(world.world_id), cmd, ctx)
-        await container.simulation_service.step(world.world_id)
+        await container.simulation_service.step(world.world_id, rc)
 
         df = await world.get_components([UpdateRegressionPos], entity_ids=[eid])
         rows = df.collect().to_pylist()
@@ -265,7 +270,6 @@ async def test_update_command_widens_archetype_with_new_component(tmp_path):
     ADD_COMPONENT — the entity moves to a wider archetype and picks up the
     new values."""
     from archetype.core.component import Component
-    from archetype.core.config import RunConfig
 
     class UpdateWidenPos(Component):
         x: int = 0
@@ -280,8 +284,9 @@ async def test_update_command_widens_archetype_with_new_component(tmp_path):
             WorldConfig(name="update-widen"), storage
         )
 
+        rc = RunConfig()
         eid = await world.create_entity([UpdateWidenPos(x=1)])
-        await world.run(RunConfig(num_steps=1))
+        await world.run(rc)
 
         ctx = ActorCtx(id=uuid7(), roles={"admin"})
         cmd = Command(
@@ -293,7 +298,7 @@ async def test_update_command_widens_archetype_with_new_component(tmp_path):
             },
         )
         await container.command_service.submit(str(world.world_id), cmd, ctx)
-        await container.simulation_service.step(world.world_id)
+        await container.simulation_service.step(world.world_id, rc)
 
         df = await world.get_components([UpdateWidenPos, UpdateWidenVel], entity_ids=[eid])
         rows = df.collect().to_pylist()
@@ -335,6 +340,7 @@ async def test_remove_component_resolves_string_type_names(tmp_path):
             WorldConfig(name="remove-strings"), storage
         )
 
+        rc = RunConfig()
         ctx = ActorCtx(id=uuid7(), roles={"admin"})
         spawn_cmd = Command(
             type=CommandType.SPAWN,
@@ -347,7 +353,7 @@ async def test_remove_component_resolves_string_type_names(tmp_path):
             },
         )
         await container.command_service.submit(str(world.world_id), spawn_cmd, ctx)
-        await container.simulation_service.step(world.world_id)
+        await container.simulation_service.step(world.world_id, rc)
 
         assert frozenset({_RemovePosition, _RemoveVelocity}) in {
             frozenset(sig) for sig in world._live
@@ -368,8 +374,8 @@ async def test_remove_component_resolves_string_type_names(tmp_path):
             },
         )
         await container.command_service.submit(str(world.world_id), remove_cmd, ctx)
-        await container.simulation_service.step(world.world_id)
-        await container.simulation_service.step(world.world_id)
+        await container.simulation_service.step(world.world_id, rc)
+        await container.simulation_service.step(world.world_id, rc)
 
         # Entity must now live in the (_RemovePosition,) archetype.
         new_sig = world._entity2sig[entity_id]
@@ -395,6 +401,7 @@ async def test_remove_component_unknown_string_type_raises(tmp_path):
             WorldConfig(name="remove-unknown"), storage
         )
 
+        rc = RunConfig()
         ctx = ActorCtx(id=uuid7(), roles={"admin"})
         spawn_cmd = Command(
             type=CommandType.SPAWN,
@@ -402,7 +409,7 @@ async def test_remove_component_unknown_string_type_raises(tmp_path):
             payload={"components": [Tag(label="x").to_payload()]},
         )
         await container.command_service.submit(str(world.world_id), spawn_cmd, ctx)
-        await container.simulation_service.step(world.world_id)
+        await container.simulation_service.step(world.world_id, rc)
 
         entity_id = next(iter(world._entity2sig))
         # Ask the service to apply directly so the ValueError surfaces (drain_and_apply
@@ -545,7 +552,8 @@ async def test_step_reports_accurate_applied_count(tmp_path):
         await container.command_service.submit(str(world.world_id), good, ctx)
         await container.command_service.submit(str(world.world_id), bad, ctx)
 
-        count = await container.simulation_service.step(world.world_id)
+        rc = RunConfig()
+        count = await container.simulation_service.step(world.world_id, rc)
 
         assert count == 1
     finally:


### PR DESCRIPTION
## Summary

- `SimulationService.step` defaulted `run_config=None` and minted a fresh `RunConfig(num_steps=1)` per call, so each step carried a new `run_id` — breaking store reads filtered by `run_id` across ticks and obscuring that a step belongs to a run.
- Make `run_config` required. Update every call site (tests, examples, evals, docs) to pass an explicit `RunConfig`.
- Delete the 10-line `_live` rationale comment in `AsyncWorld._run_archetype` (and its pointer in `SyncWorld`) that justified the cache-first read by citing the now-removed run_id churn. The behavior stands on its own — `_live` is authoritative after tick 0 because it's the most recent in-memory snapshot.

## Test plan

- [x] `uv run pytest` — 474 passed
- [x] `uv run ruff check` on modified files — clean
- [x] New test `test_step_requires_run_config` — `TypeError` when omitted
- [x] New test `test_step_forwards_caller_run_config` — same `RunConfig` passes through to `world.step`

🤖 Generated with [Claude Code](https://claude.com/claude-code)