### PR TITLE
fix(evals): align simulation_correctness with the initial-conditions contract; gate capability evals in CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -72,9 +72,11 @@ jobs:
       - name: Run regression evals
         run: make eval-reg
 
-      - name: Run capability evals (non-blocking)
+      # Capability evals are deterministic and credential-free; they gate the
+      # merge so behavior regressions (e.g. tick-semantics changes) can't slip
+      # through eval-reg alone.
+      - name: Run capability evals
         run: make eval-cap
-        continue-on-error: true
 
   format:
     runs-on: ubuntu-latest

--- a/evals/suites/capability.py
+++ b/evals/suites/capability.py
@@ -189,8 +189,12 @@ async def _task_simulation_correctness() -> list[GraderResult]:
             }
 
             # Grader 2: Processor correctness (outcome verification)
-            # After N_STEPS of ApplyVelocity(dx=1, dy=-1):
-            #   x_final = x_init + N_STEPS, y_final = y_init - N_STEPS
+            # Initial-conditions contract (spec World Contracts): the spawn tick
+            # persists raw initial state and processors first apply on the
+            # following tick, so N_STEPS ticks apply ApplyVelocity(dx=1, dy=-1)
+            # exactly N_STEPS - 1 times:
+            #   x_final = x_init + (N_STEPS - 1), y_final = y_init - (N_STEPS - 1)
+            applied_ticks = N_STEPS - 1
             position_checks = {}
             for idx in range(entity_count):
                 eid = entity_ids[idx]
@@ -198,8 +202,8 @@ async def _task_simulation_correctness() -> list[GraderResult]:
                 if x_init is None:
                     position_checks[f"eid_{eid}_found"] = False
                     continue
-                position_checks[f"eid_{eid}_x"] = rows["position__x"][idx] == x_init + N_STEPS
-                position_checks[f"eid_{eid}_y"] = rows["position__y"][idx] == y_init - N_STEPS
+                position_checks[f"eid_{eid}_x"] = rows["position__x"][idx] == x_init + applied_ticks
+                position_checks[f"eid_{eid}_y"] = rows["position__y"][idx] == y_init - applied_ticks
 
             # Grader 3: Untouched data preserved (velocity, health unchanged)
             preservation_checks = {}


### PR DESCRIPTION
## What

Two surgical changes closing the follow-up from the merge sequence:

1. **`evals/suites/capability.py` — one stale expectation.** The tick-zero PR's initial-conditions contract (spec World Contracts) persists raw state at the spawn tick; processors first apply on the following tick. So `N_STEPS` ticks apply `ApplyVelocity` exactly `N_STEPS − 1` times. The eval still expected `N_STEPS` applications, failing `simulation_correctness` at 0.75 on main since the stack merged. Verified empirically before editing: `init=(10,20)`, 3 steps of `(dx=1, dy=-1)` lands at `(12,18)` — exactly `steps − 1`. Every other grader in the task (entity preservation, untouched data, query completeness) was already passing; only the displacement expectation changed.

2. **`.github/workflows/python-tests.yml` — capability evals now gate.** The step was `continue-on-error: true`, which is exactly how this regression slipped through (`make ci` gates only `eval-reg`). Both capability tasks are deterministic and credential-free, so they now block. The spec suite is already gated via `tests/spec_contracts/` in the test job.

## Validation

All suites green locally: regression 10/10, spec 6/6, capability 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)