### PR TITLE
fix: convert entity_id to int in DESPAWN, ADD_COMPONENT, REMOVE_COMPONENT handlers

### DIFF
--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -317,7 +317,7 @@ class CommandService:
                     await self._apply_reserved_spawn(world, int(entity_id), components)
 
             case CommandType.DESPAWN:
-                entity_id = payload["entity_id"]
+                entity_id = int(payload["entity_id"])
                 await world.remove_entity(entity_id)
 
             case CommandType.UPDATE:
@@ -326,12 +326,12 @@ class CommandService:
                 await self._apply_update(world, int(entity_id), components)
 
             case CommandType.ADD_COMPONENT:
-                entity_id = payload["entity_id"]
+                entity_id = int(payload["entity_id"])
                 components = self._hydrate_components(payload.get("components", []))
                 await world.add_components(entity_id, components)
 
             case CommandType.REMOVE_COMPONENT:
-                entity_id = payload["entity_id"]
+                entity_id = int(payload["entity_id"])
                 component_types = self._hydrate_component_types(payload.get("component_types", []))
                 await world.remove_components(entity_id, component_types)
 

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -594,3 +594,136 @@ async def test_step_reports_accurate_applied_count(tmp_path):
         assert count == 1
     finally:
         await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_despawn_converts_string_entity_id_to_int(tmp_path):
+    """DESPAWN must convert entity_id from payload to int.
+
+    When commands arrive via the REST API, JSON-parsed payloads may
+    contain entity_id as a string. SPAWN and UPDATE already call int(),
+    but DESPAWN was missing the conversion.
+    """
+    from archetype.core.component import Component
+
+    class Marker(Component):
+        tag: str = ""
+
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await container.world_service.create_world(
+            WorldConfig(name="despawn-str-id"), storage
+        )
+
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        entity_id = await container.command_service.submit_spawn(
+            world.world_id, [Marker(tag="x")], ctx
+        )
+        await container.simulation_service.step(world.world_id, RunConfig())
+
+        assert entity_id in world._entity2sig
+
+        despawn_cmd = Command(
+            type=CommandType.DESPAWN,
+            tick=0,
+            payload={"entity_id": str(entity_id)},
+        )
+        await container.command_service.submit(str(world.world_id), despawn_cmd, ctx)
+        await container.simulation_service.step(world.world_id, RunConfig())
+
+        assert entity_id not in world._entity2sig
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_add_component_converts_string_entity_id_to_int(tmp_path):
+    """ADD_COMPONENT must convert entity_id from payload to int.
+
+    Same root cause as DESPAWN: payload values from JSON may be strings.
+    """
+    from archetype.core.component import Component
+
+    class Base(Component):
+        v: int = 0
+
+    class Extra(Component):
+        label: str = ""
+
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await container.world_service.create_world(
+            WorldConfig(name="add-comp-str-id"), storage
+        )
+
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        entity_id = await container.command_service.submit_spawn(world.world_id, [Base(v=1)], ctx)
+        await container.simulation_service.step(world.world_id, RunConfig())
+
+        add_cmd = Command(
+            type=CommandType.ADD_COMPONENT,
+            tick=0,
+            payload={
+                "entity_id": str(entity_id),
+                "components": [Extra(label="added")],
+            },
+        )
+        await container.command_service.submit(str(world.world_id), add_cmd, ctx)
+        await container.simulation_service.step(world.world_id, RunConfig())
+
+        sig = world._entity2sig.get(entity_id)
+        assert sig is not None
+        assert Extra in sig
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_remove_component_converts_string_entity_id_to_int(tmp_path):
+    """REMOVE_COMPONENT must convert entity_id from payload to int.
+
+    Same root cause as DESPAWN: payload values from JSON may be strings.
+    """
+    from archetype.core.component import Component
+
+    class Alpha(Component):
+        a: int = 0
+
+    class Beta(Component):
+        b: int = 0
+
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await container.world_service.create_world(
+            WorldConfig(name="rm-comp-str-id"), storage
+        )
+
+        ctx = ActorCtx(id=uuid7(), roles={"admin"})
+        entity_id = await container.command_service.submit_spawn(
+            world.world_id, [Alpha(a=1), Beta(b=2)], ctx
+        )
+        await container.simulation_service.step(world.world_id, RunConfig())
+
+        sig = world._entity2sig.get(entity_id)
+        assert Alpha in sig and Beta in sig
+
+        rm_cmd = Command(
+            type=CommandType.REMOVE_COMPONENT,
+            tick=0,
+            payload={
+                "entity_id": str(entity_id),
+                "component_types": [Beta],
+            },
+        )
+        await container.command_service.submit(str(world.world_id), rm_cmd, ctx)
+        await container.simulation_service.step(world.world_id, RunConfig())
+
+        sig = world._entity2sig.get(entity_id)
+        assert sig is not None
+        assert Alpha in sig
+        assert Beta not in sig
+    finally:
+        await container.shutdown()


### PR DESCRIPTION
## Summary

- **Bug**: `CommandService.apply()` passed raw payload `entity_id` values to `AsyncWorld.remove_entity()`, `add_components()`, and `remove_components()` — all of which expect `int`. The `SPAWN` and `UPDATE` handlers in the same method correctly called `int(entity_id)`, but `DESPAWN`, `ADD_COMPONENT`, and `REMOVE_COMPONENT` did not. When commands arrive via the REST API with JSON payloads, `entity_id` may be a string, causing type mismatches downstream.
- **Fix**: Add `int()` conversion for `entity_id` in the three affected handlers, matching the existing `SPAWN`/`UPDATE` pattern.
- **Regression tests**: Three integration tests submit commands with string `entity_id` values (simulating JSON payloads) and verify the operations succeed. All three fail without the fix.

### Files changed

| File | What changed |
|------|-------------|
| `src/archetype/app/command_service.py` | Added `int()` conversion on lines 320, 329, 334 |
| `tests/integration/test_command_flow.py` | Three regression tests for string entity_id handling |

## Test plan

- [x] `test_despawn_converts_string_entity_id_to_int` — verifies DESPAWN works with string entity_id
- [x] `test_add_component_converts_string_entity_id_to_int` — verifies ADD_COMPONENT works with string entity_id
- [x] `test_remove_component_converts_string_entity_id_to_int` — verifies REMOVE_COMPONENT works with string entity_id
- [x] `make ci` passes (506 tests, 10/10 evals, 86.8% coverage)
- [x] No changes to `src/archetype/core/` (read-only layer respected)

Closes #178

https://claude.ai/code/session_01FUzbmE1v5s7hqpYgLx8pT8