### PR TITLE
feat(ζ1b/C3): Phase-6 migration-gate suite + mid-run-spawn bench

### DIFF
--- a/crates/archetype-bench/src/bin/mid_run_spawn.rs
+++ b/crates/archetype-bench/src/bin/mid_run_spawn.rs
@@ -1,0 +1,244 @@
+//! Mid-run-spawn benchmark scenario.
+//!
+//! Exercises the tick-zero-correct spawn ordering with entities that arrive
+//! at different ticks during the simulation, providing a fair performance
+//! comparison against the all-at-start scenario in `movement_compare`.
+//!
+//! Timeline:
+//!   tick 0:       entities 0..initial_entities spawn raw (x₀ preserved).
+//!   tick spawn_at: entities initial_entities..total_entities spawn mid-run raw.
+//!   Final tick (ticks-1): all surviving entities have been processed correctly.
+//!
+//! Correctness check (tick-zero contract):
+//!   An entity spawned at tick T with initial value xᵢ should have value
+//!   xᵢ + (final_tick - T) * dt at the final tick, because processors first
+//!   apply on tick T+1.
+//!
+//!   early  entities (spawn tick 0):  xᵢ + (ticks-1) * dt
+//!   late   entities (spawn tick S):  xᵢ + (ticks-1-S) * dt
+//!
+//! The benchmark reports correctness fields alongside timing so results
+//! cannot be considered valid unless `correct` is true.
+
+use std::env;
+use std::sync::Arc;
+use std::time::Instant;
+
+use archetype_core::archetype::ArchetypeTable;
+use archetype_core::processors::movement::MovementProcessor;
+use archetype_core::{AsyncSystem, AsyncWorld, ReadFilter};
+use archetype_parquet::ParquetStore;
+use arrow_array::{Array, ArrayRef, Float64Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use serde_json::json;
+
+fn component_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("position__x", DataType::Float64, false),
+        Field::new("position__y", DataType::Float64, false),
+        Field::new("velocity__dx", DataType::Float64, false),
+        Field::new("velocity__dy", DataType::Float64, false),
+    ]))
+}
+
+fn spawn_batch(component_schema: SchemaRef, start_idx: usize, count: usize) -> RecordBatch {
+    let x: Vec<f64> = (start_idx..start_idx + count).map(|i| i as f64).collect();
+    RecordBatch::try_new(
+        component_schema,
+        vec![
+            Arc::new(Float64Array::from(x)) as ArrayRef,
+            Arc::new(Float64Array::from(vec![0.0; count])) as ArrayRef,
+            Arc::new(Float64Array::from(vec![1.0; count])) as ArrayRef,
+            Arc::new(Float64Array::from(vec![-0.5; count])) as ArrayRef,
+        ],
+    )
+    .unwrap()
+}
+
+fn float64_sum(batch: &RecordBatch, column_name: &str) -> f64 {
+    let values = batch
+        .column(batch.schema().index_of(column_name).unwrap())
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    (0..batch.num_rows())
+        .filter(|idx| !values.is_null(*idx))
+        .map(|idx| values.value(idx))
+        .sum()
+}
+
+#[tokio::main]
+async fn main() {
+    // Defaults: 1 000 initial entities, 200 late-spawn entities, spawn at tick 2, 5 ticks total.
+    let mut initial_entities = 1000usize;
+    let mut late_entities = 200usize;
+    let mut spawn_at_tick = 2i32;
+    let mut ticks = 5i32;
+    let mut root = env::temp_dir().join(format!(
+        "archetype-rust-mid-run-spawn-{}",
+        std::process::id()
+    ));
+
+    let mut args = env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--initial-entities" => initial_entities = args.next().unwrap().parse().unwrap(),
+            "--late-entities" => late_entities = args.next().unwrap().parse().unwrap(),
+            "--spawn-at-tick" => spawn_at_tick = args.next().unwrap().parse().unwrap(),
+            "--ticks" => ticks = args.next().unwrap().parse().unwrap(),
+            "--root" => root = args.next().unwrap().into(),
+            _ => panic!("unknown argument: {arg}"),
+        }
+    }
+
+    assert!(
+        spawn_at_tick < ticks,
+        "--spawn-at-tick ({spawn_at_tick}) must be less than --ticks ({ticks})"
+    );
+
+    let total_entities = initial_entities + late_entities;
+    let store = ParquetStore::new(&root, "mid_run_spawn_bench");
+    let table = ArchetypeTable::new("position_velocity", component_schema()).unwrap();
+
+    let setup_start = Instant::now();
+    let mut system = AsyncSystem::new();
+    system.add_processor(MovementProcessor { dt: 1.0 });
+    let mut world = AsyncWorld::from_ids("mid-run-world", "mid-run-run", store, system);
+
+    // Spawn initial entities at tick 0.
+    let initial_batch = spawn_batch(component_schema(), 0, initial_entities);
+    world.queue_spawn_batch(&table, initial_batch).unwrap();
+    let setup_sec = setup_start.elapsed().as_secs_f64();
+
+    let run_start = Instant::now();
+    let mut read_prior_sec = 0.0;
+    let mut materialize_sec = 0.0;
+    let mut process_sec = 0.0;
+    let mut append_sec = 0.0;
+    let mut live_snapshot_sec = 0.0;
+    let mut profiled_tick_sec = 0.0;
+
+    for tick in 0..ticks {
+        if tick == spawn_at_tick {
+            // Mid-run spawn: these entities land raw this tick; processor
+            // first applies on tick (spawn_at_tick + 1).
+            let late_batch = spawn_batch(component_schema(), initial_entities, late_entities);
+            world.queue_spawn_batch(&table, late_batch).unwrap();
+        }
+
+        let profile = world.step_profiled().await.unwrap();
+        profiled_tick_sec += profile.tick_sec;
+        for table_profile in profile.tables {
+            read_prior_sec += table_profile.read_prior_sec;
+            materialize_sec += table_profile.materialize_sec;
+            process_sec += table_profile.process_sec;
+            append_sec += table_profile.append_sec;
+            live_snapshot_sec += table_profile.live_snapshot_sec;
+        }
+    }
+    let run_sec = run_start.elapsed().as_secs_f64();
+
+    let query_start = Instant::now();
+    let final_batches = world
+        .query_table(
+            table.table_name(),
+            ReadFilter {
+                ticks: Some(vec![ticks - 1]),
+                active_only: true,
+                ..ReadFilter::default()
+            },
+        )
+        .await
+        .unwrap();
+    let rows = final_batches.iter().map(|b| b.num_rows()).sum::<usize>();
+    let sum_position_x = final_batches
+        .iter()
+        .map(|b| float64_sum(b, "position__x"))
+        .sum::<f64>();
+    let sum_position_y = final_batches
+        .iter()
+        .map(|b| float64_sum(b, "position__y"))
+        .sum::<f64>();
+    let query_sec = query_start.elapsed().as_secs_f64();
+
+    // Tick-zero contract correctness check.
+    //
+    // Early entities (spawn tick 0): position__x[i] = i + (ticks-1) * dt
+    // Late  entities (spawn tick S): position__x[i] = i + (ticks-1-S) * dt
+    //
+    // sum_x (early) = Σ_{i=0}^{n_e - 1}  i  +  n_e * (ticks-1) * dt
+    //               = n_e*(n_e-1)/2          +  n_e * (ticks-1)
+    //
+    // sum_x (late)  = Σ_{i=n_e}^{n_tot-1} i  +  n_l * (ticks-1-S) * dt
+    //               = n_l*(2*n_e + n_l - 1)/2  +  n_l * (ticks-1-S)
+    //
+    // sum_y = n_e * (ticks-1) * dy  +  n_l * (ticks-1-S) * dy
+    //       (dy = -0.5)
+    let n_e = initial_entities as f64;
+    let n_l = late_entities as f64;
+    let n_tot = total_entities as f64;
+    let t_final = (ticks - 1) as f64;
+    let t_late_steps = (ticks - 1 - spawn_at_tick) as f64; // steps applied to late entities
+    let _ = n_tot;
+
+    // sum_x for early entities: Σi for i in 0..n_e + n_e * t_final
+    let expected_sum_x_early = n_e * (n_e - 1.0) / 2.0 + n_e * t_final;
+    // sum_x for late entities: Σi for i in n_e..n_e+n_l + n_l * t_late_steps
+    let expected_sum_x_late = n_l * (2.0 * n_e + n_l - 1.0) / 2.0 + n_l * t_late_steps;
+    let expected_sum_x = expected_sum_x_early + expected_sum_x_late;
+
+    // sum_y for early: n_e * t_final * dy
+    let expected_sum_y_early = n_e * t_final * -0.5;
+    // sum_y for late: n_l * t_late_steps * dy
+    let expected_sum_y_late = n_l * t_late_steps * -0.5;
+    let expected_sum_y = expected_sum_y_early + expected_sum_y_late;
+
+    let sum_x_abs_error = (sum_position_x - expected_sum_x).abs();
+    let sum_y_abs_error = (sum_position_y - expected_sum_y).abs();
+    let correct = rows == total_entities && sum_x_abs_error < 1e-9 && sum_y_abs_error < 1e-9;
+
+    println!(
+        "{}",
+        json!({
+            "backend": "rust-arrow-parquet-mid-run-spawn",
+            "scenario": "mid_run_spawn",
+            "initial_entities": initial_entities,
+            "late_entities": late_entities,
+            "total_entities": total_entities,
+            "ticks": ticks,
+            "spawn_at_tick": spawn_at_tick,
+            "rows": rows,
+            "setup_sec": setup_sec,
+            "run_sec": run_sec,
+            "query_sec": query_sec,
+            "total_sec": setup_sec + run_sec + query_sec,
+            "phases_sec": {
+                "setup": setup_sec,
+                "run": run_sec,
+                "read_prior": read_prior_sec,
+                "materialize": materialize_sec,
+                "process": process_sec,
+                "append": append_sec,
+                "live_snapshot": live_snapshot_sec,
+                "profiled_tick": profiled_tick_sec,
+                "query": query_sec,
+                "total": setup_sec + run_sec + query_sec,
+            },
+            "correctness": {
+                "expected_rows": total_entities,
+                "rows_match": rows == total_entities,
+                "sum_position_x": sum_position_x,
+                "sum_position_y": sum_position_y,
+                "expected_sum_position_x": expected_sum_x,
+                "expected_sum_position_y": expected_sum_y,
+                "sum_x_abs_error": sum_x_abs_error,
+                "sum_y_abs_error": sum_y_abs_error,
+                "position_sums_match": sum_x_abs_error < 1e-9 && sum_y_abs_error < 1e-9,
+                "correct": correct,
+            },
+            "correct": correct,
+        })
+    );
+
+    assert!(correct, "mid-run-spawn correctness check failed");
+}

--- a/crates/archetype-core/tests/migration_gate.rs
+++ b/crates/archetype-core/tests/migration_gate.rs
@@ -1,0 +1,666 @@
+//! Phase-6 entry gate: migration contract suite.
+//!
+//! Every behavioral contract the Python async reference pins is encoded here,
+//! one test per contract, annotated with the mirroring Python test.  Gaps
+//! where the Rust kernel has no implementation yet are marked `#[ignore]`
+//! with a rationale rather than omitted.
+//!
+//! Contract areas covered (in order):
+//!
+//! 1. x₀ raw at spawn tick / f applied next tick  (first and mid-run)
+//! 2. Same-tick spawn-cancel: no tombstone, no active row
+//! 3. Spawn materialization order deterministic (first-seen, last-write-wins)
+//! 4. Despawn: tombstone at current tick; active_only reads exclude it
+//! 5. Update / overlay semantics  [#[ignore] — not yet implemented in kernel]
+//! 6. Metadata stamping (world/run/tick) on every persisted row
+//!
+//! Python reference:
+//!   tests/core/test_initial_conditions_contract.py   — contracts 1, 6
+//!   tests/core/test_async_world_duplicate_spawn_overwrite.py — contract 3
+//!   crates/archetype-core/src/aio/async_world.rs (inline tests) — contracts 2, 4
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use arrow_array::{BooleanArray, Float64Array, Int32Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use arrow_select::filter::filter_record_batch;
+use async_trait::async_trait;
+
+use archetype_core::aio::async_processor::{Processor, ProcessorContext};
+use archetype_core::aio::async_store::{ReadFilter, Store};
+use archetype_core::aio::async_system::AsyncSystem;
+use archetype_core::aio::async_world::AsyncWorld;
+use archetype_core::archetype::{ArchetypeTable, ENTITY_ID, IS_ACTIVE, RUN_ID, TICK, WORLD_ID};
+use archetype_core::{EntityId, Result};
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+fn position_table() -> ArchetypeTable {
+    let component = Arc::new(Schema::new(vec![Field::new(
+        "position__x",
+        DataType::Float64,
+        false,
+    )]));
+    ArchetypeTable::new("position", component).unwrap()
+}
+
+fn component_batch(x_values: &[f64]) -> RecordBatch {
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "position__x",
+            DataType::Float64,
+            false,
+        )])),
+        vec![Arc::new(Float64Array::from(x_values.to_vec()))],
+    )
+    .unwrap()
+}
+
+fn entity_ids(batch: &RecordBatch) -> Vec<i32> {
+    let col = batch
+        .column(batch.schema().index_of(ENTITY_ID).unwrap())
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    (0..batch.num_rows()).map(|i| col.value(i)).collect()
+}
+
+fn x_values(batch: &RecordBatch) -> Vec<f64> {
+    let col = batch
+        .column(batch.schema().index_of("position__x").unwrap())
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    (0..batch.num_rows()).map(|i| col.value(i)).collect()
+}
+
+fn active_flags(batch: &RecordBatch) -> Vec<bool> {
+    let col = batch
+        .column(batch.schema().index_of(IS_ACTIVE).unwrap())
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .unwrap();
+    (0..batch.num_rows()).map(|i| col.value(i)).collect()
+}
+
+fn tick_values(batch: &RecordBatch) -> Vec<i32> {
+    let col = batch
+        .column(batch.schema().index_of(TICK).unwrap())
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    (0..batch.num_rows()).map(|i| col.value(i)).collect()
+}
+
+// ── In-memory ledger store ────────────────────────────────────────────────────
+//
+// Persists every append; filters by tick and active status on read.  Used in
+// contract tests that need to inspect the full historical ledger.
+
+#[derive(Clone, Default)]
+struct LedgerStore {
+    ledger: Arc<Mutex<Vec<(String, RecordBatch)>>>,
+}
+
+#[async_trait]
+impl Store for LedgerStore {
+    async fn append(&self, table_name: &str, batch: &RecordBatch) -> Result<()> {
+        self.ledger
+            .lock()
+            .unwrap()
+            .push((table_name.to_string(), batch.clone()));
+        Ok(())
+    }
+
+    async fn read_table(&self, table_name: &str, filter: ReadFilter) -> Result<Vec<RecordBatch>> {
+        let ledger = self.ledger.lock().unwrap();
+        let mut result = Vec::new();
+        for (tname, batch) in ledger.iter() {
+            if tname != table_name {
+                continue;
+            }
+            if let Some(ticks) = &filter.ticks {
+                let tick_col = batch
+                    .column(batch.schema().index_of(TICK).unwrap())
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap();
+                let has_tick = (0..batch.num_rows()).any(|i| ticks.contains(&tick_col.value(i)));
+                if !has_tick {
+                    continue;
+                }
+            }
+            if filter.active_only {
+                let active_col = batch
+                    .column(batch.schema().index_of(IS_ACTIVE).unwrap())
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .unwrap();
+                let mask = BooleanArray::from_iter(
+                    (0..batch.num_rows()).map(|i| Some(active_col.value(i))),
+                );
+                let filtered =
+                    filter_record_batch(batch, &mask).expect("ledger store filter failed");
+                if filtered.num_rows() > 0 {
+                    result.push(filtered);
+                }
+            } else {
+                result.push(batch.clone());
+            }
+        }
+        Ok(result)
+    }
+}
+
+/// Read all rows for a given tick from the world's ledger.
+/// Returns entity_id → position__x mapping.
+async fn ledger_x_at_tick(
+    world: &AsyncWorld<LedgerStore>,
+    table_name: &str,
+    tick: i32,
+) -> HashMap<EntityId, f64> {
+    let batches = world
+        .query_table(
+            table_name,
+            ReadFilter {
+                ticks: Some(vec![tick]),
+                active_only: false,
+                ..ReadFilter::default()
+            },
+        )
+        .await
+        .unwrap();
+    let mut map = HashMap::new();
+    for batch in &batches {
+        let eids = entity_ids(batch);
+        let xs = x_values(batch);
+        let tick_col = batch
+            .column(batch.schema().index_of(TICK).unwrap())
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            if tick_col.value(i) == tick {
+                map.insert(eids[i], xs[i]);
+            }
+        }
+    }
+    map
+}
+
+// ── AddOne processor ─────────────────────────────────────────────────────────
+
+struct AddOne;
+
+impl Processor for AddOne {
+    fn name(&self) -> &str {
+        "add_one"
+    }
+
+    fn required_columns(&self) -> &[&'static str] {
+        &["position__x"]
+    }
+
+    fn process(&self, batch: RecordBatch, _ctx: &ProcessorContext) -> Result<RecordBatch> {
+        let values = batch
+            .column(batch.schema().index_of("position__x")?)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        let next: Vec<f64> = (0..batch.num_rows())
+            .map(|i| values.value(i) + 1.0)
+            .collect();
+        let mut columns = batch.columns().to_vec();
+        columns[batch.schema().index_of("position__x")?] = Arc::new(Float64Array::from(next));
+        RecordBatch::try_new(batch.schema(), columns).map_err(Into::into)
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Contract 1a: x₀ raw at spawn tick, f applied next tick (first spawn)
+//
+// Mirrors: tests/core/test_initial_conditions_contract.py
+//          ::test_initial_conditions_persist_at_spawn_tick
+//
+// Python contract: "The first persisted row is x_0, not f(x_0)."
+// Ledger must contain x₀=5.0 at tick 0, f(x₀)=6.0 at tick 1,
+// f²(x₀)=7.0 at tick 2.
+// ════════════════════════════════════════════════════════════════════════════
+#[tokio::test]
+async fn contract1a_x0_raw_at_spawn_tick_f_applied_next_tick() {
+    let table = position_table();
+    let mut system = AsyncSystem::new();
+    system.add_processor(AddOne);
+    let mut world = AsyncWorld::from_ids("world-a", "run-a", LedgerStore::default(), system);
+
+    world
+        .queue_spawn_batch(&table, component_batch(&[5.0]))
+        .unwrap();
+    world.run(3).await.unwrap();
+
+    let at_tick: HashMap<i32, f64> = {
+        let mut m = HashMap::new();
+        for t in 0i32..3 {
+            let rows = ledger_x_at_tick(&world, table.table_name(), t).await;
+            assert_eq!(
+                rows.len(),
+                1,
+                "tick {t}: expected 1 ledger row, got {}",
+                rows.len()
+            );
+            m.insert(t, *rows.values().next().unwrap());
+        }
+        m
+    };
+
+    // Strict equality enforced by the Python test.
+    assert_eq!(
+        at_tick[&0], 5.0,
+        "tick 0 must be raw spawn (x₀=5.0); got {}",
+        at_tick[&0]
+    );
+    assert_eq!(
+        at_tick[&1], 6.0,
+        "tick 1 must be f(x₀)=6.0; got {}",
+        at_tick[&1]
+    );
+    assert_eq!(
+        at_tick[&2], 7.0,
+        "tick 2 must be f²(x₀)=7.0; got {}",
+        at_tick[&2]
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Contract 1b: x₀ raw at spawn tick, f applied next tick (mid-run spawn)
+//
+// Mirrors: tests/core/test_initial_conditions_contract.py
+//          ::test_mid_run_spawn_persists_initial_conditions
+//
+// Python contract: "An entity spawned mid-simulation lands raw at its spawn
+// tick and is first transformed on the next tick — while older entities
+// keep advancing uninterrupted."
+//
+// Timeline:
+//   tick 0: first → 0.0 (raw x₀)
+//   tick 1: first → 1.0 (f applied)
+//   tick 2: first → 2.0, second → 100.0 (raw x₀ for mid-run spawn)
+//   tick 3: first → 3.0, second → 101.0 (f applied to second)
+// ════════════════════════════════════════════════════════════════════════════
+#[tokio::test]
+async fn contract1b_mid_run_spawn_lands_raw_older_entities_keep_advancing() {
+    let table = position_table();
+    let mut system = AsyncSystem::new();
+    system.add_processor(AddOne);
+    let mut world = AsyncWorld::from_ids("world-b", "run-b", LedgerStore::default(), system);
+
+    let first_ids = world
+        .queue_spawn_batch(&table, component_batch(&[0.0]))
+        .unwrap();
+    let first_id = first_ids[0];
+    world.run(2).await.unwrap(); // ticks 0 (raw) and 1 (f applied)
+
+    let second_ids = world
+        .queue_spawn_batch(&table, component_batch(&[100.0]))
+        .unwrap();
+    let second_id = second_ids[0];
+    world.run(2).await.unwrap(); // ticks 2 and 3
+
+    let t2 = ledger_x_at_tick(&world, table.table_name(), 2).await;
+    assert_eq!(
+        t2[&first_id], 2.0,
+        "tick 2: first entity must be at f²(0)=2.0; got {}",
+        t2[&first_id]
+    );
+    assert_eq!(
+        t2[&second_id], 100.0,
+        "tick 2: mid-run spawn must land raw (x₀=100.0); got {}",
+        t2[&second_id]
+    );
+
+    let t3 = ledger_x_at_tick(&world, table.table_name(), 3).await;
+    assert_eq!(
+        t3[&first_id], 3.0,
+        "tick 3: first entity must be at f³(0)=3.0; got {}",
+        t3[&first_id]
+    );
+    assert_eq!(
+        t3[&second_id], 101.0,
+        "tick 3: second entity must be at f(x₀)=101.0; got {}",
+        t3[&second_id]
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Contract 2: same-tick spawn-cancel leaves no tombstone and no active row
+//
+// Mirrors: crates/archetype-core/src/aio/async_world.rs
+//          ::tests::despawn_in_same_tick_cancels_pending_spawn
+//          (which mirrors AsyncWorld.remove_entity same-tick cancel semantics)
+//
+// Python analogue: AsyncWorld.remove_entity called in the same command batch
+//   as create_entity for the same entity — entity is never observed in the
+//   ledger (no active row, no tombstone).
+//
+// The invariant: a same-tick cancel removes the pending spawn row entirely.
+// The materialized batch must contain only surviving entities.
+// ════════════════════════════════════════════════════════════════════════════
+#[tokio::test]
+async fn contract2_same_tick_spawn_cancel_no_tombstone_no_active_row() {
+    // Simple in-memory store that counts every append so we can verify
+    // that a cancelled entity never reaches the store.
+    #[derive(Clone, Default)]
+    struct AppendStore {
+        appends: Arc<Mutex<Vec<RecordBatch>>>,
+    }
+
+    #[async_trait]
+    impl Store for AppendStore {
+        async fn append(&self, _table_name: &str, batch: &RecordBatch) -> Result<()> {
+            self.appends.lock().unwrap().push(batch.clone());
+            Ok(())
+        }
+
+        async fn read_table(
+            &self,
+            _table_name: &str,
+            _filter: ReadFilter,
+        ) -> Result<Vec<RecordBatch>> {
+            Ok(vec![])
+        }
+    }
+
+    let table = position_table();
+    let store = AppendStore::default();
+    let appends = store.appends.clone();
+    let mut world = AsyncWorld::from_ids("world-c", "run-c", store, AsyncSystem::new());
+
+    // Spawn two entities, then immediately cancel the first.
+    let ids = world
+        .queue_spawn_batch(&table, component_batch(&[1.5, 2.5]))
+        .unwrap();
+    world.queue_despawn(ids[0]).unwrap(); // same-tick cancel of entity 0
+    world.step().await.unwrap();
+
+    let stored = appends.lock().unwrap();
+    // Exactly one append must have happened (entity 1 only).
+    assert_eq!(stored.len(), 1);
+    let batch = &stored[0];
+    let eids = entity_ids(batch);
+    let flags = active_flags(batch);
+
+    // Only entity ids[1] is present — ids[0] was cancelled entirely.
+    assert_eq!(eids.len(), 1, "only the surviving entity reaches the store");
+    assert_eq!(eids[0], ids[1], "surviving entity is ids[1]");
+    assert!(flags[0], "surviving entity must be active");
+
+    // No tombstone for the cancelled entity: it must not appear in any row.
+    let all_cancelled: bool = eids.iter().all(|&e| e != ids[0]);
+    assert!(
+        all_cancelled,
+        "cancelled entity must not appear in any stored row"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Contract 3: spawn materialization order deterministic
+//             (first-seen, last-write-wins for duplicates)
+//
+// Mirrors: tests/core/test_async_world_duplicate_spawn_overwrite.py
+//          ::test_duplicate_spawn_same_entity_overwrites
+//
+// Python contract: "Simulate duplicate spawn commands for the same entity
+// within the same tick; ensure last write wins."
+//
+// Three distinct entities are spawned in order x=1, 2, 3.  Their entity IDs
+// must appear in first-seen insertion order (1, 2, 3) in the materialized
+// batch.  A duplicate spawn for entity 1 (value 99) must overwrite the
+// first entry (last-write-wins) while preserving the original first-seen
+// position.
+// ════════════════════════════════════════════════════════════════════════════
+#[tokio::test]
+async fn contract3_spawn_order_deterministic_first_seen_last_write_wins() {
+    use archetype_core::aio::async_world::WorldState;
+
+    let table = position_table();
+    let mut state = WorldState::new("world-d", "run-d");
+
+    // Three sequential spawns → entity IDs 1, 2, 3.
+    for x in [1.0f64, 2.0, 3.0] {
+        state
+            .queue_spawn_batch(table.table_name(), table.schema(), component_batch(&[x]))
+            .unwrap();
+    }
+
+    let frames = state.drain_spawn_frames(table.table_name()).unwrap();
+    let batch = arrow_select::concat::concat_batches(&table.schema(), &frames).unwrap();
+
+    // Insertion order preserved.
+    let eids = entity_ids(&batch);
+    assert_eq!(
+        eids,
+        vec![1, 2, 3],
+        "entities must appear in first-seen order"
+    );
+    let xs = x_values(&batch);
+    assert_eq!(xs, vec![1.0, 2.0, 3.0]);
+
+    // Now test last-write-wins: re-spawn entity 1 with value 99.
+    // Use queue_spawn_batch_with_entity_ids to force a duplicate entity ID,
+    // mirroring the Python test which sets world.next_entity_id = eid.
+    let mut state2 = WorldState::new("world-d2", "run-d2");
+    state2
+        .queue_spawn_batch(table.table_name(), table.schema(), component_batch(&[1.0]))
+        .unwrap();
+    // Spawn again with the same entity ID (1) — simulates duplicate command targeting
+    // the same entity before materialization.
+    state2
+        .queue_spawn_batch_with_entity_ids(
+            table.table_name(),
+            table.schema(),
+            component_batch(&[99.0]),
+            &[1],
+        )
+        .unwrap();
+
+    let frames2 = state2.drain_spawn_frames(table.table_name()).unwrap();
+    let batch2 = arrow_select::concat::concat_batches(&table.schema(), &frames2).unwrap();
+
+    assert_eq!(
+        batch2.num_rows(),
+        1,
+        "duplicate entity collapsed to one row"
+    );
+    let eids2 = entity_ids(&batch2);
+    let xs2 = x_values(&batch2);
+    assert_eq!(eids2[0], 1, "entity ID preserved");
+    assert_eq!(xs2[0], 99.0, "last-write-wins: value must be 99.0, not 1.0");
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Contract 4: despawn tombstones at current tick;
+//             active_only reads exclude despawned entities
+//
+// Mirrors: crates/archetype-core/src/aio/async_world.rs
+//          ::tests::despawn_marks_prior_row_inactive
+//          ::tests::live_snapshot_after_despawn_excludes_inactive_entities
+//
+// Python analogue: world.remove_entity(eid) → next step writes tombstone
+//   (is_active=false) for that entity; subsequent get_components active_only
+//   reads do not include it.
+//
+// Two-phase test:
+//   Phase A: spawn entity x=1.5, step → tick 0 persisted active.
+//   Phase B: despawn, step → tick 1 persisted inactive (tombstone).
+//   Active-only query at tick 1 returns 0 rows.
+// ════════════════════════════════════════════════════════════════════════════
+#[tokio::test]
+async fn contract4_despawn_tombstone_at_current_tick_active_only_excludes_it() {
+    let table = position_table();
+    let store = LedgerStore::default();
+    let ledger = store.ledger.clone();
+    let mut world = AsyncWorld::from_ids("world-e", "run-e", store, AsyncSystem::new());
+
+    let ids = world
+        .queue_spawn_batch(&table, component_batch(&[1.5]))
+        .unwrap();
+    world.step().await.unwrap(); // tick 0: active row persisted
+
+    world.queue_despawn(ids[0]).unwrap();
+    world.step().await.unwrap(); // tick 1: tombstone persisted
+
+    // Verify the ledger has exactly 2 appends: active at tick 0, tombstone at tick 1.
+    let rows_all = {
+        let l = ledger.lock().unwrap();
+        l.iter()
+            .filter(|(t, _)| t == table.table_name())
+            .map(|(_, b)| b.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        rows_all.len(),
+        2,
+        "two persisted batches (tick 0 active, tick 1 tombstone)"
+    );
+
+    let tick0 = &rows_all[0];
+    let tick1 = &rows_all[1];
+
+    // Tick 0: active row.
+    assert_eq!(active_flags(tick0), vec![true]);
+    assert_eq!(tick_values(tick0), vec![0]);
+
+    // Tick 1: tombstone (is_active=false).
+    assert_eq!(
+        active_flags(tick1),
+        vec![false],
+        "despawn must produce tombstone"
+    );
+    assert_eq!(tick_values(tick1), vec![1], "tombstone must be at tick 1");
+
+    // active_only read at tick 1 must return 0 rows.
+    let active_rows = world
+        .query_table(
+            table.table_name(),
+            ReadFilter {
+                ticks: Some(vec![1]),
+                active_only: true,
+                ..ReadFilter::default()
+            },
+        )
+        .await
+        .unwrap();
+    let total_active: usize = active_rows.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total_active, 0,
+        "active_only read must exclude the tombstoned entity"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Contract 5: update / overlay semantics
+//
+// Python reference: AsyncWorld.update_entity overlays values without changing
+//   archetype/table identity (src/archetype/core/aio/async_world.py).
+//
+// Status: NOT IMPLEMENTED in the Rust kernel.
+//   The Rust WorldState has no `update_entity` or equivalent overlay
+//   operation.  The kernel supports component migration (via
+//   `queue_migration_batch`) but not in-place overlay.
+//
+// Gap rationale: overlay semantics require locating the entity's current
+//   component values in the live snapshot, merging the provided patch, and
+//   queuing a re-spawn at the current tick.  This is deferred pending the
+//   split-step FFI design (ζ2/C2) which governs how Python-side patch data
+//   crosses the Arrow C boundary.
+//
+// When implemented, the contract to assert is:
+//   - queue_update(entity_id, patch_batch) for a live entity
+//   - After step(), the persisted row at the current tick reflects the
+//     merged values.
+//   - The entity remains on the same table (archetype unchanged).
+//   - The overlay does not produce a tombstone for the old values.
+// ════════════════════════════════════════════════════════════════════════════
+#[test]
+#[ignore = "Update/overlay not yet implemented in the Rust kernel; \
+            deferred pending split-step FFI design (ζ2/C2). \
+            When implemented: assert merged patch values, same table, no tombstone."]
+fn contract5_update_overlay_semantics_gap() {
+    // Placeholder — this test body will be replaced when the kernel gains
+    // queue_update / overlay support.
+    todo!("implement when update_entity is ported to Rust")
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Contract 6: metadata stamping (world_id, run_id, tick) on every row
+//
+// Mirrors: tests/core/test_initial_conditions_contract.py (implicit in all
+//   query assertions that rely on correct tick values)
+//   crates/archetype-core/src/aio/async_world.rs
+//   ::tests::async_world_persists_world_run_and_tick_metadata
+//
+// Python contract: every persisted row carries the correct world_id, run_id,
+//   and tick values so that historical queries can filter by time and run.
+//
+// This test spawns one entity and runs 3 steps.  It then reads the ledger
+// at each tick and asserts that world_id, run_id, and tick are correct on
+// every row.
+// ════════════════════════════════════════════════════════════════════════════
+#[tokio::test]
+async fn contract6_metadata_stamped_on_every_persisted_row() {
+    let table = position_table();
+    let store = LedgerStore::default();
+    let ledger_ref = store.ledger.clone();
+    let mut world = AsyncWorld::from_ids("world-f", "run-f", store, AsyncSystem::new());
+
+    world
+        .queue_spawn_batch(&table, component_batch(&[0.0]))
+        .unwrap();
+    world.run(3).await.unwrap();
+
+    let rows_all = {
+        let l = ledger_ref.lock().unwrap();
+        l.iter()
+            .filter(|(t, _)| t == table.table_name())
+            .map(|(_, b)| b.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(rows_all.len(), 3, "three persisted batches (ticks 0, 1, 2)");
+
+    for (expected_tick, batch) in rows_all.iter().enumerate() {
+        let world_ids = batch
+            .column(batch.schema().index_of(WORLD_ID).unwrap())
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let run_ids = batch
+            .column(batch.schema().index_of(RUN_ID).unwrap())
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let ticks_col = batch
+            .column(batch.schema().index_of(TICK).unwrap())
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+
+        assert_eq!(
+            world_ids.value(0),
+            "world-f",
+            "row at tick {expected_tick}: world_id must be 'world-f'"
+        );
+        assert_eq!(
+            run_ids.value(0),
+            "run-f",
+            "row at tick {expected_tick}: run_id must be 'run-f'"
+        );
+        assert_eq!(
+            ticks_col.value(0),
+            expected_tick as i32,
+            "row at tick {expected_tick}: tick column must match"
+        );
+    }
+}

--- a/docs/guide/rust-core-plan.md
+++ b/docs/guide/rust-core-plan.md
@@ -1,0 +1,495 @@
+# Rust Core HTN Plan
+
+**Document type:** Implementation plan.
+**Scope:** `crates/`, `src/archetype/core/aio/`, and the Python adapter layer that
+will bridge them.
+
+This plan describes the migration from the current Python async core prototype
+to a Rust core engine built on `arrow-rs`, `tokio`, the Arrow C Data Interface,
+and an append-only Parquet store. It is an HTN-style plan: each phase decomposes
+into ordered tasks, explicit products, acceptance checks, and dependencies.
+
+## Current Definition of Done
+
+The next feature is not "rewrite Archetype in Rust." The feature is:
+
+> A Rust Arrow/Parquet tick kernel, callable from the existing Python runtime
+> boundary, passing core parity tests against the Python async world, with
+> benchmarks showing reduced per-tick overhead without taking over app,
+> runtime, auth, audit, or broker semantics.
+
+### Rust Owns
+
+- Arrow schema composition after Python supplies component schemas.
+- Archetype table descriptors after Python supplies table names.
+- Spawn, despawn, update, component migration, and tick materialization.
+- Active live snapshots below the service layer.
+- Processor scheduling for native processors.
+- Local append-only Parquet storage for the benchmark/control backend.
+- Arrow C Data Interface import/export and ABI diagnostics.
+
+### Python Owns
+
+- `ArchetypeRuntime`, service container, API, CLI, and docs examples.
+- RBAC, quotas, audit emission, command broker ordering, and command policy.
+- Python component classes and table-name hashing.
+- Python processors, hooks, resources, and object lifetimes.
+- Daft/Iceberg/LanceDB production paths until a later storage boundary is
+  explicitly accepted.
+
+### Non-Goals for This Feature
+
+- No Rust ownership of auth, audit, command routing, or runtime handles.
+- No Iceberg catalog/transaction implementation.
+- No LanceDB implementation.
+- No DataFusion query planner unless parity proves simple Parquet scans are the
+  bottleneck.
+- No `cuTile-rs` integration inside the engine. GPU work is a processor backend
+  experiment, not world-state ownership.
+- No PyO3 requirement. Arrow C Data remains the native boundary unless packaging
+  forces a separate decision.
+
+## 0. Constraints
+
+The following decisions are fixed for this migration:
+
+- The async Python implementation is the behavioral reference.
+- A component is an Arrow schema. Rust does not model Python component classes as
+  the canonical component identity.
+- Rust does not own table-name hashing. Table names are supplied by the caller,
+  preserving the current Python naming policy until a separate policy change is
+  made.
+- Data crosses the native boundary through the Arrow C Data Interface.
+- Lance storage is out of scope for the first Rust engine. The first native
+  store is append-only Parquet.
+- Python remains the runtime, API, CLI, auth, audit, and beginner-facing surface.
+- `cuTile-rs` is not part of the core engine plan. It remains a possible future
+  processor accelerator for dense numeric component columns.
+
+Daft's native extension authoring guide is the reference for the boundary shape:
+use `ArrowSchema` and `ArrowArray` as the stable ABI, and convert into
+`arrow-rs` types inside Rust.
+
+## 1. Target Architecture
+
+```text
+Python runtime / app / API / CLI
+        |
+        | Arrow C Data Interface
+        v
+crates/archetype-ffi
+        |
+        v
+crates/archetype-core
+  - Arrow schema composition
+  - world state machine
+  - mutation buffers
+  - tick materialization
+  - query/update/store traits
+        |
+        v
+crates/archetype-parquet
+  - append-only local Parquet store
+```
+
+The Python service layer continues to enforce governance and audit. Rust owns the
+engine invariants below the service layer.
+
+## 2. HTN Root Task
+
+**Task:** make Rust the canonical implementation of Archetype's core engine
+semantics without breaking the Python public surface.
+
+The root decomposes into these phases:
+
+1. Preserve and name current async semantics.
+2. Add the Rust workspace and core crates.
+3. Implement Arrow-native schema and world primitives.
+4. Implement append-only Parquet storage.
+5. Add the Arrow C Data Interface boundary.
+6. Bridge Python to Rust behind the existing async core API.
+7. Migrate runtime/service paths incrementally.
+8. Retire duplicated Python core semantics.
+9. Explore optional native processor acceleration.
+
+## 2.1 Execution HTN
+
+The executable task network is intentionally narrower than the long-term
+migration. Each leaf has a concrete artifact and can run when its dependencies
+are satisfied.
+
+```text
+R0 Define done for Rust backend
+├── R0.1 Record ownership boundary
+├── R0.2 Record non-goals
+└── R0.3 Record crate split
+
+R1 Harden native processor ABI
+├── R1.1 Add ABI error diagnostics
+├── R1.2 Add Python adapter error surfacing
+├── R1.3 Add negative Arrow C tests
+└── R1.4 Document build/load path
+
+R2 Move movement into shared Rust kernel
+├── R2.1 Add movement processor module in archetype-core
+├── R2.2 Reuse it from archetype-ffi
+├── R2.3 Reuse it from archetype-bench
+└── R2.4 Keep benchmark output stable
+
+R3 Establish parity harness
+├── R3.1 Mark Python async tests that define engine semantics
+├── R3.2 Add Rust parity tests for materialization edge cases
+├── R3.3 Add native-mode Python tests through the service boundary
+└── R3.4 Keep native mode opt-in
+
+R4 Benchmark the hot loop
+├── R4.1 Validate final DataFrames match by backend
+├── R4.2 Split timing into plan/query/process/persist phases
+├── R4.3 Compare Daft live-read, Daft cached-read, and Rust Parquet
+└── R4.4 Publish reproducible JSON fixtures
+
+R5 Decide storage graduation
+├── R5.1 Stay local Parquet if tick-loop overhead is already solved
+├── R5.2 Add object_store only for remote/local abstraction
+├── R5.3 Add DataFusion only for Rust-owned query planning
+└── R5.4 Add Iceberg only for Rust-owned table transactions
+```
+
+### Parallel Leaves
+
+- `R0` can run immediately and is documentation-only.
+- `R1.3` can run in parallel with `R2` because adapter tests define behavior
+  without changing the Rust kernel shape.
+- `R2.1` through `R2.3` are sequential inside one Rust ownership lane.
+- `R3` depends on `R1` and `R2` because parity tests need the hardened ABI and
+  shared movement kernel.
+- `R4` depends on `R3.1` for correctness checks, but timing collection can
+  evolve in parallel after the benchmark schema is stable.
+- `R5` is a decision gate only. It must not add crates before `R4` shows the
+  actual bottleneck.
+
+### Crate Admission Rules
+
+The current crates stay minimal:
+
+| Crate | Responsibility |
+|---|---|
+| `archetype-core` | Engine invariants, Arrow schemas, materialization, processor traits |
+| `archetype-parquet` | Local append-only Parquet `Store` implementation |
+| `archetype-ffi` | C ABI and Arrow C Data Interface |
+| `archetype-bench` | Benchmark binaries only |
+
+New crates require a concrete boundary:
+
+| Candidate crate | Admission trigger |
+|---|---|
+| `archetype-object-store` | Local filesystem is no longer enough for storage tests or deployment |
+| `archetype-datafusion` | Rust must own query planning, expressions, or predicate pushdown |
+| `archetype-iceberg` | Rust must own Iceberg commits, catalogs, snapshots, or transactions |
+| `archetype-pyo3` | C ABI is insufficient for packaging or lifecycle management |
+
+Dependencies should not leak upward into `archetype-core`; the core crate should
+stay free of storage engine, Python, and catalog policy.
+
+### Execution Status
+
+| Node | Status | Notes |
+|---|---|---|
+| `R0` | Done | The ownership boundary, non-goals, crate split, and definition of done are recorded in this document. |
+| `R1` | Done for movement ABI | The FFI boundary reports thread-local last errors. The dedicated movement ABI now treats missing required columns as errors. |
+| `R2` | Done | Movement is implemented once in `archetype-core` and reused from FFI and benchmark paths. |
+| `R3` | Kernel done, service bridge pending | Rust core parity tests cover spawn, despawn, reserved IDs, metadata, live snapshots, filters, and component-table migration. Python service native-mode parity remains pending because the runtime adapter is not implemented yet. |
+| `R4` | Done for movement envelope | Movement benchmark records correctness for both backends. Rust reports setup, read-prior, materialize, process, append, live-snapshot, profiled tick, query, and total phases; Python reports the existing setup/run/query phases. |
+| `R5` | Done as decision gate | No new storage/query crates are admitted yet. Local Parquet remains the control backend until benchmarks prove a storage/planner bottleneck. |
+
+### Decisions Made During Execution
+
+- Dedicated processor ABI functions are strict. `arct_movement_process` validates
+  its required columns before scheduling through `NativeSystem`; missing columns
+  are caller errors, not silent skips.
+- Generic system scheduling remains permissive. A processor registered with
+  `NativeSystem` still skips batches that do not contain its required columns,
+  matching the archetype-subset scheduling model.
+- ABI diagnostics are thread-local strings exposed through
+  `arct_last_error_message()`. The primary ABI still returns integer status
+  codes so C callers stay simple.
+- Benchmarks now carry correctness fields. Timing claims are not considered valid
+  unless the final row count and final position sums match the expected movement
+  model.
+- Rust world profiling belongs in the core executor, not in benchmark-only
+  wrappers. `step_profiled()` keeps `step()` behavior intact while exposing the
+  phase timings needed to analyze the hot loop.
+- Component migration is represented as a caller-supplied new table plus
+  caller-supplied component batch. Rust preserves entity IDs and materializes the
+  old table tombstone and new table active row; Python still owns deciding table
+  names and component schemas.
+- No `object_store`, DataFusion, Iceberg, PyO3, or `cuTile-rs` crate was added.
+  The current bottleneck must be demonstrated before widening dependencies.
+
+## 3. Phase 1: Preserve Current Async Semantics
+
+**Intent:** prevent the rewrite from changing behavior accidentally.
+
+### Tasks
+
+1. Inventory the async core contracts from `src/archetype/core/aio/`.
+2. Add contract tests for any behavior currently covered only implicitly.
+3. Mark sync/async divergences as migration risks, not Rust requirements.
+4. Decide which current behaviors are bugs before porting them.
+
+### Required Contracts
+
+- `AsyncWorld.step()` lifecycle:
+  pre-tick hook, query previous tick, materialize mutations, execute processors,
+  persist, increment tick, post-tick hook.
+- `active_signatures` is the union of registered entity signatures, pending spawn
+  tables, and pending despawn tables.
+- Spawn materialization deduplicates same-entity rows with last-write-wins.
+- Despawn materialization marks previous rows inactive; it does not delete rows.
+- `update_entity` overlays values without changing archetype/table identity.
+- `add_components` and `remove_components` migrate an entity between tables by
+  appending an inactive row to the old table and an active row to the new table.
+- Store writes are append-only.
+- Persistence failures must become observable. The current Python updater logs
+  and returns a stamped DataFrame; Rust must return an error.
+
+### Acceptance
+
+- A contract matrix exists mapping Python tests to Rust test cases.
+- Known semantic divergences are documented with a decision: preserve, fix, or
+  defer.
+- The Phase-6 entry gate suite `crates/archetype-core/tests/migration_gate.rs`
+  passes.  That suite is the normative contract matrix: each test cites its
+  Python counterpart and gaps are marked `#[ignore]` with rationale.
+
+## 4. Phase 2: Rust Workspace
+
+**Intent:** introduce Rust without changing Python behavior.
+
+### Tasks
+
+1. Add a root `Cargo.toml` workspace.
+2. Add `crates/archetype-core`.
+3. Add `crates/archetype-parquet`.
+4. Add `crates/archetype-ffi`.
+5. Add `cargo test --workspace` to local validation docs and eventually CI.
+
+### Crate Boundaries
+
+| Crate | Responsibility |
+|---|---|
+| `archetype-core` | Arrow schemas, world state, mutation materialization, traits |
+| `archetype-parquet` | Append-only local Parquet `Store` implementation |
+| `archetype-ffi` | C ABI over Arrow C Data Interface |
+
+### Acceptance
+
+- `cargo test --workspace` passes.
+- Python tests still pass without importing Rust.
+
+## 5. Phase 3: Arrow-Native Core
+
+**Intent:** move the actual engine semantics into Rust.
+
+### Tasks
+
+1. Define base columns:
+   `world_id`, `run_id`, `entity_id`, `tick`, `is_active`.
+2. Define component schemas as caller-provided Arrow schemas.
+3. Define archetype table descriptors as caller-provided table name plus Arrow
+   schema.
+4. Validate no missing required base columns after composition.
+5. Implement `WorldState`.
+6. Implement `MutationBuffer`.
+7. Implement spawn queueing from Arrow batches.
+8. Implement despawn queueing.
+9. Implement materialization over prior tick Arrow batches.
+10. Return explicit errors for schema mismatch, missing columns, invalid types,
+    and failed appends.
+
+### Non-Goals
+
+- No table-name hashing.
+- No Python class lookup.
+- No LanceDB.
+- No Daft processor execution in Rust.
+
+### Acceptance
+
+- Rust tests cover spawn, duplicate spawn overwrite, despawn, empty prior batch,
+  and metadata stamping.
+- Rust materialization returns Arrow `RecordBatch` values that Python can ingest
+  through Arrow C.
+
+## 6. Phase 4: Append-Only Parquet Store
+
+**Intent:** provide a simple native durable backend for the Rust core.
+
+### Layout
+
+```text
+<root>/<namespace>/<table_name>/part-<uuid>.parquet
+```
+
+### Tasks
+
+1. Implement `Store::append`.
+2. Implement `Store::read_table`.
+3. Implement filter application for `world_id`, `run_id`, `tick`, `entity_id`,
+   and `active_only`.
+4. Keep writes append-only; never rewrite existing files.
+5. Defer predicate pushdown until correctness is stable.
+
+### Acceptance
+
+- Appending twice produces two files.
+- Reading a table returns the concatenation of all parts.
+- Filters match the Python async store semantics.
+
+## 7. Phase 5: Arrow C Data Interface
+
+**Intent:** make the native boundary stable and Daft-compatible.
+
+### Tasks
+
+1. In `archetype-ffi`, define exported C ABI functions over `ArrowSchema` and
+   `ArrowArray`.
+2. Convert `ArrowSchema`/`ArrowArray` to `arrow-rs` `SchemaRef` and
+   `RecordBatch`.
+3. Convert returned Rust `RecordBatch` values back to `ArrowArray`.
+4. Define ownership rules for every pointer crossing the boundary.
+5. Add a memory-safety test harness.
+
+Phase 5's split-step ownership, error-code, panic, and partial-failure contract
+is specified in `docs/design/split-step-ffi.md`.
+
+### Acceptance
+
+- A caller can pass an Arrow batch into Rust and receive an Arrow batch back
+  without Python object serialization.
+- FFI functions never panic across the boundary.
+
+## 8. Phase 6: Python Adapter
+
+**Intent:** route existing Python async core operations through Rust while
+preserving Python APIs.
+
+### Tasks
+
+1. Add an internal adapter under `src/archetype/core/native/`.
+2. Convert Daft/PyArrow batches to Arrow C.
+3. Call `archetype-ffi`.
+4. Convert returned Arrow C data back into PyArrow/Daft.
+5. Gate native engine usage behind an explicit feature flag or config setting.
+
+Phase 6's adapter shape, native fallback behavior, and parity/benchmark gate are
+specified in `docs/design/split-step-ffi.md`.
+
+### Phase-6 Entry Gate
+
+Before any Phase-6 Python-adapter work begins, the migration-gate suite
+`crates/archetype-core/tests/migration_gate.rs` must pass in full.  The suite
+encodes every behavioral contract the Python async reference pins:
+
+| Contract | Test | Python counterpart |
+|---|---|---|
+| x₀ raw at spawn tick / f next tick (first spawn) | `contract1a_x0_raw_at_spawn_tick_f_applied_next_tick` | `test_initial_conditions_persist_at_spawn_tick` |
+| x₀ raw at spawn tick / f next tick (mid-run) | `contract1b_mid_run_spawn_lands_raw_older_entities_keep_advancing` | `test_mid_run_spawn_persists_initial_conditions` |
+| Same-tick spawn-cancel: no tombstone, no active row | `contract2_same_tick_spawn_cancel_no_tombstone_no_active_row` | `AsyncWorld.remove_entity` same-tick cancel semantics |
+| Spawn order deterministic (first-seen, last-write-wins) | `contract3_spawn_order_deterministic_first_seen_last_write_wins` | `test_duplicate_spawn_same_entity_overwrites` |
+| Despawn tombstone at current tick; active_only excludes it | `contract4_despawn_tombstone_at_current_tick_active_only_excludes_it` | `despawn_marks_prior_row_inactive` / `live_snapshot_after_despawn_excludes_inactive_entities` |
+| Update/overlay semantics | `contract5_update_overlay_semantics_gap` (**`#[ignore]`** — not yet implemented) | `AsyncWorld.update_entity` |
+| Metadata stamping (world/run/tick) on every row | `contract6_metadata_stamped_on_every_persisted_row` | `async_world_persists_world_run_and_tick_metadata` |
+
+The `archetype-bench` crate also includes a `mid_run_spawn` scenario that
+exercises the tick-zero-correct spawn ordering for entities arriving at
+different ticks.  Its correctness output (`"correct": true`) must hold before
+Phase-6 work proceeds.
+
+### Acceptance
+
+- The Phase-6 entry gate suite (`crates/archetype-core/tests/migration_gate.rs`)
+  passes: `cargo test --package archetype-core --test migration_gate` is green.
+- `cargo run --package archetype-bench --bin mid_run_spawn` reports `"correct": true`.
+- Existing async world tests pass with native mode off.
+- A narrow native-mode test passes for spawn/materialize/update.
+- Failures surface as Python exceptions, not logged-only errors.
+
+## 9. Phase 7: Incremental Migration
+
+**Intent:** migrate behavior in dependency order.
+
+### Order
+
+1. Schema composition and metadata validation.
+2. Spawn/despawn materialization.
+3. Update materialization.
+4. Add/remove component migration.
+5. Query filtering.
+6. Parquet append/read.
+7. Runtime integration.
+
+Each step must leave the Python public surface stable.
+
+### Acceptance
+
+- At each migration point, Python and Rust contract tests both pass.
+- The app/runtime layers still call through `CommandService`.
+
+## 10. Phase 8: Retirement
+
+**Intent:** remove duplicated Python semantics only after Rust parity is proven.
+
+### Tasks
+
+1. Replace Python async core state-machine logic with native calls.
+2. Keep Python processors and hooks as adapter-level features.
+3. Remove or freeze sync-core duplication.
+4. Keep Python fallback behind a temporary compatibility switch until release.
+
+### Acceptance
+
+- No semantic drift remains between sync and async implementations because there
+  is only one native engine path.
+- Rust is the normative core implementation.
+
+## 11. Phase 9: Optional Processor Acceleration
+
+**Intent:** leave room for GPU work without contaminating core storage/state.
+
+### Candidate Work
+
+- Native Rust processors over Arrow arrays.
+- Dense tensor component views for numeric columns.
+- `cuTile-rs` experiments for fused numeric processors.
+
+### Rule
+
+GPU acceleration must be an optional processor backend. It must not own world
+state, append-only history, table naming, or governance.
+
+## 12. First Milestone
+
+The first implementation milestone was:
+
+> Given a caller-supplied table name, an Arrow schema, a prior tick Arrow batch,
+> and queued spawn/despawn mutations, Rust produces the next tick Arrow batch and
+> can append/read it through an append-only Parquet store.
+
+This proves the kernel before touching Python runtime behavior.
+
+The next implementation milestone is:
+
+> Given a single Arrow batch from Python, Rust executes the shared movement
+> processor through the Arrow C Data Interface with stable errors, then the same
+> processor is reused by the Rust benchmark world.
+
+Acceptance:
+
+- `cargo test --workspace` passes.
+- `cargo clippy --workspace --all-targets -- -D warnings` passes.
+- `uv run pytest tests/core/test_native_movement_adapter.py
+  tests/bench/test_movement_compare.py` passes.
+- Missing columns, wrong dtypes, multi-batch tables, missing libraries, and ABI
+  mismatch produce explicit Python failures.
+- The benchmark JSON schema stays stable.


### PR DESCRIPTION
## Summary

- Adds `crates/archetype-core/tests/migration_gate.rs`: the Phase-6 entry gate suite encoding all six behavioral contracts the Python async reference pins, each annotated with its Python counterpart. Contract-5 (update/overlay) is `#[ignore]`d with rationale — the gap is documented rather than omitted.
- Adds `crates/archetype-bench/src/bin/mid_run_spawn.rs`: a bench scenario that spawns entities mid-run, exercising the tick-zero-correct ordering and reporting correctness (`"correct": true` with 1 200 entities across 5 ticks).
- Updates `docs/guide/rust-core-plan.md` Phase 1 and Phase 6 acceptance sections to name `migration_gate.rs` as the Phase-6 entry gate, with a contract table mapping each test to its Python counterpart.

## What the Codex gate should scrutinize

1. **Contract completeness** — six contract areas; contract-5 is `#[ignore]`d with the correct rationale (Rust kernel lacks `update_entity`; deferred to ζ2/C2 split-step FFI design). Confirm the gap justification is accurate.
2. **Python counterpart annotations** — each test cites the mirroring Python test in a comment. Confirm the citations match the actual Python test names and files.
3. **Bench correctness formula** — `mid_run_spawn.rs` computes expected sums for early entities (spawn tick 0, `ticks-1` movement steps) and late entities (spawn tick `S`, `ticks-1-S` steps). Confirm the formula correctly encodes the tick-zero contract.
4. **No materialization inside `src/`** — no `.collect()` or `.to_pylist()` calls were added; no `lazy_audit.toml` entries are needed.
5. **Gate wording in `rust-core-plan.md`** — Phase 6 entry gate section names the suite and the bench binary, with the contract table.

## New lazy-audit entries

None. No Python `src/` files were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)