### PR TITLE
Build Day: batched ledger-native harness for conditioning-space optimization of frozen VLAs (GEPA × VLA-JEPA × LIBERO)

### DIFF
--- a/.claude/hooks/guard-modal-run.sh
+++ b/.claude/hooks/guard-modal-run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard: block the Modal "footgun" launch pattern.
+#
+# `modal run` keeps the local CLI as the job driver; when this session is reaped the
+# job is cancelled mid-run. Long jobs must use deploy + spawn (bench/libero/submit_gepa.py).
+# Denies `modal run` only when it targets a long job (--detach or a known job script).
+# Escape hatch: include ALLOW_MODAL_RUN=1 in the command to override.
+#
+# stdin = PreToolUse JSON; deny via hookSpecificOutput.permissionDecision.
+
+cmd="$(jq -r '.tool_input.command // ""')"
+
+# Escape hatch — explicit override.
+case "$cmd" in
+  *ALLOW_MODAL_RUN=1*) exit 0 ;;
+esac
+
+# Only inspect `modal run` invocations; everything else (deploy, app, logs…) is fine.
+case "$cmd" in
+  *"modal run"*) ;;
+  *) exit 0 ;;
+esac
+
+# Footgun iff it's a long job: --detach, or one of the long-running pipeline scripts.
+if printf '%s' "$cmd" | grep -qE -- '--detach|gepa_daft\.py|libero_plus_sweep\.py|baseline_sweep\.py'; then
+  reason="Blocked: long Modal jobs must use deploy + spawn, not 'modal run' (it ties the job to this session and gets cancelled mid-run). Do: 'modal deploy bench/libero/gepa_daft.py' then 'uv run --with modal python bench/libero/submit_gepa.py …'. If this is genuinely a short/interactive run, prefix the command with ALLOW_MODAL_RUN=1 to override."
+  jq -nc --arg r "$reason" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-modal-run.sh",
+            "statusMessage": "checking modal launch pattern"
+          }
+        ]
+      }
     ]
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,17 @@ help:
 	@echo "  make docs-lint      Run doc quality checks (spelling, markdown lint, link check)"
 	@echo ""
 	@echo "Utilities:"
+	@echo "  make status         One-screen sitrep: what we're doing + green/red"
 	@echo "  make clean          Remove build artifacts"
 	@echo "  make clean-all      Remove all generated files"
+
+# ------------------------------------------------------------------------------
+# Status
+# ------------------------------------------------------------------------------
+
+.PHONY: status
+status:
+	@./status.sh
 
 # ------------------------------------------------------------------------------
 # Setup

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,21 +7,22 @@ sections current; run `./status.sh` for live git/Modal/run signals._
 Prove the **GEPA-on-frozen-VLA** pipeline works (LIBERO-Plus Language, zero weight changes),
 then run the overnight A/B + GEPA experiment (#19). Pre-flight gate before that big run.
 
-## 🚦 Health: YELLOW
-- **Code: GREEN.** Pipeline is contract-correct; the `when().otherwise(prompt)` footgun is
-  fixed + committed (`956bb42`); GEPA lib is parity-tested (5/5).
-- **Runs: BLOCKED.** Long Modal jobs launched from this session keep getting **cancelled
-  ~3–10 min in** (environment reaps the client → Modal cancels). Smoke #2 and #3 both got
-  past the bug into real rollouts with **no code error**, then were killed. So we do **not
-  yet have one cleanly-completed smoke**. This is a *launch-method* problem, not a code problem.
+## 🚦 Health: YELLOW (→ GREEN when the smoke completes)
+- **Code: GREEN.** Pipeline contract-correct; `when().otherwise(prompt)` footgun fixed
+  (`956bb42`); GEPA lib parity-tested (5/5).
+- **Launch: FIXED.** Switched from `modal run --detach` (local CLI drives the job → session
+  reaped → Modal cancels) to **`modal deploy` + `spawn()`**: the job runs server-side, fully
+  decoupled; submit returns in ~1s. Smoke re-submitted this way → running in the cloud.
+- **Pending:** one clean completed smoke result, then #23 → #19.
 
 ## ▶️ Next action
-Re-launch the smoke via **deploy + `spawn()`** (server-side, decoupled from this session — no
-local streamer to kill). Once one smoke completes green → #23 headroom scan → #19 overnight.
+Fetch the in-flight smoke (`make status`, or `submit_gepa.py --fetch <id>`). On green →
+#23 headroom scan → #19 overnight — all via `submit_gepa.py` (spawn), **never** `modal run`.
 
 ## 🧱 Blockers
-- Detached `modal run` from this session does not survive. Fix = `modal deploy` the app, then
-  `run.spawn(...)` and read the result from the ledger / function-call id.
+- None open. Long runs now use `bench/libero/submit_gepa.py` → `spawn()` on the deployed
+  `archetype-gepa-daft` app. **Never launch the overnight via `modal run`** — it ties the job
+  to this session and gets cancelled.
 
 ## ✅ Done recently
 - HTML run-book: `docs/design/gepa-run-book.html` (open it for the full end-to-end).
@@ -31,7 +32,8 @@ local streamer to kill). Once one smoke completes green → #23 headroom scan �
 
 ## 🔑 Key files
 - Pipeline: `bench/libero/gepa_daft.py`  ·  Algorithm: `src/archetype/optimize/gepa.py`
-- Run-book: `docs/design/gepa-run-book.html`  ·  Headroom probe: `bench/libero/libero_plus_sweep.py`
+- Submit/fetch (spawn): `bench/libero/submit_gepa.py`  ·  Run-book: `docs/design/gepa-run-book.html`
+- Headroom probe: `bench/libero/libero_plus_sweep.py`
 
 ## 📌 Standing decisions
 - Zero weight changes (test-time only). Sim `pass` = ground truth (never an LLM judge).

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,39 @@
+# STATUS — read this first when you come back
+
+_Single source of truth for "what are we doing + is it green or red." Claude keeps the top
+sections current; run `./status.sh` for live git/Modal/run signals._
+
+## 🎯 Goal
+Prove the **GEPA-on-frozen-VLA** pipeline works (LIBERO-Plus Language, zero weight changes),
+then run the overnight A/B + GEPA experiment (#19). Pre-flight gate before that big run.
+
+## 🚦 Health: YELLOW
+- **Code: GREEN.** Pipeline is contract-correct; the `when().otherwise(prompt)` footgun is
+  fixed + committed (`956bb42`); GEPA lib is parity-tested (5/5).
+- **Runs: BLOCKED.** Long Modal jobs launched from this session keep getting **cancelled
+  ~3–10 min in** (environment reaps the client → Modal cancels). Smoke #2 and #3 both got
+  past the bug into real rollouts with **no code error**, then were killed. So we do **not
+  yet have one cleanly-completed smoke**. This is a *launch-method* problem, not a code problem.
+
+## ▶️ Next action
+Re-launch the smoke via **deploy + `spawn()`** (server-side, decoupled from this session — no
+local streamer to kill). Once one smoke completes green → #23 headroom scan → #19 overnight.
+
+## 🧱 Blockers
+- Detached `modal run` from this session does not survive. Fix = `modal deploy` the app, then
+  `run.spawn(...)` and read the result from the ledger / function-call id.
+
+## ✅ Done recently
+- HTML run-book: `docs/design/gepa-run-book.html` (open it for the full end-to-end).
+- GEPA promoted to lib `src/archetype/optimize/gepa.py` (+ demo, parity test).
+- daft-examples PR #42 (standalone GEPA-as-Daft gist, OpenRouter).
+- Pushed 4 commits (#20); redeployed both env workers (#21).
+
+## 🔑 Key files
+- Pipeline: `bench/libero/gepa_daft.py`  ·  Algorithm: `src/archetype/optimize/gepa.py`
+- Run-book: `docs/design/gepa-run-book.html`  ·  Headroom probe: `bench/libero/libero_plus_sweep.py`
+
+## 📌 Standing decisions
+- Zero weight changes (test-time only). Sim `pass` = ground truth (never an LLM judge).
+- Tier-1 legitimacy ordering: `A-default ≤ D-paraphrase < B-seed < C-oracle`.
+- Reflect prompt is answer-blind (never names the correct target).

--- a/bench/libero/baseline_sweep.py
+++ b/bench/libero/baseline_sweep.py
@@ -319,6 +319,11 @@ if _HAS_MODAL:
                 "*.mp4",
                 ".venv",
                 "**/*.parquet",
+                # Run logs / outputs are written into bench/libero/out during a
+                # live run; copying them into the image races the active writer
+                # ("modified during build process"). They are never needed remotely.
+                "**/*.log",
+                "**/out/**",
             ],
         )
         .run_commands(
@@ -329,7 +334,7 @@ if _HAS_MODAL:
     app = modal.App("archetype-libero-baseline-sweep", image=image)
     _RESULTS_VOLUME = modal.Volume.from_name("libero-eval-results", create_if_missing=True)
 
-    @app.function(volumes={RESULTS_DIR: _RESULTS_VOLUME}, timeout=3600)
+    @app.function(volumes={RESULTS_DIR: _RESULTS_VOLUME}, timeout=21600)
     def sweep_one_task(
         suite: str,
         task_id: int,

--- a/bench/libero/baseline_sweep.py
+++ b/bench/libero/baseline_sweep.py
@@ -1,0 +1,401 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Baseline sweep — the honest LIBERO-Para frontier → val/test split.
+
+This is WS2's first deliverable (see ``docs/design/gepa-core-loop.md`` §4 and
+``docs/design/libero-para-day-plan.md``). It runs every task in a LIBERO suite
+under the **raw LIBERO instruction** (the fair baseline, never the empty
+string), a few seeds each, records every rollout to the Archetype ledger, and
+computes a per-task success rate. From those numbers it produces a deterministic
+train/val/test split:
+
+- **val = the hardest tasks** (lowest baseline success = most room to climb).
+  The GEPA reflector sees only val.
+- **test = a held-out, distribution-matched subset** — never seen by the
+  reflector; measures whether the evolved paraphrase strategy generalizes.
+
+Co-located on Modal, modelled on ``colocated_runner.py``: the Archetype world
+loop (py3.12) runs *inside a Modal Function next to the env and policy workers*,
+so every ``env.step`` / ``policy.infer_refs`` call is a same-region internal
+call rather than a Mac->cloud round trip. We fan out **one Function per task**
+with ``.starmap``; each Function builds its own ``ModalEnvClient(suite,
+task_id)`` (a distinct ``LiberoEnvBatch`` parameter set → one env container per
+task) and the VLA-JEPA worker's lifted ``max_containers=8`` lets those parallel
+rollouts share the GPU pool.
+
+Every rollout lands on the append-only ledger (episode worlds keyed by
+``ep-{suite}-t{task_id}-trial{trial}`` + ``run_id``), so any trajectory is
+queryable and replayable by ``(world_id, run_id)`` for the scorer (WS5).
+
+Run the sweep (Modal auth required; no Anthropic key needed):
+    modal run bench/libero/baseline_sweep.py
+
+    # full default: libero_spatial, all 10 tasks, 3 seeds, 256 steps
+    modal run bench/libero/baseline_sweep.py --suite libero_spatial \\
+        --trials 3 --max-steps 256
+
+The split JSON is written to ``bench/libero/out/<suite>_split.json`` (pulled
+back from the results volume) and printed to stdout.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = "/repo"
+RESULTS_DIR = "/results"
+
+
+# ``modal`` is a runner-time dependency (a uv tool / global), not a project
+# dependency, so it is absent in the CI test venv. Import it lazily: the pure
+# split logic (``build_split``) stays importable for CI unit tests, while the
+# Modal app (image, function, entrypoint) is only defined when ``modal`` is
+# present (i.e. when this file is run via ``modal run``).
+try:
+    import modal  # type: ignore[import-not-found]
+
+    _HAS_MODAL = True
+except ImportError:  # pragma: no cover - exercised only in the CI test venv
+    modal = None  # type: ignore[assignment]
+    _HAS_MODAL = False
+
+# Set under the _HAS_MODAL guard below; only ever dereferenced inside a Modal
+# Function (where modal is always present), but defined here so the name exists
+# at module scope for linters and standalone imports.
+_RESULTS_VOLUME: Any = None
+
+
+def _run_one_task(
+    suite: str,
+    task_id: int,
+    trials: int,
+    max_steps: int,
+    run_id: str,
+) -> dict[str, Any]:
+    """Run one task's rollouts in-region and return its per-task summary.
+
+    Drives the *real* VLA-JEPA policy against the deployed LIBERO env with the
+    raw task instruction (the honest baseline). Each Function instance owns one
+    ``(suite, task_id)`` env container; inference fans across the GPU pool.
+
+    Returns ``{task_id, instruction, n, successes, success_rate, per_seed,
+    ledger_path}`` — all the numbers the split needs, plus where the rollouts
+    were persisted on the ledger.
+    """
+    import asyncio
+    import shutil
+    import sys
+    import time
+    from pathlib import Path as _Path
+
+    # bench/libero is a directory of loose scripts; the driver imports
+    # modal_worker by name, so its dir must be on the path.
+    sys.path.insert(0, f"{ROOT}/bench/libero")
+
+    from eval_driver import (  # type: ignore[import-not-found]
+        DriverConfig,
+        run_eval,
+    )
+
+    # Per-task ledger on fast local disk; copied to the network volume at the
+    # end. Writing the ledger straight to a Modal Volume would reintroduce the
+    # per-write network latency the co-location removes.
+    task_run_id = f"{run_id}:task{task_id}"
+    local_out = _Path("/tmp") / f"sweep-{task_run_id}"
+    local_out.mkdir(parents=True, exist_ok=True)
+
+    config = DriverConfig(
+        suite=suite,
+        task_ids=[task_id],
+        trials=trials,
+        max_steps=max_steps,
+        out=str(local_out),
+        run_id=task_run_id,
+        env_client_type="modal",
+        use_policy=True,
+        # No overrides → each task conditions on its raw LIBERO task_language()
+        # (the honest baseline, core-loop §2).
+        instruction_overrides={},
+    )
+
+    started = time.perf_counter()
+    results = asyncio.run(run_eval(config))
+    wall_s = time.perf_counter() - started
+
+    successes = sum(1 for r in results if getattr(r, "success", False))
+    n = len(results)
+    per_seed = [
+        {
+            "seed": getattr(r, "seed", None),
+            "trial_idx": getattr(r, "trial_idx", None),
+            "success": bool(getattr(r, "success", False)),
+            "episode_length": int(getattr(r, "episode_length", 0) or 0),
+        }
+        for r in sorted(results, key=lambda r: getattr(r, "trial_idx", 0))
+    ]
+
+    # Persist this task's ledger to the network volume so rollouts survive the
+    # Function and stay queryable by (world_id, run_id).
+    dest = _Path(RESULTS_DIR) / task_run_id
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(local_out, dest)
+    _RESULTS_VOLUME.commit()
+
+    return {
+        "task_id": task_id,
+        "n": n,
+        "successes": successes,
+        "success_rate": (successes / n) if n else 0.0,
+        "per_seed": per_seed,
+        "wall_s": round(wall_s, 1),
+        "ledger_path": str(dest),
+    }
+
+
+def build_split(
+    per_task: list[dict[str, Any]],
+    *,
+    suite: str,
+    val_size: int,
+    test_size: int,
+) -> dict[str, Any]:
+    """Deterministic val/test split from per-task success rates.
+
+    Policy (core-loop §4):
+    - **val = the hardest tasks** (lowest success rate). Most room to climb;
+      the reflector sees only these.
+    - **test = a held-out, distribution-matched subset** drawn from the
+      remaining (easier) tasks. We pick test tasks evenly spread across the
+      remaining difficulty range so the test distribution is not all-easy:
+      after removing the val tasks, sort the rest by success rate and sample
+      ``test_size`` indices at even strides. Test is evaluated once, at the end,
+      with the frozen strategy.
+
+    Ties broken by ``task_id`` for determinism. Returns a JSON-serializable dict
+    that records the split *and* the baseline numbers it was derived from, so
+    the split is auditable and reproducible from the ledger.
+    """
+    # Ascending success, then task_id — hardest first, deterministic ties.
+    ranked = sorted(per_task, key=lambda t: (t["success_rate"], t["task_id"]))
+
+    n_tasks = len(ranked)
+    val_size = max(0, min(val_size, n_tasks))
+    val_tasks = ranked[:val_size]
+    remaining = ranked[val_size:]
+
+    # Distribution-matched test: even strides across the remaining difficulty
+    # ordering so test is not all-easy nor adjacent-clustered.
+    test_size = max(0, min(test_size, len(remaining)))
+    if test_size and remaining:
+        if test_size == 1:
+            picks = [len(remaining) // 2]
+        else:
+            step = (len(remaining) - 1) / (test_size - 1)
+            picks = sorted({round(i * step) for i in range(test_size)})
+            # Resolve any collisions from rounding by filling forward.
+            cursor = 0
+            filled: list[int] = []
+            for p in picks:
+                p = max(p, cursor)
+                filled.append(min(p, len(remaining) - 1))
+                cursor = filled[-1] + 1
+            picks = filled
+        test_tasks = [remaining[i] for i in picks]
+    else:
+        test_tasks = []
+
+    def _ids(tasks: list[dict[str, Any]]) -> list[int]:
+        return sorted(t["task_id"] for t in tasks)
+
+    return {
+        "suite": suite,
+        "split_policy": (
+            "val = hardest (lowest baseline success, most room to climb); "
+            "test = held-out subset sampled at even strides across the "
+            "remaining difficulty ordering (distribution-matched, not all-easy)"
+        ),
+        "val_task_ids": _ids(val_tasks),
+        "test_task_ids": _ids(test_tasks),
+        "per_task": {
+            str(t["task_id"]): {
+                "success_rate": round(t["success_rate"], 4),
+                "successes": t["successes"],
+                "n": t["n"],
+            }
+            for t in ranked
+        },
+        "baseline": {
+            "all_task_ids": _ids(per_task),
+            "overall_success_rate": (
+                round(sum(t["successes"] for t in per_task) / sum(t["n"] for t in per_task), 4)
+                if sum(t["n"] for t in per_task)
+                else 0.0
+            ),
+        },
+    }
+
+
+def aggregate_and_write(
+    per_task: list[dict[str, Any]],
+    *,
+    suite: str,
+    run_id: str,
+    trials: int,
+    max_steps: int,
+    n_tasks: int,
+    val_size: int,
+    test_size: int,
+) -> dict[str, Any]:
+    """Print per-task numbers, build the split, write + return the split JSON.
+
+    Pure (no Modal): takes the collected per-task summaries and produces the
+    split artifact. Separated from ``main`` so it is unit-testable and so the
+    entrypoint stays a thin fan-out + aggregate.
+    """
+    per_task_sorted = sorted(per_task, key=lambda t: t["task_id"])
+    print("\n=== per-task baseline success (raw instruction) ===")
+    total_succ = sum(t["successes"] for t in per_task_sorted)
+    total_n = sum(t["n"] for t in per_task_sorted)
+    for t in per_task_sorted:
+        if t.get("error"):
+            print(f"  task {t['task_id']:>2}: ERROR  {t['error']}")
+            continue
+        print(
+            f"  task {t['task_id']:>2}: {t['successes']}/{t['n']} "
+            f"= {t['success_rate'] * 100:5.1f}%  (wall={t.get('wall_s', '?')}s)"
+        )
+    overall = (total_succ / total_n) if total_n else 0.0
+    print(f"  OVERALL: {total_succ}/{total_n} = {overall * 100:.1f}%")
+
+    # Only tasks with completed rollouts (n > 0) inform the split; errored tasks
+    # are surfaced separately so the split is built on real numbers.
+    completed = [t for t in per_task_sorted if t["n"] > 0]
+    errored = [t["task_id"] for t in per_task_sorted if t.get("error")]
+    split = build_split(completed, suite=suite, val_size=val_size, test_size=test_size)
+    split["errored_task_ids"] = sorted(errored)
+    split["run_id"] = run_id
+    split["config"] = {
+        "trials": trials,
+        "max_steps": max_steps,
+        "n_tasks": n_tasks,
+        "val_size": val_size,
+        "test_size": test_size,
+    }
+
+    out_dir = Path(__file__).parent / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{suite}_split.json"
+    out_path.write_text(json.dumps(split, indent=2) + "\n")
+
+    print("\n=== val / test split ===")
+    print(json.dumps(split, indent=2))
+    print(f"\nsplit written to {out_path}")
+    return split
+
+
+# ---------------------------------------------------------------------------
+# Modal app — defined only when ``modal`` is importable (runner-time).
+# ---------------------------------------------------------------------------
+
+if _HAS_MODAL:
+    # py3.12 + the archetype package only. The env (LIBERO/MuJoCo) and policy
+    # (VLA-JEPA) live in their own deployed apps; the sweep talks to them over
+    # the EnvClient / PolicyClient boundary, so this image excludes the heavy
+    # [sim] stack — same lean recipe as colocated_runner.py.
+    image = (
+        modal.Image.debian_slim(python_version="3.12")
+        .pip_install("uv")
+        .add_local_dir(
+            ".",
+            ROOT,
+            copy=True,
+            ignore=[
+                ".git",
+                "**/__pycache__",
+                ".claude",
+                "target",
+                "*.mp4",
+                ".venv",
+                "**/*.parquet",
+            ],
+        )
+        .run_commands(
+            f"cd {ROOT} && uv pip install --system -e . && uv pip install --system pillow numpy"
+        )
+    )
+
+    app = modal.App("archetype-libero-baseline-sweep", image=image)
+    _RESULTS_VOLUME = modal.Volume.from_name("libero-eval-results", create_if_missing=True)
+
+    @app.function(volumes={RESULTS_DIR: _RESULTS_VOLUME}, timeout=3600)
+    def sweep_one_task(
+        suite: str,
+        task_id: int,
+        trials: int,
+        max_steps: int,
+        run_id: str,
+    ) -> dict[str, Any]:
+        """Modal wrapper over ``_run_one_task`` (one env container per task).
+
+        Catches its own exceptions so one failing task cannot abort the whole
+        fan-out (``.starmap`` raises on the first uncaught error). A failed task
+        is reported as ``error`` with ``n=0`` and dropped from the split.
+        """
+        import traceback
+
+        try:
+            return _run_one_task(suite, task_id, trials, max_steps, run_id)
+        except Exception as exc:  # noqa: BLE001 - isolate per-task failures
+            return {
+                "task_id": task_id,
+                "n": 0,
+                "successes": 0,
+                "success_rate": 0.0,
+                "per_seed": [],
+                "error": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(),
+            }
+
+    @app.local_entrypoint()
+    def main(
+        suite: str = "libero_spatial",
+        n_tasks: int = 10,
+        trials: int = 3,
+        max_steps: int = 256,
+        val_size: int = 4,
+        test_size: int = 3,
+        run_id: str = "",
+    ):
+        """Fan the baseline sweep across all tasks, build + write the split.
+
+        Defaults match the locked contract: ``libero_spatial`` (all 10 tasks),
+        the raw instruction, 3 seeds each, max 256 steps. The split JSON is
+        written to ``bench/libero/out/<suite>_split.json`` and printed.
+        """
+        import time
+
+        run_id = run_id or f"baseline-{suite}-{int(time.time())}"
+        task_ids = list(range(n_tasks))
+
+        print(
+            f"=== baseline sweep === suite={suite} tasks={task_ids} "
+            f"trials={trials} max_steps={max_steps} run_id={run_id}"
+        )
+
+        # Fan out one Function per task — each owns its own env container;
+        # VLA-JEPA inference parallelizes across the lifted GPU pool.
+        args = [(suite, t, trials, max_steps, run_id) for t in task_ids]
+        per_task: list[dict[str, Any]] = list(sweep_one_task.starmap(args))
+
+        aggregate_and_write(
+            per_task,
+            suite=suite,
+            run_id=run_id,
+            trials=trials,
+            max_steps=max_steps,
+            n_tasks=n_tasks,
+            val_size=val_size,
+            test_size=test_size,
+        )

--- a/bench/libero/baseline_sweep.py
+++ b/bench/libero/baseline_sweep.py
@@ -362,6 +362,7 @@ if _HAS_MODAL:
     def main(
         suite: str = "libero_spatial",
         n_tasks: int = 10,
+        task_ids: str = "",
         trials: int = 3,
         max_steps: int = 256,
         val_size: int = 4,
@@ -373,20 +374,27 @@ if _HAS_MODAL:
         Defaults match the locked contract: ``libero_spatial`` (all 10 tasks),
         the raw instruction, 3 seeds each, max 256 steps. The split JSON is
         written to ``bench/libero/out/<suite>_split.json`` and printed.
+
+        ``task_ids`` (comma-separated) overrides ``n_tasks`` to target a
+        specific subset — useful for retrying a flaked task without re-running
+        the whole suite.
         """
         import time
 
         run_id = run_id or f"baseline-{suite}-{int(time.time())}"
-        task_ids = list(range(n_tasks))
+        if task_ids:
+            task_ids_list = [int(x) for x in str(task_ids).split(",") if x != ""]
+        else:
+            task_ids_list = list(range(n_tasks))
 
         print(
-            f"=== baseline sweep === suite={suite} tasks={task_ids} "
+            f"=== baseline sweep === suite={suite} tasks={task_ids_list} "
             f"trials={trials} max_steps={max_steps} run_id={run_id}"
         )
 
         # Fan out one Function per task — each owns its own env container;
         # VLA-JEPA inference parallelizes across the lifted GPU pool.
-        args = [(suite, t, trials, max_steps, run_id) for t in task_ids]
+        args = [(suite, t, trials, max_steps, run_id) for t in task_ids_list]
         per_task: list[dict[str, Any]] = list(sweep_one_task.starmap(args))
 
         aggregate_and_write(
@@ -395,7 +403,7 @@ if _HAS_MODAL:
             run_id=run_id,
             trials=trials,
             max_steps=max_steps,
-            n_tasks=n_tasks,
+            n_tasks=len(task_ids_list),
             val_size=val_size,
             test_size=test_size,
         )

--- a/bench/libero/baseline_sweep.py
+++ b/bench/libero/baseline_sweep.py
@@ -399,8 +399,26 @@ if _HAS_MODAL:
 
         # Fan out one Function per task — each owns its own env container;
         # VLA-JEPA inference parallelizes across the lifted GPU pool.
+        # return_exceptions=True so one preempted/killed container drops to an
+        # errored cell instead of nuking the whole sweep (the RemoteError
+        # "function call was cancelled" failure mode that killed earlier runs).
         args = [(suite, t, trials, max_steps, run_id) for t in task_ids_list]
-        per_task: list[dict[str, Any]] = list(sweep_one_task.starmap(args))
+        raw = list(sweep_one_task.starmap(args, return_exceptions=True))
+        per_task: list[dict[str, Any]] = []
+        for (_suite, t, *_rest), res in zip(args, raw, strict=True):
+            if isinstance(res, BaseException):
+                per_task.append(
+                    {
+                        "task_id": t,
+                        "n": 0,
+                        "successes": 0,
+                        "success_rate": 0.0,
+                        "per_seed": [],
+                        "error": f"{type(res).__name__}: {res}",
+                    }
+                )
+            else:
+                per_task.append(res)
 
         aggregate_and_write(
             per_task,

--- a/bench/libero/eval_driver.py
+++ b/bench/libero/eval_driver.py
@@ -297,6 +297,121 @@ async def run_episode(
     return success, episode_length
 
 
+async def run_episode_batched(
+    *,
+    env_client: Any,
+    policy_client: Any | None,
+    suite: str,
+    task_id: int,
+    seeds: list[int],
+    env_keys: list[int],
+    max_steps: int,
+    storage: StorageConfig,
+    runtime: ArchetypeRuntime,
+    use_frames: bool = False,
+    instruction: str = "",
+) -> list[tuple[bool, int]]:
+    """Drive ALL trials of one task as N entities in ONE world — batched.
+
+    The proven processors (``PolicyActionProcessor`` / ``FramedEnvStepProcessor``)
+    already issue one ``env.step([live env_keys], [live actions])`` per tick over
+    the whole DataFrame, so N seeds advance together each tick instead of in N
+    serial single-entity worlds. Within an episode the tick sequence stays coupled
+    (step t+1 needs t); across seeds everything is data → one batched tick.
+
+    Returns one ``(success, episode_length)`` per seed, ordered by ``env_key``
+    (== trial index). Success latches, so the per-entity ``max`` over its rows is
+    the verdict even for entities that finished early (mirrors ``monitor.py``).
+    """
+    import daft  # noqa: PLC0415
+    from daft import col as _col  # noqa: PLC0415
+
+    reset_tick_counters()
+    # Per-env reset (one-time); the worker holds N MuJoCo envs keyed by env_id.
+    obs_list = [env_client.reset(env_keys[i], seeds[i]) for i in range(len(seeds))]
+
+    processors: list[Any] = []
+    if policy_client is not None:
+        from archetype.experiments.policy import PolicyActionProcessor  # noqa: PLC0415
+
+        processors.append(PolicyActionProcessor(policy_client))
+    processors.append(
+        FramedEnvStepProcessor(env_client) if use_frames else EnvStepProcessor(env_client)
+    )
+
+    world = runtime.world(
+        f"ep-{suite}-t{task_id}-batch{len(seeds)}",
+        storage=storage,
+        processors=processors,
+    )
+
+    spawn_action = [0.0] * ACTION_DIM
+    for i, obs in enumerate(obs_list):
+        components: list[Any] = [
+            ManipProprio(
+                eef_pos=list(obs.get("eef_pos", [0.0, 0.0, 0.0])),
+                eef_quat=list(obs.get("eef_quat", [1.0, 0.0, 0.0, 0.0])),
+                gripper=float(obs.get("gripper", 0.0)),
+                gripper_qpos=list(obs.get("gripper_qpos", [0.0, 0.0])),
+            ),
+            ManipAction(values=list(spawn_action)),
+            ManipStatus(),
+            ManipTask(
+                suite=suite,
+                task_id=task_id,
+                instruction=instruction,
+                seed=seeds[i],
+                env_key=env_keys[i],
+            ),
+        ]
+        if use_frames:
+            components.append(
+                ManipFrameRef(
+                    agentview_ref=str(obs.get("agentview_ref", "")),
+                    wrist_ref=str(obs.get("wrist_ref", "")),
+                )
+            )
+        await world.spawn(*components)
+
+    # Batched control loop: one world.step() advances every live entity via a
+    # single batched env.step. Break only when EVERY entity is done.
+    for _tick in range(max_steps):
+        reset_tick_counters()
+        await world.step()
+        info = await world.info()
+        latest_tick = info.tick - 1
+        rows = (await world.query(ManipStatus)).where(_col("tick") == latest_tick).to_pylist()
+        if rows and all(r.get("manipstatus__done", False) for r in rows):
+            break
+
+    # Per-entity terminal verdict (success latches → max), joined to env_key
+    # (constant per entity) so results come back in trial order.
+    status = (
+        (await world.query(ManipStatus))
+        .groupby("entity_id")
+        .agg(
+            _col("manipstatus__success").cast(daft.DataType.int64()).max().alias("success"),
+            _col("manipstatus__env_step").max().alias("steps"),
+        )
+        .to_pylist()
+    )
+    tasks = (
+        (await world.query(ManipTask))
+        .groupby("entity_id")
+        .agg(_col("maniptask__env_key").max().alias("env_key"))
+        .to_pylist()
+    )
+    await world.destroy()
+
+    key_by_entity = {r["entity_id"]: int(r["env_key"]) for r in tasks}
+    by_env_key: dict[int, tuple[bool, int]] = {}
+    for r in status:
+        ek = key_by_entity.get(r["entity_id"])
+        if ek is not None:
+            by_env_key[ek] = (bool(r["success"]), int(r["steps"] or 0))
+    return [by_env_key.get(ek, (False, 0)) for ek in env_keys]
+
+
 # ---------------------------------------------------------------------------
 # Top-level driver
 # ---------------------------------------------------------------------------
@@ -381,27 +496,33 @@ async def run_eval(config: DriverConfig) -> list[EvalTrialResult]:
             )
             print(f"  [{config.suite}] task={task_id} instruction={instruction!r}")
 
-            for trial_idx in range(config.trials):
-                seed = task_id * 1000 + trial_idx
-                env_key = trial_idx  # distinct per-trial env instance
+            # Batch ALL trials of this task into ONE world: N seed-entities
+            # stepped by a single batched env.step per tick — not N serial
+            # single-entity episode worlds. Across-task parallelism stays at the
+            # .starmap layer (one Function/container per task).
+            seeds = [task_id * 1000 + i for i in range(config.trials)]
+            env_keys = list(range(config.trials))
 
-                t0 = time.perf_counter()
-                success, episode_length = await run_episode(
-                    env_client=env_client,
-                    policy_client=policy_client,
-                    suite=config.suite,
-                    task_id=task_id,
-                    trial_idx=trial_idx,
-                    seed=seed,
-                    env_key=env_key,
-                    max_steps=config.max_steps,
-                    storage=ep_storage,
-                    runtime=runtime,
-                    use_frames=use_frames,
-                    instruction=instruction,
-                )
-                wall_s = time.perf_counter() - t0
+            t0 = time.perf_counter()
+            per_trial = await run_episode_batched(
+                env_client=env_client,
+                policy_client=policy_client,
+                suite=config.suite,
+                task_id=task_id,
+                seeds=seeds,
+                env_keys=env_keys,
+                max_steps=config.max_steps,
+                storage=ep_storage,
+                runtime=runtime,
+                use_frames=use_frames,
+                instruction=instruction,
+            )
+            wall_total = time.perf_counter() - t0
+            wall_each = wall_total / max(1, len(per_trial))
 
+            for trial_idx, (success, episode_length) in enumerate(per_trial):
+                seed = seeds[trial_idx]
+                env_key = env_keys[trial_idx]
                 trial_result = EvalTrialResult.make(
                     suite=config.suite,
                     task_id=task_id,
@@ -410,14 +531,13 @@ async def run_eval(config: DriverConfig) -> list[EvalTrialResult]:
                     env_key=env_key,
                     success=success,
                     episode_length=episode_length,
-                    wall_s=wall_s,
+                    wall_s=wall_each,
                     run_id=run_id,
                 )
                 results.append(trial_result)
 
-                # Append to lab world; step to persist.
-                # Reset quota counter before lab-world operations to avoid
-                # hitting the 500-command limit from accumulated episode operations.
+                # Append to lab world; step to persist. Reset quota counter to
+                # avoid the 500-command-per-tick limit from accumulated ops.
                 reset_tick_counters()
                 await lab.spawn(trial_result)
                 await lab.step()
@@ -425,7 +545,7 @@ async def run_eval(config: DriverConfig) -> list[EvalTrialResult]:
                 print(
                     f"  [{config.suite}] task={task_id} trial={trial_idx} "
                     f"success={success} steps={episode_length} "
-                    f"wall={wall_s:.1f}s seed={seed}"
+                    f"seed={seed} (batched task wall={wall_total:.1f}s)"
                 )
 
         # Mark runs as stopped.

--- a/bench/libero/eval_driver.py
+++ b/bench/libero/eval_driver.py
@@ -107,6 +107,42 @@ def _make_modal_env_client(suite: str, task_id: int, with_frames: bool = False) 
     return ModalEnvClient(suite=suite, task_id=task_id, with_frames=with_frames)
 
 
+def _resolve_instruction(
+    *,
+    suite: str,
+    task_id: int,
+    env_client: Any,
+    override_map: dict[tuple[str, int], str] | None,
+) -> str:
+    """Resolve the conditioning instruction for one (suite, task_id).
+
+    Fairness rule (core-loop §2): the baseline is the *raw* LIBERO instruction,
+    never the empty string.  Resolution order:
+
+    1. If ``override_map`` supplies a paraphrase for ``(suite, task_id)``, use it.
+       (This is the GEPA hook — a strategy can swap the conditioning text later.)
+    2. Otherwise, default to the env's native ``task_language()`` (the canonical
+       LIBERO instruction for the task), queried over the EnvClient boundary.
+    3. If neither is available (e.g. a scripted env with no ``task_language``),
+       fall back to the empty string — scripted reach envs ignore the
+       instruction entirely, so this only ever happens off the real-policy path.
+
+    The resolved string flows through ``ManipTask.instruction`` →
+    ``PolicyActionProcessor`` → ``VlaJepaPolicyClient.infer_refs(instruction=...)``.
+    """
+    if override_map is not None:
+        override = override_map.get((suite, task_id))
+        if override:
+            return override
+    task_language = getattr(env_client, "task_language", None)
+    if callable(task_language):
+        try:
+            return str(task_language())
+        except Exception:  # noqa: BLE001 - scripted/test envs may not implement it
+            return ""
+    return ""
+
+
 def _make_vla_policy_client(suite: str, task_id: int) -> Any:
     """Build a VlaJepaPolicyClient; deferred so scripted path avoids Modal."""
     from archetype.experiments.policy import VlaJepaPolicyClient  # noqa: PLC0415
@@ -138,6 +174,11 @@ class DriverConfig:
     run_id: str = ""  # free-form run label
     env_client_type: str = "modal"  # "modal" or "scripted"
     use_policy: bool = True  # False → zero-action policy (scripted path)
+    # Optional per-(suite, task_id) instruction override map. When a key is
+    # present, its paraphrase replaces the env's native task_language() for that
+    # task — the GEPA hook (core-loop §3). Absent keys fall back to the raw
+    # LIBERO instruction (the honest baseline, core-loop §2).
+    instruction_overrides: dict[tuple[str, int], str] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +199,7 @@ async def run_episode(
     storage: StorageConfig,
     runtime: ArchetypeRuntime,
     use_frames: bool = False,
+    instruction: str = "",
 ) -> tuple[bool, int]:
     """Drive one episode on an isolated world.
 
@@ -211,7 +253,7 @@ async def run_episode(
         ManipTask(
             suite=suite,
             task_id=task_id,
-            instruction="",
+            instruction=instruction,
             seed=seed,
             env_key=env_key,
         ),
@@ -328,6 +370,17 @@ async def run_eval(config: DriverConfig) -> list[EvalTrialResult]:
                     _make_vla_policy_client(config.suite, task_id) if config.use_policy else None
                 )
 
+            # Resolve the conditioning instruction once per task: paraphrase
+            # override if supplied, else the env's native task_language() (the
+            # honest baseline). Empty string only on the scripted path.
+            instruction = _resolve_instruction(
+                suite=config.suite,
+                task_id=task_id,
+                env_client=env_client,
+                override_map=config.instruction_overrides,
+            )
+            print(f"  [{config.suite}] task={task_id} instruction={instruction!r}")
+
             for trial_idx in range(config.trials):
                 seed = task_id * 1000 + trial_idx
                 env_key = trial_idx  # distinct per-trial env instance
@@ -345,6 +398,7 @@ async def run_eval(config: DriverConfig) -> list[EvalTrialResult]:
                     storage=ep_storage,
                     runtime=runtime,
                     use_frames=use_frames,
+                    instruction=instruction,
                 )
                 wall_s = time.perf_counter() - t0
 

--- a/bench/libero/eval_driver.py
+++ b/bench/libero/eval_driver.py
@@ -389,16 +389,15 @@ async def run_episode_batched(
             )
         await world.spawn(*components)
 
-    # Batched control loop: one world.step() advances every live entity via a
-    # single batched env.step. Break only when EVERY entity is done.
-    for _tick in range(max_steps):
-        reset_tick_counters()
-        await world.step()
-        info = await world.info()
-        latest_tick = info.tick - 1
-        rows = (await world.query(ManipStatus)).where(_col("tick") == latest_tick).to_pylist()
-        if rows and all(r.get("manipstatus__done", False) for r in rows):
-            break
+    # Service-layer orchestration: delegate the episode loop to
+    # SimulationService.run_episode (gate.run_episode), which owns the per-tick
+    # quota reset and steps to max_steps through the command broker — no
+    # hand-rolled tick loop. Done entities are skipped by the step processor, so
+    # spinning to max_steps costs no extra env calls. The terminal verdict is
+    # read from the ledger below (success latches → max).
+    from archetype.app.models import EpisodeConfig  # noqa: PLC0415
+
+    await world.run_episode(EpisodeConfig(max_steps=max_steps))
 
     # Per-entity terminal verdict (success latches → max), joined to env_key
     # (constant per entity) so results come back in trial order.

--- a/bench/libero/eval_driver.py
+++ b/bench/libero/eval_driver.py
@@ -107,6 +107,22 @@ def _make_modal_env_client(suite: str, task_id: int, with_frames: bool = False) 
     return ModalEnvClient(suite=suite, task_id=task_id, with_frames=with_frames)
 
 
+def _make_libero_plus_env_client(suite: str, task_id: int, with_frames: bool = False) -> Any:
+    """Build a LiberoPlusEnvClient for the LANGUAGE-perturbation dimension.
+
+    Drop-in for ``ModalEnvClient`` (same reset/step/task_language surface); here
+    ``task_id`` is the *ordinal within the suite's Language Instructions list*,
+    and ``task_language()`` returns the PERTURBED instruction — the honest
+    LIBERO-Plus baseline. Deferred import so the scripted/standard paths never
+    import the LIBERO-Plus worker module.
+    """
+    from libero_plus_worker import (
+        LiberoPlusEnvClient,  # type: ignore[import-untyped]  # noqa: PLC0415
+    )
+
+    return LiberoPlusEnvClient(suite=suite, task_id=task_id, with_frames=with_frames)
+
+
 def _resolve_instruction(
     *,
     suite: str,
@@ -172,7 +188,7 @@ class DriverConfig:
     max_steps: int = 600
     out: str = ""  # output directory for lab-world parquet
     run_id: str = ""  # free-form run label
-    env_client_type: str = "modal"  # "modal" or "scripted"
+    env_client_type: str = "modal"  # "modal", "modal_plus" (LIBERO-Plus LANGUAGE), or "scripted"
     use_policy: bool = True  # False → zero-action policy (scripted path)
     # Optional per-(suite, task_id) instruction override map. When a key is
     # present, its paraphrase replaces the env's native task_language() for that
@@ -480,7 +496,14 @@ async def run_eval(config: DriverConfig) -> list[EvalTrialResult]:
                 env_client = _make_scripted_env(task_id)
                 policy_client = None
             else:
-                env_client = _make_modal_env_client(config.suite, task_id, with_frames=use_frames)
+                if config.env_client_type == "modal_plus":
+                    env_client = _make_libero_plus_env_client(
+                        config.suite, task_id, with_frames=use_frames
+                    )
+                else:
+                    env_client = _make_modal_env_client(
+                        config.suite, task_id, with_frames=use_frames
+                    )
                 policy_client = (
                     _make_vla_policy_client(config.suite, task_id) if config.use_policy else None
                 )
@@ -574,9 +597,13 @@ def _parse_args() -> DriverConfig:
     parser.add_argument("--run-id", default="", help="Run identifier label")
     parser.add_argument(
         "--env-client",
-        choices=["modal", "scripted"],
+        choices=["modal", "modal_plus", "scripted"],
         default="modal",
-        help="'modal' uses the deployed Modal env; 'scripted' uses the in-process scripted env",
+        help=(
+            "'modal' uses the deployed standard-LIBERO env; 'modal_plus' uses the "
+            "LIBERO-Plus LANGUAGE-perturbation env (task-id = language ordinal); "
+            "'scripted' uses the in-process scripted env"
+        ),
     )
     parser.add_argument(
         "--no-policy",

--- a/bench/libero/gepa_core.py
+++ b/bench/libero/gepa_core.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The GEPA algorithm — pure, effect-injected, testable in isolation.
+
+This is a faithful, single-module implementation of GEPA (Agrawal et al. 2025,
+arXiv:2507.19457): Algorithm 1 (reflective evolution loop) + Algorithm 2
+(Pareto-based candidate selection). It has NO Daft/Modal/LLM/sim dependency — the
+two effects are injected:
+
+    eval_fn(sid, text, instance_ids)  -> {instance_id: {"s": float, "fb": str}}
+        run the candidate strategy on those instances; return per-instance score + feedback.
+    reflect_fn(text, feedback_block)  -> str
+        GEPA's UpdatePrompt: reflect on minibatch feedback → an improved strategy.
+
+`gepa_daft.py` injects Daft-backed effects (prompt() rewrite + sim rollout);
+`tests/experiments/test_gepa_daft.py` injects deterministic mocks to prove the
+control logic matches GEPA. Single MODULE: we evolve one prompt component, so
+GEPA's per-module round-robin and system-aware merge are no-ops; the parts that
+*define* GEPA — per-instance score vectors, the Pareto frontier, the
+minibatch→accept gate, and the rollout budget — are all here.
+
+GEPA Alg-line references are in the code.
+"""
+
+from __future__ import annotations
+
+from random import Random
+from typing import Any, Callable, Protocol
+
+
+class _Rng(Protocol):
+    def sample(self, population: list[int], k: int) -> list[int]: ...
+    def choices(self, population: list[Any], weights: list[float], k: int) -> list[Any]: ...
+
+
+EvalFn = Callable[[str, str, list[int]], dict[int, dict[str, Any]]]
+ReflectFn = Callable[[str, str], str]
+
+
+def pareto_select(pool: list[dict[str, Any]], instance_ids: list[int], rng: _Rng) -> dict[str, Any]:
+    """GEPA Algorithm 2 — instance-wise Pareto candidate selection.
+
+    NOT top-k-by-mean (beam). Steps, verbatim from the paper:
+      1. per-instance best:   s*[i] = max_k S[k][i]
+      2. per-instance winners: P*[i] = {k : S[k][i] == s*[i]}
+      3. prune candidates strictly dominated across instances
+      4. sample ∝ f[Φ] = #instances for which Φ ∈ P*[i]
+
+    A specialist that wins one instance survives even if its mean is low — which is
+    exactly the diversity beam search throws away.
+    """
+    star = {i: max(c["scores"][i] for c in pool) for i in instance_ids}
+    wins = {c["sid"]: sum(1 for i in instance_ids if c["scores"][i] == star[i]) for c in pool}
+    frontier = [c for c in pool if wins[c["sid"]] > 0]
+    nondominated = [
+        c
+        for c in frontier
+        if not any(
+            d is not c
+            and all(d["scores"][i] >= c["scores"][i] for i in instance_ids)
+            and any(d["scores"][i] > c["scores"][i] for i in instance_ids)
+            for d in frontier
+        )
+    ]
+    return rng.choices(nondominated, weights=[wins[c["sid"]] for c in nondominated], k=1)[0]
+
+
+def _candidate(sid: str, text: str, res: dict[int, dict[str, Any]], instance_ids: list[int]) -> dict[str, Any]:
+    return {
+        "sid": sid,
+        "text": text,
+        "scores": {i: res[i]["s"] for i in instance_ids},  # per-instance score VECTOR (Pareto needs this)
+        "fbk": {i: res[i]["fb"] for i in instance_ids},
+    }
+
+
+def gepa_search(
+    *,
+    seed_text: str,
+    instance_ids: list[int],
+    eval_fn: EvalFn,
+    reflect_fn: ReflectFn,
+    budget: int,
+    minibatch: int,
+    rng: _Rng | None = None,
+) -> dict[str, Any]:
+    """GEPA Algorithm 1 — reflective evolution with Pareto selection.
+
+    Budget is counted in metric calls (one candidate × one instance = one call).
+    Returns the best candidate on the full instance set + the search trace.
+    """
+    rng = rng or Random(0)
+
+    # Alg 1 line 7 + 18-20: P ← [base]; full-eval the seed on all instances (D_pareto).
+    pool = [_candidate("gepa-seed", seed_text, eval_fn("gepa-seed", seed_text, instance_ids), instance_ids)]
+    spent = len(instance_ids)
+    trace: list[dict[str, Any]] = []
+    gen = 0
+
+    while spent + minibatch <= budget:  # Alg 1 line 8: while budget B not exhausted
+        gen += 1
+        parent = pareto_select(pool, instance_ids, rng)                      # Alg 2
+        mb = rng.sample(instance_ids, min(minibatch, len(instance_ids)))     # minibatch from D_feedback
+        sigma = sum(parent["scores"][i] for i in mb) / len(mb)              # σ (cached parent vector/feedback)
+        fb = "\n".join(f"- instance {i}: {parent['fbk'][i]}" for i in mb)
+        child_text = reflect_fn(parent["text"], fb)                         # Alg 1 line 13: UpdatePrompt
+        csid = f"gepa-g{gen}"
+        c_res = eval_fn(f"{csid}-mb", child_text, mb)                       # evaluate child on minibatch
+        spent += len(mb)
+        sigma_prime = sum(c_res[i]["s"] for i in mb) / len(mb)            # σ'
+        accepted = sigma_prime > sigma                                      # Alg 1 line 16: acceptance gate
+        trace.append(
+            {"gen": gen, "parent": parent["sid"], "sigma": round(sigma, 4),
+             "sigma_prime": round(sigma_prime, 4), "accepted": accepted, "spent": spent}
+        )
+        if accepted and spent + len(instance_ids) <= budget:
+            full = eval_fn(csid, child_text, instance_ids)                  # Alg 1 line 18-20: full-eval D_pareto
+            spent += len(instance_ids)
+            pool.append(_candidate(csid, child_text, full, instance_ids))
+
+    best = max(pool, key=lambda c: sum(c["scores"].values()) / len(c["scores"]))  # best on D_pareto
+    return {
+        "strategy_id": best["sid"],
+        "strategy_text": best["text"],
+        "mean_success": sum(best["scores"].values()) / len(best["scores"]),
+        "pool_size": len(pool),
+        "metric_calls": spent,
+        "trace": trace,
+    }

--- a/bench/libero/gepa_daft.py
+++ b/bench/libero/gepa_daft.py
@@ -23,7 +23,7 @@ is the same `evaluate()` in a reflect→select loop. `pass` = sim ground truth.
 
 Run (after archetype-libero-plus-env + archetype-vla-jepa are deployed):
     modal run --detach bench/libero/gepa_daft.py --suite libero_goal \\
-        --n-tasks 8 --n-seeds 5 --max-steps 300 --generations 3 --beam-k 3
+        --n-tasks 8 --n-seeds 5 --max-steps 300 --budget 60 --minibatch 3
 """
 
 import os
@@ -108,9 +108,9 @@ def run(
     sys.path.insert(0, f"{ROOT}/bench/libero")
 
     import daft
-    from daft import col, lit
+    from daft import col
     from daft.functions import format as dfmt
-    from daft.functions import prompt, unnest, when
+    from daft.functions import prompt, unnest
     from pydantic import BaseModel, Field
 
     # ---- Claude as the Daft prompt() provider (OpenAI-compatible) -------------
@@ -145,13 +145,14 @@ def run(
             import tempfile
 
             _sys.path.insert(0, f"{ROOT}/bench/libero")
-            from archetype import ArchetypeRuntime
-            from archetype.core.config import StorageConfig
             from eval_driver import (
                 _make_libero_plus_env_client,
                 _make_vla_policy_client,
                 run_episode_batched,
             )
+
+            from archetype import ArchetypeRuntime
+            from archetype.core.config import StorageConfig
 
             env = self._envs.get(task_id)
             if env is None:
@@ -188,23 +189,29 @@ def run(
     def evaluate(strategies: "daft.DataFrame", tasks: "daft.DataFrame" = None) -> "daft.DataFrame":
         """strategies: [strategy_id, strategy_text(nullable)] × tasks → per-cell scores+feedback."""
         cells = strategies.join(tasks if tasks is not None else tasks_df, how="cross")
-        # rewrite: identity when strategy_text is null, else apply the strategy via Claude.
-        cells = cells.with_column(
+        # Rewrite: identity when strategy_text is null (arm A), else apply the strategy
+        # via Claude. NOTE: daft when().otherwise() evaluates BOTH branches for every row,
+        # so a prompt() in the otherwise branch still runs on null-strategy rows and chokes
+        # on the null message. Split on the predicate → prompt() only runs where a strategy
+        # is present (also avoids wasted LLM calls on identity rows).
+        named = cells.where(~col("strategy_text").is_null()).with_column(
             "grounded",
-            when(col("strategy_text").is_null(), col("perturbed_instr")).otherwise(
-                prompt(
-                    messages=dfmt(
-                        "{}\n\nOriginal instruction:\n{}\n\n"
-                        "Rewritten instruction (one imperative sentence):",
-                        col("strategy_text"),
-                        col("perturbed_instr"),
-                    ),
-                    model=REWRITE_MODEL,
-                    use_chat_completions=True,
-                    max_tokens=200,
-                )
+            prompt(
+                messages=dfmt(
+                    "{}\n\nOriginal instruction:\n{}\n\n"
+                    "Rewritten instruction (one imperative sentence):",
+                    col("strategy_text"),
+                    col("perturbed_instr"),
+                ),
+                model=REWRITE_MODEL,
+                use_chat_completions=True,
+                max_tokens=200,
             ),
         )
+        identity = cells.where(col("strategy_text").is_null()).with_column(
+            "grounded", col("perturbed_instr")
+        )
+        cells = named.concat(identity)
         cells = cells.with_column("res", evaluator.eval(col("suite"), col("task_id"), col("grounded")))
         return cells.select(
             "strategy_id",

--- a/bench/libero/gepa_daft.py
+++ b/bench/libero/gepa_daft.py
@@ -242,15 +242,15 @@ def run(
         .to_pylist()
     )
 
-    # ---- Tier 2: GEPA — algorithm in gepa_core.gepa_search; effects injected here ----
-    # gepa_core owns faithful Algorithm 1 + Pareto Algorithm 2 (no Daft/Modal dep,
+    # ---- Tier 2: GEPA — algorithm in archetype.optimize.gepa; effects injected here ----
+    # The lib owns faithful Algorithm 1 + Pareto Algorithm 2 (no Daft/Modal dep,
     # unit-tested in tests/experiments/test_gepa_daft.py). run() only supplies the two
     # EFFECTS: eval_fn (prompt-rewrite + sim rollout) and reflect_fn (Claude UpdatePrompt).
     best: dict[str, Any] | None = None
     if do_gepa:
         import random
 
-        from gepa_core import gepa_search
+        from archetype.optimize.gepa import gepa_search
 
         class Strategy(BaseModel):
             strategy_text: str = Field(description="an improved instruction-rewrite strategy")

--- a/bench/libero/gepa_daft.py
+++ b/bench/libero/gepa_daft.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GEPA as a Daft pipeline — reflective instruction evolution over the ledger.
+
+No gepa package, no nested Modal functions, no LiteLLM. The whole optimization is
+DataFrame ops:
+
+    rewrite   = daft.functions.prompt(...)        # LLM-in-expression (Claude via OAI-compat)
+    evaluate  = RolloutEvaluator @daft.cls        # async, use_process → isolated VLA-JEPA rollout
+    reflect   = daft.functions.prompt(..., return_format=Strategy)   # LLM-in-expression
+    select    = plain DataFrame / Python at the generation boundary
+
+The ONLY .remote() calls are to the *deployed* env/policy workers
+(archetype-libero-plus-env, archetype-vla-jepa) — the proven baseline_sweep path.
+The whole thing runs inside ONE Modal function (run, --detach friendly); the Daft
+executor provides intra-container parallelism. Every (strategy, task) cell is
+written to the canonical ledger as Lance, so the optimization is queryable +
+reproducible.
+
+Arms A/D/B-seed/C are gen-0 with a fixed strategy (A = identity, no rewrite); GEPA
+is the same `evaluate()` in a reflect→select loop. `pass` = sim ground truth.
+
+Run (after archetype-libero-plus-env + archetype-vla-jepa are deployed):
+    modal run --detach bench/libero/gepa_daft.py --suite libero_goal \\
+        --n-tasks 8 --n-seeds 5 --max-steps 300 --generations 3 --beam-k 3
+"""
+
+import os
+from typing import Any
+
+import modal
+
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+
+ROOT = "/repo"
+RESULTS_DIR = "/results"
+LEDGER = f"{RESULTS_DIR}/gepa_daft"
+
+# Claude via Anthropic's OpenAI-compatible endpoint (we already have the key as a
+# Modal secret). Set as the Daft session provider inside `run`.
+ANTHROPIC_OAI_BASE = "https://api.anthropic.com/v1/"
+REWRITE_MODEL = "claude-sonnet-4-6"   # apply a strategy to one instruction (cheap)
+REFLECT_MODEL = "claude-opus-4-8"     # propose improved strategies (reasoning-heavy)
+
+# The seed rewrite strategy GEPA evolves; also arm "B-seed" (one-shot, un-evolved).
+SEED_STRATEGY = (
+    "You rewrite a robot-manipulation instruction into a clearer, better-grounded "
+    "instruction for a frozen vision-language-action policy. Name the target object "
+    "by its visual appearance and spatial relation to nearby objects; state the goal "
+    "location explicitly. Keep it ONE imperative sentence. Do NOT add information that "
+    "solves the task (no coordinates, no answer) — only re-ground what is already there."
+)
+# Fixed-arm strategies. None = identity (use the perturbed instruction verbatim).
+NEUTRAL_PARAPHRASE = (
+    "Paraphrase the instruction in different words WITHOUT adding any grounding, object "
+    "descriptions, or spatial detail. Keep the same information content. One sentence."
+)
+ORACLE_SMUGGLE = (
+    "Rewrite the instruction and explicitly NAME the exact correct target object and "
+    "destination so the policy cannot pick the wrong one. One imperative sentence."
+)
+ARMS: dict[str, str | None] = {
+    "A-default": None,            # perturbed instruction as-is (the ~85% baseline)
+    "D-paraphrase": NEUTRAL_PARAPHRASE,
+    "B-seed": SEED_STRATEGY,
+    "C-oracle": ORACLE_SMUGGLE,
+}
+
+# Lean image: archetype + daft[openai] (the prompt() provider) + pydantic.
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .pip_install("uv")
+    .add_local_dir(
+        ".",
+        ROOT,
+        copy=True,
+        ignore=[".git", "**/__pycache__", ".claude", "target", "*.mp4", ".venv",
+                "**/*.parquet", "**/*.log", "**/out/**"],
+    )
+    .run_commands(
+        # archetype already pulls daft[openai,lance,iceberg]>=0.7.4 (0.7.9 has
+        # prompt() + the OpenAI provider). Do NOT force a daft upgrade — it would
+        # drift from archetype's pinned daft. Just add the LLM-output validator.
+        f"cd {ROOT} && uv pip install --system -e . && uv pip install --system pillow numpy pydantic"
+    )
+)
+
+app = modal.App("archetype-gepa-daft", image=image)
+results_volume = modal.Volume.from_name("libero-eval-results", create_if_missing=True)
+ANTHROPIC_SECRET = modal.Secret.from_name("anthropic-api-key")
+
+
+@app.function(volumes={RESULTS_DIR: results_volume}, timeout=21600, secrets=[ANTHROPIC_SECRET])
+def run(
+    suite: str = "libero_goal",
+    n_tasks: int = 8,
+    n_seeds: int = 5,
+    max_steps: int = 300,
+    budget: int = 60,        # GEPA rollout budget, counted in (strategy×task) metric calls
+    minibatch: int = 3,      # GEPA minibatch size b for the mutate→accept gate
+    do_gepa: bool = True,
+) -> dict[str, Any]:
+    """Run the fixed-arm ablation (A/D/B-seed/C) + the GEPA loop, all as Daft."""
+    import sys
+
+    sys.path.insert(0, f"{ROOT}/bench/libero")
+
+    import daft
+    from daft import col, lit
+    from daft.functions import format as dfmt
+    from daft.functions import prompt, unnest, when
+    from pydantic import BaseModel, Field
+
+    # ---- Claude as the Daft prompt() provider (OpenAI-compatible) -------------
+    daft.set_provider(
+        "openai", api_key=os.environ["ANTHROPIC_API_KEY"], base_url=ANTHROPIC_OAI_BASE
+    )
+
+    RES_DTYPE = daft.DataType.struct(
+        {
+            "success_rate": daft.DataType.float64(),
+            "successes": daft.DataType.int64(),
+            "n": daft.DataType.int64(),
+            "feedback": daft.DataType.string(),
+        }
+    )
+
+    # ---- The evaluator: one isolated process per concurrent rollout ----------
+    # use_process=True → each instance has its OWN global RBAC tick-counter, so
+    # concurrent rollouts can't race on it. async → Daft runs up to
+    # max_concurrency rollouts at once; each calls the DEPLOYED workers.
+    @daft.cls(max_concurrency=min(n_tasks, 8), use_process=True)
+    class RolloutEvaluator:
+        def __init__(self, max_steps: int, n_seeds: int):
+            self.max_steps = max_steps
+            self.n_seeds = n_seeds
+            self._envs: dict[int, Any] = {}
+            self._pols: dict[int, Any] = {}
+
+        @daft.method(return_dtype=RES_DTYPE)
+        async def eval(self, suite: str, task_id: int, instruction: str) -> dict[str, Any]:
+            import sys as _sys
+            import tempfile
+
+            _sys.path.insert(0, f"{ROOT}/bench/libero")
+            from archetype import ArchetypeRuntime
+            from archetype.core.config import StorageConfig
+            from eval_driver import (
+                _make_libero_plus_env_client,
+                _make_vla_policy_client,
+                run_episode_batched,
+            )
+
+            env = self._envs.get(task_id)
+            if env is None:
+                env = _make_libero_plus_env_client(suite, task_id, with_frames=True)
+                self._envs[task_id] = env
+            pol = self._pols.get(task_id)
+            if pol is None:
+                pol = _make_vla_policy_client(suite, task_id)
+                self._pols[task_id] = pol
+
+            seeds = [task_id * 1000 + i for i in range(self.n_seeds)]
+            env_keys = list(range(self.n_seeds))
+            store = StorageConfig(uri=tempfile.mkdtemp(prefix="gepa-"), namespace="gepa_eval")
+            try:
+                async with ArchetypeRuntime() as rt:
+                    per_trial = await run_episode_batched(
+                        env_client=env,
+                        policy_client=pol,
+                        suite=suite,
+                        task_id=task_id,
+                        seeds=seeds,
+                        env_keys=env_keys,
+                        max_steps=self.max_steps,
+                        storage=store,
+                        runtime=rt,
+                        use_frames=True,
+                        instruction=instruction,
+                    )
+            except Exception as exc:  # noqa: BLE001 — one cell failing must not kill the plan
+                return {"success_rate": 0.0, "successes": 0, "n": 0, "feedback": f"harness error: {exc}"}
+            return _summarize(per_trial, self.max_steps)
+
+    # ---- helpers --------------------------------------------------------------
+    def evaluate(strategies: "daft.DataFrame", tasks: "daft.DataFrame" = None) -> "daft.DataFrame":
+        """strategies: [strategy_id, strategy_text(nullable)] × tasks → per-cell scores+feedback."""
+        cells = strategies.join(tasks if tasks is not None else tasks_df, how="cross")
+        # rewrite: identity when strategy_text is null, else apply the strategy via Claude.
+        cells = cells.with_column(
+            "grounded",
+            when(col("strategy_text").is_null(), col("perturbed_instr")).otherwise(
+                prompt(
+                    messages=dfmt(
+                        "{}\n\nOriginal instruction:\n{}\n\n"
+                        "Rewritten instruction (one imperative sentence):",
+                        col("strategy_text"),
+                        col("perturbed_instr"),
+                    ),
+                    model=REWRITE_MODEL,
+                    use_chat_completions=True,
+                    max_tokens=200,
+                )
+            ),
+        )
+        cells = cells.with_column("res", evaluator.eval(col("suite"), col("task_id"), col("grounded")))
+        return cells.select(
+            "strategy_id",
+            "task_id",
+            "grounded",
+            col("res")["success_rate"].alias("success"),
+            col("res")["feedback"].alias("feedback"),
+        )
+
+    # ---- tasks: pull each task's PERTURBED instruction from the deployed env --
+    env_cls = modal.Cls.from_name("archetype-libero-plus-env", "LiberoPlusEnvBatch").with_options(
+        max_containers=1
+    )
+    task_rows = [
+        {
+            "suite": suite,
+            "task_id": t,
+            "perturbed_instr": str(env_cls(suite=suite, task_id=t).task_language.remote()),
+        }
+        for t in range(n_tasks)
+    ]
+    tasks_df = daft.from_pylist(task_rows)
+    evaluator = RolloutEvaluator(max_steps, n_seeds)
+
+    results_volume.reload()
+
+    # ---- Tier 1: fixed-arm ablation (A < D < B-seed < C is the legitimacy test) ----
+    arms_df = daft.from_pylist([{"strategy_id": k, "strategy_text": v} for k, v in ARMS.items()])
+    arm_cells = evaluate(arms_df).collect()
+    arm_cells.write_lance(f"{LEDGER}/arms", mode="append")
+    arm_summary = (
+        arm_cells.groupby("strategy_id")
+        .agg(col("success").mean().alias("mean_success"), col("success").count().alias("n"))
+        .sort("strategy_id")
+        .to_pylist()
+    )
+
+    # ---- Tier 2: GEPA — algorithm in gepa_core.gepa_search; effects injected here ----
+    # gepa_core owns faithful Algorithm 1 + Pareto Algorithm 2 (no Daft/Modal dep,
+    # unit-tested in tests/experiments/test_gepa_daft.py). run() only supplies the two
+    # EFFECTS: eval_fn (prompt-rewrite + sim rollout) and reflect_fn (Claude UpdatePrompt).
+    best: dict[str, Any] | None = None
+    if do_gepa:
+        import random
+
+        from gepa_core import gepa_search
+
+        class Strategy(BaseModel):
+            strategy_text: str = Field(description="an improved instruction-rewrite strategy")
+
+        def eval_fn(sid: str, text: str, ids: list[int]) -> dict[int, dict[str, Any]]:
+            """Effect: rewrite (prompt) + sim rollout for one strategy on a task subset; ledgered."""
+            sub = daft.from_pylist([r for r in task_rows if r["task_id"] in ids])
+            cells = evaluate(daft.from_pylist([{"strategy_id": sid, "strategy_text": text}]), sub).collect()
+            cells.write_lance(f"{LEDGER}/gepa", mode="append")
+            return {r["task_id"]: {"s": r["success"], "fb": r["feedback"]} for r in cells.to_pylist()}
+
+        def reflect_fn(text: str, feedback_block: str) -> str:
+            """Effect: GEPA UpdatePrompt via Claude (prompt, structured)."""
+            rdf = daft.from_pylist([{"p": (
+                f"Current rewrite strategy:\n{text}\n\nPer-instance sim outcomes:\n{feedback_block}\n\n"
+                "Propose an improved strategy that fixes the failure modes above. "
+                "Stay answer-blind (never name the correct target/answer)."
+            )}])
+            out = (
+                rdf.with_column("out", prompt(
+                    messages=col("p"),
+                    system_message="You improve instruction-rewrite strategies for a frozen VLA. Output only the improved strategy.",
+                    model=REFLECT_MODEL, use_chat_completions=True, return_format=Strategy))
+                .select(unnest(col("out"))).to_pylist()
+            )
+            return out[0]["strategy_text"]
+
+        best = gepa_search(
+            seed_text=SEED_STRATEGY,
+            instance_ids=[r["task_id"] for r in task_rows],
+            eval_fn=eval_fn,
+            reflect_fn=reflect_fn,
+            budget=budget,
+            minibatch=minibatch,
+            rng=random.Random(0),
+        )
+
+    results_volume.commit()
+    return {"arms": arm_summary, "best": best}
+
+
+def _summarize(per_trial: list[tuple[bool, int]], max_steps: int) -> dict[str, Any]:
+    """(success, length) per seed → success_rate + reflective feedback text."""
+    n = len(per_trial)
+    successes = sum(1 for s, _ in per_trial if s)
+    timeouts = sum(1 for s, ln in per_trial if not s and ln >= max_steps - 1)
+    wrong = sum(1 for s, ln in per_trial if not s and ln < max_steps - 1)
+    parts = [f"{successes}/{n} succeeded."]
+    if timeouts:
+        parts.append(f"{timeouts} timed out (target likely never grasped — instruction ambiguous about which object/order).")
+    if wrong:
+        parts.append(f"{wrong} finished but failed the goal (likely wrong object/destination — instruction underspecifies the target).")
+    if successes == n and n:
+        parts.append("All succeeded; preserve what worked.")
+    return {
+        "success_rate": (successes / n) if n else 0.0,
+        "successes": successes,
+        "n": n,
+        "feedback": " ".join(parts),
+    }
+
+
+@app.local_entrypoint()
+def main(
+    suite: str = "libero_goal",
+    n_tasks: int = 8,
+    n_seeds: int = 5,
+    max_steps: int = 300,
+    budget: int = 60,
+    minibatch: int = 3,
+    do_gepa: bool = True,
+):
+    import json
+
+    out = run.remote(
+        suite=suite,
+        n_tasks=n_tasks,
+        n_seeds=n_seeds,
+        max_steps=max_steps,
+        budget=budget,
+        minibatch=minibatch,
+        do_gepa=do_gepa,
+    )
+    print(json.dumps(out, indent=2))

--- a/bench/libero/gepa_optimize.py
+++ b/bench/libero/gepa_optimize.py
@@ -1,0 +1,331 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Genuine GEPA optimization of a frozen VLA's instruction — sim-truth reflective.
+
+We evolve a SINGLE global instruction-rewrite strategy (a natural-language prompt)
+that maps each task's default/perturbed instruction to a better-grounded one, using
+the OFFICIAL GEPA optimizer (Agrawal et al. 2025, ``pip install gepa``) wired to our
+batched LIBERO rollout harness as the evaluation function. No policy weights change:
+GEPA only edits the instruction text fed to the frozen VLA-JEPA policy.
+
+Architecture (the contribution: a reproducible, sim-grounded GEPA loop)::
+
+    gepa.optimize(seed, trainset, valset, adapter=SimRolloutAdapter, reflection_lm=...)
+        │  for each candidate strategy:
+        ▼
+    SimRolloutAdapter.evaluate(tasks, candidate)
+        │  rewrite_lm applies the evolved strategy → grounded instruction
+        ▼
+    eval_instruction.remote(suite, task_id, instruction, seeds)   ← Modal, batched
+        │  run_episode_batched: N seeds = N entities, one env.step/tick
+        ▼  sim-truth success (env.check_success) + per-rollout failure traces
+    EvaluationBatch(scores=success_rate, trajectories=feedback)
+        │  make_reflective_dataset → {"Feedback": ledger failure text}
+        ▼
+    reflection_lm reflects on the failures → mutates the strategy text
+
+``pass`` is ALWAYS the simulator's ``check_success`` — the LLM is used only to apply
+the strategy (rewrite_lm) and to reflect/mutate (GEPA's reflection_lm), never to judge.
+
+The A/B/C/D arms (run via ``--arm``):
+    A = default instruction (baseline)           D = neutral length-matched paraphrase (floor)
+    B = GEPA-evolved answer-blind rewrite        C = answer-smuggling oracle (ceiling)
+Legitimate gap requires A < D < B < C on a question-disjoint split.
+
+Run (after the env worker + ANTHROPIC secret are up)::
+
+    modal run bench/libero/gepa_optimize.py --suite libero_plus_language \\
+        --n-tasks 8 --n-seeds 5 --max-steps 300 --budget 120
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import modal
+
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+
+from colocated_runner import image as _base_image  # noqa: E402
+
+# GEPA + its reflection LM client (litellm) live in the loop container.
+image = _base_image.pip_install("gepa>=0.1.1", "litellm>=1.64.0")
+
+app = modal.App("archetype-gepa-optimize", image=image)
+results_volume = modal.Volume.from_name("libero-eval-results", create_if_missing=True)
+RESULTS_DIR = "/results"
+CANONICAL_NS = "gepa_optimize"
+
+# The reflection/rewrite LM credential. Verify the secret exists:
+#   modal secret list | grep anthropic
+ANTHROPIC_SECRET = modal.Secret.from_name("anthropic-api-key")
+
+REWRITE_LM = "anthropic/claude-sonnet-4-6"
+REFLECTION_LM = "anthropic/claude-opus-4-8"
+
+COMPONENT = "instruction_rewrite_strategy"
+
+SEED_STRATEGY = (
+    "You rewrite a robot-manipulation instruction into a clearer, better-grounded "
+    "instruction for a frozen vision-language-action policy. Identify the target "
+    "object by its visual appearance and spatial relations to nearby objects; state "
+    "the goal location explicitly and unambiguously; keep the result a single "
+    "imperative sentence. Do NOT add information that solves the task for the policy "
+    "(no coordinates, no step counts) — only re-ground what the original already says."
+)
+
+
+# ---------------------------------------------------------------------------
+# Sim evaluation — one (task, instruction) -> sim-truth success + failure traces
+# ---------------------------------------------------------------------------
+@app.function(
+    volumes={RESULTS_DIR: results_volume}, timeout=3600, secrets=[ANTHROPIC_SECRET]
+)
+def eval_instruction(
+    suite: str,
+    task_id: int,
+    instruction: str,
+    seeds: list[int],
+    max_steps: int,
+    run_name: str,
+) -> dict[str, Any]:
+    """Run one batched rollout for a given instruction; return success + feedback.
+
+    The instruction is whatever GEPA's current strategy produced (or a fixed-arm
+    string). Success is the simulator's own ``check_success`` read off the ledger;
+    the per-rollout failure traces are the reflective signal GEPA learns from.
+    """
+    import asyncio
+
+    async def _run() -> dict[str, Any]:
+        import sys
+
+        sys.path.insert(0, "/repo/bench/libero")  # so eval_driver is importable remotely
+
+        from archetype import ArchetypeRuntime
+        from archetype.core.config import StorageConfig
+        from eval_driver import (  # proven batched primitive + client factories
+            _make_libero_plus_env_client,
+            _make_vla_policy_client,
+            run_episode_batched,
+        )
+
+        # LIBERO-Plus LANGUAGE env (perturbed instruction on the same scene) +
+        # the frozen VLA-JEPA policy — same factories the proven sweep uses, so
+        # GEPA's eval is identical to the baseline path except for the instruction.
+        env = _make_libero_plus_env_client(suite, task_id, with_frames=True)
+        pol = _make_vla_policy_client(suite, task_id)
+        store = StorageConfig(uri=f"{RESULTS_DIR}/{CANONICAL_NS}", namespace=CANONICAL_NS)
+        n = len(seeds)
+        env_keys = list(range(n))
+
+        async with ArchetypeRuntime() as rt:
+            per_trial = await run_episode_batched(
+                env_client=env,
+                policy_client=pol,
+                suite=suite,
+                task_id=task_id,
+                seeds=seeds,
+                env_keys=env_keys,
+                max_steps=max_steps,
+                storage=store,
+                runtime=rt,
+                use_frames=True,
+                instruction=instruction,
+            )
+        return _summarize(per_trial, max_steps)
+
+    results_volume.reload()
+    out = asyncio.run(_run())
+    results_volume.commit()
+    out.update({"suite": suite, "task_id": task_id, "run_name": run_name})
+    return out
+
+
+def _summarize(per_trial: list[tuple[bool, int]], max_steps: int) -> dict[str, Any]:
+    """Aggregate (success, length) per seed into success_rate + textual feedback.
+
+    Feedback quality is the whole game for GEPA: we distinguish *timeout* (never
+    finished — target likely never grasped/placed; instruction may be ambiguous
+    about the object or the order) from *wrong-outcome* (motion completed but the
+    goal predicate failed — likely the wrong object or wrong destination)."""
+    n = len(per_trial) or 1
+    successes = sum(1 for s, _ in per_trial if s)
+    timeouts = sum(1 for s, ln in per_trial if not s and ln >= max_steps - 1)
+    wrong = sum(1 for s, ln in per_trial if not s and ln < max_steps - 1)
+    lines = [f"{successes}/{len(per_trial)} rollouts succeeded."]
+    if timeouts:
+        lines.append(
+            f"{timeouts} timed out at step {max_steps} without completing the task "
+            "(the policy likely never grasped/placed the target — the instruction may "
+            "be ambiguous about which object or in what order)."
+        )
+    if wrong:
+        lines.append(
+            f"{wrong} finished the motion but failed the goal check "
+            "(likely the wrong object or the wrong destination — the instruction may "
+            "not disambiguate the target clearly enough)."
+        )
+    if successes == len(per_trial):
+        lines.append("All rollouts succeeded; preserve what worked in the rewrite.")
+    return {
+        "success_rate": successes / n,
+        "successes": successes,
+        "n": len(per_trial),
+        "feedback": " ".join(lines),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GEPA adapter — our sim rollout IS the evaluator
+# ---------------------------------------------------------------------------
+def _build_adapter() -> Any:
+    from dataclasses import dataclass
+    from typing import Mapping, Sequence
+
+    import litellm
+    from gepa.core.adapter import EvaluationBatch, GEPAAdapter
+
+    @dataclass
+    class LiberoTask:
+        suite: str
+        task_id: int
+        default_instruction: str
+        seeds: list[int]
+        max_steps: int
+
+    def rewrite(strategy: str, task_instruction: str) -> str:
+        """Apply the (GEPA-evolved) strategy to one task's instruction."""
+        resp = litellm.completion(
+            model=REWRITE_LM,
+            messages=[
+                {"role": "system", "content": strategy},
+                {"role": "user", "content": f"Original instruction:\n{task_instruction}\n\nRewritten instruction:"},
+            ],
+            max_tokens=120,
+            temperature=0.0,
+        )
+        return resp["choices"][0]["message"]["content"].strip()
+
+    class SimRolloutAdapter(GEPAAdapter):
+        """Evolve ONE global instruction-rewrite prompt against VLA-JEPA sim success."""
+
+        def evaluate(self, batch, candidate, capture_traces=False):  # noqa: ANN001
+            strategy = candidate[COMPONENT]
+            outputs: list[str] = []
+            scores: list[float] = []
+            trajs: list[dict[str, Any]] = []
+            for task in batch:
+                try:
+                    grounded = rewrite(strategy, task.default_instruction)
+                    res = eval_instruction.remote(
+                        task.suite, task.task_id, grounded, task.seeds, task.max_steps, "gepa"
+                    )
+                    sr, fb = float(res["success_rate"]), str(res["feedback"])
+                except Exception as exc:  # never raise per example
+                    grounded, sr = task.default_instruction, 0.0
+                    fb = f"harness error: {exc}"
+                outputs.append(grounded)
+                scores.append(sr)
+                if capture_traces:
+                    trajs.append(
+                        {
+                            "Inputs": task.default_instruction,
+                            "Generated Outputs": grounded,
+                            "Feedback": f"Sim success {sr:.2f}. {fb}",
+                        }
+                    )
+            return EvaluationBatch(
+                outputs=outputs, scores=scores, trajectories=trajs if capture_traces else None
+            )
+
+        def make_reflective_dataset(
+            self, candidate, eval_batch, components_to_update
+        ) -> Mapping[str, Sequence[Mapping[str, Any]]]:
+            return {COMPONENT: list(eval_batch.trajectories or [])}
+
+    return SimRolloutAdapter(), LiberoTask
+
+
+# ---------------------------------------------------------------------------
+# Driver — run the real GEPA loop in-region
+# ---------------------------------------------------------------------------
+@app.function(volumes={RESULTS_DIR: results_volume}, timeout=21600, secrets=[ANTHROPIC_SECRET])
+def optimize_remote(
+    suite: str,
+    task_ids: list[int],
+    instruction_for: dict[int, str],
+    n_seeds: int,
+    max_steps: int,
+    budget: int,
+    val_frac: float,
+) -> dict[str, Any]:
+    """Run gepa.optimize with the sim-rollout adapter; return the evolved strategy."""
+    import gepa
+
+    adapter, LiberoTask = _build_adapter()
+    tasks = [
+        LiberoTask(
+            suite=suite,
+            task_id=t,
+            default_instruction=instruction_for[t],
+            seeds=list(range(t * 1000, t * 1000 + n_seeds)),
+            max_steps=max_steps,
+        )
+        for t in task_ids
+    ]
+    # Question-disjoint split: hold out the back of the task list for val/test.
+    cut = max(1, int(len(tasks) * (1.0 - val_frac)))
+    trainset, valset = tasks[:cut], tasks[cut:] or tasks[:1]
+
+    result = gepa.optimize(
+        seed_candidate={COMPONENT: SEED_STRATEGY},
+        trainset=trainset,
+        valset=valset,
+        adapter=adapter,
+        reflection_lm=REFLECTION_LM,
+        max_metric_calls=budget,
+        reflection_minibatch_size=3,
+        candidate_selection_strategy="pareto",
+        display_progress_bar=False,
+    )
+    return {
+        "best_strategy": result.best_candidate[COMPONENT],
+        "seed_strategy": SEED_STRATEGY,
+        "n_train": len(trainset),
+        "n_val": len(valset),
+        "budget": budget,
+    }
+
+
+@app.local_entrypoint()
+def main(
+    suite: str = "libero_spatial",  # base suite; LIBERO-Plus LANGUAGE variants via the libero_plus env
+    n_tasks: int = 8,
+    n_seeds: int = 5,
+    max_steps: int = 300,
+    budget: int = 120,
+    val_frac: float = 0.3,
+):
+    """Optimize the instruction-rewrite strategy on the headroom suite.
+
+    Pulls each task's default (perturbed) instruction from the env worker, runs the
+    real GEPA loop, and prints the evolved strategy. Arm A/B/C/D evaluation of the
+    frozen strategy is a follow-up pass (eval_instruction with fixed arm strings).
+    """
+    import json
+
+    # Pull each language ordinal's PERTURBED instruction from the LIBERO-Plus env
+    # (task_language() returns the perturbed string — the honest baseline GEPA repairs).
+    task_ids = list(range(n_tasks))
+    env_cls = modal.Cls.from_name("archetype-libero-plus-env", "LiberoPlusEnvBatch")
+    instruction_for = {
+        t: env_cls(suite=suite, task_id=t).task_language.remote() for t in task_ids
+    }
+    out = optimize_remote.remote(
+        suite, task_ids, instruction_for, n_seeds, max_steps, budget, val_frac
+    )
+    print(json.dumps(out, indent=2))

--- a/bench/libero/gepa_optimize.py
+++ b/bench/libero/gepa_optimize.py
@@ -144,7 +144,14 @@ def eval_instruction(
         # GEPA's eval is identical to the baseline path except for the instruction.
         env = _make_libero_plus_env_client(suite, task_id, with_frames=True)
         pol = _make_vla_policy_client(suite, task_id)
-        store = StorageConfig(uri=f"{RESULTS_DIR}/{CANONICAL_NS}", namespace=CANONICAL_NS)
+        # LOCAL per-eval Lance store (NOT the Modal Volume): Lance create/
+        # read-after-write is unreliable on the network volume mid-run (the
+        # "Table not found" failures), whereas local disk is the proven baseline
+        # path. GEPA only needs the scalar success + feedback per eval; the final
+        # frozen-arm comparison is what gets persisted to the canonical ledger.
+        import tempfile
+
+        store = StorageConfig(uri=tempfile.mkdtemp(prefix="gepa-eval-"), namespace=CANONICAL_NS)
         n = len(seeds)
         env_keys = list(range(n))
 

--- a/bench/libero/gepa_optimize.py
+++ b/bench/libero/gepa_optimize.py
@@ -49,10 +49,36 @@ import modal
 os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
 os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
 
-from colocated_runner import image as _base_image  # noqa: E402
+ROOT = "/repo"
 
-# GEPA + its reflection LM client (litellm) live in the loop container.
-image = _base_image.pip_install("gepa>=0.1.1", "litellm>=1.64.0")
+# Inline image (mirrors baseline_sweep / libero_plus_sweep). We do NOT import
+# colocated_runner: it is not on the remote container's sys.path at module load
+# (the entrypoint is mounted at /root), so a top-level import raises
+# ModuleNotFoundError remotely. py3.12 + archetype + GEPA + litellm.
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .pip_install("uv")
+    .add_local_dir(
+        ".",
+        ROOT,
+        copy=True,
+        ignore=[
+            ".git",
+            "**/__pycache__",
+            ".claude",
+            "target",
+            "*.mp4",
+            ".venv",
+            "**/*.parquet",
+            "**/*.log",
+            "**/out/**",
+        ],
+    )
+    .run_commands(
+        f"cd {ROOT} && uv pip install --system -e . "
+        "&& uv pip install --system pillow numpy 'gepa>=0.1.1' 'litellm>=1.64.0'"
+    )
+)
 
 app = modal.App("archetype-gepa-optimize", image=image)
 results_volume = modal.Volume.from_name("libero-eval-results", create_if_missing=True)

--- a/bench/libero/libero_introspect.py
+++ b/bench/libero/libero_introspect.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Introspect what LIBERO exposes as ground-truth per step.
+
+Answers the make-or-break GEPA-scorer question: are BDDL subgoal predicates
+queryable natively (per step, as True/False), or do we only get a terminal
+success bool? Run: modal run bench/libero/libero_introspect.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import modal
+from modal_worker import image
+
+# Bundle modal_worker into the image so the remote container can import this
+# module (which imports modal_worker at top level).
+image = image.add_local_python_source("modal_worker")
+
+app = modal.App("libero-introspect", image=image)
+
+
+@app.function(timeout=600)
+def introspect(suite: str = "libero_spatial", task_id: int = 0) -> dict:
+    import inspect
+    import os
+
+    from libero.libero import benchmark, get_libero_path
+    from libero.libero.envs import OffScreenRenderEnv
+
+    bm = benchmark.get_benchmark_dict()[suite]()
+    task = bm.get_task(task_id)
+    init_states = bm.get_task_init_states(task_id)
+    bddl = os.path.join(get_libero_path("bddl_files"), task.problem_folder, task.bddl_file)
+    env = OffScreenRenderEnv(bddl_file_name=bddl, camera_heights=128, camera_widths=128)
+    env.seed(0)
+    env.reset()
+    obs = env.set_init_state(init_states[0])
+
+    e = env.env  # underlying robosuite/LIBERO domain
+    report: dict = {"language": str(task.language)}
+    report["obs_object_keys"] = sorted(
+        k for k in obs if ("object" in k.lower() or k.endswith("_pos") or k.endswith("_quat"))
+    )
+    report["env_goal_attrs"] = [
+        m
+        for m in dir(e)
+        if any(s in m.lower() for s in ["pred", "goal", "success", "eval", "object_states", "state"])
+    ]
+
+    pp = getattr(e, "parsed_problem", None)
+    if pp is not None:
+        report["parsed_problem_keys"] = list(pp.keys())
+        report["goal_state"] = pp.get("goal_state")
+
+    # The gold question: can we eval each goal predicate individually, per step?
+    for meth in ("_check_success", "check_success"):
+        fn = getattr(e, meth, None) or getattr(env, meth, None)
+        if fn is not None:
+            try:
+                report[f"src::{meth}"] = inspect.getsource(fn)
+            except Exception as exc:  # noqa: BLE001
+                report[f"src::{meth}"] = f"<no source: {exc}>"
+            break
+
+    # Try to find + call a per-predicate evaluator on the current state.
+    osd = getattr(e, "object_states_dict", None)
+    if osd is not None:
+        report["object_states_dict_keys"] = list(osd.keys())
+    for cand in ("_eval_predicate", "eval_predicate"):
+        if hasattr(e, cand):
+            report["per_predicate_evaluator"] = cand
+            # Attempt to evaluate each goal predicate at the reset state.
+            try:
+                gs = pp.get("goal_state") if pp else None
+                if gs:
+                    report["predicate_values_at_reset"] = [
+                        {"predicate": p, "value": bool(getattr(e, cand)(p))} for p in gs
+                    ]
+            except Exception as exc:  # noqa: BLE001
+                report["predicate_eval_error"] = str(exc)
+            break
+
+    return report
+
+
+@app.local_entrypoint()
+def main(suite: str = "libero_spatial", task_id: int = 0):
+    import json
+
+    print(json.dumps(introspect.remote(suite=suite, task_id=task_id), indent=2, default=str))

--- a/bench/libero/libero_plus_sweep.py
+++ b/bench/libero/libero_plus_sweep.py
@@ -243,8 +243,25 @@ if _HAS_MODAL:
             f"max_steps={max_steps} run_id={run_id}"
         )
 
+        # return_exceptions=True so one preempted/killed container drops to an
+        # errored cell instead of nuking the whole sweep (see baseline_sweep).
         args = [(suite, t, trials, max_steps, run_id) for t in task_ids_list]
-        per_task: list[dict[str, Any]] = list(sweep_one_language_task.starmap(args))
+        raw = list(sweep_one_language_task.starmap(args, return_exceptions=True))
+        per_task: list[dict[str, Any]] = []
+        for (_suite, t, *_rest), res in zip(args, raw, strict=True):
+            if isinstance(res, BaseException):
+                per_task.append(
+                    {
+                        "task_id": t,
+                        "n": 0,
+                        "successes": 0,
+                        "success_rate": 0.0,
+                        "per_seed": [],
+                        "error": f"{type(res).__name__}: {res}",
+                    }
+                )
+            else:
+                per_task.append(res)
 
         # Lazy import (runs locally only): reuse the standard aggregate/split
         # writer, then re-key the output file to a language-specific name so it

--- a/bench/libero/libero_plus_sweep.py
+++ b/bench/libero/libero_plus_sweep.py
@@ -142,7 +142,12 @@ def _run_one_language_task(
 
 
 if _HAS_MODAL:
-    from baseline_sweep import aggregate_and_write  # type: ignore[import-not-found]
+    # NOTE: do NOT import ``aggregate_and_write`` at module scope. Modal imports
+    # this file inside the container to locate the app, and at that point
+    # ``bench/libero`` is not on the container's sys.path (the entrypoint is
+    # mounted at /root and baseline_sweep.py is not its sibling), so a top-level
+    # ``from baseline_sweep import ...`` raises ModuleNotFoundError there. It is
+    # imported lazily inside ``main`` instead, which only ever runs locally.
 
     # py3.12 + archetype only — the env (LIBERO-Plus) and policy (VLA-JEPA) live
     # in their own deployed apps; this Function talks to them over the client
@@ -241,8 +246,11 @@ if _HAS_MODAL:
         args = [(suite, t, trials, max_steps, run_id) for t in task_ids_list]
         per_task: list[dict[str, Any]] = list(sweep_one_language_task.starmap(args))
 
-        # Reuse the standard aggregate/split writer, then re-key the output file
-        # to a language-specific name so it never clobbers the standard split.
+        # Lazy import (runs locally only): reuse the standard aggregate/split
+        # writer, then re-key the output file to a language-specific name so it
+        # never clobbers the standard split.
+        from baseline_sweep import aggregate_and_write  # type: ignore[import-not-found]
+
         split = aggregate_and_write(
             per_task,
             suite=suite,

--- a/bench/libero/libero_plus_sweep.py
+++ b/bench/libero/libero_plus_sweep.py
@@ -1,0 +1,264 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LIBERO-Plus LANGUAGE baseline sweep — the perturbed-instruction frontier.
+
+The LIBERO-Plus analogue of ``baseline_sweep.py``. It runs the frozen VLA-JEPA
+policy against the **LIBERO-Plus Language Instructions** dimension (scene/physics/
+goal byte-identical to base LIBERO; only the instruction string rewritten),
+conditioning on the *perturbed* instruction — the honest LIBERO-Plus baseline.
+The published reference is ≈85.4% average; this sweep produces a real measured
+number on a handful of language variants.
+
+Co-located on Modal, modelled on ``baseline_sweep.py``: the Archetype world loop
+(py3.12) runs *inside a Modal Function next to the env and policy workers*, so
+every ``env.step`` / ``policy.infer_refs`` call is a same-region internal call.
+We fan out **one Function per language task** with ``.starmap``; each Function
+builds its own ``LiberoPlusEnvClient(suite, task_id)`` (a distinct
+``LiberoPlusEnvBatch`` parameter set → one env container per task), and the
+already-deployed VLA-JEPA worker handles inference unchanged.
+
+``task_id`` here is the **language ordinal** (0 = first Language Instructions
+variant for the suite), NOT the absolute benchmark index — the worker resolves it.
+
+Every rollout lands on the append-only ledger (episode worlds keyed by
+``ep-{suite}-t{task_id}-batch{n}`` + ``run_id``), persisted to the
+``libero-eval-results`` volume under ``{run_id}:task{task_id}``.
+
+Run the sweep (Modal auth required; no Anthropic key needed):
+    modal run bench/libero/libero_plus_sweep.py
+
+    # small baseline: 5 language tasks x 3 seeds, max 300 steps
+    modal run bench/libero/libero_plus_sweep.py --suite libero_spatial \\
+        --n-tasks 5 --trials 3 --max-steps 300 \\
+        --run-id liberoplus-language-baseline
+
+Reuses the pure split/aggregate helpers from ``baseline_sweep.py`` so the split
+JSON has the identical shape; it is written to
+``bench/libero/out/<suite>_language_split.json`` and printed.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# bench/libero is a directory of loose scripts; reuse the proven split/aggregate
+# helpers from the standard sweep rather than copying them.
+sys.path.insert(0, str(Path(__file__).parent))
+
+ROOT = "/repo"
+RESULTS_DIR = "/results"
+
+
+try:
+    import modal  # type: ignore[import-not-found]
+
+    _HAS_MODAL = True
+except ImportError:  # pragma: no cover - exercised only in the CI test venv
+    modal = None  # type: ignore[assignment]
+    _HAS_MODAL = False
+
+_RESULTS_VOLUME: Any = None
+
+
+def _run_one_language_task(
+    suite: str,
+    task_id: int,
+    trials: int,
+    max_steps: int,
+    run_id: str,
+) -> dict[str, Any]:
+    """Run one LANGUAGE variant's rollouts in-region; return its per-task summary.
+
+    Drives the real VLA-JEPA policy against the LIBERO-Plus LANGUAGE env with the
+    PERTURBED instruction (the honest baseline). ``task_id`` is the language
+    ordinal. Returns the same dict shape ``baseline_sweep._run_one_task`` does
+    (task_id, n, successes, success_rate, per_seed, wall_s, ledger_path) plus the
+    perturbed ``instruction`` string actually used.
+    """
+    import asyncio
+    import shutil
+    import time
+    from pathlib import Path as _Path
+
+    sys.path.insert(0, f"{ROOT}/bench/libero")
+
+    from eval_driver import (  # type: ignore[import-not-found]
+        DriverConfig,
+        run_eval,
+    )
+
+    task_run_id = f"{run_id}:task{task_id}"
+    local_out = _Path("/tmp") / f"lpsweep-{task_run_id}"
+    local_out.mkdir(parents=True, exist_ok=True)
+
+    config = DriverConfig(
+        suite=suite,
+        task_ids=[task_id],
+        trials=trials,
+        max_steps=max_steps,
+        out=str(local_out),
+        run_id=task_run_id,
+        # The only difference from baseline_sweep: the LIBERO-Plus LANGUAGE env.
+        env_client_type="modal_plus",
+        use_policy=True,
+        # No overrides → each task conditions on its PERTURBED task_language()
+        # (the honest LIBERO-Plus baseline).
+        instruction_overrides={},
+    )
+
+    started = time.perf_counter()
+    results = asyncio.run(run_eval(config))
+    wall_s = time.perf_counter() - started
+
+    successes = sum(1 for r in results if getattr(r, "success", False))
+    n = len(results)
+    per_seed = [
+        {
+            "seed": getattr(r, "seed", None),
+            "trial_idx": getattr(r, "trial_idx", None),
+            "success": bool(getattr(r, "success", False)),
+            "episode_length": int(getattr(r, "episode_length", 0) or 0),
+        }
+        for r in sorted(results, key=lambda r: getattr(r, "trial_idx", 0))
+    ]
+
+    # Persist this task's ledger to the network volume so rollouts stay queryable.
+    dest = _Path(RESULTS_DIR) / task_run_id
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(local_out, dest)
+    _RESULTS_VOLUME.commit()
+
+    return {
+        "task_id": task_id,
+        "n": n,
+        "successes": successes,
+        "success_rate": (successes / n) if n else 0.0,
+        "per_seed": per_seed,
+        "wall_s": round(wall_s, 1),
+        "ledger_path": str(dest),
+    }
+
+
+if _HAS_MODAL:
+    from baseline_sweep import aggregate_and_write  # type: ignore[import-not-found]
+
+    # py3.12 + archetype only — the env (LIBERO-Plus) and policy (VLA-JEPA) live
+    # in their own deployed apps; this Function talks to them over the client
+    # boundary. Same lean recipe as baseline_sweep.py.
+    image = (
+        modal.Image.debian_slim(python_version="3.12")
+        .pip_install("uv")
+        .add_local_dir(
+            ".",
+            ROOT,
+            copy=True,
+            ignore=[
+                ".git",
+                "**/__pycache__",
+                ".claude",
+                "target",
+                "*.mp4",
+                ".venv",
+                "**/*.parquet",
+                "**/*.log",
+                "**/out/**",
+            ],
+        )
+        .run_commands(
+            f"cd {ROOT} && uv pip install --system -e . && uv pip install --system pillow numpy"
+        )
+    )
+
+    app = modal.App("archetype-libero-plus-baseline-sweep", image=image)
+    _RESULTS_VOLUME = modal.Volume.from_name("libero-eval-results", create_if_missing=True)
+
+    @app.function(volumes={RESULTS_DIR: _RESULTS_VOLUME}, timeout=21600)
+    def sweep_one_language_task(
+        suite: str,
+        task_id: int,
+        trials: int,
+        max_steps: int,
+        run_id: str,
+    ) -> dict[str, Any]:
+        """Modal wrapper over ``_run_one_language_task`` (one env container/task).
+
+        Catches its own exceptions so one failing task cannot abort the whole
+        fan-out. A failed task is reported as ``error`` with ``n=0`` and dropped
+        from the split.
+        """
+        import traceback
+
+        try:
+            return _run_one_language_task(suite, task_id, trials, max_steps, run_id)
+        except Exception as exc:  # noqa: BLE001 - isolate per-task failures
+            return {
+                "task_id": task_id,
+                "n": 0,
+                "successes": 0,
+                "success_rate": 0.0,
+                "per_seed": [],
+                "error": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(),
+            }
+
+    @app.local_entrypoint()
+    def main(
+        suite: str = "libero_spatial",
+        n_tasks: int = 5,
+        task_ids: str = "",
+        trials: int = 3,
+        max_steps: int = 300,
+        val_size: int = 2,
+        test_size: int = 1,
+        run_id: str = "",
+    ):
+        """Fan the LANGUAGE baseline sweep across language ordinals; write the split.
+
+        Defaults to a SMALL baseline: the first 5 Language Instructions variants
+        of ``libero_spatial``, 3 seeds each, max 300 steps — enough to produce a
+        real measured success number near the published ≈85.4%. ``task_ids``
+        (comma-separated language ordinals) overrides ``n_tasks``.
+
+        The split JSON is written to
+        ``bench/libero/out/<suite>_language_split.json`` and printed.
+        """
+        import time
+
+        run_id = run_id or f"liberoplus-language-baseline-{suite}-{int(time.time())}"
+        if task_ids:
+            task_ids_list = [int(x) for x in str(task_ids).split(",") if x != ""]
+        else:
+            task_ids_list = list(range(n_tasks))
+
+        print(
+            f"=== LIBERO-Plus LANGUAGE baseline sweep === suite={suite} "
+            f"language_ordinals={task_ids_list} trials={trials} "
+            f"max_steps={max_steps} run_id={run_id}"
+        )
+
+        args = [(suite, t, trials, max_steps, run_id) for t in task_ids_list]
+        per_task: list[dict[str, Any]] = list(sweep_one_language_task.starmap(args))
+
+        # Reuse the standard aggregate/split writer, then re-key the output file
+        # to a language-specific name so it never clobbers the standard split.
+        split = aggregate_and_write(
+            per_task,
+            suite=suite,
+            run_id=run_id,
+            trials=trials,
+            max_steps=max_steps,
+            n_tasks=len(task_ids_list),
+            val_size=val_size,
+            test_size=test_size,
+        )
+
+        import json
+
+        out_dir = Path(__file__).parent / "out"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        lang_path = out_dir / f"{suite}_language_split.json"
+        split["dimension"] = "Language Instructions"
+        lang_path.write_text(json.dumps(split, indent=2) + "\n")
+        print(f"\nlanguage split written to {lang_path}")

--- a/bench/libero/libero_plus_worker.py
+++ b/bench/libero/libero_plus_worker.py
@@ -73,6 +73,17 @@ import modal
 # → 4976dc30028e805ff8094b55501d532c48fec182
 _LIBERO_PLUS_SHA = "4976dc30028e805ff8094b55501d532c48fec182"
 
+# LIBERO-Plus ships bddl/init_files but NOT the MuJoCo `assets/` tree (scene XMLs,
+# robot/object meshes, textures) — its git repo contains zero assets/ files, so a
+# bare clone raises FileNotFoundError on the first env build (e.g. the missing
+# assets/scenes/libero_tabletop_base_style.xml). The base assets are identical to
+# upstream LIBERO (same robosuite/MuJoCo base; LIBERO-Plus only overrides the
+# bddl/init layer), so we clone upstream LIBERO at the SAME SHA the standard
+# worker pins and copy its assets/ into the LIBERO-Plus install. This stays within
+# the language dimension: no assets.zip (the 6.4GB visual-perturbation download)
+# is involved — only the base scene/robot/object XMLs the simulator always needs.
+_LIBERO_BASE_SHA = "8f1084e3132a39270c3a13ebe37270a43ece2a01"
+
 # The perturbation dimension this worker serves. LIBERO-Plus labels the
 # language-rewrite variants exactly this way in task_classification.json.
 LANGUAGE_CATEGORY = "Language Instructions"
@@ -139,6 +150,14 @@ image = (
         f"git clone https://github.com/sylvestf/LIBERO-plus.git /opt/LIBERO-plus"
         f" && git -C /opt/LIBERO-plus checkout {_LIBERO_PLUS_SHA}",
         "pip install -e /opt/LIBERO-plus",
+        # Backfill the MuJoCo assets/ tree from upstream LIBERO (LIBERO-Plus omits
+        # it from git). Clone the pinned base SHA (same full clone + checkout the
+        # standard worker uses — reliable for arbitrary SHAs), copy assets/ into
+        # the LIBERO-Plus package, then drop the base clone to keep the image lean.
+        f"git clone https://github.com/Lifelong-Robot-Learning/LIBERO.git /opt/LIBERO-base"
+        f" && git -C /opt/LIBERO-base checkout {_LIBERO_BASE_SHA}",
+        "cp -r /opt/LIBERO-base/libero/libero/assets /opt/LIBERO-plus/libero/libero/assets",
+        "rm -rf /opt/LIBERO-base",
         # First import interactively prompts for a dataset folder; answer 'N'
         # (use defaults) once at build time so ~/.libero/config.yaml is baked in
         # and runtime imports never block on stdin.

--- a/bench/libero/libero_plus_worker.py
+++ b/bench/libero/libero_plus_worker.py
@@ -1,0 +1,483 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LIBERO-Plus env worker on Modal — the LANGUAGE-perturbation half of EnvClient.
+
+LIBERO-Plus (github.com/sylvestf/LIBERO-plus, arXiv 2510.13626) is a drop-in
+robustness *superset* of LIBERO on the **same robosuite/MuJoCo base** (not
+SAPIEN): "replace the originally installed LIBERO repository with our repository
+without modifying your code." It adds seven controlled perturbation dimensions;
+this worker exposes the **Language Instructions** dimension, where the scene,
+physics, and goal predicate are byte-identical to base LIBERO and only the
+``(:language ...)`` string is rewritten.
+
+Why a SEPARATE Modal app/class (not an edit to ``modal_worker.py``): the
+``archetype-libero-env`` app is already deployed and serving live probes; an
+in-place image change would rebuild and disturb them. This worker is fully
+additive — new app ``archetype-libero-plus-env``, new class
+``LiberoPlusEnvBatch`` — so the standard-LIBERO worker is untouched.
+
+Method signatures mirror ``archetype.experiments.manipulation.EnvClient`` exactly
+(reset / step / task_language), identical to ``LiberoEnvBatch``, so the harness
+side reuses the proven batched driver, the VLA-JEPA policy worker, and the
+baseline sweep without modification. The only behavioural difference is that
+``task_language()`` returns the *perturbed* instruction (read from the
+``_language_N.bddl`` variant) instead of the canonical one.
+
+How a Language task is selected (ports ~30 lines from LIBERO-Plus's
+``libero_plus_init.py`` selector idea, adapted to the repo's actual API):
+
+  - ``task_classification.json`` (baked into the LIBERO-Plus repo at
+    ``libero/libero/benchmark/task_classification.json``) is a dict keyed by the
+    four standard suites, each a list of ``{id, name, category, difficulty_level}``.
+  - The 1-based ``id`` is exactly the (id-1) 0-based index into
+    ``libero_task_map[suite]`` — verified against the suite map — which is the
+    same index the LIBERO-Plus ``Benchmark`` exposes via ``get_task(i)`` /
+    ``get_task_bddl_file_path(i)`` / ``get_task_init_states(i)`` at the default
+    task order (identity).
+  - So ``get_ids_by_category(suite, "Language Instructions")`` yields the absolute
+    benchmark indices of the language variants. The worker's ``task_id`` parameter
+    is the *ordinal within that filtered list* (0 = first language variant), kept
+    small and stable so the baseline sweep can fan out over a handful of them.
+
+Path resolution is delegated entirely to LIBERO-Plus: the language ``name`` carries
+a ``_view_0_0_100_0_0_initstate_0`` suffix, and LIBERO-Plus's ``ControlEnv``
+strips it internally (split on ``_view_`` → base ``.bddl`` + view/initstate
+params), so we just hand it ``get_task_bddl_file_path(i)`` unchanged. Init states
+reuse the base scene via ``get_task_init_states(i)`` (strips ``_language_``).
+
+NO ``assets.zip`` is needed for the language dimension — that 6.4GB download is
+only for the visual perturbation dimensions (camera/light/background/noise).
+
+Setup (one time):
+    uv tool install modal && modal setup
+
+Smoke test (builds the image on first run, ~5-10 min):
+    modal run bench/libero/libero_plus_worker.py
+
+Deploy for use from the Archetype harness:
+    modal deploy bench/libero/libero_plus_worker.py
+    # then in the harness process:
+    #   client = LiberoPlusEnvClient("libero_spatial", task_id=0, with_frames=True)
+"""
+
+# NOTE: no `from __future__ import annotations` here — modal.parameter()
+# validates real annotation objects, and PEP 563 string annotations break it.
+import uuid
+from typing import Any
+
+import modal
+
+# SHA pinned 2026-06-13 via:
+#   gh api repos/sylvestf/LIBERO-plus/commits/HEAD --jq .sha
+# → 4976dc30028e805ff8094b55501d532c48fec182
+_LIBERO_PLUS_SHA = "4976dc30028e805ff8094b55501d532c48fec182"
+
+# The perturbation dimension this worker serves. LIBERO-Plus labels the
+# language-rewrite variants exactly this way in task_classification.json.
+LANGUAGE_CATEGORY = "Language Instructions"
+
+# Reuse the SAME frames volume as the standard LIBERO worker: frame sidecars are
+# just PNGs keyed by a per-container session UUID, so the two workers cannot
+# collide, and the VLA-JEPA policy reads from one mount regardless of which env
+# produced them.
+FRAMES_VOLUME_NAME = "libero-frames"
+FRAMES_MOUNT = "/frames"
+
+frames_volume = modal.Volume.from_name(FRAMES_VOLUME_NAME, create_if_missing=True)
+
+# Same py3.10 + relaxed-pins recipe as the standard worker, but cloning
+# LIBERO-Plus instead of upstream LIBERO. Extra apt libs are LIBERO-Plus
+# specific: libexpat1 (mujoco xml parsing on some bases), libfontconfig1-dev +
+# libmagickwand-dev (the `wand`/ImageMagick dep in extra_requirements.txt used
+# by the visual-perturbation tooling; harmless for the language dim but part of
+# the documented install).
+image = (
+    modal.Image.debian_slim(python_version="3.10")
+    .apt_install(
+        "git",
+        "libegl1",
+        "libgl1",
+        "libglew-dev",
+        "libosmesa6-dev",
+        "libglfw3",
+        "patchelf",
+        # opencv-python (non-headless) links GUI-adjacent libs even offscreen.
+        "libglib2.0-0",
+        "libsm6",
+        "libxext6",
+        "libxrender1",
+        # LIBERO-Plus specific (per its README apt list / extra_requirements).
+        "libexpat1",
+        "libfontconfig1-dev",
+        "libmagickwand-dev",
+    )
+    .pip_install(
+        # <2.6: LIBERO torch.load()s init-state numpy pickles, which the
+        # weights_only=True default introduced in torch 2.6 rejects.
+        "torch>=2.2,<2.6",
+        "robosuite==1.4.1",
+        "bddl==1.0.1",
+        # The env-path slice of LIBERO-Plus's requirements (we skip the training
+        # stack: robomimic, transformers, wandb, thop).
+        "future",
+        "matplotlib",
+        "cloudpickle",
+        "gym==0.25.2",
+        "hydra-core",
+        "einops",
+        "easydict",
+        "imageio[ffmpeg]",
+        "opencv-python-headless",
+        # extra_requirements.txt: wand (ImageMagick bindings) + scikit-image.
+        "wand",
+        "scikit-image",
+    )
+    # LIBERO-Plus's top-level package dir has no __init__.py either, so the same
+    # clone + editable-install recipe the upstream repo uses is required.
+    .run_commands(
+        f"git clone https://github.com/sylvestf/LIBERO-plus.git /opt/LIBERO-plus"
+        f" && git -C /opt/LIBERO-plus checkout {_LIBERO_PLUS_SHA}",
+        "pip install -e /opt/LIBERO-plus",
+        # First import interactively prompts for a dataset folder; answer 'N'
+        # (use defaults) once at build time so ~/.libero/config.yaml is baked in
+        # and runtime imports never block on stdin.
+        "echo N | python -c 'import libero.libero'",
+    )
+    .env({"MUJOCO_GL": "egl", "PYOPENGL_PLATFORM": "egl"})
+)
+
+app = modal.App("archetype-libero-plus-env", image=image)
+
+
+def _language_indices(suite: str) -> list[int]:
+    """Absolute benchmark indices of the LANGUAGE-perturbation variants.
+
+    Ports the LIBERO-Plus category selector: read task_classification.json,
+    filter to ``category == "Language Instructions"`` for ``suite``, and return
+    the (id-1) 0-based indices in file order (sorted by id for determinism).
+    These indices are valid for ``Benchmark.get_task(i)`` etc. at the default
+    task order (identity), which is what we use.
+    """
+    import json
+    import os
+
+    from libero.libero import get_libero_path
+
+    # task_classification.json ships next to the benchmark package.
+    bench_root = get_libero_path("benchmark_root")
+    tc_path = os.path.join(bench_root, "benchmark", "task_classification.json")
+    with open(tc_path) as f:
+        classification = json.load(f)
+
+    items = classification.get(suite, [])
+    lang = [it for it in items if it.get("category") == LANGUAGE_CATEGORY]
+    lang.sort(key=lambda it: int(it["id"]))
+    return [int(it["id"]) - 1 for it in lang]
+
+
+# Same concurrency model as LiberoEnvBatch: env instances live in container
+# memory keyed by env_key, so each (suite, task_id) parameter set must own a
+# stable container for the full episode. max_containers caps the TOTAL container
+# count across parameter sets; 16 lets a small language sweep hold one dedicated
+# container per task simultaneously.
+@app.cls(
+    cpu=4,
+    memory=8192,
+    timeout=1800,
+    scaledown_window=300,
+    max_containers=16,
+    volumes={FRAMES_MOUNT: frames_volume},
+)
+class LiberoPlusEnvBatch:
+    """A batch of LIBERO-Plus LANGUAGE-perturbation envs, keyed by env_key.
+
+    ``task_id`` is the *ordinal within the suite's Language Instructions list*
+    (0 = first language variant), NOT the absolute benchmark index. The worker
+    resolves it to the absolute index via the category selector so callers stay
+    small and stable.
+
+    Method signatures and frame-sidecar behaviour are identical to
+    ``LiberoEnvBatch`` (see ``modal_worker.py``); only the task selection and the
+    perturbed ``task_language()`` differ.
+    """
+
+    suite: str = modal.parameter(default="libero_spatial")
+    # Ordinal within the Language Instructions list (0-based), not absolute index.
+    task_id: int = modal.parameter(default=0)
+    camera_size: int = modal.parameter(default=128)
+
+    @modal.enter()
+    def load_suite(self):
+        from libero.libero import benchmark
+
+        self._envs: dict[int, Any] = {}
+        self._suite = benchmark.get_benchmark_dict()[self.suite]()
+
+        # Resolve the language ordinal → absolute benchmark index.
+        lang_idx = _language_indices(self.suite)
+        if not lang_idx:
+            raise RuntimeError(f"no Language Instructions tasks for suite {self.suite!r}")
+        if not (0 <= self.task_id < len(lang_idx)):
+            raise IndexError(
+                f"language task_id {self.task_id} out of range "
+                f"(suite {self.suite!r} has {len(lang_idx)} language variants)"
+            )
+        self._abs_index = lang_idx[self.task_id]
+        self._task = self._suite.get_task(self._abs_index)
+        self._init_states = self._suite.get_task_init_states(self._abs_index)
+
+        # Per-container session UUID for unique frame keys across parallel runs.
+        self._session = str(uuid.uuid4())
+        self._step_counts: dict[int, int] = {}
+
+    def _make_env(self):
+        from libero.libero.envs import OffScreenRenderEnv
+
+        # LIBERO-Plus's ControlEnv strips the `_view_..._initstate_` suffix
+        # internally, so the absolute-index bddl path is handed over unchanged.
+        bddl = self._suite.get_task_bddl_file_path(self._abs_index)
+        return OffScreenRenderEnv(
+            bddl_file_name=bddl,
+            camera_heights=self.camera_size,
+            camera_widths=self.camera_size,
+        )
+
+    def _write_frames(
+        self, env_key: int, step_label: str, agentview_rgb, wrist_rgb
+    ) -> tuple[str, str]:
+        """Write a pair of PNGs to the shared volume and return their refs.
+
+        The ref is the path relative to the volume root (i.e. relative to
+        FRAMES_MOUNT). Callers reconstruct the full path as ``/frames/<ref>``.
+        """
+        import os
+
+        import cv2
+
+        def encode_png(rgb) -> bytes:
+            ok, buf = cv2.imencode(".png", cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR))
+            if not ok:
+                raise RuntimeError("png encode failed")
+            return buf.tobytes()
+
+        av_ref = f"{self._session}/{env_key}/{step_label}-agentview.png"
+        wr_ref = f"{self._session}/{env_key}/{step_label}-wrist.png"
+
+        av_path = os.path.join(FRAMES_MOUNT, av_ref)
+        wr_path = os.path.join(FRAMES_MOUNT, wr_ref)
+
+        os.makedirs(os.path.dirname(av_path), exist_ok=True)
+        with open(av_path, "wb") as f:
+            f.write(encode_png(agentview_rgb))
+        with open(wr_path, "wb") as f:
+            f.write(encode_png(wrist_rgb))
+
+        return av_ref, wr_ref
+
+    @staticmethod
+    def _proprio(obs: dict) -> dict[str, Any]:
+        """Extract proprio fields (no frames)."""
+        return {
+            "eef_pos": [float(v) for v in obs["robot0_eef_pos"]],
+            "eef_quat": [float(v) for v in obs["robot0_eef_quat"]],
+            "gripper": float(obs["robot0_gripper_qpos"][0]),
+            "gripper_qpos": [float(v) for v in obs["robot0_gripper_qpos"]],
+        }
+
+    def _proprio_with_frames(
+        self, obs: dict, env_key: int, step_label: str, commit: bool = True
+    ) -> dict[str, Any]:
+        """Extract proprio and write frame PNGs to the volume.
+
+        NOTE: LIBERO renders frames upside down; the policy client handles
+        orientation. We ship raw pixels.
+        """
+        import base64
+
+        import cv2
+
+        out = self._proprio(obs)
+
+        agentview_rgb = obs["agentview_image"]
+        wrist_rgb = obs["robot0_eye_in_hand_image"]
+
+        def encode_b64(rgb) -> str:
+            ok, buf = cv2.imencode(".png", cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR))
+            if not ok:
+                raise RuntimeError("png encode failed")
+            return base64.b64encode(buf.tobytes()).decode()
+
+        out["agentview_png"] = encode_b64(agentview_rgb)
+        out["wrist_png"] = encode_b64(wrist_rgb)
+
+        av_ref, wr_ref = self._write_frames(env_key, step_label, agentview_rgb, wrist_rgb)
+        out["agentview_ref"] = av_ref
+        out["wrist_ref"] = wr_ref
+
+        if commit:
+            frames_volume.commit()
+
+        return out
+
+    @modal.method()
+    def reset(self, env_id: int, seed: int, with_frames: bool = False) -> dict[str, Any]:
+        env = self._envs.get(env_id)
+        if env is None:
+            env = self._make_env()
+            self._envs[env_id] = env
+        env.seed(seed)
+        env.reset()
+        obs = env.set_init_state(self._init_states[seed % len(self._init_states)])
+        self._step_counts[env_id] = 0
+        if with_frames:
+            return self._proprio_with_frames(obs, env_id, "reset", commit=True)
+        return self._proprio(obs)
+
+    @modal.method()
+    def step(
+        self,
+        env_ids: list[int],
+        actions: list[list[float]],
+        with_frames: bool = False,
+    ) -> list[dict[str, Any]]:
+        results = []
+        for env_id, action in zip(env_ids, actions, strict=True):
+            env = self._envs[env_id]
+            obs, reward, done, info = env.step(action)
+            success = bool(env.check_success())
+            self._step_counts[env_id] = self._step_counts.get(env_id, 0) + 1
+            n = self._step_counts[env_id]
+            step_label = f"{n:05d}"
+
+            if with_frames:
+                result = self._proprio_with_frames(obs, env_id, step_label, commit=False)
+            else:
+                result = self._proprio(obs)
+
+            result.update(
+                {"reward": float(reward), "done": bool(done) or success, "success": success}
+            )
+            results.append(result)
+
+        if with_frames:
+            frames_volume.commit()
+
+        return results
+
+    @modal.method()
+    def task_language(self) -> str:
+        """The *perturbed* LIBERO-Plus language instruction for this variant."""
+        return str(self._task.language)
+
+    @modal.method()
+    def info(self) -> dict[str, Any]:
+        """Diagnostics: how the language ordinal resolved + the instruction.
+
+        Useful for the smoke test / sweep manifests: confirms the absolute
+        benchmark index, the number of language variants available, and the
+        perturbed string actually being served.
+        """
+        return {
+            "suite": self.suite,
+            "language_task_id": self.task_id,
+            "abs_index": self._abs_index,
+            "num_language_variants": len(_language_indices(self.suite)),
+            "task_name": str(self._task.name),
+            "language": str(self._task.language),
+            "n_init_states": int(len(self._init_states)),
+        }
+
+
+class LiberoPlusEnvClient:
+    """Harness-side EnvClient adapter over a deployed ``LiberoPlusEnvBatch``.
+
+    Import this from the Archetype (py3.12) process; it only needs the ``modal``
+    client package, not LIBERO. Drop-in compatible with ``ModalEnvClient``: same
+    ``reset`` / ``step`` / ``task_language`` surface, so the eval driver and
+    baseline sweep accept it without change. ``task_id`` is the language ordinal.
+
+    Pickles as ``(suite, task_id, with_frames)`` and reconnects lazily, because
+    Daft batch UDFs serialize constructor args and a live Modal handle is not
+    serializable.
+    """
+
+    def __init__(self, suite: str = "libero_spatial", task_id: int = 0, with_frames: bool = False):
+        self._suite = suite
+        self._task_id = task_id
+        self._with_frames = with_frames
+        self._worker = None
+
+    def _get_worker(self):
+        if self._worker is None:
+            cls = modal.Cls.from_name("archetype-libero-plus-env", "LiberoPlusEnvBatch")
+            self._worker = cls(suite=self._suite, task_id=self._task_id)
+        return self._worker
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {
+            "suite": self._suite,
+            "task_id": self._task_id,
+            "with_frames": self._with_frames,
+        }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self._suite = state["suite"]
+        self._task_id = state["task_id"]
+        self._with_frames = state.get("with_frames", False)
+        self._worker = None
+
+    def reset(self, env_id: int, seed: int) -> dict[str, Any]:
+        return self._get_worker().reset.remote(env_id, seed, with_frames=self._with_frames)
+
+    def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
+        return self._get_worker().step.remote(env_ids, actions, with_frames=self._with_frames)
+
+    def task_language(self) -> str:
+        """The perturbed LIBERO-Plus instruction for this (suite, language ordinal).
+
+        Threaded into ``ManipTask.instruction`` by the eval driver so the policy
+        conditions on the *perturbed* string — the honest LIBERO-Plus baseline.
+        """
+        return str(self._get_worker().task_language.remote())
+
+
+@app.local_entrypoint()
+def smoke(suite: str = "libero_spatial", task_id: int = 0, steps: int = 3):
+    """Load one LANGUAGE variant, confirm the perturbed instruction, step a few times."""
+    worker = LiberoPlusEnvBatch(suite=suite, task_id=task_id)
+
+    meta = worker.info.remote()
+    print("=== LIBERO-Plus LANGUAGE smoke ===")
+    print("suite:", meta["suite"])
+    print("language_task_id (ordinal):", meta["language_task_id"])
+    print("abs_index:", meta["abs_index"])
+    print("num_language_variants:", meta["num_language_variants"])
+    print("task_name:", meta["task_name"])
+    print("PERTURBED instruction:", repr(meta["language"]))
+    print("n_init_states:", meta["n_init_states"])
+
+    obs = worker.reset.remote(env_id=0, seed=0, with_frames=True)
+    print("reset obs eef_pos:", obs["eef_pos"])
+    print("reset agentview_ref:", obs.get("agentview_ref", "MISSING"))
+    print("reset wrist_ref:", obs.get("wrist_ref", "MISSING"))
+
+    assert "agentview_ref" in obs, "reset must return agentview_ref when with_frames=True"
+    assert "wrist_ref" in obs, "reset must return wrist_ref when with_frames=True"
+    assert obs["agentview_ref"].endswith("-agentview.png"), (
+        f"unexpected ref: {obs['agentview_ref']}"
+    )
+    assert len(obs.get("gripper_qpos", [])) == 2, "gripper_qpos must be 2-element"
+
+    zero = [0.0] * 7
+    for step_idx in range(steps):
+        (result,) = worker.step.remote([0], [zero], with_frames=True)
+        print(
+            f"step {step_idx}: eef_pos={result['eef_pos']} "
+            f"agentview_ref={result.get('agentview_ref', 'MISSING')} "
+            f"success={result.get('success')}"
+        )
+        assert "agentview_ref" in result, f"step {step_idx} must return agentview_ref"
+        assert "wrist_ref" in result, f"step {step_idx} must return wrist_ref"
+
+    print(f"smoke OK — perturbed instruction served, {steps + 1} ref pairs returned")

--- a/bench/libero/libero_plus_worker.py
+++ b/bench/libero/libero_plus_worker.py
@@ -362,7 +362,22 @@ class LiberoPlusEnvBatch:
     ) -> list[dict[str, Any]]:
         results = []
         for env_id, action in zip(env_ids, actions, strict=True):
-            env = self._envs[env_id]
+            env = self._envs.get(env_id)
+            if env is None:
+                # The env for this key was reset on a *different* container than
+                # the one serving this step() — the parameter set's pool scaled
+                # to >1 container and split its in-memory env state. Re-resetting
+                # here would silently restart mid-episode (wrong observations),
+                # so fail loudly and actionably instead of with a bare KeyError.
+                # Prevention: the harness pins one container per (suite, task_id)
+                # via Cls.with_options(max_containers=1) — see LiberoPlusEnvClient.
+                raise RuntimeError(
+                    f"env_id={env_id} not found on this container "
+                    f"(have {sorted(self._envs)}). The env pool for "
+                    f"(suite={self.suite}, task_id={self.task_id}) split across "
+                    f"containers between reset and step. Pin one container per "
+                    f"parameter set (Cls.with_options(max_containers=1))."
+                )
             obs, reward, done, info = env.step(action)
             success = bool(env.check_success())
             self._step_counts[env_id] = self._step_counts.get(env_id, 0) + 1
@@ -430,6 +445,15 @@ class LiberoPlusEnvClient:
     def _get_worker(self):
         if self._worker is None:
             cls = modal.Cls.from_name("archetype-libero-plus-env", "LiberoPlusEnvBatch")
+            # Pin this (suite, task_id) parameter set to a SINGLE container so
+            # every reset() and the batched step() in an episode hit the same
+            # in-memory env pool. Without this, the pool can scale past one
+            # container: reset(env 0) lands on container A while step([0..N])
+            # lands on B, and B has no env 0 → KeyError(0) inside step (surfaced
+            # as a ledger-append "collect failed ...: 0"). with_options returns
+            # an independently scaled handle, so different tasks still each get
+            # their own pinned container; class max_containers stays the total cap.
+            cls = cls.with_options(max_containers=1)
             self._worker = cls(suite=self._suite, task_id=self._task_id)
         return self._worker
 

--- a/bench/libero/modal_worker.py
+++ b/bench/libero/modal_worker.py
@@ -109,15 +109,26 @@ image = (
 app = modal.App("archetype-libero-env", image=image)
 
 
-# max_containers=1: env instances live in container memory keyed by env_key;
-# a second container would silently fork that state. One container per
-# parameter set until envs move to a shared store.
+# Concurrency model: env instances live in *container memory* keyed by env_key,
+# so each (suite, task_id) parameter set must own its own stable container for
+# the full episode — if Modal evicted a container mid-episode (e.g. to serve a
+# different parameter set), the in-memory ``self._envs`` would vanish and the
+# next ``step`` would raise ``KeyError(env_key)``.
+#
+# ``max_containers`` caps the TOTAL container count for this class across all
+# parameter sets, not per parameter set. With max_containers=1 a parallel
+# multi-task sweep would force all (suite, task_id) sets to contend for a single
+# container, evicting one task's env state to serve another → the KeyError
+# above. We raise it to 16 so a full 10-task suite sweep can hold one dedicated
+# container per task simultaneously (the "one env container per task" the
+# baseline sweep requires). Single-container-per-parameter-set is still
+# preserved because each parameter set pins its own container.
 @app.cls(
     cpu=4,
     memory=8192,
     timeout=1800,
     scaledown_window=300,
-    max_containers=1,
+    max_containers=16,
     volumes={FRAMES_MOUNT: frames_volume},
 )
 class LiberoEnvBatch:
@@ -350,6 +361,16 @@ class ModalEnvClient:
 
     def step(self, env_ids: list[int], actions: list[list[float]]) -> list[dict[str, Any]]:
         return self._get_worker().step.remote(env_ids, actions, with_frames=self._with_frames)
+
+    def task_language(self) -> str:
+        """The raw LIBERO instruction for this (suite, task_id).
+
+        Exposed on the harness-side adapter so the eval driver can thread the
+        canonical task language into ``ManipTask.instruction`` for the honest
+        baseline (core-loop §2). Proxies to the worker's ``task_language``,
+        which reads ``task.language`` from the loaded LIBERO benchmark suite.
+        """
+        return str(self._get_worker().task_language.remote())
 
 
 @app.local_entrypoint()

--- a/bench/libero/modal_worker.py
+++ b/bench/libero/modal_worker.py
@@ -291,7 +291,22 @@ class LiberoEnvBatch:
     ) -> list[dict[str, Any]]:
         results = []
         for env_id, action in zip(env_ids, actions, strict=True):
-            env = self._envs[env_id]
+            env = self._envs.get(env_id)
+            if env is None:
+                # The env for this key was reset on a *different* container than
+                # the one serving this step() — the parameter set's pool scaled
+                # to >1 container and split its in-memory env state. Re-resetting
+                # here would silently restart mid-episode (wrong observations),
+                # so fail loudly and actionably instead of with a bare KeyError.
+                # Prevention: the harness pins one container per (suite, task_id)
+                # via Cls.with_options(max_containers=1) — see ModalEnvClient.
+                raise RuntimeError(
+                    f"env_id={env_id} not found on this container "
+                    f"(have {sorted(self._envs)}). The env pool for "
+                    f"(suite={self.suite}, task_id={self.task_id}) split across "
+                    f"containers between reset and step. Pin one container per "
+                    f"parameter set (Cls.with_options(max_containers=1))."
+                )
             obs, reward, done, info = env.step(action)
             success = bool(env.check_success())
             self._step_counts[env_id] = self._step_counts.get(env_id, 0) + 1
@@ -340,6 +355,17 @@ class ModalEnvClient:
     def _get_worker(self):
         if self._worker is None:
             cls = modal.Cls.from_name("archetype-libero-env", "LiberoEnvBatch")
+            # Pin this (suite, task_id) parameter set to a SINGLE container so
+            # every reset() and the batched step() in an episode hit the same
+            # in-memory env pool. Without this, the parameter set's autoscaling
+            # pool can grow past one container: reset(env 0) lands on container
+            # A while reset(env 1..N) / step([0..N]) land on B, and B has no
+            # env 0 → KeyError(0) inside step (surfaced as a ledger-append
+            # "collect failed ...: 0"). with_options returns an independently
+            # scaled handle, so DIFFERENT tasks still each get their own pinned
+            # container (the per-task sweep is unaffected; class max_containers
+            # stays the total cap).
+            cls = cls.with_options(max_containers=1)
             self._worker = cls(suite=self._suite, task_id=self._task_id)
         return self._worker
 
@@ -386,7 +412,9 @@ def smoke(suite: str = "libero_spatial", task_id: int = 0, steps: int = 3):
 
     assert "agentview_ref" in obs, "reset must return agentview_ref when with_frames=True"
     assert "wrist_ref" in obs, "reset must return wrist_ref when with_frames=True"
-    assert obs["agentview_ref"].endswith("-agentview.png"), f"unexpected ref: {obs['agentview_ref']}"
+    assert obs["agentview_ref"].endswith("-agentview.png"), (
+        f"unexpected ref: {obs['agentview_ref']}"
+    )
     assert len(obs.get("gripper_qpos", [])) == 2, "gripper_qpos must be 2-element"
 
     zero = [0.0] * 7
@@ -400,7 +428,6 @@ def smoke(suite: str = "libero_spatial", task_id: int = 0, steps: int = 3):
         assert "wrist_ref" in result, f"step {step_idx} must return wrist_ref"
 
     # Verify the files actually exist in the volume.
-    import os
 
     # Re-read the volume from local context (the worker committed).
     # We can't directly list the modal volume from the local entrypoint,

--- a/bench/libero/out/libero_spatial_split.json
+++ b/bench/libero/out/libero_spatial_split.json
@@ -1,0 +1,97 @@
+{
+  "suite": "libero_spatial",
+  "split_policy": "val = hardest (lowest baseline success, most room to climb); test = held-out subset sampled at even strides across the remaining difficulty ordering (distribution-matched, not all-easy)",
+  "val_task_ids": [
+    0,
+    1,
+    2,
+    4
+  ],
+  "test_task_ids": [
+    3,
+    6,
+    9
+  ],
+  "per_task": {
+    "4": {
+      "success_rate": 0.6667,
+      "successes": 2,
+      "n": 3
+    },
+    "0": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    },
+    "1": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    },
+    "2": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    },
+    "3": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    },
+    "5": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    },
+    "6": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    },
+    "7": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    },
+    "8": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    },
+    "9": {
+      "success_rate": 1.0,
+      "successes": 3,
+      "n": 3
+    }
+  },
+  "baseline": {
+    "all_task_ids": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "overall_success_rate": 0.9667
+  },
+  "run_id": "baseline-spatial-v2+retry17",
+  "config": {
+    "trials": 3,
+    "max_steps": 256,
+    "n_tasks": 10,
+    "val_size": 4,
+    "test_size": 3
+  },
+  "provenance": {
+    "note": "Merged from two Modal runs: baseline-spatial-v2 (tasks 0,2,3,4,5,6,8,9) and baseline-spatial-retry17 (tasks 1,7 \u2014 re-run after transient Modal infra flakes in v2). All rollouts on the libero-eval-results volume, queryable by world_id/run_id.",
+    "runs": [
+      "baseline-spatial-v2",
+      "baseline-spatial-retry17"
+    ]
+  }
+}

--- a/bench/libero/prepare_dataset.py
+++ b/bench/libero/prepare_dataset.py
@@ -1,0 +1,706 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package the LIBERO×VLA-JEPA rollout ledger into a reproducible dataset.
+
+This is the hackathon "packaged reproducible ledger" deliverable: a
+data-preparation / packaging tool that reads our rollout ledger **through the
+Archetype query service** and exports a tidy, self-describing dataset anyone can
+pick up and use.
+
+What it does
+------------
+The baseline sweep (``baseline_sweep.py``) fans one Modal Function per LIBERO
+task and, when each finishes, copies that task's local Archetype store to the
+``libero-eval-results`` Modal Volume under ``{run_id}:task{task_id}``.  Each
+such *cell* contains:
+
+- a **lab** world (``StorageConfig(uri=.../lab, namespace="eval_{suite}")``)
+  whose rows are ``EvalTrialResult`` components — one per completed trial,
+  carrying ``suite / task_id / trial_idx / seed / success / episode_length /
+  run_id``; and
+- an **episodes** world (``namespace="episodes_{suite}"``) holding the full
+  per-tick trajectories.
+
+This tool runs *inside Modal* with the volume mounted at ``/results``, walks the
+cells for a set of ``run_id`` s, and for each lab world reads the
+``EvalTrialResult`` rows **via the Archetype query service** — the exact same
+read path as ``report.py`` (``AsyncStore.get_archetype_df`` /
+``AsyncQueryManager``), never a hand-rolled ``daft.read_lance``.  The rows are
+aggregated into a tidy per-rollout table and shipped back to the caller, which
+writes the artifacts into the working tree (not the volume):
+
+- ``bench/libero/out/dataset/rollouts.parquet`` + ``rollouts.csv`` — one row per
+  rollout: ``run_id, suite, task_id, trial_idx, seed, success, episode_length``.
+- ``bench/libero/out/dataset/summary.csv`` — per ``(run_id, suite, task_id)``:
+  ``rollouts, successes, success_rate, mean_steps``.
+- ``bench/libero/out/dataset/splits/*.json`` — the local ``*_split.json`` files
+  copied in as a convenience (val/test difficulty splits).
+- ``bench/libero/out/dataset/DATASHEET.md`` — what the data is, the schema, the
+  ``(world_id, run_id)`` provenance per cell, how ``success`` is sim ground
+  truth, and a snippet for re-querying any rollout's full trajectory through the
+  Archetype query service.
+
+Run it
+------
+    modal run bench/libero/prepare_dataset.py
+
+    # custom run_ids (comma-separated)
+    modal run bench/libero/prepare_dataset.py --run-ids my-run-a,my-run-b
+
+If a ``run_id`` has no committed cells yet (its batched job is still running),
+it is skipped gracefully; if *nothing* is committed yet the tool still exits 0
+and reports "0 cells committed yet" rather than crashing.  Individual cells that
+error (uncommitted / partial / mid-flush) are caught and skipped.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Where the results Volume is mounted inside the Modal Function, and where the
+# repo is copied (mirrors colocated_runner.py / baseline_sweep.py).
+ROOT = "/repo"
+RESULTS_DIR = "/results"
+
+# The two batched runs we package by default.  Either may be absent on the
+# volume while its job is still running — both are skipped gracefully.
+DEFAULT_RUN_IDS: list[str] = [
+    "libero10-longhorizon-batched",
+    "goal-headroom-batched",
+]
+
+# Tidy column order for the per-rollout table.
+ROLLOUT_COLUMNS: list[str] = [
+    "run_id",
+    "suite",
+    "task_id",
+    "trial_idx",
+    "seed",
+    "success",
+    "episode_length",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (Modal-free → importable + unit-testable in CI)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CellProvenance:
+    """Where one ``{run_id}:task{task_id}`` cell's rows came from.
+
+    Captures the lab-world coordinates the rows were queried under so the
+    DATASHEET can show callers exactly how to re-open the same world.
+    """
+
+    cell: str  # the volume dir name, e.g. "libero10-longhorizon-batched:task3"
+    run_id: str  # the sweep run label (the {run_id} prefix of the cell)
+    suite: str  # LIBERO suite (→ lab namespace "eval_{suite}")
+    namespace: str  # the Archetype storage namespace, "eval_{suite}"
+    world_ids: list[str] = field(default_factory=list)  # persisted ledger world_id(s)
+    ledger_run_ids: list[str] = field(default_factory=list)  # persisted ledger run_id(s)
+    n_rollouts: int = 0
+
+
+def summarize_rollouts(rollouts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse per-rollout rows into a per-(run_id, suite, task_id) summary.
+
+    Returns rows with ``rollouts, successes, success_rate, mean_steps`` — the
+    numbers a reader wants before drilling into individual trials.  Pure: takes
+    the tidy table and returns the summary table, both as plain dicts.
+    """
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = {}
+    for row in rollouts:
+        key = (str(row["run_id"]), str(row["suite"]), int(row["task_id"]))
+        groups.setdefault(key, []).append(row)
+
+    summary: list[dict[str, Any]] = []
+    for (run_id, suite, task_id), rows in sorted(groups.items()):
+        n = len(rows)
+        successes = sum(1 for r in rows if bool(r["success"]))
+        total_steps = sum(int(r["episode_length"]) for r in rows)
+        summary.append(
+            {
+                "run_id": run_id,
+                "suite": suite,
+                "task_id": task_id,
+                "rollouts": n,
+                "successes": successes,
+                "success_rate": round(successes / n, 4) if n else 0.0,
+                "mean_steps": round(total_steps / n, 2) if n else 0.0,
+            }
+        )
+    return summary
+
+
+def _write_csv(path: Path, columns: list[str], rows: list[dict[str, Any]]) -> None:
+    """Write ``rows`` to ``path`` as CSV with a fixed column order."""
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({c: row.get(c, "") for c in columns})
+
+
+# ---------------------------------------------------------------------------
+# The query-service read path (runs inside Modal, next to the volume).
+# ---------------------------------------------------------------------------
+
+
+async def _read_cell_via_query_service(
+    cell_dir: Path,
+    run_id: str,
+) -> tuple[list[dict[str, Any]], CellProvenance | None]:
+    """Read one cell's ``EvalTrialResult`` rows through the Archetype query service.
+
+    Mirrors ``report.py`` / the eval driver: open the lab world's Archetype store
+    and pull rows via ``AsyncQueryManager`` — **not** a raw ``daft.read_lance``.
+
+    The lab world lives at ``{cell_dir}/lab/eval_{suite}/`` (the
+    ``StorageConfig(uri=.../lab, namespace="eval_{suite}")`` written by the
+    sweep).  We:
+
+    1. discover the ``eval_{suite}`` namespace by listing ``lab/``;
+    2. build an ``AsyncLancedbStore`` over it (the default Archetype backend);
+    3. resolve the persisted ``(world_id, run_id)`` ledger coordinates (the lab
+       world's own UUIDs — distinct from the human ``run_id`` label, which is a
+       *field* on each ``EvalTrialResult``); and
+    4. query the ``EvalTrialResult`` component via ``query_components`` scoped to
+       each ``(world_id, run_id)``, exactly the contract a downstream consumer
+       would use.
+
+    Returns ``(rollout_rows, provenance)``.  On any error — an uncommitted or
+    half-flushed cell, a missing namespace, a partial Lance manifest — returns
+    ``([], None)`` so the caller can skip the cell and keep going.
+    """
+    import daft
+
+    from archetype.core.aio import AsyncLancedbStore, AsyncQueryManager
+    from archetype.experiments.components import EvalTrialResult
+
+    lab_dir = cell_dir / "lab"
+    if not lab_dir.is_dir():
+        return [], None
+
+    # The sweep writes exactly one "eval_{suite}" namespace per cell; pick the
+    # first that looks like one (be permissive: any subdir is a candidate).
+    namespaces = [p.name for p in lab_dir.iterdir() if p.is_dir()]
+    eval_namespaces = [n for n in namespaces if n.startswith("eval_")] or namespaces
+    if not eval_namespaces:
+        return [], None
+    namespace = eval_namespaces[0]
+    suite = namespace[len("eval_") :] if namespace.startswith("eval_") else namespace
+
+    # Default Archetype backend is LanceDB; the store roots at {uri}/{namespace}.
+    store = AsyncLancedbStore(str(lab_dir), namespace)
+    sig = (EvalTrialResult,)
+    prov = CellProvenance(
+        cell=cell_dir.name,
+        run_id=run_id,
+        suite=suite,
+        namespace=namespace,
+    )
+
+    try:
+        # Resolve the EvalTrialResult table; absent → this cell has no lab rows
+        # (e.g. a half-written cell). ``_ensure_table`` raises if not found.
+        table = await store._ensure_table(sig)
+
+        # Discover the persisted ledger coordinates. ``get_archetype_df`` always
+        # scopes by (world_id, run_id), so we first read the raw table once to
+        # enumerate the distinct pairs, then re-query each pair *through the
+        # query manager* (the public service contract).
+        keys_arrow = await table.query().select(["world_id", "run_id"]).to_arrow()
+        keys = daft.from_arrow(keys_arrow).distinct().to_pylist()
+        if not keys:
+            await store.shutdown()
+            return [], prov
+
+        querier = AsyncQueryManager(store=store)
+        rows: list[dict[str, Any]] = []
+        for key in keys:
+            world_id = str(key["world_id"])
+            ledger_run_id = str(key["run_id"])
+            prov.world_ids.append(world_id)
+            prov.ledger_run_ids.append(ledger_run_id)
+
+            df = await querier.query_components(
+                [EvalTrialResult],
+                world_id=world_id,
+                run_id=ledger_run_id,
+            )
+            for r in df.to_pylist():
+                rows.append(
+                    {
+                        # The human run label (the cell prefix); stable and
+                        # readable, unlike the ledger run UUID.
+                        "run_id": run_id,
+                        "suite": str(r.get("evaltrialresult__suite", suite)),
+                        "task_id": int(r.get("evaltrialresult__task_id", 0)),
+                        "trial_idx": int(r.get("evaltrialresult__trial_idx", 0)),
+                        "seed": int(r.get("evaltrialresult__seed", 0)),
+                        "success": bool(r.get("evaltrialresult__success", False)),
+                        "episode_length": int(r.get("evaltrialresult__episode_length", 0)),
+                    }
+                )
+
+        prov.n_rollouts = len(rows)
+        await store.shutdown()
+        return rows, prov
+    except Exception:
+        # Uncommitted / partial / mid-flush cell — skip it, never abort the run.
+        try:
+            await store.shutdown()
+        except Exception:
+            pass
+        return [], None
+
+
+async def _prepare_async(run_ids: list[str]) -> dict[str, Any]:
+    """Enumerate cells for ``run_ids`` and read each via the query service.
+
+    Returns a JSON-serializable payload: the tidy rollout rows, per-cell
+    provenance, and a small log of which cells were found / read / skipped.
+    Runs inside the Modal Function where ``/results`` is the mounted volume.
+    """
+    results_root = Path(RESULTS_DIR)
+
+    all_rollouts: list[dict[str, Any]] = []
+    provenances: list[dict[str, Any]] = []
+    log: list[str] = []
+
+    for run_id in run_ids:
+        # Cells for this run are dirs named "{run_id}:task{task_id}".
+        prefix = f"{run_id}:task"
+        cell_dirs = sorted(
+            p for p in results_root.iterdir() if p.is_dir() and p.name.startswith(prefix)
+        )
+        if not cell_dirs:
+            log.append(f"run_id={run_id!r}: 0 cells committed yet (skipped)")
+            continue
+
+        run_rows = 0
+        ok_cells = 0
+        for cell_dir in cell_dirs:
+            rows, prov = await _read_cell_via_query_service(cell_dir, run_id)
+            if prov is None:
+                log.append(f"  {cell_dir.name}: skipped (uncommitted/partial)")
+                continue
+            ok_cells += 1
+            run_rows += len(rows)
+            all_rollouts.extend(rows)
+            provenances.append(
+                {
+                    "cell": prov.cell,
+                    "run_id": prov.run_id,
+                    "suite": prov.suite,
+                    "namespace": prov.namespace,
+                    "world_ids": prov.world_ids,
+                    "ledger_run_ids": prov.ledger_run_ids,
+                    "n_rollouts": prov.n_rollouts,
+                }
+            )
+        log.append(
+            f"run_id={run_id!r}: {len(cell_dirs)} cell(s) found, "
+            f"{ok_cells} read, {run_rows} rollout(s)"
+        )
+
+    # Deterministic order for reproducible artifacts.
+    all_rollouts.sort(
+        key=lambda r: (r["run_id"], r["suite"], r["task_id"], r["trial_idx"], r["seed"])
+    )
+
+    # Build the parquet here (the remote env has Daft, the framework's
+    # DataFrame); the local entrypoint runs under bare ``modal`` and need not
+    # import Daft. Return the bytes so the caller writes them verbatim. We round-
+    # trip through a temp file because Daft writes a parquet *dataset* dir; we
+    # collapse it to the single file's bytes for a portable single-file artifact.
+    parquet_bytes: bytes | None = None
+    if all_rollouts:
+        import tempfile
+
+        import daft
+
+        df = daft.from_pylist(all_rollouts).select(*ROLLOUT_COLUMNS)
+        with tempfile.TemporaryDirectory() as tmp:
+            df.write_parquet(tmp)
+            parts = sorted(Path(tmp).rglob("*.parquet"))
+            if len(parts) == 1:
+                parquet_bytes = parts[0].read_bytes()
+            else:
+                # Coalesce multiple part files into one with pyarrow so the
+                # exported artifact is a single readable parquet file.
+                import pyarrow.parquet as pq
+
+                table = pq.read_table(tmp)
+                buf = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+                pq.write_table(table, buf.name)
+                parquet_bytes = Path(buf.name).read_bytes()
+                Path(buf.name).unlink(missing_ok=True)
+
+    return {
+        "rollouts": all_rollouts,
+        "provenance": provenances,
+        "log": log,
+        "n_cells": len(provenances),
+        "n_rollouts": len(all_rollouts),
+        "parquet_bytes": parquet_bytes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Local-side writers (run on the caller after the Modal Function returns).
+# ---------------------------------------------------------------------------
+
+
+def _datasheet(
+    rollouts: list[dict[str, Any]],
+    summary: list[dict[str, Any]],
+    provenance: list[dict[str, Any]],
+    run_ids: list[str],
+) -> str:
+    """Render the DATASHEET.md documenting the packaged dataset."""
+    suites = sorted({str(r["suite"]) for r in rollouts})
+    present_run_ids = sorted({str(r["run_id"]) for r in rollouts})
+
+    lines: list[str] = []
+    lines.append("# LIBERO×VLA-JEPA Rollout Dataset")
+    lines.append("")
+    lines.append(
+        "A tidy, reproducible export of LIBERO benchmark rollouts produced by the "
+        "VLA-JEPA policy and recorded on the **Archetype append-only ledger**. "
+        "Every row is one environment episode (a *rollout*); `success` is "
+        "simulator ground truth, not a model self-report."
+    )
+    lines.append("")
+
+    # --- Provenance ---
+    lines.append("## Provenance")
+    lines.append("")
+    lines.append(
+        "Rows were read **through the Archetype query service** "
+        "(`AsyncStore.get_archetype_df` / `AsyncQueryManager.query_components`) — "
+        "the same read path as `bench/libero/report.py` — from per-task ledger "
+        "cells on the `libero-eval-results` Modal Volume. Each cell is a "
+        "directory `{run_id}:task{task_id}` holding a **lab** world "
+        '(`StorageConfig(uri=.../lab, namespace="eval_{suite}")`) of '
+        "`EvalTrialResult` rows and an **episodes** world "
+        '(`namespace="episodes_{suite}"`) of full per-tick trajectories.'
+    )
+    lines.append("")
+    lines.append(f"- **Requested run_ids:** {', '.join(repr(r) for r in run_ids)}")
+    lines.append(
+        f"- **Run_ids with committed cells:** "
+        f"{', '.join(repr(r) for r in present_run_ids) or '(none yet)'}"
+    )
+    lines.append(f"- **Suites:** {', '.join(suites) or '(none)'}")
+    lines.append(f"- **Cells packaged:** {len(provenance)}")
+    lines.append(f"- **Total rollouts:** {len(rollouts)}")
+    lines.append("")
+    lines.append("Each packaged cell, with the ledger coordinates its rows were queried under:")
+    lines.append("")
+    lines.append("| cell | suite | namespace | world_id(s) | ledger run_id(s) | rollouts |")
+    lines.append("|------|-------|-----------|-------------|------------------|----------|")
+    for p in provenance:
+        world_ids = "<br>".join(p["world_ids"]) or "—"
+        run_id_cells = "<br>".join(p["ledger_run_ids"]) or "—"
+        lines.append(
+            f"| `{p['cell']}` | {p['suite']} | `{p['namespace']}` "
+            f"| {world_ids} | {run_id_cells} | {p['n_rollouts']} |"
+        )
+    lines.append("")
+
+    # --- Files ---
+    lines.append("## Files")
+    lines.append("")
+    lines.append("| file | description |")
+    lines.append("|------|-------------|")
+    lines.append("| `rollouts.parquet` | One row per rollout (tidy). Canonical artifact. |")
+    lines.append("| `rollouts.csv` | Same rows as CSV, for spreadsheet / quick-look use. |")
+    lines.append(
+        "| `summary.csv` | Per `(run_id, suite, task_id)`: "
+        "`rollouts, successes, success_rate, mean_steps`. |"
+    )
+    lines.append(
+        "| `splits/*.json` | Local val/test difficulty splits "
+        "(copied from `bench/libero/out/*_split.json`). |"
+    )
+    lines.append("| `provenance.json` | Machine-readable copy of the provenance table above. |")
+    lines.append("")
+
+    # --- Schema ---
+    lines.append("## Schema (`rollouts.parquet` / `rollouts.csv`)")
+    lines.append("")
+    lines.append("| column | type | meaning |")
+    lines.append("|--------|------|---------|")
+    lines.append("| `run_id` | str | Sweep run label (the `{run_id}` cell prefix). |")
+    lines.append("| `suite` | str | LIBERO suite, e.g. `libero_10`, `libero_spatial`. |")
+    lines.append("| `task_id` | int | Task index within the suite (0-based). |")
+    lines.append("| `trial_idx` | int | Trial index within `(suite, task_id)` (0-based). |")
+    lines.append("| `seed` | int | Env reset seed (`task_id * 1000 + trial_idx`). |")
+    lines.append("| `success` | bool | **Sim ground truth** — see below. |")
+    lines.append("| `episode_length` | int | Env steps executed before done/timeout. |")
+    lines.append("")
+
+    # --- Success semantics ---
+    lines.append("## How `success` is measured")
+    lines.append("")
+    lines.append(
+        "`success` is the LIBERO simulator's own `env.check_success()` verdict, "
+        "evaluated inside the MuJoCo environment at the end of the episode. It is "
+        "**not** a model confidence or a self-report: the policy proposes actions, "
+        "the simulator decides whether the task goal was physically achieved. The "
+        "verdict latches on the ledger (once true, it stays true), so the recorded "
+        "value is the per-episode terminal outcome. An episode that never reaches "
+        "the goal within `max_steps` is recorded as `success = false`."
+    )
+    lines.append("")
+
+    # --- Re-query snippet ---
+    lines.append("## Re-querying a rollout's full trajectory")
+    lines.append("")
+    lines.append(
+        "The summary rows above are derived from the lab world. The **full "
+        "per-tick trajectory** (proprio, actions, frame refs) for any rollout "
+        "lives in the matching *episodes* world on the same volume and is "
+        "queryable by `(world_id, run_id)` through the same Archetype query "
+        "service. Mount the `libero-eval-results` volume and:"
+    )
+    lines.append("")
+    lines.append("```python")
+    lines.append("import asyncio")
+    lines.append("from pathlib import Path")
+    lines.append("from archetype.core.aio import AsyncLancedbStore, AsyncQueryManager")
+    lines.append("from archetype.experiments.components import EvalTrialResult")
+    lines.append("from archetype.experiments.manipulation import (")
+    lines.append("    ManipProprio, ManipAction, ManipStatus,")
+    lines.append(")")
+    lines.append("")
+    lines.append("")
+    lines.append("async def main():")
+    lines.append("    # Point at one cell on the mounted volume.")
+    lines.append('    cell = Path("/results") / "RUN_ID:taskTASK_ID"')
+    lines.append("")
+    lines.append("    # --- lab world: the EvalTrialResult summary rows ---")
+    lines.append('    lab = AsyncLancedbStore(str(cell / "lab"), "eval_SUITE")')
+    lines.append("    lab_q = AsyncQueryManager(store=lab)")
+    lines.append("    # Discover the persisted ledger coordinates for this world,")
+    lines.append("    # then query the trial results scoped to (world_id, run_id):")
+    lines.append("    tbl = await lab._ensure_table((EvalTrialResult,))")
+    lines.append('    key = (await tbl.query().select(["world_id", "run_id"])')
+    lines.append("           .to_arrow()).to_pylist()[0]")
+    lines.append("    trials = await lab_q.query_components(")
+    lines.append('        [EvalTrialResult], world_id=str(key["world_id"]),')
+    lines.append('        run_id=str(key["run_id"]),')
+    lines.append("    )")
+    lines.append("    print(trials.to_pandas())")
+    lines.append("")
+    lines.append("    # --- episodes world: the full per-tick trajectory ---")
+    lines.append('    eps = AsyncLancedbStore(str(cell / "episodes"), "episodes_SUITE")')
+    lines.append("    eps_q = AsyncQueryManager(store=eps)")
+    lines.append("    etbl = await eps._ensure_table((ManipProprio, ManipAction, ManipStatus))")
+    lines.append('    ekey = (await etbl.query().select(["world_id", "run_id"])')
+    lines.append("            .to_arrow()).to_pylist()[0]")
+    lines.append("    traj = await eps_q.query_components(")
+    lines.append("        [ManipProprio, ManipAction, ManipStatus],")
+    lines.append('        world_id=str(ekey["world_id"]), run_id=str(ekey["run_id"]),')
+    lines.append("    )")
+    lines.append('    print(traj.sort("tick").to_pandas())  # one row per env step')
+    lines.append("")
+    lines.append("")
+    lines.append("asyncio.run(main())")
+    lines.append("```")
+    lines.append("")
+    lines.append(
+        "Replace `RUN_ID`, `TASK_ID`, and `SUITE` with values from "
+        "`provenance.json` / `summary.csv`. (The episodes archetype above is the "
+        "one the sweep spawns; adjust the component tuple to match the world you "
+        "are reading.)"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_dataset(payload: dict[str, Any], out_dir: Path, run_ids: list[str]) -> dict[str, Any]:
+    """Write all dataset artifacts from a Modal payload into ``out_dir``.
+
+    Pure-ish (filesystem only, no Modal): takes the rollout rows + provenance
+    returned by the Modal Function and emits parquet/csv/summary/splits/datasheet
+    into the working tree.  Returns a small manifest of what was written.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rollouts: list[dict[str, Any]] = payload["rollouts"]
+    provenance: list[dict[str, Any]] = payload["provenance"]
+    parquet_bytes: bytes | None = payload.get("parquet_bytes")
+
+    # --- rollouts.parquet + rollouts.csv ---
+    # The parquet is built remotely (where Daft lives) and shipped back as bytes;
+    # the local entrypoint runs under bare ``modal`` and writes them verbatim.
+    parquet_path = out_dir / "rollouts.parquet"
+    csv_path = out_dir / "rollouts.csv"
+    wrote_parquet = False
+    if parquet_bytes:
+        parquet_path.write_bytes(parquet_bytes)
+        wrote_parquet = True
+    _write_csv(csv_path, ROLLOUT_COLUMNS, rollouts)
+
+    # --- summary.csv ---
+    summary = summarize_rollouts(rollouts)
+    summary_path = out_dir / "summary.csv"
+    _write_csv(
+        summary_path,
+        ["run_id", "suite", "task_id", "rollouts", "successes", "success_rate", "mean_steps"],
+        summary,
+    )
+
+    # --- provenance.json ---
+    provenance_path = out_dir / "provenance.json"
+    provenance_path.write_text(json.dumps(provenance, indent=2) + "\n", encoding="utf-8")
+
+    # --- splits/*.json (fold in the local difficulty splits as a convenience) ---
+    splits_dir = out_dir / "splits"
+    splits_dir.mkdir(parents=True, exist_ok=True)
+    split_srcs = sorted((Path(__file__).parent / "out").glob("*_split.json"))
+    copied_splits: list[str] = []
+    for src in split_srcs:
+        dst = splits_dir / src.name
+        dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+        copied_splits.append(src.name)
+
+    # --- DATASHEET.md ---
+    datasheet_path = out_dir / "DATASHEET.md"
+    datasheet_path.write_text(_datasheet(rollouts, summary, provenance, run_ids), encoding="utf-8")
+
+    return {
+        "out_dir": str(out_dir),
+        "rollouts_parquet": str(parquet_path) if wrote_parquet else None,
+        "rollouts_csv": str(csv_path),
+        "summary_csv": str(summary_path),
+        "provenance_json": str(provenance_path),
+        "datasheet_md": str(datasheet_path),
+        "splits": copied_splits,
+        "n_rollouts": len(rollouts),
+        "n_cells": len(provenance),
+        "n_summary_rows": len(summary),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Modal app — defined only when ``modal`` is importable (runner-time).
+# ---------------------------------------------------------------------------
+
+# ``modal`` is a runner-time tool, absent in the CI test venv. Import it lazily
+# so the pure helpers above stay importable for unit tests, while the Modal app
+# (image, function, entrypoint) is only defined under ``modal run``.
+try:
+    import modal  # type: ignore[import-not-found]
+
+    _HAS_MODAL = True
+except ImportError:  # pragma: no cover - exercised only in the CI test venv
+    modal = None  # type: ignore[assignment]
+    _HAS_MODAL = False
+
+
+if _HAS_MODAL:
+    # Reuse the lean colocated image: py3.12 + the archetype package only (the
+    # env / policy stacks are not needed to read the ledger). The ignore list
+    # keeps run logs and the live ``out/`` dir out of the build so an active
+    # writer cannot race the image build.
+    image = (
+        modal.Image.debian_slim(python_version="3.12")
+        .pip_install("uv")
+        .add_local_dir(
+            ".",
+            ROOT,
+            copy=True,
+            ignore=[
+                ".git",
+                "**/__pycache__",
+                ".claude",
+                "target",
+                "*.mp4",
+                ".venv",
+                "**/*.parquet",
+                "**/*.log",
+                "**/out/**",
+            ],
+        )
+        .run_commands(
+            f"cd {ROOT} && uv pip install --system -e . && uv pip install --system pillow numpy"
+        )
+    )
+
+    app = modal.App("archetype-libero-prepare-dataset", image=image)
+    results_volume = modal.Volume.from_name("libero-eval-results", create_if_missing=True)
+
+    @app.function(volumes={RESULTS_DIR: results_volume}, timeout=3600)
+    def prepare_remote(run_ids: list[str]) -> dict[str, Any]:
+        """Read every committed cell for ``run_ids`` via the Archetype query service.
+
+        Runs in-region with the ``libero-eval-results`` volume mounted at
+        ``/results``. Returns the tidy rollout rows + provenance for the caller
+        to write into the working tree. Never raises on a partial cell — each is
+        caught and skipped inside ``_read_cell_via_query_service``.
+        """
+        import asyncio
+        import os
+        import sys
+
+        # Keep logfire quiet/offline and put loose bench scripts on the path
+        # (mirrors the eval driver / sweep so imports resolve identically).
+        os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+        os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+        sys.path.insert(0, f"{ROOT}/bench/libero")
+
+        # Refresh the volume view so cells committed by concurrent sweep jobs
+        # since this container started are visible.
+        results_volume.reload()
+
+        return asyncio.run(_prepare_async(run_ids))
+
+    @app.local_entrypoint()
+    def main(run_ids: str = "") -> None:
+        """Package the ledger into ``bench/libero/out/dataset/``.
+
+        ``run_ids`` is a comma-separated list; empty → the two default batched
+        runs. The Modal Function does the query-service reads in-region; this
+        entrypoint writes the artifacts locally so they land in the working tree.
+        """
+        ids = [x.strip() for x in run_ids.split(",") if x.strip()] or list(DEFAULT_RUN_IDS)
+
+        print(f"=== prepare_dataset === run_ids={ids}")
+        payload = prepare_remote.remote(ids)
+
+        # Surface the per-run / per-cell log from the remote read.
+        for line in payload.get("log", []):
+            print(f"  {line}")
+
+        out_dir = Path(__file__).parent / "out" / "dataset"
+        if payload["n_rollouts"] == 0:
+            # Nothing committed yet (or all cells partial): still write a
+            # DATASHEET + empty CSVs so the deliverable exists, and exit clean.
+            manifest = write_dataset(payload, out_dir, ids)
+            print(
+                "\n0 cells committed yet (or all partial) — wrote an empty "
+                f"dataset scaffold to {manifest['out_dir']!r}."
+            )
+            print("Re-run once the batched jobs commit their first cells.")
+            return
+
+        manifest = write_dataset(payload, out_dir, ids)
+        print("\n=== dataset written ===")
+        for key, value in manifest.items():
+            print(f"  {key}: {value}")
+
+        # Show a sample of the tidy table so the run is self-verifying.
+        print("\n=== sample rollouts (first 10) ===")
+        header = " | ".join(ROLLOUT_COLUMNS)
+        print("  " + header)
+        for row in payload["rollouts"][:10]:
+            print("  " + " | ".join(str(row[c]) for c in ROLLOUT_COLUMNS))

--- a/bench/libero/submit_gepa.py
+++ b/bench/libero/submit_gepa.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fire-and-forget GEPA runs — submit to the cloud, no persistent connection.
+
+`modal run --detach` keeps your local CLI as the driver (it blocks streaming the
+result), so a reaped session cancels the job. `spawn()` against a DEPLOYED function
+queues one input and returns in ~1s; Modal runs it server-side to completion. Close
+your laptop — the result lands in the ledger.
+
+    # 1) deploy the function once (and after any gepa_daft.py edit):
+    modal deploy bench/libero/gepa_daft.py
+
+    # 2) submit a job (returns immediately with a call id):
+    python bench/libero/submit_gepa.py --suite libero_goal --n-tasks 8 \\
+        --n-seeds 5 --max-steps 300 --budget 60 --minibatch 3
+
+    # 3) check on it later (or just `make status` / read the ledger):
+    python bench/libero/submit_gepa.py --fetch <call_id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import modal
+
+APP, FN = "archetype-gepa-daft", "run"
+LAST_CALL_FILE = "/tmp/gepa_last_call.txt"  # status.sh reads this
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--fetch", metavar="CALL_ID", help="poll a previously-submitted job and exit")
+    p.add_argument("--suite", default="libero_goal")
+    p.add_argument("--n-tasks", type=int, default=8)
+    p.add_argument("--n-seeds", type=int, default=5)
+    p.add_argument("--max-steps", type=int, default=300)
+    p.add_argument("--budget", type=int, default=60)
+    p.add_argument("--minibatch", type=int, default=3)
+    p.add_argument("--no-gepa", action="store_true", help="Tier-1 arms only (skip GEPA loop)")
+    a = p.parse_args()
+
+    if a.fetch:
+        call = modal.FunctionCall.from_id(a.fetch)
+        try:
+            res = call.get(timeout=5)
+            print("STATUS: DONE ✓")
+            print(json.dumps(res, indent=2))
+        except TimeoutError:
+            print("STATUS: RUNNING (server-side, decoupled — safe to close your laptop)")
+        except Exception as exc:  # noqa: BLE001 — result may have expired; ledger is the durable copy
+            print(f"STATUS: UNKNOWN — {type(exc).__name__}: {exc} (durable result is in the ledger)")
+        return
+
+    run = modal.Function.from_name(APP, FN)
+    call = run.spawn(
+        suite=a.suite,
+        n_tasks=a.n_tasks,
+        n_seeds=a.n_seeds,
+        max_steps=a.max_steps,
+        budget=a.budget,
+        minibatch=a.minibatch,
+        do_gepa=not a.no_gepa,
+    )
+    with open(LAST_CALL_FILE, "w") as fh:
+        fh.write(call.object_id)
+    print(f"submitted: {call.object_id}")
+    print("running server-side; this process can exit. fetch with:")
+    print(f"    python bench/libero/submit_gepa.py --fetch {call.object_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/libero/vla_jepa_worker.py
+++ b/bench/libero/vla_jepa_worker.py
@@ -82,12 +82,18 @@ app = modal.App("archetype-vla-jepa", image=image)
 ckpt_volume = modal.Volume.from_name("vla-jepa-ckpts", create_if_missing=True)
 
 
+# max_containers=8: inference is STATELESS — each infer/infer_refs call is a
+# pure function of (frames, instruction, state). The per-env action-chunk
+# buffer lives entirely client-side in VlaJepaPolicyClient, so any container
+# can serve any rollout's request. Lifting the cap from 1 to 8 lets the
+# baseline sweep's per-task rollouts run their inference in parallel across
+# GPUs instead of serializing through a single L40S.
 @app.cls(
     gpu="L40S",
     volumes={CKPT_DIR: ckpt_volume, FRAMES_MOUNT: frames_volume},
     timeout=3600,
     scaledown_window=600,
-    max_containers=1,
+    max_containers=8,
 )
 class VlaJepaPolicy:
     use_bf16: int = modal.parameter(default=1)

--- a/docs/build-day-paper.md
+++ b/docs/build-day-paper.md
@@ -243,15 +243,30 @@ an honest finding.
   the deployed `archetype-vla-jepa` worker. No weights touched.
 - **Env:** LIBERO suites on robosuite/MuJoCo, deployed `archetype-libero-env`
   (`LiberoEnvBatch`, N envs per container, batched `step`).
-- **Suites & headroom.** VLA-JEPA is at ceiling on the easy suites under the
-  default instruction (spatial **96.7%**, object **100%**) — no room for an
-  instruction gap there. We therefore select the target suite by a **headroom
-  probe** (below) and report the gap where the default success rate is in a
-  climbable band.
-- **Baseline = the raw default LIBERO task language** (the fair baseline, never an
-  empty string). **Metric = success rate** (sim `check_success`), per task and
-  suite, with seed/episode bootstrap CIs. Optimization is on a val split; the
-  frozen strategy is evaluated once on a held-out test split.
+- **Standard LIBERO is saturated — used only to validate the harness.** VLA-JEPA
+  reports ≈97.2% average across all four standard suites (spatial 96.2%, object
+  99.6%, goal 97.2%, long/LIBERO-10 95.8%); there is no instruction headroom
+  there. We run them only to confirm our batched Archetype harness **reproduces
+  the published numbers** (a systems-validity check), not as the main experiment.
+- **The headroom — and the exact match for our lever — is LIBERO-Plus.**
+  LIBERO-Plus (arXiv 2510.13626) is a standardized robustness *superset* of LIBERO
+  on the **same robosuite/MuJoCo base** (no SAPIEN), with ~10k tasks across seven
+  controlled perturbation dimensions. Its **Language** dimension rewrites the
+  instruction while keeping the scene and goal predicate byte-identical, and
+  VLA-JEPA drops to **85.4%** — ≈12 points of *instruction-induced* headroom that
+  is, by construction, recoverable by re-grounding the instruction. This is the
+  perturbed-instruction setting in standardized, citable form (not a hand-rolled
+  perturbation).
+- **Primary experiment — LIBERO-Plus *Language Instructions*.** Baseline = the
+  benchmark's perturbed instruction (≈85.4%); GEPA re-grounds it (answer-blind,
+  content-preserving); we measure **recovery toward the unperturbed ≈97% ceiling**.
+- **Stretch — non-language dimensions.** Camera (63.3%), Noise (66.3%), Robot-init
+  (67.1%) offer 30+ points; we test whether instruction *grounding cues* (spatial /
+  object descriptors) help a frozen policy survive *non-language* perturbation —
+  the VLA-Grounder grounding-access mechanism. High risk, high reward.
+- **Metric = success rate** (sim `check_success`), per task and dimension, with
+  seed/episode bootstrap CIs. Optimization is on a val split; the frozen strategy
+  is evaluated once on a held-out test split.
 
 ---
 

--- a/docs/build-day-paper.md
+++ b/docs/build-day-paper.md
@@ -1,0 +1,328 @@
+# A Ledger-Native, Massively-Parallel Harness for Conditioning-Space Optimization of Frozen Vision-Language-Action Policies
+
+*Gradient-free instruction optimization of VLA-JEPA on LIBERO, made cheap and exactly reproducible with the Archetype ECS ledger.*
+
+**Claude Build Day — Anthropic × Cerebral Valley, 2026-06-13.**
+Team: Vangelis Technologies. Repo: `github.com/VangelisTech/archetype` (public).
+
+> **Status:** method + system shipped and running; empirical cells are landing as
+> batched rollouts complete. Tables marked **(filling)** are populated from the
+> live ledger; see `bench/libero/out/dataset/` for the queryable artifact.
+
+---
+
+## Abstract
+
+Recent work shows the *conditioning input* of a frozen vision-language-action
+(VLA) policy is an optimizable variable for deployment-time gains: TTT-VLA adapts
+a learned latent prompt by self-supervised gradient descent, and VLA Grounder
+trains an upstream language policy with reinforcement learning to emit better
+commands for a black-box VLA. Both establish the lever — a frozen action expert
+is steerable through its conditioning string — but both are **gradient-based**,
+both require a bespoke simulator stack (SAPIEN/ManiSkill, π0.5/OpenVLA), and
+neither produces a reusable, exactly-reproducible record of the optimization
+loop. We contribute a **systems** result: an ECS-ledger-native harness
+(*Archetype*) that runs this class of study as **batched, append-only-logged,
+fully-queryable rollouts** — every trial keyed by `(world_id, run_id, entity_id,
+tick)` and replayable from `(init_state, action_sequence)`. On this harness we
+run **gradient-free, black-box** reflective instruction optimization (GEPA) of a
+frozen VLA-JEPA policy on LIBERO, with no weight access of any kind. The harness
+turns an optimization budget that costs the prior works hundreds of thousands of
+RL environment-steps (≈42 A100-hours/task) or a custom-trained latent head into a
+few hundred batched rollouts whose every step is on a reproducible ledger. We
+report the default→optimized instruction success gap and the rollout budget, and
+release the queryable dataset and the harness.
+
+---
+
+## 1. Introduction
+
+A vision-language-action model is usually treated as an end-to-end policy
+conditioned on a fixed natural-language task description. In practice the policy's
+behavior depends sharply on *how* the instruction is phrased — so the instruction
+is not merely a label but an **optimizable conditioning input**. Two 2026 papers
+make this concrete for frozen policies:
+
+- **TTT-VLA** optimizes a *latent* soft-prompt by gradient descent through a
+  frozen π0.5 backbone at test time, and finds gains arise "primarily from
+  correcting a small number of critical decisions rather than globally altering
+  policy behavior."
+- **VLA Grounder** keeps the VLA frozen and *black-box*, and trains an upstream
+  guiding VLM with RL (GRPO/LoRA) to emit a better-grounded command, with
+  hidden-state probe evidence that the mechanism is grounding-*access*, not new
+  motor competence.
+
+Both are real results — and both depend on a heavyweight stack: a SAPIEN/ManiSkill
+simulator (Vulkan rendering, net-new to most groups), a specific large VLA
+(π0.5 / OpenVLA-7B), and either per-environment gradient training (TTT-VLA:
+800–2000 transitions + 500–1000 optimization steps, 8×H100, 15–30 min/env) or
+sample-hungry RL (VLA Grounder; the comparable published recipe needs ≈0.4–0.8M
+env-steps and ≈42 A100-hours *per task*). None of them emits a reusable,
+exactly-reproducible record of the optimization loop.
+
+**Our contribution is a systems one.** We show that the *same genre* of study —
+conditioning-space optimization of a frozen VLA — can be run on an
+**ECS-ledger-native, massively-parallel, exactly-reproducible** harness, and we
+do it with a **gradient-free, black-box** optimizer on a stack that already runs
+end-to-end (LIBERO + VLA-JEPA on Modal). The optimizer (GEPA) is an
+implementation choice, not the novelty; the **harness and its reproducibility
+guarantees** are.
+
+### 1.1 Contributions
+
+- **C1 — A ledger-native, batched, reproducible harness (primary).** Every
+  rollout is an entity in an Archetype world; a single batched tick advances *all*
+  seeds of a task together (one `env.step([N],[N])` + one policy forward), and
+  every step is committed to an append-only store keyed by `(world_id, run_id,
+  entity_id, tick)`. Any rollout is queryable through the Archetype query service
+  and replayable from `(init_state, action_sequence)`. This makes the study
+  cheap, parallel, and bit-for-bit auditable.
+- **C2 — Gradient-free, black-box instruction optimization on a live stack.** We
+  optimize the frozen VLA-JEPA policy's natural-language instruction via GEPA's
+  reflective evolution — no gradients, no weight access, no simulator port. The
+  optimized object is human-readable and auditable.
+- **C3 — An honest-frontier reading (secondary).** We report the
+  default→optimized instruction success gap as a measure of how much the default
+  phrasing *under-elicits* a fixed policy, with `pass` defined as simulator
+  ground truth (never an LLM judge).
+
+### 1.2 What we built during Build Day *(judging-rule disclosure)*
+
+Built today, original to this event:
+- the **batched rollout primitive** (`eval_driver.run_episode_batched`) — N seeds
+  as N entities in one world, one batched `env.step` per tick;
+- the **co-located Modal harness** orchestration for batched fan-out across tasks
+  (`baseline_sweep.py` + the env/policy workers as deployed apps);
+- the **query-service dataset/packaging tool** (`prepare_dataset.py`) and live
+  monitor (`monitor.py`) that read the ledger only through the Archetype service;
+- this paper, the design docs, and the reproducible dataset artifact.
+
+Pre-existing (brought in, per the rules): the Archetype ECS framework itself, the
+VLA-JEPA model, and the LIBERO/robosuite simulator.
+
+---
+
+## 2. Hypothesis
+
+> **H.** The natural-language instruction is an optimizable, black-box
+> conditioning input for a frozen VLA. Gradient-free reflective optimization
+> (GEPA) of the instruction string raises a frozen VLA-JEPA policy's LIBERO task
+> success over the default phrasing — with zero weight updates and no model
+> internals — and an ECS ledger makes the optimization loop cheap, massively
+> parallel, and exactly reproducible.
+
+This is conditional and falsifiable: it holds only where the policy has headroom
+and the failure is grounding-related (not pure long-horizon execution). A null
+result — no legitimate rewrite beats the default — is itself an honest finding
+about that suite/checkpoint, never a trigger to train.
+
+### 2.1 Falsifiable predictions
+
+- **Confirms.** An optimized instruction raises success above the default with
+  non-overlapping bootstrap CIs, on a held-out split.
+- **Confirms-mechanism.** The improvement concentrates in failure→success flips
+  at the grounding decision while gross motor competence is unchanged — mirroring
+  TTT-VLA's "few critical decisions." *(We test this directly; we do not inherit
+  it — TTT-VLA's critical decisions were motor-timing, ours would be semantic.)*
+- **Confirms-efficiency.** GEPA reaches its best held-out gap in dramatically
+  fewer sim rollouts than a matched gradient/RL baseline (GEPA reports up to 35×
+  fewer rollouts than GRPO on text tasks; we test whether that transfers to
+  expensive sim episodes — it is a hypothesis, not an inherited property).
+- **Kills.** No legitimate rewrite beats the default beyond CI overlap → the
+  default is not under-eliciting on this suite/checkpoint (honest null).
+- **Kills-as-artifact.** A length-matched neutral paraphrase moves success as
+  much as the optimized rewrite → the effect is generic input perturbation, not
+  grounding.
+
+---
+
+## 3. System: the Archetype harness *(the contribution)*
+
+```
+        Modal (one region, co-located)
+  ┌───────────────────────────────────────────────┐
+  │  Archetype driver (py3.12, world loop + ledger) │  one Function per (suite,task)
+  │      │ EnvClient            │ PolicyClient       │  via .starmap (World axis)
+  │      ▼                      ▼                    │
+  │  archetype-libero-env   archetype-vla-jepa       │
+  │  (robosuite/MuJoCo)     (L40S, VLA-JEPA server)  │
+  └───────────────────────────────────────────────┘
+       every rollout → append-only ledger (world_id, run_id, entity_id, tick)
+```
+
+**Batched tick = the core primitive.** A task's N seeds are spawned as N
+*entities* in one world. Each tick, the proven processors issue exactly one
+batched environment call — `env.step([N env_keys],[N actions])` — and one policy
+forward over the live entities, then commit all N rows. Within an episode the tick
+sequence is genuinely coupled (step *t+1* needs *t*); across seeds nothing is
+coupled, so it is all data and batches into one tick. Cross-task parallelism is
+the Modal `.starmap` (World axis); per-task batching is the Entity axis. We
+verified the batched path end-to-end: two seeds of a task share a single batched
+world wall-time (one episode duration, not two).
+
+**Reproducibility by construction.** The store is append-only and keyed by
+`(world_id, run_id, entity_id, tick)`; `run_id` is an immutable uuidv7 and the
+optimization arm is a queryable component field (`run_name`), so `run_id` is never
+overloaded with semantics. Every rollout is queryable through the Archetype query
+service (`AsyncQueryManager.query_archetype(sig, world_id, run_id)`) — we never
+read raw files — and replayable from `(init_state, action_sequence)`. `pass` is
+the simulator's own `check_success`, computed from the ledger, never an LLM
+opinion.
+
+**Cost contrast.** TTT-VLA: 800–2000 transitions + 500–1000 gradient steps,
+8×H100, 15–30 min *per environment*. VLA Grounder–class RL: ≈0.4–0.8M env-steps,
+≈42 A100-hours *per task*. Our harness runs the comparable study as a few hundred
+batched rollouts, every one logged and replayable.
+
+---
+
+## 4. Method: gradient-free instruction optimization
+
+We optimize a **single global** instruction-rewrite strategy applied identically
+to every task instance and frozen before the held-out pass, using GEPA's
+reflective evolution: candidate rewrites are mutated from natural-language
+reflection over per-rollout reports, and a Pareto/top-k frontier selects
+survivors. The LLM is used **only** for diagnosis and mutation — never as the
+success judge. The downstream VLA-JEPA policy is **frozen** and treated as a
+**black box**: GEPA needs no gradients and no access to the policy's weights or
+activations, only the instruction string fed to `set_language()` and the
+simulator's pass/fail.
+
+**Anti-gaming protocol.** Rewrites are content-preserving and answer-blind: they
+may re-ground the task description but may not encode the solution. We bracket a
+legitimate gain between a length-matched neutral-paraphrase *floor* and an
+answer-encoding oracle *ceiling*, and evaluate on a held-out split, so any gap is
+attributable to better grounding rather than perturbation or leakage.
+
+---
+
+## 5. Related work
+
+Our work sits in a recent line treating the conditioning input of a frozen VLA as
+the optimizable variable, rather than updating the action policy. **TTT-VLA**
+(Test-Time Latent Prompt Optimization) makes a learnable latent soft-prompt `z`
+the interface and adapts it per environment via self-supervised gradient descent
+through a frozen π0.5 backbone (`z ← z − η∇_z L_proxy`), reporting consistent
+SimplerEnv gains that arise "primarily from correcting a small number of critical
+decisions." **VLA Grounder** (Language-Conditioning Space Optimization for
+Black-Box VLA Models) moves the optimizable variable into natural language,
+training an upstream guiding VLM with GRPO/LoRA to emit a better-grounded command
+for a frozen black-box VLA, with probe evidence that the mechanism is
+grounding-*access*, not new motor skill. Notably, **VLA Grounder itself benchmarks
+GEPA** as a frozen-VLA command optimizer (it reports GEPA competitive with, though
+below, its GRPO on VL-Think) — so *reflective prompt evolution on a frozen VLA is
+not itself novel*, and we do not claim it. **GEPA** (Agrawal et al., 2025)
+establishes that gradient-free reflective prompt evolution can outperform RL while
+using up to 35× fewer rollouts on text tasks.
+
+Both robot papers establish the lever our hypothesis depends on — a frozen action
+expert is steerable through its conditioning string, and the corrections are few,
+local, and grounding-driven — but both are gradient-based, both require a bespoke
+SAPIEN/ManiSkill + π0.5/OpenVLA stack, and **neither emits a reusable,
+exactly-reproducible record of the optimization loop**. Our distinct contribution
+is the **ledger-native, batched, reproducible harness** that runs this study as
+queryable append-only rollouts, demonstrated with a gradient-free black-box
+optimizer on a stack (LIBERO + VLA-JEPA) that runs end-to-end without a simulator
+port — plus the discipline that `pass` is simulator ground truth and a null gap is
+an honest finding.
+
+| Axis | TTT-VLA | VLA Grounder | **Ours** |
+|---|---|---|---|
+| Optimizer | gradient TTT (backprop→latent) | RL (GRPO/LoRA) | **gradient-free reflective (GEPA)** |
+| Access needed | white-box | reward + sim | **black-box (string + pass/fail)** |
+| Optimized object | opaque latent `z` | NL command | **NL instruction (auditable)** |
+| Sample cost | 800–2000 transitions/env, 8×H100 | ≈0.4–0.8M env-steps, ≈42 A100-h/task | **hundreds of batched rollouts** |
+| Reproducible loop | — | — | **append-only ledger, replayable** |
+| Claim | improvement | improvement | **harness + honest-frontier gap** |
+
+---
+
+## 6. Experimental setup
+
+- **Policy:** VLA-JEPA (Qwen3-VL-2B + V-JEPA2), frozen, served on Modal L40S via
+  the deployed `archetype-vla-jepa` worker. No weights touched.
+- **Env:** LIBERO suites on robosuite/MuJoCo, deployed `archetype-libero-env`
+  (`LiberoEnvBatch`, N envs per container, batched `step`).
+- **Suites & headroom.** VLA-JEPA is at ceiling on the easy suites under the
+  default instruction (spatial **96.7%**, object **100%**) — no room for an
+  instruction gap there. We therefore select the target suite by a **headroom
+  probe** (below) and report the gap where the default success rate is in a
+  climbable band.
+- **Baseline = the raw default LIBERO task language** (the fair baseline, never an
+  empty string). **Metric = success rate** (sim `check_success`), per task and
+  suite, with seed/episode bootstrap CIs. Optimization is on a val split; the
+  frozen strategy is evaluated once on a held-out test split.
+
+---
+
+## 7. Results **(filling)**
+
+**Headroom map** (default instruction, frozen VLA-JEPA):
+
+| Suite | Horizon | Default success | Headroom for instruction opt? |
+|---|---|---|---|
+| libero_spatial | short | 96.7% | none (ceiling) |
+| libero_object | short | 100% | none (ceiling) |
+| libero_goal | medium | **(filling — probe `goal-headroom-batched`)** | TBD |
+| libero_10 (LONG) | long (~520) | **(filling — probe `libero10-longhorizon-batched`, cap 700)** | TBD (execution-bound risk) |
+
+**Main result — default → optimized instruction** *(to fill on the selected
+headroom suite):*
+
+| Arm | Instruction | Success (val) | Success (held-out test) |
+|---|---|---|---|
+| A — default | raw task language | (filling) | (filling) |
+| B — GEPA rewrite (answer-blind) | optimized | (filling) | (filling) |
+| C — oracle ceiling (answer-encoding) | upper bound | (filling) | (filling) |
+| D — neutral paraphrase (floor) | length-matched | (filling) | (filling) |
+
+Legitimate gap requires **A < D < B < C** on the held-out split.
+
+**Efficiency — rollouts to best held-out gap** *(to fill):* GEPA budget vs a
+matched gradient/RL baseline; the prior works' published budgets (≈0.4–0.8M
+env-steps; 8×H100 15–30 min/env) are the external reference.
+
+All numbers above are computed from the queryable ledger (`bench/libero/out/dataset/`).
+
+---
+
+## 8. Reproducibility & artifact
+
+- **Queryable dataset:** `bench/libero/out/dataset/` — `rollouts.parquet` /
+  `.csv` (one row per rollout: run_id, suite, task_id, trial_idx, seed, success,
+  episode_length), `summary.csv`, and `DATASHEET.md` documenting schema,
+  provenance `(world_id, run_id)`, and a snippet to re-query any rollout's full
+  trajectory through the Archetype query service. Produced by
+  `bench/libero/prepare_dataset.py`, which reads the ledger only through the
+  service.
+- **Replay:** any rollout reconstructs deterministically from its
+  `(init_state, action_sequence)` on the ledger.
+- **Environment pinning:** Modal images SHA-pin LIBERO and VLA-JEPA.
+
+---
+
+## 9. Limitations
+
+- The headroom suite must be selected empirically; on ceiling suites the gap is
+  necessarily ~0, and on pure long-horizon suites the failure is execution, which
+  instruction optimization cannot fix. We report where the gap exists and where it
+  does not.
+- The "few critical decisions" mechanism is established for *motor-timing* in
+  TTT-VLA; whether it recurs for *semantic/grounding* selection is something we
+  test, not assume.
+- GEPA's 35×-fewer-rollouts efficiency is a text-task result; transfer to
+  expensive sim episodes is a hypothesis under test here.
+- We do not claim GEPA-on-frozen-VLA as novel (VLA Grounder benchmarks it). The
+  novelty is the reproducible, batched, ledger-native harness.
+
+---
+
+## 10. Conclusion
+
+Conditioning-space optimization of frozen VLAs has been shown to work with
+gradients (TTT-VLA) and with RL (VLA Grounder), each on a heavyweight bespoke
+stack and without a reusable record of the loop. We contribute the missing
+*systems* piece: an ECS-ledger-native, massively-parallel, exactly-reproducible
+harness that runs the same study as queryable append-only rollouts, demonstrated
+with a gradient-free, black-box optimizer on a stack that runs end-to-end today.
+The optimizer is swappable; the reproducible ledger is the point.

--- a/docs/design/gepa-core-loop.md
+++ b/docs/design/gepa-core-loop.md
@@ -1,0 +1,211 @@
+# GEPA Core Loop — LIBERO-Para × VLA-JEPA
+
+**Document type:** Core-loop specification. This is the *isolated* reference for
+everything that touches the GEPA optimization and VLA-JEPA. Orchestration, infra,
+ownership, and the day plan live in [`libero-para-day-plan.md`](./libero-para-day-plan.md).
+If a decision is about *what the optimization does*, it belongs here. If it's
+about *how we run it*, it belongs there.
+
+Status: **contract locked 2026-06-13** (the make-or-break scorer gate cleared —
+LIBERO exposes native subgoal predicates; see §5). Cleared to build.
+
+---
+
+## 1. Hypothesis
+
+**Sufficiency:** test-time prompt optimization can *elicit latent VLA capability
+that the default instructions under-measure*. The model may already be able to do
+a task; the canonical phrasing just fails to unlock it.
+
+The deliverable number is the **gap**:
+
+> success(VLA-JEPA | fair default instruction)  →  success(VLA-JEPA | GEPA-optimized paraphrase)
+
+That gap is "honest frontier − benchmarked frontier." It tests whether test-time
+optimization techniques that work for coding agents (GEPA) **transfer to VLAs**.
+
+Secondary framing: benchmarking a model on un-optimized prompts *under-measures*
+it. Prompt optimization gives an **honest assessment** of the model's true
+capability ceiling — a prerequisite to knowing whether training changes help.
+
+---
+
+## 2. What LIBERO-Para is
+
+LIBERO-Para = LIBERO with the **language instruction made mutable**. The simulator,
+tasks, objects, and success criteria are identical to LIBERO; only the text layer
+the policy conditions on changes. So a vanilla LIBERO run *is* a LIBERO-Para run
+at the identity paraphrase — we already know it runs (the end-to-end demo solved
+`libero_spatial` task 0).
+
+The **mutable knob is a single field**: `ManipTask.instruction`, which flows
+through the policy caller to VLA-JEPA's `infer_refs(..., instruction=...)`.
+
+**Fairness rule:** the baseline is the **raw LIBERO instruction**, never the empty
+string. (The eval driver currently spawns `instruction=""`; that must become the
+canonical task language for an honest baseline.)
+
+---
+
+## 3. The optimization target (GEPA candidate)
+
+**Candidate = a global paraphrase *strategy*** (a small evolvable system prompt /
+rewrite policy) that maps any raw LIBERO instruction → a grounded paraphrase.
+
+- **Not** per-task memorized strings. Per-task strings make the held-out test set
+  meaningless (you'd just re-optimize on it).
+- A global strategy **transfers**, so the test number is real generalization —
+  which is the entire point of the train/val/test discipline below.
+
+This is the "small thing that trains." Everything else in GEPA (mutation, Pareto
+selection) is deliberately naive and self-correcting; **only the feedback stage
+makes it improve.**
+
+---
+
+## 4. Train / Val / Test split
+
+No usable historical failure data exists (the only prior eval artifacts are the
+internal regression suite + one smoke). So the split is produced by a **baseline
+sweep**, not mined.
+
+1. **Baseline sweep:** run a validated suite (start `libero_spatial`, 10 tasks)
+   with the *raw* instruction, a few seeds each → per-task success rate.
+2. **Val set = the hardest tasks** (lowest baseline success = most room to climb).
+   This is "find the ones that fuck up." The reflector sees **only** val.
+3. **Test set = held-out, distribution-matched** tasks. Never seen by the
+   reflector. Measures whether the evolved paraphrase strategy generalizes.
+4. Choose the hardest tasks deliberately so there is **room to climb** — a val set
+   already at ceiling proves nothing.
+
+Leakage guard: the reflector/mutator touches val rollouts only; test is evaluated
+once, at the end, with the frozen strategy.
+
+---
+
+## 5. The SCORER (per-rollout feedback) — the crux
+
+**This is the only part of GEPA that matters.** Hill-climbing is luck unless, for
+any rollout, we can say *exactly where it failed, why, and the root cause.*
+
+### Ground truth is natively available (gate cleared)
+
+Verified on a live LIBERO env (`libero_introspect.py`):
+
+- `env.env._eval_predicate(pred)` evaluates **arbitrary** predicates over the
+  scene, per state — not just the goal. Confirmed returning
+  `{["on","akita_black_bowl_1","plate_1"]: false}` at reset.
+- `_check_success` = conjunction of `_eval_predicate` over `parsed_problem["goal_state"]`.
+- `object_states_dict` exposes every **object and every named region**
+  (`main_table_between_plate_ramekin_region`, `wooden_cabinet_1_top_region`, …).
+- obs carries each object's pose **and eef-relative pose**
+  (`akita_black_bowl_1_to_robot0_eef_pos`).
+- `parsed_problem["obj_of_interest"]` names the task-relevant objects.
+
+**Consequence:** even when a task's `goal_state` is one coarse predicate
+(`on(bowl, plate)`), the scorer can **construct and evaluate intermediate
+subgoals itself** — `grasped(bowl)`, `lifted(bowl)`, `in(bowl, between_region)` —
+via the same native evaluator. Fine-grained root cause on any task.
+
+### Substrate: an agentic REPL scorer (deterministic replay)
+
+Rollouts are deterministic given `(init_state, action_sequence)`, both on the
+ledger. So the scorer **replays** any rollout exactly and can restore MuJoCo state
+at any tick. The append-only ledger *is* the replay substrate.
+
+The scorer is a **multi-step agent** (dspy.RLM / ReAct Claude) in a Python REPL
+with `mujoco`/`libero` + curated helpers:
+
+```
+replay_to(t)            object_states(t)       contacts(t)
+eval_subgoals(t)        eef_to(obj, t)         frame(t, cam)
+find_grasp_attempts()   eval_predicate(pred, t)
+```
+
+It investigates adaptively per failure mode (replay → find the tick a subgoal
+*should* have flipped and didn't → render that frame → root cause), which is
+strictly more powerful than handing it pre-distilled fixed features.
+
+### Scorer output contract (per rollout)
+
+```
+{
+  "pass": bool,                 # GROUND TRUTH from sim _check_success — never the LLM's opinion
+  "subgoals": [                 # goal + constructed intermediate predicates
+    {"predicate": [...], "satisfied": bool, "flipped_at_tick": int | null}
+  ],
+  "failure_phase": "approach|grasp|lift|transport|place|none",
+  "root_cause": str,            # NL: what happened and why
+  "key_frames": [tick, ...]     # ticks the human UI should render
+}
+```
+
+Metric (`pass` + subgoal completion) and NL feedback are **always returned
+together**; both flow to the mutator.
+
+### Scorer properties (answered)
+
+- **Smart:** yes, Claude-class — reasoning about manipulation failure.
+- **Multimodal:** yes — renders & reads frames on demand.
+- **Multi-step:** yes — this is where the agentic loop lives.
+- **`pass` is sim ground truth, not LLM judgment.** The LLM produces diagnosis +
+  constructed-subgoal reasoning only.
+
+---
+
+## 6. The MUTATOR (reflection → strategy evolution)
+
+Reads the **batch** of scorer reports across val rollouts (cross-task, for a
+global strategy) → proposes an improved paraphrase strategy. Deliberately simple:
+the intelligence is in the scorer's reports, not here.
+
+- Maintains a **Pareto frontier** of strategy candidates (per-task best preserved,
+  not a single scalar-best) to keep diversity.
+- One mutation per round; sample parents from the frontier; loop.
+
+---
+
+## 7. The loop
+
+```
+baseline sweep (raw instruction) ── pick val (hardest) + test (held-out)
+        │
+        ▼
+  ┌─ evaluate current strategy on val  → rollouts on the ledger
+  │         │
+  │         ▼
+  │   SCORER (agentic REPL) per rollout → {pass, subgoals, root_cause}
+  │         │
+  │         ▼
+  │   MUTATOR reads batch → new paraphrase strategy → Pareto-keep
+  └─────────┘   repeat K rounds (or until val plateaus)
+        │
+        ▼
+  freeze best strategy → evaluate ONCE on test → report the gap
+```
+
+---
+
+## 8. Reproducibility (non-negotiable)
+
+Every rollout — baseline, val, test — is recorded **on the Archetype ledger**:
+`(init_state, action_sequence, per-tick proprio/frames/status)`, so any rollout is
+exactly replayable and the whole study is packageable. The scorer's reports and
+the mutator's strategy lineage are recorded alongside. The paper's numbers come
+from queryable ledger data, not loose logs.
+
+---
+
+## 9. Human sanity-check UI
+
+A minimal page rendering, per rollout: key frames + the subgoal trace + the
+scorer's `pass`/root-cause. We verify the scorer is *correct* on a handful of
+rollouts **before** trusting it to drive optimization. Scoring correctness is the
+prerequisite to every downstream gain.
+
+---
+
+## 10. Open build-time item
+
+Enumerate LIBERO's full predicate vocabulary (`on`/`in`/`grasp`/`up`/`open`/…) so
+the scorer's constructed-subgoal helper is concrete rather than ad hoc.

--- a/docs/design/gepa-core-loop.md
+++ b/docs/design/gepa-core-loop.md
@@ -188,9 +188,14 @@ baseline sweep (raw instruction) ── pick val (hardest) + test (held-out)
 
 ## 8. Reproducibility (non-negotiable)
 
-Every rollout — baseline, val, test — is recorded **on the Archetype ledger**:
-`(init_state, action_sequence, per-tick proprio/frames/status)`, so any rollout is
-exactly replayable and the whole study is packageable. The scorer's reports and
+Every rollout — baseline, val, test — is **already** recorded on the Archetype
+ledger: `(init_state via seed, action_sequence, per-tick proprio/frames/status)`,
+keyed by `(world_id, run_id)`. This is not something we add — it is the append-only
+invariant. `destroy_world` is **in-memory teardown only; storage is preserved**
+(verified in code + by the persisted episode table surviving destroyed worlds). The
+scorer therefore **queries** any rollout's full trajectory by `(world_id, run_id)`
+via the query service; replay is reconstructable from the persisted seed + actions.
+Any rollout is exactly replayable and the whole study is packageable. The scorer's reports and
 the mutator's strategy lineage are recorded alongside. The paper's numbers come
 from queryable ledger data, not loose logs.
 

--- a/docs/design/gepa-run-book.html
+++ b/docs/design/gepa-run-book.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GEPA × VLA-JEPA — End-to-End Run Book</title>
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true, theme: "base", themeVariables: {
+    primaryColor: "#11203a", primaryTextColor: "#e6edf3", primaryBorderColor: "#3b5bdb",
+    lineColor: "#7c8aa5", fontSize: "14px", fontFamily: "ui-sans-serif, system-ui, sans-serif"
+  }});
+</script>
+<style>
+  :root { --bg:#0d1117; --panel:#161b22; --panel2:#1c2330; --ink:#e6edf3; --muted:#9aa7b8;
+          --line:#2a3340; --accent:#5b8cff; --green:#3fb950; --amber:#d29922; --red:#f85149;
+          --code:#0b1020; }
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--ink);
+         font: 16px/1.65 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 40px 24px 120px; }
+  header.hero { border:1px solid var(--line); border-radius:14px; padding:28px 30px;
+    background: linear-gradient(135deg,#11203a,#161b22); margin-bottom:30px; }
+  h1 { font-size: 30px; margin:0 0 6px; letter-spacing:-0.5px; }
+  h2 { font-size: 22px; margin:46px 0 14px; padding-bottom:8px; border-bottom:1px solid var(--line); }
+  h3 { font-size: 17px; margin:28px 0 10px; color:#cdd9e5; }
+  .sub { color: var(--muted); font-size: 15px; }
+  p { margin: 12px 0; }
+  code { font-family: "SF Mono", SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
+  p code, li code, td code { background:var(--panel2); border:1px solid var(--line);
+    padding: 1px 6px; border-radius:5px; color:#b9c6da; }
+  pre { background: var(--code); border:1px solid var(--line); border-radius:10px;
+    padding: 16px 18px; overflow-x:auto; font-size: 12.5px; line-height:1.55; }
+  pre code { color:#c8d3e0; }
+  .kw { color:#ff7b72; } .fn { color:#d2a8ff; } .str { color:#a5d6ff; }
+  .cm { color:#7d8da3; font-style:italic; } .num{color:#79c0ff;}
+  .panel { background:var(--panel); border:1px solid var(--line); border-radius:12px;
+    padding: 18px 22px; margin: 18px 0; }
+  .grid { display:grid; grid-template-columns: 1fr 1fr; gap:16px; }
+  .card { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:16px 18px; }
+  .card h4 { margin:0 0 6px; font-size:15px; } .card .role { font-size:12px; color:var(--muted); }
+  table { width:100%; border-collapse:collapse; margin:16px 0; font-size:14px; }
+  th, td { text-align:left; padding:9px 12px; border-bottom:1px solid var(--line); vertical-align:top; }
+  th { color:#cdd9e5; font-size:13px; text-transform:uppercase; letter-spacing:.4px; }
+  tr:hover td { background:#11161f; }
+  .tag { display:inline-block; padding:2px 9px; border-radius:20px; font-size:12px; font-weight:600; }
+  .t-a{background:#30363d;color:#c9d1d9;} .t-d{background:#1f2d4d;color:#9db4ff;}
+  .t-b{background:#1d3a23;color:#7ee787;} .t-c{background:#3d2f15;color:#e3b341;}
+  .note { border-left:3px solid var(--accent); background:#10192e; padding:12px 16px; border-radius:0 8px 8px 0; margin:16px 0; }
+  .warn { border-left:3px solid var(--amber); background:#241d10; }
+  .ok   { border-left:3px solid var(--green); background:#0f1f14; }
+  .mermaid { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:18px; margin:18px 0; text-align:center; }
+  .step { display:flex; gap:14px; margin:14px 0; }
+  .step .n { flex:0 0 30px; height:30px; border-radius:50%; background:var(--accent); color:#fff;
+    display:flex; align-items:center; justify-content:center; font-weight:700; font-size:14px; }
+  .step .body { flex:1; }
+  .muted { color:var(--muted); }
+  .pill { font-size:12px; padding:2px 8px; border-radius:6px; background:var(--panel2); border:1px solid var(--line); color:var(--muted); }
+  a { color:var(--accent); }
+  hr { border:none; border-top:1px solid var(--line); margin:30px 0; }
+  .small { font-size:13px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="hero">
+  <h1>GEPA × VLA-JEPA — End-to-End Run Book</h1>
+  <div class="sub">Reflective <em>test-time</em> instruction optimization over a <strong>frozen</strong> vision-language-action policy on LIBERO-Plus. Zero weight changes — only the conditioning text evolves. Every (strategy, task) cell is written to the append-only ledger.</div>
+  <p class="small muted" style="margin-top:14px">
+    Pipeline: <code>bench/libero/gepa_daft.py</code> &nbsp;·&nbsp; Algorithm: <code>archetype.optimize.gepa</code> &nbsp;·&nbsp; Workers: <code>archetype-libero-plus-env</code>, <code>archetype-vla-jepa</code>
+  </p>
+</header>
+
+<h2>1 · The thesis in one paragraph</h2>
+<p>
+A frozen VLA policy (VLA-JEPA) underperforms on the <strong>LIBERO-Plus Language</strong> dimension — same scene, <em>perturbed instruction</em> (~85% vs. ceiling on clean text). The claim: a lot of that gap is <strong>conditioning quality, not capability</strong>. So we run <strong>GEPA</strong> (Agrawal et&nbsp;al. 2025) to evolve an <em>instruction-rewrite strategy</em> at test time — reflecting on simulator outcomes, never touching a single weight. The simulator's <code>pass</code> is ground truth (no LLM judge). The honest baseline is the perturbed instruction verbatim.
+</p>
+<div class="note">
+  <strong>Why this is a clean result either way.</strong> Tier-1 is a fixed-arm ablation whose <em>ordering</em> is the legitimacy test: <code>A&nbsp;≤&nbsp;D&nbsp;&lt;&nbsp;B-seed&nbsp;&lt;&nbsp;C</code>. If a neutral paraphrase (D) already recovers the gap, the effect is an artifact. If only grounding (B/GEPA) recovers it, the gap was conditioning. Tier-2 (GEPA) then shows how far reflective search pushes it under a fixed rollout budget.
+</div>
+
+<h2>2 · System architecture</h2>
+<p>The whole optimization is <strong>one Modal function</strong> (<code>run</code>) whose body is Daft DataFrame ops. The only <code>.remote()</code> calls leave the box to the two <em>deployed</em> workers — the same proven path as the baseline sweep. Daft gives intra-container parallelism over rollouts.</p>
+
+<div class="mermaid">
+flowchart LR
+  CLI["modal run gepa_daft.py<br/>(local entrypoint)"] -->|run.remote| RUN
+  subgraph BOX["archetype-gepa-daft · one Modal function"]
+    RUN["run()"] --> EVAL["evaluate()<br/>Daft DataFrame<br/>strategies × tasks"]
+    EVAL -->|"prompt() rewrite"| SON["Claude sonnet-4-6"]
+    EVAL -->|"RolloutEvaluator.eval<br/>(@daft.cls, use_process)"| ROLL["run_episode_batched"]
+    RUN -->|"gepa_search()"| LIB["archetype.optimize.gepa<br/>Alg 1 + Pareto Alg 2"]
+    RUN -->|"reflect prompt()"| OPU["Claude opus-4-8"]
+    EVAL -->|write_lance| LED[("Ledger · Lance<br/>/results/gepa_daft")]
+  end
+  ROLL -->|.remote| ENVW[("archetype-libero-plus-env<br/>MuJoCo · perturbed instr")]
+  ROLL -->|.remote| POLW[("archetype-vla-jepa<br/>frozen policy")]
+</div>
+
+<div class="grid">
+  <div class="card"><h4>archetype-libero-plus-env</h4><div class="role">Deployed worker · MuJoCo</div><p class="small">Serves the LIBERO-Plus <strong>Language</strong> split. <code>task_id</code> = language ordinal; <code>task_language()</code> returns the <em>perturbed</em> instruction. Pinned to one container per (suite, task) so reset/step never split across autoscaled containers.</p></div>
+  <div class="card"><h4>archetype-vla-jepa</h4><div class="role">Deployed worker · frozen policy</div><p class="small">The VLA-JEPA policy, weights frozen. Conditioned only on the (possibly rewritten) instruction + frames. Never fine-tuned in this experiment.</p></div>
+  <div class="card"><h4>gepa_daft.py · run()</h4><div class="role">Orchestrator (Daft)</div><p class="small">Builds the tasks frame, runs the Tier-1 arms, then the Tier-2 GEPA loop. Sets Claude as the Daft <code>prompt()</code> provider via Anthropic's OpenAI-compatible endpoint.</p></div>
+  <div class="card"><h4>archetype.optimize.gepa</h4><div class="role">The algorithm (pure)</div><p class="small">Faithful GEPA Algorithm&nbsp;1 + Pareto Algorithm&nbsp;2. No Daft/Modal/LLM dependency — the two effects are injected. Parity-tested in <code>tests/experiments/test_gepa_daft.py</code>.</p></div>
+</div>
+
+<h2>3 · The experiment design</h2>
+<h3>Tier 1 — fixed-arm ablation (gen-0)</h3>
+<p>Four strategies, each evaluated on every task. <code>strategy_text = None</code> means identity (use the perturbed instruction verbatim).</p>
+<table>
+  <thead><tr><th>Arm</th><th>Strategy</th><th>What it tests</th></tr></thead>
+  <tbody>
+    <tr><td><span class="tag t-a">A-default</span></td><td>identity — perturbed instruction as-is</td><td>the honest ~85% baseline</td></tr>
+    <tr><td><span class="tag t-d">D-paraphrase</span></td><td>reword, add <em>no</em> grounding</td><td>control: is any rewrite enough? (artifact check)</td></tr>
+    <tr><td><span class="tag t-b">B-seed</span></td><td>the seed grounding strategy, un-evolved</td><td>does grounding (one-shot) help?</td></tr>
+    <tr><td><span class="tag t-c">C-oracle</span></td><td>name the exact correct target/destination</td><td>upper bound (smuggles the answer — diagnostic only)</td></tr>
+  </tbody>
+</table>
+<pre><code><span class="cm"># bench/libero/gepa_daft.py — the seed strategy GEPA evolves (also arm B-seed)</span>
+SEED_STRATEGY = (
+  <span class="str">"You rewrite a robot-manipulation instruction into a clearer, better-grounded "</span>
+  <span class="str">"instruction for a frozen vision-language-action policy. Name the target object "</span>
+  <span class="str">"by its visual appearance and spatial relation to nearby objects; state the goal "</span>
+  <span class="str">"location explicitly. Keep it ONE imperative sentence. Do NOT add information that "</span>
+  <span class="str">"solves the task (no coordinates, no answer) — only re-ground what is already there."</span>
+)
+ARMS = {
+  <span class="str">"A-default"</span>:    None,                <span class="cm"># perturbed instruction verbatim</span>
+  <span class="str">"D-paraphrase"</span>: NEUTRAL_PARAPHRASE,  <span class="cm"># reword, no grounding</span>
+  <span class="str">"B-seed"</span>:       SEED_STRATEGY,       <span class="cm"># grounding, un-evolved</span>
+  <span class="str">"C-oracle"</span>:     ORACLE_SMUGGLE,      <span class="cm"># names the answer (upper bound)</span>
+}</code></pre>
+
+<h3>Tier 2 — GEPA reflective search</h3>
+<p>Same <code>evaluate()</code>, now inside a reflect→select loop. The algorithm lives in the lib; <code>run()</code> only injects the two effects.</p>
+
+<h2>4 · One evaluation cell (the inner loop)</h2>
+<p>A "metric call" = one (strategy, task) cell = <code>n_seeds</code> rollouts. This is the unit the GEPA budget is counted in.</p>
+<div class="mermaid">
+flowchart LR
+  S["strategy_text"] -->|"prompt() · sonnet"| G["grounded instruction"]
+  P["perturbed instruction<br/>(if strategy=None)"] --> G
+  G --> R["run_episode_batched<br/>n_seeds parallel rollouts"]
+  R --> ENV[("env .remote()")]
+  R --> POL[("policy .remote()")]
+  R --> SUM["_summarize"]
+  SUM --> OUT["{success_rate, feedback}"]
+  OUT --> L[("write_lance")]
+</div>
+<pre><code><span class="cm"># evaluate(): rewrite is split on the null predicate so prompt() NEVER runs on the</span>
+<span class="cm"># identity arm (daft when().otherwise() evaluates BOTH branches for every row).</span>
+named = cells.where(~col(<span class="str">"strategy_text"</span>).is_null()).with_column(
+    <span class="str">"grounded"</span>,
+    prompt(messages=dfmt(<span class="str">"{}\n\nOriginal instruction:\n{}\n\n"</span>
+                         <span class="str">"Rewritten instruction (one imperative sentence):"</span>,
+                         col(<span class="str">"strategy_text"</span>), col(<span class="str">"perturbed_instr"</span>)),
+           model=REWRITE_MODEL, use_chat_completions=<span class="kw">True</span>, max_tokens=<span class="num">200</span>),
+)
+identity = cells.where(col(<span class="str">"strategy_text"</span>).is_null()).with_column(
+    <span class="str">"grounded"</span>, col(<span class="str">"perturbed_instr"</span>))
+cells = named.concat(identity)
+cells = cells.with_column(<span class="str">"res"</span>, evaluator.eval(col(<span class="str">"suite"</span>), col(<span class="str">"task_id"</span>), col(<span class="str">"grounded"</span>)))</code></pre>
+<pre><code><span class="cm"># RolloutEvaluator.eval — failure-isolated: one bad cell can't abort the whole search</span>
+<span class="kw">try</span>:
+    <span class="kw">async with</span> ArchetypeRuntime() <span class="kw">as</span> rt:
+        per_trial = <span class="kw">await</span> run_episode_batched(env_client=env, policy_client=pol,
+            suite=suite, task_id=task_id, seeds=seeds, env_keys=env_keys,
+            max_steps=self.max_steps, storage=store, runtime=rt,
+            use_frames=<span class="kw">True</span>, instruction=instruction)
+<span class="kw">except</span> Exception <span class="kw">as</span> exc:
+    <span class="kw">return</span> {<span class="str">"success_rate"</span>: <span class="num">0.0</span>, <span class="str">"successes"</span>: <span class="num">0</span>, <span class="str">"n"</span>: <span class="num">0</span>, <span class="str">"feedback"</span>: <span class="str">f"harness error: {exc}"</span>}
+<span class="kw">return</span> _summarize(per_trial, self.max_steps)</code></pre>
+<p class="small muted"><code>_summarize</code> turns per-seed outcomes into the reflective feedback GEPA reads — distinguishing <em>timeouts</em> ("target likely never grasped — instruction ambiguous") from <em>wrong-outcome</em> failures ("finished but failed the goal — instruction underspecifies the target").</p>
+
+<h2>5 · The GEPA loop, step by step</h2>
+<div class="mermaid">
+flowchart TD
+  SEED["seed strategy → full-eval on ALL tasks"] --> POOL[("candidate pool<br/>per-instance score vectors")]
+  POOL --> SEL["Pareto-select a parent (Alg 2)<br/>sample ∝ #instances won"]
+  SEL --> MB["sample a minibatch of tasks"]
+  MB --> REF["reflect on feedback → child strategy<br/>(Claude opus-4-8)"]
+  REF --> CE["eval child on the minibatch → σ'"]
+  CE --> GATE{"σ' &gt; σ ?"}
+  GATE -->|no| SEL
+  GATE -->|yes| FULL["full-eval child on ALL tasks"]
+  FULL --> POOL
+  POOL -->|budget exhausted| BEST["return best candidate by mean score"]
+</div>
+<div class="step"><div class="n">1</div><div class="body"><strong>Seed.</strong> Full-eval <code>SEED_STRATEGY</code> on every task → the first pool entry, with a <em>per-instance</em> score vector (Pareto needs the vector, not the mean).</div></div>
+<div class="step"><div class="n">2</div><div class="body"><strong>Pareto-select a parent (Algorithm 2).</strong> Per instance, find the best score; a candidate "wins" an instance if it ties that best. Prune strictly-dominated candidates; sample the survivors <em>proportional to #instances won</em>. A specialist that wins one hard task survives even if its mean is low — the diversity beam search throws away.</div></div>
+<div class="step"><div class="n">3</div><div class="body"><strong>Minibatch + reflect.</strong> Sample a minibatch of tasks; build a feedback block from the parent's cached per-instance outcomes; Claude proposes an improved strategy (answer-blind).</div></div>
+<div class="step"><div class="n">4</div><div class="body"><strong>Accept gate.</strong> Eval the child on the minibatch (σ′). Accept iff <code>σ′ &gt; σ</code> (the parent's score on that same minibatch). Only then pay for a full-eval and add it to the pool.</div></div>
+<div class="step"><div class="n">5</div><div class="body"><strong>Budget.</strong> Loop while metric calls remain (1 call = 1 strategy × 1 task = <code>n_seeds</code> rollouts). Return the pool's best by mean score.</div></div>
+<pre><code><span class="cm"># archetype/optimize/gepa.py — the loop (effects injected by gepa_daft)</span>
+pool = [_candidate(<span class="str">"gepa-seed"</span>, seed_text, eval_fn(<span class="str">"gepa-seed"</span>, seed_text, instance_ids), instance_ids)]
+spent = len(instance_ids)
+<span class="kw">while</span> spent + minibatch &lt;= budget:                          <span class="cm"># Alg 1 L8: budget</span>
+    parent = pareto_select(pool, instance_ids, rng)          <span class="cm"># Alg 2</span>
+    mb = rng.sample(instance_ids, min(minibatch, len(instance_ids)))
+    sigma = sum(parent[<span class="str">"scores"</span>][i] <span class="kw">for</span> i <span class="kw">in</span> mb) / len(mb)
+    child_text = reflect_fn(parent[<span class="str">"text"</span>], fb)               <span class="cm"># UpdatePrompt</span>
+    c_res = eval_fn(<span class="str">f"{csid}-mb"</span>, child_text, mb)
+    sigma_prime = sum(c_res[i][<span class="str">"s"</span>] <span class="kw">for</span> i <span class="kw">in</span> mb) / len(mb)
+    <span class="kw">if</span> sigma_prime &gt; sigma <span class="kw">and</span> spent + len(instance_ids) &lt;= budget:  <span class="cm"># accept gate</span>
+        full = eval_fn(csid, child_text, instance_ids)        <span class="cm"># full-eval on D_pareto</span>
+        pool.append(_candidate(csid, child_text, full, instance_ids))</code></pre>
+
+<h2>6 · The ledger (queryable, reproducible)</h2>
+<p>Every cell is appended as Lance under <code>/results/gepa_daft</code> (the <code>libero-eval-results</code> Modal Volume). Tier-1 arms → <code>/arms</code>; every GEPA cell → <code>/gepa</code>. Each row: <code>strategy_id, task_id, grounded, success, feedback</code>. The whole search is replayable from the ledger.</p>
+<pre><code><span class="cm"># after a run, read it back with daft:</span>
+<span class="kw">import</span> daft
+arms = daft.read_lance(<span class="str">"/results/gepa_daft/arms"</span>)
+arms.groupby(<span class="str">"strategy_id"</span>).agg(daft.col(<span class="str">"success"</span>).mean()).sort(<span class="str">"strategy_id"</span>).show()
+<span class="cm"># A ≤ D &lt; B-seed &lt; C  is the legitimacy ordering; GEPA's best should beat B-seed.</span></code></pre>
+
+<h2>7 · How to run it</h2>
+<h3>Prereqs — deploy the two workers (once / after edits)</h3>
+<pre><code>modal deploy bench/libero/libero_plus_worker.py   <span class="cm"># archetype-libero-plus-env</span>
+modal deploy bench/libero/modal_worker.py         <span class="cm"># archetype-libero-env (standard suites)</span>
+<span class="cm"># archetype-vla-jepa (frozen policy) is already deployed and serving.</span></code></pre>
+
+<h3>Smoke (cheap — proves the whole pipeline)</h3>
+<pre><code>modal run --detach bench/libero/gepa_daft.py \
+  --suite libero_goal --n-tasks <span class="num">2</span> --n-seeds <span class="num">2</span> --max-steps <span class="num">40</span> \
+  --budget <span class="num">14</span> --minibatch <span class="num">1</span></code></pre>
+
+<h3>Headroom scan (which suite is worth optimizing)</h3>
+<pre><code><span class="cm"># baseline (perturbed-instruction) success per Language ordinal, per suite</span>
+modal run --detach bench/libero/libero_plus_sweep.py \
+  --suite libero_goal --n-tasks <span class="num">10</span> --trials <span class="num">3</span> --max-steps <span class="num">300</span>
+<span class="cm"># repeat for libero_object, libero_10. Spatial is already confirmed at ceiling.</span>
+<span class="cm"># Pick the suite with the LOWEST baseline → most room for a real Δ.</span></code></pre>
+
+<h3>The overnight run (#19 — the big one)</h3>
+<pre><code>modal run --detach bench/libero/gepa_daft.py \
+  --suite &lt;headroom-suite&gt; --n-tasks <span class="num">8</span> --n-seeds <span class="num">5</span> --max-steps <span class="num">300</span> \
+  --budget <span class="num">60</span> --minibatch <span class="num">3</span></code></pre>
+<div class="note warn"><strong>Flags map 1:1 to <code>main()</code>.</strong> <code>--n-tasks</code>→<code>n_tasks</code>, <code>--max-steps</code>→<code>max_steps</code>, <code>--budget</code>→GEPA rollout budget (metric calls), <code>--minibatch</code>→the mutate/accept minibatch size. <code>--no-do-gepa</code> runs Tier-1 arms only.</div>
+
+<h2>8 · Cost &amp; scale (overnight config)</h2>
+<table>
+  <thead><tr><th>Phase</th><th>Rollouts</th><th>LLM calls</th></tr></thead>
+  <tbody>
+    <tr><td>Tier-1 arms (4 × 8 tasks × 5 seeds)</td><td>160 episodes</td><td>~24 rewrites (3 non-identity arms × 8)</td></tr>
+    <tr><td>Tier-2 GEPA (budget 60 cells × 5 seeds)</td><td>~300 episodes</td><td>~60 rewrites + ~1 reflect / generation</td></tr>
+    <tr><td><strong>Total</strong></td><td><strong>~460 episodes × 300 steps</strong></td><td>~90 Claude calls</td></tr>
+  </tbody>
+</table>
+<p class="small muted">Wall-clock is dominated by GPU rollouts; Daft runs up to <code>min(n_tasks, 8)</code> concurrently (per-process RBAC isolation via <code>use_process=True</code>). LLM calls are cheap relative to rollouts. Timeout on <code>run()</code> is 6&nbsp;h. Episodes are bounded by <code>max_steps</code>; a cell that never grasps just times out and is recorded as a failure (not a crash).</p>
+
+<h2>9 · What to watch</h2>
+<ul>
+  <li><strong>Ordering, not absolute numbers.</strong> <code>A ≤ D &lt; B-seed</code> validates the conditioning hypothesis; <code>D ≈ B</code> would mean "any rewrite helps" (weaker claim).</li>
+  <li><strong>GEPA &gt; B-seed.</strong> The reflective search should beat the un-evolved seed, and approach C-oracle <em>without</em> ever naming the answer (answer-blind is enforced in the reflect prompt).</li>
+  <li><strong>Pool diversity.</strong> The trace records each generation's parent, σ, σ′, accept/reject. Healthy runs accept early then plateau (rejects) as the frontier saturates.</li>
+  <li><strong>No silent zeros.</strong> A cell with <code>feedback="harness error: …"</code> is an isolated failure, not a real 0% — grep the ledger for it before trusting an arm's mean.</li>
+</ul>
+
+<hr>
+<p class="small muted">Algorithm: Agrawal et&nbsp;al., <em>GEPA: Reflective Prompt Evolution Can Outperform Reinforcement Learning</em>, arXiv:2507.19457. Implementation: <code>archetype.optimize.gepa</code> (parity-tested). Pipeline: <code>bench/libero/gepa_daft.py</code>. <span class="pill">status: smoke validating before #19</span></p>
+
+</div>
+</body>
+</html>

--- a/docs/design/gepa-run-book.html
+++ b/docs/design/gepa-run-book.html
@@ -220,10 +220,14 @@ arms.groupby(<span class="str">"strategy_id"</span>).agg(daft.col(<span class="s
 modal deploy bench/libero/modal_worker.py         <span class="cm"># archetype-libero-env (standard suites)</span>
 <span class="cm"># archetype-vla-jepa (frozen policy) is already deployed and serving.</span></code></pre>
 
+<div class="note warn"><strong>Always submit via <code>spawn()</code>, never <code>modal run</code>.</strong> <code>modal run --detach</code> keeps your local CLI as the job driver — if the session is reaped, Modal cancels the run mid-flight. <code>modal deploy</code> + <code>spawn()</code> runs the job server-side, fully decoupled (submit returns in ~1s; close your laptop). <code>bench/libero/submit_gepa.py</code> wraps this.</div>
+<h3>Deploy once (and after any gepa_daft.py edit)</h3>
+<pre><code>modal deploy bench/libero/gepa_daft.py   <span class="cm"># registers run() as a persistent cloud function</span></code></pre>
 <h3>Smoke (cheap — proves the whole pipeline)</h3>
-<pre><code>modal run --detach bench/libero/gepa_daft.py \
+<pre><code>python bench/libero/submit_gepa.py \
   --suite libero_goal --n-tasks <span class="num">2</span> --n-seeds <span class="num">2</span> --max-steps <span class="num">40</span> \
-  --budget <span class="num">14</span> --minibatch <span class="num">1</span></code></pre>
+  --budget <span class="num">14</span> --minibatch <span class="num">1</span>
+<span class="cm"># → prints a call id; fetch with: submit_gepa.py --fetch &lt;id&gt;  (or `make status`)</span></code></pre>
 
 <h3>Headroom scan (which suite is worth optimizing)</h3>
 <pre><code><span class="cm"># baseline (perturbed-instruction) success per Language ordinal, per suite</span>
@@ -233,9 +237,11 @@ modal run --detach bench/libero/libero_plus_sweep.py \
 <span class="cm"># Pick the suite with the LOWEST baseline → most room for a real Δ.</span></code></pre>
 
 <h3>The overnight run (#19 — the big one)</h3>
-<pre><code>modal run --detach bench/libero/gepa_daft.py \
+<pre><code>python bench/libero/submit_gepa.py \
   --suite &lt;headroom-suite&gt; --n-tasks <span class="num">8</span> --n-seeds <span class="num">5</span> --max-steps <span class="num">300</span> \
-  --budget <span class="num">60</span> --minibatch <span class="num">3</span></code></pre>
+  --budget <span class="num">60</span> --minibatch <span class="num">3</span>
+<span class="cm"># returns a call id in ~1s; the 6h run executes server-side. close the laptop.</span>
+<span class="cm"># check later: submit_gepa.py --fetch &lt;id&gt;  ·  make status  ·  or read the ledger</span></code></pre>
 <div class="note warn"><strong>Flags map 1:1 to <code>main()</code>.</strong> <code>--n-tasks</code>→<code>n_tasks</code>, <code>--max-steps</code>→<code>max_steps</code>, <code>--budget</code>→GEPA rollout budget (metric calls), <code>--minibatch</code>→the mutate/accept minibatch size. <code>--no-do-gepa</code> runs Tier-1 arms only.</div>
 
 <h2>8 · Cost &amp; scale (overnight config)</h2>

--- a/docs/design/gepa-visualizer-handoff.md
+++ b/docs/design/gepa-visualizer-handoff.md
@@ -1,0 +1,401 @@
+# Handoff: couple the daft-GEPA demo with GEPA's candidate-tree visualizer
+
+**Goal.** Add a `--visualize` flag to the daft-GEPA demo (`prompt_gepa.py`) that, after a
+run, renders GEPA's official **candidate-tree HTML** for *our* run and opens it in a
+browser. Works for both the live and the offline-mock run (the mock produces a real
+candidate tree). It's a fun, legible payoff: you watch the seed prompt fan out into a
+Pareto frontier of children, best in cyan, frontier in orange, full prompt text on hover.
+
+**Why this is an offload (not a one-liner).** It needs four things: (1) surface the
+candidate-tree data the optimizer already computes internally, (2) a render + browser-launch
+path, (3) a vendor-vs-depend decision with attribution, (4) verification the HTML actually
+renders from a run. ~1–2 hours, self-contained.
+
+---
+
+## What exists today
+
+| Thing | Path |
+|---|---|
+| daft-examples PR (OpenRouter) | `Eventual-Inc/daft-examples` **PR #42**, `examples/prompt/prompt_gepa.py` |
+| archetype demo (Anthropic, imports the lib) | `examples/gepa_daft_demo.py` |
+| archetype lib (the algorithm) | `src/archetype/optimize/gepa.py` — `gepa_search`, `pareto_select` |
+| parity eval (proves it == GEPA) | `tests/experiments/test_gepa_daft.py` |
+
+`gepa_search(...)` today returns `{text, mean, pool, calls, trace}` where
+`trace[g] = {gen, parent(sid), sigma, sigma_prime, accepted}`. It does **not** yet expose
+the full candidate pool with lineage + per-instance Pareto sets — that's task 1.
+
+## The target: GEPA's visualizer
+
+- **File:** `gepa/visualization.py` in the official repo (`github.com/gepa-ai/gepa`).
+  Dependency-free: it emits a self-contained HTML page that renders the graph client-side
+  via `@viz-js/viz` from a CDN. © 2025 Lakshya A Agrawal and the GEPA contributors.
+- **Entry point we want** (raw data — no `GEPAState` needed):
+
+  ```python
+  candidate_tree_html_from_data(candidates, parents, val_scores, pareto_front_programs) -> str
+  candidate_tree_dot_from_data(...)  -> str   # Graphviz DOT, if you want a static render
+  ```
+
+- **Arg shapes** (this is the whole contract):
+  - `candidates: Sequence[dict[str,str]]` — per candidate, `{component_name: prompt_text}`.
+    For us: `[{"instruction": cand_text}, ...]`, **index 0 must be the seed** (the viz treats
+    idx 0 as `Seed`).
+  - `parents: Sequence[Sequence[int|None]]` — `parents[i]` = list of parent candidate indices,
+    `[None]` for the seed. (List-of-parents because GEPA merge can have two; ours is single → `[idx]`.)
+  - `val_scores: Sequence[float]` — per-candidate aggregate score (our `mean` over instances).
+  - `pareto_front_programs: Mapping[Any, set[int]]` — **per validation instance**, the set of
+    candidate indices achieving the max score on that instance. The viz derives the orange
+    "Pareto front" nodes from this via `find_dominator_programs(pareto_front_programs, list(val_scores))`
+    (`gepa.gepa_utils`).
+
+Colors: best=cyan, Pareto-dominators=orange, others=gray; hover tooltip = full prompt text + score + parent.
+
+---
+
+## Task 1 — surface the candidate-tree data from `gepa_search`
+
+Everything needed is already computed; just record lineage and emit the four arrays.
+
+1. In `_candidate(...)`, also store `parent_sid` (None for the seed).
+2. In `gepa_search`, when building the accepted child, pass `parent_sid=parent["sid"]`.
+3. After the loop, the pool is already in insertion order (seed first → index 0). Build:
+
+```python
+sid_to_idx = {c["sid"]: i for i, c in enumerate(pool)}
+candidates = [{"instruction": c["text"]} for c in pool]
+parents = [
+    [None] if c["parent_sid"] is None else [sid_to_idx[c["parent_sid"]]]
+    for c in pool
+]
+val_scores = [sum(c["scores"].values()) / len(c["scores"]) for c in pool]
+pareto_front_programs = {
+    i: {k for k, c in enumerate(pool) if c["scores"][i] == max(d["scores"][i] for d in pool)}
+    for i in instance_ids
+}
+return {..., "tree": {
+    "candidates": candidates, "parents": parents,
+    "val_scores": val_scores, "pareto_front_programs": pareto_front_programs,
+}}
+```
+
+> Note this `pareto_front_programs` is the same `star`/`wins` idea as `pareto_select`, but
+> computed once over the **final** pool. Keep `pareto_select` unchanged — the parity test
+> depends on it.
+
+The archetype lib change should land with a small unit test (mock eval/reflect) asserting
+`tree.candidates[0]` is the seed, `tree.parents[0] == [None]`, and every non-seed parent
+index resolves into range.
+
+## Task 2 — render + launch
+
+**Sourcing the visualizer — two options:**
+
+- **(a) Depend on `gepa`:** `dependencies += ["gepa"]`; `from gepa.visualization import candidate_tree_html_from_data`.
+  Cleanest attribution. Caveat: the `*_from_data` functions import `gepa.gepa_utils.find_dominator_programs`,
+  so the **package** must be installed, not just the one file.
+- **(b) Vendor:** copy `candidate_tree_*_from_data` + `find_dominator_programs` into a local
+  `gepa_viz.py` with the GEPA copyright/attribution header preserved + a link. Keeps the
+  daft-example's "**deps = `daft[openai]` only**" property.
+
+**Recommendation:** vendor for the **daft-examples PR** (preserve the deps property; keep the
+attribution header); depend on `gepa` for the **archetype** demo (it already has heavier deps).
+
+**Launch:**
+
+```python
+import os, pathlib, webbrowser
+html = candidate_tree_html_from_data(**result["tree"])
+out = pathlib.Path("gepa_tree.html"); out.write_text(html)
+if not os.environ.get("CI"):
+    webbrowser.open(out.resolve().as_uri())
+print(f"wrote {out}")
+```
+
+Gate the whole thing behind `--visualize` (argparse) so the base demo stays zero-UI and
+CI-safe. Only call `webbrowser.open` outside CI (the HTML still gets written for inspection).
+
+## Task 3 — verify
+
+- `uv run prompt_gepa.py --visualize` (mock is fine) writes `gepa_tree.html`, opens it, and the
+  tree shows the real lineage: seed at idx 0 (gray/SEED), accepted children as descendants,
+  one cyan BEST, orange PARETO nodes; hovering a node shows the evolved instruction text.
+- Confirm `find_dominator_programs` resolves (option a) or is vendored (option b).
+- No regression to the no-flag run or to CI (no browser in CI — guard with the `CI` env check).
+
+## Gotchas
+
+- **idx 0 = seed**, always. The viz labels idx 0 as `Seed`.
+- `pareto_front_programs` keys are **per instance**, values are **sets of candidate indices**.
+- The HTML pulls `@viz-js/viz` from a CDN → needs browser network to render (GEPA's design).
+- Keep `parents[i]` a **list** even though ours is single-parent.
+- Don't touch `pareto_select` / the parity test — only add the post-loop `tree` builder.
+
+---
+
+## Cross-check: this *is* the same algorithm GEPA ships
+
+The official repo's toy (`examples/langchain_adapter/pair_sum_product.py`) calls
+`gepa.optimize(seed_candidate=..., adapter=..., candidate_selection_strategy="pareto",
+use_merge=True, max_metric_calls=..., reflection_minibatch_size=...)` where the adapter's
+`eval_fn` returns `(score, feedback)`. That maps 1:1 onto our `gepa_search`
+(`eval_fn -> {id:{s,fb}}`, Pareto selection, reflection minibatch, metric-call budget). Ours
+is single-module (no `use_merge`) and batch-native via Daft; theirs is LangChain + threads.
+
+---
+
+## Full current script (`examples/prompt/prompt_gepa.py`, the daft-examples / OpenRouter variant)
+
+```python
+# /// script
+# description = "GEPA: reflective prompt optimization as a Daft pipeline (Pareto selection + reflect-and-mutate)"
+# requires-python = ">=3.12"
+# dependencies = ["daft[openai]>=0.7.10"]
+# ///
+"""GEPA, as a Daft pipeline — reflective prompt optimization in one file.
+
+GEPA (Agrawal et al. 2025, arXiv:2507.19457) evolves a prompt by *reflecting* on
+its own failures and keeping a Pareto frontier of candidates — not a single
+best-by-mean. The algorithm below is ~70 lines of plain Python; its two effects
+are Daft expressions:
+
+    eval    = daft.functions.prompt(...)  -> classify each example, score vs gold
+    reflect = daft.functions.prompt(...)  -> rewrite the instruction from failures
+
+No agent framework, no orchestration glue: the optimizer is a loop, the LLM is a
+column, and Daft runs the batch.
+
+    export OPENROUTER_API_KEY=sk-or-...
+    uv run prompt_gepa.py
+    # No key? It runs a deterministic mock so the loop is still visible.
+"""
+
+from __future__ import annotations
+
+import os
+from random import Random
+
+# ===========================================================================
+# GEPA — the algorithm (pure; the two effects are injected by the caller).
+# Agrawal et al. 2025, arXiv:2507.19457 — Algorithm 1 (reflective evolution) +
+# Algorithm 2 (Pareto candidate selection). Alg-line refs inline.
+# ===========================================================================
+
+
+def pareto_select(pool, instance_ids, rng):
+    """GEPA Algorithm 2 — instance-wise Pareto selection (NOT top-k-by-mean).
+
+    1. per-instance best:    s*[i] = max_k S[k][i]
+    2. per-instance winners: P*[i] = {k : S[k][i] == s*[i]}
+    3. prune candidates strictly dominated across instances
+    4. sample ∝ #instances each candidate wins
+
+    A specialist that wins one instance survives even if its mean is low — exactly
+    the diversity beam search throws away.
+    """
+    star = {i: max(c["scores"][i] for c in pool) for i in instance_ids}
+    wins = {c["sid"]: sum(1 for i in instance_ids if c["scores"][i] == star[i]) for c in pool}
+    frontier = [c for c in pool if wins[c["sid"]] > 0]
+    nondominated = [
+        c
+        for c in frontier
+        if not any(
+            d is not c
+            and all(d["scores"][i] >= c["scores"][i] for i in instance_ids)
+            and any(d["scores"][i] > c["scores"][i] for i in instance_ids)
+            for d in frontier
+        )
+    ]
+    return rng.choices(nondominated, weights=[wins[c["sid"]] for c in nondominated], k=1)[0]
+
+
+def _candidate(sid, text, res, instance_ids):
+    return {
+        "sid": sid,
+        "text": text,
+        "scores": {i: res[i]["s"] for i in instance_ids},  # per-instance VECTOR (Pareto needs it)
+        "fbk": {i: res[i]["fb"] for i in instance_ids},
+    }
+
+
+def gepa_search(*, seed_text, instance_ids, eval_fn, reflect_fn, budget, minibatch, rng):
+    """GEPA Algorithm 1 — reflective evolution with Pareto selection.
+
+    eval_fn(sid, text, ids) -> {id: {"s": float, "fb": str}}   # score + feedback
+    reflect_fn(text, feedback_block) -> str                    # GEPA's UpdatePrompt
+    Budget is counted in metric calls (one candidate x one instance = one call).
+    """
+    seed_res = eval_fn("gepa-seed", seed_text, instance_ids)
+    pool = [_candidate("gepa-seed", seed_text, seed_res, instance_ids)]
+    spent = len(instance_ids)  # Alg 1 L7 + L18-20: seed full-eval on D_pareto
+    trace, gen = [], 0
+
+    while spent + minibatch <= budget:  # Alg 1 L8: while budget not exhausted
+        gen += 1
+        parent = pareto_select(pool, instance_ids, rng)                   # Alg 2
+        mb = rng.sample(instance_ids, min(minibatch, len(instance_ids)))  # minibatch
+        sigma = sum(parent["scores"][i] for i in mb) / len(mb)          # sigma (cached)
+        fb = "\n".join(f"- instance {i}: {parent['fbk'][i]}" for i in mb)
+        child_text = reflect_fn(parent["text"], fb)                      # Alg 1 L13: UpdatePrompt
+        csid = f"gepa-g{gen}"
+        c_res = eval_fn(f"{csid}-mb", child_text, mb)                    # eval child on minibatch
+        spent += len(mb)
+        sigma_prime = sum(c_res[i]["s"] for i in mb) / len(mb)        # sigma'
+        accepted = sigma_prime > sigma                                   # Alg 1 L16: accept gate
+        trace.append(
+            {"gen": gen, "parent": parent["sid"], "sigma": round(sigma, 3),
+             "sigma_prime": round(sigma_prime, 3), "accepted": accepted}
+        )
+        if accepted and spent + len(instance_ids) <= budget:
+            full = eval_fn(csid, child_text, instance_ids)              # Alg 1 L18-20: full-eval
+            spent += len(instance_ids)
+            pool.append(_candidate(csid, child_text, full, instance_ids))
+
+    best = max(pool, key=lambda c: sum(c["scores"].values()) / len(c["scores"]))
+    return {
+        "text": best["text"],
+        "mean": sum(best["scores"].values()) / len(best["scores"]),
+        "pool": len(pool),
+        "calls": spent,
+        "trace": trace,
+    }
+
+
+# ===========================================================================
+# The task: a tiny sentiment set. Gold labels => deterministic scoring (no LLM
+# judge). The last three are the hard cases the seed instruction trips on; GEPA
+# has to *discover* them from feedback and write guidance for them.
+# ===========================================================================
+DATA = [
+    ("Absolutely loved every minute of it.", "positive"),
+    ("A complete waste of my evening.", "negative"),
+    ("Best purchase I've made all year.", "positive"),
+    ("It broke on the second day.", "negative"),
+    ("Oh great, another Monday. Just what I needed.", "negative"),  # sarcasm
+    ("This is not bad at all, honestly.", "positive"),  # negation
+    ("Well, it certainly exists, I'll give it that.", "negative"),  # faint praise
+]
+IDS = list(range(len(DATA)))
+SEED = "Classify the sentiment of the text as 'positive' or 'negative'."
+
+# Any OpenRouter model id works. A small task model leaves more headroom for GEPA
+# to demonstrate a lift; a strong reflection model writes better instructions.
+TASK_MODEL = "meta-llama/llama-3.1-8b-instruct"  # runs per example
+REFLECT_MODEL = "openai/gpt-4o"  # runs once per generation
+FORMAT = "\nRespond with exactly one word: positive or negative."  # fixed scaffold; GEPA evolves only SEED
+
+
+# ---------------------------------------------------------------------------
+# Effects, backed by Daft. Each eval/reflect is one prompt() over a batch.
+# ---------------------------------------------------------------------------
+def daft_effects():
+    import daft
+    from daft.functions import prompt
+
+    daft.set_provider(
+        "openai",
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        base_url="https://openrouter.ai/api/v1",
+        # Anthropic swap: base_url="https://api.anthropic.com/v1/", api_key=os.environ["ANTHROPIC_API_KEY"]
+    )
+
+    def eval_fn(sid, instruction, ids):
+        df = (
+            daft.from_pydict(
+                {"id": ids, "text": [DATA[i][0] for i in ids], "gold": [DATA[i][1] for i in ids]}
+            )
+            .with_column(
+                "resp",
+                prompt(
+                    daft.col("text"),
+                    system_message=instruction + FORMAT,
+                    model=TASK_MODEL,
+                    use_chat_completions=True,
+                ),
+            )
+            .with_column("pred_pos", daft.col("resp").lower().contains("positive"))
+            .with_column(
+                "ok",
+                (daft.col("pred_pos") == (daft.col("gold") == "positive")).cast(daft.DataType.float32()),
+            )
+            .select("id", "text", "gold", "pred_pos", "ok")
+            .collect()  # one materialization per candidate eval — this IS the metric call
+        )
+        out = {}
+        for r in df.to_pylist():
+            pred = "positive" if r["pred_pos"] else "negative"
+            out[r["id"]] = {
+                "s": float(r["ok"]),
+                "fb": "correct" if r["ok"] else f"said {pred}, gold {r['gold']} for: {r['text']!r}",
+            }
+        return out
+
+    def reflect_fn(instruction, feedback_block):
+        msg = (
+            "Improve this sentiment-classification instruction given how it did on a minibatch.\n\n"
+            f"INSTRUCTION:\n{instruction}\n\nFEEDBACK:\n{feedback_block}\n\n"
+            "Write one improved instruction that fixes the mistakes. Output only the instruction."
+        )
+        df = (
+            daft.from_pydict({"x": [msg]})
+            .with_column("out", prompt(daft.col("x"), model=REFLECT_MODEL, use_chat_completions=True))
+            .collect()
+        )
+        return df.to_pylist()[0]["out"].strip()
+
+    return eval_fn, reflect_fn
+
+
+# ---------------------------------------------------------------------------
+# Offline mock — same loop shape, no key, no daft import. A prompt "scores" by
+# how many failure modes it names; reflect adds the next missing one.
+# ---------------------------------------------------------------------------
+def mock_effects():
+    cues = {4: "sarcasm", 5: "negation", 6: "faint praise"}
+
+    def eval_fn(sid, instruction, ids):
+        out = {}
+        for i in ids:
+            cue = cues.get(i)
+            ok = cue is None or cue in instruction.lower()
+            out[i] = {"s": 1.0 if ok else 0.0, "fb": "correct" if ok else f"missed the {cue} case"}
+        return out
+
+    def reflect_fn(instruction, feedback_block):
+        for cue in ("sarcasm", "negation", "faint praise"):
+            if f"the {cue} case" in feedback_block and cue not in instruction.lower():
+                return f"{instruction} Also handle {cue}."
+        return instruction
+
+    return eval_fn, reflect_fn
+
+
+def main():
+    live = bool(os.environ.get("OPENROUTER_API_KEY"))
+    eval_fn, reflect_fn = daft_effects() if live else mock_effects()
+    mode = "LIVE (prompt() via OpenRouter)" if live else "offline mock (set OPENROUTER_API_KEY for live)"
+    print(f"GEPA as a Daft pipeline  |  {mode}\n")
+
+    out = gepa_search(
+        seed_text=SEED, instance_ids=IDS, eval_fn=eval_fn, reflect_fn=reflect_fn,
+        budget=60, minibatch=3, rng=Random(0),
+    )
+
+    print("trace — Pareto-selected parent -> reflect -> minibatch gate:")
+    for t in out["trace"]:
+        verdict = "accept" if t["accepted"] else "reject"
+        print(f"  gen {t['gen']:>2}  parent={t['parent']:<10}  sigma={t['sigma']:.2f} -> sigma'={t['sigma_prime']:.2f}  {verdict}")
+    print(f"\nseed    : {SEED}")
+    print(f"best    : mean={out['mean']:.2f}  (pool={out['pool']}, llm_calls={out['calls']})")
+    print(f"evolved : {out['text']}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+> The archetype variant (`examples/gepa_daft_demo.py`) is identical in structure but imports
+> `from archetype.optimize.gepa import gepa_search` instead of inlining it, and defaults to
+> Anthropic. For the visualizer, do task 1 in `src/archetype/optimize/gepa.py` (so both
+> variants benefit) and vendor/depend per task 2.

--- a/docs/design/libero-para-day-plan.md
+++ b/docs/design/libero-para-day-plan.md
@@ -1,0 +1,141 @@
+# Day Plan & Orchestration — Hackathon Sprint
+
+**Document type:** Orchestration + big-picture plan. The optimization itself
+(everything JEPA/GEPA) is specified separately in
+[`gepa-core-loop.md`](./gepa-core-loop.md). This doc is *how we run the day*:
+architecture, parallel workstreams, ownership, timeline, and deliverables.
+
+**Hard deadline: paper publishable by 5:00 PM + demo video with materials.**
+
+---
+
+## 1. North star
+
+Demonstrate that **GEPA-style test-time prompt optimization improves VLA-JEPA
+grounding on LIBERO-Para** — measured as a success-rate gap from the fair-default
+instruction to the optimized paraphrase strategy, generalizing to a held-out test
+set. Everything reproducible and packageable in Archetype format.
+
+Two benchmarks in flight (decoupled, parallel):
+- **LIBERO-Para** (this team) — the primary GEPA demonstration.
+- **RoboSemanticBench** (Darin) — second benchmark, same tight-loop pattern, own
+  branch off `main`.
+
+---
+
+## 2. Architecture (the tight loop)
+
+```
+        Modal (one region, co-located)
+  ┌───────────────────────────────────────────────┐
+  │  Archetype driver  (py3.12, world loop+ledger) │  ← co-located runner
+  │        │ EnvClient            │ PolicyClient    │
+  │        ▼                      ▼                 │
+  │  archetype-libero-env    archetype-vla-jepa     │
+  │  (LIBERO/robosuite/      (L40S, VLA-JEPA        │
+  │   MuJoCo, frames vol)     websocket server)     │
+  │                                                 │
+  │  end-of-rollout ──▶ Reflection agent (REPL,     │
+  │                     mujoco/libero libs, replay) │
+  └───────────────────────────────────────────────┘
+        rollouts + scores + strategy lineage → Archetype ledger (reproducible)
+```
+
+- Archetype on Modal = the tight loop (in-region calls, not Mac↔cloud).
+- Rollouts orchestrated by Archetype; **all data on the append-only ledger**.
+- At the end of each rollout batch, spin up a **reflection agent** inside the
+  Modal environment (robotics libs present) to do REPL-based scoring (see
+  core-loop §5).
+
+---
+
+## 3. Workstreams (parallel) & ownership
+
+| # | Workstream | Owner | Output | Branch |
+|---|---|---|---|---|
+| WS1 | **Tight loop on Modal**, merged to main (throughput pass: per-episode volume commit + `env_key` batching → <1 s/step) | Claude | mergeable tight loop | `main` via PR |
+| WS2 | **GEPA core loop** — baseline sweep, split, mutator, loop | Claude | runnable optimizer | `everettVT/libero-para-gepa` |
+| WS3 | **Reflection agent** — agent in the Python REPL loop, integrated into Archetype end-of-rollout (Darin has most of the code) | Darin + Claude | the scorer | `everettVT/libero-para-gepa` |
+| WS4 | **RoboSemanticBench** — second benchmark on the tight-loop pattern | Darin | second result | own branch off `main` |
+| WS5 | **Persist-trajectory episode** (stop destroying episode worlds; retain full ledger for replay) | Claude | replayable rollouts | `everettVT/libero-para-gepa` |
+| WS6 | **Human sanity-check UI** — per-rollout frames + subgoal trace + scorer verdict | Claude | review page | `everettVT/libero-para-gepa` |
+| WS7 | **Reproducibility & packaging** — session/data packaging in Archetype format | Claude | packaged artifact | `everettVT/libero-para-gepa` |
+| WS8 | **Paper + demo video + materials** | all | publishable paper, video | `everettVT/libero-para-gepa` |
+
+Branch strategy: **iterate fast on `everettVT/libero-para-gepa`** (don't gate on
+merge-to-main). Only WS1 (the tight loop) merges to `main` so RoboSemanticBench
+has a stable base. Everything else stays on the dedicated branch until the end.
+
+---
+
+## 4. Critical path & sequencing
+
+```
+WS5 persist-trajectory ──┐
+WS1 throughput pass ─────┼──▶ WS2 baseline sweep ──▶ pick val/test ──▶ WS2+WS3 GEPA rounds ──▶ test eval ──▶ WS8 paper/video
+WS3 reflection scorer ───┘                                    │
+WS6 sanity UI ───────────────────(verify scorer before trusting)┘
+```
+
+- **Gate before any GEPA round:** the scorer must be verified correct on a handful
+  of rollouts via the sanity UI (WS6). Garbage feedback = wasted compute.
+- WS4 (RoboSemanticBench) runs fully in parallel, decoupled.
+
+---
+
+## 5. Timeline to 5:00 PM (adjust as we go)
+
+| Block | Target |
+|---|---|
+| now → +45m | WS5 persist-trajectory + WS1 throughput pass; WS3 scorer skeleton; WS4 Darin bootstraps off main |
+| +45m → +90m | Baseline sweep (libero_spatial) → val/test split; scorer verified on real rollouts via WS6 UI |
+| +90m → +3h | GEPA rounds on val; watch val climb; RoboSemanticBench first numbers |
+| +3h → +4h | Freeze strategy → test-set eval → final numbers; package data (WS7) |
+| +4h → 5:00 | Paper writeup from ledger numbers; demo video + materials |
+
+If throughput or scorer slips, **scope down the val set** (fewer hard tasks),
+never the rigor of the scorer.
+
+---
+
+## 6. Reproducibility & packaging (requirement)
+
+- **All runs and all data in Archetype format** — rollouts, scores, and strategy
+  lineage on the append-only ledger; any rollout exactly replayable from
+  `(init_state, action_sequence)`.
+- The whole study **packageable at the end** (one artifact: ledger parquet +
+  frame volume manifest + strategy lineage + the two design docs).
+- Paper numbers are computed from queryable ledger data, not loose logs.
+- Modal images SHA-pin LIBERO and VLA-JEPA (already done) for environment repro.
+
+---
+
+## 7. Paper + demo video (WS8)
+
+- **Paper skeleton:** hypothesis (latent capability / honest frontier) → method
+  (GEPA × LIBERO-Para, the scorer contract) → setup (split, fairness baseline) →
+  results (val climb + test generalization gap) → reproducibility (Archetype
+  ledger) → second benchmark (RoboSemanticBench) as corroboration.
+- **Demo video:** the tight loop running on Modal; a side-by-side of a task
+  failing under the default instruction and succeeding under the optimized
+  paraphrase; the scorer's root-cause readout; the sanity UI.
+- **Materials:** the two design docs, the packaged ledger, the success/failure
+  rollout clips.
+
+---
+
+## 8. Decisions already locked (don't relitigate)
+
+- GEPA candidate = global paraphrase strategy (transferable). [core-loop §3]
+- Baseline = raw LIBERO instruction, not empty. [core-loop §2]
+- Scorer = agentic REPL, deterministic replay, native subgoal predicates. [core-loop §5]
+- `pass` = sim ground truth, never LLM opinion. [core-loop §5]
+- Episodes persist their trajectory (no destroy). [WS5]
+- Fast iteration on `everettVT/libero-para-gepa`; only the tight loop merges to main.
+
+---
+
+## 9. People / access
+
+- Darin (`darinkishore`, they/them) — added as a write collaborator (invite
+  pending acceptance). Owns RoboSemanticBench + the reflection-agent code.

--- a/docs/design/libero-para-day-plan.md
+++ b/docs/design/libero-para-day-plan.md
@@ -57,7 +57,7 @@ Two benchmarks in flight (decoupled, parallel):
 | WS2 | **GEPA core loop** — baseline sweep, split, mutator, loop | Claude | runnable optimizer | `everettVT/libero-para-gepa` |
 | WS3 | **Reflection agent** — agent in the Python REPL loop, integrated into Archetype end-of-rollout (Darin has most of the code) | Darin + Claude | the scorer | `everettVT/libero-para-gepa` |
 | WS4 | **RoboSemanticBench** — second benchmark on the tight-loop pattern | Darin | second result | own branch off `main` |
-| WS5 | **Persist-trajectory episode** (stop destroying episode worlds; retain full ledger for replay) | Claude | replayable rollouts | `everettVT/libero-para-gepa` |
+| WS5 | **Query persisted rollouts** by `(world_id, run_id)` via the query service to feed the scorer. *(Data is already persisted — `destroy_world` is in-memory-only, append-only invariant verified. No "don't destroy" change; destroy/fork are fine. The only orchestration gap was the eval driver not querying the trajectory back.)* | Claude | scorer reads ledger | `everettVT/libero-para-gepa` |
 | WS6 | **Human sanity-check UI** — per-rollout frames + subgoal trace + scorer verdict | Claude | review page | `everettVT/libero-para-gepa` |
 | WS7 | **Reproducibility & packaging** — session/data packaging in Archetype format | Claude | packaged artifact | `everettVT/libero-para-gepa` |
 | WS8 | **Paper + demo video + materials** | all | publishable paper, video | `everettVT/libero-para-gepa` |
@@ -130,7 +130,7 @@ never the rigor of the scorer.
 - Baseline = raw LIBERO instruction, not empty. [core-loop §2]
 - Scorer = agentic REPL, deterministic replay, native subgoal predicates. [core-loop §5]
 - `pass` = sim ground truth, never LLM opinion. [core-loop §5]
-- Episodes persist their trajectory (no destroy). [WS5]
+- Data is already persisted (append-only); scorer queries rollouts by `(world_id, run_id)`. `destroy_world` is in-memory-only — verified. No "don't destroy" change. [WS5]
 - Fast iteration on `everettVT/libero-para-gepa`; only the tight loop merges to main.
 
 ---

--- a/examples/gepa_daft_demo.py
+++ b/examples/gepa_daft_demo.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["daft[openai]>=0.7.9", "pydantic>=2", "archetype-ecs"]
+# dependencies = ["daft[openai]>=0.7.9", "archetype-ecs"]
 # ///
 """GEPA, as a Daft pipeline — reflective prompt optimization in ~one screen.
 
@@ -57,7 +57,6 @@ def make_daft_effects():
     import daft
     from daft import col
     from daft.functions import prompt
-    from pydantic import BaseModel
 
     daft.set_provider(
         "openai",
@@ -65,33 +64,37 @@ def make_daft_effects():
         base_url="https://api.anthropic.com/v1/",
     )
 
-    class Sentiment(BaseModel):
-        label: str  # "positive" | "negative"
+    # Fixed output scaffold so responses parse cleanly; GEPA evolves only the strategy.
+    fmt = "\nRespond with exactly one word: positive or negative."
 
     def eval_fn(sid: str, prompt_text: str, ids: list[int]) -> dict[int, dict]:
         rows = {"id": ids, "text": [DATA[i][0] for i in ids], "gold": [DATA[i][1] for i in ids]}
         df = (
             daft.from_pydict(rows)
             .with_column(
-                "pred",
+                "resp",
                 prompt(
                     col("text"),
-                    system_message=prompt_text,
-                    return_format=Sentiment,
+                    system_message=prompt_text + fmt,
                     model=REWRITE_MODEL,
+                    use_chat_completions=True,  # Anthropic's OAI-compat endpoint has no Responses API
                 ),
             )
-            .with_column("label", col("pred")["label"])
-            .with_column("ok", (col("label") == col("gold")).cast(daft.DataType.float32()))
-            .select("id", "text", "gold", "label", "ok")
+            .with_column("pred_pos", col("resp").lower().contains("positive"))
+            .with_column(
+                "ok",
+                (col("pred_pos") == (col("gold") == "positive")).cast(daft.DataType.float32()),
+            )
+            .select("id", "text", "gold", "pred_pos", "ok")
             .collect()  # one materialization per candidate eval — this IS the metric call
         )
         out: dict[int, dict] = {}
         for r in df.to_pylist():
+            pred = "positive" if r["pred_pos"] else "negative"
             fb = (
                 "correct"
                 if r["ok"]
-                else f"got '{r['label']}', expected '{r['gold']}' for: {r['text']!r}"
+                else f"said '{pred}', expected '{r['gold']}' for: {r['text']!r}"
             )
             out[r["id"]] = {"s": float(r["ok"]), "fb": fb}
         return out
@@ -104,7 +107,7 @@ def make_daft_effects():
         )
         df = (
             daft.from_pydict({"x": [instruction]})
-            .with_column("out", prompt(col("x"), model=REFLECT_MODEL))
+            .with_column("out", prompt(col("x"), model=REFLECT_MODEL, use_chat_completions=True))
             .collect()
         )
         return df.to_pylist()[0]["out"].strip()

--- a/examples/gepa_daft_demo.py
+++ b/examples/gepa_daft_demo.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["daft[openai]>=0.7.9", "pydantic>=2", "archetype-ecs"]
+# ///
+"""GEPA, as a Daft pipeline — reflective prompt optimization in ~one screen.
+
+GEPA (Agrawal et al. 2025, arXiv:2507.19457) evolves a prompt by *reflecting* on
+its own failures, keeping a Pareto frontier of candidates instead of a single
+best-by-mean. The algorithm lives in `archetype.optimize.gepa` (pure, ~120 lines,
+parity-tested against the paper). This script supplies its two effects with Daft:
+
+    eval_fn    = daft.functions.prompt(...)  -> classify each example, score vs gold
+    reflect_fn = daft.functions.prompt(...)  -> rewrite the prompt given failures
+
+No LiteLLM, no agent framework, no orchestration glue — the optimizer is a loop,
+the LLM is a column expression, and Daft runs the batch.
+
+Run it:
+    export ANTHROPIC_API_KEY=sk-...            # live: Claude via the OpenAI-compatible API
+    uv run examples/gepa_daft_demo.py
+    # no key? it runs a deterministic mock so the loop is still visible (and CI-green).
+"""
+
+from __future__ import annotations
+
+import os
+from random import Random
+
+from archetype.optimize.gepa import gepa_search
+
+# A tiny sentiment task. Gold labels => deterministic scoring, no LLM judge. The
+# last three are the hard cases (sarcasm, negation, faint praise) the seed prompt
+# trips on — GEPA has to *discover* them from feedback and write guidance for them.
+DATA: list[tuple[str, str]] = [
+    ("Absolutely loved every minute of it.", "positive"),
+    ("A complete waste of my evening.", "negative"),
+    ("Best purchase I've made all year.", "positive"),
+    ("It broke on the second day.", "negative"),
+    ("Oh great, another Monday. Just what I needed.", "negative"),  # sarcasm
+    ("This is not bad at all, honestly.", "positive"),  # negation
+    ("Well, it certainly exists, I'll give it that.", "negative"),  # faint praise
+]
+INSTANCE_IDS = list(range(len(DATA)))
+
+SEED_PROMPT = "Classify the sentiment of the text as 'positive' or 'negative'."
+
+REWRITE_MODEL = "claude-sonnet-4-6"  # the task model (cheap, runs per example)
+REFLECT_MODEL = "claude-opus-4-8"  # the reflector (smart, runs once per generation)
+
+
+# --------------------------------------------------------------------------- #
+# Effects, backed by Daft. Each call is one prompt() expression over a batch.
+# --------------------------------------------------------------------------- #
+def make_daft_effects():
+    import daft
+    from daft import col
+    from daft.functions import prompt
+    from pydantic import BaseModel
+
+    daft.set_provider(
+        "openai",
+        api_key=os.environ["ANTHROPIC_API_KEY"],
+        base_url="https://api.anthropic.com/v1/",
+    )
+
+    class Sentiment(BaseModel):
+        label: str  # "positive" | "negative"
+
+    def eval_fn(sid: str, prompt_text: str, ids: list[int]) -> dict[int, dict]:
+        rows = {"id": ids, "text": [DATA[i][0] for i in ids], "gold": [DATA[i][1] for i in ids]}
+        df = (
+            daft.from_pydict(rows)
+            .with_column(
+                "pred",
+                prompt(
+                    col("text"),
+                    system_message=prompt_text,
+                    return_format=Sentiment,
+                    model=REWRITE_MODEL,
+                ),
+            )
+            .with_column("label", col("pred")["label"])
+            .with_column("ok", (col("label") == col("gold")).cast(daft.DataType.float32()))
+            .select("id", "text", "gold", "label", "ok")
+            .collect()  # one materialization per candidate eval — this IS the metric call
+        )
+        out: dict[int, dict] = {}
+        for r in df.to_pylist():
+            fb = (
+                "correct"
+                if r["ok"]
+                else f"got '{r['label']}', expected '{r['gold']}' for: {r['text']!r}"
+            )
+            out[r["id"]] = {"s": float(r["ok"]), "fb": fb}
+        return out
+
+    def reflect_fn(prompt_text: str, feedback_block: str) -> str:
+        instruction = (
+            "You improve a sentiment-classification instruction. Here is the current instruction "
+            f"and how it did on a minibatch:\n\nINSTRUCTION:\n{prompt_text}\n\nFEEDBACK:\n{feedback_block}\n\n"
+            "Write a single improved instruction that fixes the observed mistakes. Output only the instruction."
+        )
+        df = (
+            daft.from_pydict({"x": [instruction]})
+            .with_column("out", prompt(col("x"), model=REFLECT_MODEL))
+            .collect()
+        )
+        return df.to_pylist()[0]["out"].strip()
+
+    return eval_fn, reflect_fn
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic mock — same loop shape, no key needed (keeps CI green and the
+# demo legible offline). A prompt "scores" by how many failure modes it names.
+# --------------------------------------------------------------------------- #
+def make_mock_effects():
+    cues = {
+        4: "sarcasm",
+        5: "negation",
+        6: "faint praise",
+    }  # hard cases -> the cue a good prompt must mention
+
+    def eval_fn(sid: str, prompt_text: str, ids: list[int]) -> dict[int, dict]:
+        out = {}
+        for i in ids:
+            cue = cues.get(i)
+            ok = (
+                cue is None or cue in prompt_text.lower()
+            )  # easy cases always pass; hard cases need the cue named
+            out[i] = {"s": 1.0 if ok else 0.0, "fb": "correct" if ok else f"missed the {cue} case"}
+        return out
+
+    def reflect_fn(prompt_text: str, feedback_block: str) -> str:
+        for cue in ("sarcasm", "negation", "faint praise"):
+            if f"the {cue} case" in feedback_block and cue not in prompt_text.lower():
+                return f"{prompt_text} Also handle {cue}."
+        return prompt_text
+
+    return eval_fn, reflect_fn
+
+
+def main() -> None:
+    live = bool(os.environ.get("ANTHROPIC_API_KEY"))
+    eval_fn, reflect_fn = make_daft_effects() if live else make_mock_effects()
+    print(
+        f"GEPA-as-Daft  |  mode={'LIVE (Claude via Daft prompt())' if live else 'mock (no API key)'}\n"
+    )
+
+    result = gepa_search(
+        seed_text=SEED_PROMPT,
+        instance_ids=INSTANCE_IDS,
+        eval_fn=eval_fn,
+        reflect_fn=reflect_fn,
+        budget=60,
+        minibatch=3,
+        rng=Random(0),
+    )
+
+    print("trace (Pareto-selected parent → reflect → minibatch gate):")
+    for t in result["trace"]:
+        mark = "✓ accept" if t["accepted"] else "· reject"
+        print(
+            f"  gen {t['gen']:>2}  parent={t['parent']:<10}  σ={t['sigma']:.2f} → σ'={t['sigma_prime']:.2f}  {mark}"
+        )
+
+    print(f"\nseed accuracy : evaluate it yourself — seed='{SEED_PROMPT}'")
+    print(
+        f"best accuracy : {result['mean_success']:.2f}  (pool={result['pool_size']}, metric_calls={result['metric_calls']})"
+    )
+    print(f"evolved prompt:\n  {result['strategy_text']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/archetype/app/simulation_service.py
+++ b/src/archetype/app/simulation_service.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 
 from uuid_utils import UUID
 
+from archetype.app.auth.guard import reset_tick_counters
 from archetype.app.models import EpisodeResult, RolloutResult, RunResult
 from archetype.core.aio import AsyncWorld
 from archetype.core.config import RunConfig
@@ -61,6 +62,12 @@ class SimulationService:
         **input_kwargs,
     ) -> int:
         """Advance a world by one tick."""
+        # Per-tick RBAC quota window: each tick starts fresh. Resetting here —
+        # rather than relying on external callers to do it before every step —
+        # makes step/run/run_episode/run_rollout correct through the service
+        # layer. Previously the loop accumulated commands across ticks and
+        # tripped MAX_CMDS_PER_TICK, which forced drivers to hand-roll the loop.
+        reset_tick_counters()
         world = self._world_service.get_world(UUID(str(world_id)))
         commands_applied = 0
         if self._drain_commands is not None:

--- a/src/archetype/optimize/__init__.py
+++ b/src/archetype/optimize/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optimizers over prompts/strategies, expressed against the Archetype data model."""
+
+from archetype.optimize.gepa import gepa_search, pareto_select
+
+__all__ = ["gepa_search", "pareto_select"]

--- a/src/archetype/optimize/gepa.py
+++ b/src/archetype/optimize/gepa.py
@@ -1,48 +1,45 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""The GEPA algorithm — pure, effect-injected, testable in isolation.
+"""GEPA — pure, effect-injected, testable in isolation.
 
-This is a faithful, single-module implementation of GEPA (Agrawal et al. 2025,
+A faithful single-module implementation of GEPA (Agrawal et al. 2025,
 arXiv:2507.19457): Algorithm 1 (reflective evolution loop) + Algorithm 2
-(Pareto-based candidate selection). It has NO Daft/Modal/LLM/sim dependency — the
-two effects are injected:
+(Pareto-based candidate selection). NO Daft/Modal/LLM/sim dependency — the two
+effects are injected by the caller, so the same algorithm drives a sim rollout, an
+LLM-graded task, or a deterministic test:
 
     eval_fn(sid, text, instance_ids)  -> {instance_id: {"s": float, "fb": str}}
-        run the candidate strategy on those instances; return per-instance score + feedback.
+        run the candidate on those instances; return per-instance score + feedback.
     reflect_fn(text, feedback_block)  -> str
-        GEPA's UpdatePrompt: reflect on minibatch feedback → an improved strategy.
+        GEPA's UpdatePrompt: reflect on minibatch feedback -> an improved candidate.
 
-`gepa_daft.py` injects Daft-backed effects (prompt() rewrite + sim rollout);
-`tests/experiments/test_gepa_daft.py` injects deterministic mocks to prove the
-control logic matches GEPA. Single MODULE: we evolve one prompt component, so
-GEPA's per-module round-robin and system-aware merge are no-ops; the parts that
-*define* GEPA — per-instance score vectors, the Pareto frontier, the
-minibatch→accept gate, and the rollout budget — are all here.
+`bench/libero/gepa_daft.py` injects Daft-backed effects (``prompt()`` rewrite + sim
+rollout); `examples/gepa_daft_demo.py` injects an LLM-graded text task; the parity
+suite in `tests/experiments/test_gepa_daft.py` injects deterministic mocks to prove
+the control logic matches GEPA.
 
-GEPA Alg-line references are in the code.
+Single MODULE: we evolve one component, so GEPA's per-module round-robin and
+system-aware merge are no-ops; the parts that *define* GEPA — per-instance score
+vectors, the Pareto frontier, the minibatch->accept gate, and the rollout budget —
+are all here. GEPA Alg-line references are inline.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from random import Random
-from typing import Any, Callable, Protocol
-
-
-class _Rng(Protocol):
-    def sample(self, population: list[int], k: int) -> list[int]: ...
-    def choices(self, population: list[Any], weights: list[float], k: int) -> list[Any]: ...
-
+from typing import Any
 
 EvalFn = Callable[[str, str, list[int]], dict[int, dict[str, Any]]]
 ReflectFn = Callable[[str, str], str]
 
 
-def pareto_select(pool: list[dict[str, Any]], instance_ids: list[int], rng: _Rng) -> dict[str, Any]:
+def pareto_select(pool: list[dict[str, Any]], instance_ids: list[int], rng: Random) -> dict[str, Any]:
     """GEPA Algorithm 2 — instance-wise Pareto candidate selection.
 
     NOT top-k-by-mean (beam). Steps, verbatim from the paper:
-      1. per-instance best:   s*[i] = max_k S[k][i]
+      1. per-instance best:    s*[i] = max_k S[k][i]
       2. per-instance winners: P*[i] = {k : S[k][i] == s*[i]}
       3. prune candidates strictly dominated across instances
       4. sample ∝ f[Φ] = #instances for which Φ ∈ P*[i]
@@ -66,11 +63,15 @@ def pareto_select(pool: list[dict[str, Any]], instance_ids: list[int], rng: _Rng
     return rng.choices(nondominated, weights=[wins[c["sid"]] for c in nondominated], k=1)[0]
 
 
-def _candidate(sid: str, text: str, res: dict[int, dict[str, Any]], instance_ids: list[int]) -> dict[str, Any]:
+def _candidate(
+    sid: str, text: str, res: dict[int, dict[str, Any]], instance_ids: list[int]
+) -> dict[str, Any]:
     return {
         "sid": sid,
         "text": text,
-        "scores": {i: res[i]["s"] for i in instance_ids},  # per-instance score VECTOR (Pareto needs this)
+        "scores": {
+            i: res[i]["s"] for i in instance_ids
+        },  # per-instance score VECTOR (Pareto needs this)
         "fbk": {i: res[i]["fb"] for i in instance_ids},
     }
 
@@ -83,39 +84,51 @@ def gepa_search(
     reflect_fn: ReflectFn,
     budget: int,
     minibatch: int,
-    rng: _Rng | None = None,
+    rng: Random | None = None,
 ) -> dict[str, Any]:
     """GEPA Algorithm 1 — reflective evolution with Pareto selection.
 
     Budget is counted in metric calls (one candidate × one instance = one call).
     Returns the best candidate on the full instance set + the search trace.
     """
-    rng = rng or Random(0)
+    rng = rng if rng is not None else Random(0)
 
     # Alg 1 line 7 + 18-20: P ← [base]; full-eval the seed on all instances (D_pareto).
-    pool = [_candidate("gepa-seed", seed_text, eval_fn("gepa-seed", seed_text, instance_ids), instance_ids)]
+    pool = [
+        _candidate(
+            "gepa-seed", seed_text, eval_fn("gepa-seed", seed_text, instance_ids), instance_ids
+        )
+    ]
     spent = len(instance_ids)
     trace: list[dict[str, Any]] = []
     gen = 0
 
     while spent + minibatch <= budget:  # Alg 1 line 8: while budget B not exhausted
         gen += 1
-        parent = pareto_select(pool, instance_ids, rng)                      # Alg 2
-        mb = rng.sample(instance_ids, min(minibatch, len(instance_ids)))     # minibatch from D_feedback
-        sigma = sum(parent["scores"][i] for i in mb) / len(mb)              # σ (cached parent vector/feedback)
+        parent = pareto_select(pool, instance_ids, rng)  # Alg 2
+        mb = rng.sample(
+            instance_ids, min(minibatch, len(instance_ids))
+        )  # minibatch from D_feedback
+        sigma = sum(parent["scores"][i] for i in mb) / len(mb)  # σ (cached parent vector/feedback)
         fb = "\n".join(f"- instance {i}: {parent['fbk'][i]}" for i in mb)
-        child_text = reflect_fn(parent["text"], fb)                         # Alg 1 line 13: UpdatePrompt
+        child_text = reflect_fn(parent["text"], fb)  # Alg 1 line 13: UpdatePrompt
         csid = f"gepa-g{gen}"
-        c_res = eval_fn(f"{csid}-mb", child_text, mb)                       # evaluate child on minibatch
+        c_res = eval_fn(f"{csid}-mb", child_text, mb)  # evaluate child on minibatch
         spent += len(mb)
-        sigma_prime = sum(c_res[i]["s"] for i in mb) / len(mb)            # σ'
-        accepted = sigma_prime > sigma                                      # Alg 1 line 16: acceptance gate
+        sigma_prime = sum(c_res[i]["s"] for i in mb) / len(mb)  # σ'
+        accepted = sigma_prime > sigma  # Alg 1 line 16: acceptance gate
         trace.append(
-            {"gen": gen, "parent": parent["sid"], "sigma": round(sigma, 4),
-             "sigma_prime": round(sigma_prime, 4), "accepted": accepted, "spent": spent}
+            {
+                "gen": gen,
+                "parent": parent["sid"],
+                "sigma": round(sigma, 4),
+                "sigma_prime": round(sigma_prime, 4),
+                "accepted": accepted,
+                "spent": spent,
+            }
         )
         if accepted and spent + len(instance_ids) <= budget:
-            full = eval_fn(csid, child_text, instance_ids)                  # Alg 1 line 18-20: full-eval D_pareto
+            full = eval_fn(csid, child_text, instance_ids)  # Alg 1 line 18-20: full-eval D_pareto
             spent += len(instance_ids)
             pool.append(_candidate(csid, child_text, full, instance_ids))
 

--- a/status.sh
+++ b/status.sh
@@ -26,16 +26,13 @@ echo "git      : branch=${branch}  unpushed=${unpushed}  dirty=${dirty} file(s)"
 running=$(modal app list 2>/dev/null | grep -iE 'archetype-(gepa|libero|vla)' | grep -ci running || true)
 echo "modal    : ${running:-0} archetype app(s) currently running"
 
-# 4) Last smoke verdict (parse the most recent detached log)
-last=$(ls -t /tmp/gepa_smoke*.log 2>/dev/null | head -1)
-if [ -n "${last:-}" ]; then
-  if grep -q '"best"' "$last" 2>/dev/null;          then v="GREEN ✓ completed (has result JSON)"
-  elif grep -qiE 'cancellation|cancelled' "$last";  then v="RED ✗ CANCELLED mid-run (env reaped — not a code bug)"
-  elif grep -q 'Traceback' "$last";                 then v="RED ✗ CODE ERROR (grep the log)"
-  else                                                   v="… running / unknown"; fi
-  echo "last run : $(basename "$last") → $v"
+# 4) Last submitted job (spawn pattern — runs in the cloud, decoupled from this session)
+if [ -f /tmp/gepa_last_call.txt ]; then
+  cid=$(cat /tmp/gepa_last_call.txt)
+  state=$(uv run --with modal python bench/libero/submit_gepa.py --fetch "$cid" 2>/dev/null | grep '^STATUS:' | head -1)
+  echo "last job : ${cid} → ${state:-(could not query — try --fetch directly)}"
 else
-  echo "last run : (no /tmp/gepa_smoke*.log found)"
+  echo "last job : (none submitted via spawn yet — bench/libero/submit_gepa.py)"
 fi
 
 # 5) Recent commits

--- a/status.sh
+++ b/status.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# One-screen sitrep: the curated narrative (STATUS.md) + live ground-truth signals.
+# Run `./status.sh` any time you come back cold. Tells you what we're doing + green/red.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+echo "════════════════════ STATUS · $(date '+%Y-%m-%d %H:%M %Z') ════════════════════"
+echo
+
+# 1) Curated narrative (goal / health / next action / blockers)
+if [ -f STATUS.md ]; then
+  sed -n '/^## 🎯/,/^## ✅/p' STATUS.md | sed '$d'
+else
+  echo "(no STATUS.md — Claude should create one)"
+fi
+
+echo "──────────────────────────── live signals ────────────────────────────"
+
+# 2) Git health
+branch=$(git branch --show-current 2>/dev/null)
+unpushed=$(git log --oneline @{u}..HEAD 2>/dev/null | wc -l | tr -d ' ')
+dirty=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+echo "git      : branch=${branch}  unpushed=${unpushed}  dirty=${dirty} file(s)"
+
+# 3) In-flight Modal apps (running only)
+running=$(modal app list 2>/dev/null | grep -iE 'archetype-(gepa|libero|vla)' | grep -ci running || true)
+echo "modal    : ${running:-0} archetype app(s) currently running"
+
+# 4) Last smoke verdict (parse the most recent detached log)
+last=$(ls -t /tmp/gepa_smoke*.log 2>/dev/null | head -1)
+if [ -n "${last:-}" ]; then
+  if grep -q '"best"' "$last" 2>/dev/null;          then v="GREEN ✓ completed (has result JSON)"
+  elif grep -qiE 'cancellation|cancelled' "$last";  then v="RED ✗ CANCELLED mid-run (env reaped — not a code bug)"
+  elif grep -q 'Traceback' "$last";                 then v="RED ✗ CODE ERROR (grep the log)"
+  else                                                   v="… running / unknown"; fi
+  echo "last run : $(basename "$last") → $v"
+else
+  echo "last run : (no /tmp/gepa_smoke*.log found)"
+fi
+
+# 5) Recent commits
+echo "commits  :"
+git log --oneline -5 2>/dev/null | sed 's/^/           /'
+
+echo "───────────────────────────────────────────────────────────────────────"
+echo "full plan → docs/design/gepa-run-book.html   ·   cross-worktree board → /plots"

--- a/tests/bench/test_baseline_sweep.py
+++ b/tests/bench/test_baseline_sweep.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the baseline-sweep split logic and instruction threading.
+
+CI-safe (no Modal, no GPU): exercises the pure ``build_split`` policy and the
+``_resolve_instruction`` resolution order. Both are the load-bearing decisions
+of WS2 — the split determines what GEPA optimizes against, and the instruction
+fix is the honest baseline (core-loop §2, §4).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make bench/libero importable.
+_BENCH_LIBERO = str(Path(__file__).resolve().parents[2] / "bench" / "libero")
+if _BENCH_LIBERO not in sys.path:
+    sys.path.insert(0, _BENCH_LIBERO)
+
+from baseline_sweep import build_split  # type: ignore[import-not-found]  # noqa: E402
+from eval_driver import _resolve_instruction  # type: ignore[import-not-found]  # noqa: E402
+
+
+def _mk(task_id: int, success_rate: float, n: int = 3):
+    return {
+        "task_id": task_id,
+        "n": n,
+        "successes": round(success_rate * n),
+        "success_rate": success_rate,
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_split
+# ---------------------------------------------------------------------------
+
+
+def test_val_is_hardest_tasks():
+    """val must be the lowest-success tasks (most room to climb)."""
+    per_task = [
+        _mk(0, 0.9),
+        _mk(1, 0.1),
+        _mk(2, 0.5),
+        _mk(3, 0.0),
+        _mk(4, 0.7),
+    ]
+    split = build_split(per_task, suite="libero_spatial", val_size=2, test_size=1)
+    # Hardest two: task 3 (0.0) and task 1 (0.1).
+    assert split["val_task_ids"] == [1, 3]
+
+
+def test_val_and_test_are_disjoint():
+    per_task = [_mk(i, i / 10.0) for i in range(10)]
+    split = build_split(per_task, suite="s", val_size=4, test_size=3)
+    val = set(split["val_task_ids"])
+    test = set(split["test_task_ids"])
+    assert val.isdisjoint(test), f"val {val} and test {test} overlap"
+    assert len(val) == 4
+    assert len(test) == 3
+
+
+def test_test_drawn_from_non_val_tasks():
+    """test tasks must never be the val (hardest) tasks — no leakage."""
+    per_task = [_mk(i, i / 10.0) for i in range(10)]
+    split = build_split(per_task, suite="s", val_size=4, test_size=3)
+    hardest = {0, 1, 2, 3}  # rates 0.0..0.3
+    assert set(split["val_task_ids"]) == hardest
+    assert set(split["test_task_ids"]).isdisjoint(hardest)
+
+
+def test_test_is_distribution_matched_not_all_easiest():
+    """test should spread across remaining difficulty, not cluster at the top."""
+    per_task = [_mk(i, i / 10.0) for i in range(10)]
+    split = build_split(per_task, suite="s", val_size=4, test_size=3)
+    # Remaining after val = tasks 4..9 (rates 0.4..0.9). Even strides over 6
+    # remaining → indices {0, 2 or 3, 5} → tasks {4, 6/7, 9}. The key property:
+    # test spans both ends of the remaining range, not three adjacent easies.
+    test_ids = split["test_task_ids"]
+    assert min(test_ids) <= 5, f"test should include a harder remaining task: {test_ids}"
+    assert max(test_ids) >= 8, f"test should include an easy remaining task: {test_ids}"
+
+
+def test_deterministic_tie_break_by_task_id():
+    """Equal success rates break ties by task_id, deterministically."""
+    per_task = [_mk(2, 0.0), _mk(0, 0.0), _mk(1, 0.0), _mk(3, 0.9)]
+    split = build_split(per_task, suite="s", val_size=2, test_size=1)
+    # All three hardest tie at 0.0; lowest task_ids win val slots.
+    assert split["val_task_ids"] == [0, 1]
+
+
+def test_per_task_and_overall_recorded():
+    per_task = [_mk(0, 1.0, n=2), _mk(1, 0.0, n=2)]
+    split = build_split(per_task, suite="libero_spatial", val_size=1, test_size=1)
+    assert split["per_task"]["0"]["success_rate"] == 1.0
+    assert split["per_task"]["1"]["success_rate"] == 0.0
+    # 2 successes out of 4 trials = 0.5 overall.
+    assert split["baseline"]["overall_success_rate"] == 0.5
+    assert split["suite"] == "libero_spatial"
+
+
+def test_split_sizes_clamped_to_available():
+    """Requesting more val/test than tasks must not error or overlap."""
+    per_task = [_mk(0, 0.5), _mk(1, 0.5)]
+    split = build_split(per_task, suite="s", val_size=5, test_size=5)
+    val = set(split["val_task_ids"])
+    test = set(split["test_task_ids"])
+    assert val.isdisjoint(test)
+    assert len(val) <= 2
+    assert len(val) + len(test) <= 2
+
+
+# ---------------------------------------------------------------------------
+# _resolve_instruction
+# ---------------------------------------------------------------------------
+
+
+class _FakeEnv:
+    def __init__(self, language: str):
+        self._language = language
+
+    def task_language(self) -> str:
+        return self._language
+
+
+class _NoLanguageEnv:
+    pass
+
+
+def test_resolve_defaults_to_task_language():
+    """Default baseline = the env's raw task_language (never empty)."""
+    env = _FakeEnv("pick up the black bowl and place it on the plate")
+    instr = _resolve_instruction(
+        suite="libero_spatial", task_id=0, env_client=env, override_map=None
+    )
+    assert instr == "pick up the black bowl and place it on the plate"
+
+
+def test_resolve_override_takes_precedence():
+    """A per-(suite, task_id) override (the GEPA paraphrase) wins over the raw."""
+    env = _FakeEnv("raw libero instruction")
+    overrides = {("libero_spatial", 0): "grasp the dark bowl, set it on the dish"}
+    instr = _resolve_instruction(
+        suite="libero_spatial", task_id=0, env_client=env, override_map=overrides
+    )
+    assert instr == "grasp the dark bowl, set it on the dish"
+
+
+def test_resolve_override_miss_falls_back_to_task_language():
+    """An override map without this task's key falls back to the raw instruction."""
+    env = _FakeEnv("raw libero instruction")
+    overrides = {("libero_spatial", 5): "some other paraphrase"}
+    instr = _resolve_instruction(
+        suite="libero_spatial", task_id=0, env_client=env, override_map=overrides
+    )
+    assert instr == "raw libero instruction"
+
+
+def test_resolve_no_task_language_returns_empty():
+    """Scripted envs without task_language fall back to empty (off the policy path)."""
+    instr = _resolve_instruction(
+        suite="scripted", task_id=0, env_client=_NoLanguageEnv(), override_map=None
+    )
+    assert instr == ""

--- a/tests/experiments/test_eval_driver.py
+++ b/tests/experiments/test_eval_driver.py
@@ -29,8 +29,15 @@ _BENCH_LIBERO = str(Path(__file__).parents[2] / "bench" / "libero")
 if _BENCH_LIBERO not in sys.path:
     sys.path.insert(0, _BENCH_LIBERO)
 
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
 from archetype.experiments.components import EvalTrialResult  # noqa: E402
-from bench.libero.eval_driver import DriverConfig, run_eval  # noqa: E402
+from archetype.experiments.manipulation import ScriptedReachEnv  # noqa: E402
+from bench.libero.eval_driver import (  # noqa: E402
+    DriverConfig,
+    run_episode_batched,
+    run_eval,
+)
 from bench.libero.report import generate_report, report_from_components  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -49,6 +56,40 @@ class FakeChunkPolicy:
     ) -> list[list[float]]:
         # Zero action on all envs — ScriptedReachEnv converges on its own.
         return [[0.0] * 7 for _ in env_keys]
+
+
+class StaggeredReachEnv(ScriptedReachEnv):
+    """Scripted env where each env_key finishes at a DIFFERENT tick.
+
+    env_key ``k`` reports ``done`` after exactly ``k+1`` steps, so a batch of
+    N entities always carries a MIX of done and live rows for several ticks —
+    the condition the batched step/policy processors must survive when the
+    world spins to ``max_steps`` (done entities skipped, their terminal state
+    carried forward). Regression guard for the ledger-append KeyError seen in
+    batched runs where episodes finish at staggered ticks.
+    """
+
+    def step(self, env_ids, actions):
+        self._step_counts = getattr(self, "_step_counts", {})
+        results = []
+        for env_id, action in zip(env_ids, actions, strict=True):
+            pos = self._state[env_id]
+            for axis in range(3):
+                pos[axis] += action[axis]
+            self._step_counts[env_id] = self._step_counts.get(env_id, 0) + 1
+            done = self._step_counts[env_id] >= (env_id + 1)
+            results.append(
+                {
+                    "eef_pos": list(pos),
+                    "eef_quat": [1.0, 0.0, 0.0, 0.0],
+                    "gripper": 0.0,
+                    "gripper_qpos": [0.0, 0.0],
+                    "reward": -1.0,
+                    "done": done,
+                    "success": done,
+                }
+            )
+        return results
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +227,77 @@ async def test_success_accounting(tmp_path):
     n_success = sum(1 for r in results if r.success)
     rate = n_success / len(results)
     assert 0.0 <= rate <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Batched rollout: staggered-done carry-forward (no Modal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batched_staggered_done_runs_to_max_steps(tmp_path):
+    """Entities finishing at different ticks must spin to max_steps without the
+    ledger-append failure, with each entity's terminal verdict latched.
+
+    Reproduces the batched-run topology where some episodes are done while
+    others are still live across many ticks: the step processor must skip done
+    rows and carry their state forward (never look a done env_key up in the
+    live-only env), and success must latch for entities that finished early.
+    """
+    n = 3
+    env = StaggeredReachEnv(targets={i: (999.0, 0.0, 0.5) for i in range(64)}, tolerance=0.01)
+    storage = StorageConfig(uri=str(tmp_path / "episodes"), namespace="staggered")
+
+    async with ArchetypeRuntime() as runtime:
+        per_trial = await run_episode_batched(
+            env_client=env,
+            policy_client=None,
+            suite="scripted",
+            task_id=0,
+            seeds=list(range(n)),
+            env_keys=list(range(n)),
+            max_steps=8,  # well past the last finish tick (n) so done rows persist
+            storage=storage,
+            runtime=runtime,
+            use_frames=False,
+            instruction="",
+        )
+
+    # env_key k reports done after k+1 steps; success latches → (True, k+1).
+    assert per_trial == [(True, i + 1) for i in range(n)], per_trial
+
+
+@pytest.mark.asyncio
+async def test_batched_staggered_done_with_policy(tmp_path):
+    """Same as above but with a policy in the loop (policy + env both batched).
+
+    Exercises both the policy action UDF and the env step UDF done-freeze paths
+    simultaneously, the real-rollout topology.
+    """
+    from archetype.experiments.policy import ScriptedReachPolicy
+
+    n = 4
+    env = StaggeredReachEnv(targets={i: (999.0, 0.0, 0.5) for i in range(64)}, tolerance=0.01)
+    # Targets cover only the spawned env_keys, like the real driver.
+    policy = ScriptedReachPolicy(targets={i: (0.5, 0.0, 0.5) for i in range(n)})
+    storage = StorageConfig(uri=str(tmp_path / "episodes"), namespace="staggered_pol")
+
+    async with ArchetypeRuntime() as runtime:
+        per_trial = await run_episode_batched(
+            env_client=env,
+            policy_client=policy,
+            suite="scripted",
+            task_id=0,
+            seeds=list(range(n)),
+            env_keys=list(range(n)),
+            max_steps=10,
+            storage=storage,
+            runtime=runtime,
+            use_frames=False,
+            instruction="",
+        )
+
+    assert per_trial == [(True, i + 1) for i in range(n)], per_trial
 
 
 # ---------------------------------------------------------------------------

--- a/tests/experiments/test_gepa_daft.py
+++ b/tests/experiments/test_gepa_daft.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Demonstrates that bench/libero/gepa_core.py IS the GEPA algorithm.
+
+These tests inject deterministic mocks for the two effects (eval_fn, reflect_fn)
+so they exercise the pure control logic — no Daft, Modal, LLM, or sim. They assert
+the behaviors that *define* GEPA (Agrawal et al. 2025) and distinguish it from
+naive beam / top-k-by-mean prompt evolution:
+
+  - Pareto frontier keeps a SPECIALIST a top-k-by-mean beam would cull (Alg 2).
+  - Strictly-dominated candidates are pruned (Alg 2).
+  - Candidates are sampled ∝ number of instances won (Alg 2).
+  - The minibatch acceptance gate (σ'>σ) admits only real improvements (Alg 1).
+  - The rollout budget is respected (Alg 1, line 8).
+"""
+
+import sys
+from collections import Counter
+from pathlib import Path
+from random import Random
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "bench" / "libero"))
+
+from gepa_core import gepa_search, pareto_select  # noqa: E402
+
+
+def test_pareto_keeps_specialist_a_beam_would_cull():
+    # generalist mean 0.60; specialist mean 0.33 — top-1-by-mean would drop the
+    # specialist. GEPA keeps it because it wins instance 0. THIS is the distinction.
+    pool = [
+        {"sid": "generalist", "scores": {0: 0.6, 1: 0.6, 2: 0.6}},
+        {"sid": "specialist", "scores": {0: 1.0, 1: 0.0, 2: 0.0}},
+    ]
+    rng = Random(0)
+    picks = {pareto_select(pool, [0, 1, 2], rng)["sid"] for _ in range(200)}
+    assert picks == {"generalist", "specialist"}  # both on the frontier; specialist survives
+
+
+def test_pareto_prunes_strictly_dominated():
+    pool = [
+        {"sid": "strong", "scores": {0: 0.9, 1: 0.9}},
+        {"sid": "weak", "scores": {0: 0.5, 1: 0.5}},  # dominated by strong on every instance
+        {"sid": "spec", "scores": {0: 1.0, 1: 0.0}},  # wins instance 0
+    ]
+    rng = Random(1)
+    picks = {pareto_select(pool, [0, 1], rng)["sid"] for _ in range(200)}
+    assert "weak" not in picks
+    assert picks == {"strong", "spec"}
+
+
+def test_pareto_samples_proportional_to_instances_won():
+    pool = [
+        {"sid": "A", "scores": {0: 1.0, 1: 1.0, 2: 0.0}},  # wins 2 instances
+        {"sid": "B", "scores": {0: 0.0, 1: 0.0, 2: 1.0}},  # wins 1 instance
+    ]
+    rng = Random(2)
+    c = Counter(pareto_select(pool, [0, 1, 2], rng)["sid"] for _ in range(4000))
+    assert 1.6 < c["A"] / c["B"] < 2.5  # ∝ #wins (2:1)
+
+
+# A mock "world": a strategy's per-instance success = fraction of target keywords it
+# contains. reflect_fn adds one missing keyword per round → improvable children.
+_KEYWORDS = ["ground", "spatial", "explicit"]
+
+
+def _mock_eval(sid, text, ids):
+    score = sum(k in text for k in _KEYWORDS) / len(_KEYWORDS)
+    miss = [k for k in _KEYWORDS if k not in text]
+    return {i: {"s": score, "fb": f"missing: {miss}"} for i in ids}
+
+
+def _mock_reflect(text, _fb):
+    miss = [k for k in _KEYWORDS if k not in text]
+    return text + ((" " + miss[0]) if miss else "")
+
+
+def test_gepa_search_improves_over_seed_and_respects_budget():
+    out = gepa_search(
+        seed_text="rewrite", instance_ids=[0, 1, 2, 3],
+        eval_fn=_mock_eval, reflect_fn=_mock_reflect, budget=40, minibatch=2, rng=Random(0),
+    )
+    assert out["mean_success"] >= 0.66          # climbed well past the 0.0 seed
+    assert out["metric_calls"] <= 40            # budget respected
+    assert out["pool_size"] > 1                 # accepted real improvements
+    assert any(t["accepted"] for t in out["trace"])
+
+
+def test_acceptance_gate_rejects_non_improving_mutations():
+    # A no-op reflect never improves σ → the gate admits nothing; pool stays the seed.
+    out = gepa_search(
+        seed_text="rewrite", instance_ids=[0, 1, 2, 3],
+        eval_fn=_mock_eval, reflect_fn=lambda t, _fb: t, budget=40, minibatch=2, rng=Random(0),
+    )
+    assert out["pool_size"] == 1
+    assert all(not t["accepted"] for t in out["trace"])

--- a/tests/experiments/test_gepa_daft.py
+++ b/tests/experiments/test_gepa_daft.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Demonstrates that bench/libero/gepa_core.py IS the GEPA algorithm.
+"""Parity eval: archetype.optimize.gepa IS the GEPA algorithm.
 
 These tests inject deterministic mocks for the two effects (eval_fn, reflect_fn)
 so they exercise the pure control logic — no Daft, Modal, LLM, or sim. They assert
@@ -15,14 +15,10 @@ naive beam / top-k-by-mean prompt evolution:
   - The rollout budget is respected (Alg 1, line 8).
 """
 
-import sys
 from collections import Counter
-from pathlib import Path
 from random import Random
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "bench" / "libero"))
-
-from gepa_core import gepa_search, pareto_select  # noqa: E402
+from archetype.optimize.gepa import gepa_search, pareto_select
 
 
 def test_pareto_keeps_specialist_a_beam_would_cull():
@@ -77,20 +73,30 @@ def _mock_reflect(text, _fb):
 
 def test_gepa_search_improves_over_seed_and_respects_budget():
     out = gepa_search(
-        seed_text="rewrite", instance_ids=[0, 1, 2, 3],
-        eval_fn=_mock_eval, reflect_fn=_mock_reflect, budget=40, minibatch=2, rng=Random(0),
+        seed_text="rewrite",
+        instance_ids=[0, 1, 2, 3],
+        eval_fn=_mock_eval,
+        reflect_fn=_mock_reflect,
+        budget=40,
+        minibatch=2,
+        rng=Random(0),
     )
-    assert out["mean_success"] >= 0.66          # climbed well past the 0.0 seed
-    assert out["metric_calls"] <= 40            # budget respected
-    assert out["pool_size"] > 1                 # accepted real improvements
+    assert out["mean_success"] >= 0.66  # climbed well past the 0.0 seed
+    assert out["metric_calls"] <= 40  # budget respected
+    assert out["pool_size"] > 1  # accepted real improvements
     assert any(t["accepted"] for t in out["trace"])
 
 
 def test_acceptance_gate_rejects_non_improving_mutations():
     # A no-op reflect never improves σ → the gate admits nothing; pool stays the seed.
     out = gepa_search(
-        seed_text="rewrite", instance_ids=[0, 1, 2, 3],
-        eval_fn=_mock_eval, reflect_fn=lambda t, _fb: t, budget=40, minibatch=2, rng=Random(0),
+        seed_text="rewrite",
+        instance_ids=[0, 1, 2, 3],
+        eval_fn=_mock_eval,
+        reflect_fn=lambda t, _fb: t,
+        budget=40,
+        minibatch=2,
+        rng=Random(0),
     )
     assert out["pool_size"] == 1
     assert all(not t["accepted"] for t in out["trace"])


### PR DESCRIPTION
## Claude Build Day — Vangelis Technologies

**One-liner.** We turn *conditioning-space optimization of a frozen VLA* — the genre of TTT-VLA and VLA Grounder — into **batched, append-only-logged, exactly-reproducible** rollouts on the Archetype ECS ledger, and run it with a **gradient-free, black-box** optimizer (GEPA) on a stack that runs end-to-end today (**VLA-JEPA + LIBERO on Modal**).

The novel contribution is the **systems harness**, not the optimizer. (GEPA-on-frozen-VLA is *not* novel — VLA Grounder already benchmarks it — and we say so in the paper.)

### What this PR adds
- **`eval_driver.run_episode_batched`** — the core primitive: a task's **N seeds become N entities in ONE world**, advanced by a *single* batched `env.step([N],[N])` per tick (replacing N serial single-entity episodes). Within an episode the tick sequence is coupled; across seeds it's all data → one batched tick. Per-entity terminal verdict via `groupby(entity_id).max(success)`.
- **`run_eval`** batches all trials of a task into one world; cross-task parallelism stays at the Modal `.starmap` layer with per-task **isolated stores** (concurrent-write-safe).
- **`baseline_sweep.py`** — image now ignores `**/*.log` + `**/out/**` (fixes a "modified during build" race with the live run log); per-task timeout 1h → 6h for long-horizon.
- **`docs/build-day-paper.md`** — the paper (systems + research): hypothesis, the Archetype harness, honest related-work positioning vs **TTT-VLA** (gradient latent TTT) and **VLA Grounder** (RL command-space), falsifiable predictions, anti-gaming protocol, and results tables that fill from the live ledger.

### Verification
- Batched path smoke-tested end-to-end: 2 seeds of a task share **one** batched-world wall-time (`73.2s`), not 2× serial — confirming a single batched tick advances both seeds.
- Two long-horizon/headroom runs are live on Modal, writing to the ledger now (`libero10-longhorizon-batched`, `goal-headroom-batched`).

### Built during Build Day vs pre-existing (per judging rules)
- **Built today (original):** the batched rollout primitive, the co-located Modal batched fan-out, the query-service dataset/packaging tool *(incoming follow-up commit)*, the live monitor, and the paper + design docs.
- **Pre-existing (brought in):** the Archetype ECS framework, the VLA-JEPA model, and the LIBERO/robosuite simulator.

### Landing next (follow-up commits to this branch)
- `bench/libero/prepare_dataset.py` + `out/dataset/` (queryable rollout dataset + DATASHEET) — reads the ledger only through the Archetype query service.
- Results tables populated from the headroom + long-horizon runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)