### PR TITLE
The forkable world ledger: fix fork-after-step + loud failures, cut the payment fiction, reframe the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ archetypes at once — one pass over the entire matching population, not a
 loop over objects. That collapse — component set → signature → schema →
 table → query — is the core of the system. Everything below is consequence.
 
+Big data's founding move was decoupling storage from compute — that is
+where Iceberg and Daft come from. The decoupling bought scale but severed
+provenance: the code that produces a table and the knowledge of how to
+read it became separate artifacts. Archetype keeps the physical decoupling
+and restores the connection where it belongs, in the declaration: whatever
+you process — a simulation, a training run, an agent population — the
+results are managed for you and queryable **with the same code that
+created them**. The component that wrote the rows is the schema you filter
+on; the processor that transformed them is the lineage. Provenance is
+derivation, not a catalog.
+
 ## Data is the point
 
 Nothing is deleted. There is no update path and no delete path in the
@@ -90,6 +101,11 @@ trust the result by reviewing code, not by re-running it:
   order. The audit trail this produces is the raw material for
   auto-research loops — the engine improving things that run on the
   engine.
+
+The design is meant to scale with its user. The more capable the model,
+the more it can do with two orthogonal primitives — richer components,
+sharper processors, deeper experiment loops. Frameworks built as
+scaffolding depreciate as models improve; primitives appreciate.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # Archetype
 
-**A forkable, append-only world ledger for simulations and AI agents.**
+**Two primitives — components and processors — on a dataframe engine.
+The rest of the data stack is derived.**
 
 [![CI](https://github.com/VangelisTech/archetype/actions/workflows/python-tests.yml/badge.svg)](https://github.com/VangelisTech/archetype/actions/workflows/python-tests.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://python.org)
@@ -12,81 +13,84 @@
 
 ![Archetype Architecture Diagram](assets/archetype_diagram2.png)
 
-Every tick of a running world persists as queryable Arrow rows keyed
-`(world_id, run_id, tick)`. Nothing is ever overwritten — there is no update
-path and no delete path anywhere in the storage layer. Everything distinctive
-about Archetype falls out of that one decision:
+Archetype is a state machine that uses big-data technology to run itself,
+built for the AI-native world. You define data as `Component` classes and
+behavior as `Processor` transforms. The engine derives the rest of what a
+data stack normally makes you build by hand: schemas, columnar tables,
+partitioning, queries, history, audit.
 
-- **Time travel is a query.** `df.where(col("tick") == t)` is the state of the
-  world at tick `t`. Forever.
-- **Forking is branching the timeline.** Fork any moment of any run, vary one
-  condition, and diff the branches with a dataframe query. Forks read pre-fork
-  history through lineage — O(metadata), no row copying.
-- **Every run leaves a dataset behind.** Trajectories, rollout results, and
-  audit history land in the same store as world state, ready for analysis
-  without an export step.
-- **A tick either commits or it didn't happen.** Failed persistence raises; a
-  failed processor fails its tick. The ledger has no silent holes.
+```python
+class Position(Component):        # a component is a schema
+    x: float = 0.0
+    y: float = 0.0
 
-Mechanically, Archetype is an ECS on the [Daft](https://daft.ai) dataframe
-engine: entities are rows grouped into columnar archetype tables by exact
-component set, behavior is DataFrame transforms over whole archetypes, and a
-deterministic tick loop is the ledger's commit protocol.
 
-## What it's for
+class MovementProcessor(AsyncProcessor):   # a processor is a transform
+    components = (Position, Velocity)
 
-Workloads where history is part of the model, not exhaust:
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        return df.with_columns(
+            {"position__x": col("position__x") + col("velocity__dx")}
+        )
+```
 
-- **Counterfactual evaluation of agent populations** — run many LLM agents in
-  a shared world, fork mid-history, replay a branch under a different
-  condition, and compare outcomes as tables.
-- **Rollout-heavy simulation** — episodes and rollouts are first-class; every
-  rollout's full tick history is queryable after the fact.
-- **Trajectory datasets** — agent runs recorded as rows you can filter, join,
-  grade, and train on (`archetype.experiments`).
-- **Multi-agent worlds with replay** — anything you'd want to rewind, audit,
-  or branch.
+Entities that share an exact component set share an **archetype**: a
+canonical signature that *is* an Arrow schema that *is* a columnar table.
+Processors are [Daft](https://daft.ai) DataFrame transforms over whole
+archetypes at once — one pass over the entire matching population, not a
+loop over objects. That collapse — component set → signature → schema →
+table → query — is the core of the system. Everything below is consequence.
 
-Orchestration frameworks checkpoint a conversation thread. Game ECS engines
-snapshot in-process memory. RL environments discard state on `reset()`.
-Archetype persists the whole world, every tick, as data — so replay, forks,
-and audit are storage facts rather than features.
+## Data is the point
 
-## The tick
+Nothing is deleted. There is no update path and no delete path in the
+storage layer; every tick appends rows keyed `(world_id, run_id, tick)`.
+The one-off run you were about to throw away — leave it. Deletion is an
+inductive bias.
 
-One pass of the loop, for every archetype concurrently:
+What you get for keeping everything:
 
-1. external calls enter through the command gate, which authorizes, audits,
-   and defers mutations to the next tick boundary
-2. queued commands drain in deterministic `(tick, priority, sequence)` order,
-   with entity ids reserved at submit time
-3. the world reads tick `N-1`, materializes spawns/despawns
-4. processors transform the archetype's DataFrame in priority order
-5. the result is appended at tick `N` — or the step raises
+- **Time travel** — `df.where(col("tick") == t)` is the world at tick `t`
+- **Forking** — branch any moment of any run; forks read pre-fork history
+  through lineage and diverge from there
+- **Experiments over runs** — runs, results, and trajectories are
+  components too (`archetype.experiments`); comparing branches is a query,
+  which is the statistical, experiment-based mindset an AI-native data
+  engine asks of you
+- **The engine's own operation is data** — every gated command lands in an
+  append-only audit table on the same substrate that stores world state:
+  consistent, partitioned, queryable, trainable
 
-The tick boundary is the frame of the system: the deterministic answer to
-"when does an agent's action land." Same world state + same command queue +
-same processor outputs → same ledger.
+## Built for agents
 
-## Installation
+The intended user of this system is an agent.
+
+Everything is arranged so that an agent can build here and a human can
+trust the result by reviewing code, not by re-running it:
+
+- **Code is the source of truth.** The contracts live in
+  `docs/guide/specification.md` and the focused spec pages, and each one is
+  pinned by named tests. What the spec says, a test enforces.
+- **The primitives are safe to extend.** New capability means a new
+  `Component` or a new `Processor` — small, local, reviewable diffs whose
+  behavior is determined by component presence, not by control flow
+  threaded through a framework.
+- **The invariants will not move under you.** Append-only stores. Canonical
+  archetype signatures. All mutation through one gate. A tick either
+  commits or it didn't happen — failed persistence raises, a failed
+  processor fails its tick.
+- **Recursive operation stays governed.** Agents running simulations
+  inside simulations go through the same gate: authorized, audited,
+  applied at deterministic tick boundaries in `(tick, priority, sequence)`
+  order. The audit trail this produces is the raw material for
+  auto-research loops — the engine improving things that run on the
+  engine.
+
+## Quickstart
 
 ```bash
 pip install archetype-ecs
 ```
-
-Development:
-
-```bash
-git clone https://github.com/VangelisTech/archetype.git
-cd archetype
-uv sync --group dev
-```
-
-## Quickstart
-
-`ArchetypeRuntime` is the recommended entry point. It owns the shared
-container, activates a world lazily on first use, and returns a real
-`entity_id` from `spawn()`.
 
 ```python
 import asyncio
@@ -133,7 +137,7 @@ async def main():
 asyncio.run(main())
 ```
 
-Fork-and-diff — the move the storage model exists for:
+Fork-and-diff:
 
 ```python
 fork = await world.fork("counterfactual")  # inherits the source's store
@@ -143,149 +147,29 @@ source_df = await world.query(Position)
 fork_df = await fork.query(Position)       # pre-fork history + its own branch
 ```
 
-For sync scripts, use `with ArchetypeRuntime.sync() as runtime:` and drop the
-`await`s.
-
-Two things to know:
-
-- component columns are prefixed `componentname__field` (e.g., `position__x`)
-- `ArchetypeRuntime` is the script boundary. Process lifetime and world
-  lifetime are separate concerns. See `docs/guide/runtime.md` and the
-  Specifications group for the full contract set. Drop to `ServiceContainer`
-  only when you need explicit RBAC, custom command routing, or a non-script
-  host.
+For sync scripts, use `with ArchetypeRuntime.sync() as runtime:` and drop
+the `await`s. Component columns are prefixed `componentname__field`
+(e.g. `position__x`). `ArchetypeRuntime` is the script boundary; drop to
+`ServiceContainer` only for custom command routing or a non-script host.
 
 ## How it's organized
 
 | Layer | What it is |
 |---|---|
-| `src/archetype/core` | The ledger and the tick loop. Hard invariants: append-only stores, canonical archetype identity, lineage-aware reads, loud persistence failures. |
-| `src/archetype/app` | The gate. Every operation is authorized, audited, and — for mutations — deferred to the tick boundary through a deterministic broker. |
-| `src/archetype/runtime` | `ArchetypeRuntime` — the recommended script boundary. World handles that route everything through the gate. |
-| `src/archetype/api` + `src/archetype/cli` | A reference deployment of the gate over HTTP, plus a thin CLI client. Inspection and ops — worlds get their behavior (processors, hooks) in-process. |
-| `src/archetype/experiments` | Experiment tracking as components: runs, results, trajectories, branch heads. The ledger's first first-party consumer. |
-
-## Core Concepts
-
-### Components
-
-Components are typed `LanceModel` subclasses. Their fields define the
-archetype schema fragments that get flattened into storage columns.
-
-```python
-class Health(Component):
-    hp: int = 100
-    max_hp: int = 100
-```
-
-`Health` becomes columns like `health__hp` and `health__max_hp`.
-
-### Archetypes
-
-An archetype is the exact set of component types attached to an entity.
-Signatures are canonicalized by sorted component type name, so component
-order is not meaningful. Adding or removing a component migrates the entity
-to a different archetype table.
-
-### Processors
-
-Processors are pure DataFrame transforms selected by subset match on
-component signatures:
-
-```python
-class ThinkProcessor(AsyncProcessor):
-    components = (Agent, Memory)
-    priority = 20
-```
-
-If an archetype contains at least `Agent` and `Memory`, that processor runs
-on its DataFrame. Because a processor sees the whole population at once, an
-LLM-backed processor batches inference across every matching agent in one
-pass instead of looping agent by agent.
-
-### Forking and lineage
-
-A fork gets a new `world_id` and `run_id`, preserves the tick position, and
-carries a *lineage* — pointers to the ancestor segments of its timeline.
-Pre-fork ticks resolve to the ancestor's immutable rows; post-fork ticks are
-the fork's own. The parent can keep running or be destroyed without affecting
-the fork's view. Lineage is persisted append-only at fork time, so ancestry
-survives process restarts and dead worlds. See
-`docs/guide/world-lifecycle.md`.
-
-### Commands and governance
-
-All external mutations flow through one gate:
-
-```text
-caller → CommandService → direct delegate or tick-deferred CommandBroker → world → store
-```
-
-The gate enforces role permissions (`viewer`, `player`, `operator`, `admin`),
-per-tick command quotas, token budgets, and emits one audit row per gated
-call — to an append-only audit table you query like any other DataFrame.
-Auth today is developer-mode (role-as-bearer-token); treat the RBAC surface
-as single-trusted-user until v2 auth lands.
-
-### Storage
-
-Two async backends behind the same contracts: `AsyncLancedbStore` (LanceDB,
-default) and `AsyncStore` (Daft catalog / Iceberg). `StorageService` pools
-instances by `(uri, namespace, backend, cache config)`, and the gate resolves
-each world's recorded store so readers find rows wherever the world wrote
-them.
-
-## CLI and REST (reference deployment)
-
-`archetype serve` exposes the gate over HTTP; the CLI is a thin client for
-it. This surface is for inspection and operations — listing worlds, stepping,
-forking, reading audit history. Worlds created over the wire have no
-processors; behavior is attached in-process through `ArchetypeRuntime`.
-
-```bash
-archetype serve                       # start the FastAPI server
-archetype world create demo           # create a world
-archetype run <world-id> --steps 10   # run ticks
-archetype world fork <world-id> --name branch-a
-archetype history <world-id>          # audit history
-```
-
-Full route table and flags: `docs/guide/api-layer.md`.
+| `src/archetype/core` | The engine: components, archetypes, worlds, the tick loop, append-only stores |
+| `src/archetype/app` | The gate: every operation authorized, audited, and applied at tick boundaries |
+| `src/archetype/runtime` | `ArchetypeRuntime` — the recommended script boundary |
+| `src/archetype/api` + `src/archetype/cli` | Reference deployment of the gate over HTTP, plus a thin CLI |
+| `src/archetype/experiments` | Runs, results, trajectories, branch heads — as components |
 
 ## Status
 
-Honest state of the system:
-
-- the ledger — append-only write path, tick loop, time travel, fork lineage —
-  is the most mature part, and the most heavily contract-tested
-- `archetype.experiments` (runs, results, trajectories) is young but real;
-  the AutoResearch loop controller is early
-- the FastAPI layer runs a default admin `ActorCtx` — not multi-tenant auth
-  yet; the four-role model is enforced at the gate but identities are
-  developer-mode
-- a Rust core implementing the same engine semantics (arrow-rs, append-only
-  Parquet, Arrow C Data Interface) is in progress on a separate branch
-
-Start with `src/archetype/runtime` (`ArchetypeRuntime`) to use the system.
-Read `src/archetype/core` and `src/archetype/app` to understand how it works
-underneath.
-
-## Repository Map
-
-```text
-archetype/
-├── src/archetype/runtime/   # ArchetypeRuntime — recommended top-level API
-├── src/archetype/core/      # The ledger: ECS runtime and storage contracts
-├── src/archetype/app/       # The gate: command service, broker, audit
-├── src/archetype/api/       # FastAPI server (reference deployment)
-├── src/archetype/cli/       # Typer CLI (thin client)
-├── src/archetype/experiments/ # Runs, results, trajectories as components
-├── examples/                # Runnable examples
-├── tests/                   # Test suite (contract tests pin the spec)
-├── docs/                    # MkDocs site
-├── AGENTS.md                # Repo-specific collaborator guidance
-└── LEARNINGS.md             # Architecture notes
-```
+- the engine — append-only write path, tick loop, time travel, fork
+  lineage — is the most mature part and the most heavily contract-tested
+- `archetype.experiments` and the auto-research loop are young but real
+- the FastAPI layer runs developer-mode auth (a default admin `ActorCtx`)
+- a Rust core implementing the same engine semantics is in progress on a
+  separate branch
 
 ## Examples
 
@@ -304,9 +188,8 @@ require `OPENAI_API_KEY`.
 
 ## Observability
 
-Archetype ships with [Logfire](https://pydantic.dev/logfire) integration at
-three levels: gate spans on every `CommandService` method, step-phase spans
-inside each tick (query / materialize / execute / update), and opt-in
+[Logfire](https://pydantic.dev/logfire) spans on every gated call and every
+tick phase (query / materialize / execute / update), plus opt-in
 per-tick/per-entity hooks:
 
 ```python
@@ -315,14 +198,10 @@ from archetype.contrib.logfire_observer import logfire_hooks
 world = runtime.world("demo", processors=[...], hooks=logfire_hooks())
 ```
 
-The runtime calls `logfire.configure()` automatically, and stdlib logging is
-bridged in, so `logger.*` calls appear as Logfire events.
-
 ## Development
 
 ```bash
 make test        # fast test suite
-make test-cov    # coverage run
 make check       # format + lint
 make ci          # CI gate
 make docs        # build docs
@@ -333,10 +212,9 @@ make docs        # build docs
 - Docs site: `https://archetype-docs.pages.dev`
 - Examples index: `examples/README.md`
 - Architecture notes: `LEARNINGS.md`
-- Specifications: `docs/guide/specification.md`, `docs/guide/runtime.md`,
-  `docs/guide/service-protocols.md`, `docs/guide/command-gate.md`,
-  `docs/guide/execution-hierarchy.md`, `docs/guide/world-lifecycle.md`,
-  `docs/guide/audit-log.md`
+- Specifications: `docs/guide/specification.md` and the focused pages it
+  links (runtime, service protocols, command gate, execution hierarchy,
+  world lifecycle, audit log)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Archetype
 
-**A dataframe-first, append-only ECS runtime for simulations and AI agents.**
+**A forkable, append-only world ledger for simulations and AI agents.**
 
 [![CI](https://github.com/VangelisTech/archetype/actions/workflows/python-tests.yml/badge.svg)](https://github.com/VangelisTech/archetype/actions/workflows/python-tests.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://python.org)
@@ -12,51 +12,69 @@
 
 ![Archetype Architecture Diagram](assets/archetype_diagram2.png)
 
-Archetype stores world state as columnar archetype tables, executes behavior as DataFrame transforms, and persists every tick as a new snapshot instead of overwriting rows. Consequences of that storage model:
+Every tick of a running world persists as queryable Arrow rows keyed
+`(world_id, run_id, tick)`. Nothing is ever overwritten — there is no update
+path and no delete path anywhere in the storage layer. Everything distinctive
+about Archetype falls out of that one decision:
 
-- entities are grouped by exact component sets
-- processors run over whole archetype DataFrames
-- writes are append-only
-- time-travel and world forking fall out of the storage model
+- **Time travel is a query.** `df.where(col("tick") == t)` is the state of the
+  world at tick `t`. Forever.
+- **Forking is branching the timeline.** Fork any moment of any run, vary one
+  condition, and diff the branches with a dataframe query. Forks read pre-fork
+  history through lineage — O(metadata), no row copying.
+- **Every run leaves a dataset behind.** Trajectories, rollout results, and
+  audit history land in the same store as world state, ready for analysis
+  without an export step.
+- **A tick either commits or it didn't happen.** Failed persistence raises; a
+  failed processor fails its tick. The ledger has no silent holes.
 
-## What It Is
+Mechanically, Archetype is an ECS on the [Daft](https://daft.ai) dataframe
+engine: entities are rows grouped into columnar archetype tables by exact
+component set, behavior is DataFrame transforms over whole archetypes, and a
+deterministic tick loop is the ledger's commit protocol.
 
-Archetype is split into layers:
+## What it's for
 
-| Layer | Purpose |
-|---|---|
-| `src/archetype/runtime` | `ArchetypeRuntime` — recommended top-level API for scripts and simulations |
-| `src/archetype/core` | ECS primitives: `Component`, `Archetype`, `AsyncWorld`, `AsyncProcessor`, storage/query/update contracts |
-| `src/archetype/app` | Service layer (lower-level): command gate, audit log, broker, world/simulation/query services |
-| `src/archetype/api` + `src/archetype/cli` | FastAPI server and Typer CLI |
+Workloads where history is part of the model, not exhaust:
 
-The runtime model is:
+- **Counterfactual evaluation of agent populations** — run many LLM agents in
+  a shared world, fork mid-history, replay a branch under a different
+  condition, and compare outcomes as tables.
+- **Rollout-heavy simulation** — episodes and rollouts are first-class; every
+  rollout's full tick history is queryable after the fact.
+- **Trajectory datasets** — agent runs recorded as rows you can filter, join,
+  grade, and train on (`archetype.experiments`).
+- **Multi-agent worlds with replay** — anything you'd want to rewind, audit,
+  or branch.
 
-1. external calls enter through `iCommandService`,
-2. the gate authorizes, delegates, and audits,
-3. tick-deferred commands are drained when a world steps,
-4. worlds materialize structural mutations,
-5. processors transform matching archetype DataFrames,
-6. updated rows are appended to storage.
+Orchestration frameworks checkpoint a conversation thread. Game ECS engines
+snapshot in-process memory. RL environments discard state on `reset()`.
+Archetype persists the whole world, every tick, as data — so replay, forks,
+and audit are storage facts rather than features.
 
-## Use Cases
+## The tick
 
-Simulations where tick-by-tick history is part of the model:
+One pass of the loop, for every archetype concurrently:
 
-- multi-agent worlds
-- counterfactual branches and forks
-- rollout-heavy evaluation
-- LLM-powered processors running over many entities in parallel
+1. external calls enter through the command gate, which authorizes, audits,
+   and defers mutations to the next tick boundary
+2. queued commands drain in deterministic `(tick, priority, sequence)` order,
+   with entity ids reserved at submit time
+3. the world reads tick `N-1`, materializes spawns/despawns
+4. processors transform the archetype's DataFrame in priority order
+5. the result is appended at tick `N` — or the step raises
+
+The tick boundary is the frame of the system: the deterministic answer to
+"when does an agent's action land." Same world state + same command queue +
+same processor outputs → same ledger.
 
 ## Installation
-
-### Package
 
 ```bash
 pip install archetype-ecs
 ```
 
-### Development
+Development:
 
 ```bash
 git clone https://github.com/VangelisTech/archetype.git
@@ -66,7 +84,9 @@ uv sync --group dev
 
 ## Quickstart
 
-`ArchetypeRuntime` is the recommended entry point. It owns the shared container, activates a world lazily on first use, and returns a real `entity_id` from `spawn()`.
+`ArchetypeRuntime` is the recommended entry point. It owns the shared
+container, activates a world lazily on first use, and returns a real
+`entity_id` from `spawn()`.
 
 ```python
 import asyncio
@@ -106,101 +126,51 @@ async def main():
         await world.spawn(Position(x=0, y=0), Velocity(dx=1, dy=2))
         await world.run(steps=3)
 
-        df = await world.query(Position)
+        df = await world.query(Position)  # full append-only history
         print(df.collect().to_pylist())
 
 
 asyncio.run(main())
 ```
 
-For sync scripts, use `with ArchetypeRuntime.sync() as runtime:` and drop the `await`s.
+Fork-and-diff — the move the storage model exists for:
+
+```python
+fork = await world.fork("counterfactual")  # inherits the source's store
+await fork.step()                          # continues from the source's last tick
+
+source_df = await world.query(Position)
+fork_df = await fork.query(Position)       # pre-fork history + its own branch
+```
+
+For sync scripts, use `with ArchetypeRuntime.sync() as runtime:` and drop the
+`await`s.
 
 Two things to know:
 
-- processor columns are prefixed `componentname__field` (e.g., `position__x`)
-- `ArchetypeRuntime` is the script boundary. Process lifetime and world lifetime are separate concerns. See `docs/guide/runtime.md` and the Specifications group for the full contract set. Drop to `ServiceContainer` only when you need explicit RBAC, custom command routing, or a non-script host.
+- component columns are prefixed `componentname__field` (e.g., `position__x`)
+- `ArchetypeRuntime` is the script boundary. Process lifetime and world
+  lifetime are separate concerns. See `docs/guide/runtime.md` and the
+  Specifications group for the full contract set. Drop to `ServiceContainer`
+  only when you need explicit RBAC, custom command routing, or a non-script
+  host.
 
-## CLI
+## How it's organized
 
-The CLI is a thin HTTP client. Except for `serve`, every command talks to a running FastAPI server.
-
-```bash
-# Start the server
-archetype serve
-
-# Create a world
-archetype world create demo
-
-# List worlds
-archetype world list
-
-# Spawn an entity from component payload JSON
-archetype entity spawn <world-id> --components '[{"type":"Position","x":0,"y":0}]'
-
-# Run 10 ticks
-archetype run <world-id> --steps 10
-
-# Run an episode or rollout
-archetype episode <world-id> --max-steps 100
-archetype rollout <world-id> --num-episodes 4 --max-steps 100
-
-# Fork the current world state
-archetype world fork <world-id> --name branch-a
-
-# Drop the live world object; storage and audit rows remain
-archetype world destroy <world-id>
-
-# Show audit history
-archetype history <world-id>
-```
-
-Useful environment variables:
-
-- `ARCHETYPE_URL`: base URL for the CLI, default `http://localhost:8000`
-
-Useful per-command flags:
-
-- `--url`: override `ARCHETYPE_URL` for one command
-- `--role` / `-r`: developer-mode auth shortcut (`admin`, `operator`, `player`, `viewer`)
-- `--token`: send `Authorization: Bearer <token>`; intended for production auth once v2 auth lands
-- `--json`: emit raw JSON for read commands
-
-## REST API
-
-`archetype serve` exposes a FastAPI app with these routes:
-
-| Method | Endpoint | Purpose |
-|---|---|---|
-| `POST` | `/worlds` | Create a world |
-| `GET` | `/worlds` | List worlds |
-| `GET` | `/worlds/{world_id}` | Inspect one world |
-| `DELETE` | `/worlds/{world_id}` | Destroy a live world |
-| `POST` | `/worlds/{world_id}/fork` | Fork a world |
-| `POST` | `/worlds/{world_id}/entities` | Spawn an entity |
-| `DELETE` | `/worlds/{world_id}/entities/{entity_id}` | Despawn an entity |
-| `PATCH` | `/worlds/{world_id}/entities/{entity_id}` | Update entity components |
-| `POST` | `/worlds/{world_id}/entities/{entity_id}/components` | Add components |
-| `DELETE` | `/worlds/{world_id}/entities/{entity_id}/components` | Remove components |
-| `POST` | `/worlds/{world_id}/commands` | Submit one command |
-| `POST` | `/worlds/{world_id}/commands/batch` | Submit multiple commands |
-| `GET` | `/worlds/{world_id}/commands` | Audit-backed command history |
-| `POST` | `/worlds/{world_id}/step` | Run one tick |
-| `POST` | `/worlds/{world_id}/run` | Run multiple ticks |
-| `POST` | `/worlds/{world_id}/episode` | Run one episode |
-| `POST` | `/worlds/{world_id}/rollout` | Run a rollout |
-| `GET` | `/worlds/{world_id}/processors` | List processors |
-| `GET` | `/worlds/{world_id}/hooks` | List hooks |
-| `GET` | `/worlds/{world_id}/resources` | List resources |
-| `GET` | `/worlds/{world_id}/state` | Query world snapshot |
-| `GET` | `/worlds/{world_id}/entities/{entity_id}` | Query one entity |
-| `GET` | `/worlds/{world_id}/components` | Query component projections |
-| `GET` | `/worlds/{world_id}/history` | Query audit history |
+| Layer | What it is |
+|---|---|
+| `src/archetype/core` | The ledger and the tick loop. Hard invariants: append-only stores, canonical archetype identity, lineage-aware reads, loud persistence failures. |
+| `src/archetype/app` | The gate. Every operation is authorized, audited, and — for mutations — deferred to the tick boundary through a deterministic broker. |
+| `src/archetype/runtime` | `ArchetypeRuntime` — the recommended script boundary. World handles that route everything through the gate. |
+| `src/archetype/api` + `src/archetype/cli` | A reference deployment of the gate over HTTP, plus a thin CLI client. Inspection and ops — worlds get their behavior (processors, hooks) in-process. |
+| `src/archetype/experiments` | Experiment tracking as components: runs, results, trajectories, branch heads. The ledger's first first-party consumer. |
 
 ## Core Concepts
 
 ### Components
 
-Components are typed `LanceModel` subclasses. Their fields define the archetype schema fragments that get flattened into storage columns.
+Components are typed `LanceModel` subclasses. Their fields define the
+archetype schema fragments that get flattened into storage columns.
 
 ```python
 class Health(Component):
@@ -212,13 +182,15 @@ class Health(Component):
 
 ### Archetypes
 
-An archetype is the exact set of component types attached to an entity. Archetype signatures are canonicalized by sorted component type name, so component order is not meaningful.
-
-If you add or remove a component, the entity migrates to a different archetype table.
+An archetype is the exact set of component types attached to an entity.
+Signatures are canonicalized by sorted component type name, so component
+order is not meaningful. Adding or removing a component migrates the entity
+to a different archetype table.
 
 ### Processors
 
-Processors are pure-ish DataFrame transforms selected by subset match on component signatures:
+Processors are pure DataFrame transforms selected by subset match on
+component signatures:
 
 ```python
 class ThinkProcessor(AsyncProcessor):
@@ -226,85 +198,90 @@ class ThinkProcessor(AsyncProcessor):
     priority = 20
 ```
 
-If an archetype contains at least `Agent` and `Memory`, that processor runs on its DataFrame.
+If an archetype contains at least `Agent` and `Memory`, that processor runs
+on its DataFrame. Because a processor sees the whole population at once, an
+LLM-backed processor batches inference across every matching agent in one
+pass instead of looping agent by agent.
 
-### Worlds
+### Forking and lineage
 
-`AsyncWorld` owns:
+A fork gets a new `world_id` and `run_id`, preserves the tick position, and
+carries a *lineage* — pointers to the ancestor segments of its timeline.
+Pre-fork ticks resolve to the ancestor's immutable rows; post-fork ticks are
+the fork's own. The parent can keep running or be destroyed without affecting
+the fork's view. Lineage is persisted append-only at fork time, so ancestry
+survives process restarts and dead worlds. See
+`docs/guide/world-lifecycle.md`.
 
-- entity-to-archetype bookkeeping
-- pending spawn/despawn caches
-- the live in-memory snapshot for the latest tick
-- lifecycle hooks
-- query / execute / update orchestration
+### Commands and governance
 
-Different archetypes are processed concurrently; processors within one archetype run in ascending `priority`.
-
-### Commands and RBAC
-
-All external mutations are designed to flow through:
+All external mutations flow through one gate:
 
 ```text
-API / CLI / caller
-  → CommandService
-  → direct service delegate or tick-deferred CommandBroker
-  → AsyncWorld / storage
+caller → CommandService → direct delegate or tick-deferred CommandBroker → world → store
 ```
 
-The command gate enforces:
-
-- role permissions
-- per-tick command quotas
-- daily token budgets
-- audit emission
-
-Current roles are `viewer`, `player`, `operator`, and `admin`.
+The gate enforces role permissions (`viewer`, `player`, `operator`, `admin`),
+per-tick command quotas, token budgets, and emits one audit row per gated
+call — to an append-only audit table you query like any other DataFrame.
+Auth today is developer-mode (role-as-bearer-token); treat the RBAC surface
+as single-trusted-user until v2 auth lands.
 
 ### Storage
 
-Archetype supports two async storage backends behind the same contracts:
+Two async backends behind the same contracts: `AsyncLancedbStore` (LanceDB,
+default) and `AsyncStore` (Daft catalog / Iceberg). `StorageService` pools
+instances by `(uri, namespace, backend, cache config)`, and the gate resolves
+each world's recorded store so readers find rows wherever the world wrote
+them.
 
-- `AsyncLancedbStore` for LanceDB-backed archetype tables
-- `AsyncStore` for the Daft catalog-backed path
+## CLI and REST (reference deployment)
 
-`StorageService` shares backend instances across worlds with the same effective storage pool key: `(uri, namespace, backend, cache config)`.
+`archetype serve` exposes the gate over HTTP; the CLI is a thin client for
+it. This surface is for inspection and operations — listing worlds, stepping,
+forking, reading audit history. Worlds created over the wire have no
+processors; behavior is attached in-process through `ArchetypeRuntime`.
 
-## World Forking
+```bash
+archetype serve                       # start the FastAPI server
+archetype world create demo           # create a world
+archetype run <world-id> --steps 10   # run ticks
+archetype world fork <world-id> --name branch-a
+archetype history <world-id>          # audit history
+```
 
-Forking is a first-class operation in `WorldService`.
-
-A fork:
-
-- gets a new `world_id`
-- gets a new `run_id`
-- preserves tick position
-- copies entity mappings and pending mutation caches
-- copies hook registrations present at fork time
-- shares processor and resource instances by default
-
-Source and fork diverge independently after that point.
+Full route table and flags: `docs/guide/api-layer.md`.
 
 ## Status
 
-Current state worth knowing before using it:
+Honest state of the system:
 
-- the core runtime and append-only write path are the most mature parts
-- the Python service layer is richer than the REST read models
-- the FastAPI layer currently uses a default admin `ActorCtx` — not multi-tenant auth yet
+- the ledger — append-only write path, tick loop, time travel, fork lineage —
+  is the most mature part, and the most heavily contract-tested
+- `archetype.experiments` (runs, results, trajectories) is young but real;
+  the AutoResearch loop controller is early
+- the FastAPI layer runs a default admin `ActorCtx` — not multi-tenant auth
+  yet; the four-role model is enforced at the gate but identities are
+  developer-mode
+- a Rust core implementing the same engine semantics (arrow-rs, append-only
+  Parquet, Arrow C Data Interface) is in progress on a separate branch
 
-Start with `src/archetype/runtime` (`ArchetypeRuntime`) to use the system. Read `src/archetype/core` and `src/archetype/app` to understand how it works underneath.
+Start with `src/archetype/runtime` (`ArchetypeRuntime`) to use the system.
+Read `src/archetype/core` and `src/archetype/app` to understand how it works
+underneath.
 
 ## Repository Map
 
 ```text
 archetype/
 ├── src/archetype/runtime/   # ArchetypeRuntime — recommended top-level API
-├── src/archetype/core/      # ECS runtime and storage contracts
-├── src/archetype/app/       # Gated service layer (lower-level)
-├── src/archetype/api/       # FastAPI server
-├── src/archetype/cli/       # Typer CLI
+├── src/archetype/core/      # The ledger: ECS runtime and storage contracts
+├── src/archetype/app/       # The gate: command service, broker, audit
+├── src/archetype/api/       # FastAPI server (reference deployment)
+├── src/archetype/cli/       # Typer CLI (thin client)
+├── src/archetype/experiments/ # Runs, results, trajectories as components
 ├── examples/                # Runnable examples
-├── tests/                   # Test suite
+├── tests/                   # Test suite (contract tests pin the spec)
 ├── docs/                    # MkDocs site
 ├── AGENTS.md                # Repo-specific collaborator guidance
 └── LEARNINGS.md             # Architecture notes
@@ -312,29 +289,25 @@ archetype/
 
 ## Examples
 
-Run the examples directly:
-
 ```bash
 uv run python examples/01_world_mutations.py
 uv run python examples/02_fork_counterfactual.py
-uv run python examples/03_time_travel.py
+uv run python examples/03_time_travel.py      # historical reads + fork-and-diff
 uv run python examples/04_messaging.py
 uv run python examples/05_llm_agents.py
 uv run python examples/06_trajectory_analysis.py
 uv run python examples/07_hooks.py
 ```
 
-`examples/05_llm_agents.py` and parts of `examples/06_trajectory_analysis.py` require `OPENAI_API_KEY`.
+`examples/05_llm_agents.py` and parts of `examples/06_trajectory_analysis.py`
+require `OPENAI_API_KEY`.
 
 ## Observability
 
-Archetype ships with [Logfire](https://pydantic.dev/logfire) integration at three levels:
-
-**Gate spans** — every `CommandService` method is instrumented with `@logfire.instrument`. You see operation type, world_id, actor_id, and duration for every gated call.
-
-**Step phases** — inside each tick, four spans cover query/materialize/execute/update. This tells you whether time is in store I/O or processor compute.
-
-**Simulation hooks** — opt-in per-tick and per-entity event tracing:
+Archetype ships with [Logfire](https://pydantic.dev/logfire) integration at
+three levels: gate spans on every `CommandService` method, step-phase spans
+inside each tick (query / materialize / execute / update), and opt-in
+per-tick/per-entity hooks:
 
 ```python
 from archetype.contrib.logfire_observer import logfire_hooks
@@ -342,9 +315,8 @@ from archetype.contrib.logfire_observer import logfire_hooks
 world = runtime.world("demo", processors=[...], hooks=logfire_hooks())
 ```
 
-The runtime calls `logfire.configure()` automatically. Python stdlib logging is bridged into Logfire via `LogfireLoggingHandler`, so all `logger.*` calls throughout the codebase appear as Logfire events.
-
-For the FastAPI server, `logfire.instrument_fastapi` auto-traces every route.
+The runtime calls `logfire.configure()` automatically, and stdlib logging is
+bridged in, so `logger.*` calls appear as Logfire events.
 
 ## Development
 
@@ -361,7 +333,10 @@ make docs        # build docs
 - Docs site: `https://archetype-docs.pages.dev`
 - Examples index: `examples/README.md`
 - Architecture notes: `LEARNINGS.md`
-- Specifications: `docs/guide/runtime.md`, `docs/guide/service-protocols.md`, `docs/guide/command-gate.md`, `docs/guide/execution-hierarchy.md`, `docs/guide/world-lifecycle.md`, `docs/guide/audit-log.md`
+- Specifications: `docs/guide/specification.md`, `docs/guide/runtime.md`,
+  `docs/guide/service-protocols.md`, `docs/guide/command-gate.md`,
+  `docs/guide/execution-hierarchy.md`, `docs/guide/world-lifecycle.md`,
+  `docs/guide/audit-log.md`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Archetype
 
-**Two primitives — components and processors — on a dataframe engine.
-The rest of the data stack is derived.**
+**An opinion about what data engineering should be:
+composable, declarative, and data-centric.**
 
 [![CI](https://github.com/VangelisTech/archetype/actions/workflows/python-tests.yml/badge.svg)](https://github.com/VangelisTech/archetype/actions/workflows/python-tests.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://python.org)
@@ -14,10 +14,15 @@ The rest of the data stack is derived.**
 ![Archetype Architecture Diagram](assets/archetype_diagram2.png)
 
 Archetype is a state machine that uses big-data technology to run itself,
-built for the AI-native world. You define data as `Component` classes and
-behavior as `Processor` transforms. The engine derives the rest of what a
-data stack normally makes you build by hand: schemas, columnar tables,
-partitioning, queries, history, audit.
+built for the AI-native world.
+
+- **Composable** — two primitives only: components (data) and processors
+  (behavior). Archetypes, worlds, and forks are compositions of them.
+- **Declarative** — you declare shapes and transforms; the engine derives
+  what a data stack normally makes you build by hand: schemas, columnar
+  tables, partitioning, dispatch, queries, history, audit.
+- **Data-centric** — nothing is deleted. State, history, and the engine's
+  own operation are rows in the same store.
 
 ```python
 class Position(Component):        # a component is a schema

--- a/docs/guide/audit-log.md
+++ b/docs/guide/audit-log.md
@@ -46,13 +46,8 @@ Required identity and operation fields:
 - `accepted_at`
 - `applied_at`
 
-Payment-bearing fields are nullable:
+Nullable fields:
 
-- `signer_address`
-- `tx_hash`
-- `price_paid_atomic`
-- `asset`
-- `chain_id`
 - `idempotency_key`
 
 ## 5. Query Contract
@@ -62,7 +57,6 @@ Payment-bearing fields are nullable:
 - `world_id`
 - `tick_range`
 - `actor_id`
-- `signer_address`
 - `idempotency_key`
 - `limit`
 

--- a/docs/guide/command-gate.md
+++ b/docs/guide/command-gate.md
@@ -240,10 +240,12 @@ This is also how multi-tenant API servers map authenticated principals to ActorC
 
 Every gated call emits one audit row. The audit row schema is defined in [Audit Log](audit-log.md); fields include:
 
-- `command_id`, `world_id`, `tick`, `actor_id`, `actor_roles`
+- `command_id`, `world_id`, `actor_id`
 - `command_type`, `payload_json`, `idempotency_key`
 - `accepted_at`, `applied_at`, `status`
-- Payment-bearing columns (nullable): `signer_address`, `tx_hash`, `price_paid_atomic`, `asset`, `chain_id`
+
+(`tick` and per-row `actor_roles` are not yet recorded; adding them is
+tracked as audit-log hardening.)
 
 Multi-step gate methods (e.g. `destroy_world` orchestrating broker.clear + audit.flush + world_service.destroy_world) emit ONE audit row, not one per step. The row's `payload_json` captures sub-operation outcomes.
 
@@ -268,4 +270,3 @@ Existing code that constructs `ActorCtx(roles={"maintainer"})` should be updated
 - **Role hierarchy.** Today: flat sets, explicit composition.
 - **Custom roles.** Products may extend `COMMANDS_BY_ROLE` with new keys.
 - **Quota differentiation.** Per-tick command quotas key off `ctx.id`, not role. Quotas-by-role is a v2 addition.
-- **Payment-aware role.** A `paid` role indicates the request was paid for via x402. Composes with other roles. See platform spec § 3.3.

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -84,7 +84,8 @@ These cover:
 
 Some of the most important contracts are enforced directly in tests:
 
-- [`tests/app/test_sugar_runtime.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_sugar_runtime.py)
+- [`tests/app/test_runtime_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_contracts.py)
+- [`tests/app/test_runtime_fork_storage.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_fork_storage.py)
 - [`tests/sync/test_sync_stack_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/sync/test_sync_stack_contracts.py)
 - [`tests/integration/test_command_flow.py`](https://github.com/VangelisTech/archetype/blob/main/tests/integration/test_command_flow.py)
 - [`tests/app/test_services.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_services.py)

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -113,7 +113,9 @@ Forks share resource instances by default; attach replacement resources through 
 
 ## 3. Time-Travel Queries
 
-Run 10 ticks, then query any point in history. Every tick is preserved.
+Run ticks, rewind to any past tick by filtering the `tick` column, then fork
+a counterfactual branch and diff it against the source at the same tick.
+Every tick is preserved.
 
 ```bash
 uv run python examples/03_time_travel.py
@@ -121,56 +123,22 @@ uv run python examples/03_time_travel.py
 
 Source: [`examples/03_time_travel.py`](https://github.com/VangelisTech/archetype/blob/main/examples/03_time_travel.py)
 
-This example uses lower-level service calls for historical storage queries, but
-external reads still enter through `CommandService` so viewer permissions and
-audit behavior apply.
+`world.query(...)` returns the full append-only history, so a point-in-time
+view is a Daft filter:
 
 ```python
-import asyncio
-
-from uuid_utils import uuid7
-
-from archetype.app.auth.models import ActorCtx
-from archetype.app.container import ServiceContainer
-from archetype.app.models import Command, CommandType
-from archetype.core.config import RunConfig, StorageConfig, WorldConfig
-
-
-async def main():
-    container = ServiceContainer()
-    ctx = ActorCtx(id=uuid7(), roles={"admin"})
-
-    info = await container.command_service.create_world(
-        ctx, WorldConfig(name="time-travel-demo"), StorageConfig(),
-    )
-
-    # Spawn 3 entities and run 5 ticks
-    for _ in range(3):
-        cmd = Command(type=CommandType.SPAWN, payload={"components": []})
-        await container.command_service.submit(ctx, info.world_id, cmd)
-    await container.command_service.run(ctx, info.world_id, RunConfig(num_steps=5))
-
-    # Spawn 2 more and run 5 more ticks
-    for _ in range(2):
-        cmd = Command(type=CommandType.SPAWN, payload={"components": []})
-        await container.command_service.submit(ctx, info.world_id, cmd)
-    await container.command_service.run(ctx, info.world_id, RunConfig(num_steps=5))
-
-    # Query state at different ticks
-    for tick in [1, 5, 10]:
-        state = await container.command_service.query_archetype(
-            ctx, (), str(info.world_id), str(info.run_id or ""), ticks=[tick]
-        )
-        print(f"tick {tick:>2}: {len(state.collect().to_pylist())} rows")
-
-    # Full command audit trail
-    history = await container.command_service.get_audit_history(ctx, info.world_id)
-    print(history)
-
-    await container.shutdown()
-
-asyncio.run(main())
+df = await world.query(Position, Velocity)
+at_tick_2 = df.where(col("tick") == 2)
 ```
+
+The fork half of the example stages a divergent component value on the fork
+(`fork.update(entity, Velocity(vx=10.0))`), steps both worlds the same number
+of ticks, and prints the source-vs-fork diff at the same tick — plus the
+fork's view of its pre-fork history, read through lineage.
+
+One subtlety worth knowing: tick 0 is persisted *after* processors run, so
+spawn-time component values are never queryable as a row — tick 0 already
+reflects one processor pass.
 
 ---
 

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -129,7 +129,7 @@ Append-only record of accepted-and-applied commands. Schema is fixed in [Audit L
 async def record(row: AuditRow) -> None
 async def flush() -> None
 async def query(world_id=None, *, tick_range=None, actor_id=None,
-                 signer_address=None, idempotency_key=None, limit=None) -> DataFrame
+                 idempotency_key=None, limit=None) -> DataFrame
 async def shutdown() -> None
 ```
 
@@ -210,7 +210,7 @@ async def list_processors(ctx, world_id) -> list[ProcessorInfo]
 async def list_hooks(ctx, world_id) -> list[HookInfo]
 async def list_resources(ctx, world_id) -> list[ResourceInfo]
 async def get_audit_history(ctx, world_id=None, *, tick_range=None, actor_id=None,
-                             signer_address=None, idempotency_key=None, limit=None) -> DataFrame
+                             idempotency_key=None, limit=None) -> DataFrame
 ```
 
 #### Tick-deferred path (queued submit)

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -21,7 +21,8 @@ The current contract set is split across design docs and executable tests.
 | [Execution Hierarchy](execution-hierarchy.md) | Step/run/episode/rollout | Simulation levels and rollout fork semantics. |
 | [World Lifecycle](world-lifecycle.md) | Create/fork/destroy | Append-only lifecycle, info-class downgrade, fork sharing/copy rules. |
 | [Audit Log](audit-log.md) | Audit rows | Append-only audit history and query contract. |
-| [`tests/app/test_sugar_runtime.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_sugar_runtime.py) | Executable runtime contracts | Enforces activation single-flight, runtime-vs-world lifetime, fork isolation, spawn visibility, governance, and smoke paths. |
+| [`tests/app/test_runtime_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_contracts.py) | Executable runtime contracts | Enforces activation single-flight, runtime-vs-world lifetime, fork isolation, spawn visibility, governance, and smoke paths. |
+| [`tests/app/test_runtime_fork_storage.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_fork_storage.py) | Runtime fork storage contracts | Enforces fork storage inheritance through the runtime layer, lineage reads on fork handles, fork run_id minting, and gate-side storage resolution. |
 | [`tests/sync/test_sync_stack_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/sync/test_sync_stack_contracts.py) | Executable sync engine contracts | Enforces store/querier/updater/world behavior, mutation materialization, component migration, and despawn semantics. |
 | [`tests/integration/test_command_flow.py`](https://github.com/VangelisTech/archetype/blob/main/tests/integration/test_command_flow.py) | Reserved spawn chain | Verifies reserved `entity_id` survives submit -> drain -> apply -> materialize. |
 | [`tests/app/test_services.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_services.py) | Service-layer execution contracts | Covers simulation service boundaries, processor metadata, and read-service expectations. |
@@ -150,11 +151,12 @@ Idempotency:
 - Store `get_archetype_df()` is idempotent for the same persisted data.
 - Cached-store shutdown MUST be idempotent even if called multiple times.
 
-CURRENT GAP:
+Failure observability:
 
-- `AsyncUpdateManager` currently logs append failures and still returns a
-  stamped DataFrame. Durability success is therefore ambiguous. The contract
-  should be hardened so failed persistence is observable to callers.
+- A failed append MUST raise to the caller. Stores log the failure and
+  re-raise; they MUST NOT return as if the write happened. Empty appends
+  (zero rows or empty schema) remain safe no-ops.
+- Contract tests: `tests/core/test_async_store_updater_failures.py`.
 
 ## Querier Contracts
 
@@ -188,10 +190,13 @@ Idempotency:
 - Idempotency for world mutation replay must therefore be provided by world or
   command semantics, not by the updater.
 
-CURRENT GAP:
+Failure observability:
 
-- Failed appends are currently swallowed and logged. The updater contract should
-  distinguish successful persistence from a stamped-but-uncommitted DataFrame.
+- The updater MUST raise when the store append fails. Persistence success is
+  observable: a returned DataFrame means the rows were committed. A
+  schemaless empty frame is skipped as a no-op before stamping.
+- Contract tests: `tests/core/test_async_store_updater_failures.py`,
+  `tests/sync/test_sync_stack_contracts.py::test_sync_update_manager_raises_on_store_errors`.
 
 ## System and Processor Contracts
 
@@ -208,13 +213,12 @@ CURRENT GAP:
 Failure policy:
 
 - Processor failures MUST NOT silently corrupt world bookkeeping.
-- If the engine continues after a processor failure, that continuation policy
-  MUST be explicit and tested.
-
-Current behavior:
-
-- Processor errors are logged and execution continues with the last good
-  DataFrame.
+- A processor failure fails its archetype's tick: the error is logged,
+  `step()` raises, the tick counter does not advance, and nothing is
+  appended for that tick. The engine does not append a frame the failed
+  processor never transformed.
+- Contract test:
+  `tests/core/test_async_world_error_propagation.py::test_async_world_processor_error_fails_the_step`.
 
 Idempotency:
 

--- a/docs/guide/world-lifecycle.md
+++ b/docs/guide/world-lifecycle.md
@@ -104,6 +104,14 @@ For users who want isolated resources per fork, they instantiate new resource in
 
 The fork writes to the same physical store as the source by default, with rows partitioned by `world_id`. The optional `storage_config` argument allows the fork to write to a different store entirely.
 
+Routing a fork to a different store severs read lineage (§ 4.6): ancestor
+segments name rows in the source's store, and the fork's reads only see its
+own store. A cross-store fork therefore starts from transferred pending
+state (un-materialized spawns/despawns), not from the source's persisted
+history. Forking with an explicit `storage_config` on a stepped source logs
+a warning for this reason. Same-store forks — the default — get full
+history continuation.
+
 ### 4.6 — Read lineage (copy-on-write history)
 
 A fork does not copy the source's materialized rows. Instead it carries a `lineage` — an ascending list of `(world_id, run_id, up_to_tick)` segments: the source's own lineage plus, if the source has stepped, one segment covering the source's rows for ticks `0..tick-1`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Archetype
 
-## A forkable, append-only world ledger for simulations and AI agents
+## An opinion about what data engineering should be: composable, declarative, and data-centric
 
 Every tick of a running world persists as queryable Arrow rows keyed
 `(world_id, run_id, tick)`. Nothing is ever overwritten — there is no update

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,42 +1,67 @@
 # Archetype
 
-## A dataframe-first, append-only ECS runtime for simulations and AI agents
+## A forkable, append-only world ledger for simulations and AI agents
 
-Archetype stores world state as columnar archetype tables, executes behavior as DataFrame transforms, and persists every tick as a new snapshot instead of overwriting rows. Consequences of that storage model:
+Every tick of a running world persists as queryable Arrow rows keyed
+`(world_id, run_id, tick)`. Nothing is ever overwritten — there is no update
+path and no delete path anywhere in the storage layer. Everything distinctive
+about Archetype falls out of that one decision:
 
-- entities are grouped by exact component sets
-- processors run over whole archetype DataFrames
-- writes are append-only
-- time-travel and world forking fall out of the storage model
+- **Time travel is a query.** `df.where(col("tick") == t)` is the state of the
+  world at tick `t`. Forever.
+- **Forking is branching the timeline.** Fork any moment of any run, vary one
+  condition, and diff the branches with a dataframe query. Forks read
+  pre-fork history through lineage — O(metadata), no row copying.
+- **Every run leaves a dataset behind.** Trajectories, rollout results, and
+  audit history land in the same store as world state.
+- **A tick either commits or it didn't happen.** Failed persistence raises; a
+  failed processor fails its tick. The ledger has no silent holes.
 
-## What It Is
+Mechanically, Archetype is an ECS on the [Daft](https://daft.ai) dataframe
+engine: entities are rows grouped into columnar archetype tables by exact
+component set, behavior is DataFrame transforms over whole archetypes, and a
+deterministic tick loop is the ledger's commit protocol.
 
-Archetype is split into layers:
+## What it's for
 
-| Layer | Purpose |
+Workloads where history is part of the model, not exhaust:
+
+- **Counterfactual evaluation of agent populations** — run many LLM agents in
+  a shared world, fork mid-history, replay a branch under a different
+  condition, and compare outcomes as tables
+- **Rollout-heavy simulation** — episodes and rollouts are first-class; every
+  rollout's full tick history is queryable after the fact
+- **Trajectory datasets** — agent runs recorded as rows you can filter, join,
+  grade, and train on (see [Trajectories](guide/trajectories.md) and
+  [AutoResearch](guide/autoresearch.md))
+- **Multi-agent worlds with replay** — anything you'd want to rewind, audit,
+  or branch
+
+## The tick
+
+One pass of the loop, for every archetype concurrently:
+
+1. external calls enter through the command gate, which authorizes, audits,
+   and defers mutations to the next tick boundary
+2. queued commands drain in deterministic `(tick, priority, sequence)` order,
+   with entity ids reserved at submit time
+3. the world reads tick `N-1`, materializes spawns/despawns
+4. processors transform the archetype's DataFrame in priority order
+5. the result is appended at tick `N` — or the step raises
+
+The tick boundary is the frame of the system: the deterministic answer to
+"when does an agent's action land." Same world state + same command queue +
+same processor outputs → same ledger.
+
+## How it's organized
+
+| Layer | What it is |
 |---|---|
-| `src/archetype/runtime` | `ArchetypeRuntime` — recommended top-level API for scripts and simulations |
-| `src/archetype/core` | ECS primitives: `Component`, `Archetype`, `AsyncWorld`, `AsyncProcessor`, storage/query/update contracts |
-| `src/archetype/app` | Service layer (lower-level): command gate, audit log, broker, world/simulation/query services |
-| `src/archetype/api` + `src/archetype/cli` | FastAPI server and Typer CLI |
-
-The runtime model is:
-
-1. external calls enter through `iCommandService`
-2. the gate authorizes, delegates, and audits
-3. tick-deferred commands are drained when a world steps
-4. worlds materialize structural mutations
-5. processors transform matching archetype DataFrames
-6. updated rows are appended to storage
-
-## Use Cases
-
-Simulations where tick-by-tick history is part of the model:
-
-- multi-agent worlds
-- counterfactual branches and forks
-- rollout-heavy evaluation
-- LLM-powered processors running over many entities in parallel
+| `src/archetype/core` | The ledger and the tick loop. Hard invariants: append-only stores, canonical archetype identity, lineage-aware reads, loud persistence failures. |
+| `src/archetype/app` | The gate. Every operation is authorized, audited, and — for mutations — deferred to the tick boundary through a deterministic broker. |
+| `src/archetype/runtime` | `ArchetypeRuntime` — the recommended script boundary. World handles that route everything through the gate. |
+| `src/archetype/api` + `src/archetype/cli` | A reference deployment of the gate over HTTP, plus a thin CLI client. Inspection and ops — worlds get their behavior in-process. |
+| `src/archetype/experiments` | Experiment tracking as components: runs, results, trajectories, branch heads. |
 
 ## Quickstart
 
@@ -44,14 +69,6 @@ Install the package:
 
 ```bash
 pip install archetype-ecs
-```
-
-For development:
-
-```bash
-git clone https://github.com/VangelisTech/archetype.git
-cd archetype
-uv sync --group dev
 ```
 
 The recommended entry point for scripts is `ArchetypeRuntime`:
@@ -94,169 +111,118 @@ async def main():
         await world.spawn(Position(x=0, y=0), Velocity(dx=1, dy=2))
         await world.run(steps=3)
 
-        df = await world.query(Position)
+        df = await world.query(Position)  # full append-only history
         print(df.collect().to_pylist())
 
 
 asyncio.run(main())
 ```
 
-Two important details:
+Fork-and-diff — the move the storage model exists for:
 
-- processor columns are always prefixed as `componentname__field`
-- `ArchetypeRuntime` is the script boundary; use `world.as_actor(...)` for explicit roles and drop to `ServiceContainer` only for custom command routing or lower-level lifecycle control
+```python
+fork = await world.fork("counterfactual")  # inherits the source's store
+await fork.step()                          # continues from the source's last tick
 
-See [Quickstart](guide/quickstart.md) for more.
-
-## CLI
-
-The CLI is a thin HTTP client. Except for `serve`, every command talks to a running FastAPI server.
-
-```bash
-archetype serve
-archetype world create demo
-archetype world list
-archetype entity spawn <world-id> --components '[{"type":"Position","x":0,"y":0}]'
-archetype run <world-id> --steps 10
-archetype rollout <world-id> --num-episodes 4 --max-steps 100
-archetype world fork <world-id> --name branch-a
-archetype world destroy <world-id>
-archetype history <world-id>
+source_df = await world.query(Position)
+fork_df = await fork.query(Position)       # pre-fork history + its own branch
 ```
 
-Useful environment variables:
+Two important details:
 
-- `ARCHETYPE_URL` for the CLI base URL
-- `--url` for a per-command URL override
-- `--role` / `-r` for the developer auth shortcut (`admin`, `operator`, `player`, `viewer`)
-- `--token` for `Authorization: Bearer <token>`
+- component columns are always prefixed `componentname__field`
+- `ArchetypeRuntime` is the script boundary; use `world.as_actor(...)` for
+  explicit roles and drop to `ServiceContainer` only for custom command
+  routing or lower-level lifecycle control
 
-See [CLI Reference](reference/cli.md) for the generated command docs.
-
-## REST API
-
-`archetype serve` exposes a FastAPI app with these routes:
-
-| Method | Endpoint | Purpose |
-|---|---|---|
-| `POST` | `/worlds` | Create a world |
-| `GET` | `/worlds` | List worlds |
-| `GET` | `/worlds/{world_id}` | Inspect one world |
-| `DELETE` | `/worlds/{world_id}` | Destroy a live world |
-| `POST` | `/worlds/{world_id}/fork` | Fork a world |
-| `POST` | `/worlds/{world_id}/commands` | Submit one command |
-| `POST` | `/worlds/{world_id}/commands/batch` | Submit multiple commands |
-| `GET` | `/worlds/{world_id}/commands` | Audit-backed command history |
-| `POST` | `/worlds/{world_id}/step` | Run one tick |
-| `POST` | `/worlds/{world_id}/run` | Run multiple ticks |
-| `POST` | `/worlds/{world_id}/episode` | Run one episode |
-| `POST` | `/worlds/{world_id}/rollout` | Run a rollout |
-| `GET` | `/worlds/{world_id}/processors` | List processors |
-| `GET` | `/worlds/{world_id}/hooks` | List hooks |
-| `GET` | `/worlds/{world_id}/resources` | List resources |
-| `GET` | `/worlds/{world_id}/state` | Query world snapshot |
-| `GET` | `/worlds/{world_id}/entities/{entity_id}` | Query one entity |
-| `GET` | `/worlds/{world_id}/components` | Query component projections |
-| `GET` | `/worlds/{world_id}/history` | Query audit history |
-
-See [REST API Reference](reference/rest-api.md) for the generated API docs.
+See [Quickstart](guide/quickstart.md) for more.
 
 ## Core Concepts
 
 ### Components
 
-Components are typed `LanceModel` subclasses. Their fields define the archetype schema fragments that get flattened into storage columns.
-
+Components are typed `LanceModel` subclasses. Their fields define the
+archetype schema fragments that get flattened into storage columns.
 See [Components](guide/components.md).
 
 ### Archetypes
 
-An archetype is the exact set of component types attached to an entity. If you add or remove a component, the entity migrates to a different archetype table.
-
-See [Archetype](guide/archetype.md).
+An archetype is the exact set of component types attached to an entity.
+Adding or removing a component migrates the entity to a different archetype
+table. See [Archetype](guide/archetype.md).
 
 ### Processors
 
-Processors are DataFrame transforms selected by subset match on component signatures.
-
-See [Processors](guide/processors.md) and [System Execution](guide/system-execution.md).
+Processors are DataFrame transforms selected by subset match on component
+signatures. Because a processor sees the whole population at once, an
+LLM-backed processor batches inference across every matching agent in one
+pass. See [Processors](guide/processors.md) and
+[System Execution](guide/system-execution.md).
 
 ### Worlds
 
-`AsyncWorld` owns:
+`AsyncWorld` owns entity-to-archetype bookkeeping, pending mutation caches,
+lifecycle hooks, and the query / execute / update orchestration of the tick.
+Different archetypes are processed concurrently; processors within one
+archetype run in ascending `priority`. See [Worlds](guide/worlds.md).
 
-- entity-to-archetype bookkeeping
-- pending spawn/despawn caches
-- the live in-memory snapshot for the latest tick
-- lifecycle hooks
-- query / execute / update orchestration
+### Forking and lineage
 
-Different archetypes are processed concurrently. Processors within one archetype run in ascending `priority`.
+A fork gets a new `world_id` and `run_id`, preserves the tick position, and
+carries a *lineage* — pointers to the ancestor segments of its timeline.
+Pre-fork ticks resolve to the ancestor's immutable rows; post-fork ticks are
+the fork's own. Lineage is persisted append-only at fork time, so ancestry
+survives process restarts and destroyed worlds.
+See [World Lifecycle](guide/world-lifecycle.md).
 
-See [Worlds](guide/worlds.md).
+### Commands and governance
 
-### Commands and RBAC
-
-All external mutations are designed to flow through:
+All external mutations flow through one gate:
 
 ```text
-API / CLI / caller
-  → CommandService
-  → direct service delegate or tick-deferred CommandBroker
-  → AsyncWorld / storage
+caller → CommandService → direct delegate or tick-deferred CommandBroker → world → store
 ```
 
-The command gate enforces:
-
-- role permissions
-- per-tick command quotas
-- daily token budgets
-- audit emission
-
-See [Command Gate](guide/command-gate.md), [Services](guide/services.md), and [Data Flow](guide/data-flow.md).
+The gate enforces role permissions, per-tick command quotas, token budgets,
+and emits one audit row per gated call — to an append-only audit table you
+query like any other DataFrame. See [Command Gate](guide/command-gate.md),
+[Services](guide/services.md), and [Data Flow](guide/data-flow.md).
 
 ### Storage
 
-Archetype supports two async storage backends behind the same contracts:
-
-- `AsyncLancedbStore` for LanceDB-backed archetype tables
-- `AsyncStore` for the Daft catalog-backed path
-
+Two async storage backends behind the same contracts: `AsyncLancedbStore`
+(LanceDB, default) and `AsyncStore` (Daft catalog / Iceberg).
+`StorageService` pools instances by `(uri, namespace, backend, cache config)`.
 See [Stores](guide/stores.md).
 
 ### Resources
 
-Resources are world-scoped dependencies injected into processors outside the entity/component storage path.
+Resources are world-scoped dependencies injected into processors outside the
+entity/component storage path. See [Resources](guide/resources.md).
 
-See [Resources](guide/resources.md).
+## CLI and REST (reference deployment)
 
-### Run Configuration
+`archetype serve` exposes the gate over HTTP; the CLI is a thin client for
+it. This surface is for inspection and operations — listing worlds, stepping,
+forking, reading audit history. Worlds created over the wire have no
+processors; behavior is attached in-process through `ArchetypeRuntime`.
 
-`RunConfig` controls run-level execution behavior such as step count and debug options.
+```bash
+archetype serve
+archetype world create demo
+archetype run <world-id> --steps 10
+archetype world fork <world-id> --name branch-a
+archetype history <world-id>
+```
 
-See [Run Config](guide/run-config.md).
-
-## World Forking
-
-Forking is a first-class operation in `WorldService`.
-
-A fork:
-
-- gets a new `world_id`
-- gets a new `run_id`
-- preserves tick position
-- copies entity mappings and pending mutation caches at fork time
-- copies hook registrations present at fork time
-- shares processor and resource instances by default
-
-Source and fork diverge independently after that point.
-
-Destroying a world removes the live in-memory world only. Storage rows and audit rows remain queryable.
+See [API Layer](guide/api-layer.md), [REST API Reference](reference/rest-api.md),
+and [CLI Reference](reference/cli.md).
 
 ## Specifications
 
 Normative behavior lives in the Specifications group:
 
+- [Overview](guide/specification.md)
 - [Runtime](guide/runtime.md)
 - [Service Protocols](guide/service-protocols.md)
 - [Command Gate](guide/command-gate.md)
@@ -266,15 +232,25 @@ Normative behavior lives in the Specifications group:
 
 ## Status
 
-Current state worth knowing before using it:
+Honest state of the system:
 
-- the core runtime and append-only write path are the most mature parts
-- the Python service layer is richer than the REST read models
-- the FastAPI layer currently uses a default admin `ActorCtx` — not multi-tenant auth yet
+- the ledger — append-only write path, tick loop, time travel, fork lineage —
+  is the most mature part, and the most heavily contract-tested
+- `archetype.experiments` (runs, results, trajectories) is young but real
+- the FastAPI layer currently uses a default admin `ActorCtx` — not
+  multi-tenant auth yet
 
 ## Where to Start
 
-- **New to Archetype?** Start with the [Quickstart](guide/quickstart.md), which leads with `ArchetypeRuntime`, then read the [Architecture](guide/architecture.md) overview
-- **Building a simulation?** See [Building Simulations](guide/building-simulations.md) for the full workflow
-- **Integrating with the API?** See [App Overview](guide/app-overview.md) for how core connects through services to the HTTP layer
-- **Changing contracts?** Start with [Service Protocols](guide/service-protocols.md) and the focused specification pages
+- **New to Archetype?** Start with the [Quickstart](guide/quickstart.md),
+  which leads with `ArchetypeRuntime`, then read the
+  [Architecture](guide/architecture.md) overview
+- **Building a simulation?** See
+  [Building Simulations](guide/building-simulations.md) for the full workflow
+- **Evaluating agents?** See [Trajectories](guide/trajectories.md) and
+  [AutoResearch](guide/autoresearch.md)
+- **Integrating with the API?** See [App Overview](guide/app-overview.md) for
+  how core connects through services to the HTTP layer
+- **Changing contracts?** Start with
+  [Service Protocols](guide/service-protocols.md) and the focused
+  specification pages

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,7 +55,6 @@ archetype history <WORLD_ID> [OPTIONS]
 |------|------|---------|-------------|
 | `--limit` / `-n` | integer | `50` | Max audit rows to show |
 | `--actor-id` | text | — | Actor ID filter |
-| `--signer-address` | text | — | Signer filter |
 | `--idempotency-key` | text | — | Idempotency key |
 | `--tick-from` | integer | — | Reserved for API v2 |
 | `--tick-to` | integer | — | Reserved for API v2 |

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -334,7 +334,6 @@ Read audit history. Requires viewer, player, operator, or admin.
 | `limit` | integer | `100` |  |
 | `tick_range` | string \| null | — | Comma-separated inclusive start,end |
 | `actor_id` | string \| null | — |  |
-| `signer_address` | string \| null | — |  |
 | `idempotency_key` | string \| null | — |  |
 
 **Error codes:** `422`

--- a/examples/03_time_travel.py
+++ b/examples/03_time_travel.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Time-Travel Queries
-====================
+Time Travel and Fork-and-Diff
+==============================
 
-Run a simulation for 10 ticks, then query the state at different
-points in history. Every tick is preserved — nothing is overwritten.
-
-This example uses the ArchetypeRuntime high-level API with an escape
-hatch to the lower-level query service for historical tick reads.
+Every tick persists as immutable rows — nothing is overwritten. This
+example runs a small simulation, rewinds to any past tick by filtering
+the `tick` column, then forks a counterfactual branch, diverges it, and
+diffs source vs fork at the same tick.
 
 No external dependencies — runs entirely in-process.
 
@@ -19,46 +18,90 @@ Usage:
 
 import asyncio
 
+from daft import DataFrame, col
+
 from archetype import ArchetypeRuntime
+from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
 from archetype.core.config import StorageConfig
 
 
-class Marker(Component):
-    """Empty component used to track entity count across ticks."""
+class Position(Component):
+    x: float = 0.0
 
-    label: str = ""
+
+class Velocity(Component):
+    vx: float = 0.0
+
+
+class MovementProcessor(AsyncProcessor):
+    components = (Position, Velocity)
+    priority = 10
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        return df.with_columns({"position__x": col("position__x") + col("velocity__vx")})
+
+
+def positions_at(df: DataFrame, tick: int) -> dict[int, float]:
+    """Extract {entity_id: x} for one tick from the append-only history."""
+    rows = df.where(col("tick") == tick).select("entity_id", "position__x").to_pylist()
+    return {row["entity_id"]: row["position__x"] for row in rows}
 
 
 async def main():
     storage = StorageConfig(uri="./archetype_data", namespace="time_travel")
 
     async with ArchetypeRuntime() as runtime:
-        world = runtime.world("time-travel-demo", storage=storage)
+        world = runtime.world("time-travel-demo", storage=storage, processors=[MovementProcessor()])
 
-        # Spawn 3 entities and run 5 ticks
-        for i in range(3):
-            await world.spawn(Marker(label=f"wave-1-{i}"))
+        # Spawn 3 entities moving at different speeds and run 5 ticks
+        walker = await world.spawn(Position(x=0.0), Velocity(vx=1.0))
+        runner = await world.spawn(Position(x=0.0), Velocity(vx=2.0))
+        sprinter = await world.spawn(Position(x=0.0), Velocity(vx=3.0))
         await world.run(steps=5)
 
         info = await world.info()
-        print(f"After 5 ticks: tick={info.tick}, 3 entities spawned")
+        latest = info.tick - 1  # rows exist for ticks 0..tick-1
+        print(f"Ran {info.tick} ticks: walker={walker}, runner={runner}, sprinter={sprinter}\n")
 
-        # Spawn 2 more entities and run another 5 ticks
-        for i in range(2):
-            await world.spawn(Marker(label=f"wave-2-{i}"))
-        await world.run(steps=5)
+        # ── 1. TIME TRAVEL ────────────────────────────────────────────────────
+        # query() returns the FULL history. Rewind by filtering the tick column.
 
-        info = await world.info()
-        print(f"After 10 ticks: tick={info.tick}\n")
+        print("1. TIME TRAVEL")
+        history = await world.query(Position)
+        for t in (0, 2, latest):
+            state = positions_at(history, t)
+            label = "latest" if t == latest else f"tick {t}"
+            print(
+                f"   {label:>7}: walker.x={state[walker]:5.1f}  "
+                f"runner.x={state[runner]:5.1f}  sprinter.x={state[sprinter]:5.1f}"
+            )
 
-        # Query current state (all 5 entities visible)
-        print(f"  Current state (tick {info.tick}):")
-        (await world.query(Marker)).show()
+        # ── 2. FORK AND DIFF ──────────────────────────────────────────────────
+        # The fork inherits the source's store, continues from its state, and
+        # reads pre-fork ticks through lineage. Diverge it: what if the walker
+        # had sped up at the fork point?
 
-        print("\nCommand history:")
-        history = await world.history()
-        history.select("command_type", "actor_id").show()
+        print("\n2. FORK AND DIFF")
+        fork = await world.fork("counterfactual")
+        await fork.update(walker, Velocity(vx=10.0))
+
+        await world.run(steps=3)
+        await fork.run(steps=3)
+
+        cmp_tick = (await world.info()).tick - 1
+        source_state = positions_at(await world.query(Position), cmp_tick)
+        fork_history = await fork.query(Position)
+        fork_state = positions_at(fork_history, cmp_tick)
+
+        print(f"   walker.x at tick {cmp_tick}:")
+        print(f"     source (vx=1.0):  {source_state[walker]:5.1f}")
+        print(f"     fork   (vx=10.0): {fork_state[walker]:5.1f}")
+        print(f"     diff:             {fork_state[walker] - source_state[walker]:+5.1f}")
+
+        # The fork still sees its pre-fork history through lineage
+        pre_fork = positions_at(fork_history, 0)
+        print(f"   fork at pre-fork tick 0: walker.x={pre_fork[walker]:.1f} (inherited history)")
 
 
 if __name__ == "__main__":

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ uv run python examples/<filename>.py
 |---|---------|-------------|----------|
 | 1 | [`01_world_mutations.py`](01_world_mutations.py) | Every mutation type: spawn, despawn, add_processor, RBAC, fork, audit history | None |
 | 2 | [`02_fork_counterfactual.py`](02_fork_counterfactual.py) | Fork a world three times, run each branch, compare results | None |
-| 3 | [`03_time_travel.py`](03_time_travel.py) | Run 10 ticks, query any point in history — every tick is preserved | None |
+| 3 | [`03_time_travel.py`](03_time_travel.py) | Rewind to any past tick by filtering the `tick` column, then fork a counterfactual branch and diff it against the source | None |
 | 4 | [`04_messaging.py`](04_messaging.py) | Agent-to-agent messaging via tick-deferred `MESSAGE` commands, resources, and lifecycle hooks | None |
 | 5 | [`05_llm_agents.py`](05_llm_agents.py) | LLM-powered agents — each entity gets a parallel LLM call every tick via `daft.functions.prompt` | `OPENAI_API_KEY` |
 | 6 | [`06_trajectory_analysis.py`](06_trajectory_analysis.py) | Trajectory analysis — ingest, label, and compare agent trajectories using world forking | Optional: `OPENAI_API_KEY` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Archetype
-site_description: A forkable, append-only world ledger for simulations and AI agents
+site_description: An opinion about what data engineering should be — composable, declarative, and data-centric
 site_url: https://archetype-docs.pages.dev
 repo_url: https://github.com/VangelisTech/archetype
 repo_name: VangelisTech/archetype

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Archetype
-site_description: Entity-Component-System simulation engine for AI agents
+site_description: A forkable, append-only world ledger for simulations and AI agents
 site_url: https://archetype-docs.pages.dev
 repo_url: https://github.com/VangelisTech/archetype
 repo_name: VangelisTech/archetype
@@ -17,7 +17,7 @@ extra_css:
 
 nav:
   - Getting Started:
-      - archetype-ecs: index.md
+      - Archetype: index.md
       - Quickstart: guide/quickstart.md
       - Examples: guide/examples.md
       - Contributing Guide: guide/contributing.md
@@ -29,13 +29,15 @@ nav:
       - Execution Hierarchy: guide/execution-hierarchy.md
       - World Lifecycle: guide/world-lifecycle.md
       - Audit Log: guide/audit-log.md
-  - Guides:
+  - Building:
       - Building Simulations: guide/building-simulations.md
       - Custom Commands: guide/custom-commands.md
       - Token Quotas: guide/token-quotas.md
+      - Mutation Testing: guide/mutation-testing.md
+  - Agent Evaluation:
       - Trajectories: guide/trajectories.md
       - AutoResearch: guide/autoresearch.md
-      - Mutation Testing: guide/mutation-testing.md
+      - Tragedy of the Commons: experiments/tragedy-of-the-commons.md
   - Core Architecture:
       - Overview: guide/architecture.md
       - Archetypes: guide/archetype.md
@@ -59,8 +61,6 @@ nav:
       - REST API: reference/rest-api.md
       - CLI: reference/cli.md
       - Python API: reference/python-api.md
-  - Experiments:
-      - Tragedy of the Commons: experiments/tragedy-of-the-commons.md
 
 markdown_extensions:
   - admonition

--- a/src/archetype/api/routes/query.py
+++ b/src/archetype/api/routes/query.py
@@ -182,7 +182,6 @@ async def get_audit_history(
     limit: int = 100,
     tick_range: str | None = Query(None, description="Comma-separated inclusive start,end"),
     actor_id: str | None = None,
-    signer_address: str | None = None,
     idempotency_key: str | None = None,
     cs: CommandService = Depends(get_command_service),
     ctx: ActorCtx = Depends(get_actor_ctx),
@@ -194,7 +193,6 @@ async def get_audit_history(
             world_id,
             tick_range=_tick_range(tick_range),
             actor_id=actor_id,
-            signer_address=signer_address,
             idempotency_key=idempotency_key,
             limit=limit,
         )

--- a/src/archetype/app/audit_log.py
+++ b/src/archetype/app/audit_log.py
@@ -42,11 +42,6 @@ _AUDIT_COLUMNS = (
     "payload_json",
     "accepted_at",
     "applied_at",
-    "signer_address",
-    "tx_hash",
-    "price_paid_atomic",
-    "asset",
-    "chain_id",
     "idempotency_key",
 )
 
@@ -63,11 +58,6 @@ def _audit_schema() -> pa.Schema:
             ("payload_json", pa.string()),
             ("accepted_at", pa.string()),
             ("applied_at", pa.string()),
-            ("signer_address", pa.string()),
-            ("tx_hash", pa.string()),
-            ("price_paid_atomic", pa.int64()),
-            ("asset", pa.string()),
-            ("chain_id", pa.int64()),
             ("idempotency_key", pa.string()),
         ]
     )
@@ -84,11 +74,6 @@ def _row_to_dict(row: AuditRow) -> dict:
         "payload_json": row.payload_json,
         "accepted_at": row.accepted_at,
         "applied_at": row.applied_at,
-        "signer_address": row.signer_address,
-        "tx_hash": row.tx_hash,
-        "price_paid_atomic": row.price_paid_atomic,
-        "asset": row.asset,
-        "chain_id": row.chain_id,
         "idempotency_key": row.idempotency_key,
     }
 
@@ -203,7 +188,6 @@ class AuditLog:
         *,
         tick_range: tuple[int, int] | None = None,
         actor_id: str | UUID | None = None,
-        signer_address: str | None = None,
         idempotency_key: str | None = None,
         limit: int | None = None,
     ) -> daft.DataFrame:
@@ -230,9 +214,6 @@ class AuditLog:
         if actor_id is not None:
             aid = str(actor_id)
             predicates.append(lambda row, aid=aid: row["actor_id"] == aid)
-
-        if signer_address is not None:
-            predicates.append(lambda row: row["signer_address"] == signer_address)
 
         if idempotency_key is not None:
             predicates.append(lambda row: row["idempotency_key"] == idempotency_key)

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -377,6 +377,7 @@ class CommandService:
     ) -> DataFrame:
         """Query entities by component subset. Gated read."""
         self._gate(Command(type=CommandType.QUERY_WORLD), ctx)
+        storage_config = self._resolve_storage(world_id, storage_config)
         result = await self._queries.query_components(
             components=components,
             world_id=world_id,
@@ -388,6 +389,22 @@ class CommandService:
         )
         await self._emit(ctx, "query_world", world_id)
         return result
+
+    def _resolve_storage(
+        self,
+        world_id: str | UUID,
+        storage_config: StorageConfig | None,
+    ) -> StorageConfig | None:
+        """Resolve which store holds a world's rows.
+
+        An explicit storage_config is an override and wins. Otherwise the
+        world's recorded storage is used, so readers find the rows wherever
+        the world actually wrote them — forks included.
+        """
+        if storage_config is not None:
+            return storage_config
+        record = self._worlds.storage_record(world_id)
+        return record[0] if record is not None else None
 
     async def _resolve_lineage(
         self,
@@ -423,6 +440,7 @@ class CommandService:
         components: list[type[Component]] | None = None,
     ) -> DataFrame:
         self._gate(Command(type=CommandType.QUERY_WORLD), ctx)
+        storage_config = self._resolve_storage(world_id, storage_config)
         result = await self._queries.query_archetype(
             sig,
             world_id,
@@ -547,7 +565,6 @@ class CommandService:
         *,
         tick_range: tuple[int, int] | None = None,
         actor_id: str | UUID | None = None,
-        signer_address: str | None = None,
         idempotency_key: str | None = None,
         limit: int | None = None,
     ):
@@ -558,7 +575,6 @@ class CommandService:
             world_id=world_id,
             tick_range=tick_range,
             actor_id=actor_id,
-            signer_address=signer_address,
             idempotency_key=idempotency_key,
             limit=limit,
         )

--- a/src/archetype/app/interfaces.py
+++ b/src/archetype/app/interfaces.py
@@ -235,7 +235,6 @@ class iAuditLog(Protocol):
         *,
         tick_range: tuple[int, int] | None = None,
         actor_id: str | UUID | None = None,
-        signer_address: str | None = None,
         idempotency_key: str | None = None,
         limit: int | None = None,
     ) -> DataFrame: ...
@@ -348,7 +347,6 @@ class iCommandService(Protocol):
         *,
         tick_range: tuple[int, int] | None = None,
         actor_id: str | UUID | None = None,
-        signer_address: str | None = None,
         idempotency_key: str | None = None,
         limit: int | None = None,
     ) -> DataFrame: ...

--- a/src/archetype/app/models.py
+++ b/src/archetype/app/models.py
@@ -247,11 +247,7 @@ class ResourceInfo(BaseModel):
 
 
 class AuditRow(BaseModel):
-    """One row in the append-only audit log.
-
-    Schema matches platform spec § 3.3 Appendix A.5. Payment-bearing
-    columns are nullable for non-paid commands.
-    """
+    """One row in the append-only audit log."""
 
     model_config = dict(frozen=True, arbitrary_types_allowed=True)
 
@@ -270,10 +266,5 @@ class AuditRow(BaseModel):
     accepted_at: str = Field(default_factory=lambda: "")
     applied_at: str = Field(default_factory=lambda: "")
 
-    # Payment (Tier 2, nullable)
-    signer_address: str | None = None
-    tx_hash: str | None = None
-    price_paid_atomic: int | None = None
-    asset: str | None = None
-    chain_id: int | None = None
+    # Deduplication (nullable)
     idempotency_key: str | None = None

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -203,6 +203,9 @@ class WorldOrchestrator:
 
         fork_config = WorldConfig(
             name=name,
+            # Minted here, not at first step: persist_lineage keys the fork's
+            # provenance rows by run_id, so the id must exist at fork time.
+            run_id=str(uuid7()),
             tick=source.tick,
             next_entity_id=source.next_entity_id,
             entity2sig=dict(source.entity2sig),
@@ -284,6 +287,17 @@ class WorldService:
     def get_world(self, world_id: UUID) -> iWorld:
         return self._orchestrator.get_world(world_id)
 
+    def storage_record(
+        self, world_id: str | UUID
+    ) -> tuple[StorageConfig, CacheConfig | None] | None:
+        """The storage/cache config backing a world, or None if unknown.
+
+        This is how readers locate a world's rows without being told the
+        storage config out of band. Records outlive destroy_world: storage is
+        append-only and destroyed worlds remain queryable.
+        """
+        return self._storage_configs.get(str(world_id))
+
     def get_world_by_name(self, name: str) -> iWorld:
         return self._orchestrator.get_world_by_name(name)
 
@@ -306,14 +320,26 @@ class WorldService:
         same physical store as the source by default; an explicit
         ``storage_config`` argument routes the fork to a different store.
         """
+        source_record = self._storage_configs.get(str(source_world_id))
         if storage_config is None:
-            source_record = self._storage_configs.get(str(source_world_id))
             if source_record is not None:
                 storage_config, source_cache = source_record
                 if cache_config is None:
                     cache_config = source_cache
             else:
                 storage_config = StorageConfig()
+        elif source_record is not None and storage_config != source_record[0]:
+            source = self._orchestrator.get_world(UUID(str(source_world_id)))
+            if getattr(source, "tick", 0) > 0:
+                # Lineage segments name rows in the source's store; a fork on
+                # a different store cannot read them (world-lifecycle.md § 4.5).
+                logger.warning(
+                    "fork_world: explicit storage_config differs from source's; "
+                    "the fork will not see the source's persisted history "
+                    "(world %s, tick %d)",
+                    source_world_id,
+                    source.tick,
+                )
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
         fork = self._orchestrator.fork_world(store, source_world_id, name=name)
         self._storage_configs[str(fork.world_id)] = (storage_config, cache_config)
@@ -329,9 +355,13 @@ class WorldService:
         return fork
 
     async def destroy_world(self, world_id: UUID | str) -> None:
-        """Destroy a world. In-memory cleanup only. Storage is preserved."""
+        """Destroy a world. In-memory cleanup only. Storage is preserved.
+
+        The storage record is retained: destroyed worlds' rows are still in
+        the store (append-only), and readers resolve them through
+        storage_record().
+        """
         await self._orchestrator.destroy_world(world_id)
-        self._storage_configs.pop(str(world_id), None)
 
     async def add_resource(self, world_id: str | UUID, resource: object) -> None:
         """Attach a resource to a world's Resources container."""

--- a/src/archetype/cli/main.py
+++ b/src/archetype/cli/main.py
@@ -598,7 +598,6 @@ def history(
     world_id: str = typer.Argument(..., help="World ID"),
     limit: int = typer.Option(50, "--limit", "-n", help="Max audit rows to show"),
     actor_id: str | None = typer.Option(None, "--actor-id", help="Actor ID filter"),
-    signer_address: str | None = typer.Option(None, "--signer-address", help="Signer filter"),
     idempotency_key: str | None = typer.Option(None, "--idempotency-key", help="Idempotency key"),
     tick_from: int | None = typer.Option(None, "--tick-from", help="Reserved for API v2"),
     tick_to: int | None = typer.Option(None, "--tick-to", help="Reserved for API v2"),
@@ -611,7 +610,6 @@ def history(
     params = {
         "limit": limit,
         "actor_id": actor_id,
-        "signer_address": signer_address,
         "idempotency_key": idempotency_key,
         "tick_from": tick_from,
         "tick_to": tick_to,

--- a/src/archetype/core/aio/async_lancedb_store.py
+++ b/src/archetype/core/aio/async_lancedb_store.py
@@ -144,8 +144,10 @@ class AsyncLancedbStore(iAsyncStore):
                 )
                 return
         except Exception as e:
+            # A frame that cannot materialize cannot be persisted; the caller
+            # must see that, not a silent no-op.
             logger.error(f"Append collect failed for {Archetype.get_name(sig)}: {e}")
-            return
+            raise
 
         async_table = await self._ensure_table(sig)
         table_name = async_table.name

--- a/src/archetype/core/aio/async_store.py
+++ b/src/archetype/core/aio/async_store.py
@@ -137,8 +137,10 @@ class AsyncStore(iAsyncStore):
                 )
                 return
         except Exception as e:
+            # A frame that cannot materialize cannot be persisted; the caller
+            # must see that, not a silent no-op.
             logger.error(f"Append collect failed for {Archetype.get_name(sig)}: {e}")
-            return
+            raise
 
         table = self._ensure_table(sig)
 

--- a/src/archetype/core/aio/async_system.py
+++ b/src/archetype/core/aio/async_system.py
@@ -86,8 +86,9 @@ class AsyncSystem(iAsyncSystem):
                         f"(priority={proc_instance.priority}, archetype={archetype_name})"
                     )
 
-                # Gracefully handle errors in processors.
-                # Dataframes are immutable so we are continuously returning an updated variant of the original.
+                # A processor failure fails the archetype's tick: the world
+                # step surfaces it (gather → RuntimeError) instead of
+                # appending a frame the failed processor never transformed.
                 try:
                     assert isinstance(proc_instance, AsyncProcessor)
                     # Filter kwargs to what the processor accepts; pass all if it has **kwargs.
@@ -112,5 +113,6 @@ class AsyncSystem(iAsyncSystem):
                     logger.error(
                         f"Error processing archetype {sig}: {e} with processor {proc_instance} of type {type(proc_instance)}"
                     )
+                    raise
 
         return df

--- a/src/archetype/core/aio/async_updater.py
+++ b/src/archetype/core/aio/async_updater.py
@@ -32,6 +32,11 @@ class AsyncUpdateManager(iAsyncUpdateManager):
     async def update(
         self, df: DataFrame, sig: ArchetypeSignature, tick: int, world_id: str, run_id: str
     ) -> DataFrame:
+        # A schemaless frame (no columns) cannot be stamped and carries
+        # nothing to persist — a legitimate no-op, distinct from a failure.
+        if not df.column_names:
+            logger.info(f"Update skipped (empty schema): archetype={Archetype.get_name(sig)}")
+            return df
         try:
             df = df.with_columns(
                 {
@@ -51,5 +56,9 @@ class AsyncUpdateManager(iAsyncUpdateManager):
             )
 
         except Exception as e:
+            # Persistence failure must be observable: a tick that did not
+            # commit its rows did not happen. Swallowing here would let the
+            # world advance past a hole in the ledger.
             logger.error(f"Error updating table {Archetype.get_name(sig)}: {e}")
+            raise
         return df

--- a/src/archetype/core/sync/updater.py
+++ b/src/archetype/core/sync/updater.py
@@ -34,6 +34,11 @@ class UpdateManager(iUpdateManager):
         Update the store with the given DataFrame.
         Returns the DataFrame with stamped metadata for live snapshots.
         """
+        # A schemaless frame (no columns) cannot be stamped and carries
+        # nothing to persist — a legitimate no-op, distinct from a failure.
+        if not df.column_names:
+            logger.info(f"Update skipped (empty schema): archetype={Archetype.get_name(sig)}")
+            return df
         df = df.with_columns(
             {
                 "tick": lit(tick).cast(daft.DataType.uint32()),
@@ -45,5 +50,9 @@ class UpdateManager(iUpdateManager):
         try:
             self.store.append(sig, df)
         except Exception as e:
+            # Same contract as AsyncUpdateManager: persistence failure must be
+            # observable, so a failed append raises instead of returning a
+            # stamped-but-uncommitted frame.
             logger.error(f"Error updating table {Archetype.get_name(sig)}: {e}")
+            raise
         return df

--- a/src/archetype/runtime/_config.py
+++ b/src/archetype/runtime/_config.py
@@ -8,10 +8,16 @@ from pathlib import Path
 from archetype.core.config import CacheConfig, StorageConfig
 
 
-def coerce_storage(value: str | Path | StorageConfig | None) -> StorageConfig:
-    """Coerce a user-friendly storage value to StorageConfig."""
+def coerce_storage(value: str | Path | StorageConfig | None) -> StorageConfig | None:
+    """Coerce a user-friendly storage value to StorageConfig.
+
+    None passes through unchanged: the service layer owns the default, and
+    fork_world inherits the source world's storage when no override is given
+    (world-lifecycle.md § 4.5). Manufacturing a default here would defeat
+    that inheritance and strand a fork on a store its source never wrote to.
+    """
     if value is None:
-        return StorageConfig()
+        return None
     if isinstance(value, StorageConfig):
         return value
     return StorageConfig(uri=str(value))

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -46,7 +46,7 @@ class _RuntimeWorldState:
         *,
         runtime: ArchetypeRuntime,
         name: str,
-        storage_config: StorageConfig,
+        storage_config: StorageConfig | None,
         cache_config: CacheConfig | None,
         init_processors: list,
         init_resources: list,
@@ -250,22 +250,28 @@ class RuntimeWorld:
         """Fork this world. Returns a new handle."""
         from archetype.runtime._config import coerce_cache, coerce_storage
 
+        # None means "inherit the source's storage" (world-lifecycle.md § 4.5):
+        # the gate resolves it to the source's store, and the fork handle keeps
+        # the source handle's config so its own reads hit the same store.
+        fork_storage = coerce_storage(storage)
+        fork_cache = coerce_cache(cache)
+
         async with self._state.op_lock:
             wid = await self._ensure_id()
             info = await self._gate.fork_world(
                 self._ctx,
                 wid,
                 name,
-                storage_config=coerce_storage(storage),
-                cache_config=coerce_cache(cache),
+                storage_config=fork_storage,
+                cache_config=fork_cache,
             )
 
             # Build a pre-activated state for the fork
             fork_state = _RuntimeWorldState(
                 runtime=self._state.runtime,
                 name=info.name or name or "fork",
-                storage_config=coerce_storage(storage),
-                cache_config=coerce_cache(cache),
+                storage_config=fork_storage if storage is not None else self._state.storage_config,
+                cache_config=fork_cache if cache is not None else self._state.cache_config,
                 init_processors=[],
                 init_resources=[],
                 init_hooks=[],

--- a/tests/aio/test_async_world_execution.py
+++ b/tests/aio/test_async_world_execution.py
@@ -42,14 +42,6 @@ class P2IncY(AsyncProcessor):
         return df.with_column("position__y", col("position__y") + lit(1))
 
 
-class PBug(AsyncProcessor):
-    components = (Position,)
-    priority = 7
-
-    async def process(self, df, **kwargs):
-        raise RuntimeError("boom")
-
-
 @pytest_asyncio.fixture(params=["async", "async_cached"], scope="function")
 async def store_backend(request, tmp_path):
     uri = str(tmp_path)
@@ -85,7 +77,6 @@ async def world(store_backend):
         hooks=HookRegistry(),
     )
     await w.add_processor(P1ScaleX())
-    await w.add_processor(PBug())
     await w.add_processor(P2IncY())
     return w
 
@@ -97,8 +88,9 @@ async def test_processors_run_in_priority_and_filter_kwargs(world, store_backend
 
     # After one step with scale=4:
     # P1: x *= 4  → 8
-    # PBug: raises but should be swallowed
     # P2: y += 1  → 4
+    # (A raising processor fails the step — see
+    #  tests/core/test_async_world_error_propagation.py)
     rc = RunConfig()
     await world.step(rc, scale=4)
 

--- a/tests/app/test_runtime_fork_storage.py
+++ b/tests/app/test_runtime_fork_storage.py
@@ -1,0 +1,214 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime-layer fork storage contracts.
+
+The service layer inherits a fork's storage from its source when no
+override is given (world-lifecycle.md § 4.5) and reads pre-fork ticks
+through lineage. These tests pin the RUNTIME layer's side of that
+bargain: RuntimeWorld.fork() must not manufacture a default
+StorageConfig (which would strand the fork on a store its source never
+wrote to), gated reads must resolve a world's recorded store, and the
+fork's persisted lineage rows must be keyed by its real run_id.
+
+The service-level tests in tests/integration/test_fork_destroy_contracts.py
+pass storage_config=None directly, so they cannot catch a runtime layer
+that replaces None with a default before the service ever sees it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from daft import DataFrame, col
+
+from archetype import ArchetypeRuntime, AsyncProcessor, Component
+from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
+from archetype.core.config import StorageConfig
+
+
+class Meter(Component):
+    value: float = 0.0
+
+
+class Inc(AsyncProcessor):
+    components = (Meter,)
+    priority = 10
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        return df.with_column("meter__value", col("meter__value") + 1.0)
+
+
+@pytest.fixture(autouse=True)
+def _reset_quotas():
+    reset_tick_counters()
+    reset_daily_tokens()
+    yield
+    reset_tick_counters()
+    reset_daily_tokens()
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+
+
+@pytest.mark.asyncio
+async def test_runtime_fork_reads_parent_history(tmp_path):
+    """fork() with no storage argument sees the source's persisted ticks."""
+    async with ArchetypeRuntime() as rt:
+        world = rt.world("src", storage=_storage(tmp_path), processors=[Inc()])
+        await world.spawn(Meter(value=0.0))
+        await world.step()
+        await world.step()
+
+        fork = await world.fork("fork")
+        df = await fork.query(Meter)
+        rows = df.to_pylist()
+        assert len(rows) == 2, (
+            f"fork must read its pre-fork history through lineage; got {len(rows)} rows"
+        )
+        assert sorted(r["tick"] for r in rows) == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_runtime_fork_step_continues_parent_state(tmp_path):
+    """The fork's first step transforms the source's last state, not an
+    empty frame: values continue across the fork point."""
+    async with ArchetypeRuntime() as rt:
+        world = rt.world("src", storage=_storage(tmp_path), processors=[Inc()])
+        await world.spawn(Meter(value=0.0))
+        await world.step()  # value -> 1.0 at tick 0
+        await world.step()  # value -> 2.0 at tick 1
+
+        fork = await world.fork("fork")
+        await fork.step()  # must read 2.0, write 3.0 at tick 2
+
+        df = await fork.query(Meter)
+        by_tick = {r["tick"]: r["meter__value"] for r in df.to_pylist()}
+        assert by_tick[2] == 3.0, f"fork did not continue source state: {by_tick}"
+        # Pre-fork history still visible alongside the fork's own row
+        assert by_tick[0] == 1.0 and by_tick[1] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_runtime_fork_writes_land_in_source_store(tmp_path):
+    """A fork created without a storage override writes to the source's
+    store — never to a fresh default ./archetype_db."""
+    storage = _storage(tmp_path)
+    async with ArchetypeRuntime() as rt:
+        world = rt.world("src", storage=storage, processors=[Inc()])
+        await world.spawn(Meter(value=0.0))
+        await world.step()
+
+        fork = await world.fork("fork")
+        await fork.step()
+
+        container = rt._container
+        fork_world = container.world_service.get_world(fork.world_id)
+        rows_in_source_store = (
+            await container.query_service.query_components(
+                [Meter],
+                world_id=str(fork.world_id),
+                run_id=str(fork_world.run_id),
+                storage_config=storage,
+            )
+        ).count_rows()
+        rows_in_default_store = (
+            await container.query_service.query_components(
+                [Meter],
+                world_id=str(fork.world_id),
+                run_id=str(fork_world.run_id),
+                storage_config=StorageConfig(),
+            )
+        ).count_rows()
+        assert rows_in_source_store >= 1
+        assert rows_in_default_store == 0, (
+            "fork wrote to the default store instead of inheriting the source's"
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_fork_explicit_storage_override_still_wins(tmp_path, caplog):
+    """An explicit storage argument routes the fork to a different store.
+
+    Cross-store forks sever read lineage (world-lifecycle.md § 4.5): only
+    pending state carries over, so new writes land in the override store
+    and the engine warns that persisted history stays behind.
+    """
+    import logging
+
+    fork_storage = StorageConfig(uri=str(tmp_path / "fork_store"), namespace="ns")
+    async with ArchetypeRuntime() as rt:
+        world = rt.world("src", storage=_storage(tmp_path), processors=[Inc()])
+        await world.spawn(Meter(value=0.0))
+        await world.step()
+
+        with caplog.at_level(logging.WARNING):
+            fork = await world.fork("fork", storage=fork_storage)
+        assert any("persisted history" in rec.message for rec in caplog.records), (
+            "cross-store fork of a stepped source must warn that lineage is severed"
+        )
+
+        # New state spawned in the fork lands in the override store.
+        await fork.spawn(Meter(value=10.0))
+        await fork.step()
+
+        container = rt._container
+        fork_world = container.world_service.get_world(fork.world_id)
+        record = container.world_service.storage_record(fork.world_id)
+        assert record is not None
+        assert record[0].uri == fork_storage.uri
+        rows = (
+            await container.query_service.query_components(
+                [Meter],
+                world_id=str(fork.world_id),
+                run_id=str(fork_world.run_id),
+                storage_config=fork_storage,
+            )
+        ).count_rows()
+        assert rows >= 1
+
+
+@pytest.mark.asyncio
+async def test_fork_lineage_persisted_under_fork_run_id(tmp_path):
+    """The fork's run_id exists at fork time, so its durable lineage rows
+    are keyed by the id its own rows will carry — not by str(None)."""
+    storage = _storage(tmp_path)
+    async with ArchetypeRuntime() as rt:
+        world = rt.world("src", storage=storage, processors=[Inc()])
+        await world.spawn(Meter(value=0.0))
+        await world.step()
+
+        fork = await world.fork("fork")
+        container = rt._container
+        fork_world = container.world_service.get_world(fork.world_id)
+        assert fork_world.run_id, "fork must mint its run_id at fork time"
+
+        recovered = await container.query_service.get_lineage(
+            str(fork.world_id), str(fork_world.run_id), storage_config=storage
+        )
+        assert recovered == list(fork_world.lineage)
+        assert recovered, "persisted lineage must be recoverable by the fork's run_id"
+
+
+@pytest.mark.asyncio
+async def test_gated_query_resolves_world_storage_without_config(tmp_path):
+    """The gate knows where a world's rows live: a gated read with no
+    storage_config resolves the world's recorded store."""
+    from archetype.runtime._actor import default_actor_ctx
+
+    storage = _storage(tmp_path)
+    async with ArchetypeRuntime() as rt:
+        world = rt.world("src", storage=storage, processors=[Inc()])
+        await world.spawn(Meter(value=0.0))
+        await world.step()
+
+        container = rt._container
+        live = container.world_service.get_world(world.world_id)
+        df = await container.command_service.query_components(
+            default_actor_ctx(),
+            [Meter],
+            str(world.world_id),
+            str(live.run_id),
+            # no storage_config: the gate must find the rows anyway
+        )
+        assert df.count_rows() >= 1

--- a/tests/core/test_async_store_updater_failures.py
+++ b/tests/core/test_async_store_updater_failures.py
@@ -38,8 +38,13 @@ async def test_async_store_append_skips_on_empty_df(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_async_store_append_handles_collect_failure(tmp_path, caplog):
-    """AsyncStore.append should catch collect() failures and return without raising."""
+async def test_async_store_append_raises_on_collect_failure(tmp_path, caplog):
+    """A frame that cannot materialize must fail the append, not no-op.
+
+    Persistence failure is observable to callers (specification.md, updater
+    contracts): a swallowed collect failure would let a tick 'succeed' while
+    persisting nothing.
+    """
     session, cfg = _build_session_and_config(tmp_path)
     store = AsyncStore(session, io_config=cfg.io_config)
     sig = Archetype.sig_from_components([Demo(v=1)])
@@ -49,13 +54,16 @@ async def test_async_store_append_handles_collect_failure(tmp_path, caplog):
             raise RuntimeError("boom")
 
     with caplog.at_level("ERROR"):
-        await store.append(sig, BadDf())
+        with pytest.raises(RuntimeError, match="boom"):
+            await store.append(sig, BadDf())
     assert any("Append collect failed" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.asyncio
-async def test_async_store_append_bad_schema_raises_and_is_caught(tmp_path, caplog):
-    """AsyncStore.get_archetype_df/_ensure_table should create schema, but appending with incompatible schema should be handled by update path. Here we simulate a mismatch by passing wrong columns and verify updater logs error."""
+async def test_async_updater_raises_on_bad_schema(tmp_path, caplog):
+    """An append with an incompatible schema must raise out of the updater."""
+    from daft.exceptions import DaftCoreException
+
     session, cfg = _build_session_and_config(tmp_path)
     store = AsyncStore(session, io_config=cfg.io_config)
     updater = AsyncUpdateManager(store)
@@ -67,14 +75,18 @@ async def test_async_store_append_bad_schema_raises_and_is_caught(tmp_path, capl
     bad = daft.from_arrow(pa.Table.from_pylist([{"not_entity_id": 1}]))
 
     with caplog.at_level("ERROR"):
-        # Should log an error from updater when append fails in backend
-        await updater.update(bad, sig, tick=0, world_id="w", run_id="r")
+        with pytest.raises(DaftCoreException):
+            await updater.update(bad, sig, tick=0, world_id="w", run_id="r")
     assert any("Error updating table" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.asyncio
-async def test_async_updater_logs_error_on_store_failure(tmp_path, caplog):
-    """AsyncUpdateManager should catch store.append exceptions and log them, returning the original df."""
+async def test_async_updater_raises_on_store_failure(tmp_path, caplog):
+    """AsyncUpdateManager must surface store.append failures to its caller.
+
+    The old contract (log and return a stamped frame) made durability
+    unobservable — a world could advance past a hole in its own history.
+    """
     session, cfg = _build_session_and_config(tmp_path)
     store = FailingStore(session, io_config=cfg.io_config)
     updater = AsyncUpdateManager(store)
@@ -95,8 +107,7 @@ async def test_async_updater_logs_error_on_store_failure(tmp_path, caplog):
             schema=schema,
         )
     )
-    # Force a failure path by raising in store.append
     with caplog.at_level("ERROR"):
-        out = await updater.update(df, sig, tick=1, world_id="w", run_id="r")
-    assert out.count_rows() == df.count_rows()
+        with pytest.raises(RuntimeError, match="append failed"):
+            await updater.update(df, sig, tick=1, world_id="w", run_id="r")
     assert any("Error updating table" in rec.message for rec in caplog.records)

--- a/tests/core/test_async_world_error_propagation.py
+++ b/tests/core/test_async_world_error_propagation.py
@@ -27,8 +27,14 @@ class BadProc(AsyncProcessor):
 
 
 @pytest.mark.asyncio
-async def test_async_world_processor_error_is_logged_not_raised(tmp_path, caplog):
-    """If processors raise, system logs error and world continues (current design)."""
+async def test_async_world_processor_error_fails_the_step(tmp_path, caplog):
+    """A processor failure fails the tick: the step raises and the world
+    does not advance.
+
+    The old contract (log and continue with the pre-failure frame) would
+    append rows the failed processor never transformed — a silent hole in
+    the per-tick history.
+    """
     ws = make_world_service()
     try:
         storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
@@ -39,7 +45,10 @@ async def test_async_world_processor_error_is_logged_not_raised(tmp_path, caplog
         await world.create_entity([Foo(x=1)])
 
         with caplog.at_level("ERROR"):
-            await world.run(RunConfig(num_steps=1))
+            with pytest.raises(RuntimeError, match="boom"):
+                await world.run(RunConfig(num_steps=1))
         assert any("Error processing archetype" in rec.message for rec in caplog.records)
+        # The failed tick did not happen: the counter never advanced.
+        assert world.tick == 0
     finally:
         await ws.shutdown()

--- a/tests/sync/test_sync_stack_contracts.py
+++ b/tests/sync/test_sync_stack_contracts.py
@@ -241,7 +241,11 @@ def test_sync_update_manager_appends_stamped_rows_to_store():
     ]
 
 
-def test_sync_update_manager_stamps_metadata_and_swallows_store_errors(caplog):
+def test_sync_update_manager_raises_on_store_errors(caplog):
+    """Persistence failure is observable: a failed append raises instead of
+    returning a stamped-but-uncommitted frame (specification.md, updater
+    contracts)."""
+
     class ExplodingStore:
         def append(self, sig, df):
             raise RuntimeError("append failed")
@@ -250,13 +254,8 @@ def test_sync_update_manager_stamps_metadata_and_swallows_store_errors(caplog):
     updater = UpdateManager(store=ExplodingStore())
     df = _df_from_rows(sig, [Archetype.to_row_dict(3, 0, [Position(x=4, y=5)], "old", "old")])
 
-    stamped = updater.update(df, sig, tick=7, world_id="world-z", run_id="run-z")
-    rows = stamped.collect().to_pylist()
-
-    assert rows[0]["tick"] == 7
-    assert rows[0]["world_id"] == "world-z"
-    assert rows[0]["run_id"] == "run-z"
-    assert rows[0]["entity_id"] == 3
+    with pytest.raises(RuntimeError, match="append failed"):
+        updater.update(df, sig, tick=7, world_id="world-z", run_id="run-z")
     assert "append failed" in caplog.text
 
 


### PR DESCRIPTION
## What this is

Archetype's identity, made true in code and then claimed in the docs:

> **A forkable, append-only world ledger for simulations and AI agents.** Every tick persists as queryable Arrow rows keyed `(world_id, run_id, tick)`; time travel, counterfactual forks, and trajectory datasets are storage facts, not features.

A 15-agent audit of the whole codebase converged on this as the one property that is simultaneously enforced in code, sacred in the spec, pinned by the densest tests, and unoccupied in the market. Two bugs gated saying it out loud. This PR fixes both, subtracts the schema fiction that undercut credibility, and rewrites the narrative surface around the asset.

## 1. Fork-after-step actually works now (`fix`)

**The bug chain** (empirical repro: spawn → step → fork → query = **0 rows**):

1. `coerce_storage(None)` manufactured a default `StorageConfig`, so `RuntimeWorld.fork` never passed `None` down — #204's storage inheritance never engaged and the fork landed on `./archetype_db` while its source lived elsewhere
2. the fork's lineage reads (#221) hit the wrong store and returned empty frames
3. the swallowed-append path made the empty tick look like success
4. bonus: `persist_lineage` keyed the fork's durable provenance rows by `str(None)` because `fork.run_id` wasn't minted until first step

**Fixes:** `coerce_storage` preserves `None`; fork handles inherit the source handle's storage/cache; the gate resolves a world's recorded store (`WorldService.storage_record`) so readers find rows wherever the world wrote them; storage records survive `destroy_world` (storage is append-only — readers must still resolve it); `fork_world` mints `run_id` at fork time; cross-store forks of a stepped source warn that lineage is severed (documented in `world-lifecycle.md` § 4.5).

**New contract suite:** `tests/app/test_runtime_fork_storage.py` — six tests at the runtime seam the service-level tests structurally could not see (they pass `None` directly, so they never caught the layer above replacing it).

After the fix, the original repro: fork pre-step sees its full pre-fork history (through lineage, no row copying), the fork's first step continues the source's state (`n=2 → n=3`), and its rows land in the source's store under its own `(world_id, run_id)`.

## 2. A tick either commits or it didn't happen (`fix`)

The spec listed this as CURRENT GAP twice; it's now the contract:

- async + sync updaters **raise** on append failure instead of returning a stamped-but-uncommitted frame (schemaless empty frames skip as legitimate no-ops)
- store-level `collect()` failures in append **raise** instead of silently no-opping
- a processor failure **fails its archetype's tick**: `step()` raises, the tick counter does not advance, nothing is appended for that tick

`specification.md` updater/store/processor contracts updated accordingly; the tests that pinned the old swallow behavior now pin the new contract.

## 3. Subtraction (`refactor`)

Removed the payment/blockchain columns (`signer_address`, `tx_hash`, `price_paid_atomic`, `asset`, `chain_id`) from `AuditRow`, the audit table schema, query predicates, gate/CLI/API signatures, and all docs — they were schema-only, never populated, and cited a "platform spec § 3.3" that does not exist in the repo. Also corrected `command-gate.md`'s audit-field list to match the real `AuditRow`.

## 4. Reframe (`docs`)

- **README + docs index** lead with the ledger identity, name the tick boundary as the system's frame (deterministic `(tick, priority, seq)` command drain with reserved entity ids), present API/CLI honestly as a *reference deployment* of the gate, and aim the use-case story at counterfactual evaluation of agent populations
- **mkdocs**: new *Agent Evaluation* nav group (Trajectories, AutoResearch, Tragedy of the Commons); site description updated
- **example 03** now does what its docstring always claimed: historical reads by filtering the `tick` column, then a fork that diverges (staged component update on the fork only) diffed against its source at the same tick — `source x=8.0 vs fork x=35.0 at tick 7`, with pre-fork history intact through lineage
- stale `test_sugar_runtime.py` references → the real contract suites

## Verification

- `make ci` green: lint, lock-check, **603 tests**, coverage gate, eval regression gate 10/10
- `make docs` builds clean with the new nav
- footgun-detector pass over the full diff: no findings (checked the `None`-coercion chain end to end, lineage routing through `_move_entity`, Daft `collect()` semantics on the new guards, run_id minting × `SimulationService` pinning, audit-schema removal completeness)

## Follow-ups (intentionally not in this PR)

- `RuntimeWorld` has no post-hoc `add_resource`, so "fork with different physics" has no clean top-level path (forks share resource instances); `fork.update(entity, Component(...))` is the workable divergence mechanism today
- a `world.query(..., at_tick=...)` / `latest=True` convenience would remove the `info.tick - 1` ritual repeated across examples
- audit-log hardening: record real `applied_at` on drain, add `tick`/`actor_roles`, honor `tick_range`
- tick-0 semantics (spawn values are never queryable as a row; tick 0 reflects one processor pass) deserves a line in the time-travel docs
- cross-store lineage reads (segments carrying their own storage) if cross-store forks ever need history continuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)