### PR TITLE
feat(sim): MuJoCo rollouts on the ledger — bit-for-bit parity, ~7ms/tick overhead

### DIFF
--- a/bench/mujoco/rollout_overhead.py
+++ b/bench/mujoco/rollout_overhead.py
@@ -1,0 +1,154 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ledger overhead per recorded MuJoCo step.
+
+Compares a raw MuJoCo cartpole rollout against the same rollout recorded
+through Archetype (one tick = ``substeps`` physics steps, every tick
+persisted to the append-only store). The interesting number is
+``overhead_per_tick_ms``: what one ledgered control step costs over bare
+physics. Later stages put a VLA policy inference (tens of ms) inside each
+tick, so this number certifies how far below the policy budget the
+ledger sits.
+
+Usage:
+    uv run python bench/mujoco/rollout_overhead.py --case 1x20 --case 64x20
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+
+from archetype import ArchetypeRuntime
+from archetype.core.config import StorageConfig
+from archetype.experiments.mujoco_cartpole import (
+    DEFAULT_SUBSTEPS,
+    CartpoleState,
+    CartpoleStepProcessor,
+    raw_rollout,
+)
+
+
+def initial_states(envs: int) -> list[tuple[float, float, float, float]]:
+    return [(0.01 * i, 0.1 + 0.001 * i, 0.0, 0.0) for i in range(envs)]
+
+
+def run_raw_trial(envs: int, ticks: int, substeps: int) -> float:
+    states = initial_states(envs)
+    start = time.perf_counter()
+    raw_rollout(states, ticks=ticks, substeps=substeps)
+    return time.perf_counter() - start
+
+
+async def run_ledger_trial(envs: int, ticks: int, substeps: int, root: Path) -> dict[str, float]:
+    storage = StorageConfig(uri=str(root), namespace="mujoco_bench")
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "mujoco-bench",
+            storage=storage,
+            processors=[CartpoleStepProcessor(substeps=substeps)],
+        )
+
+        setup_start = time.perf_counter()
+        for cart_pos, pole_angle, cart_vel, pole_vel in initial_states(envs):
+            await world.spawn(
+                CartpoleState(
+                    cart_pos=cart_pos,
+                    pole_angle=pole_angle,
+                    cart_vel=cart_vel,
+                    pole_vel=pole_vel,
+                )
+            )
+        setup_sec = time.perf_counter() - setup_start
+
+        run_start = time.perf_counter()
+        await world.run(steps=ticks)
+        run_sec = time.perf_counter() - run_start
+
+        return {"setup_sec": setup_sec, "run_sec": run_sec}
+
+
+async def run_case(
+    envs: int, ticks: int, substeps: int, trials: int, warmups: int
+) -> dict[str, Any]:
+    for _ in range(warmups):
+        run_raw_trial(envs, ticks, substeps)
+        with tempfile.TemporaryDirectory() as tmp:
+            await run_ledger_trial(envs, ticks, substeps, Path(tmp) / "store")
+
+    raw_secs = []
+    ledger_records = []
+    for _ in range(trials):
+        raw_secs.append(run_raw_trial(envs, ticks, substeps))
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger_records.append(
+                await run_ledger_trial(envs, ticks, substeps, Path(tmp) / "store")
+            )
+
+    raw_sec = median(raw_secs)
+    ledger_sec = median(r["run_sec"] for r in ledger_records)
+    physics_steps = envs * ticks * substeps
+    return {
+        "envs": envs,
+        "ticks": ticks,
+        "substeps": substeps,
+        "trials": trials,
+        "raw_sec": raw_sec,
+        "ledger_run_sec": ledger_sec,
+        "ledger_setup_sec": median(r["setup_sec"] for r in ledger_records),
+        "overhead_per_tick_ms": (ledger_sec - raw_sec) / ticks * 1000.0,
+        "raw_steps_per_sec": physics_steps / raw_sec,
+        "ledger_steps_per_sec": physics_steps / ledger_sec,
+        "ledger_overhead_factor": ledger_sec / raw_sec,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--case",
+        action="append",
+        default=[],
+        help="Benchmark case as ENVSxTICKS, e.g. 64x20. Repeatable.",
+    )
+    parser.add_argument("--substeps", type=int, default=DEFAULT_SUBSTEPS)
+    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--out", default=None)
+    return parser.parse_args()
+
+
+async def main() -> None:
+    args = parse_args()
+    cases = []
+    for value in args.case or ["1x20", "64x20", "256x20"]:
+        envs, ticks = value.split("x", 1)
+        cases.append((int(envs), int(ticks)))
+
+    results = [
+        await run_case(envs, ticks, args.substeps, args.trials, args.warmups)
+        for envs, ticks in cases
+    ]
+
+    payload = json.dumps(results, indent=2, sort_keys=True)
+    if args.out:
+        path = Path(args.out)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(payload)
+    else:
+        print(payload)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -66,3 +66,27 @@ path = "src/archetype/app/autoresearch_service.py"
 line = 302
 method = "to_pylist"
 reason = "Single-row loop-state extract: the latest BranchHead row must enter Python control flow (incumbent score comparison, head entity id for the next update) at the autoresearch loop boundary; the comparison drives imperative orchestration, not a further dataframe computation."
+
+[[entries]]
+path = "src/archetype/experiments/mujoco_cartpole.py"
+line = 99
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary: the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; MuJoCo's mj_step is a stateful C call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/mujoco_cartpole.py"
+line = 100
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary (pole_angle input column); same batch-UDF executor boundary as line 99."
+
+[[entries]]
+path = "src/archetype/experiments/mujoco_cartpole.py"
+line = 101
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary (cart_vel input column); same batch-UDF executor boundary as line 99."
+
+[[entries]]
+path = "src/archetype/experiments/mujoco_cartpole.py"
+line = 102
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary (pole_vel input column); same batch-UDF executor boundary as line 99."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ archetype = "archetype.cli.main:app"
 
 [project.optional-dependencies]
 benchmark  = ["esper>=2.45"]
+sim        = ["mujoco>=3.2"]
 otel       = ["opentelemetry-api>=1.20", "opentelemetry-sdk>=1.20", "opentelemetry-exporter-otlp-proto-grpc>=1.20"]
 dev        = [
     "pytest>=8.3", "pytest-asyncio>=0.26", "pytest-cov>=5.0",
@@ -109,6 +110,7 @@ dev = [
     "httpx>=0.27",
     "pre-commit>=4.0",
     "mutmut>=3.5",
+    "mujoco>=3.2",  # physics parity tests (tests/experiments/test_mujoco_rollout.py)
 ]
 
 # Mutation testing. Scoped narrowly: mutmut runs each mutation as a full

--- a/src/archetype/experiments/mujoco_cartpole.py
+++ b/src/archetype/experiments/mujoco_cartpole.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cartpole-on-the-ledger: MuJoCo dynamics as an Archetype processor.
+
+Stage 1 of the LIBERO/VLA-JEPA ladder. Proves two things end to end:
+
+1. Initial conditions land raw on the ledger at the spawn tick
+   (the x_0-is-given contract from the initial-conditions spec).
+2. The ledgered trajectory is bit-for-bit identical to a raw MuJoCo
+   rollout: row at tick t equals the state after t * substeps physics
+   steps, for every entity.
+
+One Archetype tick = ``substeps`` MuJoCo steps (the control-timestep
+pattern: later stages run one policy inference per tick while physics
+integrates at a finer timestep).
+
+The cartpole model is contact-free and unconstrained (no joint limits,
+collisions disabled) with the RK4 integrator, so a MuJoCo step is a pure
+function of (qpos, qvel) and bit-exact parity is well-defined. The ledger
+row is therefore the *complete* physical state: restoring qpos/qvel from
+any tick is a true fork of the world, MuJoCo included.
+
+Requires the ``sim`` extra (``pip install archetype[sim]``). The module
+imports without mujoco; only constructing the processor needs it.
+"""
+
+from __future__ import annotations
+
+import daft
+from daft import DataType, Series, col
+
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.core.component import Component
+
+CARTPOLE_XML = """
+<mujoco model="cartpole">
+  <option timestep="0.002" integrator="RK4"/>
+  <worldbody>
+    <body name="cart" pos="0 0 1">
+      <joint name="slider" type="slide" axis="1 0 0" damping="0.05"/>
+      <geom name="cart_geom" type="box" size="0.2 0.15 0.1" mass="1.0"
+            contype="0" conaffinity="0"/>
+      <body name="pole" pos="0 0 0">
+        <joint name="hinge" type="hinge" axis="0 1 0" damping="0.01"/>
+        <geom name="pole_geom" type="capsule" fromto="0 0 0 0 0 0.6"
+              size="0.045" mass="0.1" contype="0" conaffinity="0"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+DEFAULT_SUBSTEPS = 5
+
+
+class CartpoleState(Component):
+    """Complete cartpole state: qpos = (cart_pos, pole_angle), qvel likewise."""
+
+    cart_pos: float = 0.0
+    pole_angle: float = 0.0
+    cart_vel: float = 0.0
+    pole_vel: float = 0.0
+
+
+_STATE_STRUCT = DataType.struct(
+    {
+        "cart_pos": DataType.float64(),
+        "pole_angle": DataType.float64(),
+        "cart_vel": DataType.float64(),
+        "pole_vel": DataType.float64(),
+    }
+)
+
+
+@daft.cls()
+class _CartpoleStepper:
+    """MuJoCo is a stateful C library; its step cannot be a lazy Daft
+    expression. This is the sanctioned escape hatch: model loads once per
+    worker, each batch crosses Python -> C once."""
+
+    def __init__(self, xml: str, substeps: int):
+        import mujoco
+
+        self._mujoco = mujoco
+        self._model = mujoco.MjModel.from_xml_string(xml)
+        self._data = mujoco.MjData(self._model)
+        self._substeps = substeps
+
+    @daft.method.batch(return_dtype=_STATE_STRUCT)
+    def step(
+        self,
+        cart_pos: Series,
+        pole_angle: Series,
+        cart_vel: Series,
+        pole_vel: Series,
+    ) -> Series:
+        mujoco, model, data = self._mujoco, self._model, self._data
+        cp = cart_pos.to_pylist()
+        pa = pole_angle.to_pylist()
+        cv = cart_vel.to_pylist()
+        pv = pole_vel.to_pylist()
+
+        out: list[dict[str, float]] = []
+        for i in range(len(cp)):
+            # The model has no contacts or constraints, so stepping is a pure
+            # function of (qpos, qvel): resetting scratch MjData per row is
+            # exactly equivalent to a continuous rollout.
+            mujoco.mj_resetData(model, data)
+            data.qpos[0] = cp[i]
+            data.qpos[1] = pa[i]
+            data.qvel[0] = cv[i]
+            data.qvel[1] = pv[i]
+            for _ in range(self._substeps):
+                mujoco.mj_step(model, data)
+            out.append(
+                {
+                    "cart_pos": float(data.qpos[0]),
+                    "pole_angle": float(data.qpos[1]),
+                    "cart_vel": float(data.qvel[0]),
+                    "pole_vel": float(data.qvel[1]),
+                }
+            )
+        return Series.from_pylist(out)
+
+
+class CartpoleStepProcessor(AsyncProcessor):
+    components = (CartpoleState,)
+    priority = 10
+
+    def __init__(self, substeps: int = DEFAULT_SUBSTEPS, xml: str = CARTPOLE_XML):
+        self._stepper = _CartpoleStepper(xml, substeps)
+
+    async def process(self, df, **kwargs):
+        nxt = self._stepper.step(
+            col("cartpolestate__cart_pos"),
+            col("cartpolestate__pole_angle"),
+            col("cartpolestate__cart_vel"),
+            col("cartpolestate__pole_vel"),
+        )
+        return (
+            df.with_column("_mj_next", nxt)
+            .with_columns(
+                {
+                    "cartpolestate__cart_pos": col("_mj_next")["cart_pos"],
+                    "cartpolestate__pole_angle": col("_mj_next")["pole_angle"],
+                    "cartpolestate__cart_vel": col("_mj_next")["cart_vel"],
+                    "cartpolestate__pole_vel": col("_mj_next")["pole_vel"],
+                }
+            )
+            .exclude("_mj_next")
+        )
+
+
+def raw_rollout(
+    initial_states: list[tuple[float, float, float, float]],
+    ticks: int,
+    substeps: int = DEFAULT_SUBSTEPS,
+    xml: str = CARTPOLE_XML,
+) -> list[list[tuple[float, float, float, float]]]:
+    """Continuous raw MuJoCo rollouts, one per initial state.
+
+    Returns, per env, the state sequence [x_0, x_1, ..., x_{ticks-1}] where
+    x_t is the state after t * substeps physics steps — the exact sequence
+    the ledger must contain at ticks 0..ticks-1.
+    """
+    import mujoco
+
+    model = mujoco.MjModel.from_xml_string(xml)
+    trajectories = []
+    for state in initial_states:
+        data = mujoco.MjData(model)
+        data.qpos[0], data.qpos[1], data.qvel[0], data.qvel[1] = state
+        trajectory = [state]
+        for _ in range(ticks - 1):
+            for _ in range(substeps):
+                mujoco.mj_step(model, data)
+            trajectory.append(
+                (
+                    float(data.qpos[0]),
+                    float(data.qpos[1]),
+                    float(data.qvel[0]),
+                    float(data.qvel[1]),
+                )
+            )
+        trajectories.append(trajectory)
+    return trajectories

--- a/tests/experiments/test_mujoco_rollout.py
+++ b/tests/experiments/test_mujoco_rollout.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MuJoCo rollout parity contract.
+
+The ledger must contain the exact physics trajectory: the spawn-tick row
+is the raw initial conditions (x_0 is given), and the row at tick t is
+bit-for-bit equal to the state after t * substeps MuJoCo steps. If these
+hold, recording a rollout through Archetype provably does not perturb or
+lose dynamics.
+"""
+
+import pytest
+
+from archetype.core.aio import AsyncSystem
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.experiments.mujoco_cartpole import (
+    CartpoleState,
+    CartpoleStepProcessor,
+    raw_rollout,
+)
+from tests.conftest import make_world_service
+
+# mujoco_cartpole imports mujoco lazily, so the module imports above are safe.
+pytest.importorskip("mujoco")
+
+TICKS = 4
+SUBSTEPS = 5
+
+INITIAL_STATES = [
+    (0.0, 0.10, 0.0, 0.0),
+    (-0.2, 0.35, 0.4, -0.1),
+    (0.15, -0.25, -0.3, 0.2),
+]
+
+
+def _row_state(row) -> tuple[float, float, float, float]:
+    return (
+        row["cartpolestate__cart_pos"],
+        row["cartpolestate__pole_angle"],
+        row["cartpolestate__cart_vel"],
+        row["cartpolestate__pole_vel"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_ledger_matches_raw_mujoco_rollout_bit_for_bit(tmp_path):
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="mujoco")
+        system = AsyncSystem()
+        await system.add_processor(CartpoleStepProcessor(substeps=SUBSTEPS))
+        world = await ws.create_world(
+            WorldConfig(name="cartpole"), storage_config=storage, system=system
+        )
+
+        entity_ids = []
+        for cart_pos, pole_angle, cart_vel, pole_vel in INITIAL_STATES:
+            entity_ids.append(
+                await world.create_entity(
+                    [
+                        CartpoleState(
+                            cart_pos=cart_pos,
+                            pole_angle=pole_angle,
+                            cart_vel=cart_vel,
+                            pole_vel=pole_vel,
+                        )
+                    ]
+                )
+            )
+
+        await world.run(RunConfig(num_steps=TICKS))
+
+        reference = raw_rollout(INITIAL_STATES, ticks=TICKS, substeps=SUBSTEPS)
+        expected = dict(zip(entity_ids, reference, strict=True))
+
+        sig = (CartpoleState,)
+        for tick in range(TICKS):
+            rows = (await world.query_archetype(sig=sig, ticks=[tick])).to_pylist()
+            assert len(rows) == len(INITIAL_STATES), (
+                f"tick {tick}: expected one row per env, got {len(rows)}"
+            )
+            for row in rows:
+                got = _row_state(row)
+                want = expected[row["entity_id"]][tick]
+                assert got == want, (
+                    f"entity {row['entity_id']} tick {tick}: ledger {got} != raw MuJoCo {want}"
+                )
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_spawn_tick_row_is_raw_initial_conditions(tmp_path):
+    """Tick 0 is x_0 exactly — the physics processor must not touch it."""
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="mujoco")
+        system = AsyncSystem()
+        await system.add_processor(CartpoleStepProcessor(substeps=SUBSTEPS))
+        world = await ws.create_world(
+            WorldConfig(name="cartpole-ic"), storage_config=storage, system=system
+        )
+        await world.create_entity(
+            [CartpoleState(cart_pos=0.5, pole_angle=0.25, cart_vel=-1.0, pole_vel=2.0)]
+        )
+
+        await world.run(RunConfig(num_steps=1))
+
+        rows = (await world.query_archetype(sig=(CartpoleState,), ticks=[0])).to_pylist()
+        assert len(rows) == 1
+        assert _row_state(rows[0]) == (0.5, 0.25, -1.0, 2.0)
+    finally:
+        await ws.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,15 @@ resolution-markers = [
 exclude-newer = "2026-04-15T00:00:00Z"
 
 [[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -101,10 +110,14 @@ otel = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-sdk" },
 ]
+sim = [
+    { name = "mujoco" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "mujoco" },
     { name = "mutmut" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -127,6 +140,7 @@ requires-dist = [
     { name = "mkdocs-mermaid2-plugin", marker = "extra == 'docs'" },
     { name = "mkdocs-shadcn", marker = "extra == 'docs'" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27" },
+    { name = "mujoco", marker = "extra == 'sim'", specifier = ">=3.2" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.20" },
@@ -151,11 +165,12 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29" },
     { name = "viztracer", marker = "extra == 'dev'", specifier = ">=1.0.4" },
 ]
-provides-extras = ["benchmark", "otel", "dev", "docs"]
+provides-extras = ["benchmark", "sim", "otel", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27" },
+    { name = "mujoco", specifier = ">=3.2" },
     { name = "mutmut", specifier = ">=3.5" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.3.5" },
@@ -661,6 +676,22 @@ wheels = [
 ]
 
 [[package]]
+name = "etils"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/ce/6e067242fde898841922ac6fc82b0bb2fe35c38e995880bdffdfbe30182a/etils-1.14.0.tar.gz", hash = "sha256:8136e7f4c4173cd0af0ca5481c4475152f0b8686192951eefa60ee8711e1ede4", size = 108127, upload-time = "2026-03-04T17:41:36.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl", hash = "sha256:b5df7341f54dbe1405a4450b2741207b4a8c279780402b45f87202b94dfc52b4", size = 172934, upload-time = "2026-03-04T17:41:35.01Z" },
+]
+
+[package.optional-dependencies]
+epath = [
+    { name = "fsspec" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -781,6 +812,38 @@ wheels = [
 ]
 
 [[package]]
+name = "glfw"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/72/642d4f12f61816ac96777f7360d413e3977a7dd08237d196f02da681b186/glfw-2.10.0.tar.gz", hash = "sha256:801e55d8581b34df9aa2cfea43feb06ff617576e2a8cc5dac23ee75b26d10abe", size = 31475, upload-time = "2025-09-12T08:54:38.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/1f/a9ce08b1173b0ab625ee92f0c47a5278b3e76fd367699880d8ee7d56c338/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-macosx_10_6_intel.whl", hash = "sha256:5f365a8c94bcea71ec91327e7c16e7cf739128479a18b8c1241b004b40acc412", size = 105329, upload-time = "2025-09-12T08:54:27.938Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/96/5a2220abcbd027eebcf8bedd28207a2de168899e51be13ba01ebdd4147a1/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-macosx_11_0_arm64.whl", hash = "sha256:5328db1a92d07abd988730517ec02aa8390d3e6ef7ce98c8b57ecba2f43a39ba", size = 102179, upload-time = "2025-09-12T08:54:29.163Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/41/a5bd1d9e1808f400102bd7d328c4ac17b65fb2fc8014014ec6f23d02f662/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux2014_aarch64.whl", hash = "sha256:312c4c1dd5509613ed6bc1e95a8dbb75a36b6dcc4120f50dc3892b40172e9053", size = 230039, upload-time = "2025-09-12T08:54:30.201Z" },
+    { url = "https://files.pythonhosted.org/packages/80/aa/3b503c448609dee6cb4e7138b4109338f0e65b97be107ab85562269d378d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux2014_x86_64.whl", hash = "sha256:59c53387dc08c62e8bed86bbe3a8d53ab1b27161281ffa0e7f27b64284e2627c", size = 241984, upload-time = "2025-09-12T08:54:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/2d/bfe39a42cad8e80b02bf5f7cae19ba67832c1810bbd3624a8e83153d74a4/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux_2_28_aarch64.whl", hash = "sha256:c6f292fdaf3f9a99e598ede6582d21c523a6f51f8f5e66213849101a6bcdc699", size = 231052, upload-time = "2025-09-12T08:54:32.859Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/02/6e639e90f181dc9127046e00d0528f9f7ad12d428972e3a5378b9aefdb0b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux_2_28_x86_64.whl", hash = "sha256:7916034efa867927892635733a3b6af8cd95ceb10566fd7f1e0d2763c2ee8b12", size = 243525, upload-time = "2025-09-12T08:54:34.006Z" },
+    { url = "https://files.pythonhosted.org/packages/84/06/cb588ca65561defe0fc48d1df4c2ac12569b81231ae4f2b52ab37007d0bd/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-win32.whl", hash = "sha256:6c9549da71b93e367b4d71438798daae1da2592039fd14204a80a1a2348ae127", size = 552685, upload-time = "2025-09-12T08:54:35.723Z" },
+    { url = "https://files.pythonhosted.org/packages/86/27/00c9c96af18ac0a5eac2ff61cbe306551a2d770d7173f396d0792ee1a59e/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-win_amd64.whl", hash = "sha256:6292d5d6634d668cd23d337e6089491d3945a9aa4ac6e1667b0003520d7caa51", size = 559466, upload-time = "2025-09-12T08:54:37.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/87/de0b33f6f00687499ca1371f22aa73396341b85bf88f1a284f9da8842493/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-macosx_10_6_intel.whl", hash = "sha256:2aab89d2d9535635ba011fc7303390685169a1aa6731ad580d08d043524b8899", size = 105326, upload-time = "2026-01-28T05:57:56.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a6/6ea2f73ad4474896d9e38b3ffbe6ffd5a802c738392269e99e8c6621a461/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:23936202a107039b5372f0b88ae1d11080746aa1c78910a45d4a0c4cf408cfaa", size = 102180, upload-time = "2026-01-28T05:57:57.787Z" },
+    { url = "https://files.pythonhosted.org/packages/58/19/d81b19e8261b9cb51b81d1402167791fef81088dfe91f0c4e9d136fdc5ca/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux2014_aarch64.whl", hash = "sha256:7be06d0838f61df67bd54cb6266a6193d54083acb3624ff3c3812a6358406fa4", size = 230038, upload-time = "2026-01-28T05:57:59.105Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/b035636cd82198b97b51a93efe9cfc4343d6b15cefbd336a3f2be871d848/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux2014_x86_64.whl", hash = "sha256:91d36b3582a766512eff8e3b5dcc2d3ffcbf10b7cf448551085a08a10f1b8244", size = 241983, upload-time = "2026-01-28T05:58:00.352Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b4/f7b6cc022dd7c68b6c702d19da5d591f978f89c958b9bd3090615db0c739/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_aarch64.whl", hash = "sha256:27c9e9a2d5e1dc3c9e3996171d844d9df9a5a101e797cb94cce217b7afcf8fd9", size = 231053, upload-time = "2026-01-28T05:58:01.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce6724bb7cb3d0543dcba17206dce909f94176e68220b8eafee72e9f92bcf542", size = 243522, upload-time = "2026-01-28T05:58:03.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/b9/b04c3aa0aad2870cfe799f32f8b59789c98e1816bbce9e83f4823c5b840b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win32.whl", hash = "sha256:fca724a21a372731edb290841edd28a9fb1ee490f833392752844ac807c0086a", size = 552682, upload-time = "2026-01-28T05:58:05.649Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e1/6d6816b296a529ac9b897ad228b1e084eb1f92319e96371880eebdc874a6/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:823c0bd7770977d4b10e0ed0aef2f3682276b7c88b8b65cfc540afce5951392f", size = 559464, upload-time = "2026-01-28T05:58:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a8/d4dab8a58fc2e6981fc7a58c4e56ba9d777fb24931cec6a22152edbb3540/glfw-2.10.0-py2.py3-none-macosx_10_6_intel.whl", hash = "sha256:a0d1f29f206219cc291edfb6cace663a86da2470632551c998e3db82d48ea177", size = 105288, upload-time = "2026-03-10T17:21:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/68d35e001872a7705112418da236fa2418d4f2e5419f8b2837f9b81bb3da/glfw-2.10.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d28d6f3ef217e64e35dc6fd0a7acb4cec9bfe7cd14dd9b35a7228a87002de154", size = 102139, upload-time = "2026-03-10T17:21:21.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/ca5984081aaae07c9d371cb11dc4e4ff603510678ed9b73e58b6c351fe63/glfw-2.10.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:f968b522bb6a0e04aaf4dcac30a476d7229308bb2bac406a60587debb5a61e29", size = 229998, upload-time = "2026-03-10T17:21:23.549Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c4/82ac75fdcfba2896da7a573c0fc7f8ceb8f77ead6866d500d06c32f1c464/glfw-2.10.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:68cf3752bdadb6f4bc0a876247c28c88c7251ac39f8af076ed938fdfd71e72dd", size = 241944, upload-time = "2026-03-10T17:21:26.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/96/9f691823cca5eb6a08f346bd0ff03b78032db9370b509a1e9c8976fb20a5/glfw-2.10.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:44d98de5dbf8f727e0cb29f9b29d29528ea7570f2e6f42f8430a69df05f12b48", size = 231009, upload-time = "2026-03-10T17:21:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -801,9 +864,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -811,9 +872,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -821,9 +880,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -831,9 +888,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
@@ -1794,6 +1849,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mujoco"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "etils", extra = ["epath"] },
+    { name = "glfw" },
+    { name = "numpy" },
+    { name = "pyopengl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/6e/9cba0cf43410aee5123ed670ce6e57f901974cc6a59093ce49200494b604/mujoco-3.7.0.tar.gz", hash = "sha256:d325c5448702a919db5b3d0050fff0af86d47da146d59678722b2112f7b55084", size = 917551, upload-time = "2026-04-14T12:50:31.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/7d/e1ad3b1b604b009c0df7246b50b5c5cf9e8e0689a10279661951c69850ea/mujoco-3.7.0-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:9193b8bc478708f199c2decb7bdeb06a962849f550ac182c35168ac9938ca859", size = 7217455, upload-time = "2026-04-14T12:50:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fc/225a068a2bec3de5029ba08866e03df9f159719cecedfc0cf100d4db6a18/mujoco-3.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:52b60fd634885c43c494868a992f696c078402c32b9c7a11bffa0fbf385687a7", size = 7162325, upload-time = "2026-04-14T12:50:11.025Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4d/a92e635cf1d38140c04fd504d07bacfd5d814753449fa75f3e7187660adb/mujoco-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a7216abee4fafe4bd6121548cb22dcacdb27f466da2f645bd9cbc404c0a29c9", size = 6709175, upload-time = "2026-04-14T12:50:13.188Z" },
+    { url = "https://files.pythonhosted.org/packages/97/fa/a8698b7bb0168483845f8e492991ee5cf01695eb0d1f20ea7d8bf3d61344/mujoco-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79f741d93e2b4f315f32e7199ab1b21eb7b7ed82acd9daf7be24382e436f98b7", size = 7201272, upload-time = "2026-04-14T12:50:15.264Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b9/96a06d51d1b8a13ce010642c5e9a1b83b2364d6c290c2aba2d8c515f9871/mujoco-3.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:b0e31da299ff182d1063f9991ad21c21a8b086593b8dee588d19e910f2e49833", size = 5757244, upload-time = "2026-04-14T12:50:17.562Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c8/1fedcd0d0b7dd86dd238502bc8ea228c0d48a901ffffc5d39272351c515c/mujoco-3.7.0-cp313-cp313-macosx_10_16_x86_64.whl", hash = "sha256:79730bec1e23a324cf66ccfa93585b5a8d3ba162d813cc0bfa6a42f776079983", size = 7217812, upload-time = "2026-04-14T12:50:19.583Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/75/8a54a9de7581f46e8dfb248d8cd2f972ef0d1db6ecfd8a70abb4ab12d56b/mujoco-3.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:70e008a2080156121caa60a7e0736c20b2278108cb35d1ab732f98e2e7c334f1", size = 7162437, upload-time = "2026-04-14T12:50:21.983Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bf/2180496f94c7a96b4520ad06e54505ef39b84b205ad674494c0d014584be/mujoco-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a81480e6dbbdcb5a5f4027c825935d5bcd34e3b9865bb818698701ee089e12f", size = 6709051, upload-time = "2026-04-14T12:50:24.407Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/de/4ebdd81f66f2d3879335e0f21f7be9b552d7edbc80c53f31472706d4e338/mujoco-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:246f61c885d8ac291a4f3b8e10d1deb3820302ab7a48b1edbf8a3539722841c3", size = 7201646, upload-time = "2026-04-14T12:50:26.473Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/24/313f0d31628123593af23441df7124ca1cc26dd0611ed5d31675899b190e/mujoco-3.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:67cae63b4c2c439ebffce7e185a0e129446a636af538dd3ccb5c9cd3f674033c", size = 5757431, upload-time = "2026-04-14T12:50:29.027Z" },
+]
+
+[[package]]
 name = "mutmut"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2620,6 +2700,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
+name = "pyopengl"
+version = "3.1.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/16/912b7225d56284859cd9a672827f18be43f8012f8b7b932bc4bd959a298e/pyopengl-3.1.10.tar.gz", hash = "sha256:c4a02d6866b54eb119c8e9b3fb04fa835a95ab802dd96607ab4cdb0012df8335", size = 1915580, upload-time = "2025-08-18T02:33:01.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl", hash = "sha256:794a943daced39300879e4e47bd94525280685f42dbb5a998d336cfff151d74f", size = 3194996, upload-time = "2025-08-18T02:32:59.902Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this is

Stage 1 of the LIBERO/VLA-JEPA ladder: MuJoCo dynamics as an Archetype processor, with a parity contract proving the ledger records the exact physics trajectory. Stacked on #224 because it is that PR's first external consumer: a physics rollout is the **x₀ is given; x_{t+1} = f(x_t)** contract made literal.

## The two claims, both tested with float equality (no tolerance)

1. **Initial conditions land raw on the ledger.** The tick-0 row equals (qpos₀, qvel₀) exactly — the physics processor never touches it.
2. **The ledger is the trajectory.** For every entity and every tick t, the ledgered row equals the state after t·substeps steps of a *continuous* raw MuJoCo rollout, bit for bit. Recording through Archetype provably does not perturb or lose dynamics.

The cartpole model is contact-free and unconstrained with RK4, so a MuJoCo step is a pure function of (qpos, qvel) — bit-exact parity is well-defined, and the ledger row is the complete physical state: restoring qpos/qvel from any tick is a true fork of the world, MuJoCo included.

## Measured overhead (M-series MacBook, local, 3-trial median, substeps=5, 20 ticks)

| envs | raw physics | ledgered run | overhead/tick | factor |
|---|---|---|---|---|
| 1 | 1.1ms | 147ms | 7.3ms | 128× |
| 64 | 36ms | 172ms | 6.8ms | 4.7× |
| 256 | 151ms | 301ms | 7.5ms | 2.0× |

The number that matters: **overhead is ~7ms per tick and flat from 1→256 envs** — the ledger costs per tick, not per entity. Stage 3 puts a VLA policy inference (tens of ms, one per tick) inside the loop, so full provenance rides along well under the policy budget. Reproduce with `uv run python bench/mujoco/rollout_overhead.py`.

## Design notes

- The MuJoCo boundary is a `@daft.cls` batch UDF (`LEARNINGS.md` pattern): model loads once per worker, one Python→C crossing per batch.
- One Archetype tick = `substeps` MuJoCo steps — the control-timestep pattern later stages reuse for action chunks.
- `mujoco>=3.2` joins the dev group (CI runs the parity tests; manylinux/macOS wheels) and a new `sim` extra; tests `importorskip` so environments without it skip gracefully.

## Lazy-audit disclosure (per the audit's policy)

Four new allowlist entries, all the same site class: `Series.to_pylist()` on the four input columns **inside** the `@daft.method.batch` UDF. The executor has already materialised the batch to invoke the UDF — these are per-batch Series accesses at the C-library boundary, not DataFrame collects. Flagging reviewer sign-off here explicitly.

## Verification

- `make ci` green: lint, lock-check, 627 tests, coverage, lazy audit (13 sites accounted for), eval regression gate 10/10
- Parity suite passes with strict `==` on float tuples across 3 envs × 4 ticks and a single-entity spawn-tick check

## Follow-up (noted, not in scope)

- Per-entity `world.spawn` is ~34ms/entity at 256 envs (8.6s setup) — a batch-spawn API is worth having before Stage 2's parallel-env counts.
- Stage 2: LIBERO/robosuite env as a world (needs a Linux/EGL box); Stage 3: VLA-JEPA policy-in-the-loop; Stage 4: LIBERO suite success rates on the experiments/evals vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)