### PR TITLE
fix(app): fork_world inherits source storage by default

### DIFF
--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -245,6 +245,9 @@ class WorldService:
         self._factory = WorldFactory()
         self._registry = WorldRegistry()
         self._orchestrator = WorldOrchestrator(self._factory, self._registry)
+        # Records the storage/cache config that backs each world so fork_world
+        # can default to "same store as source" per world-lifecycle.md § 4.5.
+        self._storage_configs: dict[str, tuple[StorageConfig, CacheConfig | None]] = {}
 
     async def create_world(
         self,
@@ -258,7 +261,9 @@ class WorldService:
             storage_config = StorageConfig()
 
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
-        return self._orchestrator.create_world(store, config, system=system)
+        world = self._orchestrator.create_world(store, config, system=system)
+        self._storage_configs[str(world.world_id)] = (storage_config, cache_config)
+        return world
 
     def get_world(self, world_id: UUID) -> iWorld:
         return self._orchestrator.get_world(world_id)
@@ -276,15 +281,29 @@ class WorldService:
         storage_config: StorageConfig | None = None,
         cache_config: CacheConfig | None = None,
     ) -> iWorld:
-        """Fork a world. Resolves storage from source if not overridden."""
+        """Fork a world. Inherits source's storage when no override is given.
+
+        Per ``docs/guide/world-lifecycle.md`` § 4.5, the fork writes to the
+        same physical store as the source by default; an explicit
+        ``storage_config`` argument routes the fork to a different store.
+        """
         if storage_config is None:
-            storage_config = StorageConfig()
+            source_record = self._storage_configs.get(str(source_world_id))
+            if source_record is not None:
+                storage_config, source_cache = source_record
+                if cache_config is None:
+                    cache_config = source_cache
+            else:
+                storage_config = StorageConfig()
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
-        return self._orchestrator.fork_world(store, source_world_id, name=name)
+        fork = self._orchestrator.fork_world(store, source_world_id, name=name)
+        self._storage_configs[str(fork.world_id)] = (storage_config, cache_config)
+        return fork
 
     async def destroy_world(self, world_id: UUID | str) -> None:
         """Destroy a world. In-memory cleanup only. Storage is preserved."""
         await self._orchestrator.destroy_world(world_id)
+        self._storage_configs.pop(str(world_id), None)
 
     async def add_resource(self, world_id: str | UUID, resource: object) -> None:
         """Attach a resource to a world's Resources container."""

--- a/tests/integration/test_fork_destroy_contracts.py
+++ b/tests/integration/test_fork_destroy_contracts.py
@@ -302,3 +302,108 @@ async def test_audit_row_monotonicity(tmp_path):
         assert high_water > 0
     finally:
         await c.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# 7. Fork inherits source's storage by default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fork_inherits_source_storage(tmp_path):
+    """spec: docs/guide/world-lifecycle.md § 4.5 — "The fork writes to the same
+    physical store as the source by default".
+
+    A fork created without an explicit storage_config must land in the source's
+    store, not in a fresh default StorageConfig() (./archetype_db).
+    """
+    c = ServiceContainer()
+    source_storage = StorageConfig(uri=str(tmp_path / "src_store"), namespace="ns")
+    try:
+        source = await c.world_service.create_world(WorldConfig(name="src"), source_storage)
+        await c.mutation_service.create_entity(source.world_id, [Tag(label="seed")])
+        await c.simulation_service.step(source.world_id, RunConfig())
+
+        # Fork without specifying storage — must inherit source's store.
+        fork = await c.world_service.fork_world(source.world_id, name="fork")
+
+        # Spawn a fresh entity in the fork and step it so a write is forced.
+        fork_eid = await c.mutation_service.create_entity(fork.world_id, [Tag(label="fork-only")])
+        await c.simulation_service.step(fork.world_id, RunConfig())
+
+        rows_in_source_store = (
+            await c.query_service.query_components(
+                [Tag],
+                world_id=str(fork.world_id),
+                run_id=str(fork.run_id),
+                storage_config=source_storage,
+                entity_ids=[fork_eid],
+            )
+        ).count_rows()
+        rows_in_default_store = (
+            await c.query_service.query_components(
+                [Tag],
+                world_id=str(fork.world_id),
+                run_id=str(fork.run_id),
+                storage_config=StorageConfig(),
+                entity_ids=[fork_eid],
+            )
+        ).count_rows()
+
+        assert rows_in_source_store >= 1, (
+            f"fork's data must land in source's store; got {rows_in_source_store} rows there "
+            f"and {rows_in_default_store} rows in the default store"
+        )
+        assert rows_in_default_store == 0, (
+            "fork without explicit storage_config must NOT write to ./archetype_db; "
+            f"found {rows_in_default_store} stray rows there"
+        )
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_fork_explicit_storage_override(tmp_path):
+    """spec: docs/guide/world-lifecycle.md § 4.5 — "The optional storage_config
+    argument allows the fork to write to a different store entirely."
+
+    Override path stays intact: an explicit storage_config wins over the
+    source's store.
+    """
+    c = ServiceContainer()
+    source_storage = StorageConfig(uri=str(tmp_path / "src_store"), namespace="ns")
+    fork_storage = StorageConfig(uri=str(tmp_path / "fork_store"), namespace="ns")
+    try:
+        source = await c.world_service.create_world(WorldConfig(name="src"), source_storage)
+        await c.mutation_service.create_entity(source.world_id, [Tag(label="seed")])
+        await c.simulation_service.step(source.world_id, RunConfig())
+
+        fork = await c.world_service.fork_world(
+            source.world_id, name="fork", storage_config=fork_storage
+        )
+        fork_eid = await c.mutation_service.create_entity(fork.world_id, [Tag(label="fork-only")])
+        await c.simulation_service.step(fork.world_id, RunConfig())
+
+        rows_in_fork_store = (
+            await c.query_service.query_components(
+                [Tag],
+                world_id=str(fork.world_id),
+                run_id=str(fork.run_id),
+                storage_config=fork_storage,
+                entity_ids=[fork_eid],
+            )
+        ).count_rows()
+        rows_in_source_store = (
+            await c.query_service.query_components(
+                [Tag],
+                world_id=str(fork.world_id),
+                run_id=str(fork.run_id),
+                storage_config=source_storage,
+                entity_ids=[fork_eid],
+            )
+        ).count_rows()
+
+        assert rows_in_fork_store >= 1
+        assert rows_in_source_store == 0
+    finally:
+        await c.shutdown()


### PR DESCRIPTION
## Summary

Closes #203.

`WorldService.fork_world` (and by extension `RuntimeWorld.fork`) silently substituted a fresh default `StorageConfig()` (uri `./archetype_db`) whenever the caller didn't pass an explicit `storage_config`. This contradicted `docs/guide/world-lifecycle.md` § 4.5:

> The fork writes to the same physical store as the source by default, with rows partitioned by world_id. The optional storage_config argument allows the fork to write to a different store entirely.

Practically, a user creating a source world with an explicit storage path (a temp dir, a tenant prefix, an S3 location) and then calling `fork_world(source_id, name="fork")` got a fork backed by `./archetype_db` in the working directory. Rollouts (`run_rollout`) magnified the issue: every episode forks per-iteration with no `storage_config`, so every episode silently landed in the default location.

## Changes

- `WorldService` now records `(world_id → storage_config, cache_config)` for every world it creates or forks.
- `fork_world` resolves a missing `storage_config` from the source's record before it asks `StorageService` for a store. An explicit `storage_config` (and `cache_config`) still wins, preserving the override path.
- `destroy_world` removes the entry so the map stays in sync with the registry.
- New contract tests in `tests/integration/test_fork_destroy_contracts.py` cover both the inherit-by-default and explicit-override paths.

`src/archetype/core/` is untouched, per `CLAUDE.md`.

## Test plan

- [x] `uv run pytest tests/integration/test_fork_destroy_contracts.py` — 8 passed (6 existing + 2 new)
- [x] `uv run pytest` — 562 passed, no regressions
- [x] `uv run ruff check` clean on touched files
- [x] MRE in the linked issue: fork's data lands in source's store; `./archetype_db` is no longer created as a side effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)