### PR TITLE
chore: lazy-evaluation audit (.collect / .to_pylist gating)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,13 @@ repos:
         files: '^src/.*\.py$'
         pass_filenames: true
 
+      - id: lazy-audit
+        name: Lazy-evaluation audit (.collect / .to_pylist gating)
+        entry: uv run python scripts/check_lazy_audit.py
+        language: system
+        files: '^src/.*\.py$|^lazy_audit\.toml$'
+        pass_filenames: false
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ format:
 	@uv run ruff format src tests
 
 .PHONY: lint
-lint:
+lint: lazy-audit
 	@uv run ruff check src tests
 
 .PHONY: lint-fix
@@ -87,6 +87,13 @@ format-check:
 
 .PHONY: check
 check: format lint
+
+# Lazy-evaluation audit: gate .collect()/.to_pylist() call sites against
+# lazy_audit.toml. Every premature materialization is a contract exception
+# and must be justified in writing. See scripts/check_lazy_audit.py.
+.PHONY: lazy-audit
+lazy-audit:
+	@uv run python scripts/check_lazy_audit.py
 
 # Cyclomatic complexity + maintainability report.
 # Uses uvx so radon stays out of the project lock file.

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -1,0 +1,51 @@
+# Lazy-evaluation audit allowlist.
+#
+# Each entry documents an exception to Archetype's lazy execution
+# contract. .collect() and .to_pylist() force a Daft DataFrame through
+# Python memory and defeat query planning. Adding an entry here is
+# auditable: PR reviewers will challenge any new entry whose reason
+# does not name a specific technical boundary (storage write, single-row
+# migration extract, debug logging).
+#
+# Generic reasons ("needed", "for the test", "convenience") are
+# rejected automatically by scripts/check_lazy_audit.py.
+#
+# Scope: src/ only. Tests are exempt — terminal materialization at the
+# assertion boundary is expected and not part of the audited contract.
+
+[[entries]]
+path = "src/archetype/core/aio/async_store.py"
+line = 84
+method = "collect"
+reason = "Storage write boundary: defensive empty-frame probe before delegating to the backing table writer; cannot be expressed as a Daft predicate because count_rows requires materialised state."
+
+[[entries]]
+path = "src/archetype/core/aio/async_world.py"
+line = 286
+method = "collect"
+reason = "Cross-archetype entity migration: collect a single-entity slice so the subsequent emptiness probe and row-overlay run against materialised state; migration is inherently row-oriented at the boundary."
+
+[[entries]]
+path = "src/archetype/core/aio/async_world.py"
+line = 291
+method = "to_pylist"
+reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
+
+[[entries]]
+path = "src/archetype/core/storage/lancedb.py"
+line = 161
+method = "collect"
+reason = "LanceDB write boundary: defensive empty-frame probe to avoid Lance casting errors on zero-row appends; precedes the actual table.append call."
+
+[[entries]]
+path = "src/archetype/core/sync/store.py"
+line = 96
+method = "collect"
+reason = "Debug-mode-only logging: materialise so count_rows and df.show emit diagnostics; gated on self.debug and never reached in production execution paths."
+
+[[entries]]
+path = "src/archetype/core/sync/world.py"
+line = 214
+method = "to_pylist"
+reason = "Cross-archetype entity migration (sync mirror of async_world): extract the latest tick row for component overlay before re-insertion."
+

--- a/scripts/check_lazy_audit.py
+++ b/scripts/check_lazy_audit.py
@@ -1,0 +1,267 @@
+# Copyright 2025 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lazy-evaluation audit.
+
+Daft is lazily evaluated. DataFrames represent computations, not results.
+Calling ``.collect()`` or ``.to_pylist()`` forces the frame through Python
+memory, defeats query planning, and stops scaling at in-memory size.
+
+Every such call inside ``src/`` is a contract exception against Archetype's
+lazy execution model. This script enumerates production call sites and
+gates them against ``lazy_audit.toml``. New, undocumented sites cause a
+non-zero exit; stale entries (allowlisted lines that no longer hold a
+matching call) are also surfaced so the audit stays honest under refactors.
+
+Tests are intentionally out of scope: terminal materialization at the
+assertion boundary is expected. The contract being audited is the
+production execution model, not test ergonomics.
+
+Run via ``make lazy-audit`` or as a pre-commit hook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOTS: tuple[str, ...] = ("src",)
+ALLOWLIST_FILENAME = "lazy_audit.toml"
+SELF_RELATIVE = "scripts/check_lazy_audit.py"
+
+# Match attribute-style calls only. Whitespace before the dot avoids hits on
+# e.g. ``module.collect(`` where ``collect`` is a free function in another
+# package — the audit is about chained DataFrame methods, not arbitrary names.
+PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("collect", re.compile(r"\.collect\s*\(")),
+    ("to_pylist", re.compile(r"\.to_pylist\s*\(")),
+)
+
+
+@dataclass(frozen=True)
+class Site:
+    path: str
+    line: int
+    method: str
+    snippet: str
+
+
+@dataclass(frozen=True)
+class Entry:
+    path: str
+    line: int
+    method: str
+    reason: str
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _scan_file(path: Path, rel: str) -> list[Site]:
+    sites: list[Site] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return sites
+    for n, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.lstrip()
+        if stripped.startswith("#"):
+            continue
+        for method, pat in PATTERNS:
+            if pat.search(raw):
+                sites.append(Site(path=rel, line=n, method=method, snippet=stripped))
+    return sites
+
+
+def scan(root: Path) -> list[Site]:
+    sites: list[Site] = []
+    for top in ROOTS:
+        base = root / top
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            rel = path.relative_to(root).as_posix()
+            if rel == SELF_RELATIVE:
+                continue
+            sites.extend(_scan_file(path, rel))
+    return sites
+
+
+def load_allowlist(root: Path) -> tuple[list[Entry], str | None]:
+    path = root / ALLOWLIST_FILENAME
+    if not path.exists():
+        return [], f"missing {ALLOWLIST_FILENAME}"
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        return [], f"could not parse {ALLOWLIST_FILENAME}: {exc}"
+    raw_entries = data.get("entries", [])
+    out: list[Entry] = []
+    for raw in raw_entries:
+        try:
+            out.append(
+                Entry(
+                    path=str(raw["path"]),
+                    line=int(raw["line"]),
+                    method=str(raw["method"]),
+                    reason=str(raw.get("reason", "")).strip(),
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            return [], f"malformed entry in {ALLOWLIST_FILENAME}: {raw!r} ({exc})"
+    return out, None
+
+
+_BANNED_REASON_TOKENS = {
+    "",
+    "todo",
+    "fixme",
+    "needed",
+    "necessary",
+    "required",
+    "for the test",
+    "for tests",
+    "easier",
+    "convenience",
+    "tbd",
+}
+
+
+def _reason_is_substantive(reason: str) -> bool:
+    norm = reason.strip().lower().rstrip(".")
+    if norm in _BANNED_REASON_TOKENS:
+        return False
+    return len(norm) >= 20
+
+
+STERN_HEADER = (
+    "─────────────────────────────────────────────────────────────────────\n"
+    "LAZY EXECUTION AUDIT FAILED\n"
+    "─────────────────────────────────────────────────────────────────────"
+)
+
+STERN_BODY = """\
+Daft is lazily evaluated. DataFrames represent computations, not results.
+.collect() and .to_pylist() force the frame through Python memory, defeat
+query planning, and stop scaling at in-memory dataset sizes. Every such
+call is a contract exception against Archetype's lazy execution model.
+
+If you are reading this, the most likely answer is to rewrite the
+expression in Daft. Reach for where, select, with_column, agg, join,
+sort, distinct, count_rows before pulling rows into Python. See
+LEARNINGS.md and docs/guide/specification.md for the lazy contract.
+
+If the materialization is genuinely unavoidable (storage write boundary,
+single-row migration extract, debug logging, terminal test assertion),
+the exception must be documented in writing and visible in code review:
+
+  * The reason field in lazy_audit.toml must state the technical reason
+    the boundary cannot be expressed lazily. Generic phrases ("needed",
+    "for the test", "convenience") are rejected automatically.
+  * The new entry must be called out in the PR description or as a PR
+    comment so a human reviewer signs off on the exception explicitly.
+
+Quietly adding entries to silence this check is itself a signal that
+the change is gaming the lazy-evaluation contract. PRs that do this
+will be reverted at review.
+"""
+
+
+def _format_section(title: str, lines: list[str]) -> str:
+    if not lines:
+        return ""
+    return f"\n{title}\n" + "\n".join(f"  {ln}" for ln in lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print every detected materialization site and exit 0 (no gating).",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Optional file list (used by pre-commit). The full repo is always scanned.",
+    )
+    args = parser.parse_args()
+    del args  # we always scan the full repo so a moved call elsewhere can't slip through
+
+    root = _project_root()
+    sites = scan(root)
+
+    if "--list" in sys.argv:
+        for s in sites:
+            print(f"{s.path}:{s.line}  .{s.method}()  {s.snippet}")
+        return 0
+
+    allow, allow_err = load_allowlist(root)
+    if allow_err is not None:
+        print(STERN_HEADER, file=sys.stderr)
+        print(f"\nallowlist error: {allow_err}\n", file=sys.stderr)
+        print(STERN_BODY, file=sys.stderr)
+        return 2
+
+    site_keys = {(s.path, s.line, s.method): s for s in sites}
+    allow_keys = {(e.path, e.line, e.method): e for e in allow}
+
+    new_sites = [site_keys[k] for k in site_keys.keys() - allow_keys.keys()]
+    stale_entries = [allow_keys[k] for k in allow_keys.keys() - site_keys.keys()]
+    weak_reasons = [e for e in allow if not _reason_is_substantive(e.reason)]
+
+    new_sites.sort(key=lambda s: (s.path, s.line))
+    stale_entries.sort(key=lambda e: (e.path, e.line))
+    weak_reasons.sort(key=lambda e: (e.path, e.line))
+
+    if not (new_sites or stale_entries or weak_reasons):
+        print(f"lazy audit: {len(sites)} site(s), all accounted for.")
+        return 0
+
+    print(STERN_HEADER, file=sys.stderr)
+
+    if new_sites:
+        rendered = [f"{s.path}:{s.line}  .{s.method}()  {s.snippet}" for s in new_sites]
+        sys.stderr.write(_format_section("New, undocumented materialization points:", rendered))
+
+    if stale_entries:
+        rendered = [f"{e.path}:{e.line}  .{e.method}()  reason={e.reason!r}" for e in stale_entries]
+        sys.stderr.write(
+            _format_section(
+                "Stale allowlist entries (line no longer holds a matching call):",
+                rendered,
+            )
+        )
+
+    if weak_reasons:
+        rendered = [f"{e.path}:{e.line}  .{e.method}()  reason={e.reason!r}" for e in weak_reasons]
+        sys.stderr.write(
+            _format_section(
+                "Allowlist entries with unjustified reasons (rejected at review):",
+                rendered,
+            )
+        )
+
+    print(file=sys.stderr)
+    print(STERN_BODY, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/check_lazy_audit.py`, a stern gate that scans `src/` for `.collect()` and `.to_pylist()` calls and reconciles them against `lazy_audit.toml`. New, undocumented sites fail the audit; stale entries (line moved/removed) and unjustified reasons (placeholder phrases like `needed`, `for the test`, `convenience`, or anything under 20 chars) are also rejected.
- Seeds the allowlist with the 6 existing src-side materialization points (LanceDB / async-store write boundaries, cross-archetype migration row extracts, debug-mode logging) — each entry carries a substantive technical reason naming the specific boundary.
- Wires the audit into `make lint` (so `make ci` picks it up) and into `.pre-commit-config.yaml`, scoped to `src/**.py` and `lazy_audit.toml`.

## Why this exists
Daft is lazily evaluated. `.collect()` / `.to_pylist()` force the frame through Python memory, defeat query planning, and stop scaling at in-memory size. Every such call inside `src/` is a contract exception against the lazy execution model. The audit makes those exceptions auditable and reviewable, and the failure message explicitly calls out that quietly adding allowlist entries to silence the check is itself a spec-gaming signal.

Tests are intentionally out of scope — terminal materialization at the assertion boundary is expected and not part of the audited contract.

## Test plan
- [x] `make lazy-audit` passes clean on the seeded allowlist (6 sites)
- [x] `make lint` runs the audit before ruff
- [x] Manually verified failure path: a synthetic new `.collect().to_pylist()` in `tests/` is *not* flagged (correct: tests are out of scope)
- [x] Manually verified failure path: a synthetic new `.collect()` in `src/` is flagged under "New, undocumented materialization points"
- [x] Manually verified failure path: replacing a real reason with `"needed"` is flagged under "Allowlist entries with unjustified reasons"
- [x] Manually verified failure path: deleting a line referenced in the allowlist is flagged under "Stale allowlist entries"

🤖 Generated with [Claude Code](https://claude.com/claude-code)