### PR TITLE
fix(core): footgun fixes — signature canonicalization, non-interactive logfire, query ergonomics (γ2/B5)

### DIFF
--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -27,7 +27,7 @@ reason = "HTTP JSON response boundary: convert the already-collected Daft result
 
 [[entries]]
 path = "src/archetype/core/aio/async_store.py"
-line = 140
+line = 156
 method = "collect"
 reason = "Storage write boundary: defensive empty-frame probe before delegating to the backing table writer; cannot be expressed as a Daft predicate because count_rows requires materialised state."
 
@@ -39,7 +39,7 @@ reason = "Cross-archetype entity migration: extract the latest tick row as a Pyt
 
 [[entries]]
 path = "src/archetype/core/aio/async_lancedb_store.py"
-line = 162
+line = 173
 method = "collect"
 reason = "LanceDB write boundary: defensive empty-frame probe to avoid Lance casting errors on zero-row appends; precedes the actual table.append call."
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -33,7 +33,7 @@ reason = "Storage write boundary: defensive empty-frame probe before delegating 
 
 [[entries]]
 path = "src/archetype/core/aio/async_world.py"
-line = 334
+line = 335
 method = "to_pylist"
 reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
 

--- a/src/archetype/core/aio/__init__.py
+++ b/src/archetype/core/aio/__init__.py
@@ -27,7 +27,7 @@ from archetype.core.hooks import (
 from .async_cached_store import AsyncCachedStore
 from .async_lancedb_store import AsyncLancedbStore
 from .async_processor import AsyncProcessor
-from .async_querier import AsyncQueryManager
+from .async_querier import AsyncQueryManager, UnknownSignatureError
 from .async_store import AsyncStore
 from .async_system import AsyncSystem
 from .async_updater import AsyncUpdateManager
@@ -42,6 +42,7 @@ __all__ = [
     "AsyncSystem",
     "AsyncUpdateManager",
     "AsyncWorld",
+    "UnknownSignatureError",
     "AsyncHookHandler",
     "HookEvent",
     "HookHandle",

--- a/src/archetype/core/aio/async_cached_store.py
+++ b/src/archetype/core/aio/async_cached_store.py
@@ -190,6 +190,12 @@ class AsyncCachedStore(iAsyncStore):
         """Delegate to inner store."""
         return await self._inner.list_signatures()
 
+    async def list_committed_signatures(self) -> list[ArchetypeSignature]:
+        """Delegate committed-sigs check to inner store."""
+        if hasattr(self._inner, "list_committed_signatures"):
+            return await self._inner.list_committed_signatures()
+        return await self._inner.list_signatures()
+
     async def append(self, sig: ArchetypeSignature, df: DataFrame) -> None:
         """
         Cache driven append with built in flush logic to underlying storage (super) a table with a new dataframe.

--- a/src/archetype/core/aio/async_lancedb_store.py
+++ b/src/archetype/core/aio/async_lancedb_store.py
@@ -58,6 +58,9 @@ class AsyncLancedbStore(iAsyncStore):
         self.namespace: str = namespace
         self.lancedb = None
         self._known_sigs: dict[str, ArchetypeSignature] = {}
+        # Tracks only signatures that have been durably committed via append();
+        # excludes tables opened/created by get_archetype_df (create-on-read).
+        self._committed_sigs: set[str] = set()
 
     async def _ensure_table(self, sig):
         table_name = Archetype.get_name(sig)
@@ -157,6 +160,14 @@ class AsyncLancedbStore(iAsyncStore):
     async def list_signatures(self) -> list[ArchetypeSignature]:
         return list(self._known_sigs.values())
 
+    async def list_committed_signatures(self) -> list[ArchetypeSignature]:
+        """List only signatures that have been durably committed via append().
+
+        Excludes signatures that were only auto-created by get_archetype_df
+        (create-on-read).
+        """
+        return [sig for key, sig in self._known_sigs.items() if key in self._committed_sigs]
+
     async def append(self, sig, df: DataFrame) -> None:
         try:
             df.collect()
@@ -172,6 +183,8 @@ class AsyncLancedbStore(iAsyncStore):
             raise
 
         async_table = await self._ensure_table(sig)
+        # Record this sig as durably committed for list_committed_signatures().
+        self._committed_sigs.add(Archetype.get_name(sig))
         table_name = async_table.name
         try:
             start_time = time.time()

--- a/src/archetype/core/aio/async_querier.py
+++ b/src/archetype/core/aio/async_querier.py
@@ -54,12 +54,22 @@ class AsyncQueryManager(iAsyncQueryManager):
         entity_ids: list[int] | None = None,
         components: list[type["Component"]] | None = None,
         run_id: str | None = None,
+        **kwargs,  # ty: ignore[unknown-parameter]  # absorbs world-internal keys (e.g. run_config)
     ) -> DataFrame:
         """Query active entities for the provided archetype signature.
 
         The signature is canonicalized (sorted by class name) before table
         resolution, so callers may supply types in any order and will always
         find the same table.
+
+        Raises ``UnknownSignatureError`` when the canonical signature has never
+        been registered in the durable store — distinct from 'the signature
+        exists but has zero rows at this tick', which returns an empty DataFrame.
+
+        ``_world_validated=True`` may be passed by the world's ``query_archetype``
+        facade after it has already verified the sig against live and store sigs.
+        When set, the querier skips its own redundant check so that sigs that are
+        live (in spawn cache) but not yet committed do not cause a false positive.
         """
         if run_id is None:
             # Reads MUST be scoped by world_id and run_id (spec §137). A missing
@@ -70,6 +80,38 @@ class AsyncQueryManager(iAsyncQueryManager):
         # as its sorted counterpart.  Internals always produce sorted sigs; this
         # guard makes the public API lenient while keeping the storage layer pure.
         sig = _canonicalize(sig)
+
+        # Existence check: the sig must appear in the store's committed-signature
+        # registry.  An unknown sig must raise UnknownSignatureError distinctly
+        # rather than silently returning an empty create-on-read table.
+        #
+        # We use list_committed_signatures() so that auto-created tables from
+        # concurrent get_archetype_df calls in the same tick batch do not
+        # pollute the check.  Only sigs durably committed via append() are
+        # considered "known" here.  When the committed registry is empty (brand-
+        # new world, nothing flushed yet, or in-memory store without persistence),
+        # the check is skipped — an empty registry cannot distinguish "not yet
+        # committed" from "truly unknown", so we let the store return an empty
+        # frame naturally.
+        #
+        # Skip the check when the world-level guard has already validated the sig
+        # (``_world_validated=True``).  The world guard also considers live/pending
+        # sigs in the spawn cache, which are not yet reflected in
+        # list_committed_signatures(); without this bypass, newly-spawned sigs
+        # that haven't been flushed would produce false-positive errors.
+        world_validated: bool = kwargs.pop("_world_validated", False)
+        if not world_validated and hasattr(self._store, "list_committed_signatures"):
+            committed_sigs = {
+                _canonicalize(s) for s in await self._store.list_committed_signatures()
+            }
+            if committed_sigs and sig not in committed_sigs:
+                component_names = ", ".join(t.__name__ for t in sig)
+                raise UnknownSignatureError(
+                    f"Archetype signature ({component_names}) has never been registered in this world. "
+                    "No entity carrying exactly these component types has been spawned. "
+                    "If you want to query entities that CONTAIN these components (possibly alongside others), "
+                    "use world.query() / query_components() instead of query_archetype()."
+                )
 
         df = await self._store.get_archetype_df(
             sig=sig,

--- a/src/archetype/core/aio/async_querier.py
+++ b/src/archetype/core/aio/async_querier.py
@@ -12,12 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 
 from daft import DataFrame
 
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.interfaces import ArchetypeSignature, iAsyncQueryManager, iAsyncStore
+
+logger = logging.getLogger(__name__)
+
+
+class UnknownSignatureError(LookupError):
+    """Raised when a query targets an archetype signature that has never been
+    registered in this world (distinct from 'no rows at this tick').
+
+    A signature that exists but has zero rows at tick N produces an empty
+    DataFrame; a signature that was never spawned raises this error.
+    """
 
 
 class AsyncQueryManager(iAsyncQueryManager):
@@ -28,6 +40,8 @@ class AsyncQueryManager(iAsyncQueryManager):
         """
         Get all archetypes that contain all of the specified component types for provided world_id and run_id.
         """
+        # Canonicalize so unsorted caller-supplied tuples resolve to the same table.
+        sig = _canonicalize(sig)
         return await self._store.get_archetype_df(
             sig=sig, world_id=world_id, run_id=run_id, active_only=True
         )
@@ -41,14 +55,22 @@ class AsyncQueryManager(iAsyncQueryManager):
         components: list[type["Component"]] | None = None,
         run_id: str | None = None,
     ) -> DataFrame:
-        """
-        Queries all active entities for the provided archetype signature, world_id, run_id.
-        Filters for ticks, entities, and components are provided.
+        """Query active entities for the provided archetype signature.
+
+        The signature is canonicalized (sorted by class name) before table
+        resolution, so callers may supply types in any order and will always
+        find the same table.
         """
         if run_id is None:
             # Reads MUST be scoped by world_id and run_id (spec §137). A missing
             # run_id would otherwise stringify to "None" and silently match nothing.
             raise ValueError("query_archetype requires run_id to scope the read")
+
+        # Canonicalize so an unsorted tuple resolves to the same underlying table
+        # as its sorted counterpart.  Internals always produce sorted sigs; this
+        # guard makes the public API lenient while keeping the storage layer pure.
+        sig = _canonicalize(sig)
+
         df = await self._store.get_archetype_df(
             sig=sig,
             world_id=world_id,
@@ -76,6 +98,11 @@ class AsyncQueryManager(iAsyncQueryManager):
 
         Discovers matching archetype signatures, queries each, projects to
         the requested component columns, and unions the results.
+
+        If a requested component type does not exist in ANY registered
+        archetype, a ``KeyError`` is raised naming the missing component so
+        callers can detect the ManipProprio-vs-ManipAction style confusion
+        (querying a component that belongs to a different archetype).
         """
         import daft
         import pyarrow as pa
@@ -90,6 +117,42 @@ class AsyncQueryManager(iAsyncQueryManager):
         # Find all sigs that contain the required types
         all_sigs = await self.list_signatures()
         matching = [sig for sig in all_sigs if required.issubset(set(sig))]
+
+        # Ergonomic check: when no archetype satisfies the full component set,
+        # raise with a message that names the problematic component(s) and hints
+        # at where each one actually lives.  This catches two related traps:
+        #   (a) A component was never spawned in this world at all.
+        #   (b) Each component exists on a separate archetype but never together
+        #       (the ManipProprio-vs-ManipAction trap).
+        if not matching and all_sigs:
+            all_component_types: set[type[Component]] = set()
+            for s in all_sigs:
+                all_component_types.update(s)
+
+            # Build per-component diagnostic hints.
+            hints: list[str] = []
+            culprit_names: list[str] = []
+            for c in components:
+                providers = [s for s in all_sigs if c in s]
+                if not providers:
+                    # Case (a): component has never been spawned at all.
+                    hints.append(f"{c.__name__} has never been spawned in this world")
+                    culprit_names.append(c.__name__)
+                else:
+                    # Case (b): component exists but not together with all others.
+                    provider_names = ", ".join(
+                        "({})".format(", ".join(t.__name__ for t in s)) for s in providers
+                    )
+                    hints.append(
+                        f"{c.__name__} is provided by archetype(s) {provider_names} "
+                        "but not together with all other requested components"
+                    )
+                    culprit_names.append(c.__name__)
+
+            # Always raise when we have a clear mismatch so the caller gets
+            # the named-component error rather than an empty result.
+            culprits = ", ".join(culprit_names)
+            raise KeyError(f"No archetype contains all of: {culprits}. " + " | ".join(hints))
 
         # Start with empty DataFrame of the right schema
         result = daft.from_arrow(pa.Table.from_batches([], schema=schema))
@@ -114,3 +177,13 @@ class AsyncQueryManager(iAsyncQueryManager):
     async def _validate(self, sig: ArchetypeSignature, df: DataFrame):
         # No-op in baseline; validation lives in instrumentation layer
         return None
+
+
+def _canonicalize(sig: ArchetypeSignature) -> ArchetypeSignature:
+    """Return *sig* sorted by component class name (the canonical form).
+
+    ``Archetype.sig_from_components`` always produces sorted sigs internally.
+    This helper lets the query layer accept unsorted tuples from callers
+    without exposing a new public API function.
+    """
+    return tuple(sorted(sig, key=lambda t: t.__name__))

--- a/src/archetype/core/aio/async_store.py
+++ b/src/archetype/core/aio/async_store.py
@@ -51,6 +51,12 @@ class AsyncStore(iAsyncStore):
             io_config if io_config is not None else getattr(session, "io_config", None)
         )
         self._known_sigs: dict[str, ArchetypeSignature] = {}
+        # Tracks only signatures that have been durably committed via append().
+        # get_archetype_df may create session tables on demand (create-on-read),
+        # but those are NOT included here — only append() populates this set.
+        # This lets query_archetype distinguish an unknown sig (never committed)
+        # from an empty-but-known sig (committed with zero active rows).
+        self._committed_sigs: set[str] = set()
 
     def _ensure_table(self, sig: ArchetypeSignature) -> Table:
         """
@@ -131,6 +137,16 @@ class AsyncStore(iAsyncStore):
         """
         return list(self._known_sigs.values())
 
+    async def list_committed_signatures(self) -> list[ArchetypeSignature]:
+        """List only signatures that have been durably committed via append().
+
+        Unlike list_signatures(), this excludes signatures that were only
+        auto-created by get_archetype_df (create-on-read).  Use this when you
+        need to distinguish 'sig was never written' from 'sig exists but has
+        no rows at the queried tick'.
+        """
+        return [sig for key, sig in self._known_sigs.items() if key in self._committed_sigs]
+
     async def append(self, sig: ArchetypeSignature, df: DataFrame) -> None:
         """
         Append a table with a new dataframe.
@@ -150,6 +166,10 @@ class AsyncStore(iAsyncStore):
             raise
 
         table = self._ensure_table(sig)
+        # Record that this sig has been durably committed (not just auto-created
+        # by a read).  list_committed_signatures() uses this to give callers a
+        # reliable "was this sig ever written?" answer.
+        self._committed_sigs.add(Archetype.get_name(sig))
 
         # Daft's Table.append is synchronous; do not await
         self._append_table(table, df)

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -23,6 +23,7 @@ from daft import DataFrame, col
 from daft.functions import when
 from uuid_utils import UUID, uuid7  # noqa: F401 imported for type hints
 
+from archetype.core.aio.async_querier import UnknownSignatureError, _canonicalize
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import RunConfig
@@ -604,9 +605,18 @@ class AsyncWorld(iAsyncWorld):
     ) -> DataFrame:
         """Facade Method to query an archetype table by signature.
 
+        The signature is canonicalized (sorted by class name) before lookup,
+        so callers may supply types in any order.  If the canonical signature
+        has never been active in this world (not in the live registry AND not
+        in the store's durable record) an ``UnknownSignatureError`` is raised —
+        a distinct failure from 'the signature exists but has zero rows at
+        this tick' which returns an empty DataFrame.
+
         Defaults to the world's most recent run_id when not provided. Accepts an optional
         run_config for instrumentation; ignored by the base querier.
         """
+        # Canonicalize the input sig so unsorted tuples resolve correctly.
+        sig = _canonicalize(sig)
 
         # Back-compat: tests sometimes pass RunConfig as the 2nd positional arg
         if run_config_or_ticks is not None and not isinstance(run_config_or_ticks, list):
@@ -622,6 +632,29 @@ class AsyncWorld(iAsyncWorld):
             effective_run_id = str(run_config.run_id)
         else:
             effective_run_id = ""
+
+        # Existence check: the sig must either be currently active (live entities
+        # or pending spawns/despawns) OR have been committed to the durable store.
+        # We skip the check when the world has no knowledge at all (brand-new
+        # world that has never spawned anything) — that is indistinguishable from
+        # an incorrect sig, so we let the store return an empty frame naturally.
+        # Internal tick-loop calls always pass sigs from active_signatures, so
+        # they will always pass this guard.
+        # Also skip when the querier does not implement list_signatures (test
+        # fakes, InMemory queriers) — the check is best-effort at the API boundary.
+        all_known_sigs = self.active_signatures  # live + pending
+        if all_known_sigs and hasattr(self.querier, "list_signatures"):
+            # Also consult the durable store for despawned-but-historical sigs.
+            store_sigs = {_canonicalize(s) for s in await self.querier.list_signatures()}
+            live_sigs = {_canonicalize(s) for s in all_known_sigs}
+            if sig not in (live_sigs | store_sigs):
+                component_names = ", ".join(t.__name__ for t in sig)
+                raise UnknownSignatureError(
+                    f"Archetype signature ({component_names}) has never been registered in this world. "
+                    "No entity carrying exactly these component types has been spawned. "
+                    "If you want to query entities that CONTAIN these components (possibly alongside others), "
+                    "use world.query() / query_components() instead of query_archetype()."
+                )
 
         async def _query_one(target_world: str, target_run: str, target_ticks: list[int]):
             # Prefer to pass run_config if the querier supports it (instrumented);

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -635,19 +635,25 @@ class AsyncWorld(iAsyncWorld):
 
         # Existence check: the sig must either be currently active (live entities
         # or pending spawns/despawns) OR have been committed to the durable store.
-        # We skip the check when the world has no knowledge at all (brand-new
-        # world that has never spawned anything) — that is indistinguishable from
-        # an incorrect sig, so we let the store return an empty frame naturally.
-        # Internal tick-loop calls always pass sigs from active_signatures, so
-        # they will always pass this guard.
-        # Also skip when the querier does not implement list_signatures (test
-        # fakes, InMemory queriers) — the check is best-effort at the API boundary.
-        all_known_sigs = self.active_signatures  # live + pending
-        if all_known_sigs and hasattr(self.querier, "list_signatures"):
-            # Also consult the durable store for despawned-but-historical sigs.
+        # We always consult the durable store when the querier supports
+        # list_signatures — including when active_signatures is empty (e.g. all
+        # entities despawned, or brand-new world with no pending spawns).  Skipping
+        # the durable-store check when active_signatures is empty would allow an
+        # unknown signature to bypass the guard and silently return an empty
+        # DataFrame, violating the loud unknown-signature criterion.
+        # When the querier does not implement list_signatures (test fakes, InMemory
+        # queriers) the check is best-effort at the API boundary and is skipped.
+        if hasattr(self.querier, "list_signatures"):
+            # Consult the durable store for committed sigs and also include live
+            # sigs (pending spawns/despawns) that haven't been flushed yet.
             store_sigs = {_canonicalize(s) for s in await self.querier.list_signatures()}
-            live_sigs = {_canonicalize(s) for s in all_known_sigs}
-            if sig not in (live_sigs | store_sigs):
+            live_sigs = {_canonicalize(s) for s in self.active_signatures}
+            all_known = live_sigs | store_sigs
+            # Only raise when we have at least one committed or live sig — a truly
+            # brand-new world that has never spawned anything (empty store, no
+            # pending spawns) cannot yet distinguish a valid future sig from an
+            # incorrect one, so we let the store return an empty frame naturally.
+            if all_known and sig not in all_known:
                 component_names = ", ".join(t.__name__ for t in sig)
                 raise UnknownSignatureError(
                     f"Archetype signature ({component_names}) has never been registered in this world. "
@@ -658,7 +664,10 @@ class AsyncWorld(iAsyncWorld):
 
         async def _query_one(target_world: str, target_run: str, target_ticks: list[int]):
             # Prefer to pass run_config if the querier supports it (instrumented);
-            # otherwise omit.
+            # otherwise omit.  Also pass _world_validated=True so that the
+            # querier's own existence check is bypassed — the world-level guard
+            # above has already verified the sig against live + store sigs,
+            # including sigs that are in the spawn cache but not yet committed.
             try:
                 return await self.querier.query_archetype(
                     sig=sig,
@@ -668,6 +677,7 @@ class AsyncWorld(iAsyncWorld):
                     entity_ids=entity_ids,
                     components=components,
                     run_config=run_config,  # ty: ignore[unknown-argument]  # probed; TypeError-guarded below
+                    _world_validated=True,  # ty: ignore[unknown-argument]  # absorbed by **kwargs
                 )
             except TypeError:
                 return await self.querier.query_archetype(
@@ -677,6 +687,7 @@ class AsyncWorld(iAsyncWorld):
                     ticks=target_ticks,
                     entity_ids=entity_ids,
                     components=components,
+                    _world_validated=True,  # ty: ignore[unknown-argument]  # absorbed by **kwargs
                 )
 
         requested_ticks = ticks or [self.tick]

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -38,15 +38,23 @@ class ArchetypeRuntime:
     """Process-level runtime. Owns the container and default identity."""
 
     def __init__(self, *, actor_ctx: ActorCtx | None = None) -> None:
-        import logfire
-        from logfire.exceptions import LogfireConfigError
+        import os
 
-        try:
-            logfire.configure(service_name="archetype-runtime")
-        except LogfireConfigError:
-            # No Logfire credentials on this machine — degrade to
-            # local-only instrumentation instead of refusing to start.
-            logfire.configure(service_name="archetype-runtime", send_to_logfire=False)
+        import logfire
+
+        # Never block on an interactive logfire setup prompt.  Send to logfire
+        # only when the user has explicitly configured it via one of:
+        #   - LOGFIRE_TOKEN / LOGFIRE_API_KEY environment variable
+        #   - LOGFIRE_SEND_TO_LOGFIRE=true environment variable
+        # Without explicit opt-in, degrade to local-only instrumentation so
+        # ArchetypeRuntime() works in CI and offline environments without an
+        # EOFError or a blocking interactive prompt.
+        _has_token = bool(os.environ.get("LOGFIRE_TOKEN") or os.environ.get("LOGFIRE_API_KEY"))
+        _send_env = os.environ.get("LOGFIRE_SEND_TO_LOGFIRE", "").lower()
+        _send_explicit = _send_env in ("1", "true", "yes")
+        _send_to_logfire = _has_token or _send_explicit
+
+        logfire.configure(service_name="archetype-runtime", send_to_logfire=_send_to_logfire)
 
         self._container = ServiceContainer()
         self._actor_ctx = actor_ctx or default_actor_ctx()

--- a/tests/core/test_footgun_fixes.py
+++ b/tests/core/test_footgun_fixes.py
@@ -1,0 +1,360 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for γ2/B5 footgun fixes.
+
+Acceptance criteria:
+  1. Signature canonicalization: unsorted tuples return correct rows;
+     unknown signatures raise UnknownSignatureError distinctly from
+     'no rows at this tick'.
+  2. ArchetypeRuntime is non-interactive without logfire config (no EOFError,
+     no prompt).
+  3. Missing-column error in query_components names the providing component
+     (ManipProprio-vs-ManipAction trap).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from archetype.core.aio import AsyncSystem, UnknownSignatureError
+from archetype.core.aio.async_querier import _canonicalize
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from tests.conftest import make_world_service
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared test components
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class Alpha(Component):
+    a: float = 1.0
+
+
+class Beta(Component):
+    b: float = 2.0
+
+
+class Gamma(Component):
+    g: float = 3.0
+
+
+class Delta(Component):
+    d: float = 4.0
+
+
+# Two components that simulate the ManipProprio / ManipAction trap:
+# one is on the entity being queried, one is NOT.
+class ManipProprio(Component):
+    position: float = 0.0
+
+
+class ManipAction(Component):
+    torque: float = 0.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Signature canonicalization
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_canonicalize_helper_sorts_by_class_name():
+    """_canonicalize must produce a stable sorted order regardless of input order."""
+    sig_fwd = (Alpha, Beta, Gamma, Delta)
+    sig_rev = (Delta, Gamma, Beta, Alpha)
+    assert _canonicalize(sig_fwd) == _canonicalize(sig_rev)
+    names = [t.__name__ for t in _canonicalize(sig_fwd)]
+    assert names == sorted(names)
+
+
+@pytest.mark.asyncio
+async def test_unsorted_4component_query_returns_rows(tmp_path):
+    """An unsorted 4-component signature tuple must resolve to the same table
+    as the canonical (sorted) form and return the correct rows.
+
+    Regression: before canonicalization, unsorted sigs silently resolved to a
+    different (empty) table name and returned 0 rows.
+    """
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        system = AsyncSystem()
+        world = await ws.create_world(WorldConfig(name="w"), storage_config=storage, system=system)
+
+        # Spawn an entity with all four components
+        await world.create_entity([Alpha(a=10.0), Beta(b=20.0), Gamma(g=30.0), Delta(d=40.0)])
+
+        # Advance one tick so the entity is persisted
+        await world.run(RunConfig(num_steps=1))
+
+        # The canonical sig (sorted by class name)
+        canonical_sig = (Alpha, Beta, Delta, Gamma)  # sorted: Alpha<Beta<Delta<Gamma
+
+        # Query with the canonical form first to verify rows exist
+        df_canon = await world.query_archetype(
+            sig=canonical_sig,
+            run_id=world.run_id,
+            ticks=[0],
+        )
+        canon_rows = df_canon.collect().to_pylist()
+        assert len(canon_rows) >= 1, "canonical query returned no rows"
+
+        # Now query with a deliberately UNSORTED tuple — must return same rows
+        unsorted_sig = (Delta, Gamma, Alpha, Beta)  # reversed alphabetical order
+        df_unsorted = await world.query_archetype(
+            sig=unsorted_sig,
+            run_id=world.run_id,
+            ticks=[0],
+        )
+        unsorted_rows = df_unsorted.collect().to_pylist()
+        assert len(unsorted_rows) == len(canon_rows), (
+            f"Unsorted sig returned {len(unsorted_rows)} rows but canonical returned "
+            f"{len(canon_rows)} — canonicalization is broken"
+        )
+
+        # Entity IDs must match
+        canon_ids = {r["entity_id"] for r in canon_rows}
+        unsorted_ids = {r["entity_id"] for r in unsorted_rows}
+        assert unsorted_ids == canon_ids
+
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_unknown_signature_raises_distinctly_from_empty_tick(tmp_path):
+    """Querying a signature that was never spawned must raise UnknownSignatureError.
+
+    This is distinct from 'the signature exists but has zero rows at this tick',
+    which returns an empty DataFrame without raising.
+    """
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        system = AsyncSystem()
+        world = await ws.create_world(WorldConfig(name="w"), storage_config=storage, system=system)
+
+        # Spawn an entity with Alpha + Beta
+        await world.create_entity([Alpha(a=1.0), Beta(b=2.0)])
+        await world.run(RunConfig(num_steps=1))
+
+        # Querying a sig that WAS spawned at a tick with no rows returns empty df (OK)
+        known_sig = (Alpha, Beta)
+        df_empty_tick = await world.query_archetype(
+            sig=known_sig,
+            run_id=world.run_id,
+            ticks=[999],  # no rows at tick 999
+        )
+        assert df_empty_tick.collect().count_rows() == 0, "expected empty df for future tick"
+
+        # Querying a sig that was NEVER spawned must raise UnknownSignatureError
+        never_spawned_sig = (Gamma, Delta)  # these components were never spawned
+        with pytest.raises(UnknownSignatureError, match="never been registered"):
+            await world.query_archetype(
+                sig=never_spawned_sig,
+                run_id=world.run_id,
+                ticks=[0],
+            )
+
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_unknown_signature_message_is_descriptive(tmp_path):
+    """The UnknownSignatureError message must name the component types so the
+    user can diagnose the problem without a debugger."""
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await ws.create_world(
+            WorldConfig(name="w"), storage_config=storage, system=AsyncSystem()
+        )
+        await world.create_entity([Alpha(a=1.0)])
+        await world.run(RunConfig(num_steps=1))
+
+        with pytest.raises(UnknownSignatureError) as exc_info:
+            await world.query_archetype(
+                sig=(Beta, Gamma),  # never spawned
+                run_id=world.run_id,
+                ticks=[0],
+            )
+
+        msg = str(exc_info.value)
+        assert "Beta" in msg or "Gamma" in msg, f"error message does not name components: {msg!r}"
+        assert "never been registered" in msg or "never" in msg
+
+    finally:
+        await ws.shutdown()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. ArchetypeRuntime non-interactive logfire
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_runtime_construction_non_interactive_no_eoferror(monkeypatch, tmp_path):
+    """ArchetypeRuntime() must never block on an interactive logfire prompt.
+
+    In a CI environment (no LOGFIRE_TOKEN, no LOGFIRE_API_KEY, no credentials
+    file), constructing ArchetypeRuntime must complete without raising EOFError
+    (which would indicate it tried to read from stdin) or any other error.
+    """
+    # Ensure no logfire credentials are visible in this test environment.
+    monkeypatch.delenv("LOGFIRE_TOKEN", raising=False)
+    monkeypatch.delenv("LOGFIRE_API_KEY", raising=False)
+    monkeypatch.delenv("LOGFIRE_SEND_TO_LOGFIRE", raising=False)
+
+    # Patch stdin to raise EOFError if read — proves no prompt is issued.
+    import io
+    import sys
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO())  # empty stdin → EOFError on read
+
+    # Should not raise.
+    from archetype.runtime.runtime import ArchetypeRuntime
+
+    rt = ArchetypeRuntime()
+    assert rt is not None
+
+
+def test_runtime_construction_non_interactive_repeated(monkeypatch):
+    """ArchetypeRuntime() can be constructed multiple times in one process
+    without side effects from logfire initialization."""
+    monkeypatch.delenv("LOGFIRE_TOKEN", raising=False)
+    monkeypatch.delenv("LOGFIRE_API_KEY", raising=False)
+    monkeypatch.delenv("LOGFIRE_SEND_TO_LOGFIRE", raising=False)
+
+    from archetype.runtime.runtime import ArchetypeRuntime
+
+    rt1 = ArchetypeRuntime()
+    rt2 = ArchetypeRuntime()
+    assert rt1 is not rt2  # distinct objects
+
+
+def test_runtime_send_to_logfire_with_token_env(monkeypatch):
+    """When LOGFIRE_TOKEN is set, the runtime should attempt to send to logfire.
+
+    We can't actually connect in CI, but we verify the path through the code
+    that inspects the env var — no EOFError is the passing criterion here too,
+    since the actual send would fail at network level, not at init time.
+    """
+    monkeypatch.setenv("LOGFIRE_TOKEN", "test-fake-token-for-unit-test")
+    monkeypatch.delenv("LOGFIRE_API_KEY", raising=False)
+    monkeypatch.delenv("LOGFIRE_SEND_TO_LOGFIRE", raising=False)
+
+    import logfire
+
+    # Patch logfire.configure so we can observe the call arguments without
+    # actually connecting to logfire's API.
+    captured: dict = {}
+
+    def fake_configure(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(logfire, "configure", fake_configure)
+
+    import importlib
+
+    from archetype.runtime import runtime as rt_module
+
+    # Force re-import so monkeypatched logfire.configure is used.
+    importlib.reload(rt_module)
+    from archetype.runtime.runtime import ArchetypeRuntime
+
+    ArchetypeRuntime()
+    assert captured.get("send_to_logfire") is True, (
+        f"Expected send_to_logfire=True when LOGFIRE_TOKEN is set, got: {captured}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Query ergonomics: missing-column error names the providing component
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_query_components_missing_component_raises_with_name(tmp_path):
+    """Querying a component that does NOT exist in any archetype must raise a
+    KeyError that names the missing component type.
+
+    This catches the ManipProprio-vs-ManipAction trap: the user queries
+    ManipAction but the entity only has ManipProprio (or ManipAction is on a
+    completely different archetype).
+
+    We use the world's own querier (populated with the world's sigs) so that
+    list_signatures() correctly reflects what the world has committed.
+    """
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await ws.create_world(
+            WorldConfig(name="w"), storage_config=storage, system=AsyncSystem()
+        )
+
+        # Spawn an entity with ManipProprio ONLY (not ManipAction)
+        await world.create_entity([ManipProprio(position=1.0)])
+        await world.run(RunConfig(num_steps=1))
+
+        # Use the world's own querier which has populated _known_sigs
+        querier = world.querier
+
+        with pytest.raises(KeyError) as exc_info:
+            await querier.query_components(
+                components=[ManipAction],  # never spawned
+                world_id=world.world_id,
+                run_id=world.run_id,
+                ticks=[0],
+            )
+
+        msg = str(exc_info.value)
+        # The error must name the missing component
+        assert "ManipAction" in msg, f"error message does not name ManipAction: {msg!r}"
+
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_query_components_wrong_combination_raises_with_hint(tmp_path):
+    """When a component EXISTS in some archetype but not TOGETHER with the
+    requested co-types, the error message must hint at which archetype provides
+    that component — the ManipProprio-vs-ManipAction trap at the co-type level.
+
+    Entity has ManipProprio. Another entity has ManipAction. Querying
+    (ManipProprio, ManipAction) together should fail with a hint naming the
+    mis-matched component.
+    """
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await ws.create_world(
+            WorldConfig(name="w"), storage_config=storage, system=AsyncSystem()
+        )
+
+        # Spawn two entities with different components
+        await world.create_entity([ManipProprio(position=1.0)])
+        await world.create_entity([ManipAction(torque=2.0)])
+        await world.run(RunConfig(num_steps=1))
+
+        # Use the world's own querier which has populated _known_sigs
+        querier = world.querier
+
+        # Querying both together should fail because no archetype has both
+        with pytest.raises(KeyError) as exc_info:
+            await querier.query_components(
+                components=[ManipProprio, ManipAction],  # never on the same entity
+                world_id=world.world_id,
+                run_id=world.run_id,
+                ticks=[0],
+            )
+
+        msg = str(exc_info.value)
+        # Either component name should appear to identify the problem
+        assert "ManipProprio" in msg or "ManipAction" in msg, (
+            f"error message does not name either component: {msg!r}"
+        )
+
+    finally:
+        await ws.shutdown()


### PR DESCRIPTION
## Summary

- **Signature canonicalization** (`AsyncQueryManager`, `AsyncWorld.query_archetype`): unsorted signature tuples now sort by class name before table-name resolution — `(D, C, B, A)` resolves the same table as `(A, B, C, D)`. Unknown signatures (never spawned in this world) raise `UnknownSignatureError` (a `LookupError` subclass), distinctly from "no rows at this tick" which returns an empty DataFrame.
- **Non-interactive logfire** (`ArchetypeRuntime.__init__`): `send_to_logfire` defaults to `False` unless `LOGFIRE_TOKEN`, `LOGFIRE_API_KEY`, or `LOGFIRE_SEND_TO_LOGFIRE=true` is present. No interactive prompt, no `EOFError` in CI or offline environments.
- **Query ergonomics** (`AsyncQueryManager.query_components`): when the requested component combination matches no archetype, raises `KeyError` naming each culprit component and hinting whether it was never spawned or exists only on a different archetype (the ManipProprio-vs-ManipAction trap).

## What the Codex gate should scrutinize

1. **Existence check in `AsyncWorld.query_archetype`**: the guard uses `self.active_signatures` (live entities + pending spawns/despawns) plus `querier.list_signatures()` (durable store). Internal tick-loop calls always pass sigs from `active_signatures`, so they always pass. Queriers that lack `list_signatures()` (test fakes) skip the durable-store arm via `hasattr` guard — this is intentional; existence enforcement is best-effort at the API boundary.
2. **`_canonicalize` helper**: exposed as a module-level function in `async_querier.py` so tests can import it. It is a pure sort; it never mutates the caller's tuple.
3. **`UnknownSignatureError`**: inherits `LookupError` so callers can catch it precisely without catching all `Exception`s. It is exported from `archetype.core.aio`.
4. **No new lazy-audit entries**: the `lazy_audit.toml` change is a line-number adjustment (import addition shifted the existing `to_pylist` entry by 1); no new `.collect()` or `.to_pylist()` calls were introduced in `src/`.
5. **No changes under `experiments/` or `bench/`** — confirmed by `git diff --name-only`.

## Test plan

- [x] `test_canonicalize_helper_sorts_by_class_name` — pure unit, no I/O
- [x] `test_unsorted_4component_query_returns_rows` — regression: 4-component unsorted sig returns correct rows
- [x] `test_unknown_signature_raises_distinctly_from_empty_tick` — known sig at future tick → empty df; unknown sig → `UnknownSignatureError`
- [x] `test_unknown_signature_message_is_descriptive` — error message names the components
- [x] `test_runtime_construction_non_interactive_no_eoferror` — empty stdin, no `LOGFIRE_TOKEN` → no raise
- [x] `test_runtime_construction_non_interactive_repeated` — repeated construction is safe
- [x] `test_runtime_send_to_logfire_with_token_env` — `LOGFIRE_TOKEN` set → `logfire.configure(send_to_logfire=True)`
- [x] `test_query_components_missing_component_raises_with_name` — component never spawned → `KeyError` naming it
- [x] `test_query_components_wrong_combination_raises_with_hint` — components on separate archetypes → `KeyError` naming both
- [x] `make ci` green: 654 passed, eval gate 10/10 regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)