### PR TITLE
fix: Logfire degradation, fork lineage with persisted provenance, real autoresearch results

### DIFF
--- a/.claude/skills/footgun-detector/SKILL.md
+++ b/.claude/skills/footgun-detector/SKILL.md
@@ -60,7 +60,7 @@ Boolean or filter columns that AND onto existing state instead of recomputing fr
 Sharing a `ServiceContainer`, `CommandBroker`, `Resources`, or other stateful object between a parent world and its fork. Forks must get independent copies. Double-shutdown, cross-world mutation, and state leakage are the consequences.
 
 #### Store vs live reads
-Querying the persistent store (LanceDB) when `_live` / `get_components()` has the correct in-memory data. After `fork_world`, the fork's state is in memory — the store may have stale or empty data for the fork's world_id.
+Querying the persistent store (LanceDB) when `_live` / `get_components()` has the correct in-memory data. After `fork_world`, pre-fork ticks resolve through the fork's `lineage` (ancestor world/run segments) — but only on lineage-aware paths (`AsyncWorld.query_archetype` / `get_components`, gated `QueryService` reads). Raw store queries by the fork's `(world_id, run_id)` alone still miss pre-fork history.
 
 #### Governance bypass
 Mutating world state (spawn, despawn, modify entities) without going through `CommandService.submit()` / `CommandBroker`. Direct mutations skip RBAC checks, audit history, and serialized writes.

--- a/docs/guide/audit-log.md
+++ b/docs/guide/audit-log.md
@@ -67,4 +67,3 @@ Payment-bearing fields are nullable:
 - `limit`
 
 External callers do not call `iAuditLog` directly. They use `iCommandService.get_audit_history(ctx, ...)`, which applies the read permission check before delegating.
-

--- a/docs/guide/execution-hierarchy.md
+++ b/docs/guide/execution-hierarchy.md
@@ -5,7 +5,7 @@
 
 ## 1. The four execution levels
 
-```
+```text
 Rollout      = N episodes, each in a fork of a base world.
                Lives at iSimulationService. Forks via iWorldService directly.
                Audit unit: the rollout call (one row at the gate).
@@ -78,7 +78,7 @@ async def run_episode(world_id, config: EpisodeConfig, **kw) -> EpisodeResult: .
 
 The implementation:
 
-```
+```text
 - resolve world via iWorldService.get_world
 - start_tick = world.tick
 - step_count = 0
@@ -135,7 +135,7 @@ async def run_rollout(world_id, config: RolloutConfig, **kw) -> RolloutResult: .
 
 The implementation:
 
-```
+```text
 - base = await iWorldService.get_world(world_id)
 - async def _one(i: int) -> EpisodeResult:
     fork = await self._world_service.fork_world(

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -86,7 +86,7 @@ The first ergonomic call on a `RuntimeWorld` triggers world creation. Concurrent
 
 Activation flow at the runtime layer:
 
-```
+```text
 1. Build WorldConfig (serializable identity only).
 2. command_service.create_world(ctx, config, storage, cache) -> WorldInfo
 3. For each init_processor: command_service.add_processor(ctx, world_id, proc)
@@ -211,7 +211,7 @@ Distinct user intents → distinct methods.
 
 ## 5. Module layout
 
-```
+```text
 src/archetype/runtime/
 ├── __init__.py        public exports
 ├── runtime.py         ArchetypeRuntime, SyncArchetypeRuntime, run_sync

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -11,7 +11,7 @@ The gate (`iCommandService`) sits in front of the other services and applies aut
 
 ## 2. Service dependency graph
 
-```
+```text
 iStorageService                                                   (leaf)
     ↑             ↑                              ↑
 iWorldService     iQueryService           iAuditLog               (storage)

--- a/docs/guide/world-lifecycle.md
+++ b/docs/guide/world-lifecycle.md
@@ -43,7 +43,7 @@ async def create_world(
 ) -> WorldInfo: ...
 ```
 
-`WorldConfig` is serializable: `world_id`, `run_id`, `name`, `tick`, `next_entity_id`, plus dictionaries for `entity2sig`, `spawn_cache`, `despawn_cache`. NOTHING ELSE.
+`WorldConfig` is serializable: `world_id`, `run_id`, `name`, `tick`, `next_entity_id`, dictionaries for `entity2sig`, `spawn_cache`, `despawn_cache`, plus `lineage` (fork ancestry read segments, see §4.6). NOTHING ELSE.
 
 Processors, resources, and hooks are arbitrary Python objects; they do NOT go in `WorldConfig`. The runtime wires them at activation through dedicated gated paths:
 
@@ -104,7 +104,22 @@ For users who want isolated resources per fork, they instantiate new resource in
 
 The fork writes to the same physical store as the source by default, with rows partitioned by `world_id`. The optional `storage_config` argument allows the fork to write to a different store entirely.
 
-### 4.6 — Audit emission
+### 4.6 — Read lineage (copy-on-write history)
+
+A fork does not copy the source's materialized rows. Instead it carries a `lineage` — an ascending list of `(world_id, run_id, up_to_tick)` segments: the source's own lineage plus, if the source has stepped, one segment covering the source's rows for ticks `0..tick-1`.
+
+Reads resolve per tick: a tick at or below a segment's `up_to_tick` reads from that ancestor's run; later ticks read from the fork's own run. Because the store is append-only, ancestor rows are immutable history — a parent that keeps running (or is destroyed) after the fork never affects the fork's view, and rows the parent writes after the fork point are excluded from the fork's history.
+
+Consequences:
+
+- Forking stays O(metadata) regardless of world size.
+- A fork of a stepped world is immediately queryable, and its first step processes the parent's last tick as input — state continues across the fork point.
+- Lineage flattens across generations: a fork of a fork reads base history, mid-fork history, and its own rows through one segment list.
+- Lineage lives on the in-memory world (`WorldConfig.lineage`). Once a fork is no longer live, only its own rows remain reachable by `(world_id, run_id)`; ancestry resolution requires the live world object.
+
+Contract tests: `tests/integration/test_fork_destroy_contracts.py` (§8, fork lineage).
+
+### 4.7 — Audit emission
 
 `iCommandService.fork_world` emits one audit row with:
 

--- a/docs/guide/world-lifecycle.md
+++ b/docs/guide/world-lifecycle.md
@@ -115,9 +115,9 @@ Consequences:
 - Forking stays O(metadata) regardless of world size.
 - A fork of a stepped world is immediately queryable, and its first step processes the parent's last tick as input — state continues across the fork point.
 - Lineage flattens across generations: a fork of a fork reads base history, mid-fork history, and its own rows through one segment list.
-- Lineage lives on the in-memory world (`WorldConfig.lineage`). Once a fork is no longer live, only its own rows remain reachable by `(world_id, run_id)`; ancestry resolution requires the live world object.
+- Lineage is durable. At fork time the full ancestor chain is appended to the store as `WorldLineage` rows under the fork's `(world_id, run_id)` (negative entity ids — metadata, never live entities). The store is append-only, so provenance is never compromised: gated reads resolve ancestry for destroyed worlds by loading the persisted chain (`QueryService.get_lineage`). Live worlds resolve from memory; the persisted rows are the fallback and the system of record.
 
-Contract tests: `tests/integration/test_fork_destroy_contracts.py` (§8, fork lineage).
+Contract tests: `tests/integration/test_fork_destroy_contracts.py` (§8 fork lineage, §9 persisted lineage / dead-world ancestry).
 
 ### 4.7 — Audit emission
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -442,16 +442,7 @@ Run one episode. Requires operator or admin.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `episode_id` | string \| string | No | — | Episode Id |
-| `run_config` | object | No | — | A run represents the configuration of a sequence of world.steps, and configures the runtime options for the world.
-
-Carries configuration for the run, including:
-  - run_id: UUID - The unique identifier for the run sequence, a uuid7
-  - num_steps: int - The number of steps to execute in the run sequence
-  - debug: bool - Whether or not to enable debug mode
-  - validate: bool - Whether or not to enable validation mode
-
-TODO: Add ergonomic named constructors, e.g. RunConfig.dev(steps=1, debug=True)
-      and RunConfig.benchmark(steps, explain=False) to reduce call-site verbosity. |
+| `run_config` | object | No | — | A run represents the configuration of a sequence of world.steps, and configures the runtime options for the world. Carries configuration for the run, including: - run_id: UUID - The unique identifier for the run sequence, a uuid7 - num_steps: int - The number of steps to execute in the run sequence - debug: bool - Whether or not to enable debug mode - validate: bool - Whether or not to enable validation mode TODO: Add ergonomic named constructors, e.g. RunConfig.dev(steps=1, debug=True) and RunConfig.benchmark(steps, explain=False) to reduce call-site verbosity. |
 | `max_steps` | integer | No | `1000` | Max Steps |
 | `terminal_component` | any \| null | No | — | Terminal Component |
 | `termination` | any \| null | No | — | Termination |
@@ -607,8 +598,8 @@ Create a world. Requires admin.
 | `storage_config` | StorageConfig \| null | No | — |  |
 | `cache_config` | CacheConfig \| null | No | — |  |
 | `name` | string \| null | No | — | Name |
-| `storage_uri` | string | No | `"./archetype_data"` | Storage Uri |
-| `namespace` | string | No | `"archetypes"` | Namespace |
+| `storage_uri` | string | No | `"./archetype_db"` | Storage Uri |
+| `namespace` | string | No | `"ecs"` | Namespace |
 
 **Response** (`201`):
 

--- a/experiments/cooperative_emergence.py
+++ b/experiments/cooperative_emergence.py
@@ -206,6 +206,28 @@ async def main():
     print()
 
     async with ArchetypeRuntime() as rt:
+        # Create the base world with processors
+        world = rt.world(
+            "commons",
+            processors=[HarvestProcessor(), RegrowthProcessor(), DepletionProcessor()],
+        )
+
+        # Seed: 4 cooperative + 3 greedy agents + 1 pool
+        for _ in range(4):
+            await world.spawn(Strategy(type="cooperative", energy=100.0))
+        for _ in range(3):
+            await world.spawn(Strategy(type="greedy", energy=100.0))
+        pool_id = await world.spawn(Pool(current=1000.0, capacity=1000.0, regen_rate=0.05))
+        # Hooks registered before forking are deep-copied onto every fork,
+        # including the per-episode forks created by run_rollout.
+        await world.add_hook(PostTick, detect_collapse)
+        await world.step()  # materialize the seed state
+
+        info = await world.info()
+        print(f"Base world: {info.world_id}")
+        print("  4 cooperative + 3 greedy agents, pool=1000")
+        print()
+
         # ── Parameter Sweep ───────────────────────────────────────────────
 
         regen_rates = [0.01, 0.03, 0.05, 0.10, 0.20]
@@ -214,29 +236,19 @@ async def main():
 
         print(f"Sweeping {len(regen_rates)} regen rates × {episodes_per_point} episodes each")
         print(f"Max steps per episode: {max_steps}")
-        print("Seed per point: 4 cooperative + 3 greedy agents, pool=1000")
         print()
 
         svc = rt._container.autoresearch_service
         results: dict[float, float] = {}
 
         for regen in regen_rates:
-            # One UNSTEPPED base world per parameter point. The fork
-            # contract transfers pending spawn_cache (not materialized
-            # rows), so episode forks only inherit the seed entities if
-            # the base never steps before run_rollout forks from it.
-            world = rt.world(
-                f"commons-regen-{regen}",
-                processors=[HarvestProcessor(), RegrowthProcessor(), DepletionProcessor()],
-            )
-            for _ in range(4):
-                await world.spawn(Strategy(type="cooperative", energy=100.0))
-            for _ in range(3):
-                await world.spawn(Strategy(type="greedy", energy=100.0))
-            await world.spawn(Pool(current=1000.0, capacity=1000.0, regen_rate=regen))
-            # Hooks registered before forking are deep-copied onto every
-            # episode fork created by run_rollout.
-            await world.add_hook(PostTick, detect_collapse)
+            # Fork the base for this parameter point. Fork lineage makes
+            # the parent's materialized rows readable from the fork, so
+            # the update below finds its prior row and episode forks see
+            # the full seed state.
+            fork = await world.fork(f"regen-{regen}")
+            await fork.update(pool_id, Pool(current=1000.0, capacity=1000.0, regen_rate=regen))
+            await fork.step()  # materialize the regen update before episodes fork
 
             config = AutoResearchConfig(
                 experiment_name=f"commons-regen-{regen}",
@@ -250,9 +262,9 @@ async def main():
                 destroy_forks_on_complete=True,
             )
 
-            info = await world.info()
+            fork_info = await fork.info()
             result = await svc.run(
-                info.world_id,
+                fork_info.world_id,
                 config,
                 make_cooperation_score(max_steps),
             )

--- a/experiments/cooperative_emergence.py
+++ b/experiments/cooperative_emergence.py
@@ -25,6 +25,7 @@ from archetype import ArchetypeRuntime, AsyncProcessor, Component
 from archetype.app.autoresearch_service import AutoResearchConfig
 from archetype.app.models import EpisodeConfig, RolloutResult
 from archetype.core.config import RunConfig
+from archetype.core.hooks import PostTick
 
 
 # ── Components ────────────────────────────────────────────────────────────
@@ -141,6 +142,29 @@ class DepletionProcessor(AsyncProcessor):
         )
 
 
+# ── Termination ───────────────────────────────────────────────────────────
+
+# World ids whose pool has hit zero. The PostTick hook below is registered
+# on the base world and carried onto every fork (fork deep-copies the hook
+# registry), so episode forks report collapse here under their own world_id.
+_collapsed_worlds: set[str] = set()
+
+
+async def detect_collapse(event: PostTick) -> None:
+    """Flag the world as collapsed once its pool reaches zero."""
+    for df in event.results.values():
+        if "pool__current" not in df.column_names:
+            continue
+        values = df.to_pydict().get("pool__current", [])
+        if any(v is not None and v <= 0.0 for v in values):
+            _collapsed_worlds.add(str(event.world_id))
+
+
+def pool_collapsed(world) -> bool:
+    """EpisodeConfig.termination predicate — must be synchronous."""
+    return str(world.world_id) in _collapsed_worlds
+
+
 # ── Evaluator ─────────────────────────────────────────────────────────────
 
 
@@ -152,18 +176,24 @@ def survival_rate(result: RolloutResult) -> float:
     return survived / len(result.episodes)
 
 
-def cooperation_score(result: RolloutResult) -> float:
+def make_cooperation_score(max_steps: int):
     """Score = average episode duration / max_steps.
 
     Longer episodes mean the commons sustained longer.
     1.0 = all episodes ran to max_steps (sustainable).
     0.0 = all episodes collapsed immediately.
+
+    Normalizes by the configured step budget, not the longest observed
+    episode — otherwise uniform collapse scores a perfect 1.0.
     """
-    if not result.episodes:
-        return 0.0
-    max_steps = max(ep.duration_steps for ep in result.episodes) or 1
-    avg_duration = sum(ep.duration_steps for ep in result.episodes) / len(result.episodes)
-    return avg_duration / max_steps
+
+    def cooperation_score(result: RolloutResult) -> float:
+        if not result.episodes:
+            return 0.0
+        avg_duration = sum(ep.duration_steps for ep in result.episodes) / len(result.episodes)
+        return avg_duration / max_steps
+
+    return cooperation_score
 
 
 # ── Main ──────────────────────────────────────────────────────────────────
@@ -176,25 +206,6 @@ async def main():
     print()
 
     async with ArchetypeRuntime() as rt:
-        # Create the base world with processors
-        world = rt.world(
-            "commons",
-            processors=[HarvestProcessor(), RegrowthProcessor(), DepletionProcessor()],
-        )
-
-        # Seed: 4 cooperative + 3 greedy agents + 1 pool
-        for _ in range(4):
-            await world.spawn(Strategy(type="cooperative", energy=100.0))
-        for _ in range(3):
-            await world.spawn(Strategy(type="greedy", energy=100.0))
-        await world.spawn(Pool(current=1000.0, capacity=1000.0, regen_rate=0.05))
-        await world.step()  # materialize the seed state
-
-        info = await world.info()
-        print(f"Base world: {info.world_id}")
-        print(f"  4 cooperative + 3 greedy agents, pool=1000")
-        print()
-
         # ── Parameter Sweep ───────────────────────────────────────────────
 
         regen_rates = [0.01, 0.03, 0.05, 0.10, 0.20]
@@ -203,30 +214,47 @@ async def main():
 
         print(f"Sweeping {len(regen_rates)} regen rates × {episodes_per_point} episodes each")
         print(f"Max steps per episode: {max_steps}")
+        print("Seed per point: 4 cooperative + 3 greedy agents, pool=1000")
         print()
 
         svc = rt._container.autoresearch_service
         results: dict[float, float] = {}
 
         for regen in regen_rates:
-            # Fork the base world for this parameter point
-            fork = await world.fork(f"regen-{regen}")
+            # One UNSTEPPED base world per parameter point. The fork
+            # contract transfers pending spawn_cache (not materialized
+            # rows), so episode forks only inherit the seed entities if
+            # the base never steps before run_rollout forks from it.
+            world = rt.world(
+                f"commons-regen-{regen}",
+                processors=[HarvestProcessor(), RegrowthProcessor(), DepletionProcessor()],
+            )
+            for _ in range(4):
+                await world.spawn(Strategy(type="cooperative", energy=100.0))
+            for _ in range(3):
+                await world.spawn(Strategy(type="greedy", energy=100.0))
+            await world.spawn(Pool(current=1000.0, capacity=1000.0, regen_rate=regen))
+            # Hooks registered before forking are deep-copied onto every
+            # episode fork created by run_rollout.
+            await world.add_hook(PostTick, detect_collapse)
 
             config = AutoResearchConfig(
                 experiment_name=f"commons-regen-{regen}",
                 episode_config=EpisodeConfig(
                     run_config=RunConfig(),
                     max_steps=max_steps,
+                    termination=pool_collapsed,
                 ),
                 num_episodes=episodes_per_point,
                 max_iterations=1,  # single iteration per param point
                 destroy_forks_on_complete=True,
             )
 
+            info = await world.info()
             result = await svc.run(
-                fork.world_id,
+                info.world_id,
                 config,
-                cooperation_score,
+                make_cooperation_score(max_steps),
             )
 
             score = result.final_score

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -54,3 +54,9 @@ path = "src/archetype/core/sync/world.py"
 line = 243
 method = "to_pylist"
 reason = "Cross-archetype entity migration (sync mirror of async_world): extract the latest tick row for component overlay before re-insertion."
+
+[[entries]]
+path = "src/archetype/core/lineage.py"
+line = 94
+method = "to_pylist"
+reason = "Lineage metadata extract: a fork's ancestor segments (bounded by fork depth, typically 1-3 rows) must become Python (world_id, run_id, up_to_tick) tuples because they route subsequent per-tick store queries; the routing decision cannot be expressed inside a single Daft plan."

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -33,7 +33,7 @@ reason = "Storage write boundary: defensive empty-frame probe before delegating 
 
 [[entries]]
 path = "src/archetype/core/aio/async_world.py"
-line = 257
+line = 262
 method = "to_pylist"
 reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
 

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -80,11 +80,17 @@ def schema_to_table(schema: dict[str, Any], root: dict[str, Any], indent: int = 
             default = "`null`"
         elif default != "—":
             default = f"`{json.dumps(default)}`"
-        desc = prop.get("description", prop.get("title", ""))
+        desc = _table_cell(prop.get("description", prop.get("title", "")))
         prefix = "&nbsp;" * (indent * 4)
         lines.append(f"| {prefix}`{name}` | {typ} | {req} | {default} | {desc} |")
 
     return lines
+
+
+def _table_cell(text: str) -> str:
+    """Flatten text for a Markdown table cell: collapse newlines/whitespace
+    and escape pipes so multi-line docstrings cannot break the table."""
+    return " ".join(str(text).split()).replace("|", "\\|")
 
 
 def _type_label(prop: dict[str, Any], root: dict[str, Any]) -> str:
@@ -145,7 +151,7 @@ def render_operation(
         for p in path_params:
             schema = p.get("schema", {})
             typ = _type_label(schema, root) if schema else "string"
-            desc = p.get("description", "")
+            desc = _table_cell(p.get("description", ""))
             lines.append(f"| `{p['name']}` | {typ} | {desc} |")
         lines.append("")
 
@@ -160,7 +166,7 @@ def render_operation(
             default = schema.get("default", "—")
             if default != "—":
                 default = f"`{json.dumps(default)}`"
-            desc = p.get("description", "")
+            desc = _table_cell(p.get("description", ""))
             lines.append(f"| `{p['name']}` | {typ} | {default} | {desc} |")
         lines.append("")
 

--- a/src/archetype/api/app.py
+++ b/src/archetype/api/app.py
@@ -8,11 +8,17 @@ from logging import basicConfig
 
 import logfire
 from fastapi import FastAPI
+from logfire.exceptions import LogfireConfigError
 
 from archetype.api.deps import get_container, set_container
 from archetype.api.routes import commands, entities, query, simulation, worlds
 
-logfire.configure(service_name="archetype-ecs")
+try:
+    logfire.configure(service_name="archetype-ecs")
+except LogfireConfigError:
+    # No Logfire credentials on this machine — degrade to local-only
+    # instrumentation instead of refusing to import.
+    logfire.configure(service_name="archetype-ecs", send_to_logfire=False)
 basicConfig(handlers=[logfire.LogfireLoggingHandler()])
 
 

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -384,23 +384,30 @@ class CommandService:
             storage_config=storage_config,
             ticks=ticks,
             entity_ids=entity_ids,
-            lineage=self._live_lineage(world_id),
+            lineage=await self._resolve_lineage(world_id, run_id, storage_config),
         )
         await self._emit(ctx, "query_world", world_id)
         return result
 
-    def _live_lineage(self, world_id: str) -> list[tuple[str, str, int]] | None:
-        """Fork ancestry for a live world, so reads cover pre-fork ticks.
+    async def _resolve_lineage(
+        self,
+        world_id: str,
+        run_id: str,
+        storage_config: StorageConfig | None,
+    ) -> list[tuple[str, str, int]] | None:
+        """Fork ancestry for a world, so reads cover pre-fork ticks.
 
-        Worlds no longer in memory have no recoverable lineage; their own
-        rows remain queryable as before.
+        Live worlds carry lineage in memory; destroyed worlds fall back to
+        the lineage rows persisted at fork time (append-only, never lost).
         """
         try:
             world = self._worlds.get_world(UUID(str(world_id)))
         except Exception:
-            return None
-        lineage = getattr(world, "lineage", None)
-        return list(lineage) if lineage else None
+            world = None
+        if world is not None:
+            lineage = getattr(world, "lineage", None)
+            return list(lineage) if lineage else None
+        return await self._queries.get_lineage(world_id, run_id, storage_config)
 
     @logfire.instrument("gate.query_archetype")
     async def query_archetype(
@@ -424,7 +431,7 @@ class CommandService:
             ticks=ticks,
             entity_ids=entity_ids,
             components=components,
-            lineage=self._live_lineage(world_id),
+            lineage=await self._resolve_lineage(world_id, run_id, storage_config),
         )
         await self._emit(ctx, "query_world", world_id)
         return result

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -384,9 +384,23 @@ class CommandService:
             storage_config=storage_config,
             ticks=ticks,
             entity_ids=entity_ids,
+            lineage=self._live_lineage(world_id),
         )
         await self._emit(ctx, "query_world", world_id)
         return result
+
+    def _live_lineage(self, world_id: str) -> list[tuple[str, str, int]] | None:
+        """Fork ancestry for a live world, so reads cover pre-fork ticks.
+
+        Worlds no longer in memory have no recoverable lineage; their own
+        rows remain queryable as before.
+        """
+        try:
+            world = self._worlds.get_world(UUID(str(world_id)))
+        except Exception:
+            return None
+        lineage = getattr(world, "lineage", None)
+        return list(lineage) if lineage else None
 
     @logfire.instrument("gate.query_archetype")
     async def query_archetype(
@@ -410,6 +424,7 @@ class CommandService:
             ticks=ticks,
             entity_ids=entity_ids,
             components=components,
+            lineage=self._live_lineage(world_id),
         )
         await self._emit(ctx, "query_world", world_id)
         return result

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -18,6 +18,7 @@ from archetype.core.aio import AsyncQueryManager
 from archetype.core.component import Component
 from archetype.core.config import StorageConfig
 from archetype.core.interfaces import ArchetypeSignature
+from archetype.core.lineage import load_lineage
 
 
 class QueryService:
@@ -139,6 +140,20 @@ class QueryService:
             result = result.concat(df)
             previous_up_to = up_to_tick
         return result
+
+    async def get_lineage(
+        self,
+        world_id: str,
+        run_id: str,
+        storage_config: StorageConfig | None = None,
+    ) -> list[tuple[str, str, int]] | None:
+        """Recover a world's persisted fork ancestry from the store.
+
+        Lineage rows are append-only, so this works for destroyed worlds.
+        Returns None for root worlds (nothing was recorded at fork time).
+        """
+        store = await self._storage_service.get_or_create_store(storage_config or StorageConfig())
+        return await load_lineage(store, world_id=world_id, run_id=run_id)
 
     async def list_signatures(
         self,

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -10,7 +10,7 @@ including worlds that no longer exist in memory.
 
 from __future__ import annotations
 
-from daft import DataFrame
+from daft import DataFrame, col
 
 from archetype.app.models import Command, CommandType
 from archetype.app.storage_service import StorageService
@@ -41,6 +41,7 @@ class QueryService:
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
         components: list[type[Component]] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
     ) -> DataFrame:
         """Query an archetype table by signature, world, and run.
 
@@ -48,10 +49,13 @@ class QueryService:
         not just worlds that are currently live. The store is resolved via
         get_or_create_store, so repeated calls with the same config reuse
         the cached instance.
+
+        When `lineage` is provided (a fork's ancestor segments), pre-fork
+        ticks are read from the owning ancestor's run and unioned in.
         """
         store = await self._storage_service.get_or_create_store(storage_config or StorageConfig())
         querier = AsyncQueryManager(store=store)
-        return await querier.query_archetype(
+        result = await querier.query_archetype(
             sig=sig,
             world_id=world_id,
             run_id=run_id,
@@ -59,6 +63,18 @@ class QueryService:
             entity_ids=entity_ids,
             components=components,
         )
+
+        async def _segment(seg_world: str, seg_run: str, seg_ticks: list[int] | None):
+            return await querier.query_archetype(
+                sig=sig,
+                world_id=seg_world,
+                run_id=seg_run,
+                ticks=seg_ticks,
+                entity_ids=entity_ids,
+                components=components,
+            )
+
+        return await self._union_lineage(result, lineage, ticks, _segment)
 
     async def query_components(
         self,
@@ -69,21 +85,60 @@ class QueryService:
         *,
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
     ) -> DataFrame:
         """Query all entities that contain the requested component types.
 
         Subset matching: finds all archetype signatures that contain the
         requested types, queries each, projects to requested columns, unions.
+
+        When `lineage` is provided (a fork's ancestor segments), pre-fork
+        ticks are read from the owning ancestor's run and unioned in.
         """
         store = await self._storage_service.get_or_create_store(storage_config or StorageConfig())
         querier = AsyncQueryManager(store=store)
-        return await querier.query_components(
+        result = await querier.query_components(
             components=components,
             world_id=world_id,
             run_id=run_id,
             ticks=ticks,
             entity_ids=entity_ids,
         )
+
+        async def _segment(seg_world: str, seg_run: str, seg_ticks: list[int] | None):
+            return await querier.query_components(
+                components=components,
+                world_id=seg_world,
+                run_id=seg_run,
+                ticks=seg_ticks,
+                entity_ids=entity_ids,
+            )
+
+        return await self._union_lineage(result, lineage, ticks, _segment)
+
+    @staticmethod
+    async def _union_lineage(result, lineage, ticks, segment_query) -> DataFrame:
+        """Union ancestor-segment rows into a query result.
+
+        Each segment owns ticks in (previous_up_to, up_to]. Rows the ancestor
+        wrote after the fork point are excluded so a parent that kept running
+        never leaks post-fork state into the fork's history.
+        """
+        previous_up_to = -1
+        for ancestor_world, ancestor_run, up_to_tick in lineage or []:
+            if ticks is not None:
+                segment_ticks = [t for t in ticks if previous_up_to < t <= up_to_tick]
+                if not segment_ticks:
+                    previous_up_to = up_to_tick
+                    continue
+            else:
+                segment_ticks = None
+            df = await segment_query(str(ancestor_world), str(ancestor_run), segment_ticks)
+            if ticks is None:
+                df = df.where((col("tick") > previous_up_to) & (col("tick") <= up_to_tick))
+            result = result.concat(df)
+            previous_up_to = up_to_tick
+        return result
 
     async def list_signatures(
         self,

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -67,6 +67,7 @@ class WorldFactory:
             entity2sig=dict(config.entity2sig) if config.entity2sig else None,
             spawn_cache=dict(config.spawn_cache) if config.spawn_cache else None,
             despawn_cache=dict(config.despawn_cache) if config.despawn_cache else None,
+            lineage=list(config.lineage) if config.lineage else None,
         )
 
 
@@ -184,10 +185,20 @@ class WorldOrchestrator:
           generated:    world_id (uuid7), run_id (uuid7)
           deep-copied:  tick, next_entity_id, entity2sig, spawn_cache, despawn_cache
           shared:       resources (same instance), processors (same instances)
+          lineage:      source's lineage plus a segment covering the source's
+                        materialized rows, so the fork reads pre-fork ticks
+                        from its ancestry (append-only store: those rows are
+                        immutable history)
         """
         source = self._registry.get(source_world_id)
         if not isinstance(source, AsyncWorld):
             raise TypeError("Can only fork AsyncWorld instances")
+
+        lineage = list(source.lineage)
+        if source.tick > 0:
+            # The source has written rows for ticks 0..tick-1 under its own
+            # run; the fork's writes start at `tick`.
+            lineage.append((str(source.world_id), str(source.run_id), source.tick - 1))
 
         fork_config = WorldConfig(
             name=name,
@@ -196,6 +207,7 @@ class WorldOrchestrator:
             entity2sig=dict(source.entity2sig),
             spawn_cache={sig: list(rows) for sig, rows in source.spawn_cache.items()},
             despawn_cache={sig: list(ids) for sig, ids in source.despawn_cache.items()},
+            lineage=lineage,
         )
 
         fork = self._factory.create_async_world(store, fork_config)

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -27,6 +27,7 @@ from archetype.core.aio import (
 from archetype.core.config import CacheConfig, StorageConfig, WorldConfig
 from archetype.core.hooks import HookRegistry
 from archetype.core.interfaces import iAsyncStore, iAsyncSystem, iWorld
+from archetype.core.lineage import persist_lineage
 from archetype.core.resources import Resources
 
 if TYPE_CHECKING:
@@ -316,6 +317,15 @@ class WorldService:
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
         fork = self._orchestrator.fork_world(store, source_world_id, name=name)
         self._storage_configs[str(fork.world_id)] = (storage_config, cache_config)
+        # Persist the fork's ancestor chain (append-only): provenance must
+        # survive the fork being destroyed or the process restarting.
+        await persist_lineage(
+            store,
+            world_id=str(fork.world_id),
+            run_id=str(fork.run_id),
+            tick=fork.tick,
+            lineage=fork.lineage,
+        )
         return fork
 
     async def destroy_world(self, world_id: UUID | str) -> None:

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -71,6 +71,7 @@ class AsyncWorld(iAsyncWorld):
         entity2sig: dict[int, ArchetypeSignature] | None = None,
         spawn_cache: dict[ArchetypeSignature, list[dict[str, Any]]] | None = None,
         despawn_cache: dict[ArchetypeSignature, list[int]] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
     ):
         """
         Initialize the fully parallel async world.
@@ -93,6 +94,10 @@ class AsyncWorld(iAsyncWorld):
         self.entity2sig = entity2sig if entity2sig is not None else {}
         self.spawn_cache = spawn_cache if spawn_cache is not None else {}
         self.despawn_cache = despawn_cache if despawn_cache is not None else {}
+        # Ancestor read segments (world_id, run_id, up_to_tick), ascending.
+        # Rows for ticks <= up_to_tick live under that ancestor's run; the
+        # store is append-only, so those rows are immutable history.
+        self.lineage = list(lineage) if lineage else []
 
     @property
     def _entity2sig(self):
@@ -462,26 +467,59 @@ class AsyncWorld(iAsyncWorld):
             or (run_config and str(run_config.run_id))
             or ""
         )
-        # Prefer to pass run_config if the querier supports it (instrumented); otherwise omit.
-        try:
-            return await self.querier.query_archetype(
-                sig=sig,
-                world_id=self.world_id,
-                run_id=effective_run_id,
-                ticks=ticks or [self.tick],
-                entity_ids=entity_ids,
-                components=components,
-                run_config=run_config,
-            )  # type: ignore[call-arg]
-        except TypeError:
-            return await self.querier.query_archetype(
-                sig=sig,
-                world_id=self.world_id,
-                run_id=effective_run_id,
-                ticks=ticks or [self.tick],
-                entity_ids=entity_ids,
-                components=components,
-            )
+
+        async def _query_one(target_world: str, target_run: str, target_ticks: list[int]):
+            # Prefer to pass run_config if the querier supports it (instrumented);
+            # otherwise omit.
+            try:
+                return await self.querier.query_archetype(
+                    sig=sig,
+                    world_id=target_world,
+                    run_id=target_run,
+                    ticks=target_ticks,
+                    entity_ids=entity_ids,
+                    components=components,
+                    run_config=run_config,
+                )  # type: ignore[call-arg]
+            except TypeError:
+                return await self.querier.query_archetype(
+                    sig=sig,
+                    world_id=target_world,
+                    run_id=target_run,
+                    ticks=target_ticks,
+                    entity_ids=entity_ids,
+                    components=components,
+                )
+
+        requested_ticks = ticks or [self.tick]
+        if not self.lineage:
+            return await _query_one(self.world_id, effective_run_id, requested_ticks)
+
+        # Group ticks by the lineage segment that owns them, preserving
+        # segment order so pre-fork history reads from the ancestor's run.
+        groups: dict[tuple[str, str], list[int]] = {}
+        for t in requested_ticks:
+            groups.setdefault(self._tick_source(t, effective_run_id), []).append(t)
+
+        frames = [
+            await _query_one(target_world, target_run, group_ticks)
+            for (target_world, target_run), group_ticks in groups.items()
+        ]
+        result = frames[0]
+        for frame in frames[1:]:
+            result = result.concat(frame)
+        return result
+
+    def _tick_source(self, tick: int, own_run_id: str | None = None) -> tuple[str, str]:
+        """Resolve which (world_id, run_id) owns the rows for a tick.
+
+        Forks own ticks after their fork point; earlier ticks live under the
+        ancestor that wrote them. Lineage segments ascend by up_to_tick.
+        """
+        for ancestor_world, ancestor_run, up_to_tick in self.lineage:
+            if tick <= up_to_tick:
+                return str(ancestor_world), str(ancestor_run)
+        return str(self.world_id), str(own_run_id or self.run_id or "")
 
     async def get_components(
         self,
@@ -493,10 +531,11 @@ class AsyncWorld(iAsyncWorld):
         Passthrough to the querier's query_components method.
         """
         read_tick = max(self.tick - 1, 0)
+        source_world, source_run = self._tick_source(read_tick)
         return await self.querier.query_components(
             components=components,
-            world_id=self.world_id,
-            run_id=self.run_id,
+            world_id=source_world,
+            run_id=source_run,
             ticks=[read_tick],
             entity_ids=entity_ids,
         )

--- a/src/archetype/core/config.py
+++ b/src/archetype/core/config.py
@@ -196,5 +196,13 @@ class WorldConfig(BaseModel):
         default_factory=dict,
         description="Pending despawn entity IDs keyed by archetype signature",
     )
+    lineage: list[tuple[str, str, int]] = Field(
+        default_factory=list,
+        description=(
+            "Ancestor read segments as (world_id, run_id, up_to_tick), ascending. "
+            "Reads for ticks <= up_to_tick resolve to that ancestor's rows; later "
+            "ticks belong to this world's own run. Populated by fork."
+        ),
+    )
 
     model_config = dict(arbitrary_types_allowed=True)

--- a/src/archetype/core/lineage.py
+++ b/src/archetype/core/lineage.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""World fork lineage: durable provenance for forked worlds.
+
+A fork reads pre-fork ticks through its lineage — ascending
+(world_id, run_id, up_to_tick) ancestor segments. The live segments hang
+off ``AsyncWorld.lineage``; this module makes them durable by appending
+one ``WorldLineage`` row per segment to the store at fork time, under the
+fork's own (world_id, run_id).
+
+The store is append-only, so provenance written here is never deleted:
+ancestry remains resolvable after the fork is destroyed or the process
+restarts. Lineage rows use negative entity ids — they are world metadata,
+never live entities, and never enter ``entity2sig`` or the tick loop.
+"""
+
+from __future__ import annotations
+
+import daft
+import pyarrow as pa
+
+from archetype.core.archetype import Archetype
+from archetype.core.component import Component
+from archetype.core.interfaces import iAsyncStore
+
+
+class WorldLineage(Component):
+    """One ancestor segment of a fork's read lineage."""
+
+    parent_world_id: str = ""
+    parent_run_id: str = ""
+    up_to_tick: int = 0
+    position: int = 0
+
+
+LINEAGE_SIG = (WorldLineage,)
+
+
+async def persist_lineage(
+    store: iAsyncStore,
+    *,
+    world_id: str,
+    run_id: str,
+    tick: int,
+    lineage: list[tuple[str, str, int]],
+) -> None:
+    """Append the fork's full ancestor chain to the store.
+
+    Written once at fork time. The chain is already flattened (the source's
+    lineage plus the source's own segment), so a single read recovers the
+    complete ancestry without recursion.
+    """
+    if not lineage:
+        return
+    rows = [
+        Archetype.to_row_dict(
+            entity_id=-(position + 1),
+            tick=tick,
+            components=[
+                WorldLineage(
+                    parent_world_id=str(parent_world_id),
+                    parent_run_id=str(parent_run_id),
+                    up_to_tick=int(up_to_tick),
+                    position=position,
+                )
+            ],
+            world_id=str(world_id),
+            run_id=str(run_id),
+        )
+        for position, (parent_world_id, parent_run_id, up_to_tick) in enumerate(lineage)
+    ]
+    schema = Archetype.get_archetype_schema(LINEAGE_SIG)
+    df = daft.from_arrow(pa.Table.from_pylist(rows, schema=schema))
+    await store.append(LINEAGE_SIG, df)
+
+
+async def load_lineage(
+    store: iAsyncStore,
+    *,
+    world_id: str,
+    run_id: str,
+) -> list[tuple[str, str, int]] | None:
+    """Recover a world's ancestor chain from its persisted lineage rows.
+
+    Returns None when no lineage was recorded (root worlds, pre-lineage
+    data). Works for destroyed worlds: the rows are append-only.
+    """
+    df = await store.get_archetype_df(
+        sig=LINEAGE_SIG,
+        world_id=str(world_id),
+        run_id=str(run_id),
+    )
+    rows = df.to_pylist()
+    if not rows:
+        return None
+    rows.sort(key=lambda r: r["worldlineage__position"])
+    return [
+        (
+            str(r["worldlineage__parent_world_id"]),
+            str(r["worldlineage__parent_run_id"]),
+            int(r["worldlineage__up_to_tick"]),
+        )
+        for r in rows
+    ]

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -28,8 +28,14 @@ class ArchetypeRuntime:
 
     def __init__(self, *, actor_ctx: ActorCtx | None = None) -> None:
         import logfire
+        from logfire.exceptions import LogfireConfigError
 
-        logfire.configure(service_name="archetype-runtime")
+        try:
+            logfire.configure(service_name="archetype-runtime")
+        except LogfireConfigError:
+            # No Logfire credentials on this machine — degrade to
+            # local-only instrumentation instead of refusing to start.
+            logfire.configure(service_name="archetype-runtime", send_to_logfire=False)
 
         self._container = ServiceContainer()
         self._actor_ctx = actor_ctx or default_actor_ctx()

--- a/tests/app/test_runtime_contracts.py
+++ b/tests/app/test_runtime_contracts.py
@@ -239,3 +239,28 @@ class TestPreActivationHookRaises:
 
             with pytest.raises(RuntimeError, match="Cannot add_hook before activation"):
                 await world.add_hook(PreTick, handler)
+
+
+# ── Logfire degradation ──────────────────────────────────────────────────
+
+
+class TestLogfireDegradation:
+    """ArchetypeRuntime must construct without Logfire credentials."""
+
+    def test_runtime_constructs_when_logfire_unauthenticated(self, monkeypatch):
+        import logfire
+        from logfire.exceptions import LogfireConfigError
+
+        calls: list[dict] = []
+
+        def fake_configure(**kwargs):
+            calls.append(kwargs)
+            if "send_to_logfire" not in kwargs:
+                raise LogfireConfigError("You are not logged into Logfire.")
+
+        monkeypatch.setattr(logfire, "configure", fake_configure)
+
+        runtime = ArchetypeRuntime()
+        asyncio.run(runtime.shutdown())
+
+        assert calls[-1]["send_to_logfire"] is False

--- a/tests/integration/test_fork_destroy_contracts.py
+++ b/tests/integration/test_fork_destroy_contracts.py
@@ -407,3 +407,162 @@ async def test_fork_explicit_storage_override(tmp_path):
         assert rows_in_source_store == 0
     finally:
         await c.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# 8. Fork lineage: pre-fork ticks readable through ancestry
+# ---------------------------------------------------------------------------
+
+
+class Score(Component):
+    value: float = 0.0
+
+
+@pytest.mark.asyncio
+async def test_fork_after_step_reads_parent_history(tmp_path):
+    """Fork a world that has already materialized rows. The fork's
+    pre-fork ticks resolve to the parent's run via lineage."""
+    c = ServiceContainer()
+    storage = _storage(tmp_path)
+    try:
+        source = await c.world_service.create_world(WorldConfig(name="src"), storage)
+        await c.mutation_service.create_entity(source.world_id, [Score(value=7.0)])
+        await c.simulation_service.step(source.world_id, RunConfig())
+
+        fork = await c.world_service.fork_world(
+            source.world_id, name="fork", storage_config=storage
+        )
+        assert fork.lineage == [(str(source.world_id), str(source.run_id), source.tick - 1)]
+
+        fork_df = await c.query_service.query_components(
+            [Score],
+            world_id=str(fork.world_id),
+            run_id=str(fork.run_id),
+            storage_config=storage,
+            lineage=fork.lineage,
+        )
+        rows = fork_df.to_pydict()
+        assert rows["score__value"] == [7.0]
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_fork_after_step_processes_parent_state(tmp_path):
+    """The fork's first step must read the parent's last tick as input,
+    not an empty frame: state continues across the fork point."""
+    from daft import DataFrame, col
+
+    from archetype.core.aio.async_processor import AsyncProcessor
+
+    class Inc(AsyncProcessor):
+        components = (Score,)
+        priority = 10
+
+        async def process(self, df: DataFrame, **kw) -> DataFrame:
+            return df.with_column("score__value", col("score__value") + 1.0)
+
+    c = ServiceContainer()
+    storage = _storage(tmp_path)
+    try:
+        source = await c.world_service.create_world(WorldConfig(name="src"), storage)
+        source.system.processors = [Inc()]
+        await c.mutation_service.create_entity(source.world_id, [Score(value=0.0)])
+        await c.simulation_service.step(source.world_id, RunConfig())  # value -> 1.0
+
+        fork = await c.world_service.fork_world(
+            source.world_id, name="fork", storage_config=storage
+        )
+        await c.simulation_service.step(fork.world_id, RunConfig())  # must see 1.0 -> 2.0
+
+        fork_df = await c.query_service.query_components(
+            [Score],
+            world_id=str(fork.world_id),
+            run_id=str(fork.run_id),
+            storage_config=storage,
+            ticks=[fork.tick - 1],
+        )
+        assert fork_df.to_pydict()["score__value"] == [2.0]
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_fork_lineage_excludes_parent_post_fork_rows(tmp_path):
+    """A parent that keeps running after the fork must not leak its
+    post-fork rows into the fork's history."""
+    c = ServiceContainer()
+    storage = _storage(tmp_path)
+    try:
+        source = await c.world_service.create_world(WorldConfig(name="src"), storage)
+        await c.mutation_service.create_entity(source.world_id, [Score(value=1.0)])
+        await c.simulation_service.step(source.world_id, RunConfig())
+
+        fork = await c.world_service.fork_world(
+            source.world_id, name="fork", storage_config=storage
+        )
+        # Parent advances past the fork point
+        await c.simulation_service.step(source.world_id, RunConfig())
+        await c.simulation_service.step(source.world_id, RunConfig())
+
+        fork_df = await c.query_service.query_components(
+            [Score],
+            world_id=str(fork.world_id),
+            run_id=str(fork.run_id),
+            storage_config=storage,
+            lineage=fork.lineage,
+        )
+        # Only the single pre-fork tick — not the parent's two later ticks
+        assert fork_df.count_rows() == 1
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_fork_of_fork_lineage_chain(tmp_path):
+    """Lineage flattens across fork generations: a fork of a fork reads
+    base history, mid-fork history, and its own rows."""
+    c = ServiceContainer()
+    storage = _storage(tmp_path)
+    try:
+        base = await c.world_service.create_world(WorldConfig(name="base"), storage)
+        await c.mutation_service.create_entity(base.world_id, [Score(value=5.0)])
+        await c.simulation_service.step(base.world_id, RunConfig())
+
+        mid = await c.world_service.fork_world(base.world_id, name="mid", storage_config=storage)
+        await c.simulation_service.step(mid.world_id, RunConfig())
+
+        leaf = await c.world_service.fork_world(mid.world_id, name="leaf", storage_config=storage)
+        assert len(leaf.lineage) == 2
+        await c.simulation_service.step(leaf.world_id, RunConfig())
+
+        leaf_df = await c.query_service.query_components(
+            [Score],
+            world_id=str(leaf.world_id),
+            run_id=str(leaf.run_id),
+            storage_config=storage,
+            lineage=leaf.lineage,
+        )
+        ticks = sorted(leaf_df.to_pydict()["tick"])
+        assert ticks == [0, 1, 2]  # base tick, mid tick, leaf tick
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_unstepped_fork_has_no_lineage_segment(tmp_path):
+    """Forking an unstepped world adds no lineage segment — the
+    pending-spawn-transfer contract covers that case unchanged."""
+    c = ServiceContainer()
+    storage = _storage(tmp_path)
+    try:
+        source = await c.world_service.create_world(WorldConfig(name="src"), storage)
+        await c.mutation_service.create_entity(source.world_id, [Score(value=1.0)])
+
+        fork = await c.world_service.fork_world(
+            source.world_id, name="fork", storage_config=storage
+        )
+        assert fork.lineage == []
+    finally:
+        await c.shutdown()

--- a/tests/integration/test_fork_destroy_contracts.py
+++ b/tests/integration/test_fork_destroy_contracts.py
@@ -566,3 +566,66 @@ async def test_unstepped_fork_has_no_lineage_segment(tmp_path):
         assert fork.lineage == []
     finally:
         await c.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# 9. Persisted lineage: ancestry survives dead worlds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_destroyed_fork_ancestry_remains_resolvable(tmp_path):
+    """Lineage is persisted append-only at fork time: after the fork is
+    destroyed, gated reads still resolve pre-fork ticks through ancestry."""
+    c = ServiceContainer()
+    storage = _storage(tmp_path)
+    ctx = _admin_ctx()
+    try:
+        source = await c.world_service.create_world(WorldConfig(name="src"), storage)
+        await c.mutation_service.create_entity(source.world_id, [Score(value=9.0)])
+        await c.simulation_service.step(source.world_id, RunConfig())
+
+        fork = await c.world_service.fork_world(
+            source.world_id, name="fork", storage_config=storage
+        )
+        await c.simulation_service.step(fork.world_id, RunConfig())
+        fork_world_id, fork_run_id = str(fork.world_id), str(fork.run_id)
+        expected_lineage = list(fork.lineage)
+
+        await c.command_service.destroy_world(ctx, fork.world_id)
+
+        # Persisted lineage is recoverable without the live world object
+        recovered = await c.query_service.get_lineage(
+            fork_world_id, fork_run_id, storage_config=storage
+        )
+        assert recovered == expected_lineage
+
+        # Gated read on the dead fork still includes the pre-fork tick
+        df = await c.command_service.query_components(
+            ctx,
+            [Score],
+            fork_world_id,
+            fork_run_id,
+            storage_config=storage,
+        )
+        assert sorted(df.to_pydict()["tick"]) == [0, 1]
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_root_world_has_no_persisted_lineage(tmp_path):
+    """Root worlds record nothing; get_lineage returns None, not []."""
+    c = ServiceContainer()
+    storage = _storage(tmp_path)
+    try:
+        source = await c.world_service.create_world(WorldConfig(name="src"), storage)
+        await c.mutation_service.create_entity(source.world_id, [Score(value=1.0)])
+        await c.simulation_service.step(source.world_id, RunConfig())
+
+        recovered = await c.query_service.get_lineage(
+            str(source.world_id), str(source.run_id), storage_config=storage
+        )
+        assert recovered is None
+    finally:
+        await c.shutdown()


### PR DESCRIPTION
## What

Rebased onto current `main` (#202/#204/#208 — the original lint-fix commit dropped out, main upstreamed the same fixes). Three substantive changes remain:

### 1. `ArchetypeRuntime` crashed without Logfire credentials (`07851af`)

Falls back to `send_to_logfire=False` only when unauthenticated; authenticated behavior unchanged. Contract test added. Same commit fixes the cooperative emergence experiment's three dead contracts (no termination wired, evaluator normalized by observed max instead of `max_steps`, swept regen never applied).

### 2. Copy-on-write fork lineage (`53cf829`)

Forks carried entity structure but no materialized rows: a fork of a stepped world queried its own empty `(world_id, run_id)` partition and **silently simulated nothing** — every rollout episode ran on an empty world.

`WorldConfig` gains `lineage`: ascending `(world_id, run_id, up_to_tick)` segments populated by `fork_world`. Reads resolve per tick to the owning ancestor's run:

- `AsyncWorld.query_archetype` / `get_components` route the tick loop and `_move_entity` through lineage — a fork's first step processes the parent's last tick; update-on-fork finds its prior row.
- `QueryService` unions ancestor segments, excluding rows a parent wrote after the fork point; the gate resolves lineage automatically.
- Fork stays O(metadata); the store stays append-only and lineage-unaware.

### 3. Persisted lineage — ancestry survives dead worlds (`b619436`)

Provenance must never be compromised. At fork time the full ancestor chain is appended to the store as `WorldLineage` rows under the fork's `(world_id, run_id)` (negative entity ids — world metadata, never live entities, never in the tick loop). `QueryService.get_lineage` recovers the chain from the store, and the gate falls back to it when the world is no longer live — so gated reads resolve pre-fork ticks **for destroyed worlds**. Append-only, written once at fork, never deleted.

Spec updated: `docs/guide/world-lifecycle.md` §3 (`WorldConfig` fields) and §4.6 (read lineage + durability).

**Contract tests** (`tests/integration/test_fork_destroy_contracts.py`, 15 passing): §8 fork lineage (fork-after-step readable; first-step state continuity `1.0 → 2.0` across the fork point; parent post-fork rows excluded; fork-of-fork chains; unstepped forks unchanged) and §9 persisted lineage (destroyed-fork ancestry resolvable end-to-end through the gate; root worlds record nothing).

**Lazy-audit reviewer notes (2):**
- `async_world.py` `to_pylist` entry re-pinned 257 → 262 (same pre-existing call in `_move_entity`, shifted by insertions).
- New documented entry: `core/lineage.py:94` `to_pylist` — ancestor segments (bounded by fork depth, 1–3 rows) become Python tuples because they route subsequent per-tick store queries; not expressible inside one Daft plan.

## Results

The cooperative emergence experiment, in its natural structure (one stepped base, fork + regen update per parameter point):

```
  regen_rate     score  durations           terminated
        0.01     0.400  collapse @ tick 20     5/5  COLLAPSED
        0.03     0.440  collapse @ tick 22     5/5  COLLAPSED
        0.05     0.480  collapse @ tick 24     5/5  COLLAPSED
        0.10     0.620  collapse @ tick 31     5/5  stressed
        0.20     1.000  full 50 steps          0/5  SUSTAINABLE
```

Matches the model: drain is 50/tick, logistic regrowth peaks at `regen × capacity/4`, so only regen=0.20 reaches equilibrium.

## Verification

- `make ci` green after rebase and after each commit: format-check, lint, lazy-audit, API-boundary audit, lock-check, full suite with coverage (15/15 fork/destroy contracts), regression evals.
- Experiment runs end-to-end with no Logfire credentials.

https://claude.ai/code/session_01WvsPybmKh8uDjjQCxKkvya