### PR TITLE
feat(sim): Stage 2 — manipulation episodes on the ledger, LIBERO behind EnvClient

### DIFF
--- a/bench/libero/e2e_ledger_smoke.py
+++ b/bench/libero/e2e_ledger_smoke.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end Stage 2 smoke: a real LIBERO episode on the Archetype ledger.
+
+Drives the deployed Modal LIBERO worker through the EnvStepProcessor from
+the local (py3.12) harness process: reset obs spawn as the raw tick-0 row,
+each subsequent tick records exactly one remote control step.
+
+Prereqs:
+    modal deploy bench/libero/modal_worker.py
+
+Usage:
+    uv run --with modal python bench/libero/e2e_ledger_smoke.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from modal_worker import ModalEnvClient  # noqa: E402
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.experiments.manipulation import (  # noqa: E402
+    EnvStepProcessor,
+    ManipAction,
+    ManipProprio,
+    ManipStatus,
+    ManipTask,
+)
+
+TICKS = 3
+
+
+async def main() -> None:
+    client = ModalEnvClient(suite="libero_spatial", task_id=0)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = StorageConfig(uri=str(Path(tmp) / "store"), namespace="libero_e2e")
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "libero-e2e",
+                storage=storage,
+                processors=[EnvStepProcessor(client)],
+            )
+
+            obs = client.reset(0, seed=0)
+            print(f"reset obs (will be the raw tick-0 row): {obs['eef_pos']}")
+            eid = await world.spawn(
+                ManipProprio(
+                    eef_pos=obs["eef_pos"], eef_quat=obs["eef_quat"], gripper=obs["gripper"]
+                ),
+                ManipAction(values=[0.0, 0.0, -0.1, 0.0, 0.0, 0.0, 0.0]),
+                ManipStatus(),
+                ManipTask(suite="libero_spatial", task_id=0, instruction="", seed=0, env_key=0),
+            )
+
+            await world.run(steps=TICKS)
+
+            history = await world.query(ManipProprio)
+            rows = sorted(
+                history.select("tick", "entity_id", "manipproprio__eef_pos").to_pylist(),
+                key=lambda r: r["tick"],
+            )
+            print(f"\nledger for entity {eid} ({len(rows)} rows):")
+            for row in rows:
+                print(f"  tick {row['tick']}: eef_pos={row['manipproprio__eef_pos']}")
+
+            assert rows[0]["manipproprio__eef_pos"] == obs["eef_pos"], (
+                "tick-0 row must be the raw reset observation"
+            )
+            zs = [row["manipproprio__eef_pos"][2] for row in rows]
+            assert zs[-1] < zs[0], f"-z action should lower the eef across ticks: {zs}"
+            print("\ne2e ledger smoke OK: reset obs raw at tick 0, env stepped on ledger")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bench/libero/modal_worker.py
+++ b/bench/libero/modal_worker.py
@@ -28,13 +28,14 @@ Deploy for use from the Archetype harness:
     #   client = ModalEnvClient("libero_spatial")
     #   processor = EnvStepProcessor(client)
 
-STATUS: scaffold — follows the standard OpenVLA-style LIBERO eval setup
-(py3.10, LIBERO from git, MUJOCO_GL=egl). Unverified until the first
-`modal run`; expect to iterate on image pins once.
+STATUS: verified 2026-06-11 — `modal run` smoke passes end to end:
+libero_spatial task 0 loads, resets with real proprio obs, and steps
+under EGL offscreen rendering. (Benign EGL teardown noise appears at
+interpreter exit from robosuite's context __del__; harmless.)
 """
 
-from __future__ import annotations
-
+# NOTE: no `from __future__ import annotations` here — modal.parameter()
+# validates real annotation objects, and PEP 563 string annotations break it.
 from typing import Any
 
 import modal
@@ -51,23 +52,52 @@ image = (
         "libosmesa6-dev",
         "libglfw3",
         "patchelf",
+        # LIBERO's requirements pull full opencv-python (not headless),
+        # which links against GUI-adjacent system libs even offscreen.
+        "libglib2.0-0",
+        "libsm6",
+        "libxext6",
+        "libxrender1",
     )
     .pip_install(
-        "torch>=2.2",
+        # <2.6: LIBERO torch.load()s init-state numpy pickles, which the
+        # weights_only=True default introduced in torch 2.6 rejects.
+        "torch>=2.2,<2.6",
         "robosuite==1.4.1",
         "bddl==1.0.1",
+        # The env-path slice of LIBERO's requirements.txt (we skip the
+        # training stack: robomimic, transformers, wandb, thop).
+        "future",
+        "matplotlib",
+        "cloudpickle",
+        "gym==0.25.2",
+        "hydra-core",
+        "einops",
         "easydict",
         "imageio[ffmpeg]",
         "opencv-python-headless",
     )
-    .pip_install("libero @ git+https://github.com/Lifelong-Robot-Learning/LIBERO.git")
+    # LIBERO's top-level package dir has no __init__.py, so find_packages()
+    # produces an empty wheel from a plain `pip install git+...`. The repo's
+    # own recipe — clone + editable install — is the only one that works.
+    .run_commands(
+        "git clone --depth 1 https://github.com/Lifelong-Robot-Learning/LIBERO.git /opt/LIBERO",
+        "pip install -e /opt/LIBERO",
+        # First import interactively prompts for a dataset folder; answer
+        # 'N' (use defaults) once at build time so ~/.libero/config.yaml is
+        # baked into the image and runtime imports never block on stdin.
+        "echo N | python -c 'import libero.libero'",
+    )
     .env({"MUJOCO_GL": "egl", "PYOPENGL_PLATFORM": "egl"})
 )
 
 app = modal.App("archetype-libero-env", image=image)
 
 
-@app.cls(cpu=4, memory=8192, timeout=1800, scaledown_window=300)
+# max_containers=1: env instances live in container memory keyed by env_key;
+# a second container would silently fork that state. One container per
+# parameter set until envs move to a shared store.
+@app.cls(cpu=4, memory=8192, timeout=1800, scaledown_window=300, max_containers=1)
 class LiberoEnvBatch:
     """A batch of LIBERO envs for one task suite, keyed by env_key.
 
@@ -148,17 +178,36 @@ class ModalEnvClient:
 
     Import this from the Archetype (py3.12) process; it only needs the
     `modal` client package, not LIBERO.
+
+    Pickles as just (suite, task_id) and reconnects lazily: Daft batch
+    UDFs serialize their constructor args, and a live Modal handle is not
+    serializable.
     """
 
     def __init__(self, suite: str = "libero_spatial", task_id: int = 0):
-        cls = modal.Cls.from_name("archetype-libero-env", "LiberoEnvBatch")
-        self._worker = cls(suite=suite, task_id=task_id)
+        self._suite = suite
+        self._task_id = task_id
+        self._worker = None
+
+    def _get_worker(self):
+        if self._worker is None:
+            cls = modal.Cls.from_name("archetype-libero-env", "LiberoEnvBatch")
+            self._worker = cls(suite=self._suite, task_id=self._task_id)
+        return self._worker
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {"suite": self._suite, "task_id": self._task_id}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self._suite = state["suite"]
+        self._task_id = state["task_id"]
+        self._worker = None
 
     def reset(self, env_id: int, seed: int) -> dict[str, Any]:
-        return self._worker.reset.remote(env_id, seed)
+        return self._get_worker().reset.remote(env_id, seed)
 
     def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
-        return self._worker.step.remote(env_ids, actions)
+        return self._get_worker().step.remote(env_ids, actions)
 
 
 @app.local_entrypoint()

--- a/bench/libero/modal_worker.py
+++ b/bench/libero/modal_worker.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LIBERO env worker on Modal — the out-of-process half of EnvClient.
+
+Why a separate process at all: upstream LIBERO pins Python 3.8-3.10-era
+dependencies (and Linux + EGL for offscreen rendering), which cannot
+coexist with Archetype's Python 3.12 process on any machine. The worker
+therefore runs in its own container with its own interpreter; the
+Archetype harness talks to it through the EnvClient protocol
+(`archetype.experiments.manipulation`).
+
+Why Modal specifically: nothing in the protocol requires it — any Linux
+box or Docker image exposing reset/step works. Modal buys ephemeral
+Linux+EGL containers without owning a box, and Stage 4's LIBERO sweep
+(4 suites x 10 tasks x 50 rollouts) fans out across containers with one
+`.map()`.
+
+Setup (one time):
+    uv tool install modal && modal setup
+
+Smoke test (builds the image on first run, ~5-10 min):
+    modal run bench/libero/modal_worker.py
+
+Deploy for use from the Archetype harness:
+    modal deploy bench/libero/modal_worker.py
+    # then in the harness process:
+    #   client = ModalEnvClient("libero_spatial")
+    #   processor = EnvStepProcessor(client)
+
+STATUS: scaffold — follows the standard OpenVLA-style LIBERO eval setup
+(py3.10, LIBERO from git, MUJOCO_GL=egl). Unverified until the first
+`modal run`; expect to iterate on image pins once.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import modal
+
+# The OpenVLA-style LIBERO environment: python 3.10 with relaxed pins
+# rather than upstream's frozen 3.8.13 lockfile.
+image = (
+    modal.Image.debian_slim(python_version="3.10")
+    .apt_install(
+        "git",
+        "libegl1",
+        "libgl1",
+        "libglew-dev",
+        "libosmesa6-dev",
+        "libglfw3",
+        "patchelf",
+    )
+    .pip_install(
+        "torch>=2.2",
+        "robosuite==1.4.1",
+        "bddl==1.0.1",
+        "easydict",
+        "imageio[ffmpeg]",
+        "opencv-python-headless",
+    )
+    .pip_install("libero @ git+https://github.com/Lifelong-Robot-Learning/LIBERO.git")
+    .env({"MUJOCO_GL": "egl", "PYOPENGL_PLATFORM": "egl"})
+)
+
+app = modal.App("archetype-libero-env", image=image)
+
+
+@app.cls(cpu=4, memory=8192, timeout=1800, scaledown_window=300)
+class LiberoEnvBatch:
+    """A batch of LIBERO envs for one task suite, keyed by env_key.
+
+    Method signatures mirror archetype.experiments.manipulation.EnvClient
+    so the harness-side adapter is a thin .remote() passthrough.
+    """
+
+    suite: str = modal.parameter(default="libero_spatial")
+    task_id: int = modal.parameter(default=0)
+    camera_size: int = modal.parameter(default=128)
+
+    @modal.enter()
+    def load_suite(self):
+        from libero.libero import benchmark
+
+        self._envs: dict[int, Any] = {}
+        self._suite = benchmark.get_benchmark_dict()[self.suite]()
+        self._task = self._suite.get_task(self.task_id)
+        self._init_states = self._suite.get_task_init_states(self.task_id)
+
+    def _make_env(self):
+        import os
+
+        from libero.libero import get_libero_path
+        from libero.libero.envs import OffScreenRenderEnv
+
+        bddl = os.path.join(
+            get_libero_path("bddl_files"),
+            self._task.problem_folder,
+            self._task.bddl_file,
+        )
+        return OffScreenRenderEnv(
+            bddl_file_name=bddl,
+            camera_heights=self.camera_size,
+            camera_widths=self.camera_size,
+        )
+
+    @staticmethod
+    def _proprio(obs: dict) -> dict[str, Any]:
+        return {
+            "eef_pos": [float(v) for v in obs["robot0_eef_pos"]],
+            "eef_quat": [float(v) for v in obs["robot0_eef_quat"]],
+            "gripper": float(obs["robot0_gripper_qpos"][0]),
+        }
+
+    @modal.method()
+    def reset(self, env_id: int, seed: int) -> dict[str, Any]:
+        env = self._envs.get(env_id)
+        if env is None:
+            env = self._make_env()
+            self._envs[env_id] = env
+        env.seed(seed)
+        env.reset()
+        obs = env.set_init_state(self._init_states[seed % len(self._init_states)])
+        return self._proprio(obs)
+
+    @modal.method()
+    def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
+        results = []
+        for env_id, action in zip(env_ids, actions, strict=True):
+            env = self._envs[env_id]
+            obs, reward, done, info = env.step(action)
+            success = bool(env.check_success())
+            result = self._proprio(obs)
+            result.update(
+                {"reward": float(reward), "done": bool(done) or success, "success": success}
+            )
+            results.append(result)
+        return results
+
+    @modal.method()
+    def task_language(self) -> str:
+        return str(self._task.language)
+
+
+class ModalEnvClient:
+    """Harness-side EnvClient adapter over a deployed LiberoEnvBatch.
+
+    Import this from the Archetype (py3.12) process; it only needs the
+    `modal` client package, not LIBERO.
+    """
+
+    def __init__(self, suite: str = "libero_spatial", task_id: int = 0):
+        cls = modal.Cls.from_name("archetype-libero-env", "LiberoEnvBatch")
+        self._worker = cls(suite=suite, task_id=task_id)
+
+    def reset(self, env_id: int, seed: int) -> dict[str, Any]:
+        return self._worker.reset.remote(env_id, seed)
+
+    def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
+        return self._worker.step.remote(env_ids, actions)
+
+
+@app.local_entrypoint()
+def smoke(suite: str = "libero_spatial", task_id: int = 0, steps: int = 5):
+    """Reset one env and take a few zero actions; print what comes back."""
+    worker = LiberoEnvBatch(suite=suite, task_id=task_id)
+    print("task:", worker.task_language.remote())
+    obs = worker.reset.remote(env_id=0, seed=0)
+    print("reset obs:", obs)
+    zero = [0.0] * 7
+    for step_idx in range(steps):
+        (result,) = worker.step.remote([0], [zero])
+        print(
+            f"step {step_idx}: eef_pos={result['eef_pos']} "
+            f"reward={result['reward']} done={result['done']} success={result['success']}"
+        )
+    print("smoke OK")

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -90,3 +90,57 @@ path = "src/archetype/experiments/mujoco_cartpole.py"
 line = 102
 method = "to_pylist"
 reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary (pole_vel input column); same batch-UDF executor boundary as line 99."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 133
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (env_key input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 134
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (action input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 136
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (eef_pos input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 137
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (eef_quat input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 138
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (gripper input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 139
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (reward input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 140
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (done input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 141
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (success input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/manipulation.py"
+line = 142
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (env_step input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."

--- a/src/archetype/experiments/manipulation.py
+++ b/src/archetype/experiments/manipulation.py
@@ -1,0 +1,248 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Manipulation episodes on the ledger: external envs behind a step boundary.
+
+Stage 2 of the LIBERO/VLA-JEPA ladder. LIBERO pins an incompatible Python
+(3.8-3.10 lineage, old torch), so the simulator can never live in the
+Archetype process: it runs behind ``EnvClient`` — in-process for the
+scripted contract env, out-of-process (subprocess, Docker, or a Modal
+container) for robosuite/LIBERO.
+
+The episode contract mirrors Stage 1's physics contract:
+
+- ``env.reset()`` produces the initial observation, which the driver spawns
+  as raw component values — reset obs land on the ledger at tick 0
+  untouched (x_0 is given).
+- Each tick, ``EnvStepProcessor`` sends the current action to the env and
+  records the returned observation: row at tick t+1 is exactly
+  ``env.step(action_t)``.
+- ``done`` rows are frozen: the env is not stepped again and the terminal
+  state persists unchanged, so success is latched on the ledger.
+
+One Archetype tick = one control step. Action *chunks* (Stage 3) execute
+inside the env worker between control steps, exactly like Stage 1's
+physics substeps.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import daft
+from daft import DataType, Series, col
+
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.core.component import Component
+
+ACTION_DIM = 7  # 6-DoF delta pose + gripper, the LIBERO/OSC convention
+
+
+class ManipProprio(Component):
+    """Proprioceptive observation: end-effector pose and gripper opening."""
+
+    eef_pos: list[float] = [0.0, 0.0, 0.0]
+    eef_quat: list[float] = [1.0, 0.0, 0.0, 0.0]
+    gripper: float = 0.0
+
+
+class ManipAction(Component):
+    """The action applied during the next env step (delta pose + gripper)."""
+
+    values: list[float] = [0.0] * ACTION_DIM
+
+
+class ManipTask(Component):
+    """Task identity. ``env_key`` routes rows to the env instance: the driver
+    chooses it at ``reset`` time, before the entity id exists, so the raw
+    reset observation can be spawned as the tick-0 row."""
+
+    suite: str = ""
+    task_id: int = 0
+    instruction: str = ""
+    seed: int = 0
+    env_key: int = 0
+
+
+class ManipStatus(Component):
+    """Episode bookkeeping. ``success`` latches; ``done`` freezes the row."""
+
+    reward: float = 0.0
+    done: bool = False
+    success: bool = False
+    env_step: int = 0
+
+
+class EnvClient(Protocol):
+    """Boundary to an external manipulation simulator.
+
+    Implementations own env instances keyed by ``env_id`` (the entity id).
+    ``reset`` is called by the episode driver *before* spawning, so the
+    returned observation becomes the entity's raw tick-0 row. ``step``
+    advances each env one control step.
+    """
+
+    def reset(self, env_id: int, seed: int) -> dict[str, Any]:
+        """Create/reset the env and return the initial observation dict with
+        keys: eef_pos, eef_quat, gripper."""
+        ...
+
+    def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
+        """Step each env with its action. Returns one dict per env with keys:
+        eef_pos, eef_quat, gripper, reward, done, success."""
+        ...
+
+
+_STEP_STRUCT = DataType.struct(
+    {
+        "eef_pos": DataType.list(DataType.float64()),
+        "eef_quat": DataType.list(DataType.float64()),
+        "gripper": DataType.float64(),
+        "reward": DataType.float64(),
+        "done": DataType.bool(),
+        "success": DataType.bool(),
+        "env_step": DataType.int64(),
+    }
+)
+
+
+@daft.cls()
+class _EnvStepper:
+    """The env RPC boundary as a batch UDF: one client call per batch.
+
+    The simulator is an external stateful process; its step cannot be a
+    lazy Daft expression. Same sanctioned escape hatch as Stage 1's
+    MuJoCo boundary."""
+
+    def __init__(self, client: EnvClient):
+        self._client = client
+
+    @daft.method.batch(return_dtype=_STEP_STRUCT)
+    def step(
+        self,
+        env_key: Series,
+        action: Series,
+        eef_pos: Series,
+        eef_quat: Series,
+        gripper: Series,
+        reward: Series,
+        done: Series,
+        success: Series,
+        env_step: Series,
+    ) -> Series:
+        ids = env_key.to_pylist()
+        actions = action.to_pylist()
+        prev = {
+            "eef_pos": eef_pos.to_pylist(),
+            "eef_quat": eef_quat.to_pylist(),
+            "gripper": gripper.to_pylist(),
+            "reward": reward.to_pylist(),
+            "done": done.to_pylist(),
+            "success": success.to_pylist(),
+            "env_step": env_step.to_pylist(),
+        }
+
+        # Done rows are frozen: never step a finished episode.
+        live = [i for i in range(len(ids)) if not prev["done"][i]]
+        stepped: dict[int, dict[str, Any]] = {}
+        if live:
+            results = self._client.step([ids[i] for i in live], [actions[i] for i in live])
+            stepped = dict(zip(live, results, strict=True))
+
+        out: list[dict[str, Any]] = []
+        for i in range(len(ids)):
+            if i in stepped:
+                obs = stepped[i]
+                out.append(
+                    {
+                        "eef_pos": [float(v) for v in obs["eef_pos"]],
+                        "eef_quat": [float(v) for v in obs["eef_quat"]],
+                        "gripper": float(obs["gripper"]),
+                        "reward": float(obs["reward"]),
+                        "done": bool(obs["done"]),
+                        # Success latches even if the env reports a
+                        # post-success regression.
+                        "success": bool(obs["success"]) or bool(prev["success"][i]),
+                        "env_step": int(prev["env_step"][i]) + 1,
+                    }
+                )
+            else:
+                out.append({key: prev[key][i] for key in prev})
+        return Series.from_pylist(out)
+
+
+class EnvStepProcessor(AsyncProcessor):
+    components = (ManipProprio, ManipAction, ManipStatus, ManipTask)
+    priority = 10  # after any policy processor writes actions
+
+    def __init__(self, client: EnvClient):
+        self._stepper = _EnvStepper(client)
+
+    async def process(self, df, **kwargs):
+        nxt = self._stepper.step(
+            col("maniptask__env_key"),
+            col("manipaction__values"),
+            col("manipproprio__eef_pos"),
+            col("manipproprio__eef_quat"),
+            col("manipproprio__gripper"),
+            col("manipstatus__reward"),
+            col("manipstatus__done"),
+            col("manipstatus__success"),
+            col("manipstatus__env_step"),
+        )
+        return (
+            df.with_column("_env_next", nxt)
+            .with_columns(
+                {
+                    "manipproprio__eef_pos": col("_env_next")["eef_pos"],
+                    "manipproprio__eef_quat": col("_env_next")["eef_quat"],
+                    "manipproprio__gripper": col("_env_next")["gripper"],
+                    "manipstatus__reward": col("_env_next")["reward"],
+                    "manipstatus__done": col("_env_next")["done"],
+                    "manipstatus__success": col("_env_next")["success"],
+                    "manipstatus__env_step": col("_env_next")["env_step"],
+                }
+            )
+            .exclude("_env_next")
+        )
+
+
+class ScriptedReachEnv:
+    """Deterministic in-process EnvClient for contract tests.
+
+    A point end-effector integrates the first three action components;
+    success when within ``tolerance`` of the per-env target. Pure float
+    arithmetic, so tests can assert ledger rows with strict equality.
+    """
+
+    def __init__(self, targets: dict[int, tuple[float, float, float]], tolerance: float = 0.05):
+        self._targets = targets
+        self._tolerance = tolerance
+        self._state: dict[int, list[float]] = {}
+
+    def reset(self, env_id: int, seed: int) -> dict[str, Any]:
+        # Deterministic seed-derived start, no RNG: contract tests replay it.
+        start = [0.001 * seed, -0.001 * seed, 0.5]
+        self._state[env_id] = list(start)
+        return {"eef_pos": list(start), "eef_quat": [1.0, 0.0, 0.0, 0.0], "gripper": 0.0}
+
+    def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
+        results = []
+        for env_id, action in zip(env_ids, actions, strict=True):
+            pos = self._state[env_id]
+            for axis in range(3):
+                pos[axis] += action[axis]
+            target = self._targets[env_id]
+            dist = sum((pos[i] - target[i]) ** 2 for i in range(3)) ** 0.5
+            success = dist < self._tolerance
+            results.append(
+                {
+                    "eef_pos": list(pos),
+                    "eef_quat": [1.0, 0.0, 0.0, 0.0],
+                    "gripper": 0.0,
+                    "reward": -dist,
+                    "done": success,
+                    "success": success,
+                }
+            )
+        return results

--- a/tests/experiments/test_manipulation_harness.py
+++ b/tests/experiments/test_manipulation_harness.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Manipulation episode contract, against the scripted in-process env.
+
+Mirrors the Stage 1 physics contract at the episode level, with strict
+float equality throughout:
+
+- reset observations land raw on the ledger at the spawn tick;
+- the row at tick t+1 is exactly env.step(action_t);
+- success latches and done rows freeze (terminal state persists, env is
+  never stepped past done).
+"""
+
+import pytest
+
+from archetype.core.aio import AsyncSystem
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.experiments.manipulation import (
+    ACTION_DIM,
+    EnvStepProcessor,
+    ManipAction,
+    ManipProprio,
+    ManipStatus,
+    ManipTask,
+    ScriptedReachEnv,
+)
+from tests.conftest import make_world_service
+
+# Canonical signature order: sorted by class name.
+SIG = (ManipAction, ManipProprio, ManipStatus, ManipTask)
+
+
+async def _spawn_episode(world, client, env_key: int, seed: int, action: list[float]):
+    """Reset-then-spawn: the env's reset obs become the raw tick-0 row."""
+    obs = client.reset(env_key, seed)
+    return await world.create_entity(
+        [
+            ManipProprio(eef_pos=obs["eef_pos"], eef_quat=obs["eef_quat"], gripper=obs["gripper"]),
+            ManipAction(values=action),
+            ManipStatus(),
+            ManipTask(suite="scripted", task_id=0, instruction="reach", seed=seed, env_key=env_key),
+        ]
+    )
+
+
+async def _rows_at(world, tick: int) -> dict[int, dict]:
+    rows = (await world.query_archetype(sig=SIG, ticks=[tick])).to_pylist()
+    return {r["entity_id"]: r for r in rows}
+
+
+@pytest.mark.asyncio
+async def test_reset_obs_are_raw_tick0_and_steps_match_env_exactly(tmp_path):
+    client = ScriptedReachEnv(targets={0: (1.0, 0.0, 0.5), 1: (0.0, 1.0, 0.5)}, tolerance=0.05)
+    reference = ScriptedReachEnv(targets={0: (1.0, 0.0, 0.5), 1: (0.0, 1.0, 0.5)}, tolerance=0.05)
+
+    actions = {
+        0: [0.3, 0.0, 0.0] + [0.0] * (ACTION_DIM - 3),
+        1: [0.0, 0.2, 0.0] + [0.0] * (ACTION_DIM - 3),
+    }
+
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="manip")
+        system = AsyncSystem()
+        await system.add_processor(EnvStepProcessor(client))
+        world = await ws.create_world(
+            WorldConfig(name="reach"), storage_config=storage, system=system
+        )
+
+        eids = {}
+        for env_key in (0, 1):
+            eids[env_key] = await _spawn_episode(
+                world, client, env_key=env_key, seed=env_key + 7, action=actions[env_key]
+            )
+
+        ticks = 3
+        await world.run(RunConfig(num_steps=ticks))
+
+        # Replay the same episodes against an identical scripted env.
+        expected = {k: [reference.reset(k, k + 7)] for k in (0, 1)}
+        for _ in range(ticks - 1):
+            stepped = reference.step([0, 1], [actions[0], actions[1]])
+            for env_key, obs in zip((0, 1), stepped, strict=True):
+                expected[env_key].append(obs)
+
+        for tick in range(ticks):
+            rows = await _rows_at(world, tick)
+            assert len(rows) == 2
+            for env_key in (0, 1):
+                row = rows[eids[env_key]]
+                want = expected[env_key][tick]
+                assert row["manipproprio__eef_pos"] == want["eef_pos"], (
+                    f"env {env_key} tick {tick}: ledger obs != env obs"
+                )
+                if tick == 0:
+                    assert row["manipstatus__reward"] == 0.0
+                    assert row["manipstatus__env_step"] == 0
+                else:
+                    assert row["manipstatus__reward"] == want["reward"]
+                    assert row["manipstatus__env_step"] == tick
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_success_latches_and_done_rows_freeze(tmp_path):
+    # Target reachable in 2 steps of 0.05: start (0,0,0.5), target (0.1,0,0.5).
+    client = ScriptedReachEnv(targets={0: (0.1, 0.0, 0.5)}, tolerance=0.06)
+    action = [0.05, 0.0, 0.0] + [0.0] * (ACTION_DIM - 3)
+
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="manip")
+        system = AsyncSystem()
+        await system.add_processor(EnvStepProcessor(client))
+        world = await ws.create_world(
+            WorldConfig(name="reach-done"), storage_config=storage, system=system
+        )
+        eid = await _spawn_episode(world, client, env_key=0, seed=0, action=action)
+
+        await world.run(RunConfig(num_steps=5))
+
+        history = {}
+        for tick in range(5):
+            history[tick] = (await _rows_at(world, tick))[eid]
+
+        # Step 1: pos 0.05, dist 0.05 < 0.06 -> success at tick 1.
+        assert history[0]["manipstatus__success"] is False
+        assert history[1]["manipstatus__success"] is True
+        assert history[1]["manipstatus__done"] is True
+
+        # Done rows freeze: position, env_step, and success persist unchanged.
+        for tick in (2, 3, 4):
+            assert history[tick]["manipstatus__success"] is True
+            assert history[tick]["manipstatus__done"] is True
+            assert history[tick]["manipstatus__env_step"] == 1
+            assert history[tick]["manipproprio__eef_pos"] == history[1]["manipproprio__eef_pos"]
+
+        # The frozen env was never stepped past done.
+        assert client._state[0] == [0.05, 0.0, 0.5]
+    finally:
+        await ws.shutdown()


### PR DESCRIPTION
## What this is

Stage 2 of the LIBERO/VLA-JEPA ladder, stacked on #226. The external simulator moves behind a process boundary, and the episode lifecycle gets the same contract treatment Stage 1 gave physics.

## Why the boundary is mandatory (not a Modal preference)

Upstream LIBERO pins **Python 3.8.13 + torch 1.11 + Linux** — it cannot coexist with Archetype's py3.12 process on any machine. So the env always runs in its own interpreter behind the `EnvClient` protocol (`reset`/`step`). Where that interpreter lives is deployment detail: in-process scripted env for contract tests, a Modal container (or any Linux/Docker box) for the real thing.

## Episode contract — tested with strict equality against a scripted env

1. **Reset obs are the raw tick-0 row.** The driver calls `env.reset()` *before* spawning and spawns the returned observation as initial component values — initial conditions on the ledger, again. (`env_key` on `ManipTask` makes this possible: env routing is chosen at reset time, before the entity id exists.)
2. **Row at tick t+1 is exactly `env.step(action_t)`** — replayed against an identical scripted env, asserted with `==`.
3. **Success latches, done rows freeze.** A finished episode's terminal state persists unchanged on the ledger and the env is provably never stepped past done.

The env RPC is a `@daft.cls` batch UDF — one client call per batch, same sanctioned boundary pattern as Stage 1's MuJoCo crossing. One tick = one control step; Stage 3's action chunks execute inside the env worker between control steps, exactly like Stage 1's physics substeps.

## The Modal scaffold (`bench/libero/modal_worker.py`)

`LiberoEnvBatch`: py3.10 image, EGL headless rendering, OpenVLA-style LIBERO install, exposing `reset`/`step`/`task_language`; `ModalEnvClient` is the harness-side adapter (needs only the `modal` pip package in the py3.12 process). **Status: verified end-to-end 2026-06-11** (commit 85261c5; see `modal_worker.py` header). Earlier drafts of this description called it an unverified scaffold. First run:

```
uv tool install modal && modal setup
modal run bench/libero/modal_worker.py        # smoke: reset + 5 zero-action steps
modal deploy bench/libero/modal_worker.py     # then ModalEnvClient from the harness
```

Expect one iteration on image pins (LIBERO-from-git on py3.10 is the standard OpenVLA recipe, but the first build always finds something).

## Lazy-audit disclosure

Nine entries, all the same site class as #226: `Series.to_pylist()` on input columns **inside** the `@daft.method.batch` UDF — executor-materialised batch access at the RPC boundary, not DataFrame collects. Flagging for explicit reviewer sign-off.

## Verification

- `make ci` green: lint, lock-check, 629 tests, coverage, lazy audit (22 sites accounted for), eval regression 10/10
- Episode contract suite passes with strict `==` (2 envs × 3 ticks replay + success-latch/freeze over 5 ticks)

## Next

- First `modal run` smoke of the LIBERO worker (needs `modal setup` — account/token)
- Camera obs: JEPA latents on the ledger + frames to sidecar storage (decision recorded in the ladder doc)
- Batch-spawn API before high env counts (carried from #226)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
