### PR TITLE
chore: fix ruff 0.15.10 lint violations on main (greens CI fleet-wide)

### DIFF
--- a/tests/app/test_import_boundaries.py
+++ b/tests/app/test_import_boundaries.py
@@ -14,7 +14,6 @@ import ast
 import typing
 from pathlib import Path
 
-
 _ROOT = Path(__file__).resolve().parents[2] / "src" / "archetype"
 _RUNTIME_DIR = _ROOT / "runtime"
 _API_DIR = _ROOT / "api"
@@ -137,7 +136,7 @@ class TestRuntimeAppBoundary:
     def test_runtime_imports_only_allowed_app_modules(self):
         violations: list[str] = []
         for py in _python_files(_RUNTIME_DIR):
-            for module, lineno, in_tc in _extract_app_imports(py):
+            for module, lineno, _in_tc in _extract_app_imports(py):
                 if module not in _RUNTIME_ALLOWED_APP:
                     rel = py.relative_to(_ROOT)
                     violations.append(f"{rel}:{lineno}  imports {module}")
@@ -153,7 +152,7 @@ class TestApiAppBoundary:
     def test_api_imports_only_allowed_app_modules(self):
         violations: list[str] = []
         for py in _python_files(_API_DIR):
-            for module, lineno, in_tc in _extract_app_imports(py):
+            for module, lineno, _in_tc in _extract_app_imports(py):
                 if module not in _API_ALLOWED_APP:
                     rel = py.relative_to(_ROOT)
                     violations.append(f"{rel}:{lineno}  imports {module}")

--- a/tests/app/test_old_role_cleanup.py
+++ b/tests/app/test_old_role_cleanup.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-
 _PROJECT = Path(__file__).resolve().parents[2]
 _SEARCH_DIRS = [_PROJECT / "src", _PROJECT / "tests", _PROJECT / "examples"]
 

--- a/tests/integration/test_fork_destroy_contracts.py
+++ b/tests/integration/test_fork_destroy_contracts.py
@@ -23,7 +23,6 @@ from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 from archetype.core.hooks import PostTick
 
-
 # ---------------------------------------------------------------------------
 # Test component
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
`make lint` (`ruff check src tests`) has been **failing on `main`** since the ruff 0.15.10 bump — 5 violations in test files:
- `I001` (unsorted import block) ×3
- `B007` (unused loop control variable `in_tc`) ×2

This reds out `ci (3.12)` on `main` itself (red since 2026-04-30) and is **inherited by every open PR**, which is why the whole PR fleet shows a red `ci (3.12)`. There are no *required* checks, so it didn't block merges — but it masks real signal.

## What
- `ruff check --fix` sorts the three import blocks
- rename the unused loop var `in_tc` → `_in_tc` (2 sites)

No logic changes. `ruff check`, `ruff format --check`, and the affected tests all pass. Merging this greens `main` and unblocks green CI across the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)