### PR TITLE
feat(bench): co-located eval runner — drive LIBERO eval from inside Modal

### DIFF
--- a/bench/libero/colocated_runner.py
+++ b/bench/libero/colocated_runner.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Co-located eval runner: drive the LIBERO eval from inside Modal.
+
+The Mac-driven eval pays a transcontinental round trip on every control
+step (env.step + frame transfer + a per-step volume sync), which the a3
+smoke measured at 6-9 s/step. Nothing there is compute — it is latency.
+
+This runner moves the *driver itself* into a Modal Function next to the
+env and policy workers. The Archetype world loop still runs in its own
+py3.12 process (LIBERO's py3.10 pin is untouched — the EnvClient /
+PolicyClient boundary is exactly what lets the driver relocate), but the
+``env.step`` / ``policy.infer`` calls it makes are now Modal-internal,
+same region, instead of Mac->cloud. The eval logic is unchanged: this
+imports ``eval_driver.run_eval`` verbatim and only changes where it runs.
+
+Storage writes go to fast local container disk; the final lab-world
+parquet is copied to the ``libero-eval-results`` volume so results
+survive the function and can be pulled back.
+
+Smoke (1 task x 2 trials, builds the image on first run):
+    modal run bench/libero/colocated_runner.py
+
+Throughput-tuning knobs are CLI flags on the entrypoint below.
+"""
+
+from typing import Any
+
+import modal
+
+ROOT = "/repo"
+RESULTS_DIR = "/results"
+
+# py3.12 + the archetype package. Deliberately excludes the [sim] extra
+# (LIBERO/torch/mujoco) — the driver only needs the world loop and the
+# Modal client; the env and policy live in their own deployed apps.
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .pip_install("uv")
+    .add_local_dir(
+        ".",
+        ROOT,
+        copy=True,
+        # Keep the image lean and the build cache stable: no VCS, caches,
+        # local worktrees, or the heavy demo asset.
+        ignore=[
+            ".git",
+            "**/__pycache__",
+            ".claude",
+            "target",
+            "*.mp4",
+            ".venv",
+            "**/*.parquet",
+        ],
+    )
+    .run_commands(
+        f"cd {ROOT} && uv pip install --system -e . && uv pip install --system pillow numpy"
+    )
+)
+
+app = modal.App("archetype-libero-eval", image=image)
+results_volume = modal.Volume.from_name("libero-eval-results", create_if_missing=True)
+
+
+@app.function(volumes={RESULTS_DIR: results_volume}, timeout=3600)
+def run_eval_remote(
+    suite: str,
+    task_ids: list[int],
+    trials: int,
+    max_steps: int,
+    use_policy: bool,
+    run_id: str,
+) -> dict[str, Any]:
+    """Run the eval driver in-region and return a throughput summary."""
+    import asyncio
+    import shutil
+    import sys
+    import time
+    from pathlib import Path
+
+    # bench/libero is a directory of loose scripts, not a package; the eval
+    # driver imports modal_worker by name, so it must be on the path.
+    sys.path.insert(0, f"{ROOT}/bench/libero")
+
+    from eval_driver import DriverConfig, run_eval  # type: ignore[import-not-found]
+
+    # Storage on fast local disk; only the final parquet is copied to the
+    # network volume. Writing the ledger directly to a Modal Volume would
+    # reintroduce per-write network latency — the very thing we removed.
+    local_out = Path("/tmp") / f"eval-{run_id}"
+    local_out.mkdir(parents=True, exist_ok=True)
+
+    config = DriverConfig(
+        suite=suite,
+        task_ids=task_ids,
+        trials=trials,
+        max_steps=max_steps,
+        out=str(local_out),
+        run_id=run_id,
+        env_client_type="modal",
+        use_policy=use_policy,
+    )
+
+    started = time.perf_counter()
+    results = asyncio.run(run_eval(config))
+    wall_s = time.perf_counter() - started
+
+    total_steps = sum(getattr(r, "episode_length", 0) or 0 for r in results)
+    successes = sum(1 for r in results if getattr(r, "success", False))
+
+    dest = Path(RESULTS_DIR) / run_id
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(local_out, dest)
+    results_volume.commit()
+
+    return {
+        "suite": suite,
+        "task_ids": task_ids,
+        "trials": trials,
+        "episodes": len(results),
+        "successes": successes,
+        "total_steps": total_steps,
+        "wall_s": round(wall_s, 1),
+        "sec_per_step": round(wall_s / total_steps, 3) if total_steps else None,
+        "results_path": str(dest),
+    }
+
+
+@app.local_entrypoint()
+def main(
+    suite: str = "libero_spatial",
+    task_ids: str = "0",
+    trials: int = 2,
+    max_steps: int = 80,
+    use_policy: bool = True,
+    run_id: str = "smoke",
+):
+    """Throughput smoke. Defaults to 1 task x 2 trials so it is cheap.
+
+    Compare sec_per_step here against the Mac-driven baseline (~6-9 s/step
+    from the a3 eval smoke) to read the co-location speedup.
+    """
+    ids = [int(x) for x in str(task_ids).split(",") if x != ""]
+    summary = run_eval_remote.remote(
+        suite=suite,
+        task_ids=ids,
+        trials=trials,
+        max_steps=max_steps,
+        use_policy=use_policy,
+        run_id=run_id,
+    )
+    print("=== co-located eval throughput ===")
+    for key, value in summary.items():
+        print(f"  {key}: {value}")
+    baseline = 7.3
+    if summary.get("sec_per_step"):
+        speedup = baseline / summary["sec_per_step"]
+        print(f"  speedup_vs_mac_baseline: {speedup:.1f}x  (baseline {baseline}s/step)")

--- a/bench/libero/eval_driver.py
+++ b/bench/libero/eval_driver.py
@@ -70,7 +70,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from archetype import ArchetypeRuntime  # noqa: E402
 from archetype.app.auth.guard import reset_tick_counters  # noqa: E402
-from archetype.core.config import RunConfig, StorageConfig  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
 from archetype.experiments.components import (  # noqa: E402
     EvalTrialResult,
     Experiment,
@@ -80,7 +80,9 @@ from archetype.experiments.components import (  # noqa: E402
 from archetype.experiments.manipulation import (  # noqa: E402
     ACTION_DIM,
     EnvStepProcessor,
+    FramedEnvStepProcessor,
     ManipAction,
+    ManipFrameRef,
     ManipProprio,
     ManipStatus,
     ManipTask,
@@ -92,11 +94,17 @@ from archetype.experiments.manipulation import (  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
-def _make_modal_env_client(suite: str, task_id: int) -> Any:
-    """Build a ModalEnvClient; deferred so scripted path avoids the import."""
+def _make_modal_env_client(suite: str, task_id: int, with_frames: bool = False) -> Any:
+    """Build a ModalEnvClient; deferred so scripted path avoids the import.
+
+    ``with_frames`` must be True whenever the VLA policy is in the loop: that
+    policy consumes ``agentview_ref``/``wrist_ref`` from the ledger, which only
+    exist when the env returns frame refs and the framed step processor carries
+    them.
+    """
     from modal_worker import ModalEnvClient  # type: ignore[import-untyped]  # noqa: PLC0415
 
-    return ModalEnvClient(suite=suite, task_id=task_id, with_frames=False)
+    return ModalEnvClient(suite=suite, task_id=task_id, with_frames=with_frames)
 
 
 def _make_vla_policy_client(suite: str, task_id: int) -> Any:
@@ -149,6 +157,7 @@ async def run_episode(
     max_steps: int,
     storage: StorageConfig,
     runtime: ArchetypeRuntime,
+    use_frames: bool = False,
 ) -> tuple[bool, int]:
     """Drive one episode on an isolated world.
 
@@ -176,7 +185,12 @@ async def run_episode(
         from archetype.experiments.policy import PolicyActionProcessor  # noqa: PLC0415
 
         processors.append(PolicyActionProcessor(policy_client))
-    processors.append(EnvStepProcessor(env_client))
+    # The VLA policy consumes frame refs; carry them with the framed step
+    # processor and a ManipFrameRef on the archetype so the policy's ref columns
+    # exist from tick 0 (reset refs land raw, like every other initial value).
+    processors.append(
+        FramedEnvStepProcessor(env_client) if use_frames else EnvStepProcessor(env_client)
+    )
 
     world = runtime.world(
         f"ep-{suite}-t{task_id}-trial{trial_idx}",
@@ -185,7 +199,7 @@ async def run_episode(
     )
 
     spawn_action = [0.0] * ACTION_DIM
-    await world.spawn(
+    spawn_components: list[Any] = [
         ManipProprio(
             eef_pos=list(obs.get("eef_pos", [0.0, 0.0, 0.0])),
             eef_quat=list(obs.get("eef_quat", [1.0, 0.0, 0.0, 0.0])),
@@ -201,7 +215,15 @@ async def run_episode(
             seed=seed,
             env_key=env_key,
         ),
-    )
+    ]
+    if use_frames:
+        spawn_components.append(
+            ManipFrameRef(
+                agentview_ref=str(obs.get("agentview_ref", "")),
+                wrist_ref=str(obs.get("wrist_ref", "")),
+            )
+        )
+    await world.spawn(*spawn_components)
 
     # Run until done or max_steps.  We step one tick at a time so we can
     # break early when all entities are done (single entity here).
@@ -294,11 +316,14 @@ async def run_eval(config: DriverConfig) -> list[EvalTrialResult]:
 
         for task_id in config.task_ids:
             # Build per-task clients (Modal creates per-task containers).
+            # The VLA policy on the Modal env needs frame refs on the ledger;
+            # the scripted env and the no-policy path do not.
+            use_frames = config.env_client_type != "scripted" and config.use_policy
             if config.env_client_type == "scripted":
                 env_client = _make_scripted_env(task_id)
                 policy_client = None
             else:
-                env_client = _make_modal_env_client(config.suite, task_id)
+                env_client = _make_modal_env_client(config.suite, task_id, with_frames=use_frames)
                 policy_client = (
                     _make_vla_policy_client(config.suite, task_id) if config.use_policy else None
                 )
@@ -319,6 +344,7 @@ async def run_eval(config: DriverConfig) -> list[EvalTrialResult]:
                     max_steps=config.max_steps,
                     storage=ep_storage,
                     runtime=runtime,
+                    use_frames=use_frames,
                 )
                 wall_s = time.perf_counter() - t0
 


### PR DESCRIPTION
## What this is

The throughput pass on the LIBERO eval. The Mac-driven driver pays a transcontinental round trip on **every control step** (~7s, pure latency). `bench/libero/colocated_runner.py` moves the driver *itself* into a Modal Function next to the env and policy workers — the Archetype world loop still runs in its own py3.12 process (LIBERO's py3.10 pin untouched; the EnvClient/PolicyClient seam is exactly what lets the driver relocate), but its `env.step`/`policy.infer` calls are now datacenter-internal.

It imports `eval_driver.run_eval` **verbatim** — one eval implementation, no second copy to drift — and only changes where it runs and where storage lands (local container disk during the run, final parquet copied to the `libero-eval-results` volume).

## A real bug this surfaced (and fixed)

This was the **first** run to drive the Modal env *and* the VLA policy together through the eval driver — the a3 eval smoke used zero-action. It immediately hit `KeyError 'agentview_ref'`: `run_episode` wired neither frames nor the framed processor when the VLA policy (which reads `agentview_ref`/`wrist_ref` from the ledger) was active. Fixed in `eval_driver.py`: when the VLA policy is in the loop, build the env client `with_frames=True`, use `FramedEnvStepProcessor`, and spawn `ManipFrameRef` so reset refs land **raw at tick 0** like every other initial value. Scripted and no-policy paths are unchanged; all 12 driver unit tests pass untouched.

## Measured

Smoke (libero_spatial task 0, 2 trials, in-region, **real VLA policy**):

| | Mac baseline (a3) | co-located |
|---|---|---|
| sec/step | 7.3 (zero-action) | **4.20 (with policy)** |

1.7x by the raw number — but the baseline did **no** inference and this run does real GPU inference every chunk, so the transport win is larger than 1.7x once controlled for. The remaining per-step cost is dominated by the env worker committing the frames volume **every step** (a network fsync); committing once per episode + vectorizing `env_keys` is the next lever and should get this well under 1s/step.

## Scrutiny for the gate

- The frames-wiring fix changes run_episode() behavior only on the new use_frames path; scripted and no-policy parity is covered by the 12 existing driver unit tests (all pass unchanged).
- No new lazy-audit entries (no new src/ materializations).
- The runner is bench-only; not in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
