### PR TITLE
chore: add `make complexity` for cyclomatic / maintainability reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ help:
 	@echo "  make lint           Lint code (ruff)"
 	@echo "  make lint-fix       Lint and auto-fix"
 	@echo "  make check          Format + lint"
+	@echo "  make complexity     Cyclomatic complexity / maintainability report (radon)"
 	@echo ""
 	@echo "Tests:"
 	@echo "  make test           Run tests (fast)"
@@ -86,6 +87,21 @@ format-check:
 
 .PHONY: check
 check: format lint
+
+# Cyclomatic complexity + maintainability report.
+# Uses uvx so radon stays out of the project lock file.
+# CC ranks: A (1-5) B (6-10) C (11-20) D (21-30) E (31-40) F (41+).
+# Surfaces rank C+ for CC and rank B+ for MI — the "review me" set.
+.PHONY: complexity
+complexity:
+	@echo "=== Cyclomatic complexity (functions ranked C or worse) ==="
+	@uvx radon cc src -n C -s -a --total-average || true
+	@echo ""
+	@echo "=== Maintainability index (files ranked B or worse) ==="
+	@uvx radon mi src -n B -s || true
+	@echo ""
+	@echo "=== Raw line counts ==="
+	@uvx radon raw src -s
 
 # ------------------------------------------------------------------------------
 # Tests


### PR DESCRIPTION
## Summary

- Adds `make complexity` to the dev workflow — surfaces functions ranked **C+** on cyclomatic complexity and files ranked **B+** on maintainability index.
- Uses `uvx radon` so the tool stays out of `pyproject.toml` / `uv.lock`. No dep churn.
- Advisory only — not wired into `make ci`.

Sample output on current `main`:

```
=== Cyclomatic complexity (functions ranked C or worse) ===
src/archetype/chronicle/loaders.py
    F 359:0 _parse_chatgpt_conversation - D (24)
    F 498:0 _load_via_osxphotos - D (24)
src/archetype/app/world_service.py
    M 166:4 WorldService.fork_world - C (16)
...
462 blocks analyzed. Average complexity: A (2.53)
```

CC ranks: A (1-5), B (6-10), C (11-20), D (21-30), E (31-40), F (41+).

## Test plan

- [x] `make complexity` runs cleanly and produces the expected three sections.
- [x] No changes to `pyproject.toml` or `uv.lock`.
- [x] Help text under "Quality" updated.

https://claude.ai/code/session_017DFW65SrhFiNjWskfRH7ci

---
_Generated by [Claude Code](https://claude.ai/code/session_017DFW65SrhFiNjWskfRH7ci)_