### PR TITLE
[codex] Expand runtime mutation contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,33 @@ archetype/
 | Layer | Access |
 |-------|--------|
 | `core/` | Modify only after discussion. It holds the hard invariants; breakage there cascades everywhere. |
-| `app/` | Extend carefully. Service contracts are in the specification. |
-| `api/`, `cli/`, `sugar.py` | Write freely, subject to the contracts they wrap. |
+| `app/` | Extend carefully. Service contracts are in the specification. Lower-level interface. |
+| `sugar.py` | Recommended top-level API (`ArchetypeRuntime`). Additive only; top-level `World`/`Processor` exports stay stable. |
+| `api/`, `cli/` | Write freely, subject to the contracts they wrap. |
 
-## Using the service layer
+## Top-level runtime (recommended)
+
+`ArchetypeRuntime` is the recommended entry point for scripts and beginner docs. Process lifetime and world lifetime are separate concerns: the runtime owns the shared container; `world()` handles are lazy and world-local. See `docs/guide/specification.md` § "Contracts Before Sugar" for the full contract set (single-flight activation, honest `spawn()`, fork isolation, world-local shutdown).
+
+```python
+import asyncio
+from archetype import ArchetypeRuntime
+
+async def main():
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("experiment")
+        entity_id = await world.spawn()  # real entity_id, reserved through the chain
+        result = await world.run(steps=10)
+        print(f"Completed {result.ticks_completed} ticks")
+
+asyncio.run(main())
+```
+
+Sync scripts use `with ArchetypeRuntime.sync() as runtime:` instead.
+
+## Using the service layer (lower-level)
+
+`ServiceContainer`, `CommandService`, and broker semantics are lower-level interfaces. Reach for them when you need explicit `ActorCtx` / RBAC, custom command routing, or to wire a non-script host. Beginner docs and quickstarts should default to `ArchetypeRuntime`.
 
 ```python
 import asyncio
@@ -157,6 +180,8 @@ Roles (flat, not hierarchical):
 
 - Integration tests in `tests/integration/`.
 - Use the `tmp_path` fixture for storage isolation.
+- Prefer contract tests over happy-path coverage: concurrent first-use activation, shutdown/fork races, multi-world lifetime isolation, spawn materialization timing, and example-script smoke execution. If a test feels "too specific," it is usually testing the real semantic boundary.
+- Examples are part of the contract. Run them in CI; gate LLM-backed ones on credentials or degrade gracefully.
 
 ### Commits
 
@@ -169,7 +194,10 @@ Roles (flat, not hierarchical):
 |------|---------|
 | `docs/guide/specification.md` | Normative contracts (engine, app, sugar/runtime) |
 | `LEARNINGS.md` | Daft patterns, UDF rules, data-centric principle |
+| `src/archetype/sugar.py` | `ArchetypeRuntime` — recommended top-level API |
 | `src/archetype/app/container.py` | Service wiring |
 | `src/archetype/app/command_service.py` | Mutation dispatch |
 | `src/archetype/app/broker.py` | RBAC + priority queue |
 | `src/archetype/core/aio/async_world.py` | World runtime |
+| `tests/app/test_sugar_runtime.py` | Executable runtime contracts |
+| `tests/sync/test_sync_stack_contracts.py` | Executable sync engine contracts |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,15 @@ Skills in `.claude/skills/` enforce framework rules automatically. They fire bas
 | Layer | Access |
 |-------|--------|
 | `src/archetype/core/` | Modify only after discussion. Holds the hard invariants. |
-| `src/archetype/app/` | Extend carefully. Service contracts live in the specification. |
+| `src/archetype/app/` | Extend carefully. Service contracts live in the specification. Lower-level interface. |
+| `src/archetype/sugar.py` | Recommended top-level API (`ArchetypeRuntime`). Add sugar additively; keep `World`/`Processor` exports stable. |
 | Everything else | Write freely, subject to the contracts they wrap. |
+
+## Top-level API
+
+`ArchetypeRuntime` is the recommended entry point for scripts and beginner docs. `ServiceContainer` / `CommandService` / broker semantics are lower-level interfaces — document them as such. Script boundary is `async with ArchetypeRuntime()` or `with ArchetypeRuntime.sync()`; process lifetime and world lifetime are separate concerns. See `docs/guide/specification.md` § "Contracts Before Sugar" for the full rationale.
+
+Examples must run in CI. LLM-backed examples need explicit credential gating or graceful degradation when keys are missing.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ Archetype stores world state as columnar archetype tables, executes behavior as 
 
 ## What It Is
 
-Archetype is split into three layers:
+Archetype is split into layers:
 
 | Layer | Purpose |
 |---|---|
+| `src/archetype/sugar.py` | `ArchetypeRuntime` — recommended top-level API for scripts and simulations |
 | `src/archetype/core` | ECS primitives: `Component`, `Archetype`, `AsyncWorld`, `AsyncProcessor`, storage/query/update contracts |
-| `src/archetype/app` | Service layer: `CommandBroker`, `CommandService`, `WorldService`, `SimulationService`, `QueryService` |
+| `src/archetype/app` | Service layer (lower-level): `CommandBroker`, `CommandService`, `WorldService`, `SimulationService`, `QueryService` |
 | `src/archetype/api` + `src/archetype/cli` | FastAPI server and Typer CLI |
 
 The runtime model is:
@@ -62,20 +63,14 @@ uv sync --group dev
 
 ## Quickstart
 
-The most complete interface today is the in-process Python API.
+`ArchetypeRuntime` is the recommended entry point. It owns the shared container, activates a world lazily on first use, and returns a real `entity_id` from `spawn()`.
 
 ```python
 import asyncio
 
 from daft import DataFrame, col
-from uuid_utils import uuid7
 
-from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
-from archetype.core.aio.async_processor import AsyncProcessor
-from archetype.core.component import Component
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype import ArchetypeRuntime, AsyncProcessor, Component
 
 
 class Position(Component):
@@ -102,41 +97,25 @@ class MovementProcessor(AsyncProcessor):
 
 
 async def main():
-    container = ServiceContainer()
-    world = await container.world_service.create_world(
-        WorldConfig(name="demo"),
-        StorageConfig(),
-    )
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("demo", processors=[MovementProcessor()])
 
-    await world.system.add_processor(MovementProcessor())
+        await world.spawn(Position(x=0, y=0), Velocity(dx=1, dy=2))
+        await world.run(steps=3)
 
-    ctx = ActorCtx(id=uuid7(), roles={"admin"})
-    cmd = Command(
-        type=CommandType.SPAWN,
-        payload={
-            "components": [
-                Position(x=0, y=0).to_payload(),
-                Velocity(dx=1, dy=2).to_payload(),
-            ]
-        },
-    )
-    await container.command_service.submit(world.world_id, cmd, ctx)
-
-    await container.simulation_service.run(world.world_id, RunConfig(num_steps=3))
-
-    df = await world.get_components([Position])
-    print(df.collect().to_pylist())
-
-    await container.shutdown()
+        df = await world.query(Position)
+        print(df.collect().to_pylist())
 
 
 asyncio.run(main())
 ```
 
-Two important details from the code:
+For sync scripts, use `with ArchetypeRuntime.sync() as runtime:` and drop the `await`s.
 
-- use `Component.to_payload()` when sending components through `CommandService`
-- processor columns are always prefixed as `componentname__field`
+Two things to know:
+
+- processor columns are prefixed `componentname__field` (e.g., `position__x`)
+- `ArchetypeRuntime` is the script boundary — process lifetime and world lifetime are separate concerns. See `docs/guide/specification.md` § "Contracts Before Sugar" for the full contract set (single-flight activation, honest `spawn()`, fork isolation, world-local shutdown). Drop to `ServiceContainer` only when you need explicit RBAC, custom command routing, or a non-script host.
 
 ## CLI
 
@@ -284,14 +263,15 @@ Current state worth knowing before using it:
 - the Python service layer is richer than the REST read models
 - the FastAPI layer currently uses a default admin `ActorCtx` — not multi-tenant auth yet
 
-Start with `src/archetype/core` and `src/archetype/app` to understand the system.
+Start with `src/archetype/sugar.py` (`ArchetypeRuntime`) to use the system. Read `src/archetype/core` and `src/archetype/app` to understand how it works underneath.
 
 ## Repository Map
 
 ```text
 archetype/
+├── src/archetype/sugar.py   # ArchetypeRuntime — recommended top-level API
 ├── src/archetype/core/      # ECS runtime and storage contracts
-├── src/archetype/app/       # Brokered service layer
+├── src/archetype/app/       # Brokered service layer (lower-level)
 ├── src/archetype/api/       # FastAPI server
 ├── src/archetype/cli/       # Typer CLI
 ├── examples/                # Runnable examples

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -9,6 +9,8 @@ Archetype is a data-centric Entity-Component-System (ECS) simulation engine. Wor
 ```text
 archetype.api / cli          External interface (REST + HTTP client)
        |
+archetype.sugar             ArchetypeRuntime, RuntimeWorld (recommended scripts)
+       |
 archetype.app                Services, RBAC, CommandBroker, WorldRegistry
        |
 archetype.core               AsyncWorld, AsyncProcessor, Resources, Storage
@@ -16,13 +18,43 @@ archetype.core               AsyncWorld, AsyncProcessor, Resources, Storage
 
 The system runs as a single `archetype serve` process. The CLI is a thin HTTP client.
 
+## Runtime Layer
+
+`ArchetypeRuntime` is the recommended script entry point. It owns the shared
+service container, gives you lazy world handles, keeps process lifetime
+separate from world lifetime, and exposes the brokered mutation surface on
+`RuntimeWorld`:
+
+```python
+from uuid_utils import uuid7
+
+from archetype import ArchetypeRuntime, Component
+from archetype.app.auth.models import ActorCtx
+
+
+class Position(Component):
+    x: float = 0.0
+    y: float = 0.0
+
+async with ArchetypeRuntime() as runtime:
+    world = runtime.world("demo")
+    entity_id = await world.spawn(Position(x=0, y=0))
+    admin = world.as_actor(ActorCtx(id=uuid7(), roles={"admin"}))
+    await admin.update(entity_id, Position(x=1, y=0))
+    await world.run(steps=10)
+```
+
+Drop to the service layer only when you need custom command routing,
+non-script hosting, or lower-level read-path / lifecycle control.
+
 ## Service Layer
 
 The service layer mediates all access to worlds.
 
 ### ServiceContainer
 
-Instantiates and exposes all service-layer subsystems:
+Lower-level composition root that instantiates and exposes all service-layer
+subsystems:
 
 ```python
 from archetype.app.container import ServiceContainer

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -1,6 +1,9 @@
 # Examples
 
-Every example on this page runs end-to-end with a single command. Copy, paste, run.
+Every example on this page runs end-to-end with a single command. The
+recommended pattern is `ArchetypeRuntime` for scripts. A small number of
+examples intentionally drop lower when the read path is still below the
+runtime API, most notably the time-travel example.
 
 ## 1. World Mutations
 
@@ -12,38 +15,31 @@ uv run python examples/01_world_mutations.py
 
 Source: [`examples/01_world_mutations.py`](https://github.com/VangelisTech/archetype/blob/main/examples/01_world_mutations.py)
 
+This example uses `ArchetypeRuntime` plus `world.as_actor(...)` to show
+multiple `ActorCtx` roles on one logical world without dropping to the
+service layer.
+
 **What it demonstrates:**
 
-- **SPAWN** with typed components (`Position`, `Velocity`, `Health`)
+- **SPAWN / DESPAWN / UPDATE** through the brokered runtime surface
+- **ADD_COMPONENT / REMOVE_COMPONENT** with archetype migration at tick boundaries
 - **ADD_PROCESSOR** to inject a `MovementProcessor` at runtime
-- **RBAC** checks: viewer denied spawn, player allowed spawn, player denied add_processor
-- **FORK** a world and run source and fork independently
-- **Command history** as a full audit trail
+- **RBAC** checks through actor-bound handles: viewer denied spawn, player denied add_processor
+- **FORK** from an actor-bound handle while keeping the same actor binding on the branch
+- **Command history** through `world.command_history()`
 
 Output:
 
 ```text
-1. SPAWN — create entities with components
-   Spawned 2 entities (tick=1)
-
-2. ADD_PROCESSOR — inject behavior at runtime
-   Added MovementProcessor (priority=10)
-   Ran 3 ticks (tick=4)
-
-4. RBAC — permission checks
+1. SPAWN + RBAC
    viewer: SPAWN denied (correct)
-   player: SPAWN allowed (correct)
+   player: spawned scout=1, dummy=2
+
+2. UPDATE + COMPONENT MUTATIONS
+   scout after update/add_components: pos=(2.0, 1.0), vel=(1.5, 0.5), hp=80
+
+3. PROCESSOR MUTATIONS
    player: ADD_PROCESSOR denied (correct)
-
-5. FORK — branch the world
-   Fork tick=5 (matches source tick=5)
-   Fork after 5 more ticks: tick=10
-   Source unchanged: tick=5
-
-6. COMMAND HISTORY — full audit trail
-   tick=0: spawn
-   tick=0: spawn
-   tick=0: spawn
 ```
 
 **Command types** (15 total, including `run_rollout` and `run_episode` for MCTS):
@@ -80,12 +76,7 @@ Source: [`examples/02_fork_counterfactual.py`](https://github.com/VangelisTech/a
 import asyncio
 from dataclasses import dataclass
 
-from uuid_utils import uuid7
-
-from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype import ArchetypeRuntime, Component, StorageConfig
 
 
 @dataclass
@@ -94,32 +85,25 @@ class PhysicsConfig:
     drag: float = 0.1
 
 
+class Probe(Component):
+    label: str = ""
+
+
 async def main():
-    container = ServiceContainer()
-    ctx = ActorCtx(id=uuid7(), roles={"admin"})
+    storage = StorageConfig(uri="./archetype_data", namespace="counterfactuals")
 
-    # Create the base world and spawn an entity
-    base = await container.world_service.create_world(
-        WorldConfig(name="base"), StorageConfig(),
-    )
-    cmd = Command(type=CommandType.SPAWN, payload={"components": []})
-    await container.command_service.submit(base.world_id, cmd, ctx)
-    await container.simulation_service.run(base.world_id, RunConfig(num_steps=1))
+    async with ArchetypeRuntime() as runtime:
+        base = runtime.world("base", storage=storage)
+        await base.spawn(Probe(label="seed"))
+        await base.run(steps=1)
 
-    # Fork with different gravity values and run each
-    for gravity in [1.0, 9.8, 25.0]:
-        fork = await container.world_service.fork_world(
-            source_world_id=base.world_id,
-            name=f"gravity-{gravity}",
-            storage_config=StorageConfig(),
-        )
-        fork.resources.insert(PhysicsConfig(gravity=gravity))
-        await container.simulation_service.run(fork.world_id, RunConfig(num_steps=10))
+        for gravity in [1.0, 9.8, 25.0]:
+            fork = await base.fork(f"gravity-{gravity}", storage=storage)
+            fork.resources.insert(PhysicsConfig(gravity=gravity))
 
-        state = await container.query_service.get_world_state(fork.world_id)
-        print(f"gravity={gravity:>5.1f}: tick={state.tick}")
-
-    await container.shutdown()
+            result = await fork.run(steps=10)
+            rows = (await fork.query(Probe)).collect().to_pylist()
+            print(f"gravity={gravity:>5.1f}: tick={result.final_tick}, entities={len(rows)}")
 
 asyncio.run(main())
 ```
@@ -145,6 +129,11 @@ uv run python examples/03_time_travel.py
 ```
 
 Source: [`examples/03_time_travel.py`](https://github.com/VangelisTech/archetype/blob/main/examples/03_time_travel.py)
+
+This example intentionally uses the lower-level `QueryService` because
+historical snapshot reads are part of the read path rather than the current
+top-level runtime sugar. Current-state runtime mutation helpers exist; history
+snapshot helpers do not yet.
 
 ```python
 import asyncio
@@ -243,7 +232,7 @@ Source: [`examples/05_llm_agents.py`](https://github.com/VangelisTech/archetype/
 
 - **Component**: `Agent` with name, role, and a JSON journal of thoughts
 - **Processor**: `ThinkProcessor` uses `daft.functions.prompt` to call an LLM for every agent entity in a single DataFrame operation
-- **Pattern**: Thoughts accumulate in a journal column across ticks
+- **Pattern**: `ArchetypeRuntime` keeps the script surface to `world.spawn(...)`, `world.run(...)`, and `world.query(...)`
 
 Requires an OpenAI API key (or any provider via `daft.set_provider()`).
 
@@ -263,5 +252,5 @@ Source: [`examples/06_trajectory_analysis.py`](https://github.com/VangelisTech/a
 
 - **Components**: `Trajectory` (JSON-encoded turns), `Label` (evaluation result)
 - **Processors**: `SamplingProcessor` (filter), `LabelingProcessor` (LLM eval), `ScoringProcessor` (normalize)
-- **Resources**: `SamplingConfig`, `LabelingConfig` injected via `world.resources`
-- **Fork-based comparison**: Clone a world with `fork_world()`, swap config, run independently
+- **Resources**: `SamplingConfig`, `LabelingConfig` staged on `runtime.world(..., resources=[...])`
+- **Fork-based comparison**: Clone a world with `world.fork(...)`, swap config, run independently

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -20,14 +20,8 @@ Define components, write a processor, spawn entities, run:
 import asyncio
 
 from daft import DataFrame, col
-from uuid_utils import uuid7
 
-from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
-from archetype.core.aio.async_processor import AsyncProcessor
-from archetype.core.component import Component
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype import ArchetypeRuntime, AsyncProcessor, Component
 
 
 # 1. Define components — typed data models that become table columns
@@ -53,44 +47,22 @@ class MovementProcessor(AsyncProcessor):
 
 
 async def main():
-    container = ServiceContainer()
+    async with ArchetypeRuntime() as runtime:
+        # 3. Create a lazy world handle and stage the processor
+        world = runtime.world("quickstart", processors=[MovementProcessor()])
 
-    # 3. Create a world
-    world = await container.world_service.create_world(
-        WorldConfig(name="quickstart"),
-        StorageConfig(),
-    )
+        # 4. Spawn entities
+        for dx, dy in [(1, 2), (-1, 0.5)]:
+            await world.spawn(Position(x=0, y=0), Velocity(dx=dx, dy=dy))
 
-    # 4. Register the processor
-    await world.system.add_processor(MovementProcessor())
+        # 5. Run 5 ticks
+        result = await world.run(steps=5)
+        print(f"Done: {result.ticks_completed} ticks, {result.commands_applied} commands")
 
-    # 5. Spawn entities with components via the command pipeline
-    ctx = ActorCtx(id=uuid7(), roles={"admin"})
-    for dx, dy in [(1, 2), (-1, 0.5)]:
-        cmd = Command(
-            type=CommandType.SPAWN,
-            payload={
-                "components": [
-                    Position(x=0, y=0).to_payload(),
-                    Velocity(dx=dx, dy=dy).to_payload(),
-                ]
-            },
-        )
-        await container.command_service.submit(world.world_id, cmd, ctx)
-
-    # 6. Run 5 ticks — each tick: drain commands, materialize, process, persist
-    result = await container.simulation_service.run(
-        world.world_id,
-        RunConfig(num_steps=5),
-    )
-    print(f"Done: {result.ticks_completed} ticks, {result.commands_applied} commands")
-
-    # 7. Query state
-    df = await world.get_components([Position])
-    for row in df.collect().to_pylist():
-        print(f"  entity {row['entity_id']}: x={row['position__x']}, y={row['position__y']}")
-
-    await container.shutdown()
+        # 6. Query state
+        df = await world.query(Position)
+        for row in df.collect().to_pylist():
+            print(f"  entity {row['entity_id']}: x={row['position__x']}, y={row['position__y']}")
 
 asyncio.run(main())
 ```
@@ -98,9 +70,8 @@ asyncio.run(main())
 Key patterns in this example:
 
 - Components are `LanceModel` subclasses — their fields become prefixed columns (`position__x`)
-- `to_payload()` serializes components for the command pipeline
 - Processors declare their component requirements via `components = (...)` — the engine routes matching entities automatically
-- All external mutations go through `CommandService.submit()` with an `ActorCtx`
+- `ArchetypeRuntime` is the recommended script boundary; use `world.as_actor(...)` for explicit roles and `ServiceContainer` only for custom routing or lower-level orchestration
 
 ## Option B: HTTP API (curl)
 

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -560,6 +560,30 @@ Required behavior:
   brokered mutation contract unless that method is explicitly documented as a
   lower-level escape hatch
 
+#### C7. Same-tick composition must be defined
+
+Deferred materialization at the tick boundary must not make ordered command
+semantics ambiguous.
+
+Required behavior:
+
+- If multiple commands targeting the same entity are drained in one tick, the
+  implementation MUST define whether later commands observe earlier staged
+  mutations from that same drain cycle
+- If the public contract claims ordered broker semantics for runtime mutation
+  verbs, later commands SHOULD observe earlier same-tick mutations for the same
+  entity even though none of them become query-visible until `step()` completes
+- If the implementation does not provide that composition guarantee, the
+  weaker behavior MUST be documented explicitly in user-facing runtime docs and
+  examples
+
+CURRENT GAP:
+
+- `UPDATE` followed by `ADD_COMPONENT` for the same entity in one drain cycle
+  does not currently compose intuitively. The second command reads from `_live`
+  rather than from the staged update row, so broker history order and final
+  materialized state can diverge.
+
 ### Multi-World Lifetime Contract
 
 #### L1. Separate runtime lifetime from world lifetime
@@ -625,6 +649,23 @@ Required behavior:
 - Global singletons, if used at all, must have an explicit reset or opt-out
   path for tests
 - Test suites must be able to exercise multiple runtimes in one process
+
+#### L6. Actor-bound aliases share one world lifecycle
+
+Sugar may expose multiple actor-bound handles to one logical world, but those
+handles must not become independent world lifecycles by accident.
+
+Required behavior:
+
+- `world.as_actor(ctx)` MUST be pure before activation
+- Actor-bound aliases MUST resolve to the same backing world identity after
+  activation
+- First activation MUST remain single-flight across all aliases of the same
+  logical world
+- Shutting down one alias MUST invalidate all aliases of that world, but MUST
+  NOT invalidate sibling worlds in the same runtime
+- `fork()` from an actor-bound alias SHOULD preserve the caller's actor binding
+  on the returned fork handle
 
 ### Script Ceremony Contract
 
@@ -692,6 +733,36 @@ Required behavior:
   naming and documentation
 - Direct resource mutation must not be described as governed by the broker
 
+#### S6. Recommended runtime APIs should be mutation-complete
+
+If a runtime wrapper is presented as the recommended script boundary, it should
+cover the common governed mutation verbs without forcing the user to drop to
+the service layer.
+
+Required behavior:
+
+- The recommended runtime world handle SHOULD expose brokered entity mutation
+  verbs for `spawn`, `despawn`, `update`, `add_components`, and
+  `remove_components`
+- The recommended runtime world handle SHOULD expose brokered processor
+  mutation verbs for `add_processor` and `remove_processor`
+- Runtime audit access such as command history SHOULD remain available without
+  requiring direct container access
+
+#### S7. Non-brokered scaffolding must remain explicit
+
+Some runtime operations are world-local scaffolding rather than governed
+simulation mutations. That distinction must be explicit.
+
+Required behavior:
+
+- World-handle construction and actor rebinding may be immediate runtime
+  operations rather than brokered commands
+- Hook registration and direct resource mutation may remain immediate runtime
+  operations rather than brokered commands
+- Documentation MUST distinguish these immediate scaffolding operations from
+  brokered simulation mutations
+
 ### Sugar Runtime Acceptance Criteria
 
 No sugar API may be considered ready for implementation until the design can
@@ -699,9 +770,15 @@ show how it satisfies all of the following:
 
 - Concurrent first-use of the same wrapper creates exactly one world
 - `spawn()` return semantics are correct and tested
+- Actor-bound aliases are pure before activation and share one world identity
 - One world's shutdown does not break a sibling world in the same runtime
 - Runtime teardown is explicit and distinct from world teardown
 - Forked worlds remain valid after the source world is shut down
+- Recommended runtime mutation verbs cover entity, component, and processor
+  mutations without dropping to the service layer
+- Non-brokered scaffolding boundaries are documented and tested
+- Same-entity same-tick mutation composition is either guaranteed and tested or
+  explicitly documented as weaker
 - Async and sync script entry points have a clear resource ownership model
 - Existing public imports remain compatible, or the change is explicitly marked
   as breaking and tested accordingly
@@ -724,8 +801,10 @@ the constraints that any acceptable design must satisfy.
 | `CommandService.submit_spawn()` | Returns one reserved `entity_id` per successful call; repeated calls create new entities unless the caller reuses an explicit reservation |
 | `AsyncWorld.create_entity()` | Not idempotent; each call allocates a new world-local entity ID |
 | `AsyncWorld.remove_entity(missing)` | Safe no-op with observability |
+| `RuntimeWorld.as_actor(ctx)` | Idempotent as handle binding only; creates another alias, not another world |
 | Duplicate despawn in one tick | Idempotent collapse by entity ID |
 | Duplicate spawn for same entity in one tick | Deterministic last-write-wins |
+| `RuntimeWorld.command_history()` | Idempotent for fixed broker history |
 | `add_components()` with no signature change | Idempotent no-op |
 | `remove_components()` with no signature change | Idempotent no-op |
 | `world.step()` | Not idempotent; advances tick and appends new rows |
@@ -749,6 +828,8 @@ coherent engine contract:
 6. Give `QueryService` a real read contract or clearly mark it as provisional.
 7. Define world-local teardown semantics that do not leak broker or shared
    runtime state.
+8. Resolve or explicitly codify same-entity same-tick mutation composition so
+   broker command order and final materialized state cannot diverge silently.
 
 ## Acceptance Criteria
 
@@ -764,3 +845,93 @@ all of the following:
 - explicit multi-world isolation and fork divergence
 - explicit runtime-vs-world lifetime boundaries
 - clear distinction between idempotent and non-idempotent operations
+
+## Contracts Before Sugar (Apr 2026)
+
+The top-level runtime sugar looked directionally right, but the first proposal
+was unsafe because it collapsed three separate concerns into one API shape:
+
+1. **Concurrency** — first-use initialization races
+2. **Multi-world lifetime** — world shutdown vs process/runtime shutdown
+3. **Script ceremony** — making simple scripts ergonomic without hiding real
+   lifecycle boundaries
+
+The fix was to make the contract explicit before changing the API.
+
+**Key lesson:** the safe top-level abstraction is `ArchetypeRuntime`, not a
+world-scoped context manager. Process lifetime and world lifetime are different
+concerns. A `World` handle can be lazy, but the shared runtime/container needs
+an explicit boundary.
+
+### Runtime / sugar contracts we chose to enforce
+
+- `spawn()` must reserve and return a real `entity_id` all the way through the
+  chain. Returning a command ID is a contract violation.
+- World-handle construction must be pure: no I/O, no registration, no backend
+  allocation.
+- First activation must be single-flight. Concurrent first calls must produce
+  exactly one backing world.
+- A world must never expose partially initialized state.
+- Shutdown, fork, and activation must have defined race behavior.
+- World shutdown must be world-local.
+- Runtime shutdown must be process-scoped and explicit.
+- Forked worlds share a runtime, but not world identity or lifecycle.
+- The recommended script boundary is `async with ArchetypeRuntime()` or
+  `with ArchetypeRuntime.sync()`, not implicit per-call global setup/teardown.
+- Top-level `World` and `Processor` exports should remain stable unless there
+  is an intentional versioned breaking change. Add sugar additively first.
+
+### Testing lesson
+
+These contracts should not live only in docs. They need executable tests.
+
+The highest-value tests from this session were not generic coverage tests.
+They were contract tests for:
+
+- concurrent first-use activation
+- shutdown vs init and fork vs init races
+- multi-world lifetime isolation
+- spawn materialization timing
+- async/sync smoke paths
+- example script smoke execution
+
+Once those existed, several real bugs surfaced immediately.
+
+### Sync-core bugs contract tests exposed
+
+Contract-focused tests found real correctness issues that happy-path tests had
+missed:
+
+- store append/read paths were inconsistent about table lookup and namespace
+  context
+- query projection used the wrong schema API
+- duplicate spawns were not true last-write-wins
+- component migration used instances where signature expansion required types
+- moving an entity from a missing source archetype crashed instead of returning
+  empty
+- final despawns could be skipped because despawn-only signatures were not
+  materialized
+
+**Lesson:** if a contract test feels "too specific," that usually means it is
+finally testing the real semantic boundary.
+
+### Docs and examples are part of the contract
+
+The recommended public API now lives at the runtime layer, so beginner docs
+and quickstarts must teach `ArchetypeRuntime`, not the lower-level service
+container. Low-level docs can still document `ServiceContainer`,
+`CommandService`, broker semantics, and raw ECS flows, but they should be
+explicit that they are lower-level interfaces.
+
+Examples also need to be executed in CI. An example that "looks right" but is
+never run is not documentation; it is an unverified claim.
+
+This mattered especially for LLM-backed examples: they need explicit
+credential gating or graceful degraded behavior when keys are missing.
+
+### Specification lesson
+
+A temporary `REQUIREMENTS.md` was useful as a forcing function, but the clean
+end state is one canonical specification document. Normative contracts should
+converge into `Specification`, with tests enforcing them and contributor docs
+pointing back to that single source of truth.

--- a/docs/guide/trajectories.md
+++ b/docs/guide/trajectories.md
@@ -3,7 +3,9 @@ title: Trajectory Analysis
 description: Evaluate and compare agent trajectories using LLM-based labeling
 ---
 
-Trajectory analysis uses the standard ECS pattern: define components for the data, processors for the pipeline stages, and run it all through a world. Fork the world to compare different evaluation criteria.
+Trajectory analysis uses the recommended runtime script pattern: define
+components for the data, stage processors and resources on a runtime world,
+run the pipeline, then fork to compare evaluation criteria.
 
 The full runnable example is in [`examples/06_trajectory_analysis.py`](https://github.com/VangelisTech/archetype/blob/main/examples/06_trajectory_analysis.py).
 
@@ -119,49 +121,32 @@ Clamps `label__score` to [0, 1].
 
 ## Wiring It Up
 
-Standard ECS setup — no framework abstraction:
+Recommended runtime setup:
 
 ```python
-container = ServiceContainer()
-ctx = ActorCtx(id=uuid7(), roles={"operator"})
+from archetype import ArchetypeRuntime
+from archetype.core.config import RunConfig, StorageConfig
 
-world = await container.world_service.create_world(
-    WorldConfig(name="trajectory-eval"),
-    StorageConfig(uri="./trajectory_data", namespace="trajectories"),
-)
+async with ArchetypeRuntime() as runtime:
+    world = runtime.world(
+        "trajectory-eval",
+        storage=StorageConfig(uri="./trajectory_data", namespace="trajectories"),
+        processors=[SamplingProcessor(), LabelingProcessor(), ScoringProcessor()],
+        resources=[
+            SamplingConfig(min_turns=3),
+            LabelingConfig(model="gpt-5-mini"),
+        ],
+    )
 
-# Add processors
-await world.system.add_processor(SamplingProcessor())
-await world.system.add_processor(LabelingProcessor())
-await world.system.add_processor(ScoringProcessor())
+    for trajectory in trajectories:
+        for technique, description in label_specs:
+            label = Label(technique=technique, description=description)
+            await world.spawn(trajectory, label)
 
-# Inject config
-world.resources.insert(SamplingConfig(min_turns=3))
-world.resources.insert(LabelingConfig(model="gpt-5-mini"))
+    await world.step(config=RunConfig(num_steps=1, prefer_live_reads=True))
 
-# Spawn one entity per (trajectory, technique) pair
-for trajectory in trajectories:
-    for technique, description in label_specs:
-        label = Label(technique=technique, description=description)
-        cmd = Command(
-            type=CommandType.SPAWN,
-            payload={
-                "components": [
-                    {"type": "Trajectory", **trajectory.model_dump()},
-                    {"type": "Label", **label.model_dump()},
-                ],
-            },
-        )
-        await container.command_service.submit(world.world_id, cmd, ctx)
-
-# Run: one tick = sample -> label -> score
-await container.simulation_service.step(
-    world.world_id, RunConfig(num_steps=1, prefer_live_reads=True),
-)
-
-# Collect results
-df = await world.get_components([Trajectory, Label])
-rows = df.collect().to_pylist()
+    df = await world.query(Trajectory, Label)
+    rows = df.collect().to_pylist()
 ```
 
 ## Fork-Based Comparison
@@ -169,24 +154,12 @@ rows = df.collect().to_pylist()
 Clone the world, swap config, run independently:
 
 ```python
-fork = await container.world_service.fork_world(
-    source_world_id=world.world_id,
-    name="strict-eval",
-    storage_config=StorageConfig(uri="./trajectory_data", namespace="trajectories"),
+fork = await world.fork(
+    "strict-eval",
+    storage=StorageConfig(uri="./trajectory_data", namespace="trajectories"),
 )
-
-# Re-add processors (not cloned)
-await fork.system.add_processor(SamplingProcessor())
-await fork.system.add_processor(LabelingProcessor())
-await fork.system.add_processor(ScoringProcessor())
-
-# Different config
-fork.resources.insert(SamplingConfig(min_turns=3))
-fork.resources.insert(LabelingConfig(model="gpt-5-mini"))
-
-await container.simulation_service.step(
-    fork.world_id, RunConfig(num_steps=1, prefer_live_reads=True),
-)
+fork.resources.insert(SamplingConfig(min_turns=8))
+await fork.step(config=RunConfig(num_steps=1, prefer_live_reads=True))
 ```
 
 Both worlds persist to the same storage. Query either one at any tick.
@@ -196,7 +169,7 @@ Both worlds persist to the same storage. Query either one at any tick.
 | Scenario | Trajectory analysis? |
 |----------|---------------------|
 | Evaluating recorded agent sessions | Yes |
-| Comparing labeling criteria (A/B) | Yes, with `fork_world()` |
+| Comparing labeling criteria (A/B) | Yes, with `world.fork()` |
 | Benchmarking prompt variations | Yes |
 | Real-time agent processing per tick | No, use regular processors |
 | Simple data transforms | No, use DataFrame expressions |

--- a/docs/guide/worlds.md
+++ b/docs/guide/worlds.md
@@ -1,19 +1,60 @@
 # Worlds
 
-`AsyncWorld` is the central simulation coordinator. It orchestrates entity-archetype mappings, mutation caches, the parallel tick cycle, and lifecycle hooks. Each world is an independent simulation with its own entity space, tick counter, and resources.
+`AsyncWorld` is the central simulation coordinator in Archetype's core layer,
+but beginner-facing scripts should usually interact with a `RuntimeWorld`
+handle from `ArchetypeRuntime`. `RuntimeWorld` is the governed script API;
+`AsyncWorld` is the underlying engine object that owns entity-archetype
+mappings, mutation caches, the parallel tick cycle, and lifecycle hooks.
 
 ## Creating a World
 
-Worlds are typically created through the service layer:
+Recommended for scripts:
 
 ```python
+from archetype import ArchetypeRuntime
+
+async with ArchetypeRuntime() as runtime:
+    world = runtime.world("my-sim")
+```
+
+## RuntimeWorld vs AsyncWorld
+
+`ArchetypeRuntime.world(...)` returns `RuntimeWorld`, not a raw `AsyncWorld`.
+That distinction is intentional:
+
+- `RuntimeWorld` is the public script surface. Its entity and processor
+  mutations (`spawn`, `despawn`, `update`, `add_components`,
+  `remove_components`, `add_processor`, `remove_processor`) route through
+  `CommandService` and `CommandBroker`, so they honor RBAC and appear in broker
+  history. `RuntimeWorld.command_history()` reads that audit trail back through
+  the read path.
+- `RuntimeWorld.as_actor(ctx)` returns another handle to the same logical
+  world, bound to a different `ActorCtx`, without creating a new world or
+  storage backend.
+- `AsyncWorld` remains the direct engine API. Calling it directly may bypass
+  broker semantics, which is appropriate for engine and service-layer code.
+
+The runtime intentionally keeps a few script-scaffolding operations immediate
+instead of brokered:
+
+- `runtime.world(...)` / `world.as_actor(...)`
+- `world.resources.insert(...)` / `world.resources.remove(...)`
+- `world.add_hook(...)` / `world.remove_hook(...)`
+
+The rest of this page describes the engine-level `AsyncWorld` behavior that
+those runtime calls ultimately drive.
+
+Lower-level via the service layer:
+
+```python
+from archetype.core.config import WorldConfig
 from archetype.app.container import ServiceContainer
 
 container = ServiceContainer()
-world = await container.world_service.create_world(name="my-sim")
+world = await container.world_service.create_world(WorldConfig(name="my-sim"))
 ```
 
-Directly:
+Direct construction is core-internal / advanced:
 
 ```python
 from archetype.core.aio.async_world import AsyncWorld
@@ -38,6 +79,11 @@ world = AsyncWorld(
 | `run_id` | `str` | Current run identifier (set by `run()`) |
 
 ## Entity Management
+
+On `RuntimeWorld`, the corresponding public verbs are `spawn`, `despawn`,
+`update`, `add_components`, and `remove_components`. Those calls still
+materialize at tick boundaries; the sections below describe the underlying
+`AsyncWorld` mechanics.
 
 ### Creating Entities
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,12 +11,13 @@ Archetype stores world state as columnar archetype tables, executes behavior as 
 
 ## What It Is
 
-Archetype is split into three layers:
+Archetype is split into layers:
 
 | Layer | Purpose |
 |---|---|
+| `src/archetype/sugar.py` | `ArchetypeRuntime` — recommended top-level API for scripts and simulations |
 | `src/archetype/core` | ECS primitives: `Component`, `Archetype`, `AsyncWorld`, `AsyncProcessor`, storage/query/update contracts |
-| `src/archetype/app` | Service layer: `CommandBroker`, `CommandService`, `WorldService`, `SimulationService`, `QueryService` |
+| `src/archetype/app` | Service layer (lower-level): `CommandBroker`, `CommandService`, `WorldService`, `SimulationService`, `QueryService` |
 | `src/archetype/api` + `src/archetype/cli` | FastAPI server and Typer CLI |
 
 The runtime model is:
@@ -52,20 +53,14 @@ cd archetype
 uv sync --group dev
 ```
 
-The most complete interface today is the in-process Python API:
+The recommended entry point for scripts is `ArchetypeRuntime`:
 
 ```python
 import asyncio
 
 from daft import DataFrame, col
-from uuid_utils import uuid7
 
-from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
-from archetype.core.aio.async_processor import AsyncProcessor
-from archetype.core.component import Component
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype import ArchetypeRuntime, AsyncProcessor, Component
 
 
 class Position(Component):
@@ -92,41 +87,23 @@ class MovementProcessor(AsyncProcessor):
 
 
 async def main():
-    container = ServiceContainer()
-    world = await container.world_service.create_world(
-        WorldConfig(name="demo"),
-        StorageConfig(),
-    )
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("demo", processors=[MovementProcessor()])
 
-    await world.system.add_processor(MovementProcessor())
+        await world.spawn(Position(x=0, y=0), Velocity(dx=1, dy=2))
+        await world.run(steps=3)
 
-    ctx = ActorCtx(id=uuid7(), roles={"admin"})
-    cmd = Command(
-        type=CommandType.SPAWN,
-        payload={
-            "components": [
-                Position(x=0, y=0).to_payload(),
-                Velocity(dx=1, dy=2).to_payload(),
-            ]
-        },
-    )
-    await container.command_service.submit(world.world_id, cmd, ctx)
-
-    await container.simulation_service.run(world.world_id, RunConfig(num_steps=3))
-
-    df = await world.get_components([Position])
-    print(df.collect().to_pylist())
-
-    await container.shutdown()
+        df = await world.query(Position)
+        print(df.collect().to_pylist())
 
 
 asyncio.run(main())
 ```
 
-Two important details from the code:
+Two important details:
 
-- use `Component.to_payload()` when sending components through `CommandService`
 - processor columns are always prefixed as `componentname__field`
+- `ArchetypeRuntime` is the script boundary; use `world.as_actor(...)` for explicit roles and drop to `ServiceContainer` only for custom command routing or lower-level lifecycle control
 
 See [Quickstart](guide/quickstart.md) for more.
 
@@ -273,6 +250,6 @@ Current state worth knowing before using it:
 
 ## Where to Start
 
-- **New to Archetype?** Start with the [Quickstart](guide/quickstart.md) to get a simulation running, then read the [Architecture](guide/architecture.md) overview
+- **New to Archetype?** Start with the [Quickstart](guide/quickstart.md), which leads with `ArchetypeRuntime`, then read the [Architecture](guide/architecture.md) overview
 - **Building a simulation?** See [Building Simulations](guide/building-simulations.md) for the full workflow
 - **Integrating with the API?** See [App Overview](guide/app-overview.md) for how core connects through services to the HTTP layer

--- a/examples/01_world_mutations.py
+++ b/examples/01_world_mutations.py
@@ -5,9 +5,9 @@
 World Mutations
 ================
 
-Demonstrates every mutation type: spawn, despawn, update,
-add/remove components, add/remove processors, fork, and
-the RBAC system that gates all of it.
+Demonstrates the brokered runtime mutation surface: spawn, despawn, update,
+add/remove components, add/remove processors, fork, actor-bound handles, and
+broker audit history.
 
 No external dependencies — runs entirely in-process.
 
@@ -20,15 +20,11 @@ import asyncio
 from daft import DataFrame, col
 from uuid_utils import uuid7
 
+from archetype import ArchetypeRuntime
 from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
-
-
-# ── Components ──────────────────────────────────────────────────────────────
+from archetype.core.config import StorageConfig
 
 
 class Position(Component):
@@ -46,12 +42,7 @@ class Health(Component):
     max_hp: int = 100
 
 
-# ── Processors ──────────────────────────────────────────────────────────────
-
-
 class MovementProcessor(AsyncProcessor):
-    """Move entities by their velocity each tick."""
-
     components = (Position, Velocity)
     priority = 10
 
@@ -64,131 +55,96 @@ class MovementProcessor(AsyncProcessor):
         )
 
 
-# ── Main ────────────────────────────────────────────────────────────────────
-
-
 async def main():
-    container = ServiceContainer()
-    admin = ActorCtx(id=uuid7(), roles={"admin"})
+    storage = StorageConfig(uri="./archetype_data", namespace="world_mutations")
 
-    world = await container.world_service.create_world(
-        WorldConfig(name="mutations-demo"), StorageConfig(),
-    )
-    wid = world.world_id
-    rc = RunConfig()
-    print(f"Created world: {wid}\n")
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("mutations-demo", storage=storage)
+        viewer = world.as_actor(ActorCtx(id=uuid7(), roles={"viewer"}))
+        player = world.as_actor(ActorCtx(id=uuid7(), roles={"player"}))
+        admin = world.as_actor(ActorCtx(id=uuid7(), roles={"admin"}))
 
-    # ── 1. SPAWN: create entities with components ───────────────────────
-    print("1. SPAWN — create entities with components")
+        print("1. SPAWN + RBAC")
+        scout = await player.spawn(Position(x=0.0, y=0.0))
+        dummy = await player.spawn(Position(x=10.0, y=10.0))
+        try:
+            await viewer.spawn(Position(x=99.0, y=99.0))
+            print("   viewer: SPAWN allowed (unexpected)")
+        except PermissionError:
+            print("   viewer: SPAWN denied (correct)")
+        await admin.step()
+        print(f"   Created world: {world.world_id}")
+        print(f"   player: spawned scout={scout}, dummy={dummy}")
 
-    # Entity with Position + Velocity
-    # NOTE: use Component.to_payload() (not model_dump) so CommandService can
-    # reconstruct the concrete subclass on the other side. See Archetype #90.
-    cmd = Command(
-        type=CommandType.SPAWN,
-        payload={
-            "components": [
-                Position(x=0, y=0).to_payload(),
-                Velocity(vx=1, vy=2).to_payload(),
-            ],
-        },
-    )
-    await container.command_service.submit(wid, cmd, admin)
+        print("\n2. UPDATE + COMPONENT MUTATIONS")
+        await player.update(scout, Position(x=2.0, y=1.0))
+        await admin.step()
+        await admin.add_components(
+            scout,
+            Velocity(vx=1.5, vy=0.5),
+            Health(hp=80, max_hp=100),
+        )
+        await admin.step()
 
-    # Entity with just Position
-    cmd = Command(
-        type=CommandType.SPAWN,
-        payload={
-            "components": [
-                Position(x=10, y=10).to_payload(),
-            ],
-        },
-    )
-    await container.command_service.submit(wid, cmd, admin)
+        enriched = (await admin.query(Position, Velocity, Health, entity_ids=[scout])).collect().to_pylist()[0]
+        print(
+            "   scout after update/add_components:"
+            f" pos=({enriched['position__x']}, {enriched['position__y']})"
+            f", vel=({enriched['velocity__vx']}, {enriched['velocity__vy']})"
+            f", hp={enriched['health__hp']}"
+        )
 
-    # Step to materialize
-    await container.simulation_service.step(wid, rc)
-    print(f"   Spawned 2 entities (tick={world.tick})")
+        await admin.remove_components(scout, Health)
+        await player.despawn(dummy)
+        await admin.step()
 
-    # ── 2. ADD_PROCESSOR: inject behavior at runtime ────────────────────
-    print("\n2. ADD_PROCESSOR — inject behavior at runtime")
+        narrowed = (await admin.query(Position, Velocity, entity_ids=[scout])).collect().to_pylist()[0]
+        removed = (await admin.query(Position, entity_ids=[dummy])).collect().to_pylist()
+        print(
+            "   scout after remove_components:"
+            f" pos=({narrowed['position__x']}, {narrowed['position__y']})"
+            f", vel=({narrowed['velocity__vx']}, {narrowed['velocity__vy']})"
+        )
+        print(f"   dummy present after despawn: {bool(removed)}")
 
-    await world.system.add_processor(MovementProcessor())
-    print("   Added MovementProcessor (priority=10)")
+        print("\n3. PROCESSOR MUTATIONS")
+        try:
+            await player.add_processor(MovementProcessor())
+            print("   player: ADD_PROCESSOR allowed (unexpected)")
+        except PermissionError:
+            print("   player: ADD_PROCESSOR denied (correct)")
 
-    # Run 3 ticks — entities with both Position+Velocity will move
-    await container.simulation_service.run(wid, RunConfig(num_steps=3))
-    print(f"   Ran 3 ticks (tick={world.tick})")
+        await admin.add_processor(MovementProcessor())
+        await admin.step()
+        moved = (await admin.query(Position, Velocity, entity_ids=[scout])).collect().to_pylist()[0]
+        print(
+            "   scout after MovementProcessor:"
+            f" pos=({moved['position__x']}, {moved['position__y']})"
+        )
+        await admin.remove_processor(MovementProcessor)
 
-    # ── 3. ADD_COMPONENT: add components to existing entity ─────────────
-    print("\n3. ADD_COMPONENT — add components to existing entity")
+        print("\n4. FORK")
+        branch = await player.fork("branch-a", storage=storage)
+        branch_seed = await branch.spawn(Position(x=-5.0, y=0.0), Velocity(vx=0.5, vy=0.0))
+        await branch.step()
 
-    # Find the entity that only has Position (no Velocity)
-    for sig, df in world._live.items():
-        component_names = [c.__name__ for c in sig]
-        rows = df.collect().to_pylist()
-        for row in rows:
-            eid = row["entity_id"]
-            print(f"   Entity {eid}: {component_names}")
+        source_state = (await admin.query(Position, Velocity, entity_ids=[scout])).collect().to_pylist()[0]
+        branch_state = (await branch.query(Position, Velocity, entity_ids=[branch_seed])).collect().to_pylist()[0]
+        print(f"   source tick={world.tick}, branch tick={branch.tick}")
+        print(
+            "   source scout:"
+            f" pos=({source_state['position__x']}, {source_state['position__y']})"
+        )
+        print(
+            "   branch new entity:"
+            f" pos=({branch_state['position__x']}, {branch_state['position__y']})"
+        )
 
-    # ── 4. RBAC: who can do what ────────────────────────────────────────
-    print("\n4. RBAC — permission checks")
-
-    viewer = ActorCtx(id=uuid7(), roles={"viewer"})
-    player = ActorCtx(id=uuid7(), roles={"player"})
-
-    # Viewer cannot spawn
-    try:
-        cmd = Command(type=CommandType.SPAWN, payload={"components": []})
-        await container.command_service.submit(wid, cmd, viewer)
-        print("   viewer: SPAWN allowed (unexpected)")
-    except PermissionError:
-        print("   viewer: SPAWN denied (correct)")
-
-    # Player can spawn
-    try:
-        cmd = Command(type=CommandType.SPAWN, payload={"components": []})
-        await container.command_service.submit(wid, cmd, player)
-        print("   player: SPAWN allowed (correct)")
-    except PermissionError:
-        print("   player: SPAWN denied (unexpected)")
-
-    # Player cannot add processors
-    try:
-        cmd = Command(type=CommandType.ADD_PROCESSOR, payload={})
-        await container.command_service.submit(wid, cmd, player)
-        print("   player: ADD_PROCESSOR allowed (unexpected)")
-    except PermissionError:
-        print("   player: ADD_PROCESSOR denied (correct)")
-
-    # ── 5. FORK: branch the world ───────────────────────────────────────
-    print("\n5. FORK — branch the world")
-
-    # Step to materialize any pending commands first
-    await container.simulation_service.step(wid, rc)
-
-    fork = await container.world_service.fork_world(
-        source_world_id=wid,
-        name="branch-A",
-        storage_config=StorageConfig(),
-    )
-    print(f"   Forked: {fork.world_id}")
-    print(f"   Fork tick={fork.tick} (matches source tick={world.tick})")
-
-    # Run fork independently
-    await container.simulation_service.run(fork.world_id, RunConfig(num_steps=5))
-    print(f"   Fork after 5 more ticks: tick={fork.tick}")
-    print(f"   Source unchanged: tick={world.tick}")
-
-    # ── 6. Command history ──────────────────────────────────────────────
-    print("\n6. COMMAND HISTORY — full audit trail")
-
-    history = await container.query_service.get_command_history(wid)
-    for cmd in history:
-        print(f"   tick={cmd.tick}: {cmd.type.value}")
-
-    await container.shutdown()
-    print("\nDone.")
+        print("\n5. COMMAND HISTORY")
+        for cmd in await admin.command_history():
+            print(f"   source tick={cmd.tick}: {cmd.type.value}")
+        for cmd in await branch.command_history():
+            print(f"   branch tick={cmd.tick}: {cmd.type.value}")
 
 
 if __name__ == "__main__":

--- a/examples/02_fork_counterfactual.py
+++ b/examples/02_fork_counterfactual.py
@@ -17,12 +17,9 @@ Usage:
 import asyncio
 from dataclasses import dataclass
 
-from uuid_utils import uuid7
-
-from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype import ArchetypeRuntime
+from archetype.core.component import Component
+from archetype.core.config import StorageConfig
 
 
 @dataclass
@@ -31,50 +28,33 @@ class PhysicsConfig:
     drag: float = 0.1
 
 
+class Probe(Component):
+    label: str = ""
+
+
 async def main():
-    container = ServiceContainer()
-    ctx = ActorCtx(id=uuid7(), roles={"admin"})
+    storage = StorageConfig(uri="./archetype_data", namespace="counterfactuals")
 
-    # Create the base world
-    base = await container.world_service.create_world(
-        WorldConfig(name="base"), StorageConfig(),
-    )
-    wid = base.world_id
+    async with ArchetypeRuntime() as runtime:
+        base = runtime.world("base", storage=storage)
 
-    # Spawn an entity so there's state to fork
-    cmd = Command(type=CommandType.SPAWN, payload={"components": []})
-    await container.command_service.submit(wid, cmd, ctx)
+        await base.spawn(Probe(label="seed"))
+        await base.run(steps=1)
 
-    # Step once to materialize the entity
-    await container.simulation_service.run(wid, RunConfig(num_steps=1))
+        print(f"Base world: {base.world_id}")
+        print(f"Base state: tick={base.tick}\n")
 
-    print(f"Base world: {wid}")
-    print(f"Base state: tick={base.tick}\n")
+        branches_run = 0
+        for gravity in [1.0, 9.8, 25.0]:
+            fork = await base.fork(f"gravity-{gravity}", storage=storage)
+            fork.resources.insert(PhysicsConfig(gravity=gravity))
 
-    # Fork with different gravity values and run each
-    results = {}
-    for gravity in [1.0, 9.8, 25.0]:
-        fork = await container.world_service.fork_world(
-            source_world_id=wid,
-            name=f"gravity-{gravity}",
-            storage_config=StorageConfig(),
-        )
-        fork.resources.insert(PhysicsConfig(gravity=gravity))
+            result = await fork.run(steps=10)
+            rows = (await fork.query(Probe)).collect().to_pylist()
+            branches_run += 1
+            print(f"gravity={gravity:>5.1f}: tick={result.final_tick}, entities={len(rows)}")
 
-        await container.simulation_service.run(
-            fork.world_id, RunConfig(num_steps=10),
-        )
-
-        state = await container.query_service.get_world_state(fork.world_id)
-        results[gravity] = {
-            "world_id": str(fork.world_id),
-            "final_tick": state.tick,
-            "entity_count": len(state.entities),
-        }
-        print(f"gravity={gravity:>5.1f}: tick={state.tick}, entities={len(state.entities)}")
-
-    print(f"\nRan {len(results)} counterfactual branches from the same base state.")
-    await container.shutdown()
+        print(f"\nRan {branches_run} counterfactual branches from the same base state.")
 
 
 if __name__ == "__main__":

--- a/examples/03_time_travel.py
+++ b/examples/03_time_travel.py
@@ -8,6 +8,10 @@ Time-Travel Queries
 Run a simulation for 10 ticks, then query the state at different
 points in history. Every tick is preserved — nothing is overwritten.
 
+This example intentionally uses the lower-level query service because
+historical snapshot reads live on the read path rather than the current
+runtime sugar.
+
 No external dependencies — runs entirely in-process.
 
 Usage:
@@ -28,42 +32,31 @@ async def main():
     container = ServiceContainer()
     ctx = ActorCtx(id=uuid7(), roles={"admin"})
 
-    # Create world and spawn entities at different ticks
     world = await container.world_service.create_world(
         WorldConfig(name="time-travel-demo"), StorageConfig(),
     )
     wid = world.world_id
 
-    # Spawn 3 entities
-    for i in range(3):
-        cmd = Command(
-            type=CommandType.SPAWN,
-            payload={"components": []},
-        )
-        await container.command_service.submit(wid, cmd, ctx)
+    async def spawn_empty(count: int):
+        for _ in range(count):
+            await container.command_service.submit(
+                wid,
+                Command(type=CommandType.SPAWN, payload={"components": []}),
+                ctx,
+            )
 
-    # Run to tick 5
+    await spawn_empty(3)
     await container.simulation_service.run(wid, RunConfig(num_steps=5))
     print(f"After 5 ticks: {world.tick} tick, entities spawned")
 
-    # Spawn 2 more entities
-    for i in range(2):
-        cmd = Command(
-            type=CommandType.SPAWN,
-            payload={"components": []},
-        )
-        await container.command_service.submit(wid, cmd, ctx)
-
-    # Run to tick 10
+    await spawn_empty(2)
     await container.simulation_service.run(wid, RunConfig(num_steps=5))
     print(f"After 10 ticks: {world.tick} tick\n")
 
-    # Time-travel: query state at different ticks
     for tick in [1, 5, 10]:
         state = await container.query_service.get_world_state(wid, tick=tick)
         print(f"  tick {tick:>2}: {len(state.entities)} entities, archetype_counts={state.archetype_counts}")
 
-    # Show the full command history
     print("\nCommand history:")
     history = await container.query_service.get_command_history(wid)
     for cmd in history:

--- a/examples/04_messaging.py
+++ b/examples/04_messaging.py
@@ -17,13 +17,12 @@ from dataclasses import dataclass
 import daft
 from daft import DataFrame, col
 
+from archetype import ArchetypeRuntime
 from archetype.app.broker import CommandBroker
 from archetype.app.models import Command, CommandType
 from archetype.core.aio.async_processor import AsyncProcessor
-from archetype.core.aio.async_system import AsyncSystem
-from archetype.core.aio.async_world import AsyncWorld
 from archetype.core.component import Component
-from archetype.core.config import RunConfig, WorldConfig
+from archetype.core.config import StorageConfig
 from archetype.core.resources import Resources
 
 # =============================================================================
@@ -60,6 +59,13 @@ class SimConfig:
     max_messages_per_tick: int = 5
 
 
+@dataclass
+class BrokerChannel:
+    """Shared broker queue key for the demo."""
+
+    key: str = "messaging-demo"
+
+
 # =============================================================================
 # Processors
 # =============================================================================
@@ -82,6 +88,7 @@ class GreetingProcessor(AsyncProcessor):
     ) -> DataFrame:
         """Generate greeting messages and enqueue via broker."""
         broker = resources.require(CommandBroker)
+        channel = resources.require(BrokerChannel).key
         resources.require(SimConfig)  # validate config exists
 
         # Collect entities to process
@@ -101,7 +108,7 @@ class GreetingProcessor(AsyncProcessor):
                             "content": f"Hello from {sender['agentstate__name']}!",
                         },
                     )
-                    await broker.enqueue("demo_world", cmd)
+                    await broker.enqueue(channel, cmd)
         
         return df
 
@@ -123,10 +130,11 @@ class MessageRealizationProcessor(AsyncProcessor):
     ) -> DataFrame:
         """Drain MESSAGE commands from broker and populate inboxes."""
         broker = resources.require(CommandBroker)
+        channel = resources.require(BrokerChannel).key
         resources.require(SimConfig)  # validate config exists
 
         # Dequeue all pending MESSAGE commands
-        cmds = await broker.dequeue("demo_world", max_items=1000)
+        cmds = await broker.dequeue(channel, max_items=1000)
         message_cmds = [c for c in cmds if c.type == CommandType.MESSAGE]
         
         if not message_cmds:
@@ -208,60 +216,6 @@ class MoodProcessor(AsyncProcessor):
 
 
 # =============================================================================
-# Minimal Async Infrastructure (no persistence for this demo)
-# =============================================================================
-
-
-class InMemoryQuerier:
-    """Minimal querier that returns empty DataFrames for tick 0, or stored data."""
-    
-    def __init__(self):
-        self._store: dict[tuple, DataFrame] = {}
-    
-    async def query_archetype(self, **kwargs):
-        import pyarrow as pa
-
-        from archetype.core.archetype import Archetype
-        sig = kwargs["sig"]
-        ticks = kwargs.get("ticks", [0])
-        
-        # Return stored data if available
-        key = (sig, ticks[0] if ticks else 0)
-        if key in self._store:
-            return self._store[key]
-        
-        # Return empty DataFrame with correct schema
-        schema = Archetype.get_archetype_schema(sig)
-        return daft.from_arrow(pa.Table.from_batches([], schema=schema))
-    
-    def store(self, sig, tick, df):
-        """Store a snapshot for later queries."""
-        self._store[(sig, tick)] = df
-
-
-class InMemoryUpdater:
-    """Minimal updater that stamps tick and returns the DataFrame."""
-    
-    def __init__(self, querier: InMemoryQuerier):
-        self._querier = querier
-    
-    async def update(self, df, sig, tick, world_id, run_id):
-        # Stamp metadata
-        df = (
-            df
-            .with_column("tick", daft.lit(tick))
-            .with_column("world_id", daft.lit(str(world_id)))
-            .with_column("run_id", daft.lit(str(run_id)))
-        )
-        df_mat = df.collect()
-        
-        # Store for next tick's queries
-        self._querier.store(sig, tick, df_mat)
-        
-        return df_mat
-
-
-# =============================================================================
 # Main Demo
 # =============================================================================
 
@@ -270,101 +224,84 @@ async def main():
     print("=" * 60)
     print("Archetype Messaging Demo: Resources + MESSAGE + Hooks")
     print("=" * 60)
-    
-    # Create world
-    world_config = WorldConfig(name="demo")
-    querier = InMemoryQuerier()
-    updater = InMemoryUpdater(querier)
-    system = AsyncSystem()
-    
-    world = AsyncWorld(
-        world_config=world_config,
-        querier=querier,
-        updater=updater,
-        system=system,
-    )
-    
-    # Setup Resources
-    broker = CommandBroker()
-    config = SimConfig(greeting_boost=15.0)
-    
-    world.resources.insert(broker)
-    world.resources.insert(config)
-    
-    print(f"\n✓ Resources registered: {world.resources}")
-    
-    # Setup Hooks
-    async def on_pre_tick(world, tick, **kwargs):
-        print(f"\n→ Pre-tick {tick}: Starting processing...")
-    
-    async def on_post_tick(world, tick, **kwargs):
-        print(f"← Post-tick {tick}: Completed!")
-        # Show pending message count
-        pending = await broker.get_pending_count("demo_world")
-        print(f"   Messages pending in broker: {pending}")
-    
-    world.add_hook("pre_tick", on_pre_tick)
-    world.add_hook("post_tick", on_post_tick)
-    
-    print("✓ Hooks registered: pre_tick, post_tick")
-    
-    # Register Processors
-    await system.add_processor(MessageRealizationProcessor())
-    await system.add_processor(GreetingProcessor())
-    await system.add_processor(MoodProcessor())
-    
-    print("✓ Processors registered: MessageRealization, Greeting, Mood")
-    
-    # Create Agents
-    agents = [
-        [AgentState(name="Alice", mood="neutral", energy=100.0), Inbox(), Outbox()],
-        [AgentState(name="Bob", mood="neutral", energy=100.0), Inbox(), Outbox()],
-        [AgentState(name="Charlie", mood="neutral", energy=100.0), Inbox(), Outbox()],
-    ]
-    
-    for components in agents:
-        await world.create_entity(components)
-    
-    print(f"✓ Created {len(agents)} agents: Alice, Bob, Charlie")
-    
-    # Run simulation
-    print("\n" + "-" * 60)
-    print("Running 3 ticks...")
-    print("-" * 60)
-    
-    run_config = RunConfig(num_steps=3)
-    await world.run(run_config)
-    
-    # Show final state
-    print("\n" + "=" * 60)
-    print("Final State")
-    print("=" * 60)
-    
-    for sig, df in world._live.items():
-        print(f"\nArchetype: {[c.__name__ for c in sig]}")
-        df.select(
+
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "demo",
+            storage=StorageConfig(uri="./archetype_data", namespace="messaging_demo"),
+            processors=[
+                MessageRealizationProcessor(),
+                GreetingProcessor(),
+                MoodProcessor(),
+            ],
+            resources=[
+                SimConfig(greeting_boost=15.0),
+                BrokerChannel(),
+            ],
+        )
+
+        async def on_pre_tick(world, tick, **kwargs):
+            print(f"\n→ Pre-tick {tick}: Starting processing...")
+
+        async def on_post_tick(world, tick, **kwargs):
+            print(f"← Post-tick {tick}: Completed!")
+            broker = world.resources.require(CommandBroker)
+            channel = world.resources.require(BrokerChannel).key
+            pending = await broker.get_pending_count(channel)
+            print(f"   Messages pending in broker: {pending}")
+
+        world.add_hook("pre_tick", on_pre_tick)
+        world.add_hook("post_tick", on_post_tick)
+
+        print("\n✓ Runtime world staged with resources, hooks, and processors")
+
+        for name in ("Alice", "Bob", "Charlie"):
+            await world.spawn(AgentState(name=name), Inbox(), Outbox())
+
+        print("✓ Created 3 agents: Alice, Bob, Charlie")
+
+        print("\n" + "-" * 60)
+        print("Running 3 ticks...")
+        print("-" * 60)
+        await world.run(steps=3)
+
+        print("\n" + "=" * 60)
+        print("Final State")
+        print("=" * 60)
+
+        final_df = await world.query(AgentState, Inbox)
+        final_df.select(
             "entity_id",
             "agentstate__name",
             "agentstate__mood",
             "agentstate__energy",
         ).show()
-        
-        # Show message counts
-        rows = df.select("entity_id", "agentstate__name", "inbox__messages").collect().to_pylist()
-        print("\n  Message counts:")
+
+        rows = final_df.select(
+            "entity_id",
+            "agentstate__name",
+            "inbox__messages",
+        ).collect().to_pylist()
+        print("\nMessage counts:")
         for row in rows:
             msgs = row.get("inbox__messages") or []
-            print(f"    {row['agentstate__name']}: {len(msgs)} messages received")
-    
-    # Show message history
-    print("\n" + "-" * 60)
-    print("Broker Message History (last 10)")
-    print("-" * 60)
-    history = await broker.get_history("demo_world", limit=10)
-    for cmd in history[-10:]:
-        if cmd.type == CommandType.MESSAGE:
-            content = cmd.payload['content'][:25] + "..." if len(cmd.payload['content']) > 25 else cmd.payload['content']
-            print(f"  tick={cmd.tick}: agent {cmd.payload['sender_id']} → agent {cmd.payload['receiver_id']}: {content}")
+            print(f"  {row['agentstate__name']}: {len(msgs)} messages received")
+
+        print("\n" + "-" * 60)
+        print("Broker Message History (last 10)")
+        print("-" * 60)
+        broker = world.resources.require(CommandBroker)
+        channel = world.resources.require(BrokerChannel).key
+        history = await broker.get_history(channel, limit=10)
+        for cmd in history[-10:]:
+            if cmd.type == CommandType.MESSAGE:
+                content = cmd.payload["content"]
+                if len(content) > 25:
+                    content = content[:25] + "..."
+                print(
+                    f"  tick={cmd.tick}: agent {cmd.payload['sender_id']} "
+                    f"→ agent {cmd.payload['receiver_id']}: {content}"
+                )
 
 
 if __name__ == "__main__":

--- a/examples/05_llm_agents.py
+++ b/examples/05_llm_agents.py
@@ -26,14 +26,11 @@ import json
 
 from daft import DataFrame, col
 from daft.functions import prompt
-from uuid_utils import uuid7
 
-from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
+from archetype import ArchetypeRuntime
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.config import StorageConfig
 
 # ── Components ──
 
@@ -105,45 +102,27 @@ class ThinkProcessor(AsyncProcessor):
 
 
 async def main():
-    container = ServiceContainer()
-    ctx = ActorCtx(id=uuid7(), roles={"admin"})
-
-    # Create world
-    world = await container.world_service.create_world(
-        WorldConfig(name="llm-agents"),
-        StorageConfig(),
-    )
-    wid = world.world_id
-
-    # Add the think processor
-    await world.system.add_processor(ThinkProcessor())
-
-    # Spawn three agents with different personalities
     agents = [
         ("Ada", "You are a curious scientist who loves discovering patterns."),
         ("Rex", "You are a bold explorer who takes risks and seeks adventure."),
         ("Iris", "You are a thoughtful philosopher who questions everything."),
     ]
+    storage = StorageConfig(uri="./archetype_data", namespace="llm_agents")
 
-    for name, role in agents:
-        cmd = Command(
-            type=CommandType.SPAWN,
-            payload={
-                "components": [
-                    Agent(name=name, role=role).to_payload(),
-                ],
-            },
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("llm-agents", storage=storage, processors=[ThinkProcessor()])
+
+        for name, role in agents:
+            await world.spawn(Agent(name=name, role=role))
+
+        print(f"Running 5 ticks with {len(agents)} LLM-powered agents...\n")
+        result = await world.run(steps=5)
+        print(f"Completed {result.ticks_completed} ticks\n")
+
+        rows = sorted(
+            (await world.query(Agent)).collect().to_pylist(),
+            key=lambda row: row.get("agent__name", ""),
         )
-        await container.command_service.submit(wid, cmd, ctx)
-
-    # Run 5 ticks — each tick calls the LLM for all agents
-    print(f"Running 5 ticks with {len(agents)} LLM-powered agents...\n")
-    result = await container.simulation_service.run(wid, RunConfig(num_steps=5))
-    print(f"Completed {result.ticks_completed} ticks\n")
-
-    # Print journals
-    for _sig, df in world._live.items():
-        rows = df.collect().to_pylist()
         for row in rows:
             name = row.get("agent__name", "?")
             journal_str = row.get("agent__journal", "[]")
@@ -155,8 +134,6 @@ async def main():
             for i, thought in enumerate(thoughts):
                 print(f"  tick {i}: {thought}")
             print()
-
-    await container.shutdown()
 
 
 if __name__ == "__main__":

--- a/examples/06_trajectory_analysis.py
+++ b/examples/06_trajectory_analysis.py
@@ -6,10 +6,10 @@ Trajectory Analysis
 ===================
 
 Ingest agent trajectories, label them with natural language descriptions,
-and compare techniques via world forking — all using the raw ECS pattern.
+and compare techniques via world forking using the runtime-level script API.
 
 Components define the schema. Processors define the pipeline stages.
-The world runs them. Fork to compare.
+The runtime owns the process boundary. Worlds stay lazy until first use.
 
 Usage:
     uv run python examples/06_trajectory_analysis.py
@@ -22,21 +22,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from dataclasses import dataclass, field
 from typing import Any
 
 import daft
 from daft import DataFrame, col
-from uuid_utils import uuid7
 
-from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
+from archetype import ArchetypeRuntime
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.config import RunConfig, StorageConfig
 from archetype.core.resources import Resources
-
 
 # ── Data Types ──────────────────────────────────────────────────────
 
@@ -427,68 +424,49 @@ async def main():
     trajectories = make_trajectories()
     print(f"Created {len(trajectories)} synthetic trajectories\n")
 
-    # ── Setup: world + processors + resources ──
+    storage = StorageConfig(uri="./trajectory_data", namespace="trajectories")
+    has_openai_key = bool(os.getenv("OPENAI_API_KEY"))
 
-    container = ServiceContainer()
-    ctx = ActorCtx(id=uuid7(), roles={"operator"})
-
-    world = await container.world_service.create_world(
-        WorldConfig(name="trajectory-eval"),
-        StorageConfig(uri="./trajectory_data", namespace="trajectories"),
-    )
-
-    await world.system.add_processor(SamplingProcessor())
-    await world.system.add_processor(LabelingProcessor())
-    await world.system.add_processor(ScoringProcessor())
-
-    world.resources.insert(SamplingConfig(min_turns=3))
-    world.resources.insert(LabelingConfig(model="gpt-5-mini"))
-
-    # ── Ingest: one entity per (trajectory, technique) pair ──
-
-    label_specs = [
-        ("efficiency", "Rate how directly the agent reached the solution without unnecessary "
-         "backtracking or wasted steps. A perfect score means the agent identified the "
-         "correct approach immediately."),
-        ("correctness", "Did the agent produce the correct final result? Score 1.0 for fully "
-         "correct, 0.5 for partially correct, 0.0 for incorrect or unresolved."),
-    ]
-
-    print("Ingesting trajectories...")
-    for trajectory in trajectories:
-        for technique, description in label_specs:
-            label = Label(technique=technique, description=description)
-            cmd = Command(
-                type=CommandType.SPAWN,
-                payload={
-                    "components": [
-                        {"type": "Trajectory", **trajectory.model_dump()},
-                        {"type": "Label", **label.model_dump()},
-                    ],
-                },
-            )
-            await container.command_service.submit(world.world_id, cmd, ctx)
-
-    total = len(trajectories) * len(label_specs)
-    print(f"  -> {len(trajectories)} trajectories x {len(label_specs)} techniques = {total} entities\n")
-
-    # ── Run: one tick = sample -> label -> score ──
-
-    print("Running pipeline (sample -> label -> score)...")
-    try:
-        await container.simulation_service.step(
-            world.world_id, RunConfig(num_steps=1, prefer_live_reads=True),
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "trajectory-eval",
+            storage=storage,
+            processors=[
+                SamplingProcessor(),
+                *([LabelingProcessor()] if has_openai_key else []),
+                ScoringProcessor(),
+            ],
+            resources=[SamplingConfig(min_turns=3), LabelingConfig(model="gpt-5-mini")],
         )
+
+        label_specs = [
+            ("efficiency", "Rate how directly the agent reached the solution without unnecessary "
+             "backtracking or wasted steps. A perfect score means the agent identified the "
+             "correct approach immediately."),
+            ("correctness", "Did the agent produce the correct final result? Score 1.0 for fully "
+             "correct, 0.5 for partially correct, 0.0 for incorrect or unresolved."),
+        ]
+
+        print("Ingesting trajectories...")
+        for trajectory in trajectories:
+            for technique, description in label_specs:
+                label = Label(technique=technique, description=description)
+                await world.spawn(trajectory, label)
+
+        total = len(trajectories) * len(label_specs)
+        print(
+            f"  -> {len(trajectories)} trajectories x {len(label_specs)} techniques = {total} entities\n"
+        )
+
+        if not has_openai_key:
+            print("OPENAI_API_KEY not set; running sampling/score pipeline without LLM labeling.\n")
+
+        print("Running pipeline (sample -> label -> score)...")
+        await world.step(config=RunConfig(num_steps=1, prefer_live_reads=True))
         print("  -> Pipeline completed\n")
-    except Exception as e:
-        print(f"  -> Pipeline errored (expected without API key): {e}\n")
 
-    # ── Results ──
-
-    print("Results:")
-    df = await world.get_components([Trajectory, Label])
-    if df is not None:
-        rows = df.collect().to_pylist()
+        print("Results:")
+        rows = (await world.query(Trajectory, Label)).collect().to_pylist()
         for row in rows:
             if not row.get("is_active", True):
                 continue
@@ -500,24 +478,12 @@ async def main():
             print(f"  [{tech}] {tid}: score={score:.2f} value={value!r}")
             if rationale:
                 print(f"    rationale: {rationale}")
-    print()
+        print()
 
-    # ── Fork: compare a stricter labeling technique ──
-
-    print("Forking world to compare a stricter correctness definition...")
-    fork = await container.world_service.fork_world(
-        source_world_id=world.world_id,
-        name="strict-eval",
-        storage_config=StorageConfig(uri="./trajectory_data", namespace="trajectories"),
-    )
-    await fork.system.add_processor(SamplingProcessor())
-    await fork.system.add_processor(LabelingProcessor())
-    await fork.system.add_processor(ScoringProcessor())
-    fork.resources.insert(SamplingConfig(min_turns=3))
-    fork.resources.insert(LabelingConfig(model="gpt-5-mini"))
-    print(f"  -> Forked at tick {fork.tick}, both worlds coexist in storage\n")
-
-    await container.shutdown()
+        print("Forking world to compare a stricter sampling threshold...")
+        fork = await world.fork("strict-eval", storage=storage)
+        fork.resources.insert(SamplingConfig(min_turns=8))
+        print(f"  -> Forked at tick {fork.tick}, both worlds coexist in storage\n")
 
 
 if __name__ == "__main__":

--- a/examples/pr_triage.py
+++ b/examples/pr_triage.py
@@ -17,54 +17,15 @@ import asyncio
 import json
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import daft
 from daft import DataFrame, col
 
+from archetype import ArchetypeRuntime
 from archetype.core.aio.async_processor import AsyncProcessor
-from archetype.core.aio.async_system import AsyncSystem
-from archetype.core.aio.async_world import AsyncWorld
 from archetype.core.component import Component
-from archetype.core.config import RunConfig, WorldConfig
-
-# ── In-memory infrastructure (no persistence needed) ─────────────────────────
-
-import pyarrow as pa
-from archetype.core.archetype import Archetype
-
-
-class InMemoryQuerier:
-    def __init__(self):
-        self._store: dict[tuple, DataFrame] = {}
-
-    async def query_archetype(self, **kwargs):
-        sig = kwargs["sig"]
-        ticks = kwargs.get("ticks", [0])
-        key = (sig, ticks[0] if ticks else 0)
-        if key in self._store:
-            return self._store[key]
-        schema = Archetype.get_archetype_schema(sig)
-        return daft.from_arrow(pa.Table.from_batches([], schema=schema))
-
-    def store(self, sig, tick, df):
-        self._store[(sig, tick)] = df
-
-
-class InMemoryUpdater:
-    def __init__(self, querier: InMemoryQuerier):
-        self._querier = querier
-
-    async def update(self, df, sig, tick, world_id, run_id):
-        df = (
-            df.with_column("tick", daft.lit(tick))
-            .with_column("world_id", daft.lit(str(world_id)))
-            .with_column("run_id", daft.lit(str(run_id)))
-        )
-        df_mat = df.collect()
-        self._querier.store(sig, tick, df_mat)
-        return df_mat
-
+from archetype.core.config import StorageConfig
 
 # ── Components ───────────────────────────────────────────────────────────────
 
@@ -126,7 +87,7 @@ class StalenessProcessor(AsyncProcessor):
     priority = 20
 
     async def process(self, df: DataFrame, **kwargs) -> DataFrame:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         @daft.func
         def age_days(created_at: str) -> float:
@@ -249,40 +210,33 @@ async def main():
         print("No PRs found.")
         return
 
-    querier = InMemoryQuerier()
-    updater = InMemoryUpdater(querier)
-    system = AsyncSystem()
-    world = AsyncWorld(
-        world_config=WorldConfig(name="pr-triage"),
-        querier=querier,
-        updater=updater,
-        system=system,
-    )
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "pr-triage",
+            storage=StorageConfig(uri="./archetype_data", namespace="pr_triage"),
+            processors=[
+                CategoryProcessor(),
+                StalenessProcessor(),
+                RiskProcessor(),
+                TriageProcessor(),
+            ],
+        )
 
-    await system.add_processor(CategoryProcessor())
-    await system.add_processor(StalenessProcessor())
-    await system.add_processor(RiskProcessor())
-    await system.add_processor(TriageProcessor())
+        for pr in prs:
+            await world.spawn(
+                PullRequest(
+                    number=pr["number"],
+                    title=pr["title"],
+                    state=pr.get("state", ""),
+                    author=pr.get("author", {}).get("login", ""),
+                    created_at=pr.get("createdAt", ""),
+                    url=pr.get("url", ""),
+                ),
+                Triage(),
+            )
 
-    for pr in prs:
-        await world.create_entity([
-            PullRequest(
-                number=pr["number"],
-                title=pr["title"],
-                state=pr.get("state", ""),
-                author=pr.get("author", {}).get("login", ""),
-                created_at=pr.get("createdAt", ""),
-                url=pr.get("url", ""),
-            ),
-            Triage(),
-        ])
-
-    await world.run(RunConfig(num_steps=1))
-
-    # Collect results
-    rows = []
-    for _sig, df in world._live.items():
-        rows.extend(df.collect().to_pylist())
+        await world.run(steps=1)
+        rows = (await world.query(PullRequest, Triage)).collect().to_pylist()
 
     rows.sort(key=lambda r: r.get("triage__priority_rank", 99))
 

--- a/examples/simulation_script.py
+++ b/examples/simulation_script.py
@@ -17,13 +17,12 @@ Usage:
 
 import asyncio
 
-from daft import DataFrame, col
+from daft import DataFrame, col, lit
 
-from archetype.app.container import ServiceContainer
+from archetype import ArchetypeRuntime
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
-
+from archetype.core.config import StorageConfig
 
 # ── Step 1: Define components ───────────────────────────────────────────────
 
@@ -68,32 +67,38 @@ class RatingProcessor(AsyncProcessor):
 # ── Step 3-5: Create world, spawn entities, run ────────────────────────────
 
 
+async def collect_agent_snapshot(world) -> DataFrame:
+    return (await world.query(Agent)).with_column("history_tick", lit(world.tick))
+
+
 async def main():
-    container = ServiceContainer()
+    storage = StorageConfig(uri="./archetype_data", namespace="simulation_script")
 
-    world = await container.world_service.create_world(
-        WorldConfig(name="skill-sim"), StorageConfig(),
-    )
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "skill-sim",
+            storage=storage,
+            processors=[ExperienceProcessor(), RatingProcessor()],
+        )
+        print("Processors: Experience (priority=10), Rating (priority=50)")
 
-    # Register processors
-    await world.system.add_processor(ExperienceProcessor())
-    await world.system.add_processor(RatingProcessor())
-    print("Processors: Experience (priority=10), Rating (priority=50)")
+        await world.spawn(Agent(name="Alice", role="engineer", skill=3.0))
+        await world.spawn(Agent(name="Bob", role="designer", skill=2.0))
+        await world.spawn(Agent(name="Charlie", role="manager", skill=1.5))
+        print("Spawned: Alice (skill=3.0), Bob (skill=2.0), Charlie (skill=1.5)\n")
 
-    # Spawn agents with different starting skills
-    await world.create_entity([Agent(name="Alice", role="engineer", skill=3.0)])
-    await world.create_entity([Agent(name="Bob", role="designer", skill=2.0)])
-    await world.create_entity([Agent(name="Charlie", role="manager", skill=1.5)])
-    print("Spawned: Alice (skill=3.0), Bob (skill=2.0), Charlie (skill=1.5)\n")
+        history_frames: list[DataFrame] = []
+        for _ in range(10):
+            await world.step()
+            history_frames.append(await collect_agent_snapshot(world))
 
-    # Run 10 ticks
-    await world.run(RunConfig(num_steps=10))
-    print(f"Ran 10 ticks (final tick={world.tick})\n")
+        print(f"Ran {len(history_frames)} ticks (final tick={world.tick})\n")
 
-    # Print final state
-    print("Final state:")
-    for _sig, df in world._live.items():
-        rows = df.collect().to_pylist()
+        print("Final state:")
+        rows = sorted(
+            (await world.query(Agent)).collect().to_pylist(),
+            key=lambda row: row["entity_id"],
+        )
         for row in rows:
             name = row.get("agent__name", "?")
             exp = row.get("agent__experience", 0)
@@ -101,7 +106,20 @@ async def main():
             skill = row.get("agent__skill", 0)
             print(f"  {name}: skill={skill:.1f}, experience={exp:.0f}, rating={rating:.1f}")
 
-    await container.shutdown()
+        history_df = history_frames[0]
+        for frame in history_frames[1:]:
+            history_df = history_df.concat(frame)
+
+        print("\nState history (DataFrame):")
+        history_row_count = len(history_frames) * len(rows)
+        history_df.select(
+            "history_tick",
+            "entity_id",
+            "agent__name",
+            "agent__skill",
+            "agent__experience",
+            "agent__rating",
+        ).collect().sort([col("history_tick"), col("entity_id")]).show(history_row_count)
 
 
 if __name__ == "__main__":

--- a/src/archetype/core/storage/lancedb.py
+++ b/src/archetype/core/storage/lancedb.py
@@ -81,7 +81,7 @@ class AsyncLancedbStore(iAsyncStore):
                 os.path.join(self.uri, self.namespace, subdir)
             )
 
-        if table_name in await self.lancedb.table_names():
+        if table_name in await self._list_table_names():
             try:
                 async_table = await self.lancedb.open_table(table_name)
             except Exception as e:
@@ -113,6 +113,16 @@ class AsyncLancedbStore(iAsyncStore):
                 raise RuntimeError(f"Error creating LanceDB table {table_name}: {e}") from e
 
         return async_table
+
+    async def _list_table_names(self) -> list[str]:
+        """List table names using the modern LanceDB API when available."""
+        assert self.lancedb is not None
+
+        list_tables = getattr(self.lancedb, "list_tables", None)
+        if list_tables is not None:
+            return list(await list_tables())
+
+        return list(await self.lancedb.table_names())
 
     # ---------------------------------------------------------------------
     # Querying
@@ -192,7 +202,10 @@ class AsyncLancedbStore(iAsyncStore):
         """
         Optimize all tables in the LanceDB catalog.
         """
-        for table_name in await self.lancedb.table_names():
+        if self.lancedb is None:
+            return
+
+        for table_name in await self._list_table_names():
             try:
                 async_table = await self.lancedb.open_table(table_name)
                 await async_table.optimize(retrain=False)

--- a/src/archetype/sugar.py
+++ b/src/archetype/sugar.py
@@ -83,7 +83,7 @@ class ArchetypeRuntime:
         resources: list[Any] | None = None,
     ) -> RuntimeWorld:
         self._ensure_open()
-        handle = RuntimeWorld(
+        state = _RuntimeWorldState(
             runtime=self,
             name=name,
             storage=storage,
@@ -91,8 +91,7 @@ class ArchetypeRuntime:
             processors=processors,
             resources=resources,
         )
-        self._register_handle(handle)
-        return handle
+        return state.bind(self._actor_ctx)
 
     async def shutdown(self) -> None:
         if self._closed:
@@ -113,8 +112,8 @@ class ArchetypeRuntime:
         self._handles.discard(handle)
 
 
-class RuntimeWorld:
-    """Lazy world handle bound to an ``ArchetypeRuntime``."""
+class _RuntimeWorldState:
+    """Shared lifecycle state for actor-bound aliases of one logical world."""
 
     def __init__(
         self,
@@ -127,62 +126,115 @@ class RuntimeWorld:
         resources: list[Any] | None = None,
         existing_world: AsyncWorld | None = None,
     ) -> None:
-        self._runtime = runtime
-        self._name = name
-        self._storage_config = _coerce_storage_config(storage)
-        self._cache_config = cache
-        self._init_processors = list(processors or [])
-        self._init_resources = list(resources or [])
-        self._pending_hooks: list[tuple[str, HookFn]] = []
-        self._world = existing_world
-        self._initialized = existing_world is not None
-        self._init_lock = asyncio.Lock()
-        self._op_lock = asyncio.Lock()
-        self._closed = False
+        self.runtime = runtime
+        self.name = name
+        self.storage_config = _coerce_storage_config(storage)
+        self.cache_config = cache
+        self.init_processors = list(processors or [])
+        self.init_resources = list(resources or [])
+        self.pending_hooks: list[tuple[str, HookFn]] = []
+        self.world = existing_world
+        self.initialized = existing_world is not None
+        self.init_lock = asyncio.Lock()
+        self.op_lock = asyncio.Lock()
+        self.closed = False
+        self.aliases: WeakSet[RuntimeWorld] = WeakSet()
 
-    async def _ensure_init(self) -> AsyncWorld:
-        self._ensure_usable()
-        if self._initialized:
-            assert self._world is not None
-            return self._world
+    def bind(self, actor_ctx: ActorCtx) -> RuntimeWorld:
+        handle = RuntimeWorld(state=self, actor_ctx=actor_ctx)
+        self.aliases.add(handle)
+        self.runtime._register_handle(handle)
+        return handle
 
-        async with self._init_lock:
-            self._ensure_usable()
-            if self._initialized:
-                assert self._world is not None
-                return self._world
+    def ensure_usable(self) -> None:
+        self.runtime._ensure_open()
+        if self.closed:
+            raise RuntimeError("World handle is closed")
 
-            world = await self._runtime._container.world_service.create_world(
-                WorldConfig(name=self._name),
-                self._storage_config,
-                self._cache_config,
+    async def ensure_init(self) -> AsyncWorld:
+        self.ensure_usable()
+        if self.initialized:
+            assert self.world is not None
+            return self.world
+
+        async with self.init_lock:
+            self.ensure_usable()
+            if self.initialized:
+                assert self.world is not None
+                return self.world
+
+            world = await self.runtime._container.world_service.create_world(
+                WorldConfig(name=self.name),
+                self.storage_config,
+                self.cache_config,
             )
             if not isinstance(world, AsyncWorld):
                 raise TypeError("ArchetypeRuntime only supports AsyncWorld instances")
 
-            for proc in self._init_processors:
+            for proc in self.init_processors:
                 await world.add_processor(proc)
-            for resource in self._init_resources:
+            for resource in self.init_resources:
                 world.resources.insert(resource)
-            for event, fn in self._pending_hooks:
+            for event, fn in self.pending_hooks:
                 world.add_hook(event, fn)
 
-            self._world = world
-            self._initialized = True
+            self.world = world
+            self.initialized = True
+            self.name = world.name or self.name
 
-        assert self._world is not None
-        return self._world
+        assert self.world is not None
+        return self.world
+
+    def require_initialized_world(self) -> AsyncWorld:
+        self.ensure_usable()
+        if not self.initialized or self.world is None:
+            raise RuntimeError("World has not been activated yet")
+        return self.world
+
+    async def shutdown(self, *, from_runtime: bool) -> None:
+        async with self.op_lock:
+            if self.closed:
+                return
+            if (
+                self.initialized
+                and self.world is not None
+                and (from_runtime or not self.runtime._closed)
+            ):
+                await self.runtime._container.broker.clear(self.world.world_id)
+                await self.runtime._container.world_service.remove_world(self.world.world_id)
+            self.closed = True
+            self.world = None
+            self.initialized = False
+            for alias in list(self.aliases):
+                self.runtime._unregister_handle(alias)
+
+
+class RuntimeWorld:
+    """Lazy world handle bound to an ``ArchetypeRuntime``."""
+
+    def __init__(
+        self,
+        *,
+        state: _RuntimeWorldState,
+        actor_ctx: ActorCtx,
+    ) -> None:
+        self._state = state
+        self._actor_ctx = actor_ctx
 
     def _ensure_usable(self) -> None:
-        self._runtime._ensure_open()
-        if self._closed:
-            raise RuntimeError("World handle is closed")
+        self._state.ensure_usable()
 
     def _require_initialized_world(self) -> AsyncWorld:
-        self._ensure_usable()
-        if not self._initialized or self._world is None:
-            raise RuntimeError("World has not been activated yet")
-        return self._world
+        return self._state.require_initialized_world()
+
+    async def _submit(self, cmd: Command) -> UUID:
+        async with self._state.op_lock:
+            world = await self._state.ensure_init()
+            return await self._state.runtime._container.command_service.submit(
+                world.world_id,
+                cmd,
+                self._actor_ctx,
+            )
 
     async def spawn(
         self,
@@ -190,30 +242,73 @@ class RuntimeWorld:
         tick: int = 0,
         priority: int = 0,
     ) -> int:
-        async with self._op_lock:
-            world = await self._ensure_init()
-            return await self._runtime._container.command_service.submit_spawn(
+        async with self._state.op_lock:
+            world = await self._state.ensure_init()
+            return await self._state.runtime._container.command_service.submit_spawn(
                 world.world_id,
                 list(components),
-                self._runtime._actor_ctx,
+                self._actor_ctx,
                 tick=tick,
                 priority=priority,
             )
 
     async def despawn(self, entity_id: int, *, tick: int = 0, priority: int = 0) -> UUID:
-        async with self._op_lock:
-            world = await self._ensure_init()
-            cmd = Command(
+        return await self._submit(
+            Command(
                 type=CommandType.DESPAWN,
                 tick=tick,
                 priority=priority,
                 payload={"entity_id": entity_id},
             )
-            return await self._runtime._container.command_service.submit(
-                world.world_id,
-                cmd,
-                self._runtime._actor_ctx,
+        )
+
+    async def update(
+        self,
+        entity_id: int,
+        *components: Component,
+        tick: int = 0,
+        priority: int = 0,
+    ) -> UUID:
+        return await self._submit(
+            Command(
+                type=CommandType.UPDATE,
+                tick=tick,
+                priority=priority,
+                payload={"entity_id": entity_id, "components": list(components)},
             )
+        )
+
+    async def add_components(
+        self,
+        entity_id: int,
+        *components: Component,
+        tick: int = 0,
+        priority: int = 0,
+    ) -> UUID:
+        return await self._submit(
+            Command(
+                type=CommandType.ADD_COMPONENT,
+                tick=tick,
+                priority=priority,
+                payload={"entity_id": entity_id, "components": list(components)},
+            )
+        )
+
+    async def remove_components(
+        self,
+        entity_id: int,
+        *component_types: type[Component],
+        tick: int = 0,
+        priority: int = 0,
+    ) -> UUID:
+        return await self._submit(
+            Command(
+                type=CommandType.REMOVE_COMPONENT,
+                tick=tick,
+                priority=priority,
+                payload={"entity_id": entity_id, "component_types": list(component_types)},
+            )
+        )
 
     async def add_processor(
         self,
@@ -222,19 +317,14 @@ class RuntimeWorld:
         tick: int = 0,
         priority: int = 0,
     ) -> UUID:
-        async with self._op_lock:
-            world = await self._ensure_init()
-            cmd = Command(
+        return await self._submit(
+            Command(
                 type=CommandType.ADD_PROCESSOR,
                 tick=tick,
                 priority=priority,
                 payload={"processor": processor},
             )
-            return await self._runtime._container.command_service.submit(
-                world.world_id,
-                cmd,
-                self._runtime._actor_ctx,
-            )
+        )
 
     async def remove_processor(
         self,
@@ -243,19 +333,14 @@ class RuntimeWorld:
         tick: int = 0,
         priority: int = 0,
     ) -> UUID:
-        async with self._op_lock:
-            world = await self._ensure_init()
-            cmd = Command(
+        return await self._submit(
+            Command(
                 type=CommandType.REMOVE_PROCESSOR,
                 tick=tick,
                 priority=priority,
                 payload={"processor_type": processor_type},
             )
-            return await self._runtime._container.command_service.submit(
-                world.world_id,
-                cmd,
-                self._runtime._actor_ctx,
-            )
+        )
 
     async def step(
         self,
@@ -264,10 +349,10 @@ class RuntimeWorld:
         config: RunConfig | None = None,
         **input_kwargs: Any,
     ) -> int:
-        async with self._op_lock:
-            world = await self._ensure_init()
+        async with self._state.op_lock:
+            world = await self._state.ensure_init()
             run_config = config or RunConfig(num_steps=1, debug=debug)
-            return await self._runtime._container.simulation_service.step(
+            return await self._state.runtime._container.simulation_service.step(
                 world.world_id,
                 run_config,
                 **input_kwargs,
@@ -281,10 +366,10 @@ class RuntimeWorld:
         config: RunConfig | None = None,
         **input_kwargs: Any,
     ) -> RunResult:
-        async with self._op_lock:
-            world = await self._ensure_init()
+        async with self._state.op_lock:
+            world = await self._state.ensure_init()
             run_config = config or RunConfig(num_steps=steps, debug=debug)
-            return await self._runtime._container.simulation_service.run(
+            return await self._state.runtime._container.simulation_service.run(
                 world.world_id,
                 run_config,
                 **input_kwargs,
@@ -295,9 +380,17 @@ class RuntimeWorld:
         *component_types: type[Component],
         entity_ids: list[int] | None = None,
     ):
-        async with self._op_lock:
-            world = await self._ensure_init()
+        async with self._state.op_lock:
+            world = await self._state.ensure_init()
             return await world.get_components(list(component_types), entity_ids=entity_ids)
+
+    async def command_history(self, *, limit: int = 100) -> list[Command]:
+        async with self._state.op_lock:
+            world = await self._state.ensure_init()
+            return await self._state.runtime._container.query_service.get_command_history(
+                world.world_id,
+                limit=limit,
+            )
 
     async def fork(
         self,
@@ -306,9 +399,9 @@ class RuntimeWorld:
         storage: str | Path | StorageConfig | None = None,
         cache: CacheConfig | None = None,
     ) -> RuntimeWorld:
-        async with self._op_lock:
-            world = await self._ensure_init()
-            forked = await self._runtime._container.world_service.fork_world(
+        async with self._state.op_lock:
+            world = await self._state.ensure_init()
+            forked = await self._state.runtime._container.world_service.fork_world(
                 world.world_id,
                 name,
                 _coerce_storage_config(storage),
@@ -316,31 +409,36 @@ class RuntimeWorld:
             )
             if not isinstance(forked, AsyncWorld):
                 raise TypeError("ArchetypeRuntime only supports AsyncWorld forks")
-            handle = RuntimeWorld(
-                runtime=self._runtime,
+            state = _RuntimeWorldState(
+                runtime=self._state.runtime,
                 name=name or forked.name or "fork",
                 storage=storage,
                 cache=cache,
                 existing_world=forked,
             )
-            self._runtime._register_handle(handle)
-            return handle
+            return state.bind(self._actor_ctx)
+
+    def as_actor(self, actor_ctx: ActorCtx) -> RuntimeWorld:
+        self._ensure_usable()
+        return self._state.bind(actor_ctx)
 
     def add_hook(self, event: str, fn: HookFn) -> None:
-        world = self._world
-        if self._initialized and world is not None:
+        self._ensure_usable()
+        world = self._state.world
+        if self._state.initialized and world is not None:
             world.add_hook(event, fn)
             return
-        self._pending_hooks.append((event, fn))
+        self._state.pending_hooks.append((event, fn))
 
     def remove_hook(self, event: str, fn: HookFn) -> None:
-        world = self._world
-        if self._initialized and world is not None:
+        self._ensure_usable()
+        world = self._state.world
+        if self._state.initialized and world is not None:
             world.remove_hook(event, fn)
             return
-        self._pending_hooks = [
+        self._state.pending_hooks = [
             (pending_event, pending_fn)
-            for pending_event, pending_fn in self._pending_hooks
+            for pending_event, pending_fn in self._state.pending_hooks
             if pending_event != event or pending_fn is not fn
         ]
 
@@ -348,20 +446,7 @@ class RuntimeWorld:
         await self._shutdown_internal(from_runtime=False)
 
     async def _shutdown_internal(self, *, from_runtime: bool) -> None:
-        async with self._op_lock:
-            if self._closed:
-                return
-            if (
-                self._initialized
-                and self._world is not None
-                and (from_runtime or not self._runtime._closed)
-            ):
-                await self._runtime._container.broker.clear(self._world.world_id)
-                await self._runtime._container.world_service.remove_world(self._world.world_id)
-            self._closed = True
-            self._world = None
-            self._initialized = False
-            self._runtime._unregister_handle(self)
+        await self._state.shutdown(from_runtime=from_runtime)
 
     @property
     def world_id(self) -> UUID:
@@ -373,9 +458,9 @@ class RuntimeWorld:
 
     @property
     def name(self) -> str | None:
-        if self._initialized and self._world is not None:
-            return self._world.name
-        return self._name
+        if self._state.initialized and self._state.world is not None:
+            return self._state.world.name
+        return self._state.name
 
     @property
     def resources(self) -> Resources:
@@ -453,6 +538,44 @@ class SyncRuntimeWorld:
     def despawn(self, entity_id: int, *, tick: int = 0, priority: int = 0) -> UUID:
         return self._run(lambda: self._world.despawn(entity_id, tick=tick, priority=priority))
 
+    def update(
+        self,
+        entity_id: int,
+        *components: Component,
+        tick: int = 0,
+        priority: int = 0,
+    ) -> UUID:
+        return self._run(
+            lambda: self._world.update(entity_id, *components, tick=tick, priority=priority)
+        )
+
+    def add_components(
+        self,
+        entity_id: int,
+        *components: Component,
+        tick: int = 0,
+        priority: int = 0,
+    ) -> UUID:
+        return self._run(
+            lambda: self._world.add_components(entity_id, *components, tick=tick, priority=priority)
+        )
+
+    def remove_components(
+        self,
+        entity_id: int,
+        *component_types: type[Component],
+        tick: int = 0,
+        priority: int = 0,
+    ) -> UUID:
+        return self._run(
+            lambda: self._world.remove_components(
+                entity_id,
+                *component_types,
+                tick=tick,
+                priority=priority,
+            )
+        )
+
     def add_processor(
         self,
         processor: AsyncProcessor,
@@ -489,6 +612,9 @@ class SyncRuntimeWorld:
     def query(self, *component_types: type[Component], entity_ids: list[int] | None = None):
         return self._run(lambda: self._world.query(*component_types, entity_ids=entity_ids))
 
+    def command_history(self, *, limit: int = 100) -> list[Command]:
+        return self._run(lambda: self._world.command_history(limit=limit))
+
     def fork(
         self,
         name: str | None = None,
@@ -500,6 +626,9 @@ class SyncRuntimeWorld:
             self._run(lambda: self._world.fork(name, storage=storage, cache=cache)),
             self._runtime,
         )
+
+    def as_actor(self, actor_ctx: ActorCtx) -> SyncRuntimeWorld:
+        return SyncRuntimeWorld(self._world.as_actor(actor_ctx), self._runtime)
 
     def add_hook(self, event: str, fn: HookFn) -> None:
         self._world.add_hook(event, fn)

--- a/tests/app/test_sugar_runtime.py
+++ b/tests/app/test_sugar_runtime.py
@@ -46,6 +46,11 @@ class Velocity(Component):
     vy: float = 0.0
 
 
+class Health(Component):
+    hp: int = 100
+    max_hp: int = 100
+
+
 class Move(AsyncProcessor):
     components = (Position, Velocity)
     priority = 10
@@ -126,6 +131,40 @@ async def test_runtime_world_construction_is_pure(tmp_path, monkeypatch):
         )
 
         assert isinstance(world, RuntimeWorld)
+        assert create_calls == 0
+        assert backend_calls == 0
+        assert app._container.world_service.list_worlds() == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_world_as_actor_is_pure_before_activation(tmp_path, monkeypatch):
+    async with ArchetypeRuntime() as app:
+        create_calls = 0
+        backend_calls = 0
+
+        original_create_world = app._container.world_service.create_world
+        original_get_backend = app._container.storage_service.get_backend
+
+        async def tracked_create_world(*args, **kwargs):
+            nonlocal create_calls
+            create_calls += 1
+            return await original_create_world(*args, **kwargs)
+
+        async def tracked_get_backend(*args, **kwargs):
+            nonlocal backend_calls
+            backend_calls += 1
+            return await original_get_backend(*args, **kwargs)
+
+        monkeypatch.setattr(app._container.world_service, "create_world", tracked_create_world)
+        monkeypatch.setattr(app._container.storage_service, "get_backend", tracked_get_backend)
+
+        world = app.world(
+            "alias-pure",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_alias_pure"),
+        )
+        viewer = world.as_actor(ActorCtx(id=uuid7(), roles={"viewer"}))
+
+        assert isinstance(viewer, RuntimeWorld)
         assert create_calls == 0
         assert backend_calls == 0
         assert app._container.world_service.list_worlds() == []
@@ -236,6 +275,38 @@ async def test_runtime_world_single_flight_across_query_and_run(tmp_path, monkey
         assert create_calls == 1
         assert df.collect().to_pylist() == []
         assert result.ticks_completed == 1
+        assert len(app._container.world_service.list_worlds()) == 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_world_actor_aliases_share_single_flight_activation_and_world_id(
+    tmp_path, monkeypatch
+):
+    async with ArchetypeRuntime() as app:
+        world = app.world(
+            "actor-aliases",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_actor_aliases"),
+        )
+        player = world.as_actor(ActorCtx(id=uuid7(), roles={"player"}))
+        maintainer = world.as_actor(ActorCtx(id=uuid7(), roles={"maintainer"}))
+
+        create_calls = 0
+        original_create_world = app._container.world_service.create_world
+
+        async def tracked_create_world(*args, **kwargs):
+            nonlocal create_calls
+            create_calls += 1
+            await asyncio.sleep(0.05)
+            return await original_create_world(*args, **kwargs)
+
+        monkeypatch.setattr(app._container.world_service, "create_world", tracked_create_world)
+
+        entity_id, df = await asyncio.gather(player.spawn(Position(x=1.0)), maintainer.query(Position))
+
+        assert create_calls == 1
+        assert entity_id == 1
+        assert df.collect().to_pylist() == []
+        assert world.world_id == player.world_id == maintainer.world_id
         assert len(app._container.world_service.list_worlds()) == 1
 
 
@@ -526,6 +597,89 @@ async def test_runtime_world_spawn_not_query_visible_until_step(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_runtime_world_update_is_not_query_visible_until_step(tmp_path):
+    async with ArchetypeRuntime() as app:
+        world = app.world(
+            "update-boundary",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_update_boundary"),
+        )
+
+        entity_id = await world.spawn(Position(x=1.0, y=2.0))
+        await world.step()
+
+        await world.update(entity_id, Position(x=9.0, y=4.0))
+        before = (await world.query(Position, entity_ids=[entity_id])).collect().to_pylist()
+        assert before[0]["position__x"] == 1.0
+        assert before[0]["position__y"] == 2.0
+
+        await world.step()
+        after = (await world.query(Position, entity_ids=[entity_id])).collect().to_pylist()
+        assert after[0]["position__x"] == 9.0
+        assert after[0]["position__y"] == 4.0
+
+
+@pytest.mark.asyncio
+async def test_runtime_world_add_components_migrates_at_tick_boundary(tmp_path):
+    async with ArchetypeRuntime() as app:
+        world = app.world(
+            "add-components-boundary",
+            storage=StorageConfig(
+                uri=str(tmp_path / "store"), namespace="runtime_add_components_boundary"
+            ),
+        )
+
+        entity_id = await world.spawn(Position(x=4.0, y=5.0))
+        await world.step()
+
+        await world.add_components(entity_id, Velocity(vx=2.0, vy=3.0))
+
+        before = (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        assert before == []
+
+        await world.step()
+        after = (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        assert len(after) == 1
+        assert after[0]["position__x"] == 4.0
+        assert after[0]["velocity__vx"] == 2.0
+        assert after[0]["velocity__vy"] == 3.0
+
+
+@pytest.mark.asyncio
+async def test_runtime_world_remove_components_applies_at_tick_boundary_and_preserves_remaining_data(
+    tmp_path,
+):
+    async with ArchetypeRuntime() as app:
+        world = app.world(
+            "remove-components-boundary",
+            storage=StorageConfig(
+                uri=str(tmp_path / "store"), namespace="runtime_remove_components_boundary"
+            ),
+        )
+
+        entity_id = await world.spawn(
+            Position(x=7.0, y=8.0),
+            Velocity(vx=1.0, vy=2.0),
+            Health(hp=80, max_hp=100),
+        )
+        await world.step()
+
+        await world.remove_components(entity_id, Velocity)
+
+        before = (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        assert len(before) == 1
+
+        await world.step()
+        after = (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        assert after == []
+
+        remaining = (await world.query(Position, Health, entity_ids=[entity_id])).collect().to_pylist()
+        assert len(remaining) == 1
+        assert remaining[0]["position__x"] == 7.0
+        assert remaining[0]["position__y"] == 8.0
+        assert remaining[0]["health__hp"] == 80
+
+
+@pytest.mark.asyncio
 async def test_runtime_world_add_processor_applies_at_tick_boundary(tmp_path):
     async with ArchetypeRuntime() as app:
         world = app.world(
@@ -562,8 +716,31 @@ async def test_runtime_world_commands_are_audited_in_broker_history_in_order(tmp
         await world.step()
         await world.despawn(entity_id)
 
-        history = await app._container.broker.get_history(world.world_id)
+        history = await world.command_history()
         assert [cmd.type.value for cmd in history] == ["spawn", "add_processor", "despawn"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_world_component_mutations_are_audited_in_broker_history_in_order(tmp_path):
+    async with ArchetypeRuntime() as app:
+        world = app.world(
+            "component-audit",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_component_audit"),
+        )
+
+        entity_id = await world.spawn(Position(x=1.0, y=1.0))
+        await world.step()
+        await world.update(entity_id, Position(x=5.0, y=6.0))
+        await world.add_components(entity_id, Health(hp=90, max_hp=100))
+        await world.remove_components(entity_id, Health)
+
+        history = await world.command_history()
+        assert [cmd.type.value for cmd in history] == [
+            "spawn",
+            "update",
+            "add_component",
+            "remove_component",
+        ]
 
 
 @pytest.mark.asyncio
@@ -587,12 +764,127 @@ async def test_runtime_world_resource_mutation_does_not_generate_broker_history(
         )
 
         await world.query(Position)
-        before = await app._container.broker.get_history(world.world_id)
+        before = await world.command_history()
         world.resources.insert(Delta(2.0))
-        after = await app._container.broker.get_history(world.world_id)
+        after = await world.command_history()
 
         assert before == []
         assert after == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_world_hook_mutation_does_not_generate_broker_history(tmp_path):
+    hook_ticks: list[int] = []
+
+    async def on_post_tick(*, tick, **kwargs):
+        hook_ticks.append(tick)
+
+    async with ArchetypeRuntime() as app:
+        world = app.world(
+            "hooks",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_hooks"),
+        )
+
+        await world.query(Position)
+        before = await world.command_history()
+        world.add_hook("post_tick", on_post_tick)
+        world.remove_hook("post_tick", on_post_tick)
+        after = await world.command_history()
+
+        assert before == []
+        assert after == []
+        assert hook_ticks == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_world_actor_aliases_enforce_rbac_by_role(tmp_path):
+    async with ArchetypeRuntime() as app:
+        world = app.world(
+            "rbac-aliases",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_rbac_aliases"),
+        )
+        viewer = world.as_actor(ActorCtx(id=uuid7(), roles={"viewer"}))
+        player = world.as_actor(ActorCtx(id=uuid7(), roles={"player"}))
+        coder = world.as_actor(ActorCtx(id=uuid7(), roles={"coder"}))
+        maintainer = world.as_actor(ActorCtx(id=uuid7(), roles={"maintainer"}))
+        admin = world.as_actor(ActorCtx(id=uuid7(), roles={"admin"}))
+
+        with pytest.raises(PermissionError):
+            await viewer.spawn(Position(x=0.0))
+
+        entity_id = await player.spawn(Position(x=1.0, y=2.0))
+        await admin.step()
+
+        await player.update(entity_id, Position(x=4.0, y=5.0))
+        await admin.step()
+
+        with pytest.raises(PermissionError):
+            await player.add_components(entity_id, Velocity(vx=1.0, vy=0.0))
+
+        await coder.add_components(entity_id, Velocity(vx=1.0, vy=0.0))
+        await admin.step()
+
+        with pytest.raises(PermissionError):
+            await coder.add_processor(Noop())
+
+        await maintainer.add_processor(Noop())
+        await admin.remove_processor(Noop)
+
+        rows = (await admin.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["position__x"] == 4.0
+        assert rows[0]["velocity__vx"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_world_shutdown_from_actor_alias_invalidates_all_aliases_but_not_siblings(tmp_path):
+    async with ArchetypeRuntime() as app:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_alias_shutdown")
+        left = app.world("left", storage=storage)
+        right = app.world("right", storage=storage)
+        player = left.as_actor(ActorCtx(id=uuid7(), roles={"player"}))
+        admin = left.as_actor(ActorCtx(id=uuid7(), roles={"admin"}))
+
+        await player.spawn(Position(x=1.0))
+        await admin.step()
+        await right.spawn(Position(x=9.0))
+        await right.step()
+
+        await player.shutdown()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await left.query(Position)
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await admin.query(Position)
+
+        rows = (await right.query(Position)).collect().to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["position__x"] == 9.0
+
+
+@pytest.mark.asyncio
+async def test_runtime_world_fork_from_actor_alias_preserves_actor_binding(tmp_path):
+    async with ArchetypeRuntime() as app:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_actor_fork")
+        world = app.world("source", storage=storage)
+        player = world.as_actor(ActorCtx(id=uuid7(), roles={"player"}))
+        admin = world.as_actor(ActorCtx(id=uuid7(), roles={"admin"}))
+
+        await player.spawn(Position(x=2.0))
+        await admin.step()
+
+        fork = await player.fork("branch", storage=storage)
+
+        await fork.spawn(Position(x=3.0))
+        with pytest.raises(PermissionError):
+            await fork.add_processor(Noop())
+
+        await admin.step()
+        await fork.step()
+
+        rows = sorted((await fork.query(Position)).collect().to_pylist(), key=lambda row: row["entity_id"])
+        assert [row["position__x"] for row in rows] == [2.0, 3.0]
 
 
 @pytest.mark.asyncio
@@ -656,6 +948,45 @@ def test_sync_runtime_preserves_state_across_multiple_calls(tmp_path):
         world.run(steps=2)
         rows = world.query(Position, entity_ids=[entity_id]).collect().to_pylist()
         assert rows[0]["position__x"] == 3.0
+
+
+def test_sync_runtime_world_supports_mutation_parity_and_actor_aliases(tmp_path):
+    with ArchetypeRuntime.sync() as app:
+        world = app.world(
+            "sync-parity",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_sync_parity"),
+        )
+        viewer = world.as_actor(ActorCtx(id=uuid7(), roles={"viewer"}))
+        player = world.as_actor(ActorCtx(id=uuid7(), roles={"player"}))
+        coder = world.as_actor(ActorCtx(id=uuid7(), roles={"coder"}))
+
+        with pytest.raises(PermissionError):
+            viewer.spawn(Position(x=0.0))
+
+        entity_id = player.spawn(Position(x=1.0, y=2.0))
+        world.step()
+
+        player.update(entity_id, Position(x=4.0, y=6.0))
+        world.step()
+
+        coder.add_components(entity_id, Velocity(vx=2.0, vy=1.0))
+        world.step()
+
+        coder.remove_components(entity_id, Velocity)
+        world.step()
+
+        rows = world.query(Position, entity_ids=[entity_id]).collect().to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["position__x"] == 4.0
+        assert rows[0]["position__y"] == 6.0
+
+        history = world.command_history()
+        assert [cmd.type.value for cmd in history] == [
+            "spawn",
+            "update",
+            "add_component",
+            "remove_component",
+        ]
 
 
 def test_sync_world_rejects_use_after_runtime_context_exit(tmp_path):

--- a/tests/app/test_sugar_runtime.py
+++ b/tests/app/test_sugar_runtime.py
@@ -301,7 +301,9 @@ async def test_runtime_world_actor_aliases_share_single_flight_activation_and_wo
 
         monkeypatch.setattr(app._container.world_service, "create_world", tracked_create_world)
 
-        entity_id, df = await asyncio.gather(player.spawn(Position(x=1.0)), maintainer.query(Position))
+        entity_id, df = await asyncio.gather(
+            player.spawn(Position(x=1.0)), maintainer.query(Position)
+        )
 
         assert create_calls == 1
         assert entity_id == 1
@@ -633,11 +635,15 @@ async def test_runtime_world_add_components_migrates_at_tick_boundary(tmp_path):
 
         await world.add_components(entity_id, Velocity(vx=2.0, vy=3.0))
 
-        before = (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        before = (
+            (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        )
         assert before == []
 
         await world.step()
-        after = (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        after = (
+            (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        )
         assert len(after) == 1
         assert after[0]["position__x"] == 4.0
         assert after[0]["velocity__vx"] == 2.0
@@ -665,14 +671,20 @@ async def test_runtime_world_remove_components_applies_at_tick_boundary_and_pres
 
         await world.remove_components(entity_id, Velocity)
 
-        before = (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        before = (
+            (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        )
         assert len(before) == 1
 
         await world.step()
-        after = (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        after = (
+            (await world.query(Position, Velocity, entity_ids=[entity_id])).collect().to_pylist()
+        )
         assert after == []
 
-        remaining = (await world.query(Position, Health, entity_ids=[entity_id])).collect().to_pylist()
+        remaining = (
+            (await world.query(Position, Health, entity_ids=[entity_id])).collect().to_pylist()
+        )
         assert len(remaining) == 1
         assert remaining[0]["position__x"] == 7.0
         assert remaining[0]["position__y"] == 8.0
@@ -883,7 +895,9 @@ async def test_runtime_world_fork_from_actor_alias_preserves_actor_binding(tmp_p
         await admin.step()
         await fork.step()
 
-        rows = sorted((await fork.query(Position)).collect().to_pylist(), key=lambda row: row["entity_id"])
+        rows = sorted(
+            (await fork.query(Position)).collect().to_pylist(), key=lambda row: row["entity_id"]
+        )
         assert [row["position__x"] for row in rows] == [2.0, 3.0]
 
 


### PR DESCRIPTION
## Summary

This PR hardens the top-level runtime contract without changing core `_live` behavior yet.

It:
- makes `RuntimeWorld` / `SyncRuntimeWorld` mutation-complete for the governed surface
- adds actor-bound runtime aliases via `world.as_actor(...)`
- migrates beginner-facing examples and docs toward the denser `ArchetypeRuntime` style
- documents the runtime boundary and same-tick composition gap in the formal specification
- removes the repeated LanceDB `table_names()` deprecation warnings

## What Changed

- Added brokered `update`, `add_components`, and `remove_components` to the runtime layer.
- Added actor-bound runtime aliases that share one logical world lifecycle.
- Added runtime command-history access so examples do not need to reach into the container.
- Expanded runtime contract tests to cover mutation parity, actor aliases, lifecycle, RBAC, sync wrappers, and non-brokered scaffolding boundaries.
- Converted `examples/01_world_mutations.py` to `ArchetypeRuntime`.
- Updated runtime-facing docs to distinguish:
  - `AsyncWorld` as the direct engine API
  - `RuntimeWorld` as the governed script API
- Switched the LanceDB adapter to prefer `list_tables()` with a compatibility fallback.

## Follow-up

The `_live` same-tick composition bug is intentionally not fixed in this PR.
Tracked in: #193

## Validation

- `uv run pytest tests/app/test_sugar_runtime.py`
- `uv run pytest tests/storage/test_lancedb_store_core.py tests/storage/test_lancedb_store_errors.py tests/storage/test_lancedb_store_open_and_optimize.py tests/storage/test_lancedb_store_index_failure.py`
- `uv run ruff check src/archetype/sugar.py tests/app/test_sugar_runtime.py examples/01_world_mutations.py examples/02_fork_counterfactual.py examples/04_messaging.py examples/05_llm_agents.py examples/06_trajectory_analysis.py examples/simulation_script.py`
- `uv run ruff check src/archetype/core/storage/lancedb.py docs/guide/specification.md`
- `uv run python examples/01_world_mutations.py`
- `uv run python examples/02_fork_counterfactual.py`
- `uv run python examples/04_messaging.py`
- `uv run python examples/06_trajectory_analysis.py`
- `uv run python examples/simulation_script.py`

## Notes

`examples/05_llm_agents.py` was not run because it still requires an LLM API key.
