### PR TITLE
feat(tooling): lazy-audit AST scope detection — prune 20 redundant allowlist entries

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -395,6 +395,49 @@ df = df.with_column("outbox__messages", agent.respond(col("agent__name"), ...))
 
 ---
 
+## Lazy-Audit UDF-Boundary Exemption (Jun 2026)
+
+``scripts/check_lazy_audit.py`` gates every ``.collect()`` and
+``.to_pylist()`` call in ``src/`` against ``lazy_audit.toml``.  There is
+**one sanctioned exception** that does not require an allowlist entry:
+
+> ``Series.to_pylist()`` called on a *parameter* of a function decorated
+> with ``@daft.method.batch`` or ``@daft.func.batch``.
+
+When Daft invokes such a function the batch is already materialised by the
+executor — the function receives concrete ``Series`` objects.  Converting
+those parameters to Python lists is the expected interface at the C-library
+or RPC boundary, not premature materialisation.  The checker detects this
+pattern via AST analysis and reports these sites as
+*"udf-boundary (sanctioned)"*.
+
+```python
+# ✅ SANCTIONED — no lazy_audit.toml entry needed
+@daft.cls()
+class Stepper:
+    @daft.method.batch(return_dtype=_STATE_STRUCT)
+    def step(self, cart_pos: Series, pole_angle: Series) -> Series:
+        cp = cart_pos.to_pylist()   # ← sanctioned: param of @daft.method.batch
+        pa = pole_angle.to_pylist() # ← sanctioned: param of @daft.method.batch
+        ...
+
+# ❌ GATED — requires a lazy_audit.toml entry with a specific technical reason
+def query_rows(df):
+    return df.to_pylist()  # ← DataFrame-level; still audited
+```
+
+Rules:
+- ``Series.to_pylist()`` on a **batch-UDF parameter** → exempt, no entry.
+- ``DataFrame.to_pylist()`` anywhere → requires entry.
+- ``DataFrame.collect()`` anywhere → requires entry.
+- ``Series.to_pylist()`` **outside** a batch-UDF → requires entry.
+- ``collect()`` inside a batch-UDF on a DataFrame (not a parameter) → requires entry.
+
+See ``lazy_audit.toml`` for the authoritative policy header and
+``tests/scripts/test_check_lazy_audit.py`` for positive/negative coverage.
+
+---
+
 ## Agent Communication: Messaging Pipeline (Mar 2026)
 
 Agent-to-agent messaging is processor-driven, not broker-driven.

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -12,6 +12,17 @@
 #
 # Scope: src/ only. Tests are exempt — terminal materialization at the
 # assertion boundary is expected and not part of the audited contract.
+#
+# **Sanctioned exemption — batch-UDF Series access**
+#
+# Series.to_pylist() called on a *parameter* of a function decorated
+# with @daft.method.batch or @daft.func.batch does NOT need an entry
+# here. When Daft invokes such a function the batch is already
+# materialised by the executor — converting parameters to Python lists
+# is the expected interface at that boundary. The checker detects this
+# pattern via AST analysis and reports these sites separately as
+# "udf-boundary (sanctioned)". See scripts/check_lazy_audit.py for
+# the full detection logic.
 
 [[entries]]
 path = "src/archetype/api/models.py"
@@ -66,123 +77,3 @@ path = "src/archetype/app/autoresearch_service.py"
 line = 313
 method = "to_pylist"
 reason = "Single-row loop-state extract: the latest BranchHead row must enter Python control flow (incumbent score comparison, head entity id for the next update) at the autoresearch loop boundary; the comparison drives imperative orchestration, not a further dataframe computation."
-
-[[entries]]
-path = "src/archetype/experiments/mujoco_cartpole.py"
-line = 116
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary: the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; MuJoCo's mj_step is a stateful C call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/mujoco_cartpole.py"
-line = 117
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary (pole_angle input column); same batch-UDF executor boundary as line 99."
-
-[[entries]]
-path = "src/archetype/experiments/mujoco_cartpole.py"
-line = 118
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary (cart_vel input column); same batch-UDF executor boundary as line 99."
-
-[[entries]]
-path = "src/archetype/experiments/mujoco_cartpole.py"
-line = 119
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the MuJoCo C-library boundary (pole_vel input column); same batch-UDF executor boundary as line 99."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 144
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (env_key input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 145
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (action input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 147
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (eef_pos input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 148
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (eef_quat input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 149
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (gripper input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 150
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (reward input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 151
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (done input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 152
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (success input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/manipulation.py"
-line = 153
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the external-simulator RPC boundary (env_step input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; the env step is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/policy.py"
-line = 91
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (env_key input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/policy.py"
-line = 92
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (instruction input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/policy.py"
-line = 93
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (eef_pos input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/policy.py"
-line = 94
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (eef_quat input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/policy.py"
-line = 95
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (gripper input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/policy.py"
-line = 96
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (done input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."
-
-[[entries]]
-path = "src/archetype/experiments/policy.py"
-line = 97
-method = "to_pylist"
-reason = "Series->Python conversion inside a @daft.method.batch UDF at the policy-inference boundary (prev_action input column): the executor has already materialised this batch to invoke the UDF, so this is per-batch Series access, not a DataFrame collect; policy inference is a remote stateful call that cannot be expressed as a Daft expression."

--- a/scripts/check_lazy_audit.py
+++ b/scripts/check_lazy_audit.py
@@ -24,6 +24,30 @@ gates them against ``lazy_audit.toml``. New, undocumented sites cause a
 non-zero exit; stale entries (allowlisted lines that no longer hold a
 matching call) are also surfaced so the audit stays honest under refactors.
 
+**UDF-boundary exemption (sanctioned pattern)**
+
+``Series.to_pylist()`` called on a *parameter* of a function decorated with
+``@daft.method.batch`` or ``@daft.func.batch`` is the sanctioned escape hatch
+at the executor boundary.  When Daft invokes such a function the batch is
+already materialised — the executor hands each parameter as a concrete
+``Series``.  Converting those parameters to Python lists is therefore not a
+premature materialisation; it is the expected interface.
+
+The checker detects this pattern via AST analysis:
+
+- Parse each file into an AST.
+- Walk all function definitions (``FunctionDef`` / ``AsyncFunctionDef``).
+- If the function has a decorator that resolves to ``daft.method.batch`` or
+  ``daft.func.batch`` (direct attribute access or aliased import — the common
+  forms are handled; pathological aliasing is not), collect the parameter
+  names as the *batch-scope parameter set*.
+- A ``.to_pylist()`` call whose receiver is one of those parameters is
+  classified as **udf-boundary (sanctioned)** and reported separately.  It
+  does not need an entry in ``lazy_audit.toml``.
+
+``DataFrame.collect()`` and ``DataFrame.to_pylist()`` anywhere, and
+``Series.to_pylist()`` *outside* batch-UDF scope, still require entries.
+
 Tests are intentionally out of scope: terminal materialization at the
 assertion boundary is expected. The contract being audited is the
 production execution model, not test ergonomics.
@@ -34,6 +58,7 @@ Run via ``make lazy-audit`` or as a pre-commit hook.
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import sys
 import tomllib
@@ -59,6 +84,7 @@ class Site:
     line: int
     method: str
     snippet: str
+    sanctioned: bool = False  # True → udf-boundary, no allowlist entry needed
 
 
 @dataclass(frozen=True)
@@ -73,19 +99,134 @@ def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+# ---------------------------------------------------------------------------
+# AST-based batch-UDF scope detection
+# ---------------------------------------------------------------------------
+
+_BATCH_DECORATOR_ATTRS = frozenset(
+    {
+        # @daft.method.batch  →  Attribute(Attribute(Name("daft"), "method"), "batch")
+        ("daft", "method", "batch"),
+        # @daft.func.batch  →  Attribute(Attribute(Name("daft"), "func"), "batch")
+        ("daft", "func", "batch"),
+    }
+)
+
+
+def _decorator_attr_chain(node: ast.expr) -> tuple[str, ...]:
+    """Return the dotted attribute chain for a decorator node, innermost last.
+
+    Handles plain ``Name``, ``Attribute``, and ``Call`` (e.g. ``@daft.cls()``).
+    Returns an empty tuple for anything too complex to classify.
+    """
+    if isinstance(node, ast.Call):
+        node = node.func
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    parts.reverse()
+    return tuple(parts)
+
+
+def _is_batch_decorator(node: ast.expr) -> bool:
+    chain = _decorator_attr_chain(node)
+    return chain in _BATCH_DECORATOR_ATTRS
+
+
+def _collect_batch_udf_param_lines(source: str) -> dict[int, frozenset[str]]:
+    """Return a mapping of {line_number: frozenset_of_param_names} for every
+    line inside a batch-UDF function body.
+
+    ``line_number`` ranges over every line from the first line of the function
+    body up to and including the last line, so callers can do a simple
+    ``line in line_to_params`` check.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+
+    line_to_params: dict[int, frozenset[str]] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not any(_is_batch_decorator(d) for d in node.decorator_list):
+            continue
+
+        # Collect parameter names (skip 'self' — it is not a Series param).
+        params: frozenset[str] = frozenset(
+            a.arg for a in node.args.args if a.arg != "self"
+        )
+        if not params:
+            continue
+
+        # Determine body line range.
+        body_lines = [
+            lineno
+            for child in ast.walk(node)
+            for lineno in ([child.lineno] if hasattr(child, "lineno") else [])
+        ]
+        if not body_lines:
+            continue
+        first_body = min(body_lines)
+        last_body = max(body_lines)
+        for ln in range(first_body, last_body + 1):
+            line_to_params[ln] = params
+
+    return line_to_params
+
+
+def _call_receiver_name(source_line: str) -> str | None:
+    """Heuristically extract the receiver name from a line like ``foo.to_pylist()``.
+
+    Returns the bare name before the last ``.method(`` or None if ambiguous.
+    This is good enough for the common ``param.to_pylist()`` pattern.
+    """
+    # Strip leading whitespace and find last occurrence of ``<name>.to_pylist``
+    # or ``<name>.collect``.
+    m = re.search(r"\b(\w+)\.(to_pylist|collect)\s*\(", source_line)
+    if m:
+        return m.group(1)
+    return None
+
+
 def _scan_file(path: Path, rel: str) -> list[Site]:
     sites: list[Site] = []
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return sites
-    for n, raw in enumerate(text.splitlines(), start=1):
+
+    # Build batch-UDF param map once per file (AST parse).
+    batch_line_params = _collect_batch_udf_param_lines(text)
+
+    lines = text.splitlines()
+    for n, raw in enumerate(lines, start=1):
         stripped = raw.lstrip()
         if stripped.startswith("#"):
             continue
         for method, pat in PATTERNS:
-            if pat.search(raw):
-                sites.append(Site(path=rel, line=n, method=method, snippet=stripped))
+            if not pat.search(raw):
+                continue
+            # Determine if this is a sanctioned UDF-boundary access.
+            sanctioned = False
+            if method == "to_pylist" and n in batch_line_params:
+                receiver = _call_receiver_name(raw)
+                if receiver and receiver in batch_line_params[n]:
+                    sanctioned = True
+            sites.append(
+                Site(
+                    path=rel,
+                    line=n,
+                    method=method,
+                    snippet=stripped,
+                    sanctioned=sanctioned,
+                )
+            )
     return sites
 
 
@@ -177,6 +318,15 @@ the exception must be documented in writing and visible in code review:
   * The new entry must be called out in the PR description or as a PR
     comment so a human reviewer signs off on the exception explicitly.
 
+**Sanctioned exemption — batch-UDF Series access**
+
+Series.to_pylist() called on a *parameter* of a function decorated with
+@daft.method.batch or @daft.func.batch does NOT require an allowlist
+entry. Daft has already materialised the batch before calling the
+function; converting parameters to Python lists is the expected interface
+at the executor boundary. These sites are reported separately as
+"udf-boundary (sanctioned)".
+
 Quietly adding entries to silence this check is itself a signal that
 the change is gaming the lazy-evaluation contract. PRs that do this
 will be reverted at review.
@@ -209,7 +359,8 @@ def main() -> int:
 
     if "--list" in sys.argv:
         for s in sites:
-            print(f"{s.path}:{s.line}  .{s.method}()  {s.snippet}")
+            tag = " [udf-boundary]" if s.sanctioned else ""
+            print(f"{s.path}:{s.line}  .{s.method}(){tag}  {s.snippet}")
         return 0
 
     allow, allow_err = load_allowlist(root)
@@ -219,7 +370,11 @@ def main() -> int:
         print(STERN_BODY, file=sys.stderr)
         return 2
 
-    site_keys = {(s.path, s.line, s.method): s for s in sites}
+    # Sanctioned sites never need an allowlist entry.
+    audited_sites = [s for s in sites if not s.sanctioned]
+    sanctioned_sites = [s for s in sites if s.sanctioned]
+
+    site_keys = {(s.path, s.line, s.method): s for s in audited_sites}
     allow_keys = {(e.path, e.line, e.method): e for e in allow}
 
     new_sites = [site_keys[k] for k in site_keys.keys() - allow_keys.keys()]
@@ -230,8 +385,17 @@ def main() -> int:
     stale_entries.sort(key=lambda e: (e.path, e.line))
     weak_reasons.sort(key=lambda e: (e.path, e.line))
 
+    # Always print sanctioned summary for visibility.
+    if sanctioned_sites:
+        print(
+            f"lazy audit: {len(sanctioned_sites)} udf-boundary site(s) exempt "
+            f"(sanctioned @daft.method.batch / @daft.func.batch parameter access)."
+        )
+
     if not (new_sites or stale_entries or weak_reasons):
-        print(f"lazy audit: {len(sites)} site(s), all accounted for.")
+        print(
+            f"lazy audit: {len(audited_sites)} audited site(s), all accounted for."
+        )
         return 0
 
     print(STERN_HEADER, file=sys.stderr)

--- a/tests/scripts/test_check_lazy_audit.py
+++ b/tests/scripts/test_check_lazy_audit.py
@@ -1,0 +1,327 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for scripts/check_lazy_audit.py — AST scope detection.
+
+Covers the two key policy assertions:
+
+1. **Positive (sanctioned):** ``Series.to_pylist()`` on a parameter of a
+   ``@daft.method.batch`` / ``@daft.func.batch`` decorated function is
+   detected as *udf-boundary* and does NOT require an allowlist entry.
+
+2. **Negative (gated):** A plain ``df.to_pylist()`` at module scope (or
+   outside a batch-UDF) is still flagged as an audited site that requires
+   an allowlist entry.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+# Make scripts/ importable without installing it as a package.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from check_lazy_audit import (  # noqa: E402
+    _collect_batch_udf_param_lines,
+    _scan_file,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_py(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(source), encoding="utf-8")
+    return p
+
+
+def _write_toml(tmp_path: Path, entries: list[dict]) -> Path:
+    lines: list[str] = [
+        "# Lazy-evaluation audit allowlist (test fixture).",
+        "#",
+        "# Each entry documents an exception to Archetype's lazy execution contract.",
+        "",
+    ]
+    for e in entries:
+        lines.append("[[entries]]")
+        for k, v in e.items():
+            lines.append(f"{k} = {v!r}")
+        lines.append("")
+    p = tmp_path / "lazy_audit.toml"
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Unit: _collect_batch_udf_param_lines
+# ---------------------------------------------------------------------------
+
+
+def test_method_batch_params_detected():
+    """Parameters of @daft.method.batch functions are collected."""
+    source = textwrap.dedent("""\
+        import daft
+        from daft import Series
+
+        @daft.cls()
+        class Stepper:
+            @daft.method.batch(return_dtype=None)
+            def step(self, cart_pos: Series, pole_angle: Series) -> Series:
+                cp = cart_pos.to_pylist()
+                pa = pole_angle.to_pylist()
+                return Series.from_pylist([])
+    """)
+    mapping = _collect_batch_udf_param_lines(source)
+    # Lines 8 and 9 are inside the method body; params exclude "self".
+    assert mapping, "should detect at least one body line"
+    param_sets = list(mapping.values())
+    assert all("cart_pos" in ps for ps in param_sets)
+    assert all("pole_angle" in ps for ps in param_sets)
+    assert all("self" not in ps for ps in param_sets)
+
+
+def test_func_batch_params_detected():
+    """Parameters of @daft.func.batch functions are collected."""
+    source = textwrap.dedent("""\
+        import daft
+        from daft import Series
+
+        @daft.func.batch(return_dtype=None)
+        def process(values: Series) -> Series:
+            data = values.to_pylist()
+            return Series.from_pylist(data)
+    """)
+    mapping = _collect_batch_udf_param_lines(source)
+    assert mapping
+    assert all("values" in ps for ps in mapping.values())
+
+
+def test_non_batch_function_not_detected():
+    """Regular (non-batch) functions do not appear in the mapping."""
+    source = textwrap.dedent("""\
+        def regular(values):
+            return values.to_pylist()
+    """)
+    mapping = _collect_batch_udf_param_lines(source)
+    assert not mapping, "regular functions must not be detected as batch-UDF scope"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _scan_file — sanctioned sites are marked
+# ---------------------------------------------------------------------------
+
+
+def test_batch_udf_series_access_is_sanctioned(tmp_path):
+    """Series.to_pylist() on a batch-UDF parameter → sanctioned=True."""
+    py = _write_py(
+        tmp_path,
+        "sanctioned.py",
+        """\
+        import daft
+        from daft import Series
+
+        @daft.cls()
+        class Stepper:
+            @daft.method.batch(return_dtype=None)
+            def step(self, cart_pos: Series, pole_angle: Series) -> Series:
+                cp = cart_pos.to_pylist()
+                pa = pole_angle.to_pylist()
+                return Series.from_pylist([])
+        """,
+    )
+    sites = _scan_file(py, "sanctioned.py")
+    assert sites, "should detect .to_pylist() calls"
+    for s in sites:
+        assert s.sanctioned, (
+            f"Line {s.line} should be sanctioned (inside batch-UDF scope), got sanctioned=False"
+        )
+
+
+def test_module_level_to_pylist_is_not_sanctioned(tmp_path):
+    """DataFrame.to_pylist() at module scope → sanctioned=False."""
+    py = _write_py(
+        tmp_path,
+        "bad.py",
+        """\
+        import daft
+
+        df = daft.from_pydict({"x": [1, 2, 3]})
+        rows = df.to_pylist()  # plain DataFrame materialization
+        """,
+    )
+    sites = _scan_file(py, "bad.py")
+    assert sites, "should detect .to_pylist() call"
+    for s in sites:
+        assert not s.sanctioned, (
+            f"Line {s.line} must NOT be sanctioned (module-level df.to_pylist())"
+        )
+
+
+def test_collect_is_never_sanctioned(tmp_path):
+    """Only .to_pylist() on batch-UDF params is sanctioned; .collect() never is."""
+    py = _write_py(
+        tmp_path,
+        "collect_test.py",
+        """\
+        import daft
+        from daft import Series
+
+        @daft.cls()
+        class X:
+            @daft.method.batch(return_dtype=None)
+            def go(self, s: Series) -> Series:
+                # .collect() inside a batch-UDF is still not sanctioned
+                df2 = daft.from_pydict({"y": [1]})
+                df2.collect()
+                return s
+        """,
+    )
+    sites = _scan_file(py, "collect_test.py")
+    collect_sites = [s for s in sites if s.method == "collect"]
+    assert collect_sites, "should detect .collect()"
+    for s in collect_sites:
+        assert not s.sanctioned, ".collect() must never be sanctioned"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full scan + allowlist gating
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_src(tmp_path: Path) -> Path:
+    """Create a minimal fake src/ tree with one sanctioned and one gated site."""
+    src = tmp_path / "src" / "mypkg"
+    src.mkdir(parents=True)
+
+    # Sanctioned: Series param inside @daft.method.batch
+    _write_py(
+        src,
+        "udf_module.py",
+        """\
+        import daft
+        from daft import Series
+
+        @daft.cls()
+        class Worker:
+            @daft.method.batch(return_dtype=None)
+            def run(self, items: Series) -> Series:
+                data = items.to_pylist()
+                return Series.from_pylist(data)
+        """,
+    )
+
+    # Gated: plain DataFrame.to_pylist() — needs an allowlist entry
+    _write_py(
+        src,
+        "boundary_module.py",
+        """\
+        import daft
+
+        def query_rows():
+            df = daft.from_pydict({"x": [1]})
+            return df.to_pylist()  # genuine DataFrame materialisation
+        """,
+    )
+
+    return tmp_path
+
+
+def test_full_scan_sanctioned_exempt(tmp_path):
+    """Sanctioned sites are exempt; the gated site requires an entry."""
+    fake_root = _make_fake_src(tmp_path)
+
+    # Patch _project_root inside check_lazy_audit so scan() looks in our fake tree.
+    import check_lazy_audit as mod
+
+    orig_root = mod._project_root
+
+    def patched_root():
+        return fake_root
+
+    mod._project_root = patched_root  # type: ignore[method-assign]
+    try:
+        sites = mod.scan(fake_root)
+    finally:
+        mod._project_root = orig_root  # type: ignore[method-assign]
+
+    sanctioned = [s for s in sites if s.sanctioned]
+    gated = [s for s in sites if not s.sanctioned]
+
+    assert sanctioned, "batch-UDF param access must be classified sanctioned"
+    assert gated, "module-level to_pylist must be classified as needing allowlist"
+
+
+def test_full_scan_with_allowlist_passes(tmp_path):
+    """When the gated site has an allowlist entry the audit exits 0."""
+    fake_root = _make_fake_src(tmp_path)
+
+    # Write an allowlist that covers the gated boundary_module.py site.
+    # The fake scan will find it at line 5.
+    _write_toml(
+        fake_root,
+        [
+            {
+                "path": "src/mypkg/boundary_module.py",
+                "line": 5,
+                "method": "to_pylist",
+                "reason": "Terminal query result returned to caller; cannot remain lazy past function boundary.",
+            }
+        ],
+    )
+
+    import check_lazy_audit as mod
+
+    orig_root = mod._project_root
+
+    def patched_root():
+        return fake_root
+
+    mod._project_root = patched_root  # type: ignore[method-assign]
+    try:
+        sites = mod.scan(fake_root)
+        allow, err = mod.load_allowlist(fake_root)
+
+        assert err is None
+        audited = [s for s in sites if not s.sanctioned]
+        site_keys = {(s.path, s.line, s.method) for s in audited}
+        allow_keys = {(e.path, e.line, e.method) for e in allow}
+        new_sites = site_keys - allow_keys
+        stale = allow_keys - site_keys
+        assert not new_sites, f"unexpected new sites: {new_sites}"
+        assert not stale, f"unexpected stale entries: {stale}"
+    finally:
+        mod._project_root = orig_root  # type: ignore[method-assign]
+
+
+def test_missing_allowlist_entry_fails(tmp_path):
+    """A gated site with no allowlist entry is detected (new_sites non-empty)."""
+    fake_root = _make_fake_src(tmp_path)
+    # Write an *empty* allowlist — the gated site has no entry.
+    _write_toml(fake_root, [])
+
+    import check_lazy_audit as mod
+
+    orig_root = mod._project_root
+
+    def patched_root():
+        return fake_root
+
+    mod._project_root = patched_root  # type: ignore[method-assign]
+    try:
+        sites = mod.scan(fake_root)
+        allow, err = mod.load_allowlist(fake_root)
+
+        assert err is None
+        audited = [s for s in sites if not s.sanctioned]
+        site_keys = {(s.path, s.line, s.method) for s in audited}
+        allow_keys = {(e.path, e.line, e.method) for e in allow}
+        new_sites = site_keys - allow_keys
+        assert new_sites, "boundary_module.py gated site must be flagged as missing"
+    finally:
+        mod._project_root = orig_root  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

- **AST scope detection**: `scripts/check_lazy_audit.py` now detects `Series.to_pylist()` calls on parameters of `@daft.method.batch` / `@daft.func.batch` decorated functions and classifies them as *udf-boundary (sanctioned)* — exempt from the allowlist.
- **Allowlist pruned**: 20 entries covering `mujoco_cartpole.py`, `manipulation.py`, and `policy.py` removed; the 9 genuine DataFrame-level boundaries remain with their reasons intact.
- **Docs updated**: `lazy_audit.toml` policy header and `LEARNINGS.md` both document the batch-UDF exemption and the precise rules.
- **Tests added**: `tests/scripts/test_check_lazy_audit.py` — 9 tests covering the AST detection unit, positive case (sanctioned batch-UDF param access passes entry-free), and negative case (module-level `df.to_pylist()` still fails).

## What the Codex gate should scrutinize

1. **AST correctness**: does `_collect_batch_udf_param_lines` correctly identify `@daft.method.batch` and `@daft.func.batch` decorators, including the `Call`-wrapped form (e.g. `@daft.method.batch(return_dtype=...)`)?
2. **Receiver heuristic**: `_call_receiver_name` uses a regex to extract the name before `.to_pylist()`. Is this sufficient or does it risk false positives on complex expressions like `obj.attr.to_pylist()`?
3. **Pruned entries**: verify the 20 removed entries all correspond to genuine `@daft.method.batch` parameter accesses in `mujoco_cartpole.py:104-119`, `manipulation.py:131-153`, `policy.py:80-97`.
4. **No new lazy-audit entries**: this PR introduces no new `[[entries]]` blocks.

## Test plan

- [x] `uv run pytest tests/scripts/test_check_lazy_audit.py -v` — 9 passed
- [x] `make ci` — 641 tests, 82.86% coverage, lazy audit green, eval gate green
- [x] `make check` — lint + format clean
- [x] Deliberate negative: module-level `df.to_pylist()` in a synthetic file → still flagged
- [x] Deliberate positive: batch-UDF `Series.to_pylist()` → classified sanctioned, no entry needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)