### PR TITLE
feat(sim): Stage 3 — policy-in-the-loop, action provenance on the ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ mutants/
 # session reflection artifacts (local corpus analysis)
 session_data/
 session_reflection_report.md
+bench/libero/out/

--- a/bench/libero/e2e_ledger_smoke.py
+++ b/bench/libero/e2e_ledger_smoke.py
@@ -32,14 +32,19 @@ from modal_worker import ModalEnvClient  # noqa: E402
 from archetype import ArchetypeRuntime  # noqa: E402
 from archetype.core.config import StorageConfig  # noqa: E402
 from archetype.experiments.manipulation import (  # noqa: E402
+    ACTION_DIM,
     EnvStepProcessor,
     ManipAction,
     ManipProprio,
     ManipStatus,
     ManipTask,
 )
+from archetype.experiments.policy import (  # noqa: E402
+    PolicyActionProcessor,
+    ScriptedReachPolicy,
+)
 
-TICKS = 3
+TICKS = 4
 
 
 async def main() -> None:
@@ -48,40 +53,75 @@ async def main() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         storage = StorageConfig(uri=str(Path(tmp) / "store"), namespace="libero_e2e")
         async with ArchetypeRuntime() as runtime:
+            obs = client.reset(0, seed=0)
+            print(f"reset obs (will be the raw tick-0 row): {obs['eef_pos']}")
+
+            # Closed loop: scripted reach policy targets 10cm below the
+            # reset pose; the env consumes the action the policy wrote
+            # the same tick (a_t = pi(obs_{t-1}), obs_t = env.step(a_t)).
+            target = (obs["eef_pos"][0], obs["eef_pos"][1], obs["eef_pos"][2] - 0.10)
+            policy = ScriptedReachPolicy(targets={0: target}, gain=5.0, max_step=0.5)
+
             world = runtime.world(
                 "libero-e2e",
                 storage=storage,
-                processors=[EnvStepProcessor(client)],
+                processors=[PolicyActionProcessor(policy), EnvStepProcessor(client)],
             )
 
-            obs = client.reset(0, seed=0)
-            print(f"reset obs (will be the raw tick-0 row): {obs['eef_pos']}")
+            spawn_action = [0.0] * ACTION_DIM
             eid = await world.spawn(
                 ManipProprio(
                     eef_pos=obs["eef_pos"], eef_quat=obs["eef_quat"], gripper=obs["gripper"]
                 ),
-                ManipAction(values=[0.0, 0.0, -0.1, 0.0, 0.0, 0.0, 0.0]),
+                ManipAction(values=list(spawn_action)),
                 ManipStatus(),
                 ManipTask(suite="libero_spatial", task_id=0, instruction="", seed=0, env_key=0),
             )
 
             await world.run(steps=TICKS)
 
-            history = await world.query(ManipProprio)
+            history = await world.query(ManipProprio, ManipAction)
             rows = sorted(
-                history.select("tick", "entity_id", "manipproprio__eef_pos").to_pylist(),
+                history.select(
+                    "tick", "entity_id", "manipproprio__eef_pos", "manipaction__values"
+                ).to_pylist(),
                 key=lambda r: r["tick"],
             )
             print(f"\nledger for entity {eid} ({len(rows)} rows):")
             for row in rows:
-                print(f"  tick {row['tick']}: eef_pos={row['manipproprio__eef_pos']}")
+                pos = row["manipproprio__eef_pos"]
+                act = row["manipaction__values"]
+                print(f"  tick {row['tick']}: z={pos[2]:.4f} action_z={act[2]:+.3f}")
 
             assert rows[0]["manipproprio__eef_pos"] == obs["eef_pos"], (
                 "tick-0 row must be the raw reset observation"
             )
+            assert rows[0]["manipaction__values"] == spawn_action, (
+                "tick-0 row must keep the spawn action untouched"
+            )
+
+            # Action provenance against the real env: replay the policy on
+            # the ledger's own observation column.
+            replay = ScriptedReachPolicy(targets={0: target}, gain=5.0, max_step=0.5)
+            for prev, row in zip(rows, rows[1:], strict=False):
+                (want,) = replay.act(
+                    [0],
+                    [""],
+                    [
+                        {
+                            "eef_pos": prev["manipproprio__eef_pos"],
+                            "eef_quat": [1.0, 0.0, 0.0, 0.0],
+                            "gripper": 0.0,
+                        }
+                    ],
+                )
+                assert row["manipaction__values"] == want, (
+                    f"tick {row['tick']}: action on ledger != pi(prev ledger obs)"
+                )
+
             zs = [row["manipproprio__eef_pos"][2] for row in rows]
-            assert zs[-1] < zs[0], f"-z action should lower the eef across ticks: {zs}"
-            print("\ne2e ledger smoke OK: reset obs raw at tick 0, env stepped on ledger")
+            assert zs[-1] < zs[0], f"policy should drive the eef downward: {zs}"
+            print("\ne2e closed-loop OK: raw tick-0 row, action provenance holds on real LIBERO")
 
 
 if __name__ == "__main__":

--- a/bench/libero/modal_worker.py
+++ b/bench/libero/modal_worker.py
@@ -136,15 +136,32 @@ class LiberoEnvBatch:
         )
 
     @staticmethod
-    def _proprio(obs: dict) -> dict[str, Any]:
-        return {
+    def _proprio(obs: dict, with_frames: bool = False) -> dict[str, Any]:
+        out = {
             "eef_pos": [float(v) for v in obs["robot0_eef_pos"]],
             "eef_quat": [float(v) for v in obs["robot0_eef_quat"]],
             "gripper": float(obs["robot0_gripper_qpos"][0]),
         }
+        if with_frames:
+            import base64
+
+            import cv2
+
+            def encode(rgb) -> str:
+                ok, buf = cv2.imencode(".png", cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR))
+                if not ok:
+                    raise RuntimeError("png encode failed")
+                return base64.b64encode(buf.tobytes()).decode()
+
+            # NOTE: LIBERO renders frames upside down; upstream eval code
+            # rotates 180 degrees before the policy sees them. We ship raw
+            # pixels and leave orientation to the policy client.
+            out["agentview_png"] = encode(obs["agentview_image"])
+            out["wrist_png"] = encode(obs["robot0_eye_in_hand_image"])
+        return out
 
     @modal.method()
-    def reset(self, env_id: int, seed: int) -> dict[str, Any]:
+    def reset(self, env_id: int, seed: int, with_frames: bool = False) -> dict[str, Any]:
         env = self._envs.get(env_id)
         if env is None:
             env = self._make_env()
@@ -152,16 +169,21 @@ class LiberoEnvBatch:
         env.seed(seed)
         env.reset()
         obs = env.set_init_state(self._init_states[seed % len(self._init_states)])
-        return self._proprio(obs)
+        return self._proprio(obs, with_frames)
 
     @modal.method()
-    def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
+    def step(
+        self,
+        env_ids: list[int],
+        actions: list[list[float]],
+        with_frames: bool = False,
+    ) -> list[dict[str, Any]]:
         results = []
         for env_id, action in zip(env_ids, actions, strict=True):
             env = self._envs[env_id]
             obs, reward, done, info = env.step(action)
             success = bool(env.check_success())
-            result = self._proprio(obs)
+            result = self._proprio(obs, with_frames)
             result.update(
                 {"reward": float(reward), "done": bool(done) or success, "success": success}
             )
@@ -184,9 +206,10 @@ class ModalEnvClient:
     serializable.
     """
 
-    def __init__(self, suite: str = "libero_spatial", task_id: int = 0):
+    def __init__(self, suite: str = "libero_spatial", task_id: int = 0, with_frames: bool = False):
         self._suite = suite
         self._task_id = task_id
+        self._with_frames = with_frames
         self._worker = None
 
     def _get_worker(self):
@@ -196,18 +219,23 @@ class ModalEnvClient:
         return self._worker
 
     def __getstate__(self) -> dict[str, Any]:
-        return {"suite": self._suite, "task_id": self._task_id}
+        return {
+            "suite": self._suite,
+            "task_id": self._task_id,
+            "with_frames": self._with_frames,
+        }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self._suite = state["suite"]
         self._task_id = state["task_id"]
+        self._with_frames = state["with_frames"]
         self._worker = None
 
     def reset(self, env_id: int, seed: int) -> dict[str, Any]:
-        return self._get_worker().reset.remote(env_id, seed)
+        return self._get_worker().reset.remote(env_id, seed, with_frames=self._with_frames)
 
     def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
-        return self._get_worker().step.remote(env_ids, actions)
+        return self._get_worker().step.remote(env_ids, actions, with_frames=self._with_frames)
 
 
 @app.local_entrypoint()

--- a/bench/libero/modal_worker.py
+++ b/bench/libero/modal_worker.py
@@ -141,6 +141,9 @@ class LiberoEnvBatch:
             "eef_pos": [float(v) for v in obs["robot0_eef_pos"]],
             "eef_quat": [float(v) for v in obs["robot0_eef_quat"]],
             "gripper": float(obs["robot0_gripper_qpos"][0]),
+            # Both gripper joint values: the VLA state vector wants the full
+            # robot0_gripper_qpos, not just the first finger.
+            "gripper_qpos": [float(v) for v in obs["robot0_gripper_qpos"]],
         }
         if with_frames:
             import base64

--- a/bench/libero/video_rollout.py
+++ b/bench/libero/video_rollout.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Record a video of VLA-JEPA driving a real LIBERO task.
+
+The first end-to-end run of both deployed workers together: every control
+step pulls camera frames from ``archetype-libero-env``, every 7th step
+sends them (plus the 8-dim state) to ``archetype-vla-jepa`` for a fresh
+action chunk — upstream's own open-loop chunk cadence.
+
+Usage:
+    uv run --with modal --with "imageio[ffmpeg]" \\
+        python bench/libero/video_rollout.py --steps 120
+
+Writes bench/libero/out/libero_vla_jepa_<suite>_task<id>.mp4
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import math
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import modal  # noqa: E402
+
+CHUNK_SIZE = 7
+
+
+def quat2axisangle(quat: list[float]) -> np.ndarray:
+    """robosuite (x, y, z, w) quaternion -> axis-angle, as upstream's eval."""
+    q = np.asarray(quat, dtype=np.float64)
+    w = max(-1.0, min(1.0, q[3]))
+    den = math.sqrt(max(0.0, 1.0 - w * w))
+    if math.isclose(den, 0.0, abs_tol=1e-9):
+        return np.zeros(3)
+    return q[:3] * 2.0 * math.acos(w) / den
+
+
+def decode_frame(b64: str) -> np.ndarray:
+    from PIL import Image
+
+    rgb = np.asarray(Image.open(io.BytesIO(base64.b64decode(b64))).convert("RGB"))
+    # LIBERO renders upside down; flip for human-oriented video.
+    return np.ascontiguousarray(rgb[::-1, ::-1])
+
+
+def state_vector(obs: dict) -> list[float]:
+    return [
+        *obs["eef_pos"],
+        *quat2axisangle(obs["eef_quat"]),
+        *obs["gripper_qpos"],
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", default="libero_spatial")
+    parser.add_argument("--task-id", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--steps", type=int, default=120)
+    parser.add_argument("--fps", type=int, default=10)
+    args = parser.parse_args()
+
+    env_cls = modal.Cls.from_name("archetype-libero-env", "LiberoEnvBatch")
+    env = env_cls(suite=args.suite, task_id=args.task_id)
+    policy_cls = modal.Cls.from_name("archetype-vla-jepa", "VlaJepaPolicy")
+    policy = policy_cls()
+
+    instruction = env.task_language.remote()
+    print(f"task: {instruction}")
+
+    obs = env.reset.remote(0, seed=args.seed, with_frames=True)
+
+    # Upstream waits 10 dummy steps after reset so the scene physics settle
+    # before the first inference (LIBERO_DUMMY_ACTION = no-op, gripper open).
+    dummy = [0.0] * 6 + [-1.0]
+    for _ in range(10):
+        (obs,) = env.step.remote([0], [dummy], with_frames=True)
+
+    frames = [decode_frame(obs["agentview_png"])]
+    chunk: list[list[float]] = []
+    success = False
+    started = time.perf_counter()
+
+    for step in range(args.steps):
+        if not chunk:
+            chunk = policy.infer.remote(
+                agentview_png=obs["agentview_png"],
+                wrist_png=obs["wrist_png"],
+                instruction=instruction,
+                state=state_vector(obs),
+            )
+            print(
+                f"step {step:3d}: new chunk ({len(chunk)} actions), "
+                f"a0={[f'{v:.3f}' for v in chunk[0]]}"
+            )
+        action = list(chunk.pop(0))
+        # Model emits gripper open in {0, 1}; robosuite wants {-1 open, +1
+        # close} — upstream's _binarize_gripper_open: 1 - 2*(open > 0.5).
+        action[6] = 1.0 - 2.0 * (action[6] > 0.5)
+
+        (result,) = env.step.remote([0], [action], with_frames=True)
+        obs = result
+        frames.append(decode_frame(result["agentview_png"]))
+
+        if result["success"]:
+            success = True
+            print(f"step {step:3d}: SUCCESS — task solved")
+            break
+        if result["done"]:
+            print(f"step {step:3d}: episode done without success")
+            break
+
+    elapsed = time.perf_counter() - started
+    print(f"{len(frames)} frames in {elapsed:.1f}s  success={success}")
+
+    out_dir = Path(__file__).parent / "out"
+    out_dir.mkdir(exist_ok=True)
+    out_path = out_dir / f"libero_vla_jepa_{args.suite}_task{args.task_id}.mp4"
+
+    import imageio.v3 as iio
+
+    iio.imwrite(out_path, np.stack(frames), fps=args.fps, codec="libx264")
+    print(f"video: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/libero/vla_jepa_worker.py
+++ b/bench/libero/vla_jepa_worker.py
@@ -1,0 +1,164 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""VLA-JEPA policy worker on Modal — the GPU half of PolicyClient.
+
+Wraps the upstream inference stack whole rather than reimplementing it:
+the container launches VLA-JEPA's own websocket model server
+(``deployment/model_server/server_policy.py``, the same process their
+``eval_libero.sh`` starts) and ``infer`` proxies to it over localhost.
+That keeps us bit-compatible with their published LIBERO evaluation —
+same server, same action un-normalization, same chunking.
+
+Checkpoint: ``VLA-JEPA-LIBERO.pt`` from https://huggingface.co/ginwind/VLA-JEPA,
+cached in the ``vla-jepa-ckpts`` Modal volume on first start.
+
+Setup:
+    modal deploy bench/libero/vla_jepa_worker.py
+    modal run bench/libero/vla_jepa_worker.py      # smoke: one inference
+
+STATUS: scaffold pending first GPU run. The websocket payload keys below
+follow examples/LIBERO/eval_libero.py + model2libero_interface.py
+(M1Inference) and must be confirmed against the live server on the first
+smoke; flash-attn build time is the other known unknown.
+"""
+
+# NOTE: no `from __future__ import annotations` — modal.parameter()
+# validates real annotation objects.
+import base64
+import subprocess
+import time
+from typing import Any
+
+import modal
+
+REPO = "https://github.com/ginwind/VLA-JEPA.git"
+CKPT_REPO = "ginwind/VLA-JEPA"
+CKPT_FILE = "LIBERO/checkpoints/VLA-JEPA-LIBERO.pt"
+CKPT_DIR = "/ckpts"
+SERVER_PORT = 15084
+
+image = (
+    modal.Image.from_registry("nvidia/cuda:12.4.1-devel-ubuntu22.04", add_python="3.10")
+    .apt_install("git", "libgl1", "libglib2.0-0")
+    .pip_install("torch>=2.4,<2.6", "packaging", "ninja", "wheel", "huggingface_hub")
+    .run_commands(
+        f"git clone --depth 1 {REPO} /opt/VLA-JEPA",
+        "pip install -r /opt/VLA-JEPA/requirements.txt",
+        "pip install -e /opt/VLA-JEPA",
+    )
+    # flash-attn last: it needs torch present at build time, and this layer
+    # is the slow one — keep everything else cached above it.
+    .run_commands("pip install flash-attn --no-build-isolation")
+    .env({"HF_HOME": f"{CKPT_DIR}/hf-cache", "PYTHONPATH": "/opt/VLA-JEPA"})
+)
+
+app = modal.App("archetype-vla-jepa", image=image)
+ckpt_volume = modal.Volume.from_name("vla-jepa-ckpts", create_if_missing=True)
+
+
+@app.cls(
+    gpu="L40S",
+    volumes={CKPT_DIR: ckpt_volume},
+    timeout=3600,
+    scaledown_window=600,
+    max_containers=1,
+)
+class VlaJepaPolicy:
+    use_bf16: int = modal.parameter(default=1)
+
+    @modal.enter()
+    def start_server(self):
+        from huggingface_hub import hf_hub_download
+
+        ckpt_path = hf_hub_download(repo_id=CKPT_REPO, filename=CKPT_FILE, local_dir=CKPT_DIR)
+        ckpt_volume.commit()
+
+        cmd = [
+            "python",
+            "/opt/VLA-JEPA/deployment/model_server/server_policy.py",
+            "--ckpt_path",
+            ckpt_path,
+            "--port",
+            str(SERVER_PORT),
+            "--cuda",
+            "0",
+        ]
+        if self.use_bf16:
+            cmd.append("--use_bf16")
+        self._server = subprocess.Popen(cmd, cwd="/opt/VLA-JEPA")
+
+        from deployment.model_server.tools.websocket_policy_client import (
+            WebsocketClientPolicy,
+        )
+
+        # Model load takes a while; poll until the websocket accepts.
+        deadline = time.monotonic() + 900
+        last_err = None
+        while time.monotonic() < deadline:
+            if self._server.poll() is not None:
+                raise RuntimeError(f"server_policy.py exited early with {self._server.returncode}")
+            try:
+                self._client = WebsocketClientPolicy("127.0.0.1", SERVER_PORT)
+                return
+            except Exception as exc:  # noqa: BLE001 - retry until deadline
+                last_err = exc
+                time.sleep(5.0)
+        raise RuntimeError(f"policy server never came up: {last_err}")
+
+    @modal.method()
+    def infer(
+        self,
+        agentview_png: str,
+        wrist_png: str,
+        instruction: str,
+        state: list[float],
+    ) -> list[list[float]]:
+        """One policy inference -> an action chunk (list of 7-dim actions).
+
+        Payload keys mirror examples/LIBERO/eval_libero.py; confirm on
+        first live smoke.
+        """
+        import cv2
+        import numpy as np
+
+        def decode(b64: str) -> "np.ndarray":
+            buf = np.frombuffer(base64.b64decode(b64), dtype=np.uint8)
+            return cv2.cvtColor(cv2.imdecode(buf, cv2.IMREAD_COLOR), cv2.COLOR_BGR2RGB)
+
+        payload: dict[str, Any] = {
+            "observation/image": decode(agentview_png),
+            "observation/wrist_image": decode(wrist_png),
+            "observation/state": np.asarray(state, dtype=np.float32),
+            "prompt": instruction,
+        }
+        result = self._client.infer(payload)
+        actions = np.asarray(result["actions"])
+        return [[float(v) for v in row] for row in actions]
+
+
+@app.local_entrypoint()
+def smoke():
+    """One inference against a synthetic frame; prints the action chunk."""
+    import io
+
+    try:
+        from PIL import Image
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit("pip install pillow for the smoke entrypoint") from exc
+
+    img = Image.new("RGB", (256, 256), color=(127, 127, 127))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+    policy = VlaJepaPolicy()
+    chunk = policy.infer.remote(
+        agentview_png=png_b64,
+        wrist_png=png_b64,
+        instruction="pick up the black bowl and place it on the plate",
+        state=[0.0] * 8,
+    )
+    print(f"action chunk: {len(chunk)} steps x {len(chunk[0])} dims")
+    print(f"first action: {chunk[0]}")
+    print("vla-jepa smoke OK")

--- a/bench/libero/vla_jepa_worker.py
+++ b/bench/libero/vla_jepa_worker.py
@@ -17,10 +17,11 @@ Setup:
     modal deploy bench/libero/vla_jepa_worker.py
     modal run bench/libero/vla_jepa_worker.py      # smoke: one inference
 
-STATUS: scaffold pending first GPU run. The websocket payload keys below
-follow examples/LIBERO/eval_libero.py + model2libero_interface.py
-(M1Inference) and must be confirmed against the live server on the first
-smoke; flash-attn build time is the other known unknown.
+STATUS: verified 2026-06-11 — `modal run` smoke returns a real 7-step x
+7-dim un-normalized action chunk from the released checkpoint on an
+L40S. Payload contract confirmed against the live server: batch_images
+(rotated 180 + resized 224), instructions, unnorm_key, state shaped
+(1, 1, 8); response under data.normalized_actions.
 """
 
 # NOTE: no `from __future__ import annotations` — modal.parameter()
@@ -41,15 +42,21 @@ SERVER_PORT = 15084
 image = (
     modal.Image.from_registry("nvidia/cuda:12.4.1-devel-ubuntu22.04", add_python="3.10")
     .apt_install("git", "libgl1", "libglib2.0-0")
-    .pip_install("torch>=2.4,<2.6", "packaging", "ninja", "wheel", "huggingface_hub")
+    .pip_install("torch==2.5.1", "packaging", "ninja", "wheel", "huggingface_hub")
+    # Their deployment/ websocket server+client deps are not in requirements.txt.
+    .pip_install("websockets", "msgpack", "msgpack-numpy")
     .run_commands(
         f"git clone --depth 1 {REPO} /opt/VLA-JEPA",
         "pip install -r /opt/VLA-JEPA/requirements.txt",
         "pip install -e /opt/VLA-JEPA",
     )
-    # flash-attn last: it needs torch present at build time, and this layer
-    # is the slow one — keep everything else cached above it.
-    .run_commands("pip install flash-attn --no-build-isolation")
+    # flash-attn from the release wheel that exactly matches
+    # torch 2.5 / cu12 / cxx11abiFALSE / cp310 — pip's sdist path guesses
+    # the ABI wrong and produces undefined C10 symbols at import.
+    .pip_install(
+        "https://github.com/Dao-AILab/flash-attention/releases/download/"
+        "v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.5cxx11abiFALSE-cp310-cp310-linux_x86_64.whl"
+    )
     .env({"HF_HOME": f"{CKPT_DIR}/hf-cache", "PYTHONPATH": "/opt/VLA-JEPA"})
 )
 
@@ -69,9 +76,19 @@ class VlaJepaPolicy:
 
     @modal.enter()
     def start_server(self):
-        from huggingface_hub import hf_hub_download
+        # from_pretrained expects the full run directory (config.yaml +
+        # dataset_statistics.json beside checkpoints/), not just the .pt.
+        # Drop previously-patched config files first so the snapshot always
+        # starts from pristine upstream copies (patching must see originals).
+        from pathlib import Path
 
-        ckpt_path = hf_hub_download(repo_id=CKPT_REPO, filename=CKPT_FILE, local_dir=CKPT_DIR)
+        from huggingface_hub import snapshot_download
+
+        for cfg in Path(f"{CKPT_DIR}/LIBERO").glob("config.*"):
+            cfg.unlink()
+        snapshot_download(repo_id=CKPT_REPO, allow_patterns=["LIBERO/**"], local_dir=CKPT_DIR)
+        ckpt_path = f"{CKPT_DIR}/{CKPT_FILE}"
+        self._patch_base_model_paths()
         ckpt_volume.commit()
 
         cmd = [
@@ -106,6 +123,30 @@ class VlaJepaPolicy:
                 time.sleep(5.0)
         raise RuntimeError(f"policy server never came up: {last_err}")
 
+    @staticmethod
+    def _patch_base_model_paths():
+        """The released config.yaml/config.json reference the author's local
+        disk for the Qwen3-VL and V-JEPA2 base models; rewrite those paths to
+        HF repo ids so transformers downloads them into the volume cache."""
+        from pathlib import Path
+
+        replacements = {
+            "Qwen3-VL-2B-Instruct": "Qwen/Qwen3-VL-2B-Instruct",
+            "vjepa2-vitl-fpc64-256": "facebook/vjepa2-vitl-fpc64-256",
+        }
+        for cfg in Path(f"{CKPT_DIR}/LIBERO").glob("config.*"):
+            text = cfg.read_text()
+            patched = text
+            for marker, repo_id in replacements.items():
+                import re
+
+                # Anchored to the author's /home/... prefix: idempotent, can
+                # never re-match an already-substituted HF repo id.
+                patched = re.sub(rf"/home/[\w./-]*{re.escape(marker)}[\w./-]*", repo_id, patched)
+            if patched != text:
+                cfg.write_text(patched)
+                print(f"patched base-model paths in {cfg.name}")
+
     @modal.method()
     def infer(
         self,
@@ -113,27 +154,55 @@ class VlaJepaPolicy:
         wrist_png: str,
         instruction: str,
         state: list[float],
+        unnorm_key: str = "franka",
     ) -> list[list[float]]:
-        """One policy inference -> an action chunk (list of 7-dim actions).
+        """One policy inference -> an un-normalized action chunk.
 
-        Payload keys mirror examples/LIBERO/eval_libero.py; confirm on
-        first live smoke.
+        Payload and response shape follow upstream M1Inference
+        (examples/LIBERO/model2libero_interface.py): the server returns
+        normalized actions (B, chunk, D) in [-1, 1]; we un-normalize here
+        with the checkpoint's dataset_statistics.json, gripper binarized,
+        exactly as their LIBERO eval does.
         """
+        import json
+
         import cv2
         import numpy as np
 
         def decode(b64: str) -> "np.ndarray":
             buf = np.frombuffer(base64.b64decode(b64), dtype=np.uint8)
-            return cv2.cvtColor(cv2.imdecode(buf, cv2.IMREAD_COLOR), cv2.COLOR_BGR2RGB)
+            rgb = cv2.cvtColor(cv2.imdecode(buf, cv2.IMREAD_COLOR), cv2.COLOR_BGR2RGB)
+            # Inputs are raw LIBERO frames; rotate 180 degrees to match the
+            # model's train-time preprocessing (their eval does [::-1, ::-1]).
+            rgb = np.ascontiguousarray(rgb[::-1, ::-1])
+            return cv2.resize(rgb, (224, 224), interpolation=cv2.INTER_AREA)
 
         payload: dict[str, Any] = {
-            "observation/image": decode(agentview_png),
-            "observation/wrist_image": decode(wrist_png),
-            "observation/state": np.asarray(state, dtype=np.float32),
-            "prompt": instruction,
+            "batch_images": [[decode(agentview_png), decode(wrist_png)]],
+            "instructions": [instruction],
+            "unnorm_key": unnorm_key,
+            "do_sample": False,
+            "use_ddim": True,
+            "num_ddim_steps": 10,
+            # Upstream wraps an already-batched (1, 8) state in a list, so the
+            # server sees (1, 1, 8); state = eef_pos(3) + axis-angle(3) +
+            # gripper_qpos(2).
+            "state": [np.asarray(state, dtype=np.float32)[None, :]],
         }
-        result = self._client.infer(payload)
-        actions = np.asarray(result["actions"])
+        response = self._client.infer(payload)
+        normalized = np.clip(np.asarray(response["data"]["normalized_actions"])[0], -1, 1)
+
+        with open(f"{CKPT_DIR}/LIBERO/dataset_statistics.json") as f:
+            norm_stats = json.load(f)
+        if unnorm_key not in norm_stats:
+            (unnorm_key,) = norm_stats.keys()
+        stats = norm_stats[unnorm_key]["action"]
+        low = np.asarray(stats["min"])
+        high = np.asarray(stats["max"])
+        mask = np.asarray(stats.get("mask", np.ones_like(low, dtype=bool)))
+
+        normalized[:, 6] = np.where(normalized[:, 6] < 0.5, 0, 1)
+        actions = np.where(mask, 0.5 * (normalized + 1) * (high - low) + low, normalized)
         return [[float(v) for v in row] for row in actions]
 
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -144,3 +144,45 @@ path = "src/archetype/experiments/manipulation.py"
 line = 142
 method = "to_pylist"
 reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (env_step input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/policy.py"
+line = 80
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (env_key input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/policy.py"
+line = 81
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (instruction input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/policy.py"
+line = 82
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (eef_pos input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/policy.py"
+line = 83
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (eef_quat input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/policy.py"
+line = 84
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (gripper input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/policy.py"
+line = 85
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (done input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
+
+[[entries]]
+path = "src/archetype/experiments/policy.py"
+line = 86
+method = "to_pylist"
+reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (prev_action input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."

--- a/src/archetype/experiments/policy.py
+++ b/src/archetype/experiments/policy.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Policy-in-the-loop: actions on the ledger with full provenance.
+
+Stage 3 of the LIBERO/VLA-JEPA ladder. A ``PolicyActionProcessor``
+(priority 1) writes the action *before* ``EnvStepProcessor`` (priority 10)
+consumes it, so each ledger row t >= 1 carries both the action chosen from
+the previous observation and the observation that action produced:
+
+    a_t = pi(obs_{t-1});  obs_t = env.step(a_t);  row_t = (a_t, obs_t)
+
+That makes every rollout self-documenting: replaying the policy against
+the ledger's own observation column must reproduce the action column
+exactly (the provenance contract tested in
+``tests/experiments/test_policy_loop.py``).
+
+``PolicyClient`` mirrors ``EnvClient``: in-process scripted policies for
+contract tests, a remote GPU worker (VLA-JEPA behind a Modal/websocket
+server) for the real thing. The tick-0 row keeps its spawn action
+untouched — like the reset observation, the initial action slot is given,
+not computed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import daft
+from daft import DataType, Series, col
+
+from archetype.core.aio.async_processor import AsyncProcessor
+
+from .manipulation import (
+    ACTION_DIM,
+    ManipAction,
+    ManipProprio,
+    ManipStatus,
+    ManipTask,
+)
+
+
+class PolicyClient(Protocol):
+    """Boundary to a policy. Implementations may hold per-env recurrent
+    state (action chunks, image history) keyed by ``env_key``."""
+
+    def act(
+        self,
+        env_keys: list[int],
+        instructions: list[str],
+        observations: list[dict[str, Any]],
+    ) -> list[list[float]]:
+        """Return one action per env given its latest observation dict
+        (keys: eef_pos, eef_quat, gripper)."""
+        ...
+
+
+_ACTION_TYPE = DataType.list(DataType.float64())
+
+
+@daft.cls()
+class _PolicyCaller:
+    """Policy inference as a batch UDF: one client call per batch, the
+    same sanctioned boundary pattern as the env and MuJoCo crossings."""
+
+    def __init__(self, client: PolicyClient):
+        self._client = client
+
+    @daft.method.batch(return_dtype=_ACTION_TYPE)
+    def act(
+        self,
+        env_key: Series,
+        instruction: Series,
+        eef_pos: Series,
+        eef_quat: Series,
+        gripper: Series,
+        done: Series,
+        prev_action: Series,
+    ) -> Series:
+        keys = env_key.to_pylist()
+        instructions = instruction.to_pylist()
+        pos = eef_pos.to_pylist()
+        quat = eef_quat.to_pylist()
+        grip = gripper.to_pylist()
+        finished = done.to_pylist()
+        actions = prev_action.to_pylist()
+
+        # Done rows are frozen: keep the terminal action unchanged.
+        live = [i for i in range(len(keys)) if not finished[i]]
+        if live:
+            chosen = self._client.act(
+                [keys[i] for i in live],
+                [instructions[i] for i in live],
+                [{"eef_pos": pos[i], "eef_quat": quat[i], "gripper": grip[i]} for i in live],
+            )
+            for i, action in zip(live, chosen, strict=True):
+                actions[i] = [float(v) for v in action]
+        return Series.from_pylist(actions)
+
+
+class PolicyActionProcessor(AsyncProcessor):
+    # Same archetype as the env step; must run BEFORE EnvStepProcessor so
+    # the env consumes this tick's action, not last tick's.
+    components = (ManipProprio, ManipAction, ManipStatus, ManipTask)
+    priority = 1
+
+    def __init__(self, client: PolicyClient):
+        self._caller = _PolicyCaller(client)
+
+    async def process(self, df, **kwargs):
+        return df.with_column(
+            "manipaction__values",
+            self._caller.act(
+                col("maniptask__env_key"),
+                col("maniptask__instruction"),
+                col("manipproprio__eef_pos"),
+                col("manipproprio__eef_quat"),
+                col("manipproprio__gripper"),
+                col("manipstatus__done"),
+                col("manipaction__values"),
+            ),
+        )
+
+
+class ScriptedReachPolicy:
+    """Deterministic proportional controller toward a per-env target.
+
+    Pure float arithmetic so the provenance contract can be asserted with
+    strict equality: action = clip(gain * (target - eef_pos)) per axis,
+    zeros for the remaining action dims.
+    """
+
+    def __init__(
+        self,
+        targets: dict[int, tuple[float, float, float]],
+        gain: float = 0.5,
+        max_step: float = 0.05,
+    ):
+        self._targets = targets
+        self._gain = gain
+        self._max_step = max_step
+
+    def act(
+        self,
+        env_keys: list[int],
+        instructions: list[str],
+        observations: list[dict[str, Any]],
+    ) -> list[list[float]]:
+        actions = []
+        for env_key, obs in zip(env_keys, observations, strict=True):
+            target = self._targets[env_key]
+            action = [0.0] * ACTION_DIM
+            for axis in range(3):
+                delta = self._gain * (target[axis] - obs["eef_pos"][axis])
+                action[axis] = max(-self._max_step, min(self._max_step, delta))
+            actions.append(action)
+        return actions

--- a/tests/experiments/test_policy_loop.py
+++ b/tests/experiments/test_policy_loop.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Action provenance contract for the policy-in-the-loop tick.
+
+With PolicyActionProcessor (priority 1) ahead of EnvStepProcessor
+(priority 10), every ledger row t >= 1 must satisfy, with strict float
+equality:
+
+    action_t == pi(obs_{t-1})        (the policy saw the previous row)
+    obs_t    == env.step(action_t)   (the env consumed this row's action)
+
+and the tick-0 row keeps its spawn action untouched. Together with the
+Stage 2 contract this makes the ledger a complete, replayable account of
+who did what to whom on every tick.
+"""
+
+import pytest
+
+from archetype.core.aio import AsyncSystem
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.experiments.manipulation import (
+    ACTION_DIM,
+    EnvStepProcessor,
+    ManipAction,
+    ManipProprio,
+    ManipStatus,
+    ManipTask,
+    ScriptedReachEnv,
+)
+from archetype.experiments.policy import PolicyActionProcessor, ScriptedReachPolicy
+from tests.conftest import make_world_service
+
+SIG = (ManipAction, ManipProprio, ManipStatus, ManipTask)
+
+TARGETS = {0: (0.15, 0.0, 0.5), 1: (-0.1, 0.05, 0.5)}
+TICKS = 8
+SPAWN_ACTION = [0.0] * ACTION_DIM
+
+
+@pytest.mark.asyncio
+async def test_ledger_rows_satisfy_action_provenance(tmp_path):
+    env = ScriptedReachEnv(targets=TARGETS, tolerance=0.02)
+    policy = ScriptedReachPolicy(targets=TARGETS)
+
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="policy")
+        system = AsyncSystem()
+        await system.add_processor(PolicyActionProcessor(policy))
+        await system.add_processor(EnvStepProcessor(env))
+        world = await ws.create_world(
+            WorldConfig(name="policy-loop"), storage_config=storage, system=system
+        )
+
+        eids = {}
+        for env_key in TARGETS:
+            obs = env.reset(env_key, seed=env_key)
+            eids[env_key] = await world.create_entity(
+                [
+                    ManipProprio(
+                        eef_pos=obs["eef_pos"],
+                        eef_quat=obs["eef_quat"],
+                        gripper=obs["gripper"],
+                    ),
+                    ManipAction(values=list(SPAWN_ACTION)),
+                    ManipStatus(),
+                    ManipTask(
+                        suite="scripted",
+                        task_id=0,
+                        instruction="reach",
+                        seed=env_key,
+                        env_key=env_key,
+                    ),
+                ]
+            )
+
+        await world.run(RunConfig(num_steps=TICKS))
+
+        history = {}
+        for tick in range(TICKS):
+            rows = (await world.query_archetype(sig=SIG, ticks=[tick])).to_pylist()
+            history[tick] = {r["entity_id"]: r for r in rows}
+
+        replay_policy = ScriptedReachPolicy(targets=TARGETS)
+        replay_env = ScriptedReachEnv(targets=TARGETS, tolerance=0.02)
+        for env_key in TARGETS:
+            replay_env.reset(env_key, seed=env_key)
+
+        for env_key, eid in eids.items():
+            assert history[0][eid]["manipaction__values"] == SPAWN_ACTION, (
+                "tick-0 row must keep the spawn action untouched"
+            )
+            for tick in range(1, TICKS):
+                prev = history[tick - 1][eid]
+                row = history[tick][eid]
+                if prev["manipstatus__done"]:
+                    # Frozen rows: action and obs persist unchanged.
+                    assert row["manipaction__values"] == prev["manipaction__values"]
+                    assert row["manipproprio__eef_pos"] == prev["manipproprio__eef_pos"]
+                    continue
+
+                (want_action,) = replay_policy.act(
+                    [env_key],
+                    ["reach"],
+                    [
+                        {
+                            "eef_pos": prev["manipproprio__eef_pos"],
+                            "eef_quat": prev["manipproprio__eef_quat"],
+                            "gripper": prev["manipproprio__gripper"],
+                        }
+                    ],
+                )
+                assert row["manipaction__values"] == want_action, (
+                    f"env {env_key} tick {tick}: action_t != pi(obs_t-1)"
+                )
+
+                (want_obs,) = replay_env.step([env_key], [want_action])
+                assert row["manipproprio__eef_pos"] == want_obs["eef_pos"], (
+                    f"env {env_key} tick {tick}: obs_t != env.step(action_t)"
+                )
+
+        # The proportional controller actually reaches both targets.
+        final = history[TICKS - 1]
+        assert all(final[eid]["manipstatus__success"] for eid in eids.values()), (
+            f"both envs should succeed within {TICKS} ticks"
+        )
+    finally:
+        await ws.shutdown()


### PR DESCRIPTION
## What this is

Stage 3 of the LIBERO/VLA-JEPA ladder, stacked on #227. The policy joins the tick, and the ledger becomes a complete causal account of the rollout.

## The provenance contract

`PolicyActionProcessor` (priority 1) writes the action before `EnvStepProcessor` (priority 10) consumes it, so every row t ≥ 1 satisfies, with strict float equality:

- **action_t = π(obs_{t-1})** — replaying the policy against the ledger's own observation column reproduces the action column exactly
- **obs_t = env.step(action_t)** — the env consumed this row's action
- tick-0 keeps its spawn action untouched (the initial action slot is given, like the reset obs); done rows freeze their terminal action

Tested two ways:
1. **Locally** — scripted policy + scripted env, full replay assertions (`tests/experiments/test_policy_loop.py`), plus convergence (both envs reach their targets and success latches).
2. **Live on real LIBERO** — the e2e smoke is now a closed loop: a scripted reach policy targets 10cm below the reset pose, the deployed Modal env executes, and the provenance replay holds row-for-row against the real simulator:

```
tick 0: z=1.1757 action_z=+0.000   <- raw spawn row
tick 1: z=1.1724 action_z=-0.500   <- a_1=pi(obs_0), obs_1=env.step(a_1)
tick 2: z=1.1664 action_z=-0.484
tick 3: z=1.1603 action_z=-0.453
e2e closed-loop OK: raw tick-0 row, action provenance holds on real LIBERO
```

## Toward the real policy

- **Camera frames**: the env worker now returns base64 PNGs of agentview + wrist when asked (`with_frames`) — verified live (29KB/27KB per frame). Next step per the ladder decision: frames to a shared Modal volume sidecar with refs on the ledger, V-JEPA latents as the ledger-native observation.
- **VLA-JEPA GPU worker** (`bench/libero/vla_jepa_worker.py`): wraps upstream's own `server_policy.py` websocket server in an L40S container — same server, same un-normalization, same chunking as their published LIBERO eval — with the `VLA-JEPA-LIBERO.pt` checkpoint pulled from HF into a Modal volume. **Status: image building at PR time**; payload keys follow their `eval_libero.py`/`M1Inference` and get confirmed on first GPU smoke.

## Disclosures

- Seven new lazy-audit entries, same class as before: `Series.to_pylist` inside the policy batch UDF.
- `make ci` green: 630 tests, lazy audit 29 sites accounted for, eval regression 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)