### PR TITLE
[codex] add idempotency eval suite

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -96,10 +96,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      CLOUDFLARE_ACCOUNT_ID: f11df81ebc1ba9b7450c59398474827a
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
-      R2_CATALOG_BUCKET: ${{ vars.R2_CATALOG_BUCKET }}
+      R2_CATALOG_URI: ${{ vars.R2_CATALOG_URI }}
+      R2_CATALOG_WAREHOUSE: ${{ vars.R2_CATALOG_WAREHOUSE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -120,7 +119,10 @@ jobs:
         run: uv sync --group dev
 
       - name: Verify R2 integration credentials
-        run: test -n "$CLOUDFLARE_API_TOKEN" && test -n "$R2_CATALOG_TOKEN"
+        run: |
+          test -n "$R2_CATALOG_TOKEN"
+          test -n "$R2_CATALOG_URI"
+          test -n "$R2_CATALOG_WAREHOUSE"
 
       - name: Run R2 Data Catalog idempotency integration
         run: make test-infra

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -96,9 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
-      R2_CATALOG_URI: ${{ vars.R2_CATALOG_URI }}
-      R2_CATALOG_WAREHOUSE: ${{ vars.R2_CATALOG_WAREHOUSE }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_API_ENDPOINT: ${{ vars.R2_API_ENDPOINT }}
+      R2_BUCKET: ${{ vars.R2_BUCKET }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -120,9 +121,10 @@ jobs:
 
       - name: Verify R2 integration credentials
         run: |
-          test -n "$R2_CATALOG_TOKEN"
-          test -n "$R2_CATALOG_URI"
-          test -n "$R2_CATALOG_WAREHOUSE"
+          test -n "$R2_ACCESS_KEY_ID"
+          test -n "$R2_SECRET_ACCESS_KEY"
+          test -n "$R2_API_ENDPOINT"
+          test -n "$R2_BUCKET"
 
       - name: Run R2 Data Catalog idempotency integration
         run: make test-infra

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -85,6 +86,43 @@ jobs:
       # through eval-reg alone.
       - name: Run capability evals
         run: make eval-cap
+
+  # Real object-store gate. The R2 catalog token vends short-lived object-store
+  # credentials, so no local or runner-side Docker service is involved.
+  infrastructure-idempotency:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CLOUDFLARE_ACCOUNT_ID: f11df81ebc1ba9b7450c59398474827a
+      R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
+      R2_CATALOG_BUCKET: ${{ vars.R2_CATALOG_BUCKET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Verify R2 integration credentials
+        run: test -n "$R2_CATALOG_TOKEN"
+
+      - name: Run R2 Data Catalog idempotency integration
+        run: make test-infra
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -97,6 +97,7 @@ jobs:
     timeout-minutes: 10
     env:
       CLOUDFLARE_ACCOUNT_ID: f11df81ebc1ba9b7450c59398474827a
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
       R2_CATALOG_BUCKET: ${{ vars.R2_CATALOG_BUCKET }}
     steps:
@@ -119,7 +120,7 @@ jobs:
         run: uv sync --group dev
 
       - name: Verify R2 integration credentials
-        run: test -n "$R2_CATALOG_TOKEN"
+        run: test -n "$CLOUDFLARE_API_TOKEN" && test -n "$R2_CATALOG_TOKEN"
 
       - name: Run R2 Data Catalog idempotency integration
         run: make test-infra

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Run capability evals
         run: make eval-cap
 
-  # Real object-store gate. The R2 catalog token vends short-lived object-store
-  # credentials, so no local or runner-side Docker service is involved.
+  # Real object-store gate using a disposable prefix and R2's S3 credentials;
+  # no local or runner-side Docker service is involved.
   infrastructure-idempotency:
     if: >-
       github.event_name != 'pull_request' ||
@@ -125,8 +125,11 @@ jobs:
           test -n "$R2_SECRET_ACCESS_KEY"
           test -n "$R2_API_ENDPOINT"
           test -n "$R2_BUCKET"
+          case "$R2_BUCKET" in
+            */*) echo "R2_BUCKET must be a bucket name, not a path" >&2; exit 1 ;;
+          esac
 
-      - name: Run R2 Data Catalog idempotency integration
+      - name: Run R2 Iceberg idempotency integration
         run: make test-infra
 
   format:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ help:
 	@echo "  make eval-reg       Run regression suite only"
 	@echo "  make eval-idem      Run idempotency suite only"
 	@echo "  make eval-cap       Run capability suite only"
+	@echo "  make test-infra     Run external-infrastructure tests (requires configured service)"
 	@echo ""
 	@echo "Build & Release:"
 	@echo "  make build          Build sdist + wheel"
@@ -76,11 +77,15 @@ sync-dev:
 
 .PHONY: format
 format:
-	@uv run ruff format src tests
+	@uv run ruff format src tests evals/suites/idempotency.py \
+		evals/suites/idempotency_durable.py evals/suites/idempotency_process.py \
+		evals/infra/idempotency_worker.py scripts/check_idempotency_contracts.py
 
 .PHONY: lint
-lint: lazy-audit api-boundary-audit
-	@uv run ruff check src tests
+lint: lazy-audit api-boundary-audit idempotency-audit
+	@uv run ruff check src tests evals/suites/idempotency.py \
+		evals/suites/idempotency_durable.py evals/suites/idempotency_process.py \
+		evals/infra/idempotency_worker.py scripts/check_idempotency_contracts.py
 
 .PHONY: lint-fix
 lint-fix:
@@ -88,7 +93,9 @@ lint-fix:
 
 .PHONY: format-check
 format-check:
-	@uv run ruff format --check src tests
+	@uv run ruff format --check src tests evals/suites/idempotency.py \
+		evals/suites/idempotency_durable.py evals/suites/idempotency_process.py \
+		evals/infra/idempotency_worker.py scripts/check_idempotency_contracts.py
 
 .PHONY: check
 check: format lint
@@ -103,6 +110,12 @@ lazy-audit:
 .PHONY: api-boundary-audit
 api-boundary-audit:
 	@uv run python scripts/check_api_import_boundaries.py
+
+# Keep every normative idempotency-matrix row mapped to a registered eval.
+# This is static and fast; make eval-idem executes the behavioral scenarios.
+.PHONY: idempotency-audit
+idempotency-audit:
+	@PYTHONPATH=$(PYTHONPATH):. uv run python scripts/check_idempotency_contracts.py
 
 # Cyclomatic complexity + maintainability report.
 # Uses uvx so radon stays out of the project lock file.
@@ -154,7 +167,7 @@ test-all:
 	@PYTHONPATH=$(PYTHONPATH) uv run pytest -v --tb=short
 
 .PHONY: ci
-ci: format-check lint lock-check test-cov eval-reg
+ci: format-check lint lock-check test-cov eval-reg eval-idem
 	@echo "CI gate passed"
 
 # Mutation testing (mutmut). Not part of `make ci` — each mutation runs the
@@ -206,6 +219,10 @@ eval-idem:
 .PHONY: eval-cap
 eval-cap:
 	@PYTHONPATH=$(PYTHONPATH) uv run python -m evals.run --suite capability
+
+.PHONY: test-infra
+test-infra:
+	@PYTHONPATH=$(PYTHONPATH):. uv run pytest -q tests/infrastructure
 
 # ------------------------------------------------------------------------------
 # Build & Release

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ help:
 	@echo "  make bench-full     Run ECS microbenchmarks (3 steps)"
 	@echo "  make eval           Run all eval suites"
 	@echo "  make eval-reg       Run regression suite only"
+	@echo "  make eval-idem      Run idempotency suite only"
 	@echo "  make eval-cap       Run capability suite only"
 	@echo ""
 	@echo "Build & Release:"
@@ -197,6 +198,10 @@ eval:
 .PHONY: eval-reg
 eval-reg:
 	@PYTHONPATH=$(PYTHONPATH) uv run python -m evals.run --suite regression
+
+.PHONY: eval-idem
+eval-idem:
+	@PYTHONPATH=$(PYTHONPATH) uv run python -m evals.run --suite idempotency
 
 .PHONY: eval-cap
 eval-cap:

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -859,6 +859,49 @@ the constraints that any acceptable design must satisfy.
 | `world.step()` | Not idempotent; advances tick and appends new rows |
 | `world.run()` | Not idempotent; performs multiple steps under one run contract |
 | `QueryManager.query_archetype()` | Idempotent for fixed persisted state |
+| Store `append()` replay | Not idempotent; repeating an append persists duplicate rows |
+| Updater `update()` replay | Not idempotent; repeating an update appends another row version |
+| Store `get_archetype_df()` replay | Idempotent for the same persisted data |
+| `QueryService` fixed-state reads | Idempotent for fixed rows, history, and signature catalog |
+| Catalog re-registration | Same identity and content is an idempotent no-op; different content conflicts loudly |
+| Coordinated tick retry after failed publish | Unpublished attempts stay invisible; retry produces exactly one visible attempt |
+| Cold discovery and reads | Repeated cold discovery and reads return stable durable state |
+| Fenced mutable resume | Resume continues from the last visible tick and stale-writer retries stay invisible |
+| `ingest_fact()` replay | Identical external identity and payload converges on one visible fact; changed payload conflicts |
+| `ingest_fact()` crash recovery | Lease takeover completes an appended orphan without creating a second visible fact |
+| `evaluate()` replay | Same evaluation identity, subject, and contract returns one receipt without re-grading |
+| Hard process crash and cold resume | Unpublished physical rows do not advance a fresh process beyond the last visible tick |
+| Independent writer-process race | Exactly one fenced writer publishes the contested tick |
+| Independent process `ingest_fact()` replay | Concurrent processes converge on one visible external fact |
+| Independent process `evaluate()` replay | Concurrent processes grade once, and changed subjects conflict before grading |
+
+The durable rows above summarize the normative amendments in
+[Durable Discovery](durable-discovery.md),
+[Atomic Visibility](atomic-visibility.md),
+[World Lifecycle](world-lifecycle.md), and [Durable Facts](durable-facts.md).
+The idempotency eval manifest must match this table exactly; `make
+idempotency-audit` is the fast static drift check, while `make eval-idem`
+executes the behavioral scenarios.
+
+The behavioral suite is an independent oracle: it does not call or import the
+feature tests under `tests/app/`. Each task builds fresh storage and asserts
+primarily on service-facing outcomes and durable query results. Deterministic
+fault injection targets only the documented manifest-publish and
+claim-completion boundaries; selected internal counters provide secondary
+failure diagnostics. Coverage is deliberately symmetric: repeated no-ops must
+collapse, non-idempotent simulation calls must remain distinct, concurrent
+durable submissions must converge, interrupted commits must recover, and
+identity reuse with changed content must fail loudly. A new matrix row
+therefore requires a registered behavioral task, and a new task must trace
+back to at least one matrix row.
+
+Four tasks cross real OS-process boundaries over shared LanceDB and SQLite
+files: hard process death followed by cold resume, a two-writer fence race,
+eight-process fact replay, and eight-process evaluation replay with an
+external grader-call ledger. The `infrastructure-idempotency` GitHub Actions
+job creates a disposable table in Cloudflare R2 Data Catalog and runs the
+Iceberg integration under `tests/infrastructure/`; local development does not
+require Docker.
 
 ## Required Hardening Work
 

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -899,9 +899,11 @@ Four tasks cross real OS-process boundaries over shared LanceDB and SQLite
 files: hard process death followed by cold resume, a two-writer fence race,
 eight-process fact replay, and eight-process evaluation replay with an
 external grader-call ledger. The `infrastructure-idempotency` GitHub Actions
-job creates a disposable table in Cloudflare R2 Data Catalog and runs the
-Iceberg integration under `tests/infrastructure/`; local development does not
-require Docker.
+job creates a disposable Iceberg table under a unique Cloudflare R2 object
+storage prefix and runs the integration under `tests/infrastructure/`; local
+development does not require Docker. The catalog metadata is isolated in a
+runner-local SQLite database, so this gate proves Archetype/Daft/PyIceberg R2
+I/O and commit visibility, not the Cloudflare Data Catalog control plane.
 
 ## Required Hardening Work
 

--- a/evals/infra/__init__.py
+++ b/evals/infra/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure workers used by process-level evaluation scenarios."""

--- a/evals/infra/idempotency_worker.py
+++ b/evals/infra/idempotency_worker.py
@@ -1,0 +1,363 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fresh-process worker for real-storage idempotency scenarios.
+
+The parent eval invokes this module with ``python -m``. Each command creates a
+new ServiceContainer, so no component registry, world registry, connection,
+or event-loop state is shared between scenario phases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+from uuid_utils import uuid7
+
+from archetype.app._catalog import ClaimConflictError, SqliteControlCatalog
+from archetype.app.auth.models import ActorCtx
+from archetype.app.container import ServiceContainer
+from archetype.app.facts import FactMeta
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.interfaces import StaleWriterError
+from archetype.experiments.receipts import EvalReceipt, GraderContract, Outcome
+
+
+class ProcessReading(Component):
+    value: float = 0.0
+
+
+def _storage(args: argparse.Namespace) -> StorageConfig:
+    return StorageConfig(uri=args.uri, namespace=args.namespace)
+
+
+def _emit(payload: dict) -> None:
+    print(json.dumps(payload, sort_keys=True), flush=True)
+
+
+def _wait_for(path: str | None, timeout: float = 30.0) -> None:
+    if path is None:
+        return
+    deadline = time.monotonic() + timeout
+    marker = Path(path)
+    while not marker.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"timed out waiting for {marker}")
+        time.sleep(0.01)
+
+
+def _ready(path: str | None, payload: dict | None = None) -> None:
+    if path is None:
+        return
+    Path(path).write_text(json.dumps(payload or {"ready": True}, sort_keys=True))
+
+
+def _record_grader_call(path: str) -> None:
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, f"{os.getpid()}\n".encode())
+    finally:
+        os.close(fd)
+
+
+def _contract() -> GraderContract:
+    return GraderContract(
+        grader_id="process-integration-grader",
+        implementation_version="1",
+        thresholds={"minimum": 1.0},
+    )
+
+
+def _actor() -> ActorCtx:
+    return ActorCtx(id=uuid7(), roles={"operator"})
+
+
+async def seed(args: argparse.Namespace) -> None:
+    container = ServiceContainer()
+    try:
+        storage = _storage(args)
+        world = await container.world_service.create_world(WorldConfig(name=args.name), storage)
+        await container.mutation_service.create_entity(
+            world.world_id, [ProcessReading(value=args.value)]
+        )
+        await container.simulation_service.step(world.world_id, RunConfig())
+        _emit(
+            {
+                "world_id": str(world.world_id),
+                "run_id": str(world.run_id),
+                "tick": world.tick,
+            }
+        )
+    finally:
+        await container.shutdown()
+
+
+async def crash_publish(args: argparse.Namespace) -> None:
+    """Hard-exit after durable appends but before manifest publication."""
+    container = ServiceContainer()
+    storage = _storage(args)
+    await container.world_service.open_world_mutable(storage, args.world_id)
+
+    async def die_before_publish(self, *publish_args, **publish_kwargs):
+        os._exit(args.exit_code)
+
+    SqliteControlCatalog.publish_manifest = die_before_publish
+    await container.simulation_service.step(args.world_id, RunConfig())
+    raise AssertionError("publish crash hook did not terminate the process")
+
+
+async def resume_verify(args: argparse.Namespace) -> None:
+    container = ServiceContainer()
+    try:
+        storage = _storage(args)
+        world = await container.world_service.open_world_mutable(storage, args.world_id)
+        resume_tick = world.tick
+        await container.simulation_service.step(args.world_id, RunConfig())
+        frame = await container.query_service.query_components(
+            [ProcessReading], args.world_id, str(world.run_id), storage, ticks=[resume_tick]
+        )
+        manifests = await container.storage_service.get_control_catalog(storage).list_manifests(
+            args.world_id
+        )
+        _emit(
+            {
+                "resume_tick": resume_tick,
+                "final_tick": world.tick,
+                "visible_rows": len(frame.to_pylist()),
+                "manifest_ticks": [record.tick for record in manifests],
+                "epoch": world.commit_coordinator.epoch,
+            }
+        )
+    finally:
+        await container.shutdown()
+
+
+async def resume_race(args: argparse.Namespace) -> None:
+    container = ServiceContainer()
+    try:
+        storage = _storage(args)
+        world = await container.world_service.open_world_mutable(storage, args.world_id)
+        _ready(args.ready, {"epoch": world.commit_coordinator.epoch})
+        _wait_for(args.go)
+        try:
+            await container.simulation_service.step(args.world_id, RunConfig())
+            status = "published"
+        except StaleWriterError:
+            status = "stale"
+        except RuntimeError as exc:
+            if "StaleWriter" not in type(exc).__name__ and "not the" not in str(exc):
+                raise
+            status = "stale"
+        _emit({"status": status, "epoch": world.commit_coordinator.epoch, "tick": world.tick})
+    finally:
+        await container.shutdown()
+
+
+async def query_world(args: argparse.Namespace) -> None:
+    container = ServiceContainer()
+    try:
+        storage = _storage(args)
+        info = await container.world_service.open_world_readonly(storage, args.world_id)
+        rows = (
+            await container.query_service.query_components(
+                [ProcessReading], args.world_id, str(info.run_id), storage
+            )
+        ).to_pylist()
+        manifests = await container.storage_service.get_control_catalog(storage).list_manifests(
+            args.world_id
+        )
+        _emit(
+            {
+                "row_ticks": sorted({row["tick"] for row in rows}),
+                "manifest_ticks": [record.tick for record in manifests],
+                "rows": len(rows),
+            }
+        )
+    finally:
+        await container.shutdown()
+
+
+async def ingest_fact(args: argparse.Namespace) -> None:
+    _ready(args.ready)
+    _wait_for(args.go)
+    container = ServiceContainer()
+    try:
+        receipt = await container.ingestion_service.ingest_fact(
+            args.world_id,
+            [ProcessReading(value=args.value)],
+            external_id=args.external_id,
+            producer=args.producer,
+            storage_config=_storage(args),
+        )
+        _emit(
+            {
+                "duplicate": receipt.duplicate,
+                "commit_token": receipt.commit_token,
+                "fact_entity_id": receipt.fact_entity_id,
+            }
+        )
+    finally:
+        await container.shutdown()
+
+
+async def query_facts(args: argparse.Namespace) -> None:
+    container = ServiceContainer()
+    try:
+        storage = _storage(args)
+        info = await container.world_service.open_world_readonly(storage, args.world_id)
+        rows = (
+            await container.query_service.query_components(
+                [FactMeta], args.world_id, str(info.run_id), storage
+            )
+        ).to_pylist()
+        _emit(
+            {
+                "rows": len(rows),
+                "external_ids": sorted(row["factmeta__external_id"] for row in rows),
+                "commit_ids": sorted({row["factmeta__commit_id"] for row in rows}),
+            }
+        )
+    finally:
+        await container.shutdown()
+
+
+async def evaluate(args: argparse.Namespace) -> None:
+    _ready(args.ready)
+    _wait_for(args.go)
+    container = ServiceContainer()
+    try:
+
+        def grader(frame):
+            _record_grader_call(args.grader_log)
+            return Outcome(status="pass", score=float(frame.count_rows()))
+
+        receipt = await container.command_service.evaluate(
+            _actor(),
+            args.world_id,
+            [ProcessReading],
+            contract=_contract(),
+            grader=grader,
+            evaluation_id=args.evaluation_id,
+            storage_config=_storage(args),
+        )
+        _emit({"duplicate": receipt.duplicate, "commit_token": receipt.commit_token})
+    finally:
+        await container.shutdown()
+
+
+async def evaluate_conflict(args: argparse.Namespace) -> None:
+    container = ServiceContainer()
+    try:
+
+        def grader(frame):
+            _record_grader_call(args.grader_log)
+            return Outcome(status="pass", score=float(frame.count_rows()))
+
+        try:
+            await container.command_service.evaluate(
+                _actor(),
+                args.world_id,
+                [ProcessReading],
+                contract=_contract(),
+                grader=grader,
+                evaluation_id=args.evaluation_id,
+                storage_config=_storage(args),
+            )
+            conflict = False
+        except ClaimConflictError:
+            conflict = True
+        _emit({"conflict": conflict})
+    finally:
+        await container.shutdown()
+
+
+async def query_receipts(args: argparse.Namespace) -> None:
+    container = ServiceContainer()
+    try:
+        storage = _storage(args)
+        info = await container.world_service.open_world_readonly(storage, args.world_id)
+        rows = (
+            await container.query_service.query_components(
+                [EvalReceipt], args.world_id, str(info.run_id), storage
+            )
+        ).to_pylist()
+        _emit(
+            {
+                "rows": len(rows),
+                "evaluation_ids": sorted(row["evalreceipt__evaluation_id"] for row in rows),
+            }
+        )
+    finally:
+        await container.shutdown()
+
+
+async def advance(args: argparse.Namespace) -> None:
+    container = ServiceContainer()
+    try:
+        storage = _storage(args)
+        world = await container.world_service.open_world_mutable(storage, args.world_id)
+        await container.simulation_service.step(args.world_id, RunConfig())
+        _emit({"tick": world.tick})
+    finally:
+        await container.shutdown()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "command",
+        choices=(
+            "seed",
+            "crash-publish",
+            "resume-verify",
+            "resume-race",
+            "query-world",
+            "ingest-fact",
+            "query-facts",
+            "evaluate",
+            "evaluate-conflict",
+            "query-receipts",
+            "advance",
+        ),
+    )
+    parser.add_argument("--uri", required=True)
+    parser.add_argument("--namespace", default="process_idempotency")
+    parser.add_argument("--world-id")
+    parser.add_argument("--name", default="process-world")
+    parser.add_argument("--value", type=float, default=1.0)
+    parser.add_argument("--exit-code", type=int, default=91)
+    parser.add_argument("--ready")
+    parser.add_argument("--go")
+    parser.add_argument("--external-id", default="process-event")
+    parser.add_argument("--producer", default="process-producer")
+    parser.add_argument("--evaluation-id", default="process-evaluation")
+    parser.add_argument("--grader-log")
+    return parser
+
+
+async def _main() -> None:
+    args = build_parser().parse_args()
+    commands = {
+        "seed": seed,
+        "crash-publish": crash_publish,
+        "resume-verify": resume_verify,
+        "resume-race": resume_race,
+        "query-world": query_world,
+        "ingest-fact": ingest_fact,
+        "query-facts": query_facts,
+        "evaluate": evaluate,
+        "evaluate-conflict": evaluate_conflict,
+        "query-receipts": query_receipts,
+        "advance": advance,
+    }
+    await commands[args.command](args)
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/evals/run.py
+++ b/evals/run.py
@@ -4,7 +4,8 @@
 """Run all evals and report results.
 
 Usage:
-    python -m evals.run [--out results.json] [--suite regression|capability] [--trials 3]
+    python -m evals.run [--out results.json] [--suite regression|spec|idempotency|capability]
+        [--trials 3]
 
 Reports pass@k (fraction of k trials that passed) and pass^k (1.0 only
 when every one of the k trials passed, 0.0 otherwise) per task, grouped
@@ -18,11 +19,11 @@ import argparse
 import json
 
 from evals.harness import EvalHarness
-from evals.suites import capability, poison_command, regression, spec_contracts
+from evals.suites import capability, idempotency, poison_command, regression, spec_contracts
 from evals.types import TaskResult
 
-REQUIRED_SUITES = frozenset({"regression", "spec"})
-KNOWN_SUITES = ("regression", "spec", "capability")
+REQUIRED_SUITES = frozenset({"regression", "spec", "idempotency"})
+KNOWN_SUITES = ("regression", "spec", "idempotency", "capability")
 
 
 def _positive_int(value: str) -> int:
@@ -41,6 +42,7 @@ def build_harness(trials: int = 1) -> EvalHarness:
     regression.register(harness)
     poison_command.register(harness)
     spec_contracts.register(harness)
+    idempotency.register(harness)
     capability.register(harness)
     return harness
 

--- a/evals/suites/idempotency.py
+++ b/evals/suites/idempotency.py
@@ -1,0 +1,966 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Idempotency eval suite.
+
+These tasks execute the idempotency matrix in ``docs/guide/specification.md``.
+They intentionally cover both sides of the contract:
+
+- operations marked idempotent collapse, reuse, or no-op on repetition
+- operations marked non-idempotent produce distinct observable effects
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from uuid_utils import uuid7
+
+from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
+from archetype.app.auth.models import ActorCtx
+from archetype.app.broker import CommandBroker
+from archetype.app.container import ServiceContainer
+from archetype.app.models import Command, CommandType
+from archetype.app.storage_service import StorageService
+from archetype.app.world_service import WorldService
+from archetype.core.archetype import Archetype
+from archetype.core.component import Component
+from archetype.core.config import CacheConfig, RunConfig, StorageConfig, WorldConfig
+from archetype.core.hooks import OnComponentAdded, OnComponentRemoved
+from archetype.core.sync import QueryManager
+from evals.graders import exact_match, state_check
+from evals.harness import EvalHarness
+from evals.types import GraderResult
+
+SUITE = "idempotency"
+ROOT = Path(__file__).resolve().parents[2]
+SPECIFICATION = ROOT / "docs" / "guide" / "specification.md"
+
+
+@dataclass(frozen=True)
+class IdempotencyCase:
+    """One row from the normative idempotency matrix mapped to an eval task."""
+
+    operation: str
+    expected_contract: str
+    task_id: str
+
+
+IDEMPOTENCY_CASES: tuple[IdempotencyCase, ...] = (
+    IdempotencyCase(
+        operation="`StorageService.get_or_create_store(key)`",
+        expected_contract=(
+            "Idempotent per `(uri, namespace, backend, cache config)` within one service instance"
+        ),
+        task_id="idempotency.storage_pooling_and_shutdown",
+    ),
+    IdempotencyCase(
+        operation="`WorldService.create_world(world_id=X)`",
+        expected_contract="Idempotent by explicit `world_id`",
+        task_id="idempotency.world_lifecycle",
+    ),
+    IdempotencyCase(
+        operation="`WorldService.destroy_world(missing)`",
+        expected_contract="Safe no-op",
+        task_id="idempotency.world_lifecycle",
+    ),
+    IdempotencyCase(
+        operation="`AsyncCachedStore.shutdown()`",
+        expected_contract="Idempotent",
+        task_id="idempotency.storage_pooling_and_shutdown",
+    ),
+    IdempotencyCase(
+        operation="`CommandBroker.enqueue()`",
+        expected_contract="Not idempotent; duplicate logical commands remain distinct",
+        task_id="idempotency.broker_and_submit_non_idempotent",
+    ),
+    IdempotencyCase(
+        operation="`CommandService.submit()`",
+        expected_contract="Not idempotent; duplicate submits create duplicate commands",
+        task_id="idempotency.broker_and_submit_non_idempotent",
+    ),
+    IdempotencyCase(
+        operation="`CommandService.submit_spawn()`",
+        expected_contract=(
+            "Returns one reserved `entity_id` per successful call; repeated calls create new "
+            "entities unless the caller reuses an explicit reservation"
+        ),
+        task_id="idempotency.submit_spawn_distinct_entities",
+    ),
+    IdempotencyCase(
+        operation="`AsyncWorld.create_entity()`",
+        expected_contract="Not idempotent; each call allocates a new world-local entity ID",
+        task_id="idempotency.async_world_entity_ids_and_missing_remove",
+    ),
+    IdempotencyCase(
+        operation="`AsyncWorld.remove_entity(missing)`",
+        expected_contract="Safe no-op with observability",
+        task_id="idempotency.async_world_entity_ids_and_missing_remove",
+    ),
+    IdempotencyCase(
+        operation="`RuntimeWorld.as_actor(ctx)`",
+        expected_contract=(
+            "Idempotent as handle binding only; creates another alias, not another world"
+        ),
+        task_id="idempotency.runtime_aliases_and_history",
+    ),
+    IdempotencyCase(
+        operation="Duplicate despawn in one tick",
+        expected_contract="Idempotent collapse by entity ID",
+        task_id="idempotency.same_tick_duplicate_mutations",
+    ),
+    IdempotencyCase(
+        operation="Duplicate spawn for same entity in one tick",
+        expected_contract="Deterministic last-write-wins",
+        task_id="idempotency.same_tick_duplicate_mutations",
+    ),
+    IdempotencyCase(
+        operation="`RuntimeWorld.history()`",
+        expected_contract="Idempotent for fixed audit history",
+        task_id="idempotency.runtime_aliases_and_history",
+    ),
+    IdempotencyCase(
+        operation="`add_components()` with no signature change",
+        expected_contract="Idempotent no-op",
+        task_id="idempotency.component_signature_noops",
+    ),
+    IdempotencyCase(
+        operation="`remove_components()` with no signature change",
+        expected_contract="Idempotent no-op",
+        task_id="idempotency.component_signature_noops",
+    ),
+    IdempotencyCase(
+        operation="`world.step()`",
+        expected_contract="Not idempotent; advances tick and appends new rows",
+        task_id="idempotency.step_and_run_non_idempotent",
+    ),
+    IdempotencyCase(
+        operation="`world.run()`",
+        expected_contract="Not idempotent; performs multiple steps under one run contract",
+        task_id="idempotency.step_and_run_non_idempotent",
+    ),
+    IdempotencyCase(
+        operation="`QueryManager.query_archetype()`",
+        expected_contract="Idempotent for fixed persisted state",
+        task_id="idempotency.query_archetype_repeatable",
+    ),
+)
+
+
+class IdemCounter(Component):
+    value: int = 0
+
+
+class IdemMarker(Component):
+    label: str = ""
+
+
+def _admin() -> ActorCtx:
+    return ActorCtx(id=uuid7(), roles={"admin"})
+
+
+def _pending_rows(world) -> tuple[int, int]:
+    spawn_rows = sum(len(rows) for rows in world.spawn_cache.values())
+    despawn_rows = sum(len(rows) for rows in world.despawn_cache.values())
+    return spawn_rows, despawn_rows
+
+
+def contract_map() -> list[dict[str, str]]:
+    """Inspectable matrix-to-task map for this suite."""
+    return [
+        {
+            "operation": case.operation,
+            "expected_contract": case.expected_contract,
+            "task_id": case.task_id,
+        }
+        for case in IDEMPOTENCY_CASES
+    ]
+
+
+def _registered_task_ids() -> set[str]:
+    harness = EvalHarness()
+    register(harness)
+    return {task_id for task_id, _, _, _ in harness._tasks}
+
+
+def task_manifest_traceability() -> list[GraderResult]:
+    """Every idempotency matrix row maps to a registered eval task."""
+    text = SPECIFICATION.read_text() if SPECIFICATION.exists() else ""
+    registered = _registered_task_ids()
+    checks: dict[str, bool] = {
+        "specification_exists": SPECIFICATION.exists(),
+        "all_task_ids_registered": all(case.task_id in registered for case in IDEMPOTENCY_CASES),
+    }
+    for case in IDEMPOTENCY_CASES:
+        checks[f"{case.operation}:operation_anchor"] = case.operation in text
+        checks[f"{case.operation}:contract_anchor"] = case.expected_contract in text
+
+    mapped_operations = {case.operation for case in IDEMPOTENCY_CASES}
+    checks["unique_operations"] = len(mapped_operations) == len(IDEMPOTENCY_CASES)
+
+    return [state_check(checks, name="idempotency_manifest_traceability")]
+
+
+def task_storage_pooling_and_shutdown() -> list[GraderResult]:
+    """Storage pooling and cached-store shutdown are repeat-safe."""
+    return asyncio.run(_task_storage_pooling_and_shutdown())
+
+
+async def _task_storage_pooling_and_shutdown() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        service = StorageService()
+        storage = StorageConfig(uri=f"{tmp}/store", namespace="idem")
+        other_namespace = storage.model_copy(update={"namespace": "idem_other"})
+        cache = CacheConfig(flush_rows=10_000, flush_mb=10_000, global_mb=10_000, idle_sec=3600)
+        try:
+            plain_a = await service.get_or_create_store(storage)
+            plain_b = await service.get_or_create_store(storage)
+            cached_a = await service.get_or_create_store(storage, cache)
+            cached_b = await service.get_or_create_store(storage, cache)
+            other = await service.get_or_create_store(other_namespace)
+
+            # The cached store itself owns an idempotent shutdown contract.
+            await cached_a.shutdown()
+            await cached_a.shutdown()
+
+            # The service wrapper should also tolerate repeated shutdowns.
+            await service.shutdown()
+            await service.shutdown()
+
+            return [
+                state_check(
+                    {
+                        "same_config_reuses_plain_store": plain_a is plain_b,
+                        "same_cache_config_reuses_cached_store": cached_a is cached_b,
+                        "cache_config_is_part_of_pool_key": plain_a is not cached_a,
+                        "namespace_is_part_of_pool_key": plain_a is not other,
+                    },
+                    name="storage_pooling_contract",
+                )
+            ]
+        finally:
+            await service.shutdown()
+
+
+def task_world_lifecycle_idempotency() -> list[GraderResult]:
+    """Explicit world IDs collapse creates; missing and double destroys no-op."""
+    return asyncio.run(_task_world_lifecycle_idempotency())
+
+
+async def _task_world_lifecycle_idempotency() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        storage_service = StorageService()
+        worlds = WorldService(storage_service)
+        storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_worlds")
+        world_id = uuid7()
+        try:
+            first = await worlds.create_world(
+                WorldConfig(world_id=world_id, name="idem-lifecycle"),
+                storage,
+            )
+            second = await worlds.create_world(
+                WorldConfig(world_id=world_id, name="ignored-on-repeat"),
+                storage,
+            )
+            before_destroy = len(worlds.list_worlds())
+
+            await worlds.destroy_world(uuid7())
+            after_missing_destroy = len(worlds.list_worlds())
+            await worlds.destroy_world(world_id)
+            after_first_destroy = len(worlds.list_worlds())
+            await worlds.destroy_world(world_id)
+            after_second_destroy = len(worlds.list_worlds())
+
+            return [
+                state_check(
+                    {
+                        "explicit_world_id_returns_same_instance": first is second,
+                        "repeat_create_does_not_insert_duplicate": before_destroy == 1,
+                        "missing_destroy_is_noop": after_missing_destroy == before_destroy,
+                        "destroy_removes_once": after_first_destroy == 0,
+                        "double_destroy_remains_noop": after_second_destroy == 0,
+                    },
+                    name="world_lifecycle_idempotency",
+                )
+            ]
+        finally:
+            await worlds.shutdown()
+
+
+def task_broker_and_submit_are_not_idempotent() -> list[GraderResult]:
+    """Duplicate logical broker/submit commands remain distinct queued work."""
+    return asyncio.run(_task_broker_and_submit_are_not_idempotent())
+
+
+async def _task_broker_and_submit_are_not_idempotent() -> list[GraderResult]:
+    reset_tick_counters()
+    reset_daily_tokens()
+    try:
+        broker = CommandBroker()
+        direct_a = Command(type=CommandType.SPAWN, payload={"components": []})
+        direct_b = Command(type=CommandType.SPAWN, payload={"components": []})
+        await broker.enqueue("direct-world", direct_a)
+        await broker.enqueue("direct-world", direct_b)
+        direct_pending = await broker.get_pending_count("direct-world")
+        direct_history = await broker.get_history("direct-world")
+        direct_dequeued = await broker.dequeue("direct-world")
+        direct_pending_after = await broker.get_pending_count("direct-world")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            container = ServiceContainer()
+            try:
+                storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_submit")
+                world = await container.world_service.create_world(
+                    WorldConfig(name="submit-non-idempotent"),
+                    storage,
+                )
+                admin = _admin()
+                service_a = Command(type=CommandType.SPAWN, payload={"components": []})
+                service_b = Command(type=CommandType.SPAWN, payload={"components": []})
+
+                service_id_a = await container.command_service.submit(
+                    admin,
+                    world.world_id,
+                    service_a,
+                )
+                service_id_b = await container.command_service.submit(
+                    admin,
+                    world.world_id,
+                    service_b,
+                )
+                service_pending = await container.broker.get_pending_count(world.world_id)
+                service_history = await container.broker.get_history(world.world_id)
+            finally:
+                await container.shutdown()
+
+        return [
+            state_check(
+                {
+                    "broker_keeps_two_pending_commands": direct_pending == 2,
+                    "broker_history_keeps_both_commands": len(direct_history) == 2,
+                    "broker_dequeues_both_commands": len(direct_dequeued) == 2,
+                    "broker_drain_clears_queue": direct_pending_after == 0,
+                    "submit_returns_distinct_command_ids": service_id_a != service_id_b,
+                    "submit_keeps_two_pending_commands": service_pending == 2,
+                    "submit_history_keeps_both_commands": len(service_history) == 2,
+                },
+                name="queued_commands_are_not_deduplicated",
+            )
+        ]
+    finally:
+        reset_tick_counters()
+        reset_daily_tokens()
+
+
+def task_submit_spawn_reserves_distinct_entities() -> list[GraderResult]:
+    """Repeated submit_spawn calls reserve and materialize distinct entities."""
+    return asyncio.run(_task_submit_spawn_reserves_distinct_entities())
+
+
+async def _task_submit_spawn_reserves_distinct_entities() -> list[GraderResult]:
+    reset_tick_counters()
+    reset_daily_tokens()
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_spawn")
+            world = await container.world_service.create_world(
+                WorldConfig(name="submit-spawn"),
+                storage,
+            )
+            admin = _admin()
+            first = await container.command_service.submit_spawn(
+                admin,
+                world.world_id,
+                [IdemCounter(value=1)],
+            )
+            second = await container.command_service.submit_spawn(
+                admin,
+                world.world_id,
+                [IdemCounter(value=2)],
+            )
+            pending_before = await container.broker.get_pending_count(world.world_id)
+            applied = await container.simulation_service.step(world.world_id, RunConfig())
+            pending_after = await container.broker.get_pending_count(world.world_id)
+
+            rows = (await world.query_archetype(sig=(IdemCounter,), ticks=[0])).to_pylist()
+            values_by_entity = {row["entity_id"]: row["idemcounter__value"] for row in rows}
+
+            return [
+                state_check(
+                    {
+                        "reserved_ids_are_monotonic": [first, second] == [1, 2],
+                        "reserved_ids_are_distinct": first != second,
+                        "both_spawns_were_queued": pending_before == 2,
+                        "both_spawns_were_applied": applied == 2,
+                        "queue_drained_after_step": pending_after == 0,
+                        "both_entities_materialized": set(values_by_entity) == {1, 2},
+                        "entity_values_remain_distinct": values_by_entity == {1: 1, 2: 2},
+                    },
+                    name="submit_spawn_non_idempotency",
+                )
+            ]
+        finally:
+            await container.shutdown()
+            reset_tick_counters()
+            reset_daily_tokens()
+
+
+def task_async_world_entity_ids_and_missing_remove() -> list[GraderResult]:
+    """AsyncWorld create_entity allocates IDs; missing remove is observable no-op."""
+    return asyncio.run(_task_async_world_entity_ids_and_missing_remove())
+
+
+async def _task_async_world_entity_ids_and_missing_remove() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        storage_service = StorageService()
+        worlds = WorldService(storage_service)
+        storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_async_world")
+        records: list[str] = []
+
+        class _ListHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record.getMessage())
+
+        logger = logging.getLogger("archetype.core.aio.async_world")
+        handler = _ListHandler()
+        previous_level = logger.level
+
+        try:
+            world = await worlds.create_world(WorldConfig(name="async-world-ids"), storage)
+            first = await world.create_entity([IdemCounter(value=11)])
+            second = await world.create_entity([IdemCounter(value=22)])
+            before_missing_remove = (
+                dict(world.entity2sig),
+                {sig: list(rows) for sig, rows in world.spawn_cache.items()},
+                {sig: list(rows) for sig, rows in world.despawn_cache.items()},
+            )
+
+            logger.addHandler(handler)
+            logger.setLevel(logging.WARNING)
+            await world.remove_entity(999_999)
+            logger.removeHandler(handler)
+            logger.setLevel(previous_level)
+
+            after_missing_remove = (
+                dict(world.entity2sig),
+                {sig: list(rows) for sig, rows in world.spawn_cache.items()},
+                {sig: list(rows) for sig, rows in world.despawn_cache.items()},
+            )
+            await world.step(RunConfig())
+            rows = (await world.query_archetype(sig=(IdemCounter,), ticks=[0])).to_pylist()
+            values_by_entity = {row["entity_id"]: row["idemcounter__value"] for row in rows}
+
+            return [
+                state_check(
+                    {
+                        "create_entity_allocates_distinct_ids": [first, second] == [1, 2],
+                        "missing_remove_preserves_world_state": (
+                            after_missing_remove == before_missing_remove
+                        ),
+                        "missing_remove_logs_observability": any(
+                            "Entity Removal Failed" in message and "999999" in message
+                            for message in records
+                        ),
+                        "created_entities_materialize": values_by_entity == {1: 11, 2: 22},
+                    },
+                    name="async_world_entity_ids_and_missing_remove",
+                )
+            ]
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(previous_level)
+            await worlds.shutdown()
+
+
+def task_runtime_aliases_and_history() -> list[GraderResult]:
+    """Runtime aliases bind handles without creating worlds; fixed history is stable."""
+    return asyncio.run(_task_runtime_aliases_and_history())
+
+
+async def _task_runtime_aliases_and_history() -> list[GraderResult]:
+    from archetype.runtime import ArchetypeRuntime
+
+    reset_tick_counters()
+    reset_daily_tokens()
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            admin = _admin()
+            sibling_ctx = ActorCtx(id=uuid7(), roles={"admin"})
+            async with ArchetypeRuntime(actor_ctx=admin) as runtime:
+                storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_runtime")
+                world = runtime.world("runtime-alias", storage=storage)
+                sibling_a = world.as_actor(sibling_ctx)
+                sibling_b = world.as_actor(sibling_ctx)
+                aliases_before_activation = len(world._state.aliases)
+                worlds_before_activation = len(runtime._container.world_service.list_worlds())
+
+                await world.spawn(IdemCounter(value=7))
+                worlds_after_activation = len(runtime._container.world_service.list_worlds())
+                world_info = await world.info()
+                sibling_info = await sibling_a.info()
+
+                # Fixed empty filter: each gated read emits an audit row, but not
+                # one matching this key, so the visible history remains stable.
+                history_a = await sibling_a.history(idempotency_key="no-such-idempotency-key")
+                history_b = await sibling_b.history(idempotency_key="no-such-idempotency-key")
+
+                return [
+                    state_check(
+                        {
+                            "aliases_share_state": (
+                                world._state is sibling_a._state is sibling_b._state
+                            ),
+                            "aliases_keep_distinct_actor_contexts": (
+                                world._ctx.id == admin.id and sibling_a._ctx.id == sibling_ctx.id
+                            ),
+                            "aliases_do_not_create_worlds_pre_activation": (
+                                aliases_before_activation == 3 and worlds_before_activation == 0
+                            ),
+                            "aliases_create_only_one_world_on_activation": (
+                                worlds_after_activation == 1
+                            ),
+                            "alias_resolves_same_world_id": (
+                                str(world_info.world_id) == str(sibling_info.world_id)
+                            ),
+                            "fixed_history_first_read_empty": history_a.count_rows() == 0,
+                            "fixed_history_second_read_still_empty": history_b.count_rows() == 0,
+                        },
+                        name="runtime_aliases_and_history",
+                    )
+                ]
+    finally:
+        reset_tick_counters()
+        reset_daily_tokens()
+
+
+def task_duplicate_same_tick_mutations_collapse() -> list[GraderResult]:
+    """Same-entity duplicate spawn/despawn commands collapse at materialization."""
+    return asyncio.run(_task_duplicate_same_tick_mutations_collapse())
+
+
+async def _task_duplicate_same_tick_mutations_collapse() -> list[GraderResult]:
+    reset_tick_counters()
+    reset_daily_tokens()
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_dupes")
+            world = await container.world_service.create_world(
+                WorldConfig(name="duplicate-mutations"),
+                storage,
+            )
+            admin = _admin()
+
+            await container.command_service.submit(
+                admin,
+                world.world_id,
+                Command(
+                    type=CommandType.SPAWN,
+                    tick=0,
+                    payload={"entity_id": 77, "components": [IdemCounter(value=1)]},
+                ),
+            )
+            await container.command_service.submit(
+                admin,
+                world.world_id,
+                Command(
+                    type=CommandType.SPAWN,
+                    tick=0,
+                    payload={"entity_id": 77, "components": [IdemCounter(value=9)]},
+                ),
+            )
+            spawn_applied = await container.simulation_service.step(world.world_id, RunConfig())
+            spawn_rows = (await world.query_archetype(sig=(IdemCounter,), ticks=[0])).to_pylist()
+
+            await container.command_service.submit(
+                admin,
+                world.world_id,
+                Command(type=CommandType.DESPAWN, tick=1, payload={"entity_id": 77}),
+            )
+            await container.command_service.submit(
+                admin,
+                world.world_id,
+                Command(type=CommandType.DESPAWN, tick=1, payload={"entity_id": 77}),
+            )
+            despawn_applied = await container.simulation_service.step(world.world_id, RunConfig())
+            store = await container.storage_service.get_or_create_store(storage)
+            despawn_rows = (
+                await store.get_archetype_df(
+                    sig=(IdemCounter,),
+                    world_id=str(world.world_id),
+                    run_id=str(world.run_id),
+                    ticks=[1],
+                    active_only=False,
+                )
+            ).to_pylist()
+
+            spawn_value = spawn_rows[0]["idemcounter__value"] if spawn_rows else None
+            spawn_active = spawn_rows[0]["is_active"] if spawn_rows else None
+            despawn_active = despawn_rows[0]["is_active"] if despawn_rows else None
+
+            return [
+                state_check(
+                    {
+                        "both_duplicate_spawns_applied": spawn_applied == 2,
+                        "duplicate_spawn_materialized_once": len(spawn_rows) == 1,
+                        "duplicate_spawn_last_write_wins": spawn_value == 9,
+                        "spawn_row_starts_active": spawn_active is True,
+                        "both_duplicate_despawns_applied": despawn_applied == 2,
+                        "duplicate_despawn_materialized_once": len(despawn_rows) == 1,
+                        "duplicate_despawn_marks_inactive": despawn_active is False,
+                    },
+                    name="same_tick_duplicate_mutation_collapse",
+                )
+            ]
+        finally:
+            await container.shutdown()
+            reset_tick_counters()
+            reset_daily_tokens()
+
+
+def task_component_signature_noops_are_idempotent() -> list[GraderResult]:
+    """Adding existing or removing absent component types is a no-op."""
+    return asyncio.run(_task_component_signature_noops_are_idempotent())
+
+
+async def _task_component_signature_noops_are_idempotent() -> list[GraderResult]:
+    reset_tick_counters()
+    reset_daily_tokens()
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_component_noops")
+            world = await container.world_service.create_world(
+                WorldConfig(name="component-noops"),
+                storage,
+            )
+            admin = _admin()
+            entity_id = await world.create_entity([IdemCounter(value=3)])
+            await world.step(RunConfig())
+
+            added: list[int] = []
+            removed: list[int] = []
+
+            async def on_added(event: OnComponentAdded) -> None:
+                added.append(event.entity_id)
+
+            async def on_removed(event: OnComponentRemoved) -> None:
+                removed.append(event.entity_id)
+
+            world.add_hook(OnComponentAdded, on_added)
+            world.add_hook(OnComponentRemoved, on_removed)
+
+            signature_before = world.entity2sig[entity_id]
+            await container.command_service.add_components(
+                admin,
+                world.world_id,
+                entity_id,
+                [IdemCounter(value=99)],
+            )
+            after_add_signature = world.entity2sig[entity_id]
+            after_add_pending = _pending_rows(world)
+
+            await container.command_service.remove_components(
+                admin,
+                world.world_id,
+                entity_id,
+                [IdemMarker],
+            )
+            after_remove_signature = world.entity2sig[entity_id]
+            after_remove_pending = _pending_rows(world)
+
+            return [
+                state_check(
+                    {
+                        "add_existing_component_keeps_signature": (
+                            after_add_signature == signature_before
+                        ),
+                        "remove_absent_component_keeps_signature": (
+                            after_remove_signature == signature_before
+                        ),
+                        "add_existing_component_stages_no_rows": after_add_pending == (0, 0),
+                        "remove_absent_component_stages_no_rows": after_remove_pending == (0, 0),
+                        "no_component_added_hook_fired": added == [],
+                        "no_component_removed_hook_fired": removed == [],
+                    },
+                    name="component_signature_noops",
+                )
+            ]
+        finally:
+            await container.shutdown()
+            reset_tick_counters()
+            reset_daily_tokens()
+
+
+def task_fixed_reads_are_idempotent() -> list[GraderResult]:
+    """Repeated query/history reads over fixed persisted state are stable."""
+    return asyncio.run(_task_fixed_reads_are_idempotent())
+
+
+async def _task_fixed_reads_are_idempotent() -> list[GraderResult]:
+    reset_tick_counters()
+    reset_daily_tokens()
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_reads")
+            world = await container.world_service.create_world(
+                WorldConfig(name="fixed-reads"),
+                storage,
+            )
+            admin = _admin()
+            await container.command_service.submit_spawn(
+                admin,
+                world.world_id,
+                [IdemCounter(value=5)],
+            )
+            await container.simulation_service.step(world.world_id, RunConfig())
+
+            rows_a = (
+                await container.query_service.query_components(
+                    [IdemCounter],
+                    str(world.world_id),
+                    str(world.run_id),
+                    storage,
+                )
+            ).to_pylist()
+            rows_b = (
+                await container.query_service.query_components(
+                    [IdemCounter],
+                    str(world.world_id),
+                    str(world.run_id),
+                    storage,
+                )
+            ).to_pylist()
+            history_a = await container.query_service.get_command_history(str(world.world_id))
+            history_b = await container.query_service.get_command_history(str(world.world_id))
+            signatures_a = await container.query_service.list_signatures(storage)
+            signatures_b = await container.query_service.list_signatures(storage)
+
+            history_shape_a = [(cmd.id, cmd.type) for cmd in history_a]
+            history_shape_b = [(cmd.id, cmd.type) for cmd in history_b]
+            signature_names_a = sorted(tuple(c.__name__ for c in sig) for sig in signatures_a)
+            signature_names_b = sorted(tuple(c.__name__ for c in sig) for sig in signatures_b)
+
+            return [
+                exact_match(rows_a, rows_b, name="query_components_repeatable"),
+                exact_match(history_shape_a, history_shape_b, name="history_repeatable"),
+                exact_match(signature_names_a, signature_names_b, name="signatures_repeatable"),
+            ]
+        finally:
+            await container.shutdown()
+            reset_tick_counters()
+            reset_daily_tokens()
+
+
+def task_query_archetype_repeatable() -> list[GraderResult]:
+    """Sync QueryManager.query_archetype is stable for fixed persisted state."""
+    import daft
+
+    sig = (IdemCounter,)
+    rows = [
+        Archetype.to_row_dict(
+            entity_id=1,
+            tick=0,
+            components=[IdemCounter(value=101)],
+            world_id="idem-query-world",
+            run_id="idem-query-run",
+        ),
+        {
+            **Archetype.to_row_dict(
+                entity_id=2,
+                tick=0,
+                components=[IdemCounter(value=202)],
+                world_id="idem-query-world",
+                run_id="idem-query-run",
+            ),
+            "is_active": False,
+        },
+    ]
+    fixed_df = daft.from_pylist(rows)
+    calls: list[tuple[tuple[type[Component], ...], str, str]] = []
+
+    class _Store:
+        def get_archetype_df(self, requested_sig, world_id, run_id):
+            calls.append((requested_sig, world_id, run_id))
+            return fixed_df
+
+    query = QueryManager(store=_Store())
+    first = (
+        query.query_archetype(
+            sig=sig,
+            world_id="idem-query-world",
+            run_id="idem-query-run",
+            ticks=[0],
+            entity_ids=[1],
+        )
+        .collect()
+        .to_pylist()
+    )
+    second = (
+        query.query_archetype(
+            sig=sig,
+            world_id="idem-query-world",
+            run_id="idem-query-run",
+            ticks=[0],
+            entity_ids=[1],
+        )
+        .collect()
+        .to_pylist()
+    )
+
+    return [
+        exact_match(first, second, name="query_archetype_repeatable_rows"),
+        state_check(
+            {
+                "one_active_filtered_row": len(first) == 1,
+                "world_scoped": first[0].get("world_id") == "idem-query-world" if first else False,
+                "run_scoped": first[0].get("run_id") == "idem-query-run" if first else False,
+                "entity_filtered": first[0].get("entity_id") == 1 if first else False,
+                "tick_filtered": first[0].get("tick") == 0 if first else False,
+                "active_only": first[0].get("is_active") is True if first else False,
+                "component_value_preserved": (
+                    first[0].get("idemcounter__value") == 101 if first else False
+                ),
+            },
+            name="query_archetype_fixed_filters",
+        ),
+        exact_match(
+            calls,
+            [
+                (sig, "idem-query-world", "idem-query-run"),
+                (sig, "idem-query-world", "idem-query-run"),
+            ],
+            name="query_archetype_scopes_by_world_and_run",
+        ),
+    ]
+
+
+def task_step_and_run_are_not_idempotent() -> list[GraderResult]:
+    """Repeated step/run calls advance time and append additional tick rows."""
+    return asyncio.run(_task_step_and_run_are_not_idempotent())
+
+
+async def _task_step_and_run_are_not_idempotent() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_step_run")
+            world = await container.world_service.create_world(
+                WorldConfig(name="step-run"),
+                storage,
+            )
+            await world.create_entity([IdemCounter(value=8)])
+
+            start_tick = world.tick
+            await world.step(RunConfig())
+            after_first_step = world.tick
+            await world.step(RunConfig())
+            after_second_step = world.tick
+
+            run_one = await container.simulation_service.run(world.world_id, RunConfig(num_steps=1))
+            run_two = await container.simulation_service.run(world.world_id, RunConfig(num_steps=1))
+
+            tick0_rows = (await world.query_archetype(sig=(IdemCounter,), ticks=[0])).to_pylist()
+            tick1_rows = (await world.query_archetype(sig=(IdemCounter,), ticks=[1])).to_pylist()
+            tick2_rows = (await world.query_archetype(sig=(IdemCounter,), ticks=[2])).to_pylist()
+            tick3_rows = (await world.query_archetype(sig=(IdemCounter,), ticks=[3])).to_pylist()
+
+            return [
+                state_check(
+                    {
+                        "first_step_advances_tick": (start_tick, after_first_step) == (0, 1),
+                        "second_step_advances_again": after_second_step == 2,
+                        "first_run_advances_again": run_one.final_tick == 3,
+                        "second_run_advances_again": run_two.final_tick == 4,
+                        "tick0_row_exists": len(tick0_rows) == 1,
+                        "tick1_row_exists": len(tick1_rows) == 1,
+                        "tick2_row_exists": len(tick2_rows) == 1,
+                        "tick3_row_exists": len(tick3_rows) == 1,
+                    },
+                    name="step_and_run_non_idempotency",
+                )
+            ]
+        finally:
+            await container.shutdown()
+
+
+def register(harness: EvalHarness) -> None:
+    """Register all idempotency tasks on the harness."""
+    harness.add(
+        "idempotency.manifest_traceability",
+        suite=SUITE,
+        fn=task_manifest_traceability,
+        desc="Idempotency matrix rows cite spec anchors and registered eval tasks.",
+    )
+    harness.add(
+        "idempotency.storage_pooling_and_shutdown",
+        suite=SUITE,
+        fn=task_storage_pooling_and_shutdown,
+        desc="StorageService pooling and cached-store shutdown idempotency.",
+    )
+    harness.add(
+        "idempotency.world_lifecycle",
+        suite=SUITE,
+        fn=task_world_lifecycle_idempotency,
+        desc="WorldService explicit-ID create and missing/double destroy idempotency.",
+    )
+    harness.add(
+        "idempotency.broker_and_submit_non_idempotent",
+        suite=SUITE,
+        fn=task_broker_and_submit_are_not_idempotent,
+        desc="CommandBroker.enqueue and CommandService.submit keep duplicate logical commands.",
+    )
+    harness.add(
+        "idempotency.submit_spawn_distinct_entities",
+        suite=SUITE,
+        fn=task_submit_spawn_reserves_distinct_entities,
+        desc="Repeated submit_spawn calls reserve and materialize distinct entity IDs.",
+    )
+    harness.add(
+        "idempotency.async_world_entity_ids_and_missing_remove",
+        suite=SUITE,
+        fn=task_async_world_entity_ids_and_missing_remove,
+        desc="AsyncWorld create_entity allocates IDs and missing remove is observable no-op.",
+    )
+    harness.add(
+        "idempotency.runtime_aliases_and_history",
+        suite=SUITE,
+        fn=task_runtime_aliases_and_history,
+        desc="RuntimeWorld.as_actor aliases handles and fixed-filter history remains stable.",
+    )
+    harness.add(
+        "idempotency.same_tick_duplicate_mutations",
+        suite=SUITE,
+        fn=task_duplicate_same_tick_mutations_collapse,
+        desc="Duplicate same-entity spawn/despawn commands collapse at materialization.",
+    )
+    harness.add(
+        "idempotency.component_signature_noops",
+        suite=SUITE,
+        fn=task_component_signature_noops_are_idempotent,
+        desc="No-signature-change add/remove component calls stage no rows and fire no hooks.",
+    )
+    harness.add(
+        "idempotency.fixed_reads",
+        suite=SUITE,
+        fn=task_fixed_reads_are_idempotent,
+        desc="Repeated fixed-state query, history, and signature reads are stable.",
+    )
+    harness.add(
+        "idempotency.query_archetype_repeatable",
+        suite=SUITE,
+        fn=task_query_archetype_repeatable,
+        desc="Sync QueryManager.query_archetype is repeatable for fixed persisted state.",
+    )
+    harness.add(
+        "idempotency.step_and_run_non_idempotent",
+        suite=SUITE,
+        fn=task_step_and_run_are_not_idempotent,
+        desc="Repeated step/run calls advance time and append additional rows.",
+    )

--- a/evals/suites/idempotency.py
+++ b/evals/suites/idempotency.py
@@ -4,10 +4,12 @@
 """Idempotency eval suite.
 
 These tasks execute the idempotency matrix in ``docs/guide/specification.md``.
-They intentionally cover both sides of the contract:
+They intentionally cover repetition, concurrency, and crash-retry boundaries:
 
 - operations marked idempotent collapse, reuse, or no-op on repetition
 - operations marked non-idempotent produce distinct observable effects
+- durable operations converge on one visible outcome after races or failures
+- identity reuse with different content fails loudly instead of silently merging
 """
 
 from __future__ import annotations
@@ -27,13 +29,27 @@ from archetype.app.container import ServiceContainer
 from archetype.app.models import Command, CommandType
 from archetype.app.storage_service import StorageService
 from archetype.app.world_service import WorldService
-from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import CacheConfig, RunConfig, StorageConfig, WorldConfig
 from archetype.core.hooks import OnComponentAdded, OnComponentRemoved
-from archetype.core.sync import QueryManager
+from archetype.core.sync import QueryManager, SyncStore, UpdateManager
+from archetype.runtime.session import configure_session
 from evals.graders import exact_match, state_check
 from evals.harness import EvalHarness
+from evals.suites.idempotency_durable import (
+    task_atomic_publish_retry,
+    task_durable_discovery,
+    task_durable_fact_crash_recovery,
+    task_durable_fact_replay,
+    task_evaluation_receipt_replay,
+    task_resume_and_writer_fencing,
+)
+from evals.suites.idempotency_process import (
+    task_process_crash_cold_resume,
+    task_process_evaluation_replay,
+    task_process_fact_replay,
+    task_process_writer_fence_race,
+)
 from evals.types import GraderResult
 
 SUITE = "idempotency"
@@ -148,6 +164,97 @@ IDEMPOTENCY_CASES: tuple[IdempotencyCase, ...] = (
         expected_contract="Idempotent for fixed persisted state",
         task_id="idempotency.query_archetype_repeatable",
     ),
+    IdempotencyCase(
+        operation="Store `append()` replay",
+        expected_contract="Not idempotent; repeating an append persists duplicate rows",
+        task_id="idempotency.query_archetype_repeatable",
+    ),
+    IdempotencyCase(
+        operation="Updater `update()` replay",
+        expected_contract="Not idempotent; repeating an update appends another row version",
+        task_id="idempotency.query_archetype_repeatable",
+    ),
+    IdempotencyCase(
+        operation="Store `get_archetype_df()` replay",
+        expected_contract="Idempotent for the same persisted data",
+        task_id="idempotency.query_archetype_repeatable",
+    ),
+    IdempotencyCase(
+        operation="`QueryService` fixed-state reads",
+        expected_contract="Idempotent for fixed rows, history, and signature catalog",
+        task_id="idempotency.fixed_reads",
+    ),
+    IdempotencyCase(
+        operation="Catalog re-registration",
+        expected_contract=(
+            "Same identity and content is an idempotent no-op; different content conflicts loudly"
+        ),
+        task_id="idempotency.durable_discovery",
+    ),
+    IdempotencyCase(
+        operation="Coordinated tick retry after failed publish",
+        expected_contract=(
+            "Unpublished attempts stay invisible; retry produces exactly one visible attempt"
+        ),
+        task_id="idempotency.atomic_publish_retry",
+    ),
+    IdempotencyCase(
+        operation="Cold discovery and reads",
+        expected_contract="Repeated cold discovery and reads return stable durable state",
+        task_id="idempotency.durable_discovery",
+    ),
+    IdempotencyCase(
+        operation="Fenced mutable resume",
+        expected_contract=(
+            "Resume continues from the last visible tick and stale-writer retries stay invisible"
+        ),
+        task_id="idempotency.resume_and_writer_fencing",
+    ),
+    IdempotencyCase(
+        operation="`ingest_fact()` replay",
+        expected_contract=(
+            "Identical external identity and payload converges on one visible fact; changed payload conflicts"
+        ),
+        task_id="idempotency.durable_fact_replay",
+    ),
+    IdempotencyCase(
+        operation="`ingest_fact()` crash recovery",
+        expected_contract=(
+            "Lease takeover completes an appended orphan without creating a second visible fact"
+        ),
+        task_id="idempotency.durable_fact_crash_recovery",
+    ),
+    IdempotencyCase(
+        operation="`evaluate()` replay",
+        expected_contract=(
+            "Same evaluation identity, subject, and contract returns one receipt without re-grading"
+        ),
+        task_id="idempotency.evaluation_receipt_replay",
+    ),
+    IdempotencyCase(
+        operation="Hard process crash and cold resume",
+        expected_contract=(
+            "Unpublished physical rows do not advance a fresh process beyond the last visible tick"
+        ),
+        task_id="idempotency.process_crash_cold_resume",
+    ),
+    IdempotencyCase(
+        operation="Independent writer-process race",
+        expected_contract="Exactly one fenced writer publishes the contested tick",
+        task_id="idempotency.process_writer_fence_race",
+    ),
+    IdempotencyCase(
+        operation="Independent process `ingest_fact()` replay",
+        expected_contract="Concurrent processes converge on one visible external fact",
+        task_id="idempotency.process_fact_replay",
+    ),
+    IdempotencyCase(
+        operation="Independent process `evaluate()` replay",
+        expected_contract=(
+            "Concurrent processes grade once, and changed subjects conflict before grading"
+        ),
+        task_id="idempotency.process_evaluation_replay",
+    ),
 )
 
 
@@ -181,28 +288,59 @@ def contract_map() -> list[dict[str, str]]:
     ]
 
 
-def _registered_task_ids() -> set[str]:
+def _registered_tasks() -> list[tuple[str, str, object, str]]:
     harness = EvalHarness()
     register(harness)
-    return {task_id for task_id, _, _, _ in harness._tasks}
+    return list(harness._tasks)
+
+
+def _registered_task_ids() -> set[str]:
+    return {task_id for task_id, _, _, _ in _registered_tasks()}
+
+
+def _spec_matrix_rows(text: str) -> list[tuple[str, str]]:
+    """Parse the normative two-column matrix without a Markdown dependency."""
+    try:
+        section = text.split("## Idempotency Matrix", 1)[1].split("\n## ", 1)[0]
+    except IndexError:
+        return []
+
+    rows: list[tuple[str, str]] = []
+    for line in section.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) != 2 or cells[0] == "Operation" or set(cells[0]) == {"-"}:
+            continue
+        rows.append((cells[0], cells[1]))
+    return rows
+
+
+def traceability_checks() -> dict[str, bool]:
+    """Return fast static checks used by the eval and the lint entry point."""
+    text = SPECIFICATION.read_text() if SPECIFICATION.exists() else ""
+    registered = _registered_task_ids()
+    mapped_rows = [(case.operation, case.expected_contract) for case in IDEMPOTENCY_CASES]
+    mapped_task_ids = {case.task_id for case in IDEMPOTENCY_CASES}
+    parsed_rows = _spec_matrix_rows(text)
+    checks: dict[str, bool] = {
+        "specification_exists": SPECIFICATION.exists(),
+        "matrix_is_not_empty": bool(parsed_rows),
+        "matrix_rows_match_eval_manifest": parsed_rows == mapped_rows,
+        "all_task_ids_registered": mapped_task_ids <= registered,
+        "all_behavior_tasks_mapped": registered
+        == mapped_task_ids | {"idempotency.manifest_traceability"},
+        "unique_operations": len({case.operation for case in IDEMPOTENCY_CASES})
+        == len(IDEMPOTENCY_CASES),
+        "unique_registered_task_ids": len(registered)
+        == len([task_id for task_id, _, _, _ in _registered_tasks()]),
+    }
+    return checks
 
 
 def task_manifest_traceability() -> list[GraderResult]:
     """Every idempotency matrix row maps to a registered eval task."""
-    text = SPECIFICATION.read_text() if SPECIFICATION.exists() else ""
-    registered = _registered_task_ids()
-    checks: dict[str, bool] = {
-        "specification_exists": SPECIFICATION.exists(),
-        "all_task_ids_registered": all(case.task_id in registered for case in IDEMPOTENCY_CASES),
-    }
-    for case in IDEMPOTENCY_CASES:
-        checks[f"{case.operation}:operation_anchor"] = case.operation in text
-        checks[f"{case.operation}:contract_anchor"] = case.expected_contract in text
-
-    mapped_operations = {case.operation for case in IDEMPOTENCY_CASES}
-    checks["unique_operations"] = len(mapped_operations) == len(IDEMPOTENCY_CASES)
-
-    return [state_check(checks, name="idempotency_manifest_traceability")]
+    return [state_check(traceability_checks(), name="idempotency_manifest_traceability")]
 
 
 def task_storage_pooling_and_shutdown() -> list[GraderResult]:
@@ -759,86 +897,74 @@ async def _task_fixed_reads_are_idempotent() -> list[GraderResult]:
 
 
 def task_query_archetype_repeatable() -> list[GraderResult]:
-    """Sync QueryManager.query_archetype is stable for fixed persisted state."""
+    """Real sync store reads repeat; updater replay deliberately appends."""
     import daft
 
-    sig = (IdemCounter,)
-    rows = [
-        Archetype.to_row_dict(
-            entity_id=1,
-            tick=0,
-            components=[IdemCounter(value=101)],
-            world_id="idem-query-world",
-            run_id="idem-query-run",
-        ),
-        {
-            **Archetype.to_row_dict(
-                entity_id=2,
-                tick=0,
-                components=[IdemCounter(value=202)],
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = StorageConfig(uri=f"{tmp}/store", namespace="real_sync_idempotency")
+        store = SyncStore(uri=str(storage.uri), session=configure_session(storage))
+        updater = UpdateManager(store)
+        query = QueryManager(store=store)
+        sig = (IdemCounter,)
+        raw = daft.from_pylist([{"entity_id": 1, "is_active": True, "idemcounter__value": 101}])
+
+        updater.update(raw, sig, tick=0, world_id="idem-query-world", run_id="idem-query-run")
+        first = (
+            query.query_archetype(
+                sig=sig,
                 world_id="idem-query-world",
                 run_id="idem-query-run",
+                ticks=[0],
+                entity_ids=[1],
+            )
+            .collect()
+            .to_pylist()
+        )
+        second = (
+            query.query_archetype(
+                sig=sig,
+                world_id="idem-query-world",
+                run_id="idem-query-run",
+                ticks=[0],
+                entity_ids=[1],
+            )
+            .collect()
+            .to_pylist()
+        )
+
+        updater.update(raw, sig, tick=0, world_id="idem-query-world", run_id="idem-query-run")
+        after_replayed_update = (
+            query.query_archetype(
+                sig=sig,
+                world_id="idem-query-world",
+                run_id="idem-query-run",
+                ticks=[0],
+                entity_ids=[1],
+            )
+            .collect()
+            .to_pylist()
+        )
+        store.shutdown()
+
+        return [
+            exact_match(first, second, name="real_store_fixed_read_repeatability"),
+            state_check(
+                {
+                    "one_active_filtered_row": len(first) == 1,
+                    "world_scoped": first[0].get("world_id") == "idem-query-world"
+                    if first
+                    else False,
+                    "run_scoped": first[0].get("run_id") == "idem-query-run" if first else False,
+                    "entity_filtered": first[0].get("entity_id") == 1 if first else False,
+                    "tick_filtered": first[0].get("tick") == 0 if first else False,
+                    "component_value_preserved": first[0].get("idemcounter__value") == 101
+                    if first
+                    else False,
+                    "replayed_updater_appends_again": len(after_replayed_update) == 2,
+                },
+                name="real_sync_store_contracts",
             ),
-            "is_active": False,
-        },
-    ]
-    fixed_df = daft.from_pylist(rows)
-    calls: list[tuple[tuple[type[Component], ...], str, str]] = []
-
-    class _Store:
-        def get_archetype_df(self, requested_sig, world_id, run_id):
-            calls.append((requested_sig, world_id, run_id))
-            return fixed_df
-
-    query = QueryManager(store=_Store())
-    first = (
-        query.query_archetype(
-            sig=sig,
-            world_id="idem-query-world",
-            run_id="idem-query-run",
-            ticks=[0],
-            entity_ids=[1],
-        )
-        .collect()
-        .to_pylist()
-    )
-    second = (
-        query.query_archetype(
-            sig=sig,
-            world_id="idem-query-world",
-            run_id="idem-query-run",
-            ticks=[0],
-            entity_ids=[1],
-        )
-        .collect()
-        .to_pylist()
-    )
-
-    return [
-        exact_match(first, second, name="query_archetype_repeatable_rows"),
-        state_check(
-            {
-                "one_active_filtered_row": len(first) == 1,
-                "world_scoped": first[0].get("world_id") == "idem-query-world" if first else False,
-                "run_scoped": first[0].get("run_id") == "idem-query-run" if first else False,
-                "entity_filtered": first[0].get("entity_id") == 1 if first else False,
-                "tick_filtered": first[0].get("tick") == 0 if first else False,
-                "active_only": first[0].get("is_active") is True if first else False,
-                "component_value_preserved": (
-                    first[0].get("idemcounter__value") == 101 if first else False
-                ),
-            },
-            name="query_archetype_fixed_filters",
-        ),
-        exact_match(
-            calls,
-            [
-                (sig, "idem-query-world", "idem-query-run"),
-                (sig, "idem-query-world", "idem-query-run"),
-            ],
-            name="query_archetype_scopes_by_world_and_run",
-        ),
-    ]
+        ]
 
 
 def task_step_and_run_are_not_idempotent() -> list[GraderResult]:
@@ -956,11 +1082,71 @@ def register(harness: EvalHarness) -> None:
         "idempotency.query_archetype_repeatable",
         suite=SUITE,
         fn=task_query_archetype_repeatable,
-        desc="Sync QueryManager.query_archetype is repeatable for fixed persisted state.",
+        desc="Real sync store reads repeat while updater replay appends another row.",
     )
     harness.add(
         "idempotency.step_and_run_non_idempotent",
         suite=SUITE,
         fn=task_step_and_run_are_not_idempotent,
         desc="Repeated step/run calls advance time and append additional rows.",
+    )
+    harness.add(
+        "idempotency.atomic_publish_retry",
+        suite=SUITE,
+        fn=task_atomic_publish_retry,
+        desc="Failed tick publication stays invisible and retry exposes one attempt.",
+    )
+    harness.add(
+        "idempotency.durable_discovery",
+        suite=SUITE,
+        fn=task_durable_discovery,
+        desc="Cold discovery, reads, and catalog re-registration converge on durable state.",
+    )
+    harness.add(
+        "idempotency.resume_and_writer_fencing",
+        suite=SUITE,
+        fn=task_resume_and_writer_fencing,
+        desc="Fenced resume owns the next tick and stale writer attempts remain invisible.",
+    )
+    harness.add(
+        "idempotency.durable_fact_replay",
+        suite=SUITE,
+        fn=task_durable_fact_replay,
+        desc="Concurrent fact replay converges and identity-content conflicts fail loudly.",
+    )
+    harness.add(
+        "idempotency.durable_fact_crash_recovery",
+        suite=SUITE,
+        fn=task_durable_fact_crash_recovery,
+        desc="Lease takeover completes an appended orphan without a duplicate visible fact.",
+    )
+    harness.add(
+        "idempotency.evaluation_receipt_replay",
+        suite=SUITE,
+        fn=task_evaluation_receipt_replay,
+        desc="Evaluation replay returns one receipt without re-running the grader.",
+    )
+    harness.add(
+        "idempotency.process_crash_cold_resume",
+        suite=SUITE,
+        fn=task_process_crash_cold_resume,
+        desc="A hard-killed process leaves invisible rows and cold resume retries one tick.",
+    )
+    harness.add(
+        "idempotency.process_writer_fence_race",
+        suite=SUITE,
+        fn=task_process_writer_fence_race,
+        desc="Two independent writer processes race and exactly one publishes.",
+    )
+    harness.add(
+        "idempotency.process_fact_replay",
+        suite=SUITE,
+        fn=task_process_fact_replay,
+        desc="Concurrent processes converge on one externally identified fact.",
+    )
+    harness.add(
+        "idempotency.process_evaluation_replay",
+        suite=SUITE,
+        fn=task_process_evaluation_replay,
+        desc="Concurrent processes grade once and changed subjects conflict before grading.",
     )

--- a/evals/suites/idempotency_durable.py
+++ b/evals/suites/idempotency_durable.py
@@ -1,0 +1,465 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Durability-amendment scenarios for the idempotency eval suite.
+
+These checks primarily use service-facing outcomes and durable query results.
+The two crash scenarios patch only the documented commit boundary in order to
+create a state that ordinary public calls cannot produce deterministically;
+selected internal counters provide secondary diagnostics when a check fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from unittest.mock import patch
+
+from uuid_utils import uuid7
+
+from archetype.app._catalog import (
+    CatalogConflictError,
+    ClaimConflictError,
+    SqliteControlCatalog,
+    WorldRecord,
+    claim_scope_key,
+)
+from archetype.app.auth.models import ActorCtx
+from archetype.app.container import ServiceContainer
+from archetype.app.facts import FactMeta
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.interfaces import StaleWriterError
+from archetype.experiments.receipts import EvalReceipt, GraderContract, Outcome
+from evals.graders import exact_match, state_check
+from evals.types import GraderResult
+
+
+class DurableReading(Component):
+    value: float = 0.0
+
+
+def _actor(role: str = "operator") -> ActorCtx:
+    return ActorCtx(id=uuid7(), roles={role})
+
+
+async def _seed_world(container: ServiceContainer, storage: StorageConfig, *, name: str):
+    world = await container.world_service.create_world(WorldConfig(name=name), storage)
+    await container.mutation_service.create_entity(world.world_id, [DurableReading(value=1.0)])
+    await container.simulation_service.step(world.world_id, RunConfig())
+    return world
+
+
+async def _visible_rows(
+    container: ServiceContainer,
+    component: type[Component],
+    world_id: str,
+    run_id: str,
+    storage: StorageConfig,
+    *,
+    ticks: list[int] | None = None,
+) -> list[dict]:
+    frame = await container.query_service.query_components(
+        [component], world_id, run_id, storage, ticks=ticks
+    )
+    return frame.to_pylist()
+
+
+async def _expire_claim(catalog: SqliteControlCatalog, scope: str) -> None:
+    """Model owner death so the documented lease-takeover path can run."""
+
+    def expire() -> None:
+        conn = catalog._connect_sync()
+        with conn:
+            conn.execute("UPDATE claims SET lease_expires_at=0 WHERE scope_key=?", (scope,))
+
+    await catalog._run(expire)
+
+
+def task_atomic_publish_retry() -> list[GraderResult]:
+    """A failed publish is invisible and a retry exposes one attempt."""
+    return asyncio.run(_task_atomic_publish_retry())
+
+
+async def _task_atomic_publish_retry() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="atomic-retry")
+            world = await container.world_service.create_world(
+                WorldConfig(name="atomic-retry"), storage
+            )
+            await container.mutation_service.create_entity(
+                world.world_id, [DurableReading(value=7.0)]
+            )
+            wid, rid = str(world.world_id), str(world.run_id)
+
+            async def crash_publish(self, *args, **kwargs):
+                raise RuntimeError("injected crash before manifest publish")
+
+            failed = False
+            with patch.object(SqliteControlCatalog, "publish_manifest", crash_publish):
+                try:
+                    await container.simulation_service.step(wid, RunConfig())
+                except RuntimeError as exc:
+                    failed = "injected crash" in str(exc)
+
+            invisible_after_failure = await _visible_rows(
+                container, DurableReading, wid, rid, storage
+            )
+            tick_after_failure = world.tick
+            caches_after_failure = sum(len(rows) for rows in world.spawn_cache.values())
+
+            await container.simulation_service.step(wid, RunConfig())
+            visible_after_retry = await _visible_rows(
+                container, DurableReading, wid, rid, storage, ticks=[0]
+            )
+            manifests = await container.storage_service.get_control_catalog(storage).list_manifests(
+                wid
+            )
+
+            return [
+                state_check(
+                    {
+                        "fault_was_injected": failed,
+                        "failed_tick_did_not_advance": tick_after_failure == 0,
+                        "successful_retry_advanced_once": world.tick == 1,
+                        "failed_attempt_was_invisible": invisible_after_failure == [],
+                        "staged_spawn_survived_failure": caches_after_failure == 1,
+                        "retry_has_one_visible_row": len(visible_after_retry) == 1,
+                        "retry_preserved_payload": (
+                            visible_after_retry[0]["durablereading__value"] == 7.0
+                            if visible_after_retry
+                            else False
+                        ),
+                        "one_manifest_won": len(manifests) == 1,
+                        "winning_manifest_is_tick_zero": (
+                            manifests[0].tick == 0 if manifests else False
+                        ),
+                    },
+                    name="atomic_publish_retry",
+                )
+            ]
+        finally:
+            await container.shutdown()
+
+
+def task_durable_discovery() -> list[GraderResult]:
+    """Fresh containers repeatably discover the same durable identity and rows."""
+    return asyncio.run(_task_durable_discovery())
+
+
+async def _task_durable_discovery() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = StorageConfig(uri=f"{tmp}/store", namespace="discovery")
+        writer = ServiceContainer()
+        try:
+            world = await _seed_world(writer, storage, name="discoverable")
+            wid, rid = str(world.world_id), str(world.run_id)
+        finally:
+            await writer.shutdown()
+
+        reader = ServiceContainer()
+        try:
+            discovered_a = await reader.world_service.discover_worlds(storage)
+            discovered_b = await reader.world_service.discover_worlds(storage)
+            info_a = await reader.world_service.open_world_readonly(storage, wid)
+            info_b = await reader.world_service.open_world_readonly(storage, wid)
+            rows_a = await _visible_rows(reader, DurableReading, wid, rid, storage)
+            rows_b = await _visible_rows(reader, DurableReading, wid, rid, storage)
+
+            catalog = reader.storage_service.get_control_catalog(storage)
+            record = await catalog.get_world(wid)
+            await catalog.register_world(record)
+            conflict_loud = False
+            try:
+                await catalog.register_world(
+                    WorldRecord(
+                        world_id=record.world_id,
+                        name="different-name",
+                        run_id=record.run_id,
+                        parent_world_id=record.parent_world_id,
+                        status=record.status,
+                        tick_head=record.tick_head,
+                    )
+                )
+            except CatalogConflictError:
+                conflict_loud = True
+
+            discovered_shape_a = [info.model_dump(mode="json") for info in discovered_a]
+            discovered_shape_b = [info.model_dump(mode="json") for info in discovered_b]
+            return [
+                exact_match(
+                    discovered_shape_a,
+                    discovered_shape_b,
+                    name="cold_discovery_repeatable",
+                ),
+                exact_match(rows_a, rows_b, name="cold_rows_repeatable"),
+                state_check(
+                    {
+                        "world_was_discovered": [str(info.world_id) for info in discovered_a]
+                        == [wid],
+                        "readonly_open_is_repeatable": info_a == info_b,
+                        "readonly_open_created_no_live_world": not reader.world_service.has_world(
+                            wid
+                        ),
+                        "cold_query_returned_durable_row": len(rows_a) == 1,
+                        "identical_catalog_registration_is_noop": (await catalog.get_world(wid))
+                        == record,
+                        "different_catalog_content_conflicts": conflict_loud,
+                    },
+                    name="durable_discovery_and_catalog_identity",
+                ),
+            ]
+        finally:
+            await reader.shutdown()
+
+
+def task_resume_and_writer_fencing() -> list[GraderResult]:
+    """Resume owns the next visible tick and fences the old writer."""
+    return asyncio.run(_task_resume_and_writer_fencing())
+
+
+async def _task_resume_and_writer_fencing() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = StorageConfig(uri=f"{tmp}/store", namespace="resume")
+        old = ServiceContainer()
+        resumed = ServiceContainer()
+        try:
+            old_world = await _seed_world(old, storage, name="resumable")
+            wid, rid = str(old_world.world_id), str(old_world.run_id)
+            new_world = await resumed.world_service.open_world_mutable(storage, wid)
+            resume_tick = new_world.tick
+
+            stale_failed = False
+            try:
+                await old.simulation_service.step(wid, RunConfig())
+            except StaleWriterError:
+                stale_failed = True
+            except RuntimeError as exc:
+                stale_failed = "StaleWriter" in type(exc).__name__ or "not the" in str(exc)
+
+            before_new_publish = await _visible_rows(
+                resumed, DurableReading, wid, rid, storage, ticks=[1]
+            )
+            await resumed.simulation_service.step(wid, RunConfig())
+            after_new_publish = await _visible_rows(
+                resumed, DurableReading, wid, rid, storage, ticks=[1]
+            )
+            manifests = await resumed.storage_service.get_control_catalog(storage).list_manifests(
+                wid
+            )
+
+            return [
+                state_check(
+                    {
+                        "resume_started_at_next_visible_tick": resume_tick == 1,
+                        "new_writer_advanced_once": new_world.tick == 2,
+                        "resume_kept_run_identity": str(new_world.run_id) == rid,
+                        "resume_incremented_writer_epoch": new_world.commit_coordinator.epoch == 2,
+                        "old_writer_failed_closed": stale_failed,
+                        "old_writer_did_not_advance": old_world.tick == 1,
+                        "stale_attempt_stayed_invisible": before_new_publish == [],
+                        "new_writer_published_one_row": len(after_new_publish) == 1,
+                        "one_manifest_per_visible_tick": [m.tick for m in manifests] == [0, 1],
+                    },
+                    name="resume_and_writer_fencing",
+                )
+            ]
+        finally:
+            await old.shutdown()
+            await resumed.shutdown()
+
+
+def task_durable_fact_replay() -> list[GraderResult]:
+    """Concurrent identical facts converge; changed content conflicts."""
+    return asyncio.run(_task_durable_fact_replay())
+
+
+async def _task_durable_fact_replay() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="facts")
+            world = await _seed_world(container, storage, name="fact-world")
+            wid, rid = str(world.world_id), str(world.run_id)
+
+            async def submit():
+                return await container.ingestion_service.ingest_fact(
+                    wid,
+                    [DurableReading(value=21.5)],
+                    external_id="sensor:event-1",
+                    producer="sensor",
+                )
+
+            receipts = await asyncio.gather(*(submit() for _ in range(32)))
+            rows = await _visible_rows(container, FactMeta, wid, rid, storage)
+            conflict_loud = False
+            try:
+                await container.ingestion_service.ingest_fact(
+                    wid,
+                    [DurableReading(value=99.0)],
+                    external_id="sensor:event-1",
+                    producer="sensor",
+                )
+            except ClaimConflictError:
+                conflict_loud = True
+
+            return [
+                state_check(
+                    {
+                        "all_callers_share_commit_token": len(
+                            {receipt.commit_token for receipt in receipts}
+                        )
+                        == 1,
+                        "one_caller_performed_append": sum(
+                            not receipt.duplicate for receipt in receipts
+                        )
+                        == 1,
+                        "one_fact_is_visible": len(rows) == 1,
+                        "visible_fact_keeps_external_identity": (
+                            rows[0]["factmeta__external_id"] == "sensor:event-1" if rows else False
+                        ),
+                        "changed_payload_conflicts": conflict_loud,
+                    },
+                    name="durable_fact_replay",
+                )
+            ]
+        finally:
+            await container.shutdown()
+
+
+def task_durable_fact_crash_recovery() -> list[GraderResult]:
+    """An append-before-complete crash is recovered without duplication."""
+    return asyncio.run(_task_durable_fact_crash_recovery())
+
+
+async def _task_durable_fact_crash_recovery() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="fact-crash")
+            world = await _seed_world(container, storage, name="fact-crash")
+            wid, rid = str(world.world_id), str(world.run_id)
+
+            async def crash_complete(self, *args, **kwargs):
+                raise RuntimeError("injected crash after fact append")
+
+            crashed = False
+            with patch.object(SqliteControlCatalog, "complete_claim", crash_complete):
+                try:
+                    await container.ingestion_service.ingest_fact(
+                        wid,
+                        [DurableReading(value=3.0)],
+                        external_id="crash-boundary",
+                        producer="sensor",
+                    )
+                except RuntimeError as exc:
+                    crashed = "injected crash" in str(exc)
+
+            invisible = await _visible_rows(container, FactMeta, wid, rid, storage)
+            catalog = container.storage_service.get_control_catalog(storage)
+            scope = claim_scope_key(wid, rid, "sensor", "crash-boundary")
+            await _expire_claim(catalog, scope)
+            receipt = await container.ingestion_service.ingest_fact(
+                wid,
+                [DurableReading(value=3.0)],
+                external_id="crash-boundary",
+                producer="sensor",
+            )
+            recovered = await _visible_rows(container, FactMeta, wid, rid, storage)
+
+            return [
+                state_check(
+                    {
+                        "fault_was_injected": crashed,
+                        "pending_claim_was_invisible": invisible == [],
+                        "takeover_kept_original_claim": not receipt.duplicate,
+                        "takeover_exposed_one_fact": len(recovered) == 1,
+                        "recovered_external_identity": (
+                            recovered[0]["factmeta__external_id"] == "crash-boundary"
+                            if recovered
+                            else False
+                        ),
+                    },
+                    name="durable_fact_crash_recovery",
+                )
+            ]
+        finally:
+            await container.shutdown()
+
+
+def task_evaluation_receipt_replay() -> list[GraderResult]:
+    """Receipt replay returns the original evidence without re-grading."""
+    return asyncio.run(_task_evaluation_receipt_replay())
+
+
+async def _task_evaluation_receipt_replay() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="receipts")
+            world = await _seed_world(container, storage, name="receipt-world")
+            wid, rid = str(world.world_id), str(world.run_id)
+            calls: list[int] = []
+
+            def grader(frame):
+                calls.append(frame.count_rows())
+                return Outcome(status="pass", score=1.0)
+
+            contract = GraderContract(
+                grader_id="idempotency-eval",
+                implementation_version="1",
+                thresholds={"minimum": 1.0},
+            )
+            first = await container.command_service.evaluate(
+                _actor(),
+                wid,
+                [DurableReading],
+                contract=contract,
+                grader=grader,
+                evaluation_id="stable-evaluation",
+            )
+            replay = await container.command_service.evaluate(
+                _actor(),
+                wid,
+                [DurableReading],
+                contract=contract,
+                grader=grader,
+                evaluation_id="stable-evaluation",
+            )
+            rows = await _visible_rows(container, EvalReceipt, wid, rid, storage)
+
+            conflict_loud = False
+            try:
+                await container.command_service.evaluate(
+                    _actor(),
+                    wid,
+                    [DurableReading],
+                    contract=GraderContract(
+                        grader_id="idempotency-eval",
+                        implementation_version="2",
+                    ),
+                    grader=grader,
+                    evaluation_id="stable-evaluation",
+                )
+            except ClaimConflictError:
+                conflict_loud = True
+
+            return [
+                state_check(
+                    {
+                        "first_call_graded_once": calls == [1],
+                        "first_receipt_is_original": not first.duplicate,
+                        "replay_is_marked_duplicate": replay.duplicate,
+                        "replay_returns_original_token": (
+                            replay.commit_token == first.commit_token
+                        ),
+                        "one_receipt_is_visible": len(rows) == 1,
+                        "changed_contract_conflicts": conflict_loud,
+                    },
+                    name="evaluation_receipt_replay",
+                )
+            ]
+        finally:
+            await container.shutdown()

--- a/evals/suites/idempotency_process.py
+++ b/evals/suites/idempotency_process.py
@@ -1,0 +1,342 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Independent-process idempotency scenarios over real LanceDB and SQLite files."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from evals.graders import state_check
+from evals.types import GraderResult
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKER_MODULE = "evals.infra.idempotency_worker"
+
+
+def _env() -> dict[str, str]:
+    env = os.environ.copy()
+    roots = [str(ROOT / "src"), str(ROOT)]
+    if env.get("PYTHONPATH"):
+        roots.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(roots)
+    return env
+
+
+def _command(action: str, uri: str, namespace: str, *args: str) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        WORKER_MODULE,
+        action,
+        "--uri",
+        uri,
+        "--namespace",
+        namespace,
+        *args,
+    ]
+
+
+def _parse_output(stdout: str, stderr: str) -> dict:
+    for line in reversed(stdout.splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"worker produced no JSON\nstdout:\n{stdout}\nstderr:\n{stderr}")
+
+
+def _run(
+    action: str,
+    uri: str,
+    namespace: str,
+    *args: str,
+    expected_returncode: int = 0,
+    timeout: float = 120.0,
+) -> dict:
+    proc = subprocess.run(
+        _command(action, uri, namespace, *args),
+        cwd=ROOT,
+        env=_env(),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != expected_returncode:
+        raise AssertionError(
+            f"worker {action!r} exited {proc.returncode}, expected {expected_returncode}\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    if expected_returncode != 0:
+        return {"returncode": proc.returncode}
+    return _parse_output(proc.stdout, proc.stderr)
+
+
+def _spawn(action: str, uri: str, namespace: str, *args: str) -> subprocess.Popen:
+    return subprocess.Popen(
+        _command(action, uri, namespace, *args),
+        cwd=ROOT,
+        env=_env(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _wait_for_markers(markers: list[Path], timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not all(marker.exists() for marker in markers):
+        if time.monotonic() >= deadline:
+            missing = [str(marker) for marker in markers if not marker.exists()]
+            raise TimeoutError(f"workers did not become ready: {missing}")
+        time.sleep(0.01)
+
+
+def _collect(processes: list[subprocess.Popen], timeout: float = 120.0) -> list[dict]:
+    results: list[dict] = []
+    try:
+        for proc in processes:
+            stdout, stderr = proc.communicate(timeout=timeout)
+            if proc.returncode != 0:
+                raise AssertionError(
+                    f"parallel worker exited {proc.returncode}\n"
+                    f"stdout:\n{stdout}\nstderr:\n{stderr}"
+                )
+            results.append(_parse_output(stdout, stderr))
+    finally:
+        for proc in processes:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10)
+    return results
+
+
+def task_process_crash_cold_resume() -> list[GraderResult]:
+    """A hard-killed writer leaves rows invisible; fresh process resumes correctly."""
+    with tempfile.TemporaryDirectory() as tmp:
+        uri = str(Path(tmp) / "store")
+        namespace = "hard_crash"
+        seed = _run("seed", uri, namespace, "--name", "hard-crash")
+        crash = _run(
+            "crash-publish",
+            uri,
+            namespace,
+            "--world-id",
+            seed["world_id"],
+            "--exit-code",
+            "91",
+            expected_returncode=91,
+        )
+        resumed = _run("resume-verify", uri, namespace, "--world-id", seed["world_id"])
+
+        return [
+            state_check(
+                {
+                    "worker_died_without_cleanup": crash["returncode"] == 91,
+                    "cold_resume_ignored_unpublished_rows": resumed["resume_tick"] == 1,
+                    "resumed_writer_advanced_once": resumed["final_tick"] == 2,
+                    "one_retry_attempt_is_visible": resumed["visible_rows"] == 1,
+                    "manifests_are_contiguous": resumed["manifest_ticks"] == [0, 1],
+                    "crash_and_resume_advanced_fences": resumed["epoch"] == 3,
+                },
+                name="process_crash_cold_resume",
+            )
+        ]
+
+
+def task_process_writer_fence_race() -> list[GraderResult]:
+    """Two fresh processes race; exactly one publishes under the winning fence."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        uri = str(root / "store")
+        namespace = "writer_race"
+        seed = _run("seed", uri, namespace, "--name", "writer-race")
+        go = root / "go"
+        ready = [root / "ready-0", root / "ready-1"]
+        processes = [
+            _spawn(
+                "resume-race",
+                uri,
+                namespace,
+                "--world-id",
+                seed["world_id"],
+                "--ready",
+                str(marker),
+                "--go",
+                str(go),
+            )
+            for marker in ready
+        ]
+        try:
+            _wait_for_markers(ready)
+            epochs = sorted(json.loads(marker.read_text())["epoch"] for marker in ready)
+            go.write_text("go")
+            results = _collect(processes)
+        finally:
+            for proc in processes:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=10)
+
+        visible = _run("query-world", uri, namespace, "--world-id", seed["world_id"])
+        statuses = sorted(result["status"] for result in results)
+        return [
+            state_check(
+                {
+                    "writers_acquired_distinct_epochs": epochs == [2, 3],
+                    "one_writer_published_one_was_stale": statuses == ["published", "stale"],
+                    "only_two_ticks_are_visible": visible["row_ticks"] == [0, 1],
+                    "one_manifest_per_tick": visible["manifest_ticks"] == [0, 1],
+                    "one_entity_version_per_tick": visible["rows"] == 2,
+                },
+                name="process_writer_fence_race",
+            )
+        ]
+
+
+def task_process_fact_replay() -> list[GraderResult]:
+    """Eight processes submit one external fact; one visible identity wins."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        uri = str(root / "store")
+        namespace = "fact_race"
+        seed = _run("seed", uri, namespace, "--name", "fact-race")
+        go = root / "go"
+        ready = [root / f"ready-{index}" for index in range(8)]
+        processes = [
+            _spawn(
+                "ingest-fact",
+                uri,
+                namespace,
+                "--world-id",
+                seed["world_id"],
+                "--ready",
+                str(marker),
+                "--go",
+                str(go),
+                "--external-id",
+                "shared-process-event",
+                "--producer",
+                "process-sensor",
+                "--value",
+                "21.5",
+            )
+            for marker in ready
+        ]
+        try:
+            _wait_for_markers(ready)
+            go.write_text("go")
+            results = _collect(processes)
+        finally:
+            for proc in processes:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=10)
+
+        facts = _run("query-facts", uri, namespace, "--world-id", seed["world_id"])
+        return [
+            state_check(
+                {
+                    "all_processes_converged_on_token": len(
+                        {result["commit_token"] for result in results}
+                    )
+                    == 1,
+                    "one_process_owned_the_append": sum(
+                        not result["duplicate"] for result in results
+                    )
+                    == 1,
+                    "one_fact_is_visible": facts["rows"] == 1,
+                    "external_identity_is_durable": facts["external_ids"]
+                    == ["shared-process-event"],
+                    "one_visible_commit_identity": len(facts["commit_ids"]) == 1,
+                },
+                name="process_fact_replay",
+            )
+        ]
+
+
+def task_process_evaluation_replay() -> list[GraderResult]:
+    """Concurrent processes grade once; changed subject conflicts before grading."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        uri = str(root / "store")
+        namespace = "evaluation_race"
+        seed = _run("seed", uri, namespace, "--name", "evaluation-race")
+        go = root / "go"
+        grader_log = root / "grader-calls.log"
+        ready = [root / f"ready-{index}" for index in range(8)]
+        processes = [
+            _spawn(
+                "evaluate",
+                uri,
+                namespace,
+                "--world-id",
+                seed["world_id"],
+                "--ready",
+                str(marker),
+                "--go",
+                str(go),
+                "--evaluation-id",
+                "shared-process-evaluation",
+                "--grader-log",
+                str(grader_log),
+            )
+            for marker in ready
+        ]
+        try:
+            _wait_for_markers(ready)
+            go.write_text("go")
+            results = _collect(processes)
+        finally:
+            for proc in processes:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=10)
+
+        receipts = _run("query-receipts", uri, namespace, "--world-id", seed["world_id"])
+        grader_calls_before_conflict = grader_log.read_text().splitlines()
+        _run("advance", uri, namespace, "--world-id", seed["world_id"])
+        conflict = _run(
+            "evaluate-conflict",
+            uri,
+            namespace,
+            "--world-id",
+            seed["world_id"],
+            "--evaluation-id",
+            "shared-process-evaluation",
+            "--grader-log",
+            str(grader_log),
+        )
+        grader_calls_after_conflict = grader_log.read_text().splitlines()
+
+        return [
+            state_check(
+                {
+                    "all_processes_converged_on_token": len(
+                        {result["commit_token"] for result in results}
+                    )
+                    == 1,
+                    "one_process_owned_evaluation": sum(
+                        not result["duplicate"] for result in results
+                    )
+                    == 1,
+                    "external_grader_side_effect_happened_once": len(grader_calls_before_conflict)
+                    == 1,
+                    "one_receipt_is_visible": receipts["rows"] == 1,
+                    "receipt_identity_is_durable": receipts["evaluation_ids"]
+                    == ["shared-process-evaluation"],
+                    "changed_subject_conflicts": conflict["conflict"] is True,
+                    "subject_conflict_did_not_run_grader": (
+                        grader_calls_after_conflict == grader_calls_before_conflict
+                    ),
+                },
+                name="process_evaluation_replay",
+            )
+        ]

--- a/scripts/check_idempotency_contracts.py
+++ b/scripts/check_idempotency_contracts.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Fail when the normative idempotency matrix and eval manifest drift."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from evals.suites.idempotency import traceability_checks  # noqa: E402
+
+
+def main() -> int:
+    failed = [name for name, passed in traceability_checks().items() if not passed]
+    if failed:
+        print("Idempotency contract audit failed:")
+        for name in failed:
+            print(f"  - {name}")
+        print("Update docs/guide/specification.md and evals/suites/idempotency.py together.")
+        return 1
+
+    print("Idempotency contract audit passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/idempotency/test_idempotency_evals.py
+++ b/tests/idempotency/test_idempotency_evals.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CI gates for the idempotency eval suite."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from evals.run import build_harness
+from evals.suites import idempotency
+
+
+def test_idempotency_eval_suite_passes() -> None:
+    harness = build_harness(trials=1)
+    results = harness.run(suite_filter=idempotency.SUITE)
+
+    assert results, "idempotency suite registered no tasks"
+
+    failures: list[str] = []
+    for result in results:
+        for trial in result.trials:
+            if trial.error:
+                failures.append(f"{result.task_id}: {trial.error}")
+            for grader in trial.grader_results:
+                if not grader.passed:
+                    failures.append(f"{result.task_id}/{grader.grader_name}: {grader.details}")
+
+    assert not failures, "idempotency eval failures:\n  " + "\n  ".join(failures)
+
+
+def test_idempotency_cli_suite_is_runnable() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "evals.run", "--suite", idempotency.SUITE, "--trials", "1"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "[IDEMPOTENCY]" in proc.stdout

--- a/tests/idempotency/test_idempotency_evals.py
+++ b/tests/idempotency/test_idempotency_evals.py
@@ -12,31 +12,37 @@ from evals.run import build_harness
 from evals.suites import idempotency
 
 
-def test_idempotency_eval_suite_passes() -> None:
+def test_idempotency_eval_suite_is_registered_and_traceable() -> None:
     harness = build_harness(trials=1)
-    results = harness.run(suite_filter=idempotency.SUITE)
+    registered = {task_id for task_id, suite, _, _ in harness._tasks if suite == idempotency.SUITE}
+    mapped = {case.task_id for case in idempotency.IDEMPOTENCY_CASES}
 
-    assert results, "idempotency suite registered no tasks"
-
-    failures: list[str] = []
-    for result in results:
-        for trial in result.trials:
-            if trial.error:
-                failures.append(f"{result.task_id}: {trial.error}")
-            for grader in trial.grader_results:
-                if not grader.passed:
-                    failures.append(f"{result.task_id}/{grader.grader_name}: {grader.details}")
-
-    assert not failures, "idempotency eval failures:\n  " + "\n  ".join(failures)
+    assert registered == mapped | {"idempotency.manifest_traceability"}
+    assert all(idempotency.traceability_checks().values())
 
 
-def test_idempotency_cli_suite_is_runnable() -> None:
+def test_idempotency_contract_audit_cli() -> None:
     proc = subprocess.run(
-        [sys.executable, "-m", "evals.run", "--suite", idempotency.SUITE, "--trials", "1"],
+        [sys.executable, "scripts/check_idempotency_contracts.py"],
         capture_output=True,
         text=True,
         check=False,
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
-    assert "[IDEMPOTENCY]" in proc.stdout
+    assert "Idempotency contract audit passed" in proc.stdout
+
+
+def test_idempotency_contract_audit_detects_unmapped_spec_row(tmp_path, monkeypatch) -> None:
+    drifted = tmp_path / "specification.md"
+    text = idempotency.SPECIFICATION.read_text()
+    text = text.replace(
+        "\n## Required Hardening Work",
+        "\n| Newly normative retry | Must have an independent eval |\n\n## Required Hardening Work",
+    )
+    drifted.write_text(text)
+    monkeypatch.setattr(idempotency, "SPECIFICATION", drifted)
+
+    checks = idempotency.traceability_checks()
+
+    assert not checks["matrix_rows_match_eval_manifest"]

--- a/tests/infrastructure/__init__.py
+++ b/tests/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Tests requiring external infrastructure supplied by CI."""

--- a/tests/infrastructure/test_r2_idempotency.py
+++ b/tests/infrastructure/test_r2_idempotency.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real Archetype/Iceberg checks against Cloudflare R2 Data Catalog."""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib.request import Request, urlopen
+
+import daft
+import pytest
+from daft.catalog import Catalog
+from daft.session import Session
+from pyiceberg.catalog.rest import RestCatalog
+from uuid_utils import uuid7
+
+from archetype.core.aio import AsyncStore, AsyncUpdateManager
+from archetype.core.component import Component
+from archetype.core.interfaces import CommitContext
+
+TOKEN = os.environ.get("R2_CATALOG_TOKEN")
+ACCOUNT_ID = os.environ.get("CLOUDFLARE_ACCOUNT_ID")
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not TOKEN or not ACCOUNT_ID,
+        reason="GitHub Actions supplies the Cloudflare R2 catalog credentials",
+    ),
+]
+
+
+class R2Reading(Component):
+    value: float = 0.0
+
+
+def _catalog_settings() -> tuple[str, str]:
+    """Discover one explicitly selected—or unambiguous—active R2 catalog."""
+    assert ACCOUNT_ID is not None
+    assert TOKEN is not None
+    request = Request(
+        f"https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/r2-catalog",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+    with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed Cloudflare origin
+        payload = json.load(response)
+
+    if not payload.get("success"):
+        pytest.fail(f"Cloudflare catalog discovery failed: {payload.get('errors', [])}")
+
+    active = [
+        item
+        for item in payload.get("result", {}).get("warehouses", [])
+        if item.get("status") == "active"
+    ]
+    requested_bucket = os.environ.get("R2_CATALOG_BUCKET")
+    if requested_bucket:
+        active = [item for item in active if item.get("bucket") == requested_bucket]
+        if len(active) != 1:
+            pytest.fail(f"No unique active R2 catalog found for bucket {requested_bucket!r}")
+    elif len(active) != 1:
+        pytest.fail("R2 catalog selection is ambiguous; set repository variable R2_CATALOG_BUCKET")
+
+    selected = active[0]
+    bucket = selected["bucket"]
+    return (
+        f"https://catalog.cloudflarestorage.com/{ACCOUNT_ID}/{bucket}",
+        selected["name"],
+    )
+
+
+async def test_r2_iceberg_commit_visibility() -> None:
+    """Exercise Archetype's real Iceberg store on one disposable R2 table."""
+    assert TOKEN is not None
+    catalog_uri, warehouse = _catalog_settings()
+    catalog = RestCatalog(
+        "archetype_ci",
+        uri=catalog_uri,
+        warehouse=warehouse,
+        token=TOKEN,
+    )
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
+    attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "0")
+    namespace = f"archetype_ci_{run_id}_{attempt}_{uuid7().hex[:8]}"
+    catalog.create_namespace(namespace)
+
+    try:
+        session = Session()
+        session.attach_catalog(Catalog.from_iceberg(catalog))
+        session.set_namespace(namespace)
+        store = AsyncStore(session)
+        updater = AsyncUpdateManager(store)
+        signature = (R2Reading,)
+        world_id = f"r2-world-{uuid7().hex}"
+        archetype_run_id = f"r2-run-{uuid7().hex}"
+        raw = daft.from_pylist([{"entity_id": 1, "is_active": True, "r2reading__value": 4.0}])
+        abandoned = CommitContext(commit_token=uuid7().hex, writer_epoch=1)
+        published = CommitContext(commit_token=uuid7().hex, writer_epoch=2)
+
+        # Two physical attempts really reach R2. Core append is intentionally
+        # non-idempotent; the published-token allowlist supplies visibility.
+        await updater.update(raw, signature, 0, world_id, archetype_run_id, commit=abandoned)
+        await updater.update(raw, signature, 0, world_id, archetype_run_id, commit=published)
+
+        physical = (await store.get_archetype_df(signature, world_id, archetype_run_id)).to_pylist()
+        visible_a = (
+            await store.get_archetype_df(
+                signature,
+                world_id,
+                archetype_run_id,
+                commit_tokens=[published.commit_token],
+            )
+        ).to_pylist()
+        visible_b = (
+            await store.get_archetype_df(
+                signature,
+                world_id,
+                archetype_run_id,
+                commit_tokens=[published.commit_token],
+            )
+        ).to_pylist()
+
+        assert len(physical) == 2, "both retry attempts must exist in real R2 storage"
+        assert len(visible_a) == 1, "only the published retry token may be visible"
+        assert visible_b == visible_a, "replaying a fixed-snapshot read must be stable"
+        assert visible_a[0]["commit_token"] == published.commit_token
+    finally:
+        for table in catalog.list_tables(namespace):
+            catalog.drop_table(table)
+        catalog.drop_namespace(namespace)

--- a/tests/infrastructure/test_r2_idempotency.py
+++ b/tests/infrastructure/test_r2_idempotency.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 import daft
@@ -36,37 +37,61 @@ class R2Reading(Component):
     value: float = 0.0
 
 
+def _cloudflare_get(url: str, token: str) -> dict | None:
+    request = Request(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed Cloudflare origin
+            return json.load(response)
+    except HTTPError:
+        return None
+
+
 def _catalog_settings() -> tuple[str, str]:
     """Discover one explicitly selected—or unambiguous—active R2 catalog."""
     assert ACCOUNT_ID is not None
     assert DISCOVERY_TOKEN is not None
-    request = Request(
-        f"https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/r2-catalog",
-        headers={"Authorization": f"Bearer {DISCOVERY_TOKEN}"},
+    assert TOKEN is not None
+
+    account_ids = [ACCOUNT_ID]
+    accounts = _cloudflare_get(
+        "https://api.cloudflare.com/client/v4/accounts?per_page=50",
+        DISCOVERY_TOKEN,
     )
-    with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed Cloudflare origin
-        payload = json.load(response)
+    if accounts and accounts.get("success"):
+        account_ids.extend(item["id"] for item in accounts.get("result", []))
+    account_ids = list(dict.fromkeys(account_ids))
 
-    if not payload.get("success"):
-        pytest.fail(f"Cloudflare catalog discovery failed: {payload.get('errors', [])}")
+    active: list[tuple[str, dict]] = []
+    for account_id in account_ids:
+        for credential in dict.fromkeys((TOKEN, DISCOVERY_TOKEN)):
+            payload = _cloudflare_get(
+                f"https://api.cloudflare.com/client/v4/accounts/{account_id}/r2-catalog",
+                credential,
+            )
+            if not payload or not payload.get("success"):
+                continue
+            active.extend(
+                (account_id, item)
+                for item in payload.get("result", {}).get("warehouses", [])
+                if item.get("status") == "active"
+            )
+            break
 
-    active = [
-        item
-        for item in payload.get("result", {}).get("warehouses", [])
-        if item.get("status") == "active"
-    ]
     requested_bucket = os.environ.get("R2_CATALOG_BUCKET")
     if requested_bucket:
-        active = [item for item in active if item.get("bucket") == requested_bucket]
+        active = [entry for entry in active if entry[1].get("bucket") == requested_bucket]
         if len(active) != 1:
             pytest.fail(f"No unique active R2 catalog found for bucket {requested_bucket!r}")
     elif len(active) != 1:
         pytest.fail("R2 catalog selection is ambiguous; set repository variable R2_CATALOG_BUCKET")
 
-    selected = active[0]
+    selected_account, selected = active[0]
     bucket = selected["bucket"]
     return (
-        f"https://catalog.cloudflarestorage.com/{ACCOUNT_ID}/{bucket}",
+        f"https://catalog.cloudflarestorage.com/{selected_account}/{bucket}",
         selected["name"],
     )
 

--- a/tests/infrastructure/test_r2_idempotency.py
+++ b/tests/infrastructure/test_r2_idempotency.py
@@ -5,10 +5,7 @@
 
 from __future__ import annotations
 
-import json
 import os
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
 
 import daft
 import pytest
@@ -22,13 +19,13 @@ from archetype.core.component import Component
 from archetype.core.interfaces import CommitContext
 
 TOKEN = os.environ.get("R2_CATALOG_TOKEN")
-DISCOVERY_TOKEN = os.environ.get("CLOUDFLARE_API_TOKEN")
-ACCOUNT_ID = os.environ.get("CLOUDFLARE_ACCOUNT_ID")
+CATALOG_URI = os.environ.get("R2_CATALOG_URI")
+WAREHOUSE = os.environ.get("R2_CATALOG_WAREHOUSE")
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.skipif(
-        not TOKEN or not DISCOVERY_TOKEN or not ACCOUNT_ID,
-        reason="GitHub Actions supplies the Cloudflare R2 catalog credentials",
+        not TOKEN or not CATALOG_URI or not WAREHOUSE,
+        reason="GitHub Actions supplies the Cloudflare R2 catalog configuration",
     ),
 ]
 
@@ -37,73 +34,15 @@ class R2Reading(Component):
     value: float = 0.0
 
 
-def _cloudflare_get(url: str, token: str) -> dict | None:
-    request = Request(
-        url,
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    try:
-        with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed Cloudflare origin
-            return json.load(response)
-    except HTTPError:
-        return None
-
-
-def _catalog_settings() -> tuple[str, str]:
-    """Discover one explicitly selected—or unambiguous—active R2 catalog."""
-    assert ACCOUNT_ID is not None
-    assert DISCOVERY_TOKEN is not None
-    assert TOKEN is not None
-
-    account_ids = [ACCOUNT_ID]
-    accounts = _cloudflare_get(
-        "https://api.cloudflare.com/client/v4/accounts?per_page=50",
-        DISCOVERY_TOKEN,
-    )
-    if accounts and accounts.get("success"):
-        account_ids.extend(item["id"] for item in accounts.get("result", []))
-    account_ids = list(dict.fromkeys(account_ids))
-
-    active: list[tuple[str, dict]] = []
-    for account_id in account_ids:
-        for credential in dict.fromkeys((TOKEN, DISCOVERY_TOKEN)):
-            payload = _cloudflare_get(
-                f"https://api.cloudflare.com/client/v4/accounts/{account_id}/r2-catalog",
-                credential,
-            )
-            if not payload or not payload.get("success"):
-                continue
-            active.extend(
-                (account_id, item)
-                for item in payload.get("result", {}).get("warehouses", [])
-                if item.get("status") == "active"
-            )
-            break
-
-    requested_bucket = os.environ.get("R2_CATALOG_BUCKET")
-    if requested_bucket:
-        active = [entry for entry in active if entry[1].get("bucket") == requested_bucket]
-        if len(active) != 1:
-            pytest.fail(f"No unique active R2 catalog found for bucket {requested_bucket!r}")
-    elif len(active) != 1:
-        pytest.fail("R2 catalog selection is ambiguous; set repository variable R2_CATALOG_BUCKET")
-
-    selected_account, selected = active[0]
-    bucket = selected["bucket"]
-    return (
-        f"https://catalog.cloudflarestorage.com/{selected_account}/{bucket}",
-        selected["name"],
-    )
-
-
 async def test_r2_iceberg_commit_visibility() -> None:
     """Exercise Archetype's real Iceberg store on one disposable R2 table."""
     assert TOKEN is not None
-    catalog_uri, warehouse = _catalog_settings()
+    assert CATALOG_URI is not None
+    assert WAREHOUSE is not None
     catalog = RestCatalog(
         "archetype_ci",
-        uri=catalog_uri,
-        warehouse=warehouse,
+        uri=CATALOG_URI,
+        warehouse=WAREHOUSE,
         token=TOKEN,
     )
     run_id = os.environ.get("GITHUB_RUN_ID", "local")

--- a/tests/infrastructure/test_r2_idempotency.py
+++ b/tests/infrastructure/test_r2_idempotency.py
@@ -57,8 +57,8 @@ async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
         uri=f"sqlite:///{tmp_path / 'catalog.db'}",
         warehouse=warehouse,
         **{
-            # PyArrow expects host[:port]; Daft's S3Config below expects URL.
-            "s3.endpoint": endpoint.netloc,
+            # PyIceberg documents a full URL; direct PyArrow cleanup below uses host[:port].
+            "s3.endpoint": API_ENDPOINT,
             "s3.access-key-id": ACCESS_KEY_ID,
             "s3.secret-access-key": SECRET_ACCESS_KEY,
             "s3.region": "auto",

--- a/tests/infrastructure/test_r2_idempotency.py
+++ b/tests/infrastructure/test_r2_idempotency.py
@@ -51,12 +51,14 @@ async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
     prefix = f"archetype-ci/idempotency/{run_id}-{attempt}-{uuid7().hex}"
     warehouse = f"s3://{BUCKET}/{prefix}"
     namespace = "archetype_ci"
+    endpoint = urlparse(API_ENDPOINT)
     catalog = SqlCatalog(
         "archetype_r2_ci",
         uri=f"sqlite:///{tmp_path / 'catalog.db'}",
         warehouse=warehouse,
         **{
-            "s3.endpoint": API_ENDPOINT,
+            # PyArrow expects host[:port]; Daft's S3Config below expects URL.
+            "s3.endpoint": endpoint.netloc,
             "s3.access-key-id": ACCESS_KEY_ID,
             "s3.secret-access-key": SECRET_ACCESS_KEY,
             "s3.region": "auto",
@@ -120,7 +122,6 @@ async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
             catalog.drop_table(table)
         catalog.drop_namespace(namespace)
 
-        endpoint = urlparse(API_ENDPOINT)
         filesystem = S3FileSystem(
             access_key=ACCESS_KEY_ID,
             secret_key=SECRET_ACCESS_KEY,

--- a/tests/infrastructure/test_r2_idempotency.py
+++ b/tests/infrastructure/test_r2_idempotency.py
@@ -21,11 +21,12 @@ from archetype.core.component import Component
 from archetype.core.interfaces import CommitContext
 
 TOKEN = os.environ.get("R2_CATALOG_TOKEN")
+DISCOVERY_TOKEN = os.environ.get("CLOUDFLARE_API_TOKEN")
 ACCOUNT_ID = os.environ.get("CLOUDFLARE_ACCOUNT_ID")
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.skipif(
-        not TOKEN or not ACCOUNT_ID,
+        not TOKEN or not DISCOVERY_TOKEN or not ACCOUNT_ID,
         reason="GitHub Actions supplies the Cloudflare R2 catalog credentials",
     ),
 ]
@@ -38,10 +39,10 @@ class R2Reading(Component):
 def _catalog_settings() -> tuple[str, str]:
     """Discover one explicitly selected—or unambiguous—active R2 catalog."""
     assert ACCOUNT_ID is not None
-    assert TOKEN is not None
+    assert DISCOVERY_TOKEN is not None
     request = Request(
         f"https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/r2-catalog",
-        headers={"Authorization": f"Bearer {TOKEN}"},
+        headers={"Authorization": f"Bearer {DISCOVERY_TOKEN}"},
     )
     with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed Cloudflare origin
         payload = json.load(response)

--- a/tests/infrastructure/test_r2_idempotency.py
+++ b/tests/infrastructure/test_r2_idempotency.py
@@ -1,31 +1,36 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Real Archetype/Iceberg checks against Cloudflare R2 Data Catalog."""
+"""Real Archetype/Iceberg checks against Cloudflare R2 object storage."""
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
+from urllib.parse import urlparse
 
 import daft
 import pytest
 from daft.catalog import Catalog
+from daft.io import IOConfig, S3Config
 from daft.session import Session
-from pyiceberg.catalog.rest import RestCatalog
+from pyarrow.fs import S3FileSystem
+from pyiceberg.catalog.sql import SqlCatalog
 from uuid_utils import uuid7
 
 from archetype.core.aio import AsyncStore, AsyncUpdateManager
 from archetype.core.component import Component
 from archetype.core.interfaces import CommitContext
 
-TOKEN = os.environ.get("R2_CATALOG_TOKEN")
-CATALOG_URI = os.environ.get("R2_CATALOG_URI")
-WAREHOUSE = os.environ.get("R2_CATALOG_WAREHOUSE")
+ACCESS_KEY_ID = os.environ.get("R2_ACCESS_KEY_ID")
+SECRET_ACCESS_KEY = os.environ.get("R2_SECRET_ACCESS_KEY")
+API_ENDPOINT = os.environ.get("R2_API_ENDPOINT")
+BUCKET = os.environ.get("R2_BUCKET")
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.skipif(
-        not TOKEN or not CATALOG_URI or not WAREHOUSE,
-        reason="GitHub Actions supplies the Cloudflare R2 catalog configuration",
+        not ACCESS_KEY_ID or not SECRET_ACCESS_KEY or not API_ENDPOINT or not BUCKET,
+        reason="GitHub Actions supplies the Cloudflare R2 S3 configuration",
     ),
 ]
 
@@ -34,27 +39,47 @@ class R2Reading(Component):
     value: float = 0.0
 
 
-async def test_r2_iceberg_commit_visibility() -> None:
-    """Exercise Archetype's real Iceberg store on one disposable R2 table."""
-    assert TOKEN is not None
-    assert CATALOG_URI is not None
-    assert WAREHOUSE is not None
-    catalog = RestCatalog(
-        "archetype_ci",
-        uri=CATALOG_URI,
-        warehouse=WAREHOUSE,
-        token=TOKEN,
-    )
+async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
+    """Exercise Archetype's real Iceberg store in one disposable R2 prefix."""
+    assert ACCESS_KEY_ID is not None
+    assert SECRET_ACCESS_KEY is not None
+    assert API_ENDPOINT is not None
+    assert BUCKET is not None
+
     run_id = os.environ.get("GITHUB_RUN_ID", "local")
     attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "0")
-    namespace = f"archetype_ci_{run_id}_{attempt}_{uuid7().hex[:8]}"
+    prefix = f"archetype-ci/idempotency/{run_id}-{attempt}-{uuid7().hex}"
+    warehouse = f"s3://{BUCKET}/{prefix}"
+    namespace = "archetype_ci"
+    catalog = SqlCatalog(
+        "archetype_r2_ci",
+        uri=f"sqlite:///{tmp_path / 'catalog.db'}",
+        warehouse=warehouse,
+        **{
+            "s3.endpoint": API_ENDPOINT,
+            "s3.access-key-id": ACCESS_KEY_ID,
+            "s3.secret-access-key": SECRET_ACCESS_KEY,
+            "s3.region": "auto",
+            "s3.force-virtual-addressing": "false",
+        },
+    )
     catalog.create_namespace(namespace)
+    io_config = IOConfig(
+        s3=S3Config(
+            endpoint_url=API_ENDPOINT,
+            region_name="auto",
+            key_id=ACCESS_KEY_ID,
+            access_key=SECRET_ACCESS_KEY,
+            use_ssl=True,
+            force_virtual_addressing=False,
+        )
+    )
 
     try:
         session = Session()
         session.attach_catalog(Catalog.from_iceberg(catalog))
         session.set_namespace(namespace)
-        store = AsyncStore(session)
+        store = AsyncStore(session, io_config=io_config)
         updater = AsyncUpdateManager(store)
         signature = (R2Reading,)
         world_id = f"r2-world-{uuid7().hex}"
@@ -63,7 +88,7 @@ async def test_r2_iceberg_commit_visibility() -> None:
         abandoned = CommitContext(commit_token=uuid7().hex, writer_epoch=1)
         published = CommitContext(commit_token=uuid7().hex, writer_epoch=2)
 
-        # Two physical attempts really reach R2. Core append is intentionally
+        # Both attempts physically reach R2. Core append is intentionally
         # non-idempotent; the published-token allowlist supplies visibility.
         await updater.update(raw, signature, 0, world_id, archetype_run_id, commit=abandoned)
         await updater.update(raw, signature, 0, world_id, archetype_run_id, commit=published)
@@ -94,3 +119,14 @@ async def test_r2_iceberg_commit_visibility() -> None:
         for table in catalog.list_tables(namespace):
             catalog.drop_table(table)
         catalog.drop_namespace(namespace)
+
+        endpoint = urlparse(API_ENDPOINT)
+        filesystem = S3FileSystem(
+            access_key=ACCESS_KEY_ID,
+            secret_key=SECRET_ACCESS_KEY,
+            region="auto",
+            scheme=endpoint.scheme,
+            endpoint_override=endpoint.netloc,
+            force_virtual_addressing=False,
+        )
+        filesystem.delete_dir(f"{BUCKET}/{prefix}")


### PR DESCRIPTION
## Summary

Adds an independent idempotency contract suite for Archetype. The normative matrix in `docs/guide/specification.md` now has 33 rows mapped to 21 behavioral tasks plus a traceability task; CI fails if the specification, manifest, or registered evals drift apart.

## What it proves

- repeated no-ops collapse while intentionally non-idempotent simulation calls stay distinct
- failed tick publication leaves physical rows invisible and a retry exposes one committed attempt
- writer epochs fence stale resumes and independent writers racing for one tick
- external fact replay converges on one visible fact, including orphan takeover after a crash
- evaluation replay returns one durable receipt and invokes the external grader once
- hard process death followed by cold discovery resumes from the last visible tick
- fixed-state queries, discovery, runtime aliases, lifecycle calls, component no-ops, and storage shutdown remain stable under repetition

The behavioral suite imports production Archetype services and core stores, creates fresh storage, and does not call the existing feature tests as its oracle. Four scenarios launch independent OS processes over shared durable storage.

## Real infrastructure gate

GitHub Actions now runs `tests/infrastructure/test_r2_idempotency.py` with repository R2 credentials. It creates a disposable Iceberg table under a unique Cloudflare R2 prefix, writes an abandoned and a published attempt through `AsyncUpdateManager`/`AsyncStore`, verifies both physical rows exist but only the published token is visible on repeated reads, then removes the prefix.

This proves the real Archetype/Daft/PyIceberg path against R2's S3 object interface without Docker. Iceberg catalog metadata is runner-local SQLite, so this PR deliberately does **not** claim to test the Cloudflare Data Catalog control plane.

## Tooling

- `make idempotency-audit`: fast static specification/manifest/registry linter
- `make eval-idem`: behavioral idempotency suite
- `make test-infra`: credential-gated external infrastructure tests
- `make ci`: now includes the audit and idempotency eval gate

## Validation

- local `make ci`: 828 passed, 1 infrastructure skip; 22/22 idempotency eval tasks passed
- local live-R2 infrastructure test: passed
- GitHub Actions: Python 3.12/3.13 CI, evals, typecheck, examples, formatting, docs, security analysis, footgun review, and live R2 infrastructure gate passed
