### PR TITLE
fix: set world.run_id in SimulationService.step and return it in step API response

### DIFF
--- a/src/archetype/api/routes/simulation.py
+++ b/src/archetype/api/routes/simulation.py
@@ -25,7 +25,11 @@ async def step_world(
     try:
         run_config = RunConfig(num_steps=1, debug=req.debug)
         commands_applied = await sim.step(UUID(world_id), run_config)
-        return {"world_id": world_id, "commands_applied": commands_applied}
+        return {
+            "world_id": world_id,
+            "commands_applied": commands_applied,
+            "run_id": str(run_config.run_id),
+        }
     except KeyError:
         raise HTTPException(status_code=404, detail=f"World {world_id} not found") from None
 

--- a/src/archetype/app/simulation_service.py
+++ b/src/archetype/app/simulation_service.py
@@ -44,6 +44,9 @@ class SimulationService:
         world = self._world_service.get_world(world_id)
         tick = getattr(world, "tick", 0)
 
+        if hasattr(world, "run_id"):
+            world.run_id = str(run_config.run_id)
+
         applied = await self._command_service.drain_and_apply(world_id, tick)
         reset_tick_counters()
 

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -254,6 +254,21 @@ class TestSimulationRoutes:
         assert resp.status_code == 200
         assert "commands_applied" in resp.json()
 
+    def test_step_response_includes_run_id(self, client, tmp_path):
+        """Regression: the step response must include the run_id under which
+        the tick's data was persisted so callers can query it back."""
+        create_resp = client.post(
+            "/worlds",
+            json={"name": "step_run_id", "storage_uri": str(tmp_path / "store")},
+        )
+        world_id = create_resp.json()["world_id"]
+
+        resp = client.post(f"/worlds/{world_id}/step", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "run_id" in data, "step response must include run_id"
+        assert data["run_id"], "run_id must be non-empty"
+
     def test_step_not_found(self, client):
         resp = client.post(
             "/worlds/00000000-0000-0000-0000-000000000000/step",

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -465,6 +465,47 @@ class TestSimulationService:
 
         assert sim.list_processors(uuid7()) == []
 
+    @pytest.mark.asyncio
+    async def test_step_sets_world_run_id(self, tmp_path):
+        """Regression: SimulationService.step must set world.run_id to the
+        RunConfig's run_id, matching the pattern already used by run()."""
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(
+                WorldConfig(name="step_run_id"), storage
+            )
+            assert world.run_id is None
+
+            rc = RunConfig(num_steps=1)
+            await container.simulation_service.step(world.world_id, rc)
+
+            assert str(world.run_id) == str(rc.run_id)
+        finally:
+            await container.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_step_consecutive_calls_update_world_run_id(self, tmp_path):
+        """Each step call should update world.run_id to match that call's
+        RunConfig so default-run queries always reflect the latest step."""
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            world = await container.world_service.create_world(
+                WorldConfig(name="step_consec"), storage
+            )
+
+            rc1 = RunConfig(num_steps=1)
+            await container.simulation_service.step(world.world_id, rc1)
+            assert str(world.run_id) == str(rc1.run_id)
+
+            rc2 = RunConfig(num_steps=1)
+            await container.simulation_service.step(world.world_id, rc2)
+            assert str(world.run_id) == str(rc2.run_id)
+            assert rc1.run_id != rc2.run_id
+        finally:
+            await container.shutdown()
+
 
 class TestQueryService:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Bug**: `SimulationService.step` did not set `world.run_id` before stepping, unlike `SimulationService.run` which does. Each call to the step API created a fresh `RunConfig` with a new `run_id`, stamped rows with that `run_id`, but never updated `world.run_id` and never returned the `run_id` to the caller. The data was written to the store under a `run_id` that nobody could discover.
- **Fix**: Set `world.run_id = str(run_config.run_id)` in `SimulationService.step`, matching the existing pattern in `run()`. Include `run_id` in the step API response so callers can query their data back.
- **Regression tests**: 3 tests — two service-layer tests verifying `world.run_id` is set after step, and one API test verifying the step response includes `run_id`. All 3 fail without the fix and pass with it.

### Files changed

| File | What changed |
|------|-------------|
| `src/archetype/app/simulation_service.py` | Added `world.run_id` assignment in `step()`, matching `run()` |
| `src/archetype/api/routes/simulation.py` | Added `run_id` to the step endpoint response |
| `tests/app/test_services.py` | 2 regression tests for `world.run_id` after step |
| `tests/api/test_routes.py` | 1 regression test for `run_id` in step response |

## Test plan

- [x] `test_step_sets_world_run_id` — verifies `world.run_id` matches `RunConfig.run_id` after a single step
- [x] `test_step_consecutive_calls_update_world_run_id` — verifies each step updates `world.run_id` to the latest call's `run_id`
- [x] `test_step_response_includes_run_id` — verifies the step API response contains a non-empty `run_id`
- [x] `make ci` passes (506 tests, 10/10 evals)

Closes #187

https://claude.ai/code/session_013ZEmfQ6NKb4HtKkJWGo48f