### PR TITLE
The harness the wearer trains on: session history as trajectory rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ eval-results.json
 # mutmut: working tree of generated mutants and its on-disk cache
 mutants/
 .mutmut-cache
+
+# session reflection artifacts (local corpus analysis)
+session_data/
+session_reflection_report.md

--- a/examples/06_trajectory_analysis.py
+++ b/examples/06_trajectory_analysis.py
@@ -80,7 +80,7 @@ class Turn:
 # ── Components ──────────────────────────────────────────────────────
 
 
-class Trajectory(Component):
+class SessionTrajectory(Component):
     """A complete agent trajectory stored as JSON-encoded turns."""
 
     trajectory_id: str = ""
@@ -103,7 +103,7 @@ class Trajectory(Component):
         outcome: str = "",
         tags: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
-    ) -> Trajectory:
+    ) -> SessionTrajectory:
         total_tokens = sum(t.tokens for t in turns)
         duration = sum(t.duration_ms for t in turns) / 1000.0
         return cls(
@@ -212,7 +212,7 @@ def extract_rationale(response: str) -> str:
 class SamplingProcessor(AsyncProcessor):
     """Selects which trajectories to evaluate based on SamplingConfig."""
 
-    components = (Trajectory, Label)
+    components = (SessionTrajectory, Label)
     priority = 10
 
     async def process(
@@ -224,18 +224,22 @@ class SamplingProcessor(AsyncProcessor):
         sampled = daft.lit(True)
 
         if config.min_turns > 0:
-            sampled = sampled & (col("trajectory__total_turns") >= config.min_turns)
+            sampled = sampled & (col("sessiontrajectory__total_turns") >= config.min_turns)
         if config.max_turns > 0:
-            sampled = sampled & (col("trajectory__total_turns") <= config.max_turns)
+            sampled = sampled & (col("sessiontrajectory__total_turns") <= config.max_turns)
         if config.outcome_filter:
             matcher = _make_outcome_matcher(config.outcome_filter)
-            sampled = sampled & matcher(col("trajectory__outcome"))
+            sampled = sampled & matcher(col("sessiontrajectory__outcome"))
         if config.require_tags:
             for tag in config.require_tags:
-                sampled = sampled & _tags_contain(col("trajectory__tags_json"), daft.lit(tag))
+                sampled = sampled & _tags_contain(
+                    col("sessiontrajectory__tags_json"), daft.lit(tag)
+                )
         if config.exclude_tags:
             for tag in config.exclude_tags:
-                sampled = sampled & ~_tags_contain(col("trajectory__tags_json"), daft.lit(tag))
+                sampled = sampled & ~_tags_contain(
+                    col("sessiontrajectory__tags_json"), daft.lit(tag)
+                )
 
         df = df.with_columns({"label__sampled": sampled})
 
@@ -254,7 +258,7 @@ class SamplingProcessor(AsyncProcessor):
 class LabelingProcessor(AsyncProcessor):
     """Applies a labeling technique to sampled trajectories via LLM."""
 
-    components = (Trajectory, Label)
+    components = (SessionTrajectory, Label)
     priority = 20
 
     async def process(
@@ -276,15 +280,15 @@ class LabelingProcessor(AsyncProcessor):
             + col("label__description")
             + "\n\n## Trajectory\n"
             "Source: "
-            + col("trajectory__source")
+            + col("sessiontrajectory__source")
             + "\nOutcome: "
-            + col("trajectory__outcome")
+            + col("sessiontrajectory__outcome")
             + "\nTotal turns: "
-            + col("trajectory__total_turns").cast(daft.DataType.string())
+            + col("sessiontrajectory__total_turns").cast(daft.DataType.string())
             + "\nDuration: "
-            + col("trajectory__duration_seconds").cast(daft.DataType.string())
+            + col("sessiontrajectory__duration_seconds").cast(daft.DataType.string())
             + "s\n\nTurns:\n"
-            + col("trajectory__turns_json")
+            + col("sessiontrajectory__turns_json")
             + "\n\n## Instructions\n"
             "Evaluate this trajectory according to the technique above.\n"
             "Respond in EXACTLY this format (no other text):\n"
@@ -313,7 +317,7 @@ class LabelingProcessor(AsyncProcessor):
 class ScoringProcessor(AsyncProcessor):
     """Clamps scores to [0, 1]."""
 
-    components = (Trajectory, Label)
+    components = (SessionTrajectory, Label)
     priority = 30
 
     async def process(self, df: DataFrame, **kwargs: Any) -> DataFrame:
@@ -327,10 +331,10 @@ class ScoringProcessor(AsyncProcessor):
 # ── Synthetic Data ──────────────────────────────────────────────────
 
 
-def make_trajectories() -> list[Trajectory]:
+def make_trajectories() -> list[SessionTrajectory]:
     """Build synthetic agent trajectories for demonstration."""
 
-    efficient = Trajectory.from_turns(
+    efficient = SessionTrajectory.from_turns(
         trajectory_id="traj-001",
         source="claude-code",
         outcome="success: implemented feature correctly on first attempt",
@@ -370,7 +374,7 @@ def make_trajectories() -> list[Trajectory]:
         ],
     )
 
-    backtracking = Trajectory.from_turns(
+    backtracking = SessionTrajectory.from_turns(
         trajectory_id="traj-002",
         source="claude-code",
         outcome="success: fixed bug after two wrong approaches",
@@ -463,7 +467,7 @@ def make_trajectories() -> list[Trajectory]:
         ],
     )
 
-    failed = Trajectory.from_turns(
+    failed = SessionTrajectory.from_turns(
         trajectory_id="traj-003",
         source="claude-code",
         outcome="failure: could not resolve circular import",
@@ -584,12 +588,12 @@ async def main():
         print("Results:")
         # query() returns the full append-only history; show the latest tick.
         info = await world.info()
-        df = await world.query(Trajectory, Label)
+        df = await world.query(SessionTrajectory, Label)
         rows = df.where(col("tick") == info.tick - 1).collect().to_pylist()
         for row in rows:
             if not row.get("is_active", True):
                 continue
-            tid = row.get("trajectory__trajectory_id", "")
+            tid = row.get("sessiontrajectory__trajectory_id", "")
             tech = row.get("label__technique", "")
             score = row.get("label__score", 0.0)
             value = row.get("label__value", "")

--- a/experiments/session_reflection.py
+++ b/experiments/session_reflection.py
@@ -1,0 +1,240 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Self-reflection over Claude Code session history.
+
+Ingests every session transcript under ~/.claude/projects into a world —
+one Trajectory header plus normalized TrajectoryTurn rows per session,
+all materialized at tick 0 as initial conditions — then reflects with
+Daft queries over the corpus: where the time went, which tools carry the
+work, where tools errored, and where the human had to push back.
+
+The correction heuristic is deliberately crude (user turns opening with
+"no", "wait", "stop", "don't", "actually", ...): it exists to surface
+candidate sessions for closer reading and later LLM labeling, not to be
+a verdict.
+
+Usage:
+    uv run python experiments/session_reflection.py [--limit N]
+        [--projects-dir DIR] [--storage DIR] [--report PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import time
+from pathlib import Path
+
+from daft import col
+from daft.functions import lower, startswith
+
+from archetype.app.container import ServiceContainer
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.experiments.claude_sessions import load_claude_sessions
+from archetype.experiments.trajectories import Trajectory, TrajectoryTurn
+
+CORRECTION_OPENERS = [
+    "no ",
+    "no,",
+    "no.",
+    "nope",
+    "wait",
+    "stop",
+    "don't",
+    "dont ",
+    "actually",
+    "that's not",
+    "thats not",
+    "wrong",
+    "not what",
+    "undo",
+    "revert",
+    "hold on",
+    "you're not",
+    "youre not",
+]
+
+
+def _correction_predicate():
+    lowered = lower(col("trajectoryturn__content"))
+    predicate = startswith(lowered, CORRECTION_OPENERS[0])
+    for opener in CORRECTION_OPENERS[1:]:
+        predicate = predicate | startswith(lowered, opener)
+    return (col("trajectoryturn__role") == "user") & predicate
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--projects-dir", default=None, help="defaults to ~/.claude/projects")
+    parser.add_argument("--storage", default="./session_data")
+    parser.add_argument("--report", default="./session_reflection_report.md")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--max-content-chars", type=int, default=2000)
+    args = parser.parse_args()
+
+    t0 = time.time()
+    sessions = load_claude_sessions(
+        args.projects_dir, limit=args.limit, max_content_chars=args.max_content_chars
+    )
+    print(f"Loaded {len(sessions)} sessions in {time.time() - t0:.1f}s")
+    if not sessions:
+        print("No sessions found.")
+        return
+
+    c = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=args.storage, namespace="sessions")
+        world = await c.world_service.create_world(WorldConfig(name="claude-sessions"), storage)
+
+        t0 = time.time()
+        n_rows = 0
+        for session in sessions:
+            for entity_components in session.components():
+                await world.create_entity(entity_components)
+                n_rows += 1
+        await c.simulation_service.step(world.world_id, RunConfig())
+        print(f"Materialized {n_rows} rows at tick 0 in {time.time() - t0:.1f}s")
+
+        headers = await world.query_archetype(sig=(Trajectory,), ticks=[0])
+        turns = await world.query_archetype(sig=(TrajectoryTurn,), ticks=[0])
+
+        # ── Reflections (Daft queries over the corpus) ─────────────────────
+        totals = headers.agg(
+            col("trajectory__total_tokens").sum().alias("tokens"),
+            col("trajectory__total_turns").sum().alias("turns"),
+            col("trajectory__duration_seconds").sum().alias("seconds"),
+        ).to_pylist()[0]
+
+        by_project = (
+            headers.groupby("trajectory__task_id")
+            .agg(
+                col("trajectory__trajectory_id").count().alias("sessions"),
+                col("trajectory__total_tokens").sum().alias("tokens"),
+            )
+            .sort("tokens", desc=True)
+            .limit(12)
+            .to_pylist()
+        )
+
+        by_model = (
+            headers.where(col("trajectory__model") != "")
+            .groupby("trajectory__model")
+            .agg(col("trajectory__trajectory_id").count().alias("sessions"))
+            .sort("sessions", desc=True)
+            .to_pylist()
+        )
+
+        tool_usage = (
+            turns.where(col("trajectoryturn__role") == "tool_call")
+            .groupby("trajectoryturn__tool_name")
+            .agg(col("trajectoryturn__seq").count().alias("calls"))
+            .sort("calls", desc=True)
+            .limit(15)
+            .to_pylist()
+        )
+
+        tool_errors = (
+            turns.where(col("trajectoryturn__error") != "")
+            .groupby("trajectoryturn__tool_name")
+            .agg(col("trajectoryturn__seq").count().alias("errors"))
+            .sort("errors", desc=True)
+            .limit(10)
+            .to_pylist()
+        )
+        total_tool_results = turns.where(col("trajectoryturn__role") == "tool_result").count_rows()
+        total_tool_errors = turns.where(col("trajectoryturn__error") != "").count_rows()
+
+        corrections = (
+            turns.where(_correction_predicate())
+            .groupby("trajectoryturn__trajectory_id")
+            .agg(col("trajectoryturn__seq").count().alias("corrections"))
+            .sort("corrections", desc=True)
+            .limit(15)
+            .to_pylist()
+        )
+        total_corrections = turns.where(_correction_predicate()).count_rows()
+        total_user_turns = turns.where(col("trajectoryturn__role") == "user").count_rows()
+
+        biggest = (
+            headers.sort("trajectory__total_tokens", desc=True)
+            .limit(10)
+            .select(
+                "trajectory__trajectory_id",
+                "trajectory__task_id",
+                "trajectory__total_tokens",
+                "trajectory__total_turns",
+            )
+            .to_pylist()
+        )
+
+        # ── Report ──────────────────────────────────────────────────────────
+        project_of = {s.trajectory.trajectory_id: s.project for s in sessions}
+        lines = [
+            "# Session Reflection Report",
+            "",
+            f"- Sessions: **{len(sessions)}**  |  Turn rows: **{int(totals['turns'])}**  |  "
+            f"Output tokens: **{int(totals['tokens']):,}**  |  "
+            f"Cumulative session span: **{totals['seconds'] / 3600:.0f}h** (parallel agents, includes idle)",
+            f"- Tool errors: **{total_tool_errors}** of {total_tool_results} tool results "
+            f"({100 * total_tool_errors / max(total_tool_results, 1):.1f}%)",
+            f"- Correction-shaped user turns: **{total_corrections}** of {total_user_turns} "
+            f"({100 * total_corrections / max(total_user_turns, 1):.1f}%) — crude heuristic, "
+            "candidates for labeling",
+            "",
+            "## Where the work happens (top projects by tokens)",
+            "",
+            "| project | sessions | output tokens |",
+            "|---|---|---|",
+        ]
+        lines += [
+            f"| {r['trajectory__task_id']} | {r['sessions']} | {int(r['tokens']):,} |"
+            for r in by_project
+        ]
+        lines += ["", "## Models", "", "| model | sessions |", "|---|---|"]
+        lines += [f"| {r['trajectory__model']} | {r['sessions']} |" for r in by_model]
+        lines += ["", "## Tools that carry the work", "", "| tool | calls |", "|---|---|"]
+        lines += [f"| {r['trajectoryturn__tool_name']} | {r['calls']} |" for r in tool_usage]
+        lines += ["", "## Tool errors", "", "| tool | errors |", "|---|---|"]
+        lines += [f"| {r['trajectoryturn__tool_name']} | {r['errors']} |" for r in tool_errors]
+        lines += [
+            "",
+            "## Sessions with the most correction-shaped turns",
+            "",
+            "| session | project | corrections |",
+            "|---|---|---|",
+        ]
+        lines += [
+            f"| {r['trajectoryturn__trajectory_id'][:8]} | "
+            f"{project_of.get(r['trajectoryturn__trajectory_id'], '?')} | {r['corrections']} |"
+            for r in corrections
+        ]
+        lines += [
+            "",
+            "## Biggest sessions",
+            "",
+            "| session | project | tokens | turns |",
+            "|---|---|---|---|",
+        ]
+        lines += [
+            f"| {r['trajectory__trajectory_id'][:8]} | {r['trajectory__task_id']} | "
+            f"{int(r['trajectory__total_tokens']):,} | {r['trajectory__total_turns']} |"
+            for r in biggest
+        ]
+        lines += [
+            "",
+            "---",
+            f"Corpus world: `{world.world_id}` (run `{world.run_id}`), storage `{args.storage}` — "
+            "the rows are durable; every query above is repeatable, and the corpus is forkable.",
+        ]
+
+        report = "\n".join(lines)
+        Path(args.report).write_text(report)
+        print(f"\nReport written to {args.report}\n")
+        print(report)
+    finally:
+        await c.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/archetype/core/component.py
+++ b/src/archetype/core/component.py
@@ -30,7 +30,13 @@ class Component(LanceModel):
         Walks the full subclass tree — ``__subclasses__()`` only returns
         direct subclasses, so a naive lookup misses components defined as
         subclasses of intermediate base classes.
+
+        Raises on ambiguity: two Component classes sharing a name would
+        make name-addressed payloads (CLI/API spawn commands) land rows in
+        whichever archetype import order happened to favor — a silent
+        wrong-table write. Ambiguity must be loud.
         """
+        matches: list[type[Component]] = []
         stack: list[type[Component]] = [cls]
         seen: set[type[Component]] = set()
         while stack:
@@ -40,9 +46,17 @@ class Component(LanceModel):
                     continue
                 seen.add(subclass)
                 if subclass.__name__ == name:
-                    return subclass
+                    matches.append(subclass)
                 stack.append(subclass)
-        raise ValueError(f"Component type '{name}' not found.")
+        if not matches:
+            raise ValueError(f"Component type '{name}' not found.")
+        if len(matches) > 1:
+            modules = ", ".join(sorted(f"{m.__module__}.{m.__name__}" for m in matches))
+            raise ValueError(
+                f"Component type name '{name}' is ambiguous ({modules}); "
+                "name-addressed payloads require unique component class names."
+            )
+        return matches[0]
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Component":

--- a/src/archetype/experiments/__init__.py
+++ b/src/archetype/experiments/__init__.py
@@ -12,6 +12,10 @@ Ingestion from archetype-runner's SQLite registry is provided by
 :func:`load_runner_state_db` and :func:`ingest_runner_state`.
 """
 
+from archetype.experiments.claude_sessions import (
+    load_claude_session,
+    load_claude_sessions,
+)
 from archetype.experiments.components import (
     BranchHead,
     Experiment,
@@ -23,6 +27,16 @@ from archetype.experiments.loaders import (
     ingest_runner_state,
     load_runner_state_db,
 )
+from archetype.experiments.trajectories import (
+    Trajectory,
+    TrajectoryAction,
+    TrajectoryCommandEvent,
+    TrajectoryObservation,
+    TrajectoryReward,
+    TrajectoryTurn,
+    Turn,
+    turns_to_components,
+)
 
 __all__ = [
     "BranchHead",
@@ -30,6 +44,16 @@ __all__ = [
     "Result",
     "Run",
     "RunStatus",
+    "Trajectory",
+    "TrajectoryAction",
+    "TrajectoryCommandEvent",
+    "TrajectoryObservation",
+    "TrajectoryReward",
+    "TrajectoryTurn",
+    "Turn",
     "ingest_runner_state",
+    "load_claude_session",
+    "load_claude_sessions",
     "load_runner_state_db",
+    "turns_to_components",
 ]

--- a/src/archetype/experiments/claude_sessions.py
+++ b/src/archetype/experiments/claude_sessions.py
@@ -1,0 +1,308 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Claude Code session transcripts -> trajectory rows.
+
+Claude Code records every session as JSONL under ``~/.claude/projects/
+<project-slug>/<session-id>.jsonl``: one line per event, with ``user`` and
+``assistant`` message lines carrying content blocks (text, thinking,
+tool_use, tool_result) plus timestamps, git branch, model, and token
+usage. This module transcribes those transcripts into the shared
+trajectory schema so an agent's own session history becomes rows in a
+world — queryable, labelable, forkable, and eventually trainable-on.
+
+This is a loader, not an archive: the JSONL files on disk remain the
+source artifacts; the trajectory rows are the analytical view. (The
+lesson of Chronicle: ideas survive here as components plus a loader.)
+
+Mapping:
+    session file        -> one LoadedSession: a Trajectory header plus
+                           Turn rows (normalized via turns_to_components)
+    user text           -> Turn(role="user")
+    assistant text      -> Turn(role="assistant", tokens=output_tokens)
+    assistant tool_use  -> Turn(role="tool_call", tool_name, tool_input)
+    user tool_result    -> Turn(role="tool_result", error when is_error)
+    thinking blocks     -> skipped (private scratchpad, not dialogue)
+    sidechain/meta rows -> skipped, counted on the LoadedSession
+
+Content fields are truncated to ``max_content_chars`` — tool outputs
+dominate transcript bytes and the full text stays on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from archetype.core.component import Component
+from archetype.experiments.trajectories import Trajectory, Turn, turns_to_components
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+
+_TRUNCATION_MARK = "…[truncated]"
+
+
+@dataclass
+class LoadedSession:
+    """One transcribed session: the header, its turns, and session facts."""
+
+    trajectory: Trajectory
+    turns: list[Turn]
+    project: str = ""
+    cwd: str = ""
+    git_branch: str = ""
+    client_version: str = ""
+    models: list[str] = field(default_factory=list)
+    started_at: str = ""
+    ended_at: str = ""
+    sidechain_turns_skipped: int = 0
+
+    def components(self) -> list[list[Component]]:
+        """Spawnable entities: [header] plus one [turn-row] per turn."""
+        rows: list[list[Component]] = [[self.trajectory]]
+        rows.extend(
+            [turn_row]
+            for turn_row in turns_to_components(self.trajectory.trajectory_id, self.turns)
+        )
+        return rows
+
+
+def _truncate(text: str, limit: int) -> str:
+    if limit <= 0 or len(text) <= limit:
+        return text
+    return text[:limit] + _TRUNCATION_MARK
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _block_text(content: Any) -> str:
+    """Flatten a content value (string, block list, or nested) to text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(p for p in parts if p)
+    return str(content)
+
+
+def iter_session_files(projects_dir: str | Path | None = None) -> list[Path]:
+    """All session transcript files, sorted for deterministic ingest order."""
+    root = Path(projects_dir) if projects_dir is not None else DEFAULT_PROJECTS_DIR
+    if not root.exists():
+        return []
+    return sorted(root.glob("*/*.jsonl"))
+
+
+def load_claude_session(
+    path: str | Path,
+    *,
+    max_content_chars: int = 4000,
+    include_sidechains: bool = False,
+) -> LoadedSession | None:
+    """Transcribe one session transcript.
+
+    Returns None for sessions with no dialogue turns (queue noise,
+    empty files, unparseable transcripts).
+    """
+    path = Path(path)
+    turns: list[Turn] = []
+    models: set[str] = set()
+    git_branch = ""
+    cwd = ""
+    version = ""
+    sidechain_skipped = 0
+    first_ts: datetime | None = None
+    last_ts: datetime | None = None
+    prev_ts: datetime | None = None
+    tool_names_by_use_id: dict[str, str] = {}
+
+    try:
+        raw_lines = path.read_text(errors="replace").splitlines()
+    except OSError as e:
+        logger.warning("unreadable session %s: %s", path, e)
+        return None
+
+    for raw in raw_lines:
+        try:
+            line = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(line, dict):
+            continue
+        line_type = line.get("type")
+        if line_type not in ("user", "assistant"):
+            continue
+        if line.get("isMeta"):
+            continue
+        if line.get("isSidechain") and not include_sidechains:
+            sidechain_skipped += 1
+            continue
+
+        message = line.get("message") or {}
+        ts = _parse_ts(line.get("timestamp"))
+        if ts is not None:
+            first_ts = first_ts or ts
+            last_ts = ts
+        duration_ms = (
+            (ts - prev_ts).total_seconds() * 1000.0
+            if ts is not None and prev_ts is not None
+            else 0.0
+        )
+        prev_ts = ts or prev_ts
+
+        git_branch = line.get("gitBranch") or git_branch
+        cwd = line.get("cwd") or cwd
+        version = line.get("version") or version
+
+        if line_type == "assistant":
+            if message.get("model"):
+                models.add(message["model"])
+            usage = message.get("usage") or {}
+            tokens = int(usage.get("output_tokens") or 0)
+            content = message.get("content") or []
+            if isinstance(content, str):
+                content = [{"type": "text", "text": content}]
+            emitted_tokens = False
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "text":
+                    text = block.get("text", "")
+                    if not text.strip():
+                        continue
+                    turns.append(
+                        Turn(
+                            role="assistant",
+                            content=_truncate(text, max_content_chars),
+                            tokens=0 if emitted_tokens else tokens,
+                            duration_ms=duration_ms,
+                        )
+                    )
+                    emitted_tokens = True
+                    duration_ms = 0.0
+                elif btype == "tool_use":
+                    if block.get("id"):
+                        tool_names_by_use_id[str(block["id"])] = str(block.get("name", ""))
+                    turns.append(
+                        Turn(
+                            role="tool_call",
+                            tool_name=str(block.get("name", "")),
+                            tool_input=_truncate(
+                                json.dumps(block.get("input", {})), max_content_chars
+                            ),
+                            tokens=0 if emitted_tokens else tokens,
+                            duration_ms=duration_ms,
+                        )
+                    )
+                    emitted_tokens = True
+                    duration_ms = 0.0
+                # thinking blocks: skipped by design
+        else:  # user line
+            content = message.get("content")
+            if isinstance(content, str):
+                if content.strip():
+                    turns.append(
+                        Turn(
+                            role="user",
+                            content=_truncate(content, max_content_chars),
+                            duration_ms=duration_ms,
+                        )
+                    )
+                continue
+            for block in content or []:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "tool_result":
+                    is_error = bool(block.get("is_error"))
+                    turns.append(
+                        Turn(
+                            role="tool_result",
+                            content=_truncate(_block_text(block.get("content")), max_content_chars),
+                            tool_name=tool_names_by_use_id.get(
+                                str(block.get("tool_use_id", "")), ""
+                            ),
+                            error="tool_error" if is_error else "",
+                            duration_ms=duration_ms,
+                        )
+                    )
+                    duration_ms = 0.0
+                elif btype == "text":
+                    text = block.get("text", "")
+                    if text.strip():
+                        turns.append(
+                            Turn(
+                                role="user",
+                                content=_truncate(text, max_content_chars),
+                                duration_ms=duration_ms,
+                            )
+                        )
+                        duration_ms = 0.0
+
+    if not turns:
+        return None
+
+    project = path.parent.name
+    trajectory = Trajectory.from_turns(
+        path.stem,
+        turns,
+        source="claude-code",
+        model=sorted(models)[0] if models else "",
+        task_id=project,
+        terminal=True,
+    )
+    return LoadedSession(
+        trajectory=trajectory,
+        turns=turns,
+        project=project,
+        cwd=cwd,
+        git_branch=git_branch,
+        client_version=version,
+        models=sorted(models),
+        started_at=first_ts.isoformat() if first_ts else "",
+        ended_at=last_ts.isoformat() if last_ts else "",
+        sidechain_turns_skipped=sidechain_skipped,
+    )
+
+
+def load_claude_sessions(
+    projects_dir: str | Path | None = None,
+    *,
+    max_content_chars: int = 4000,
+    include_sidechains: bool = False,
+    limit: int | None = None,
+) -> list[LoadedSession]:
+    """Transcribe every session under projects_dir."""
+    sessions: list[LoadedSession] = []
+    for path in iter_session_files(projects_dir):
+        if limit is not None and len(sessions) >= limit:
+            break
+        session = load_claude_session(
+            path,
+            max_content_chars=max_content_chars,
+            include_sidechains=include_sidechains,
+        )
+        if session is not None:
+            sessions.append(session)
+    return sessions

--- a/src/archetype/experiments/recorders.py
+++ b/src/archetype/experiments/recorders.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers that turn existing runtime artifacts into typed trajectory rows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from archetype.app.models import Command, EpisodeResult
+from archetype.experiments.trajectories import (
+    Trajectory,
+    TrajectoryAction,
+    TrajectoryCommandEvent,
+    TrajectoryObservation,
+    TrajectoryReward,
+)
+
+
+def command_to_event(
+    command: Command,
+    *,
+    trajectory_id: str,
+    seq: int,
+) -> TrajectoryCommandEvent:
+    """Serialize a queued command into a typed trajectory event."""
+    return TrajectoryCommandEvent(
+        trajectory_id=trajectory_id,
+        seq=seq,
+        command_id=str(command.id),
+        tick=command.tick,
+        command_type=command.type.value,
+        priority=command.priority,
+        version=command.version,
+    )
+
+
+def audit_row_to_event(
+    row: Mapping[str, Any],
+    *,
+    trajectory_id: str,
+    seq: int,
+) -> TrajectoryCommandEvent:
+    """Serialize an audit row dict into a typed trajectory event."""
+    return TrajectoryCommandEvent(
+        trajectory_id=trajectory_id,
+        seq=seq,
+        audit_id=str(row.get("audit_id") or ""),
+        command_id=str(row.get("command_id") or ""),
+        world_id=str(row.get("world_id") or ""),
+        actor_id=str(row.get("actor_id") or ""),
+        command_type=str(row.get("command_type") or ""),
+        status=str(row.get("status") or ""),
+        accepted_at=str(row.get("accepted_at") or ""),
+        applied_at=str(row.get("applied_at") or ""),
+    )
+
+
+def commands_to_events(
+    commands: Iterable[Command],
+    *,
+    trajectory_id: str,
+) -> list[TrajectoryCommandEvent]:
+    return [
+        command_to_event(command, trajectory_id=trajectory_id, seq=seq)
+        for seq, command in enumerate(commands)
+    ]
+
+
+def audit_rows_to_events(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    trajectory_id: str,
+) -> list[TrajectoryCommandEvent]:
+    return [
+        audit_row_to_event(row, trajectory_id=trajectory_id, seq=seq)
+        for seq, row in enumerate(rows)
+    ]
+
+
+def trajectory_from_episode_result(
+    episode: EpisodeResult,
+    *,
+    rollout_id: str = "",
+    run_id: str = "",
+    task_id: str = "",
+    trial_idx: int = 0,
+    source: str = "archetype.rollout",
+) -> Trajectory:
+    """Build a durable trajectory header row from one episode result."""
+    trajectory_id = (
+        f"{rollout_id}:trial-{trial_idx}:{episode.episode_id}"
+        if rollout_id
+        else str(episode.episode_id)
+    )
+    return Trajectory(
+        trajectory_id=trajectory_id,
+        run_id=run_id,
+        episode_id=str(episode.episode_id),
+        rollout_id=rollout_id,
+        task_id=task_id,
+        trial_idx=trial_idx,
+        source=source,
+        terminal=episode.terminated,
+        total_steps=episode.duration_steps,
+    )
+
+
+def observations_from_post_tick_events(
+    events: Iterable[Mapping[str, Any]],
+    *,
+    trajectory_id: str,
+) -> list[TrajectoryObservation]:
+    return [
+        TrajectoryObservation(
+            trajectory_id=trajectory_id,
+            seq=seq,
+            world_id=str(event.get("world_id") or ""),
+            tick=int(event.get("tick") or 0),
+            event_type=str(event.get("event") or ""),
+            archetype_count=int(event.get("archetype_count") or 0),
+            entity_count=int(event.get("entity_count") or 0),
+        )
+        for seq, event in enumerate(events)
+    ]
+
+
+def actions_from_observations(
+    observations: Iterable[TrajectoryObservation],
+    *,
+    action_type: str = "step",
+) -> list[TrajectoryAction]:
+    return [
+        TrajectoryAction(
+            trajectory_id=observation.trajectory_id,
+            seq=seq,
+            tick=observation.tick,
+            action_type=action_type,
+        )
+        for seq, observation in enumerate(observations)
+    ]
+
+
+def reward_row(
+    *,
+    trajectory_id: str,
+    reward: float,
+    seq: int = 0,
+) -> TrajectoryReward:
+    return TrajectoryReward(trajectory_id=trajectory_id, seq=seq, reward=reward)

--- a/src/archetype/experiments/trajectories.py
+++ b/src/archetype/experiments/trajectories.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed trajectory components for experiment and rollout data.
+
+Trajectory data is stored as normalized, Arrow-friendly component rows. The
+header row identifies the trajectory; turns, commands, observations, actions,
+and rewards are separate typed rows keyed by ``trajectory_id`` and ``seq``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from archetype.core.component import Component
+
+
+@dataclass
+class Turn:
+    """Python authoring helper for one conversational or tool-use turn."""
+
+    role: str
+    content: str = ""
+    tool_name: str = ""
+    tool_input: str = ""
+    tool_output: str = ""
+    tokens: int = 0
+    duration_ms: float = 0.0
+    error: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"role": self.role}
+        if self.content:
+            data["content"] = self.content
+        if self.tool_name:
+            data["tool_name"] = self.tool_name
+        if self.tool_input:
+            data["tool_input"] = self.tool_input
+        if self.tool_output:
+            data["tool_output"] = self.tool_output
+        if self.tokens:
+            data["tokens"] = self.tokens
+        if self.duration_ms:
+            data["duration_ms"] = self.duration_ms
+        if self.error:
+            data["error"] = self.error
+        if self.metadata:
+            data["metadata"] = self.metadata
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Turn:
+        return cls(
+            role=str(data.get("role") or ""),
+            content=str(data.get("content") or ""),
+            tool_name=str(data.get("tool_name") or ""),
+            tool_input=str(data.get("tool_input") or ""),
+            tool_output=str(data.get("tool_output") or ""),
+            tokens=int(data.get("tokens") or 0),
+            duration_ms=float(data.get("duration_ms") or 0.0),
+            error=str(data.get("error") or ""),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+    def to_component(self, trajectory_id: str, seq: int) -> TrajectoryTurn:
+        return TrajectoryTurn(
+            trajectory_id=trajectory_id,
+            seq=seq,
+            role=self.role,
+            content=self.content,
+            tool_name=self.tool_name,
+            tool_input=self.tool_input,
+            tool_output=self.tool_output,
+            tokens=self.tokens,
+            duration_ms=self.duration_ms,
+            error=self.error,
+        )
+
+
+class Trajectory(Component):
+    """One durable trajectory header row."""
+
+    trajectory_id: str = ""
+    run_id: str = ""
+    episode_id: str = ""
+    rollout_id: str = ""
+    task_id: str = ""
+    trial_idx: int = 0
+
+    source: str = ""
+    model: str = ""
+    policy_version: str = ""
+
+    terminal: bool = False
+    total_steps: int = 0
+    total_turns: int = 0
+    total_tokens: int = 0
+    duration_seconds: float = 0.0
+    outcome: str = ""
+
+    @classmethod
+    def from_turns(
+        cls,
+        trajectory_id: str,
+        turns: list[Turn],
+        *,
+        run_id: str = "",
+        episode_id: str = "",
+        rollout_id: str = "",
+        task_id: str = "",
+        trial_idx: int = 0,
+        source: str = "",
+        model: str = "",
+        policy_version: str = "",
+        terminal: bool = False,
+        outcome: str = "",
+    ) -> Trajectory:
+        return cls(
+            trajectory_id=trajectory_id,
+            run_id=run_id,
+            episode_id=episode_id,
+            rollout_id=rollout_id,
+            task_id=task_id,
+            trial_idx=trial_idx,
+            source=source,
+            model=model,
+            policy_version=policy_version,
+            terminal=terminal,
+            total_steps=0,
+            total_turns=len(turns),
+            total_tokens=sum(turn.tokens for turn in turns),
+            duration_seconds=sum(turn.duration_ms for turn in turns) / 1000.0,
+            outcome=outcome,
+        )
+
+
+class TrajectoryTurn(Component):
+    """One typed turn row belonging to a trajectory."""
+
+    trajectory_id: str = ""
+    seq: int = 0
+    role: str = ""
+    content: str = ""
+    tool_name: str = ""
+    tool_input: str = ""
+    tool_output: str = ""
+    tokens: int = 0
+    duration_ms: float = 0.0
+    error: str = ""
+
+
+class TrajectoryCommandEvent(Component):
+    """One typed command/audit event row belonging to a trajectory."""
+
+    trajectory_id: str = ""
+    seq: int = 0
+    audit_id: str = ""
+    command_id: str = ""
+    world_id: str = ""
+    actor_id: str = ""
+    command_type: str = ""
+    status: str = ""
+    tick: int = 0
+    priority: int = 0
+    version: int = 0
+    accepted_at: str = ""
+    applied_at: str = ""
+
+
+class TrajectoryObservation(Component):
+    """One typed observation/event row belonging to a trajectory."""
+
+    trajectory_id: str = ""
+    seq: int = 0
+    world_id: str = ""
+    tick: int = 0
+    event_type: str = ""
+    archetype_count: int = 0
+    entity_count: int = 0
+
+
+class TrajectoryAction(Component):
+    """One typed action row belonging to a trajectory."""
+
+    trajectory_id: str = ""
+    seq: int = 0
+    tick: int = 0
+    action_type: str = ""
+
+
+class TrajectoryReward(Component):
+    """One typed reward row belonging to a trajectory."""
+
+    trajectory_id: str = ""
+    seq: int = 0
+    reward: float = 0.0
+
+
+def turns_to_components(trajectory_id: str, turns: list[Turn]) -> list[TrajectoryTurn]:
+    return [turn.to_component(trajectory_id, seq) for seq, turn in enumerate(turns)]

--- a/tests/experiments/test_claude_sessions.py
+++ b/tests/experiments/test_claude_sessions.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Claude session transcript loader contracts."""
+
+import json
+
+from archetype.experiments.claude_sessions import (
+    load_claude_session,
+    load_claude_sessions,
+)
+from archetype.experiments.trajectories import Trajectory, TrajectoryTurn
+
+
+def _line(line_type: str, content, *, ts: str, **extra) -> str:
+    base = {
+        "type": line_type,
+        "timestamp": ts,
+        "sessionId": "s-1",
+        "cwd": "/repo",
+        "gitBranch": "main",
+        "version": "3.0.0",
+        "message": {"role": line_type, "content": content},
+    }
+    base.update(extra)
+    return json.dumps(base)
+
+
+def _write_session(path, lines):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines))
+
+
+def test_session_transcribes_to_trajectory(tmp_path):
+    session = tmp_path / "proj-a" / "abc123.jsonl"
+    _write_session(
+        session,
+        [
+            json.dumps({"type": "queue-operation", "operation": "enqueue"}),
+            _line("user", "Fix the login bug", ts="2026-06-01T10:00:00.000Z"),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-06-01T10:00:05.000Z",
+                    "gitBranch": "main",
+                    "message": {
+                        "role": "assistant",
+                        "model": "claude-fable-5",
+                        "usage": {"output_tokens": 42},
+                        "content": [
+                            {"type": "thinking", "thinking": "private"},
+                            {"type": "text", "text": "Reading auth.py"},
+                            {
+                                "type": "tool_use",
+                                "name": "Read",
+                                "input": {"file_path": "auth.py"},
+                            },
+                        ],
+                    },
+                }
+            ),
+            _line(
+                "user",
+                [{"type": "tool_result", "is_error": False, "content": "def login(): ..."}],
+                ts="2026-06-01T10:00:06.000Z",
+            ),
+            _line(
+                "user",
+                [{"type": "tool_result", "is_error": True, "content": "boom"}],
+                ts="2026-06-01T10:00:07.000Z",
+            ),
+        ],
+    )
+
+    loaded = load_claude_session(session)
+    assert loaded is not None
+    assert loaded.trajectory.trajectory_id == "abc123"
+    assert loaded.trajectory.source == "claude-code"
+    assert loaded.trajectory.model == "claude-fable-5"
+    assert loaded.trajectory.task_id == "proj-a"
+    assert loaded.project == "proj-a"
+    assert loaded.git_branch == "main"
+    assert loaded.started_at.startswith("2026-06-01T10:00:00")
+
+    roles = [t.role for t in loaded.turns]
+    # thinking skipped; assistant text + tool_use each become turns
+    assert roles == ["user", "assistant", "tool_call", "tool_result", "tool_result"]
+    assert loaded.turns[1].tokens == 42
+    assert loaded.turns[2].tokens == 0, "usage attributed once per assistant message"
+    assert loaded.turns[2].tool_name == "Read"
+    assert loaded.turns[3].error == ""
+    assert loaded.turns[4].error == "tool_error"
+    # durations derive from timestamps (5s between user and assistant)
+    assert loaded.turns[1].duration_ms == 5000.0
+
+    # header totals reflect the turns
+    assert loaded.trajectory.total_turns == 5
+    assert loaded.trajectory.total_tokens == 42
+
+
+def test_components_yield_header_and_turn_rows(tmp_path):
+    session = tmp_path / "proj-a" / "abc.jsonl"
+    _write_session(session, [_line("user", "hello", ts="2026-06-01T10:00:00.000Z")])
+
+    loaded = load_claude_session(session)
+    rows = loaded.components()
+    assert isinstance(rows[0][0], Trajectory)
+    assert all(isinstance(r[0], TrajectoryTurn) for r in rows[1:])
+    assert rows[1][0].trajectory_id == "abc"
+    assert rows[1][0].seq == 0
+
+
+def test_sidechain_and_meta_lines_skipped(tmp_path):
+    session = tmp_path / "proj-b" / "side.jsonl"
+    _write_session(
+        session,
+        [
+            _line("user", "main thread", ts="2026-06-01T10:00:00.000Z"),
+            _line("user", "subagent traffic", ts="2026-06-01T10:00:01.000Z", isSidechain=True),
+            _line("user", "meta", ts="2026-06-01T10:00:02.000Z", isMeta=True),
+        ],
+    )
+
+    loaded = load_claude_session(session)
+    assert [t.content for t in loaded.turns] == ["main thread"]
+    assert loaded.sidechain_turns_skipped == 1
+
+    with_side = load_claude_session(session, include_sidechains=True)
+    assert len(with_side.turns) == 2
+
+
+def test_content_truncation(tmp_path):
+    session = tmp_path / "proj-c" / "big.jsonl"
+    _write_session(session, [_line("user", "x" * 500, ts="2026-06-01T10:00:00.000Z")])
+
+    loaded = load_claude_session(session, max_content_chars=100)
+    content = loaded.turns[0].content
+    assert len(content) < 200
+    assert content.endswith("…[truncated]")
+
+
+def test_empty_and_noise_sessions_return_none(tmp_path):
+    empty = tmp_path / "proj-d" / "empty.jsonl"
+    _write_session(empty, [json.dumps({"type": "queue-operation"}), "not json {{{"])
+    assert load_claude_session(empty) is None
+
+
+def test_load_claude_sessions_walks_projects(tmp_path):
+    for i, proj in enumerate(["p1", "p2"]):
+        session = tmp_path / proj / f"s{i}.jsonl"
+        _write_session(session, [_line("user", f"hello {i}", ts="2026-06-01T10:00:00.000Z")])
+
+    sessions = load_claude_sessions(tmp_path)
+    assert len(sessions) == 2
+    assert sorted(s.project for s in sessions) == ["p1", "p2"]
+
+    limited = load_claude_sessions(tmp_path, limit=1)
+    assert len(limited) == 1
+
+    assert load_claude_sessions(tmp_path / "missing") == []

--- a/tests/experiments/test_trajectories.py
+++ b/tests/experiments/test_trajectories.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for typed trajectory/event-log experiment components."""
+
+import pyarrow as pa
+
+from archetype.app.models import Command, CommandType, EpisodeResult
+from archetype.core.component import Component
+from archetype.experiments import (
+    Trajectory,
+    TrajectoryAction,
+    TrajectoryCommandEvent,
+    TrajectoryObservation,
+    TrajectoryReward,
+    TrajectoryTurn,
+    Turn,
+    turns_to_components,
+)
+from archetype.experiments.recorders import (
+    actions_from_observations,
+    audit_rows_to_events,
+    commands_to_events,
+    observations_from_post_tick_events,
+    reward_row,
+    trajectory_from_episode_result,
+)
+
+
+def test_turn_authoring_helper_round_trips_optional_fields() -> None:
+    turn = Turn(
+        role="tool_call",
+        content="reading file",
+        tool_name="Read",
+        tool_input='{"path": "a.py"}',
+        tokens=5,
+        duration_ms=100,
+        metadata={"phase": "inspect"},
+    )
+
+    restored = Turn.from_dict(turn.to_dict())
+
+    assert restored.role == "tool_call"
+    assert restored.tool_name == "Read"
+    assert restored.metadata == {"phase": "inspect"}
+
+
+def test_trajectory_from_turns_is_header_only() -> None:
+    trajectory = Trajectory.from_turns(
+        "traj-1",
+        [
+            Turn(role="user", content="go", tokens=2, duration_ms=10),
+            Turn(role="assistant", content="done", tokens=3, duration_ms=20),
+        ],
+        source="unit",
+        outcome="success",
+    )
+
+    assert issubclass(Trajectory, Component)
+    assert trajectory.trajectory_id == "traj-1"
+    assert trajectory.total_turns == 2
+    assert trajectory.total_tokens == 5
+    assert trajectory.duration_seconds == 0.03
+    assert trajectory.outcome == "success"
+
+
+def test_turns_materialize_as_typed_rows() -> None:
+    rows = turns_to_components(
+        "traj-1",
+        [
+            Turn(role="user", content="go", tokens=2),
+            Turn(role="assistant", content="done", tokens=3, duration_ms=25),
+        ],
+    )
+
+    assert rows == [
+        TrajectoryTurn(trajectory_id="traj-1", seq=0, role="user", content="go", tokens=2),
+        TrajectoryTurn(
+            trajectory_id="traj-1",
+            seq=1,
+            role="assistant",
+            content="done",
+            tokens=3,
+            duration_ms=25,
+        ),
+    ]
+
+
+def test_typed_trajectory_schemas_are_arrow_materializable() -> None:
+    for component in (
+        Trajectory,
+        TrajectoryTurn,
+        TrajectoryCommandEvent,
+        TrajectoryObservation,
+        TrajectoryAction,
+        TrajectoryReward,
+    ):
+        schema = component.to_pyarrow_schema()
+        assert isinstance(schema, pa.Schema)
+        assert "trajectory_id" in schema.names
+        assert not any(name.endswith("_json") for name in schema.names)
+
+
+def test_trajectory_from_episode_result_records_header_fields() -> None:
+    episode = EpisodeResult(
+        episode_id="episode-1",
+        world_id="world-1",
+        final_tick=3,
+        terminated=True,
+        duration_steps=3,
+    )
+
+    trajectory = trajectory_from_episode_result(
+        episode,
+        rollout_id="rollout-1",
+        run_id="run-1",
+        task_id="task-1",
+        trial_idx=7,
+    )
+
+    assert trajectory.trajectory_id == "rollout-1:trial-7:episode-1"
+    assert trajectory.episode_id == "episode-1"
+    assert trajectory.rollout_id == "rollout-1"
+    assert trajectory.task_id == "task-1"
+    assert trajectory.trial_idx == 7
+    assert trajectory.terminal is True
+    assert trajectory.total_steps == 3
+
+
+def test_commands_and_audit_rows_materialize_as_typed_events() -> None:
+    command = Command(type=CommandType.SPAWN, tick=2, priority=5, version=3)
+    command_events = commands_to_events([command], trajectory_id="traj-1")
+    audit_events = audit_rows_to_events(
+        [
+            {
+                "audit_id": "audit-1",
+                "command_id": "cmd-1",
+                "world_id": "world-1",
+                "actor_id": "actor-1",
+                "command_type": "spawn",
+                "status": "applied",
+            }
+        ],
+        trajectory_id="traj-1",
+    )
+
+    assert command_events == [
+        TrajectoryCommandEvent(
+            trajectory_id="traj-1",
+            seq=0,
+            command_id=str(command.id),
+            command_type="spawn",
+            tick=2,
+            priority=5,
+            version=3,
+        )
+    ]
+    assert audit_events == [
+        TrajectoryCommandEvent(
+            trajectory_id="traj-1",
+            seq=0,
+            audit_id="audit-1",
+            command_id="cmd-1",
+            world_id="world-1",
+            actor_id="actor-1",
+            command_type="spawn",
+            status="applied",
+        )
+    ]
+
+
+def test_observations_actions_and_rewards_are_typed_rows() -> None:
+    observations = observations_from_post_tick_events(
+        [
+            {
+                "event": "post_tick",
+                "world_id": "world-1",
+                "tick": 1,
+                "archetype_count": 2,
+                "entity_count": 5,
+            }
+        ],
+        trajectory_id="traj-1",
+    )
+    actions = actions_from_observations(observations)
+    reward = reward_row(trajectory_id="traj-1", reward=1.0)
+
+    assert observations == [
+        TrajectoryObservation(
+            trajectory_id="traj-1",
+            seq=0,
+            world_id="world-1",
+            tick=1,
+            event_type="post_tick",
+            archetype_count=2,
+            entity_count=5,
+        )
+    ]
+    assert actions == [TrajectoryAction(trajectory_id="traj-1", seq=0, tick=1, action_type="step")]
+    assert reward == TrajectoryReward(trajectory_id="traj-1", seq=0, reward=1.0)

--- a/tests/integration/test_trajectory_analysis.py
+++ b/tests/integration/test_trajectory_analysis.py
@@ -28,7 +28,7 @@ sys.modules[_spec.name] = traj_mod
 _spec.loader.exec_module(traj_mod)
 
 Turn = traj_mod.Turn
-Trajectory = traj_mod.Trajectory
+SessionTrajectory = traj_mod.SessionTrajectory
 Label = traj_mod.Label
 SamplingProcessor = traj_mod.SamplingProcessor
 ScoringProcessor = traj_mod.ScoringProcessor
@@ -81,7 +81,7 @@ class TestTrajectoryComponent:
             Turn(role="user", content="hi", tokens=5, duration_ms=100),
             Turn(role="assistant", content="hey", tokens=8, duration_ms=200),
         ]
-        t = Trajectory.from_turns("t1", turns, source="test", outcome="ok", tags=["a"])
+        t = SessionTrajectory.from_turns("t1", turns, source="test", outcome="ok", tags=["a"])
         assert t.total_turns == 2
         assert t.total_tokens == 13
         assert t.duration_seconds == pytest.approx(0.3)
@@ -89,7 +89,7 @@ class TestTrajectoryComponent:
 
     def test_get_turns_round_trip(self):
         turns = [Turn(role="user", content="x", tokens=1)]
-        t = Trajectory.from_turns("t2", turns)
+        t = SessionTrajectory.from_turns("t2", turns)
         restored = t.get_turns()
         assert len(restored) == 1
         assert restored[0].role == "user"
@@ -114,13 +114,13 @@ async def test_sampling_processor_filters_by_min_turns(tmp_path):
 
         ctx = ActorCtx(id=uuid7(), roles={"operator"})
 
-        short_traj = Trajectory.from_turns(
+        short_traj = SessionTrajectory.from_turns(
             "short",
             [Turn(role="user", content="hi", tokens=1)],
             source="test",
             outcome="ok",
         )
-        long_traj = Trajectory.from_turns(
+        long_traj = SessionTrajectory.from_turns(
             "long",
             [
                 Turn(role="user", content="a", tokens=1),
@@ -138,7 +138,7 @@ async def test_sampling_processor_filters_by_min_turns(tmp_path):
                 type=CommandType.SPAWN,
                 payload={
                     "components": [
-                        {"type": "Trajectory", **traj.model_dump()},
+                        {"type": "SessionTrajectory", **traj.model_dump()},
                         {"type": "Label", **label.model_dump()},
                     ],
                 },
@@ -150,10 +150,10 @@ async def test_sampling_processor_filters_by_min_turns(tmp_path):
         await container.simulation_service.step(world.world_id, RunConfig(num_steps=1))
         await container.simulation_service.step(world.world_id, RunConfig(num_steps=1))
 
-        df = await world.get_components([Trajectory, Label])
+        df = await world.get_components([SessionTrajectory, Label])
         assert df is not None
         rows = df.collect().to_pylist()
-        sampled_by_id = {r["trajectory__trajectory_id"]: r["label__sampled"] for r in rows}
+        sampled_by_id = {r["sessiontrajectory__trajectory_id"]: r["label__sampled"] for r in rows}
         assert sampled_by_id["short"] is False
         assert sampled_by_id["long"] is True
     finally:
@@ -175,7 +175,7 @@ async def test_scoring_processor_clamps_score(tmp_path):
 
         ctx = ActorCtx(id=uuid7(), roles={"operator"})
 
-        traj = Trajectory.from_turns(
+        traj = SessionTrajectory.from_turns(
             "t1",
             [Turn(role="user", content="hi", tokens=1)],
             source="test",
@@ -186,7 +186,7 @@ async def test_scoring_processor_clamps_score(tmp_path):
             type=CommandType.SPAWN,
             payload={
                 "components": [
-                    {"type": "Trajectory", **traj.model_dump()},
+                    {"type": "SessionTrajectory", **traj.model_dump()},
                     {"type": "Label", **label.model_dump()},
                 ],
             },
@@ -198,7 +198,7 @@ async def test_scoring_processor_clamps_score(tmp_path):
         await container.simulation_service.step(world.world_id, RunConfig(num_steps=1))
         await container.simulation_service.step(world.world_id, RunConfig(num_steps=1))
 
-        df = await world.get_components([Trajectory, Label])
+        df = await world.get_components([SessionTrajectory, Label])
         assert df is not None
         rows = df.collect().to_pylist()
         assert len(rows) == 1
@@ -234,7 +234,7 @@ async def test_full_pipeline_without_llm(tmp_path):
                 type=CommandType.SPAWN,
                 payload={
                     "components": [
-                        {"type": "Trajectory", **trajectory.model_dump()},
+                        {"type": "SessionTrajectory", **trajectory.model_dump()},
                         {"type": "Label", **label.model_dump()},
                     ],
                 },
@@ -246,7 +246,7 @@ async def test_full_pipeline_without_llm(tmp_path):
         await container.simulation_service.step(world.world_id, RunConfig(num_steps=1))
         await container.simulation_service.step(world.world_id, RunConfig(num_steps=1))
 
-        df = await world.get_components([Trajectory, Label])
+        df = await world.get_components([SessionTrajectory, Label])
         assert df is not None
         rows = df.collect().to_pylist()
         assert len(rows) == 3


### PR DESCRIPTION
## What this is

Move 1 of the self-reflection loop: an agent's own Claude Code session history becomes rows in a world. Stacked on #224.

## Loader (`archetype.experiments.claude_sessions`)

`load_claude_sessions()` transcribes `~/.claude/projects/**/*.jsonl` into the trajectory schema: one `Trajectory` header + normalized `TrajectoryTurn` rows per session — roles, tool names (tool_results paired to their `tool_use_id`), tokens, durations, errors, models, git branch. Thinking blocks skipped (private scratchpad); sidechains skipped and counted; content truncated with the transcripts on disk remaining the source artifacts. **A loader, not an archive — the lesson of Chronicle.**

Also promotes the normalized trajectory components (`Trajectory` header + typed `TrajectoryTurn`/`CommandEvent`/`Observation`/`Action`/`Reward` rows, authored by @everettVT in the working tree) onto a committed branch, with their tests.

## Reflection (`experiments/session_reflection.py`)

Ingests the corpus into a world — every row materializes at **tick 0 as initial conditions** — then reflects with Daft queries: tokens/sessions per project, models, tool usage, tool-error rates, correction-shaped user turns (crude opener heuristic; labeling candidates, not verdicts), biggest sessions. Writes a markdown report.

First run over the real corpus: **429 sessions → 41,243 rows materialized in 0.3s; 34.7M output tokens queried.**

## Fix surfaced along the way (`fix(core)`)

`Component.get_type_by_name` returned the *first* subclass matching a class name — two components sharing a name made CLI/API spawn payloads land rows in whichever archetype import order favored. A silent wrong-table write, surfaced when the canonical `Trajectory` collided with example 06's inline copy. Ambiguity now **raises** with both module paths named; example 06's local component is renamed `SessionTrajectory`.

## Verification

- `make ci` green (633 tests, lazy audit clean, eval gate 10/10)
- loader contract tests use synthetic fixtures — CI never touches `~/.claude`
- example 06 verified headless; full reflection run verified against the real corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)