### PR TITLE
feat(evals): add CRAP code-quality grader

### DIFF
--- a/evals/graders.py
+++ b/evals/graders.py
@@ -68,6 +68,49 @@ def threshold(
     )
 
 
+def crap_score(
+    complexity: float,
+    coverage: float,
+    *,
+    max_crap: float = 30.0,
+    max_complexity: float | None = None,
+    name: str = "crap_score",
+) -> GraderResult:
+    """CRAP grader: passes if CRAP ≤ max_crap (and CC ≤ max_complexity, if set).
+
+    CRAP(m) = comp(m)² · (1 − cov(m))³ + comp(m)
+
+    `coverage` is a fraction in [0.0, 1.0]. Score is 1.0 on pass, otherwise
+    1 − min(crap / max_crap, 2) / 2 so worse code gets a lower partial score
+    (clamped to 0). Per Crap4J the canonical threshold is 30.
+    """
+    if not 0.0 <= coverage <= 1.0:
+        raise ValueError(f"coverage must be in [0.0, 1.0], got {coverage}")
+    if complexity < 0:
+        raise ValueError(f"complexity must be >= 0, got {complexity}")
+
+    crap = complexity * complexity * (1.0 - coverage) ** 3 + complexity
+    cc_ok = max_complexity is None or complexity <= max_complexity
+    crap_ok = crap <= max_crap
+    passed = cc_ok and crap_ok
+
+    if passed:
+        score = 1.0
+    else:
+        score = max(0.0, 1.0 - min(crap / max_crap, 2.0) / 2.0)
+
+    if passed:
+        details = ""
+    else:
+        parts = [f"crap={crap:.2f} (max {max_crap})", f"cc={complexity}"]
+        if max_complexity is not None:
+            parts[-1] += f" (max {max_complexity})"
+        parts.append(f"cov={coverage:.2%}")
+        details = ", ".join(parts)
+
+    return GraderResult(grader_name=name, passed=passed, score=score, details=details)
+
+
 def raises(exc_type: type[Exception], fn, *args, name: str = "raises", **kwargs) -> GraderResult:
     """Grader that passes if fn(*args) raises the expected exception type."""
     try:

--- a/evals/graders.py
+++ b/evals/graders.py
@@ -88,6 +88,8 @@ def crap_score(
         raise ValueError(f"coverage must be in [0.0, 1.0], got {coverage}")
     if complexity < 0:
         raise ValueError(f"complexity must be >= 0, got {complexity}")
+    if max_crap <= 0:
+        raise ValueError(f"max_crap must be > 0, got {max_crap}")
 
     crap = complexity * complexity * (1.0 - coverage) ** 3 + complexity
     cc_ok = max_complexity is None or complexity <= max_complexity

--- a/tests/eval_framework/test_crap_grader.py
+++ b/tests/eval_framework/test_crap_grader.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the CRAP code-quality grader."""
+
+from __future__ import annotations
+
+import pytest
+
+from evals.graders import crap_score
+
+
+def test_clean_code_passes() -> None:
+    r = crap_score(complexity=4, coverage=0.95)
+    assert r.passed
+    assert r.score == 1.0
+    assert r.details == ""
+
+
+def test_borderline_passes_under_default_threshold() -> None:
+    # cc=10, cov=0.80 → CRAP = 100·0.008 + 10 = 10.8 ≤ 30
+    r = crap_score(complexity=10, coverage=0.80)
+    assert r.passed
+
+
+def test_high_complexity_low_coverage_fails() -> None:
+    # cc=20, cov=0.20 → CRAP = 400·0.512 + 20 = 224.8
+    r = crap_score(complexity=20, coverage=0.20)
+    assert not r.passed
+    assert r.score == 0.0
+    assert "crap=224.80" in r.details
+    assert "20.00%" in r.details
+
+
+def test_complexity_cap_overrides_full_coverage() -> None:
+    # cc=15, cov=1.0 → CRAP = 15 (passes max_crap), but cc > max_complexity
+    r = crap_score(complexity=15, coverage=1.0, max_complexity=10)
+    assert not r.passed
+    assert "max 10" in r.details
+
+
+def test_perfect_coverage_collapses_crap_to_complexity() -> None:
+    r = crap_score(complexity=29, coverage=1.0)
+    assert r.passed  # CRAP == 29 ≤ 30
+    r2 = crap_score(complexity=31, coverage=1.0)
+    assert not r2.passed  # CRAP == 31 > 30
+
+
+def test_zero_coverage_amplifies_complexity() -> None:
+    # cc=6, cov=0 → CRAP = 36 + 6 = 42 → fails default threshold
+    r = crap_score(complexity=6, coverage=0.0)
+    assert not r.passed
+
+
+def test_invalid_coverage_raises() -> None:
+    with pytest.raises(ValueError, match=r"\[0\.0, 1\.0\]"):
+        crap_score(complexity=1, coverage=1.5)
+    with pytest.raises(ValueError, match=r"\[0\.0, 1\.0\]"):
+        crap_score(complexity=1, coverage=-0.1)
+
+
+def test_invalid_complexity_raises() -> None:
+    with pytest.raises(ValueError, match=">= 0"):
+        crap_score(complexity=-1, coverage=0.5)
+
+
+def test_partial_score_between_thresholds() -> None:
+    # cc=12, cov=0.5 → CRAP = 144·0.125 + 12 = 30 → passes (== threshold)
+    # bump complexity slightly to force failure with non-zero partial credit
+    r = crap_score(complexity=13, coverage=0.5)
+    assert not r.passed
+    assert 0.0 < r.score < 1.0
+
+
+def test_custom_name_propagates() -> None:
+    r = crap_score(complexity=1, coverage=1.0, name="my_grader")
+    assert r.grader_name == "my_grader"

--- a/tests/eval_framework/test_crap_grader.py
+++ b/tests/eval_framework/test_crap_grader.py
@@ -64,6 +64,13 @@ def test_invalid_complexity_raises() -> None:
         crap_score(complexity=-1, coverage=0.5)
 
 
+def test_invalid_max_crap_raises() -> None:
+    with pytest.raises(ValueError, match="max_crap must be > 0"):
+        crap_score(complexity=1, coverage=0.5, max_crap=0)
+    with pytest.raises(ValueError, match="max_crap must be > 0"):
+        crap_score(complexity=1, coverage=0.5, max_crap=-1)
+
+
 def test_partial_score_between_thresholds() -> None:
     # cc=12, cov=0.5 → CRAP = 144·0.125 + 12 = 30 → passes (== threshold)
     # bump complexity slightly to force failure with non-zero partial credit


### PR DESCRIPTION
## Summary
- Adds `crap_score(complexity, coverage, *, max_crap=30, max_complexity=None)` to `evals/graders.py`.
- Implements the canonical CRAP formula `comp² · (1 − cov)³ + comp` with the standard threshold of 30.
- Pure function — caller supplies CC and coverage from whatever source they prefer (radon, coverage.py, manual).

## Test plan
- [x] 10 unit tests in `tests/eval_framework/test_crap_grader.py` covering clean code, borderline cases, threshold-crossing, complexity cap override, perfect/zero coverage edges, and input validation.
- [ ] `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)