### PR TITLE
fix(commands): ensure entity_id is int for DESPAWN, ADD_COMPONENT, REMOVE_COMPONENT

### DIFF
--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -317,7 +317,7 @@ class CommandService:
                     await self._apply_reserved_spawn(world, int(entity_id), components)
 
             case CommandType.DESPAWN:
-                entity_id = payload["entity_id"]
+                entity_id = int(payload["entity_id"])
                 await world.remove_entity(entity_id)
 
             case CommandType.UPDATE:
@@ -326,12 +326,12 @@ class CommandService:
                 await self._apply_update(world, int(entity_id), components)
 
             case CommandType.ADD_COMPONENT:
-                entity_id = payload["entity_id"]
+                entity_id = int(payload["entity_id"])
                 components = self._hydrate_components(payload.get("components", []))
                 await world.add_components(entity_id, components)
 
             case CommandType.REMOVE_COMPONENT:
-                entity_id = payload["entity_id"]
+                entity_id = int(payload["entity_id"])
                 component_types = self._hydrate_component_types(payload.get("component_types", []))
                 await world.remove_components(entity_id, component_types)
 


### PR DESCRIPTION
## Problem

`CommandService.apply()` does not convert `entity_id` to `int` for `DESPAWN`, `ADD_COMPONENT`, and `REMOVE_COMPONENT` commands. The raw payload value (string from JSON) is passed directly to `AsyncWorld` methods that expect `entity_id: int`.

Compare to `SPAWN` and `UPDATE` in the same method, which correctly call `int(entity_id)`.

## Impact

- REST API commands break when `entity_id` arrives as a string — `SubmitCommandRequest.payload` is `dict[str, Any]`, so JSON payloads like `{"entity_id": "42"}` pass the string `"42"` to methods expecting `int`.
- Type mismatch causes silent failures or crashes in downstream `AsyncWorld` methods that declare `int` parameters.
- Inconsistency within the same method — SPAWN and UPDATE handle this correctly; the other three do not.

## Fix

Add `int()` conversion for `entity_id` in the DESPAWN, ADD_COMPONENT, and REMOVE_COMPONENT cases, matching the SPAWN/UPDATE pattern. 3 lines changed.

Fixes #178