### PR TITLE
ci: promote checks to required merge gates; add examples gate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,19 +11,11 @@ on:
       - "src/archetype/api/**"
       - "src/archetype/cli/**"
       - ".github/workflows/docs.yml"
+  # No path filter on pull_request: Spelling, Markdown lint, and Build docs
+  # are required status checks on main, and a required check that never runs
+  # blocks the merge forever. The jobs cost ~30s combined per PR.
   pull_request:
     branches: [main]
-    paths:
-      - "docs/**"
-      - "**/*.md"
-      - "mkdocs.yml"
-      - "scripts/generate_*.py"
-      - "src/archetype/api/**"
-      - "src/archetype/cli/**"
-      - ".markdownlint.yaml"
-      - "_typos.toml"
-      - "lychee.toml"
-      - ".github/workflows/docs.yml"
 
 concurrency:
   group: docs-${{ github.ref }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -123,3 +123,34 @@ jobs:
       # astral-sh/ty-pre-commit rev in .pre-commit-config.yaml. Blocking.
       - name: Run ty
         run: uvx ty@0.0.48 check --python .venv
+
+  # Every numbered example must run credential-free (the CLAUDE.md contract:
+  # LLM-backed examples degrade gracefully when keys are missing). Blocking.
+  examples:
+    runs-on: ubuntu-latest
+    env:
+      DO_NOT_TRACK: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run all numbered examples
+        run: |
+          for f in examples/[0-9][0-9]_*.py; do
+            echo "::group::$f"
+            uv run python "$f"
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## What

Audit found **every status check on this repo was advisory** — neither classic branch protection nor the `Protect main` ruleset required a single one. Merges were gated only by review (routinely admin-bypassed) and CodeQL alerts.

This PR + accompanying settings changes make CI the merge authority and enable strict auto-merge.

## Workflow changes (this PR)

- **`docs.yml`**: drop the `pull_request` path filter — `Spelling`, `Markdown lint`, `Build docs` now run on every PR (~30s combined) so they can be required. Push trigger keeps its filter.
- **`python-tests.yml`**: new **`examples`** job — every numbered example runs credential-free, enforcing the CLAUDE.md contract ("examples must run in CI"). All 11 verified locally without API keys.

## Settings changes (applied via API alongside this PR)

- **Ruleset `Protect main`**: added `required_status_checks` (strict / up-to-date): `ci (3.12)`, `evals`, `format`, `typecheck`, `examples`, `Spelling`, `Markdown lint`, `Build docs`. Approval count 1 → 0 (PR still mandatory; review thread resolution now required). Code-scanning gate unchanged.
- **Classic branch protection: deleted** — consolidated into the ruleset. Its code-owner + last-push-approval requirements were unsatisfiable for solo PRs (the reason every merge needed `--admin`). Prior config for revert: `required_approving_review_count: 1, dismiss_stale_reviews: true, require_code_owner_reviews: true, require_last_push_approval: true, enforce_admins: false`.
- **Repo**: `allow_auto_merge: true`, `delete_branch_on_merge: true`.

## Deliberately advisory

- `Link check` — external-network flake risk would stall auto-merge.
- `footgun` — `continue-on-error` LLM review, advisory by design.
- `Deploy to Cloudflare Pages` — preview deploy, not a gate.
- Coverage floor already enforced at 70% inside `make test-cov` (no new gate needed).

## Validation

This PR is its own test: auto-merge is armed on it, so it merges only when all 8 required checks pass — org admins retain always-bypass for emergencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)