### PR TITLE
feat(htn): HTN plan resolution as a fan-out AND/OR forest ECS pattern

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -110,6 +110,47 @@ col("result")["field"]  # ✓ Use indexing
 
 ---
 
+## UDF column args resolve to the column's FINAL value (read-then-overwrite footgun)
+
+Daft folds a `@daft.func`'s column arguments to that column's **final definition in
+the plan**, not its value at the `with_column` call site. So a processor that reads a
+column with a UDF and then overwrites that same column later in the chain feeds the UDF
+the **post-overwrite** value — even across separate `with_column`/`with_columns` calls,
+and even through an intermediate snapshot column.
+
+```python
+# ✗ BROKEN: append reads seq_next, then seq_next is bumped -> append sees the BUMPED value
+df = df.with_column("plan", append_plan(col("plan"), col("seq_next"), ...))   # reads seq_next=1, not 0!
+df = df.with_column("seq_next", col("seq_next") + 1)
+# A plain projection snapshot does NOT save you once a UDF consumes it:
+df = df.with_column("snap", col("seq_next"))   # snap also folds to the bumped value
+df = df.with_column("out",  some_udf(col("snap")))
+```
+
+This silently corrupts any "read the pre-mutation value" logic — e.g. a state-hash taken
+*before* applying an effect, or a sequence counter — and the bug is invisible until you
+assert on exact values.
+
+**Fix:** consolidate every read-then-overwrite into **one** struct-returning UDF that
+reads each input once and returns all results as struct fields, then split the struct
+back into columns. Because the output columns derive *from* the UDF, Daft cannot fold the
+UDF's own inputs to those outputs (that would be a cycle), so it reads the genuine
+pre-mutation values.
+
+```python
+# ✓ CORRECT: one UDF reads originals, returns a struct; split it back out
+df = df.with_column("eff", apply_effect(col("atoms_json"), col("plan_json"), col("seq_next"), ...))
+for f in ("atoms_json", "plan_json", "seq_next", "pre_state_sig"):
+    df = df.with_column(f, col("eff")[f])
+df = df.exclude("eff")
+```
+
+Plain projections (no UDF, e.g. a column swap via `with_columns({"a": col("b"), "b": col("a")})`)
+*do* read input values atomically — the folding hazard is specific to UDF arguments.
+Discovered building `src/archetype/htn/` (see `EffectProcessor` / `udfs.apply_effect`).
+
+---
+
 ## Archetype ECS Pattern
 
 ### Components = Data Bags

--- a/examples/08_htn_resolution.py
+++ b/examples/08_htn_resolution.py
@@ -1,0 +1,263 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Example 08 — HTN plan resolution as a fan-out AND/OR forest
+===========================================================
+
+Resolves a Hierarchical Task Network into executable plans inside an Archetype world.
+Every branch of the decomposition is ONE row of ONE ``(Branch,)`` archetype; the
+priority-ordered processor chain (Frontier -> Applicability -> Effect -> Termination)
+evaluates preconditions and applies STRIPS effects *same-tick, same-row*, while this
+driver does the ONE structural step the engine reserves for between ticks: OR fan-out
+via ``world.spawn`` (copy-on-write ``plan_id`` multiplication), retiring each expanded
+parent to ``superseded``.
+
+Two fan-out axes are visible in the trace:
+  * AXIS 1 — every live branch advances one micro-step per tick in a single vectorized
+    pass (N branches cost one tick);
+  * AXIS 2 — a ready compound with k applicable methods spawns k child branches.
+
+The dogfood domain is an agentic "resolve a software issue" HTN whose ``fix`` task has
+two rival methods (test-driven vs. direct), so resolution fans out into two distinct,
+independently-executable plans — both extracted from their branch's own append-only
+``plan_json``.
+
+This driver lives in ``examples/`` (not ``src/``) because it ``.collect()``s at the
+read-decide-spawn boundary — the same boundary as ``examples/pr_triage.py``.
+
+Run:  uv run python examples/08_htn_resolution.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from daft import col
+
+from archetype import ArchetypeRuntime
+from archetype.core.config import RunConfig
+from archetype.htn import (
+    Branch,
+    HtnDomain,
+    MethodSpec,
+    OperatorSpec,
+    Solved,
+    build_initial_network,
+    htn_processors,
+    splice_method,
+)
+
+# ============================================================================
+# The dogfood domain: "resolve a software issue"
+# ============================================================================
+
+
+def resolve_issue_domain() -> HtnDomain:
+    """resolve_issue -> understand, fix, verify, ship.
+
+    ``fix`` has two rival methods — test-driven (write a failing test, then edit) and
+    direct (edit straight away) — so the planner fans out into two solution branches.
+    """
+    operators = [
+        OperatorSpec("read_code", add=("understood",)),
+        OperatorSpec("write_failing_test", pre_pos=("understood",), add=("test_written",)),
+        OperatorSpec("edit_code", pre_pos=("test_written",), add=("code_edited",)),
+        OperatorSpec("edit_code_direct", pre_pos=("understood",), add=("code_edited",)),
+        OperatorSpec("run_tests", pre_pos=("code_edited",), add=("tests_pass",)),
+        OperatorSpec("open_pr", pre_pos=("tests_pass",), add=("pr_open",)),
+    ]
+    methods = [
+        MethodSpec(
+            "resolve_issue",
+            "resolve_issue#0",
+            subtasks=(("understand", ()), ("fix", ()), ("verify", ()), ("ship", ())),
+        ),
+        MethodSpec("understand", "understand#0", subtasks=(("read_code", ()),)),
+        # rival methods for `fix` — the OR node:
+        MethodSpec(
+            "fix",
+            "fix#test_driven",
+            pre_pos=("understood",),
+            subtasks=(("write_failing_test", ()), ("edit_code", ())),
+        ),
+        MethodSpec(
+            "fix",
+            "fix#direct",
+            pre_pos=("understood",),
+            subtasks=(("edit_code_direct", ()),),
+        ),
+        MethodSpec("verify", "verify#0", subtasks=(("run_tests", ()),)),
+        MethodSpec("ship", "ship#0", subtasks=(("open_pr", ()),)),
+    ]
+    return HtnDomain.of(operators, methods)
+
+
+# ============================================================================
+# The structural-only driver
+# ============================================================================
+
+
+def _branch_from_row(row: dict, **overrides) -> Branch:
+    """Reconstruct the FULL ``Branch`` from a queried row (``update_entity`` overlays
+    every supplied field, so a partial component would wipe state to defaults)."""
+    values = {f: row[f"branch__{f}"] for f in Branch.model_fields}
+    values.update(overrides)
+    return Branch(**values)
+
+
+async def resolve_htn(
+    world,
+    domain: HtnDomain,
+    s0: list[str],
+    tn0: list[tuple[str, list[str]]],
+    *,
+    max_ticks: int = 256,
+    max_depth: int = 64,
+    stop_on_first: bool = False,
+    verbose: bool = True,
+) -> dict:
+    """Drive HTN resolution to completion. Returns the solution plans + a tick log.
+
+    The driver does ZERO precondition / effect work — that all happens in the in-row
+    processor chain. Between ticks it only: reads the materialized frontier, OR-spawns
+    children for ready compounds, retires expanded parents, and records solved branches.
+    """
+    # Seed the root branch. The initial network embeds per-node op / method specs so the
+    # pure UDFs never need the domain object (Inv HTN-V2.15).
+    net0 = build_initial_network(domain, tn0)
+    await world.spawn(Branch.make("r", s0, net0, max_depth=max_depth))
+
+    rc = RunConfig(num_steps=1)  # ONE reused run_id for the whole resolution (Inv HTN-V2.14)
+    solutions: list[dict] = []
+    solved_ids: set[str] = set()
+    ticks: list[dict] = []
+
+    for _ in range(max_ticks):
+        await world.step(config=rc)
+        info = await world.info()
+        rows = (await world.query(Branch)).where(col("tick") == info.tick - 1).collect().to_pylist()
+        live = [r for r in rows if r["branch__status"] == "live"]
+        expansions = 0
+
+        # (1) record solved branches — extract the plan from the branch's own trace.
+        for r in rows:
+            pid = r["branch__plan_id"]
+            if r["branch__status"] == "solved" and pid not in solved_ids:
+                solved_ids.add(pid)
+                plan = json.loads(r["branch__plan_json"])
+                solutions.append({"plan_id": pid, "depth": r["branch__depth"], "plan": plan})
+
+        # (2) OR fan-out: each live, ready COMPOUND with applicable methods spawns one
+        #     child per method, then the parent is retired to `superseded`.
+        for r in live:
+            if r["branch__ready_kind"] != "compound" or not r["branch__needs_expansion"]:
+                continue
+            methods = json.loads(r["branch__applicable_methods_json"])
+            network = json.loads(r["branch__network_json"])
+            atoms = json.loads(r["branch__atoms_json"])
+            plan = json.loads(r["branch__plan_json"])
+            compound_id = r["branch__ready_node_id"]
+            for j, m in enumerate(methods):
+                child_net = splice_method(domain, network, compound_id, m["id"])
+                await world.spawn(
+                    Branch.make(
+                        f"{r['branch__plan_id']}.{j}",
+                        atoms,
+                        child_net,
+                        parent_branch_id=r["branch__plan_id"],
+                        depth=r["branch__depth"] + 1,
+                        max_depth=max_depth,
+                        plan=plan,
+                        seq_next=r["branch__seq_next"],
+                    )
+                )
+            # retire the parent (Inv HTN-V2.17) — children carry the live continuation.
+            await world.update(r["entity_id"], _branch_from_row(r, status="superseded"))
+            expansions += 1
+
+        if verbose:
+            kinds = {}
+            for r in live:
+                kinds[r["branch__ready_op_name"]] = kinds.get(r["branch__ready_op_name"], 0) + 1
+            ticks.append(
+                {
+                    "tick": info.tick - 1,
+                    "live": len(live),
+                    "solved": len(solutions),
+                    "expansions": expansions,
+                    "frontier": kinds,
+                }
+            )
+
+        if stop_on_first and solutions:
+            break
+        if not live:  # exhaustion — every branch is solved / failed / superseded
+            break
+
+    # Attach the Solved marker to each solution branch (terminal migration, Inv HTN-V2.9)
+    # and materialize it once, so solved branches are queryable via query(Branch, Solved).
+    info = await world.info()
+    latest = (await world.query(Branch)).where(col("tick") == info.tick - 1).collect().to_pylist()
+    by_pid = {r["branch__plan_id"]: r for r in latest}
+    for s in solutions:
+        r = by_pid.get(s["plan_id"])
+        if r is not None:
+            await world.add_components(
+                r["entity_id"], Solved.make(s["plan_id"], plan_length=len(s["plan"]))
+            )
+    if solutions:
+        await world.step(config=rc)
+
+    return {"solutions": solutions, "ticks": ticks}
+
+
+# ============================================================================
+# Demo
+# ============================================================================
+
+
+def _format_plan(plan: list[dict]) -> str:
+    return " -> ".join(step["op"] for step in sorted(plan, key=lambda s: s["seq"]))
+
+
+async def main() -> None:
+    domain = resolve_issue_domain()
+    s0 = ["issue_open"]
+    tn0 = [("resolve_issue", [])]
+
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("htn-resolve-issue", processors=htn_processors())
+
+        print("Resolving HTN: resolve_issue  (fix has 2 rival methods → fan-out)\n")
+        result = await resolve_htn(world, domain, s0, tn0, max_depth=32)
+
+        print(f"{'tick':>4}  {'live':>4}  {'solved':>6}  {'exp':>3}  frontier")
+        for t in result["ticks"]:
+            fr = ", ".join(f"{k}×{v}" for k, v in t["frontier"].items() if k)
+            print(f"{t['tick']:>4}  {t['live']:>4}  {t['solved']:>6}  {t['expansions']:>3}  {fr}")
+
+        print(f"\n{len(result['solutions'])} solution plan(s) found via fan-out:\n")
+        for s in sorted(result["solutions"], key=lambda x: len(x["plan"])):
+            print(f"  [{s['plan_id']}]  ({len(s['plan'])} ops)  {_format_plan(s['plan'])}")
+
+        # Solutions are first-class, queryable artifacts — reference them through the world.
+        info = await world.info()
+        solved = (
+            (await world.query(Branch, Solved))
+            .where(col("tick") == info.tick - 1)
+            .select("solved__plan_id", "solved__plan_length", "branch__atoms_json")
+            .collect()
+            .to_pylist()
+        )
+        print(f"\nSolved branches queryable via query(Branch, Solved): {len(solved)}")
+        for row in solved:
+            print(
+                f"  plan_id={row['solved__plan_id']}  len={row['solved__plan_length']}  "
+                f"final_state={json.loads(row['branch__atoms_json'])}"
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/archetype/htn/__init__.py
+++ b/src/archetype/htn/__init__.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Archetype HTN — Hierarchical Task Network plan resolution as a formal ECS pattern.
+
+Plan resolution is a single-world, ``plan_id``-tagged AND/OR forest. Every live
+branch is ONE row of ONE ``(Branch,)`` archetype carrying, co-located:
+
+  (i)   ``atoms_json``   — the progressed STRIPS state (closed-world ground atoms),
+  (ii)  ``network_json`` — the entire remaining task network,
+  (iii) op-spec columns  — the ready node's denormalized operator / method spec,
+  (iv)  ``plan_json``    — the accumulated, self-contained, append-only plan.
+
+Because all four live on ONE archetype, a priority-ordered processor chain
+(``Frontier(10) -> Applicability(20) -> Effect(30) -> Termination(40)``) evaluates
+preconditions and applies STRIPS effects *same-tick, same-row* — giving genuine
+SHOP "state-known-at-precondition-time" by construction, with no cross-archetype
+staleness window. Fan-out lives on two axes:
+
+  * AXIS 1 (in-tick, vectorized across branches): every live branch advances one
+    micro-step in ONE DataFrame pass — N branches cost one tick regardless of N.
+  * AXIS 2 (between-ticks, structural OR-spawn): the driver ``world.spawn``s one
+    child branch per applicable method (copy-on-write ``plan_id`` multiplication)
+    and retires the parent to ``superseded``.
+
+The driver (``resolve_htn``) is structural-only and lives in ``examples/`` because
+it must materialize rows (eager collection) at the spawn-decision boundary; the
+processors and UDFs here are pure ``DataFrame -> DataFrame`` and lazy-audit clean.
+
+See ``.context/htn/PATTERN.md`` for the full formal pattern and numbered invariants.
+"""
+
+from __future__ import annotations
+
+from archetype.htn.components import Branch, BranchStatus, Solved, TaskKind, TaskStatus
+from archetype.htn.domain import (
+    HtnDomain,
+    MethodSpec,
+    OperatorSpec,
+    build_initial_network,
+    splice_method,
+)
+from archetype.htn.processors import (
+    ApplicabilityProcessor,
+    EffectProcessor,
+    FrontierProcessor,
+    TerminationProcessor,
+    htn_processors,
+)
+
+__all__ = [
+    "Branch",
+    "BranchStatus",
+    "Solved",
+    "TaskKind",
+    "TaskStatus",
+    "HtnDomain",
+    "OperatorSpec",
+    "MethodSpec",
+    "build_initial_network",
+    "splice_method",
+    "FrontierProcessor",
+    "ApplicabilityProcessor",
+    "EffectProcessor",
+    "TerminationProcessor",
+    "htn_processors",
+]

--- a/src/archetype/htn/components.py
+++ b/src/archetype/htn/components.py
@@ -1,0 +1,192 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+HTN Components
+==============
+
+``Branch`` is the single live-branch archetype — one row per branch in the AND/OR
+forest, co-locating state + remaining network + ready op-spec + accumulated plan so
+the processor chain can evaluate preconditions and apply effects same-tick, same-row
+(Inv HTN-V2.1 / HTN-V2.2). ``Solved`` is the only marker, attached once by the driver
+when a branch's network has zero open nodes.
+
+House idiom (mirrors ``src/archetype/experiments/components.py``): subclass
+``Component`` (Pydantic via LanceModel, never dataclass); every field defaulted;
+scalars stored directly; complex data JSON-encoded into ``*_json``; ``StrEnum``-as-
+string for status with a helper class beside it (stored as ``.value``, never the enum
+— enums are not Arrow-serializable); timestamps as ``*_at_ms`` ints; ``@classmethod
+make(...)`` for type-safe construction; ``get_*()`` decoders for the JSON fields.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from enum import StrEnum
+
+from archetype.core.component import Component
+
+
+def _now_ms() -> int:
+    """Current time as Unix milliseconds (driver/seed side — never inside a UDF)."""
+    return int(time.time() * 1000)
+
+
+# ============================================================================
+# Helper StrEnums — NOT components. Stored on rows as their ``.value`` string.
+# ============================================================================
+
+
+class BranchStatus(StrEnum):
+    """Lifecycle of one branch in the forest.
+
+    A branch is LIVE while it is still being decomposed/progressed. It becomes
+    SOLVED (zero open nodes), FAILED (precondition unsat / no applicable method /
+    depth exceeded), PRUNED (memoized duplicate frontier), or SUPERSEDED (a parent
+    retired after OR fan-out — its children carry the live continuation).
+    """
+
+    LIVE = "live"
+    SOLVED = "solved"
+    FAILED = "failed"
+    PRUNED = "pruned"
+    SUPERSEDED = "superseded"  # retired parent after OR fan-out (Inv HTN-V2.17)
+
+    @classmethod
+    def is_terminal(cls, s: str) -> bool:
+        """Non-live = finished being processed.
+
+        SUPERSEDED is a structural retirement, NOT a failure — its children carry
+        the live continuation, but the parent row itself is done.
+        """
+        return s in (cls.SOLVED.value, cls.FAILED.value, cls.PRUNED.value, cls.SUPERSEDED.value)
+
+    @classmethod
+    def is_live(cls, s: str) -> bool:
+        return s == cls.LIVE.value
+
+
+class TaskKind(StrEnum):
+    COMPOUND = "compound"
+    PRIMITIVE = "primitive"
+
+
+class TaskStatus(StrEnum):
+    OPEN = "open"
+    RESOLVED = "resolved"
+    FAILED = "failed"
+
+
+# ============================================================================
+# Components
+# ============================================================================
+
+
+class Branch(Component):
+    """ONE row per live branch. Carries, co-located on a single archetype:
+
+       (i)   ``atoms_json``   — progressed STRIPS state (sorted ground atoms),
+       (ii)  ``network_json`` — the ENTIRE remaining task network,
+       (iii) op-spec cols     — the ready node's denormalized operator/method spec,
+       (iv)  ``plan_json``    — the accumulated, self-contained, append-only plan.
+
+    Because all four are on ONE archetype, ``Frontier/Applicability/Effect/
+    Termination`` are same-tick priority-chained column transforms — no
+    cross-archetype read is ever required (Inv HTN-V2.1 / HTN-V2.2).
+    """
+
+    plan_id: str = "r"
+    parent_branch_id: str = ""
+
+    # (i) state — sorted ["pred(a,b)", ...] = the closed-world TRUE set
+    atoms_json: str = "[]"
+
+    # (ii) the entire remaining task network:
+    #   [{node_id, name, args, kind, preds, order_index, depth, status,
+    #     chosen_method, op, candidate_methods}, ...]
+    network_json: str = "[]"
+
+    # (iv) accumulated plan (self-contained per branch, copied COW to children)
+    plan_json: str = "[]"  # [{seq, op, args, pre_sig, node_id}, ...]
+    seq_next: int = 0
+
+    # depth / termination
+    depth: int = 0
+    max_depth: int = 64  # MANDATORY-on cap (Inv HTN-V2.11)
+    status: str = "live"  # BranchStatus value
+    fail_reason: str = ""  # no_applicable_method | precond_unsat | depth_exceeded | pruned
+
+    # (iii) ready-node denormalized op-spec columns (stamped by FrontierProcessor)
+    ready_node_id: int = -1
+    ready_kind: str = ""  # compound | primitive | none
+    ready_op_name: str = ""
+    ready_args_json: str = "[]"
+    pre_pos_json: str = "[]"
+    pre_neg_json: str = "[]"
+    add_json: str = "[]"
+    del_json: str = "[]"
+    candidate_methods_json: str = "[]"  # for a ready compound: embedded per-node by driver
+
+    # applicability / expansion / witness (written by Applicability / Effect)
+    applicable: bool = False
+    applicable_methods_json: str = "[]"  # COMPLETE applicable set vs CURRENT atoms
+    needs_expansion: bool = False
+    pre_state_sig: str = ""  # written by EffectProcessor (separate with_column, Inv HTN-V2.4a)
+
+    # same-row derived columns (NOT cross-archetype folds)
+    open_count: int = 0  # recomputed post-Effect in TerminationProcessor (Inv HTN-V2.4b)
+    frontier_signature: str = ""
+    updated_at_ms: int = 0
+
+    @classmethod
+    def make(
+        cls,
+        plan_id: str,
+        atoms: list[str],
+        network: list[dict],
+        *,
+        parent_branch_id: str = "",
+        depth: int = 0,
+        max_depth: int = 64,
+        plan: list[dict] | None = None,
+        seq_next: int = 0,
+    ) -> Branch:
+        """Construct a branch row. ``atoms`` are sorted for a canonical state encoding."""
+        return cls(
+            plan_id=plan_id,
+            parent_branch_id=parent_branch_id,
+            atoms_json=json.dumps(sorted(atoms)),
+            network_json=json.dumps(network),
+            plan_json=json.dumps(plan or []),
+            seq_next=seq_next,
+            depth=depth,
+            max_depth=max_depth,
+            updated_at_ms=_now_ms(),
+        )
+
+    def get_atoms(self) -> list[str]:
+        return json.loads(self.atoms_json)
+
+    def get_network(self) -> list[dict]:
+        return json.loads(self.network_json)
+
+    def get_plan(self) -> list[dict]:
+        return json.loads(self.plan_json)
+
+    def get_applicable_methods(self) -> list[dict]:
+        return json.loads(self.applicable_methods_json)
+
+
+class Solved(Component):
+    """Attached by the DRIVER via ``add_components`` EXACTLY ONCE when a branch's
+    network has zero open nodes. Keys ``EpisodeConfig.terminal_component``. One
+    terminal migration per solved branch (Inv HTN-V2.9 / HTN-V2.16)."""
+
+    plan_id: str = "r"
+    plan_length: int = 0
+    solved_at_ms: int = 0
+
+    @classmethod
+    def make(cls, plan_id: str, plan_length: int) -> Solved:
+        return cls(plan_id=plan_id, plan_length=plan_length, solved_at_ms=_now_ms())

--- a/src/archetype/htn/domain.py
+++ b/src/archetype/htn/domain.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+HTN Domain
+==========
+
+The STATIC planning domain: STRIPS ``OperatorSpec`` (primitive tasks) and
+``MethodSpec`` (ways to decompose a compound task), grouped into an ``HtnDomain``.
+
+This module is consulted ONLY by the driver, in plain Python, to BUILD the per-node
+``op`` / ``candidate_methods`` JSON that gets embedded into ``Branch.network_json`` at
+spawn time (Inv HTN-V2.15). The domain object NEVER enters a ``@daft.func`` — every
+UDF reads only the pre-denormalized JSON columns. None of these helpers touch Daft or
+force eager materialization, so the module is lazy-audit clean and lives in ``src/``.
+
+Parameterization is light and positional: operator/method ``params`` bind to a node's
+``args`` and substitute into ``{name}`` placeholders in precondition / effect / subtask
+templates via ``str.format``. Propositional domains simply use empty ``params`` and
+literal templates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+def _subst(templates: list[str], binding: dict[str, str]) -> list[str]:
+    """Substitute a positional binding into ``{var}`` placeholders.
+
+    With an empty binding the templates pass through verbatim (propositional case).
+    """
+    if not binding:
+        return list(templates)
+    return [t.format(**binding) for t in templates]
+
+
+@dataclass(frozen=True)
+class OperatorSpec:
+    """A primitive task: STRIPS ``(pre+, pre-, add, del)`` over ground atoms.
+
+    ``applicable(a, s) <=> pre+ ⊆ s ∧ pre- ∩ s = ∅``; the transition is
+    ``gamma(s, a) = (s \\ del) ∪ add`` with delete strictly before add.
+    """
+
+    name: str
+    params: tuple[str, ...] = ()
+    pre_pos: tuple[str, ...] = ()
+    pre_neg: tuple[str, ...] = ()
+    add: tuple[str, ...] = ()
+    delete: tuple[str, ...] = ()
+
+    def ground(self, args: list[str]) -> dict:
+        """Bind ``args`` to ``params`` and substitute, yielding a ground op-spec dict
+        embedded per-node by the driver (read later by the pure UDFs)."""
+        binding = dict(zip(self.params, args, strict=False))
+        return {
+            "pre_pos": _subst(list(self.pre_pos), binding),
+            "pre_neg": _subst(list(self.pre_neg), binding),
+            "add": _subst(list(self.add), binding),
+            "del": _subst(list(self.delete), binding),
+        }
+
+
+@dataclass(frozen=True)
+class MethodSpec:
+    """A way to decompose a compound task: ``(task, pre+, pre-, subtasks)``.
+
+    ``subtasks`` is an ORDERED list of ``(name, arg_templates)`` — total-order
+    decomposition (each subtask depends on the previous). The method applies when its
+    precondition holds in the branch's CURRENT state.
+    """
+
+    task: str
+    method_id: str
+    params: tuple[str, ...] = ()
+    pre_pos: tuple[str, ...] = ()
+    pre_neg: tuple[str, ...] = ()
+    subtasks: tuple[tuple[str, tuple[str, ...]], ...] = ()
+
+    def precond(self, args: list[str]) -> dict:
+        """Ground precondition for the ``candidate_methods`` filter UDF."""
+        binding = dict(zip(self.params, args, strict=False))
+        return {
+            "id": self.method_id,
+            "pre_pos": _subst(list(self.pre_pos), binding),
+            "pre_neg": _subst(list(self.pre_neg), binding),
+        }
+
+    def ground_subtasks(self, args: list[str]) -> list[tuple[str, list[str]]]:
+        binding = dict(zip(self.params, args, strict=False))
+        return [(name, _subst(list(arg_t), binding)) for name, arg_t in self.subtasks]
+
+
+@dataclass
+class HtnDomain:
+    """Operators + methods. The driver's only source of decomposition knowledge."""
+
+    operators: dict[str, OperatorSpec] = field(default_factory=dict)
+    methods: dict[str, list[MethodSpec]] = field(default_factory=dict)
+    _method_index: dict[str, MethodSpec] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        for ms in self.methods.values():
+            for m in ms:
+                self._method_index[m.method_id] = m
+
+    @classmethod
+    def of(cls, operators: list[OperatorSpec], methods: list[MethodSpec]) -> HtnDomain:
+        ops = {o.name: o for o in operators}
+        meth: dict[str, list[MethodSpec]] = {}
+        for m in methods:
+            meth.setdefault(m.task, []).append(m)
+        return cls(operators=ops, methods=meth)
+
+    def is_primitive(self, name: str) -> bool:
+        return name in self.operators
+
+    def method_by_id(self, method_id: str) -> MethodSpec:
+        return self._method_index[method_id]
+
+    # ── per-node embedding ────────────────────────────────────────────────
+
+    def embed_node(
+        self,
+        node_id: int,
+        name: str,
+        args: list[str],
+        *,
+        preds: list[int],
+        order_index: int,
+        depth: int,
+    ) -> dict:
+        """Build a network node with its op-spec OR candidate-method preconditions
+        embedded, so the pure UDFs never need the domain object."""
+        if self.is_primitive(name):
+            kind = "primitive"
+            op = self.operators[name].ground(args)
+            candidates: list[dict] = []
+        else:
+            kind = "compound"
+            op = {}
+            candidates = [m.precond(args) for m in self.methods.get(name, [])]
+        return {
+            "node_id": node_id,
+            "name": name,
+            "args": list(args),
+            "kind": kind,
+            "preds": list(preds),
+            "order_index": order_index,
+            "depth": depth,
+            "status": "open",
+            "chosen_method": "",
+            "op": op,
+            "candidate_methods": candidates,
+        }
+
+
+# ============================================================================
+# Network construction & decomposition (pure Python, driver-side)
+# ============================================================================
+
+
+def _topo_order_index(network: list[dict]) -> None:
+    """Assign each node a dense ``order_index`` that is a topological rank over the
+    ``preds`` edges (Kahn). Guarantees the min-``order_index`` open-with-preds-resolved
+    pick respects the partial order without collisions or gaps (Inv HTN-V2.13)."""
+    by_id = {n["node_id"]: n for n in network}
+    indeg = {nid: 0 for nid in by_id}
+    succ: dict[int, list[int]] = {nid: [] for nid in by_id}
+    for n in network:
+        for p in n["preds"]:
+            if p in by_id:
+                indeg[n["node_id"]] += 1
+                succ[p].append(n["node_id"])
+    # deterministic Kahn: pop smallest node_id among the ready set
+    ready = sorted(nid for nid, d in indeg.items() if d == 0)
+    rank = 0
+    while ready:
+        nid = ready.pop(0)
+        by_id[nid]["order_index"] = rank
+        rank += 1
+        for s in sorted(succ[nid]):
+            indeg[s] -= 1
+            if indeg[s] == 0:
+                ready.append(s)
+        ready.sort()
+    # any node left (cycle) keeps a large index so it never blocks live picks
+    for n in network:
+        if n["node_id"] not in by_id or indeg.get(n["node_id"], 0) > 0:
+            n["order_index"] = 10_000 + n["node_id"]
+
+
+def build_initial_network(domain: HtnDomain, tn0: list[tuple[str, list[str]]]) -> list[dict]:
+    """Build the initial task network from ``tn0`` — an ordered list of top-level
+    ``(task_name, args)``. Tasks are chained total-order (node i depends on i-1)."""
+    network: list[dict] = []
+    prev: int | None = None
+    for i, (name, args) in enumerate(tn0):
+        preds = [prev] if prev is not None else []
+        network.append(domain.embed_node(i, name, args, preds=preds, order_index=i, depth=0))
+        prev = i
+    _topo_order_index(network)
+    return network
+
+
+def splice_method(
+    domain: HtnDomain,
+    network: list[dict],
+    compound_node_id: int,
+    method_id: str,
+) -> list[dict]:
+    """Return a NEW network (deep value-copy) for a child branch, decomposing the
+    compound node by ``method_id`` (Inv HTN-V2.13):
+
+      1. instantiate the method's subtasks with fresh node_ids, args bound, op /
+         candidate_methods embedded, chained total-order;
+      2. inherit the compound node's preds onto the method's INITIAL subtask;
+      3. rewire every successor of the compound (a node whose preds contained it) to
+         depend instead on the method's TERMINAL subtask;
+      4. mark the compound node ``resolved`` with ``chosen_method``;
+      5. densely renumber ``order_index`` as a topological sort.
+    """
+    import copy
+
+    net = copy.deepcopy(network)
+    by_id = {n["node_id"]: n for n in net}
+    compound = by_id[compound_node_id]
+    method = domain.method_by_id(method_id)
+    next_id = max(n["node_id"] for n in net) + 1
+    child_depth = compound["depth"] + 1
+
+    subtask_specs = method.ground_subtasks(compound["args"])
+    sub_ids: list[int] = []
+    for k, (name, args) in enumerate(subtask_specs):
+        nid = next_id
+        next_id += 1
+        # (2) initial subtask inherits the compound's preds; later subtasks chain.
+        preds = list(compound["preds"]) if k == 0 else [sub_ids[-1]]
+        node = domain.embed_node(nid, name, args, preds=preds, order_index=0, depth=child_depth)
+        net.append(node)
+        sub_ids.append(nid)
+
+    # (3) rewire successors of the compound to the method's terminal subtask. If the
+    # method is empty (no subtasks), successors fall back onto the compound's own preds.
+    terminal = sub_ids[-1] if sub_ids else None
+    replacement = [terminal] if terminal is not None else list(compound["preds"])
+    for n in net:
+        if n["node_id"] == compound_node_id:
+            continue
+        if compound_node_id in n["preds"]:
+            rewired = [p for p in n["preds"] if p != compound_node_id] + replacement
+            # dedup preserving determinism
+            n["preds"] = sorted(set(rewired))
+
+    # (4) retire the compound node within the child network.
+    compound["status"] = "resolved"
+    compound["chosen_method"] = method_id
+
+    # (5) topological renumber over the whole spliced network.
+    _topo_order_index(net)
+    return net

--- a/src/archetype/htn/processors.py
+++ b/src/archetype/htn/processors.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+HTN Processors
+==============
+
+Four pure ``DataFrame -> DataFrame`` processors, all ``components = (Branch,)``, run
+in ascending priority within ONE tick on ONE archetype — so the engine threads a
+single immutable df proc-to-proc (``async_system.py``) and each reads exactly the
+columns the previous wrote THIS tick:
+
+    Frontier(10) -> Applicability(20) -> Effect(30) -> Termination(40)
+
+That same-tick, same-row chain IS SHOP "state-known-at-precondition-time": the atoms
+``ApplicabilityProcessor`` tests are exactly the atoms ``EffectProcessor`` is about to
+mutate (Inv HTN-V2.2 / HTN-V2.2b). None of these forces eager materialization — all
+structural fan-out is the driver's job — so the module is lazy-audit clean in ``src/``.
+"""
+
+from __future__ import annotations
+
+from daft import col, lit
+from daft.functions import when
+
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.htn import udfs
+
+_LIVE = lit("live")
+_READY_FIELDS = (
+    "ready_node_id",
+    "ready_kind",
+    "ready_op_name",
+    "ready_args_json",
+    "pre_pos_json",
+    "pre_neg_json",
+    "add_json",
+    "del_json",
+    "candidate_methods_json",
+)
+
+
+class FrontierProcessor(AsyncProcessor):
+    """Priority 10. Pick the ready node and denormalize its op-spec into in-row
+    columns. Pure value columns — zero archetype migration per step (Inv HTN-V2.9)."""
+
+    components = (None,)  # rebound to (Branch,) after the class bodies
+    priority = 10
+
+    async def process(self, df, **kw):
+        df = df.with_column("branch__ready", udfs.pick_ready(col("branch__network_json")))
+        for k in _READY_FIELDS:
+            df = df.with_column(f"branch__{k}", col("branch__ready")[k])
+        return df.exclude("branch__ready")
+
+
+class ApplicabilityProcessor(AsyncProcessor):
+    """Priority 20. Reads the SAME-ROW op-spec columns and ``atoms_json``. Primitive:
+    ``applicable = pre+ ⊆ atoms ∧ pre- ∩ atoms = ∅``. Compound: the COMPLETE set of
+    methods whose precondition holds in CURRENT atoms (Inv HTN-V2.7)."""
+
+    components = (None,)
+    priority = 20
+
+    async def process(self, df, **kw):
+        prim = col("branch__ready_kind") == "primitive"
+        comp = col("branch__ready_kind") == "compound"
+        df = df.with_column(
+            "branch__applicable",
+            when(
+                prim,
+                then=udfs.precond_holds(
+                    col("branch__atoms_json"),
+                    col("branch__pre_pos_json"),
+                    col("branch__pre_neg_json"),
+                ),
+            ).otherwise(lit(False)),
+        )
+        df = df.with_column(
+            "branch__applicable_methods_json",
+            when(
+                comp,
+                then=udfs.methods_applicable(
+                    col("branch__atoms_json"), col("branch__candidate_methods_json")
+                ),
+            ).otherwise(lit("[]")),
+        )
+        df = df.with_column(
+            "branch__needs_expansion",
+            comp & udfs.json_list_nonempty(col("branch__applicable_methods_json")),
+        )
+        return df
+
+
+_EFFECT_FIELDS = (
+    "atoms_json",
+    "network_json",
+    "plan_json",
+    "pre_state_sig",
+    "seq_next",
+    "status",
+    "fail_reason",
+    "applicable",
+)
+
+
+class EffectProcessor(AsyncProcessor):
+    """Priority 30. Guarded, self-recording STRIPS application via ONE consolidated UDF.
+
+    Applies ``gamma`` ONLY where the ready node is a primitive that re-checks as applicable
+    in CURRENT atoms and the branch is live (Inv HTN-V2.3); records the executability
+    witness ``pre_state_sig`` from the genuine pre-mutation atoms and the plan step at
+    application time (Inv HTN-V2.4). A single struct-returning UDF is mandatory here: Daft
+    folds a UDF's column args to the column's final definition, so splitting the effect
+    across multiple UDFs that read-then-overwrite ``atoms_json`` / ``seq_next`` corrupts the
+    witness and the seq (see ``udfs.apply_effect``). Reading every input once and splitting
+    the struct back out is aliasing-proof (cycle-prevention reads the pre-mutation values)."""
+
+    components = (None,)
+    priority = 30
+
+    async def process(self, df, **kw):
+        df = df.with_column(
+            "branch__eff",
+            udfs.apply_effect(
+                col("branch__atoms_json"),
+                col("branch__network_json"),
+                col("branch__plan_json"),
+                col("branch__seq_next"),
+                col("branch__status"),
+                col("branch__fail_reason"),
+                col("branch__pre_state_sig"),
+                col("branch__ready_kind"),
+                col("branch__ready_node_id"),
+                col("branch__ready_op_name"),
+                col("branch__ready_args_json"),
+                col("branch__pre_pos_json"),
+                col("branch__pre_neg_json"),
+                col("branch__add_json"),
+                col("branch__del_json"),
+            ),
+        )
+        for f in _EFFECT_FIELDS:
+            df = df.with_column(f"branch__{f}", col("branch__eff")[f])
+        return df.exclude("branch__eff")
+
+
+class TerminationProcessor(AsyncProcessor):
+    """Priority 40. Pure in-row marking, no structural change. Recomputes ``open_count``
+    from the POST-Effect network (Inv HTN-V2.4b), then flips status: depth cap is
+    MANDATORY every tick (Inv HTN-V2.11); ``open_count == 0`` => solved; a ready compound
+    with no applicable method, or a stalled branch with no ready node, => failed."""
+
+    components = (None,)
+    priority = 40
+
+    async def process(self, df, **kw):
+        live = col("branch__status") == _LIVE
+        over_depth = col("branch__depth") > col("branch__max_depth")
+        none_ready = col("branch__ready_kind") == "none"
+        dead_compound = (col("branch__ready_kind") == "compound") & ~col("branch__needs_expansion")
+
+        # (a) authoritative post-resolution open count, same row.
+        df = df.with_column("branch__open_count", udfs.count_open(col("branch__network_json")))
+        # (b) status flips — guarded on still-live so retired/terminal rows never change.
+        df = df.with_column(
+            "branch__status",
+            when(over_depth & live, then=lit("failed"))
+            .when((col("branch__open_count") == 0) & live, then=lit("solved"))
+            .when(dead_compound & live, then=lit("failed"))
+            .when(none_ready & (col("branch__open_count") > 0) & live, then=lit("failed"))
+            .otherwise(col("branch__status")),
+        )
+        # (c) fail reason for the transition that just fired.
+        failed = col("branch__status") == "failed"
+        df = df.with_column(
+            "branch__fail_reason",
+            when(over_depth & failed, then=lit("depth_exceeded"))
+            .when(
+                dead_compound & failed & (col("branch__fail_reason") == ""),
+                then=lit("no_applicable_method"),
+            )
+            .when(
+                none_ready & failed & (col("branch__fail_reason") == ""),
+                then=lit("stalled"),
+            )
+            .otherwise(col("branch__fail_reason")),
+        )
+        # (d) memo key — state ++ remaining-open multiset, in-row.
+        df = df.with_column(
+            "branch__frontier_signature",
+            udfs.frontier_sig(col("branch__atoms_json"), col("branch__network_json")),
+        )
+        return df
+
+
+# Bind the (Branch,) signature after the class bodies to keep imports linear.
+from archetype.htn.components import Branch  # noqa: E402
+
+FrontierProcessor.components = (Branch,)
+ApplicabilityProcessor.components = (Branch,)
+EffectProcessor.components = (Branch,)
+TerminationProcessor.components = (Branch,)
+
+
+def htn_processors() -> list[AsyncProcessor]:
+    """The priority-ordered processor chain for HTN resolution."""
+    return [
+        FrontierProcessor(),
+        ApplicabilityProcessor(),
+        EffectProcessor(),
+        TerminationProcessor(),
+    ]

--- a/src/archetype/htn/udfs.py
+++ b/src/archetype/htn/udfs.py
@@ -1,0 +1,283 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+HTN UDFs
+========
+
+Pure, total ``@daft.func`` row transforms over the ``Branch`` JSON columns. None
+closes over any non-serializable state — the operator / method spec each needs is
+ALREADY embedded per-node in ``network_json`` by the driver at spawn time (Inv
+HTN-V2.15). No UDF raises on any input, so ``when(...)`` gating selects the right
+branch without partial-failure (a flag column tells effectful UDFs whether to act).
+
+Daft 0.7.x notes:
+  * struct field access is ``col("s")["field"]`` getitem — ``.struct.get()`` was
+    removed in 0.7.0 (LEARNINGS.md:173);
+  * a ``@daft.func`` returning a dict with ``return_dtype=DataType.struct({...})``
+    yields a struct column.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import daft
+from daft import DataType
+
+# Struct returned by ``pick_ready`` — must be a struct (not a JSON string), because the
+# FrontierProcessor reads its fields with ``col(...)[k]`` getitem.
+READY_DTYPE = DataType.struct(
+    {
+        "ready_node_id": DataType.int64(),
+        "ready_kind": DataType.string(),
+        "ready_op_name": DataType.string(),
+        "ready_args_json": DataType.string(),
+        "pre_pos_json": DataType.string(),
+        "pre_neg_json": DataType.string(),
+        "add_json": DataType.string(),
+        "del_json": DataType.string(),
+        "candidate_methods_json": DataType.string(),
+    }
+)
+
+_EMPTY_READY = {
+    "ready_node_id": -1,
+    "ready_kind": "none",
+    "ready_op_name": "",
+    "ready_args_json": "[]",
+    "pre_pos_json": "[]",
+    "pre_neg_json": "[]",
+    "add_json": "[]",
+    "del_json": "[]",
+    "candidate_methods_json": "[]",
+}
+
+
+@daft.func(return_dtype=READY_DTYPE)
+def pick_ready(network_json: str) -> dict:
+    """Pick the min-``order_index`` OPEN node whose ``preds`` are all resolved, and
+    denormalize its op / candidate-method spec. The spec is already embedded per-node
+    (Inv HTN-V2.15) — NO domain object here."""
+    net = json.loads(network_json)
+    resolved = {n["node_id"] for n in net if n["status"] == "resolved"}
+    ready = [n for n in net if n["status"] == "open" and set(n.get("preds", [])) <= resolved]
+    if not ready:
+        return dict(_EMPTY_READY)
+    n = min(ready, key=lambda x: x["order_index"])
+    op = n.get("op") or {}
+    return {
+        "ready_node_id": n["node_id"],
+        "ready_kind": n["kind"],
+        "ready_op_name": n["name"],
+        "ready_args_json": json.dumps(n.get("args", [])),
+        "pre_pos_json": json.dumps(op.get("pre_pos", [])),
+        "pre_neg_json": json.dumps(op.get("pre_neg", [])),
+        "add_json": json.dumps(op.get("add", [])),
+        "del_json": json.dumps(op.get("del", [])),
+        "candidate_methods_json": json.dumps(n.get("candidate_methods", [])),
+    }
+
+
+@daft.func(return_dtype=DataType.bool())
+def precond_holds(atoms_json: str, pre_pos_json: str, pre_neg_json: str) -> bool:
+    """STRIPS applicability: ``pre+ ⊆ atoms ∧ pre- ∩ atoms = ∅``."""
+    atoms = set(json.loads(atoms_json))
+    pre_pos = set(json.loads(pre_pos_json))
+    pre_neg = set(json.loads(pre_neg_json))
+    return pre_pos <= atoms and not (pre_neg & atoms)
+
+
+@daft.func(return_dtype=DataType.string())
+def methods_applicable(atoms_json: str, candidate_methods_json: str) -> str:
+    """Filter the embedded candidate methods to those applicable in CURRENT atoms.
+    Returns the COMPLETE applicable set as a JSON list (Inv HTN-V2.7)."""
+    atoms = set(json.loads(atoms_json))
+    out = [
+        m
+        for m in json.loads(candidate_methods_json)
+        if set(m.get("pre_pos", [])) <= atoms and not (set(m.get("pre_neg", [])) & atoms)
+    ]
+    return json.dumps(out)
+
+
+@daft.func(return_dtype=DataType.bool())
+def json_list_nonempty(json_list: str) -> bool:
+    return len(json.loads(json_list)) > 0
+
+
+@daft.func(return_dtype=DataType.string())
+def state_sig(atoms_json: str) -> str:
+    """Hash of the (already-sorted) ground-atom state. Recorded as the executability
+    witness's ``pre_state_sig`` BEFORE atoms are mutated (Inv HTN-V2.4 / HTN-V2.4a)."""
+    return hashlib.sha256(atoms_json.encode()).hexdigest()[:16]
+
+
+@daft.func(return_dtype=DataType.string())
+def apply_strips(atoms_json: str, add_json: str, del_json: str, apply: bool) -> str:
+    """``gamma(s, a) = (s \\ del) ∪ add`` (delete strictly before add) when ``apply``,
+    else atoms unchanged. Result is re-sorted for a canonical state encoding."""
+    if not apply:
+        return atoms_json
+    atoms = set(json.loads(atoms_json))
+    atoms -= set(json.loads(del_json))
+    atoms |= set(json.loads(add_json))
+    return json.dumps(sorted(atoms))
+
+
+@daft.func(return_dtype=DataType.string())
+def mark_resolved(network_json: str, node_id: int, apply: bool) -> str:
+    """Mark the applied node ``resolved`` in the network when ``apply``, else unchanged."""
+    if not apply:
+        return network_json
+    net = json.loads(network_json)
+    for n in net:
+        if n["node_id"] == node_id:
+            n["status"] = "resolved"
+            break
+    return json.dumps(net)
+
+
+@daft.func(return_dtype=DataType.string())
+def append_plan(
+    plan_json: str,
+    seq: int,
+    op_name: str,
+    args_json: str,
+    pre_sig: str,
+    node_id: int,
+    apply: bool,
+) -> str:
+    """Append the executability-witnessed plan step at application time (Inv HTN-V2.4)."""
+    if not apply:
+        return plan_json
+    plan = json.loads(plan_json)
+    plan.append(
+        {
+            "seq": seq,
+            "op": op_name,
+            "args": json.loads(args_json),
+            "pre_sig": pre_sig,
+            "node_id": node_id,
+        }
+    )
+    return json.dumps(plan)
+
+
+@daft.func(return_dtype=DataType.int64())
+def count_open(network_json: str) -> int:
+    """Authoritative post-Effect open-node count, same row (Inv HTN-V2.4b)."""
+    return sum(1 for n in json.loads(network_json) if n["status"] == "open")
+
+
+# The whole guarded STRIPS application, consolidated into ONE struct-returning UDF.
+#
+# Daft folds a UDF's column arguments to that column's FINAL definition in the plan
+# (verified: a separate `state_sig(atoms_json)` written before `atoms_json` is reassigned
+# reads the POST-mutation atoms, breaking Inv HTN-V2.4a). Splitting the effect across
+# several UDFs that each read `atoms_json`/`plan_json`/`seq_next` and then overwrite them
+# therefore corrupts the witness and the seq. Consolidating into one UDF that reads each
+# input ONCE and returns every result as a struct field is the only aliasing-proof shape:
+# because the output columns are derived FROM this UDF, Daft cannot fold the UDF's own
+# inputs to those outputs (that would be a cycle), so it reads the genuine pre-mutation
+# values. ``EffectProcessor`` then splits the struct back into the Branch columns.
+EFFECT_DTYPE = DataType.struct(
+    {
+        "atoms_json": DataType.string(),
+        "network_json": DataType.string(),
+        "plan_json": DataType.string(),
+        "pre_state_sig": DataType.string(),
+        "seq_next": DataType.int64(),
+        "status": DataType.string(),
+        "fail_reason": DataType.string(),
+        "applicable": DataType.bool(),
+    }
+)
+
+
+@daft.func(return_dtype=EFFECT_DTYPE)
+def apply_effect(
+    atoms_json: str,
+    network_json: str,
+    plan_json: str,
+    seq_next: int,
+    status: str,
+    fail_reason: str,
+    pre_state_sig: str,
+    ready_kind: str,
+    ready_node_id: int,
+    ready_op_name: str,
+    ready_args_json: str,
+    pre_pos_json: str,
+    pre_neg_json: str,
+    add_json: str,
+    del_json: str,
+) -> dict:
+    """Guarded, self-recording STRIPS application for the ready node (Inv HTN-V2.3/2.4).
+
+    Acts ONLY when the branch is live and its ready node is a PRIMITIVE. Re-checks
+    applicability against the CURRENT (pre-mutation) atoms in-row — never trusting a
+    possibly-stale ``applicable`` column. On success: records the witness ``pre_state_sig``
+    from the pre-mutation atoms, appends the plan step (``seq = len(plan)`` — derived, so it
+    cannot drift), applies ``gamma`` (delete-then-add), and marks the node resolved. On a
+    primitive precondition failure: the branch dies ``precond_unsat`` with atoms untouched.
+    Otherwise (compound / no-ready / not-live): a clean pass-through.
+    """
+    unchanged = {
+        "atoms_json": atoms_json,
+        "network_json": network_json,
+        "plan_json": plan_json,
+        "pre_state_sig": pre_state_sig,
+        "seq_next": seq_next,
+        "status": status,
+        "fail_reason": fail_reason,
+        "applicable": False,
+    }
+    if ready_kind != "primitive" or status != "live":
+        return unchanged
+
+    atoms = set(json.loads(atoms_json))
+    pre_pos = set(json.loads(pre_pos_json))
+    pre_neg = set(json.loads(pre_neg_json))
+    if not (pre_pos <= atoms and not (pre_neg & atoms)):
+        return {**unchanged, "status": "failed", "fail_reason": "precond_unsat"}
+
+    pre_sig = hashlib.sha256(atoms_json.encode()).hexdigest()[:16]
+    plan = json.loads(plan_json)
+    seq = len(plan)  # derived from the append-only plan — monotone by construction
+    plan.append(
+        {
+            "seq": seq,
+            "op": ready_op_name,
+            "args": json.loads(ready_args_json),
+            "pre_sig": pre_sig,
+            "node_id": ready_node_id,
+        }
+    )
+    new_atoms = sorted((atoms - set(json.loads(del_json))) | set(json.loads(add_json)))
+    net = json.loads(network_json)
+    for n in net:
+        if n["node_id"] == ready_node_id:
+            n["status"] = "resolved"
+            break
+    return {
+        "atoms_json": json.dumps(new_atoms),
+        "network_json": json.dumps(net),
+        "plan_json": json.dumps(plan),
+        "pre_state_sig": pre_sig,
+        "seq_next": seq + 1,
+        "status": status,
+        "fail_reason": fail_reason,
+        "applicable": True,
+    }
+
+
+@daft.func(return_dtype=DataType.string())
+def frontier_sig(atoms_json: str, network_json: str) -> str:
+    """Memo key encoding BOTH state AND remaining task network (Inv HTN-V2.12) — a
+    state-only key would silently prune an applicable continuation with a distinct
+    remaining network, violating completeness."""
+    net = json.loads(network_json)
+    rem = sorted((n["name"], json.dumps(n.get("args", []))) for n in net if n["status"] == "open")
+    return hashlib.sha256((atoms_json + "||" + json.dumps(rem)).encode()).hexdigest()[:16]

--- a/tests/htn/test_htn_contract.py
+++ b/tests/htn/test_htn_contract.py
@@ -1,0 +1,235 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for the HTN fan-out plan-resolution pattern.
+
+Each test pins a numbered invariant from ``.context/htn/PATTERN.md``. The end-to-end
+tests drive the real ``examples/08_htn_resolution.py`` driver through a live Archetype
+world and then independently REPLAY the extracted plans against the domain operators —
+the strongest check that resolution is sound (executable by construction, Inv HTN-V2.4).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# The runtime auto-configures Logfire; keep it offline and non-interactive in tests.
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.htn import (  # noqa: E402
+    HtnDomain,
+    MethodSpec,
+    OperatorSpec,
+    build_initial_network,
+    htn_processors,
+    splice_method,
+    udfs,  # noqa: E402
+)
+
+# Load the example driver directly — examples/ isn't a package on sys.path.
+_EXAMPLE = Path(__file__).resolve().parents[2] / "examples" / "08_htn_resolution.py"
+_spec = importlib.util.spec_from_file_location("htn_example", _EXAMPLE)
+htn_example = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = htn_example
+_spec.loader.exec_module(htn_example)
+
+resolve_htn = htn_example.resolve_htn
+resolve_issue_domain = htn_example.resolve_issue_domain
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _run(domain, s0, tn0, tmp_path, **kw) -> dict:
+    """Resolve in a fresh, isolated runtime/world and return the driver result."""
+
+    async def _go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "htn-test",
+                storage=StorageConfig(uri=str(tmp_path), namespace="htn_test"),
+                processors=htn_processors(),
+            )
+            return await resolve_htn(world, domain, s0, tn0, verbose=False, **kw)
+
+    return asyncio.run(_go())
+
+
+def _replay(domain: HtnDomain, s0: list[str], plan: list[dict]) -> set[str]:
+    """Independently execute a plan from s0, re-checking STRIPS applicability at every
+    step. Raises if any operator is applied to a state where its precondition fails —
+    so a passing replay witnesses executability-by-construction (Inv HTN-V2.4.1/4.3)."""
+    s = set(s0)
+    for step in sorted(plan, key=lambda x: x["seq"]):
+        op = domain.operators[step["op"]]
+        g = op.ground(step["args"])
+        assert set(g["pre_pos"]) <= s, f"{step['op']} pre+ not in state {sorted(s)}"
+        assert not (set(g["pre_neg"]) & s), f"{step['op']} pre- intersects state {sorted(s)}"
+        s = (s - set(g["del"])) | set(g["add"])
+    return s
+
+
+# ── pure UDF unit tests ─────────────────────────────────────────────────────
+
+
+class TestUDFs:
+    def test_precond_holds_strips(self):
+        import daft
+        from daft import col
+
+        df = daft.from_pydict(
+            {"a": [json.dumps(["x", "y"])], "pp": [json.dumps(["x"])], "pn": [json.dumps(["z"])]}
+        )
+        out = (
+            df.with_column("ok", udfs.precond_holds(col("a"), col("pp"), col("pn")))
+            .collect()
+            .to_pydict()
+        )
+        assert out["ok"][0] is True
+        # pre- now intersects -> not applicable
+        df2 = daft.from_pydict(
+            {"a": [json.dumps(["x", "z"])], "pp": [json.dumps(["x"])], "pn": [json.dumps(["z"])]}
+        )
+        out2 = (
+            df2.with_column("ok", udfs.precond_holds(col("a"), col("pp"), col("pn")))
+            .collect()
+            .to_pydict()
+        )
+        assert out2["ok"][0] is False
+
+    def test_apply_strips_delete_then_add(self):
+        import daft
+        from daft import col, lit
+
+        # delete-then-add: an atom in both del and add survives (add wins).
+        df = daft.from_pydict(
+            {
+                "a": [json.dumps(["p", "q"])],
+                "add": [json.dumps(["q", "r"])],
+                "del": [json.dumps(["q"])],
+            }
+        )
+        out = (
+            df.with_column("s", udfs.apply_strips(col("a"), col("add"), col("del"), lit(True)))
+            .collect()
+            .to_pydict()
+        )
+        assert json.loads(out["s"][0]) == ["p", "q", "r"]
+        # apply=False leaves atoms untouched
+        out2 = (
+            df.with_column("s", udfs.apply_strips(col("a"), col("add"), col("del"), lit(False)))
+            .collect()
+            .to_pydict()
+        )
+        assert json.loads(out2["s"][0]) == ["p", "q"]
+
+    def test_frontier_sig_encodes_network_not_just_state(self):
+        """Inv HTN-V2.12: the memo key must distinguish two branches with identical
+        state but different remaining task networks."""
+        import daft
+        from daft import col
+
+        atoms = json.dumps(["x"])
+        net_a = json.dumps([{"node_id": 0, "name": "a", "args": [], "status": "open"}])
+        net_b = json.dumps([{"node_id": 0, "name": "b", "args": [], "status": "open"}])
+        df = daft.from_pydict({"a": [atoms, atoms], "n": [net_a, net_b]})
+        sigs = (
+            df.with_column("sig", udfs.frontier_sig(col("a"), col("n")))
+            .collect()
+            .to_pydict()["sig"]
+        )
+        assert sigs[0] != sigs[1]
+
+
+# ── domain build / decomposition ─────────────────────────────────────────────
+
+
+class TestDomain:
+    def test_splice_resolves_compound_and_chains_subtasks(self):
+        """Inv HTN-V2.13: splice marks the compound resolved, inserts subtasks chained
+        in total order, and renumbers order_index topologically."""
+        dom = resolve_issue_domain()
+        net0 = build_initial_network(dom, [("resolve_issue", [])])
+        net1 = splice_method(dom, net0, 0, "resolve_issue#0")
+        by_name = {n["name"]: n for n in net1}
+        assert by_name["resolve_issue"]["status"] == "resolved"
+        assert by_name["resolve_issue"]["chosen_method"] == "resolve_issue#0"
+        for name in ("understand", "fix", "verify", "ship"):
+            assert by_name[name]["status"] == "open"
+        # total-order chain: each later subtask depends on the previous
+        assert by_name["fix"]["preds"] == [by_name["understand"]["node_id"]]
+        assert by_name["ship"]["preds"] == [by_name["verify"]["node_id"]]
+        # order_index is a dense topological rank
+        idxs = sorted(n["order_index"] for n in net1)
+        assert idxs == list(range(len(net1)))
+
+    def test_compound_embeds_candidate_methods(self):
+        dom = resolve_issue_domain()
+        net = build_initial_network(dom, [("resolve_issue", [])])
+        # the fix node (after splicing resolve) carries BOTH rival methods
+        net = splice_method(dom, net, 0, "resolve_issue#0")
+        fix = next(n for n in net if n["name"] == "fix")
+        ids = {m["id"] for m in fix["candidate_methods"]}
+        assert ids == {"fix#test_driven", "fix#direct"}
+
+
+# ── end-to-end resolution ────────────────────────────────────────────────────
+
+
+class TestResolution:
+    def test_fanout_produces_two_executable_plans(self, tmp_path):
+        """Inv HTN-V2.7 (OR completeness) + Inv HTN-V2.4.1 (executability)."""
+        dom = resolve_issue_domain()
+        res = _run(dom, ["issue_open"], [("resolve_issue", [])], tmp_path, max_depth=32)
+        sols = res["solutions"]
+        assert len(sols) == 2, f"expected 2 fan-out solutions, got {len(sols)}"
+
+        # the two solutions use the two rival fix methods
+        op_sets = [{s["op"] for s in sol["plan"]} for sol in sols]
+        assert any("write_failing_test" in ops and "edit_code" in ops for ops in op_sets)
+        assert any("edit_code_direct" in ops for ops in op_sets)
+
+        # every extracted plan REPLAYS from s0 and reaches the goal (soundness)
+        for sol in sols:
+            final = _replay(dom, ["issue_open"], sol["plan"])
+            assert "pr_open" in final
+            # seq is strictly monotone (Inv HTN-V2.4.4)
+            seqs = [s["seq"] for s in sorted(sol["plan"], key=lambda x: x["seq"])]
+            assert seqs == list(range(len(seqs)))
+
+    def test_stop_on_first_returns_one(self, tmp_path):
+        dom = resolve_issue_domain()
+        res = _run(
+            dom, ["issue_open"], [("resolve_issue", [])], tmp_path, max_depth=32, stop_on_first=True
+        )
+        assert len(res["solutions"]) >= 1
+
+    def test_no_applicable_method_fails_cleanly(self, tmp_path):
+        """Inv HTN-V2.3 / guarded gamma: when a method decomposes to a primitive whose
+        precondition can never hold, that branch fails precond_unsat and produces NO
+        solution — it never fabricates an unexecutable plan."""
+        dom = HtnDomain.of(
+            operators=[OperatorSpec("impossible", pre_pos=("never_true",), add=("done",))],
+            methods=[MethodSpec("goal", "goal#0", subtasks=(("impossible", ()),))],
+        )
+        res = _run(dom, [], [("goal", [])], tmp_path, max_depth=8)
+        assert res["solutions"] == []
+
+    def test_depth_cap_terminates_left_recursion(self, tmp_path):
+        """Inv HTN-V2.11: a left-recursive method must NOT hang — the mandatory depth
+        cap forces termination with zero solutions rather than diverging."""
+        # count -> [tick, count] : unbounded recursion guarded only by the depth cap.
+        dom = HtnDomain.of(
+            operators=[OperatorSpec("tick", add=("ticked",))],
+            methods=[MethodSpec("count", "count#0", subtasks=(("tick", ()), ("count", ())))],
+        )
+        res = _run(dom, [], [("count", [])], tmp_path, max_depth=5, max_ticks=200)
+        assert res["solutions"] == []  # never solves, but terminates


### PR DESCRIPTION
## What

Hierarchical Task Network (HTN) plan resolution as a formal, fan-out ECS pattern in Archetype.

Every branch of the AND/OR decomposition is **one row of one `(Branch,)` archetype**, co-locating its STRIPS state, remaining task network, ready op-spec, and accumulated plan. A priority-ordered processor chain — `Frontier(10) → Applicability(20) → Effect(30) → Termination(40)` — evaluates preconditions and applies STRIPS effects **same-tick, same-row**, so SHOP "state-known-at-precondition-time" holds *by construction* (no cross-archetype staleness). A structural-only driver does the one between-tick step: **OR fan-out** via `world.spawn` (copy-on-write `plan_id` multiplication), retiring each expanded parent to `superseded`.

**Two fan-out axes:** vectorized *across branches* in one pass per tick (AXIS 1) + structural OR-spawn per applicable method (AXIS 2). `fork()` is an opt-in isolated-branch mode, not the spine.

## Files
- `src/archetype/htn/` — `components.py`, `domain.py`, `udfs.py`, `processors.py` (pure `df→df`, lazy-audit clean)
- `examples/08_htn_resolution.py` — structural driver + dogfood "resolve a software issue" HTN (`fix` has rival methods → fans out into 2 executable plans)
- `tests/htn/test_htn_contract.py` — 9 contract tests pinned to invariants, incl. an **independent executability replay** (re-runs each extracted plan from s0)
- `LEARNINGS.md` — documents a Daft 0.7.x UDF column-arg aliasing footgun + the consolidated-UDF fix

## Verification
- 9/9 HTN contract tests pass; full suite **569 passed**, zero regressions
- `ruff check`/`format`, lazy-audit, api-boundary audit clean for new code
- Example resolves the dogfood HTN into 2 distinct executable plans, queryable via `query(Branch, Solved)`

Design + two rounds of adversarial review in `.context/htn/PATTERN.md` (17 numbered invariants `Inv HTN-V2.x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)