### PR TITLE
docs(spec): dataset & eval ontology — normative vocabulary for physical-AI readers and evals

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Run capability evals
         run: make eval-cap
 
+      # Spec-contract evals bind normative docs/guide clauses to executable
+      # guardrails (see evals/suites/spec_contracts.py). Previously this suite
+      # never ran in CI — it gates the merge now.
+      - name: Run spec-contract evals
+        run: make eval-spec
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ help:
 	@echo "  make eval           Run all eval suites"
 	@echo "  make eval-reg       Run regression suite only"
 	@echo "  make eval-cap       Run capability suite only"
+	@echo "  make eval-spec      Run spec-contract suite only"
 	@echo ""
 	@echo "Build & Release:"
 	@echo "  make build          Build sdist + wheel"
@@ -200,6 +201,10 @@ eval-reg:
 .PHONY: eval-cap
 eval-cap:
 	@PYTHONPATH=$(PYTHONPATH) uv run python -m evals.run --suite capability
+
+.PHONY: eval-spec
+eval-spec:
+	@PYTHONPATH=$(PYTHONPATH) uv run python -m evals.run --suite spec
 
 # ------------------------------------------------------------------------------
 # Build & Release

--- a/docs/guide/dataset-eval-ontology.md
+++ b/docs/guide/dataset-eval-ontology.md
@@ -1,0 +1,151 @@
+# Dataset & Eval Ontology
+
+**Document type:** Normative.
+**Scope:** Physical-AI dataset readers (DROID, EgoDex, LIBERO, LeRobot), the eval
+service, bench harnesses, and every surface that names benchmarks, tasks,
+episodes, trials, or checks.
+
+## 1. Why this page exists
+
+Archetype is growing several dataset readers and several eval surfaces at
+once. Each external dataset ships its own vocabulary, and each harness is
+tempted to redefine the same words. This page is the single source of meaning:
+readers and eval code import these nouns; dataset-native vocabulary is
+converted to them at the adapter boundary and goes no further.
+
+## 2. The nouns
+
+```text
+Benchmark   1—N  Suite         named curation (DROID, EgoDex, LIBERO, LeRobot)
+Suite       1—N  Task          a named set of tasks — never anything else
+Task        1—N  Episode       a label + instruction: what the robot did
+Episode     =    1 Trajectory + 0..N FrameStreams   the captured artifact
+Trial       1—1  Episode       one seeded execution; produces the episode
+Eval        1—1  Task          how a task is graded
+Eval        1—N  Check         one grader predicate/metric
+EvalSuite   ≅    Suite         a suite with checks bound to each task
+```
+
+- **Benchmark** — a named, versioned curation of suites, tasks, and episodes.
+  Identity: `benchmark` (string name). A dataset and a benchmark are the same
+  object; "benchmark" is the word once grading is attached.
+- **Suite** — a named set of tasks within a benchmark (LIBERO's
+  `libero_spatial` is a suite). Identity: `(benchmark, suite)`.
+- **Task** — a label plus instruction describing what the robot does
+  ("put the mug on the shelf"). Identity: `(benchmark, suite, task_key)`.
+- **Episode** — all data captured for one robot in one simulation or
+  real-world capture: exactly one trajectory plus zero or more frame streams.
+  Identity: `(benchmark, episode_id)` where `episode_id` is a
+  **dataset-scoped integer**. Bare `episode_id` is not globally unique.
+- **Trajectory** — the proprioceptive/motor signal stream of an episode
+  (joint states, effector poses, gripper actions). Not interchangeable with
+  episode in any schema, even though the field uses the words loosely.
+- **FrameStream** — one camera's image/video stream within an episode
+  (wrist cam, exterior cam). An episode may have several.
+- **Trial** — one seeded execution of a policy on a task. A trial produces
+  exactly one episode and carries execution provenance (seed, policy,
+  runtime coordinates).
+- **Check** — a single grader: a predicate or metric over an episode
+  (success flag, distance-to-goal, constraint violation).
+- **Eval** — the grading of one task: a task plus its checks, applied to
+  that task's episodes. An eval binds exactly one task.
+- **EvalSuite** — derived, not primitive. Because eval ↔ task is 1:1, a
+  suite of evals and a suite of tasks are the same set viewed from two
+  sides: `eval_suite(suite) = {eval(t) for t in suite}`.
+
+## 3. Two coordinate systems
+
+Every row in this domain is addressed by one of two key systems. They are
+never conflated.
+
+| System | Keys | Minted by | Example |
+|---|---|---|---|
+| Dataset coordinates | `benchmark`, `suite`, `task_key`, `episode_id: int` | The dataset curator | `("libero", "libero_spatial", 3, 41)` |
+| Runtime coordinates | `world_id`, `run_id`, tick range, execution UUIDs | The Archetype runtime | `EpisodeResult.world_id`, `run_id` |
+
+Rules:
+
+- Dataset coordinates are natural keys. Runtime coordinates are surrogate
+  keys. A schema MUST NOT use one where the other is meant.
+- An episode read from disk (DROID, EgoDex) has **no runtime coordinates**.
+- An episode minted by a live trial has **both**: the trial records
+  `world_id` / `run_id` / tick range as provenance, and the output dataset
+  assigns the integer `episode_id`.
+- Eval reports carry both systems side by side (as `TaskEvalReport` already
+  does with `suite`, `task_id`, `world_id`, `run_id`): dataset coordinates
+  say *what* was graded, runtime coordinates say *where the evidence lives*.
+
+## 4. Episode: dataset noun vs. runtime execution
+
+[Execution Hierarchy](execution-hierarchy.md) defines `run_episode` — a
+control-flow construct (step-until-termination) whose `EpisodeConfig` /
+`EpisodeResult` carry a UUID `episode_id`. That is a **runtime execution**,
+not the dataset noun, and its UUID is a runtime coordinate.
+
+The bridge is the trial: a trial wraps one runtime episode execution
+(typically one rollout fork), and its persisted output — trajectory rows,
+frame references, provenance — indexed with a dataset-scoped integer, **is**
+the dataset episode.
+
+```text
+run_episode(...)          runtime execution   (UUID, execution-hierarchy.md)
+    └─ wrapped by Trial   seed + policy + runtime provenance
+        └─ produces       Episode             (int id, this page)
+```
+
+Stated as a slogan: **datasets are frozen trials.** DROID and EgoDex are
+collections of trials someone else ran; LIBERO benchmarking mints new ones.
+
+## 5. The symmetry law
+
+Graders MUST NOT distinguish reader episodes from rollout episodes.
+
+- Readers and live trials emit the **same episode schema**.
+- Grading is query-backed: checks run over stored rows, never over live
+  in-process state. (This is what makes re-grading from the ledger possible.)
+- Trial provenance is present when the episode was minted live and absent
+  when it was read from an external dataset. Absence of provenance is the
+  only schema-visible difference, and no check may branch on it.
+
+## 6. Naming rules
+
+- **"Suite" only ever means a set of tasks.** The graders bound to an eval
+  are its *checks* and MUST NOT be called a suite. (`evals/suites/` — the
+  framework's own regression/capability meta-evals — is internal tooling and
+  exempt; its name does not license the other sense in this domain.)
+- An eval binds exactly one task. A report that spans tasks is an eval-suite
+  report, not an eval.
+- `trajectory` and `episode` are distinct schema words per §2, even where
+  the literature uses them interchangeably.
+- Dataset-native vocabulary stays inside its adapter (`bench/libero/`,
+  reader modules) and is converted to these nouns at the boundary. LIBERO's
+  `task_id: int` maps to `task_key`; LeRobot's `episode_index` maps to
+  `episode_id`.
+
+## 7. Reader mapping
+
+| Native term | Dataset | Ontology noun |
+|---|---|---|
+| `episode_index` | LeRobot | `episode_id` |
+| language instruction / annotation | DROID, LeRobot | Task instruction |
+| wrist / exterior camera streams | DROID, EgoDex | FrameStreams |
+| proprio / joint / effector series | all | Trajectory |
+| `libero_spatial`, `libero_object`, … | LIBERO | Suite |
+| BDDL task + instruction | LIBERO | Task |
+| seeded policy run | LIBERO bench | Trial |
+
+## 8. Conformance
+
+- **One vocabulary module.** The typed rows for these nouns live in exactly
+  one module; readers and eval services import them and never redefine them.
+- **Reader conformance suite.** One parametrized test suite that every
+  reader (DROID, EgoDex, LIBERO, LeRobot) must pass: same episode schema,
+  integer dataset-scoped `episode_id`, trajectory/frames separation, task
+  binding present. Adding a reader means adding a fixture, not assertions.
+- **Merge-gated contracts.** Ontology contracts belong in
+  `evals/suites/spec_contracts.py`; the `evals` job is a required status
+  check, so vocabulary violations cannot merge.
+
+Status: this page is normative now. The vocabulary module and reader
+conformance suite land with the first reader PR and the #252 rebase; until
+then, new code MUST NOT introduce vocabulary that conflicts with §2 and §6.

--- a/docs/guide/dataset-eval-ontology.md
+++ b/docs/guide/dataset-eval-ontology.md
@@ -3,7 +3,7 @@
 **Document type:** Normative.
 **Scope:** Physical-AI dataset readers (DROID, EgoDex, LIBERO, LeRobot), the eval
 service, bench harnesses, and every surface that names benchmarks, tasks,
-episodes, trials, or checks.
+episodes, trials, graders, or rubrics.
 
 ## 1. Why this page exists
 
@@ -13,42 +13,69 @@ tempted to redefine the same words. This page is the single source of meaning:
 readers and eval code import these nouns; dataset-native vocabulary is
 converted to them at the adapter boundary and goes no further.
 
-## 2. The nouns
+The executable mirror of this page is `archetype.datasets.definitions`, and
+the `spec` eval suite binds the two together as a required merge gate.
+
+## 2. Definitions
+
+This glossary is the iteration surface. Change the meaning here first; code
+follows.
 
 ```text
-Benchmark   1—N  Suite         named curation (DROID, EgoDex, LIBERO, LeRobot)
+Benchmark   =    Dataset + judgment (rubrics, eval results)
+Dataset     1—N  Suite         just what happened
 Suite       1—N  Task          a named set of tasks — never anything else
 Task        1—N  Episode       a label + instruction: what the robot did
 Episode     =    1 Trajectory + 0..N FrameStreams   the captured artifact
 Trial       1—1  Episode       one seeded execution; produces the episode
 Eval        1—1  Task          how a task is graded
-Eval        1—N  Check         one grader predicate/metric
-EvalSuite   ≅    Suite         a suite with checks bound to each task
+Eval        =    Task + Rubric
+Rubric      1—N  Grader        the skeleton of graders composing an eval
+Grader      ∈    {check, test, judge}
+EvalSuite   ≅    Suite         a suite with rubrics bound to each task
 ```
 
-- **Benchmark** — a named, versioned curation of suites, tasks, and episodes.
-  Identity: `benchmark` (string name). A dataset and a benchmark are the same
-  object; "benchmark" is the word once grading is attached.
+- **Dataset** — just what happened: episodes (observation and state),
+  organized by suites and tasks. A dataset contains no eval analysis.
+  Identity: `benchmark` (string name — see Benchmark).
+- **Benchmark** — what happened *plus* the analysis of what happened: a
+  dataset with rubrics bound to its tasks, and room for eval results.
+  Stated as law: **a dataset records; a benchmark judges.** The two share
+  one name string; "benchmark" is the word once grading is attached.
 - **Suite** — a named set of tasks within a benchmark (LIBERO's
-  `libero_spatial` is a suite). Identity: `(benchmark, suite)`.
+  `libero_spatial` is a suite). A suite is only ever a set of tasks.
+  A benchmark MAY have exactly one suite. Identity: `(benchmark, suite)`.
 - **Task** — a label plus instruction describing what the robot does
   ("put the mug on the shelf"). Identity: `(benchmark, suite, task_key)`.
 - **Episode** — all data captured for one robot in one simulation or
-  real-world capture: exactly one trajectory plus zero or more frame streams.
-  Identity: `(benchmark, episode_id)` where `episode_id` is a
-  **dataset-scoped integer**. Bare `episode_id` is not globally unique.
+  real-world capture: exactly one trajectory plus zero or more frame
+  streams. Identity: `(benchmark, episode_id)` where `episode_id` is a
+  **zero-based, dataset-scoped integer**. Bare `episode_id` is not
+  globally unique. Episodes have no fixed length — real captures run for
+  varying numbers of ticks — and every signal stream in an episode MUST
+  carry its sampling rate: the sampling rate is the fidelity at which the
+  dataset is curated.
 - **Trajectory** — the proprioceptive/motor signal stream of an episode
-  (joint states, effector poses, gripper actions). Not interchangeable with
-  episode in any schema, even though the field uses the words loosely.
+  (joint states, effector poses, gripper actions), with its sampling rate
+  in Hz. Not interchangeable with episode in any schema, even though the
+  field uses the words loosely.
 - **FrameStream** — one camera's image/video stream within an episode
-  (wrist cam, exterior cam). An episode may have several.
-- **Trial** — one seeded execution of a policy on a task. A trial produces
-  exactly one episode and carries execution provenance (seed, policy,
-  runtime coordinates).
-- **Check** — a single grader: a predicate or metric over an episode
-  (success flag, distance-to-goal, constraint violation).
-- **Eval** — the grading of one task: a task plus its checks, applied to
-  that task's episodes. An eval binds exactly one task.
+  (wrist cam, exterior cam), with its FPS. An episode may have several.
+- **Trial** — one seeded assignment of a task to an eval's execution.
+  Running a trial produces exactly one episode. The trial is the act; the
+  episode is the evidence. (See §5 for the readings this word does NOT
+  have.)
+- **Grader** — anything that scores an episode against a task. Three kinds:
+  - **Check** — a mechanical lint: a deterministic predicate over stored
+    state (success flag set, constraint never violated).
+  - **Test** — a deterministic behavioral assertion over episode dynamics
+    (reached the goal region within N ticks, gripper closed before lift).
+  - **Judge** — model-graded, qualitative scoring (LLM-as-judge). Use
+    sparingly: qualitative grading is the least reliable kind.
+- **Rubric** — the skeleton of graders that composes an eval. Rubrics are
+  named compositions; graders are their members.
+- **Eval** — the grading of exactly one task: a task plus its rubric,
+  applied to that task's episodes across many trials.
 - **EvalSuite** — derived, not primitive. Because eval ↔ task is 1:1, a
   suite of evals and a suite of tasks are the same set viewed from two
   sides: `eval_suite(suite) = {eval(t) for t in suite}`.
@@ -60,7 +87,7 @@ never conflated.
 
 | System | Keys | Minted by | Example |
 |---|---|---|---|
-| Dataset coordinates | `benchmark`, `suite`, `task_key`, `episode_id: int` | The dataset curator | `("libero", "libero_spatial", 3, 41)` |
+| Dataset coordinates | `benchmark`, `suite`, `task_key`, `episode_id: int` | The dataset curator | `("libero", "libero_spatial", "3", 41)` |
 | Runtime coordinates | `world_id`, `run_id`, tick range, execution UUIDs | The Archetype runtime | `EpisodeResult.world_id`, `run_id` |
 
 Rules:
@@ -71,9 +98,8 @@ Rules:
 - An episode minted by a live trial has **both**: the trial records
   `world_id` / `run_id` / tick range as provenance, and the output dataset
   assigns the integer `episode_id`.
-- Eval reports carry both systems side by side (as `TaskEvalReport` already
-  does with `suite`, `task_id`, `world_id`, `run_id`): dataset coordinates
-  say *what* was graded, runtime coordinates say *where the evidence lives*.
+- Eval reports carry both systems side by side: dataset coordinates say
+  *what* was graded, runtime coordinates say *where the evidence lives*.
 
 ## 4. Episode: dataset noun vs. runtime execution
 
@@ -96,25 +122,52 @@ run_episode(...)          runtime execution   (UUID, execution-hierarchy.md)
 Stated as a slogan: **datasets are frozen trials.** DROID and EgoDex are
 collections of trials someone else ran; LIBERO benchmarking mints new ones.
 
-## 5. The symmetry law
+**Runtime alignment (required change):** the dataset episode number is not
+currently stamped by any durable abstraction in Archetype. The simulation
+service MUST stamp a zero-based, dataset-scoped integer `episode_id` on
+trial outputs. Execution UUIDs (uuid7) remain runtime coordinates and do
+not satisfy this requirement.
+
+## 5. Trial: the readings this word does not have
+
+"Trial" is the easiest word in this domain to confuse. Three readings are
+rejected explicitly:
+
+1. A trial is **not** a task. The task is the label; the trial is one
+   execution of it.
+2. A trial is **not** many episodes of a task. Running a rubric over many
+   episodes is the *eval's* execution loop; each pass through that loop is
+   one trial.
+3. A trial is **not** the (task, episode) pair as data. That pair is the
+   trial's *identity*, but the trial itself is the seeded act of execution
+   — policy, seed, runtime provenance — from which the episode data falls
+   out.
+
+Two adjacent usages to keep quarantined: the meta-eval harness
+(`evals/types.py`) has an internal `TrialResult` for its own grader runs,
+and PR #247's "trial execution lifecycle" must be reconciled with this
+definition when it lands.
+
+## 6. The symmetry law
 
 Graders MUST NOT distinguish reader episodes from rollout episodes.
 
 - Readers and live trials emit the **same episode schema**.
-- Grading is query-backed: checks run over stored rows, never over live
-  in-process state. (This is what makes re-grading from the ledger possible.)
+- Grading is query-backed: graders run over stored rows, never over live
+  in-process state. (This is what makes re-grading from the ledger
+  possible.)
 - Trial provenance is present when the episode was minted live and absent
   when it was read from an external dataset. Absence of provenance is the
-  only schema-visible difference, and no check may branch on it.
+  only schema-visible difference, and no grader may branch on it.
 
-## 6. Naming rules
+## 7. Naming rules
 
-- **"Suite" only ever means a set of tasks.** The graders bound to an eval
-  are its *checks* and MUST NOT be called a suite. (`evals/suites/` — the
-  framework's own regression/capability meta-evals — is internal tooling and
-  exempt; its name does not license the other sense in this domain.)
-- An eval binds exactly one task. A report that spans tasks is an eval-suite
-  report, not an eval.
+- **A suite is only ever a set of tasks.** The graders bound to an eval
+  form its *rubric* and MUST NOT be called a suite. (`evals/suites/` — the
+  framework's own regression/capability meta-evals — is internal tooling
+  and exempt; its name does not license the other sense in this domain.)
+- An eval binds exactly one task. A report that spans tasks is an
+  eval-suite report, not an eval.
 - `trajectory` and `episode` are distinct schema words per §2, even where
   the literature uses them interchangeably.
 - Dataset-native vocabulary stays inside its adapter (`bench/libero/`,
@@ -122,7 +175,7 @@ Graders MUST NOT distinguish reader episodes from rollout episodes.
   `task_id: int` maps to `task_key`; LeRobot's `episode_index` maps to
   `episode_id`.
 
-## 7. Reader mapping
+## 8. Reader mapping
 
 | Native term | Dataset | Ontology noun |
 |---|---|---|
@@ -134,18 +187,19 @@ Graders MUST NOT distinguish reader episodes from rollout episodes.
 | BDDL task + instruction | LIBERO | Task |
 | seeded policy run | LIBERO bench | Trial |
 
-## 8. Conformance
+## 9. Conformance
 
-- **One vocabulary module.** The typed rows for these nouns live in exactly
-  one module; readers and eval services import them and never redefine them.
+- **Definitions module.** The typed vocabulary lives in exactly one module:
+  `archetype.datasets.definitions`. Readers and eval services import it and
+  never redefine the nouns. Identity vocabulary lands now; full row schemas
+  (episode contents, sampling metadata) land with the readers.
+- **Spec-contract gate.** `evals/suites/spec_contracts.py` binds this page
+  to the definitions module structurally (episode id is an int, eval binds
+  one task, trial produces one episode, grader kinds are exactly
+  check/test/judge). The `spec` suite runs in the required `evals` status
+  check, so vocabulary violations cannot merge.
 - **Reader conformance suite.** One parametrized test suite that every
   reader (DROID, EgoDex, LIBERO, LeRobot) must pass: same episode schema,
   integer dataset-scoped `episode_id`, trajectory/frames separation, task
-  binding present. Adding a reader means adding a fixture, not assertions.
-- **Merge-gated contracts.** Ontology contracts belong in
-  `evals/suites/spec_contracts.py`; the `evals` job is a required status
-  check, so vocabulary violations cannot merge.
-
-Status: this page is normative now. The vocabulary module and reader
-conformance suite land with the first reader PR and the #252 rebase; until
-then, new code MUST NOT introduce vocabulary that conflicts with §2 and §6.
+  binding present, sampling rates present. Adding a reader means adding a
+  fixture, not assertions. Lands with the first reader PR.

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -21,6 +21,7 @@ The current contract set is split across design docs and executable tests.
 | [Execution Hierarchy](execution-hierarchy.md) | Step/run/episode/rollout | Simulation levels and rollout fork semantics. |
 | [World Lifecycle](world-lifecycle.md) | Create/fork/destroy | Append-only lifecycle, info-class downgrade, fork sharing/copy rules. |
 | [Audit Log](audit-log.md) | Audit rows | Append-only audit history and query contract. |
+| [Dataset & Eval Ontology](dataset-eval-ontology.md) | Physical-AI dataset and eval vocabulary | Benchmark/suite/task/episode/trial/check nouns, dataset-vs-runtime coordinates, reader conformance. |
 | [`tests/app/test_runtime_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_contracts.py) | Executable runtime contracts | Enforces activation single-flight, runtime-vs-world lifetime, fork isolation, spawn visibility, governance, and smoke paths. |
 | [`tests/app/test_runtime_fork_storage.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_fork_storage.py) | Runtime fork storage contracts | Enforces fork storage inheritance through the runtime layer, lineage reads on fork handles, fork run_id minting, and gate-side storage resolution. |
 | [`tests/sync/test_sync_stack_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/sync/test_sync_stack_contracts.py) | Executable sync engine contracts | Enforces store/querier/updater/world behavior, mutation materialization, component migration, and despawn semantics. |

--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -92,6 +92,27 @@ SPEC_CASES: tuple[SpecCase, ...] = (
         anchors=("Append-only invariant", "no `drop_*` or `delete_*` methods"),
         task_id="spec.append_only_protocols",
     ),
+    SpecCase(
+        spec_id="dataset-eval-ontology.1",
+        source="dataset-eval-ontology.md",
+        anchors=("datasets are frozen trials", "exactly one episode"),
+        task_id="spec.dataset_eval_ontology",
+    ),
+    SpecCase(
+        spec_id="dataset-eval-ontology.2",
+        source="dataset-eval-ontology.md",
+        anchors=(
+            "zero-based, dataset-scoped integer",
+            "a dataset records; a benchmark judges",
+        ),
+        task_id="spec.dataset_eval_ontology",
+    ),
+    SpecCase(
+        spec_id="dataset-eval-ontology.3",
+        source="dataset-eval-ontology.md",
+        anchors=("A suite is only ever a set of tasks", "the skeleton of graders"),
+        task_id="spec.dataset_eval_ontology",
+    ),
 )
 
 _EXPECTED_TASK_IDS = frozenset(case.task_id for case in SPEC_CASES)
@@ -220,7 +241,10 @@ def _type_checking_ranges(tree: ast.AST) -> list[tuple[int, int]]:
         if not is_type_checking or not node.body:
             continue
         start = min(getattr(child, "lineno", node.lineno) for child in node.body)
-        end = max(getattr(child, "end_lineno", getattr(child, "lineno", node.lineno)) for child in node.body)
+        end = max(
+            getattr(child, "end_lineno", getattr(child, "lineno", node.lineno))
+            for child in node.body
+        )
         ranges.append((start, end))
     return ranges
 
@@ -306,10 +330,7 @@ def task_spec_manifest_traceability() -> list[GraderResult]:
 
 def task_role_permission_matrix() -> list[GraderResult]:
     """The code permission matrix exactly matches command-gate.md."""
-    actual = {
-        role: frozenset(commands)
-        for role, commands in COMMANDS_BY_ROLE.items()
-    }
+    actual = {role: frozenset(commands) for role, commands in COMMANDS_BY_ROLE.items()}
     explicit_non_admin_review = all(
         command in actual["admin"]
         and (
@@ -370,9 +391,7 @@ def task_command_service_gate_map() -> list[GraderResult]:
     path = SRC / "app" / "command_service.py"
     tree = ast.parse(path.read_text(), filename=str(path))
     functions = {
-        node.name: node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.AsyncFunctionDef)
+        node.name: node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef)
     }
 
     checks: dict[str, bool] = {}
@@ -566,6 +585,43 @@ class _UnusedService:
         raise AssertionError(f"unexpected call to unused fake service: {name}")
 
 
+def task_dataset_eval_ontology() -> list[GraderResult]:
+    """The definitions module matches the ontology's identity and cardinality laws."""
+    from dataclasses import fields, is_dataclass
+    from typing import get_type_hints
+
+    from archetype.datasets import definitions as defs
+
+    task_hints = get_type_hints(defs.TaskRef)
+    episode_hints = get_type_hints(defs.EpisodeRef)
+    eval_hints = get_type_hints(defs.Eval)
+    trial_hints = get_type_hints(defs.Trial)
+    rubric_hints = get_type_hints(defs.Rubric)
+    vocabulary = (defs.TaskRef, defs.EpisodeRef, defs.Grader, defs.Rubric, defs.Eval, defs.Trial)
+
+    checks = {
+        "task_identity_fields": [f.name for f in fields(defs.TaskRef)]
+        == ["benchmark", "suite", "task_key"],
+        "task_identity_is_strings": all(
+            task_hints[name] is str for name in ("benchmark", "suite", "task_key")
+        ),
+        "episode_identity_fields": [f.name for f in fields(defs.EpisodeRef)]
+        == ["benchmark", "episode_id"],
+        "episode_id_is_int": episode_hints["episode_id"] is int,
+        "eval_binds_single_task": eval_hints["task"] is defs.TaskRef,
+        "eval_composes_rubric": eval_hints["rubric"] is defs.Rubric,
+        "rubric_composes_graders": rubric_hints["graders"] == tuple[defs.Grader, ...],
+        "grader_kinds_exact": {kind.value for kind in defs.GraderKind}
+        == {"check", "test", "judge"},
+        "trial_produces_single_episode": trial_hints["episode"] is defs.EpisodeRef,
+        "trial_is_seeded": trial_hints["seed"] is int,
+        "vocabulary_frozen": all(
+            is_dataclass(cls) and cls.__dataclass_params__.frozen for cls in vocabulary
+        ),
+    }
+    return [state_check(checks, name="ontology_vocabulary_shape")]
+
+
 def _registered_task_ids() -> list[str]:
     harness = EvalHarness()
     register(harness)
@@ -596,6 +652,12 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_command_service_gate_map,
         desc="CommandService public methods use the documented gate and audit shape.",
+    )
+    harness.add(
+        "spec.dataset_eval_ontology",
+        suite=SUITE,
+        fn=task_dataset_eval_ontology,
+        desc="Dataset/eval vocabulary matches the ontology's identity and cardinality laws.",
     )
     harness.add(
         "spec.append_only_protocols",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - Execution Hierarchy: guide/execution-hierarchy.md
       - World Lifecycle: guide/world-lifecycle.md
       - Audit Log: guide/audit-log.md
+      - Dataset & Eval Ontology: guide/dataset-eval-ontology.md
   - Building:
       - Building Simulations: guide/building-simulations.md
       - Custom Commands: guide/custom-commands.md

--- a/src/archetype/datasets/__init__.py
+++ b/src/archetype/datasets/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Physical-AI dataset domain: vocabulary now, readers next.
+
+See ``docs/guide/dataset-eval-ontology.md`` for the normative contract.
+"""
+
+from archetype.datasets.definitions import (
+    EpisodeRef,
+    Eval,
+    Grader,
+    GraderKind,
+    Rubric,
+    TaskRef,
+    Trial,
+)
+
+__all__ = [
+    "EpisodeRef",
+    "Eval",
+    "Grader",
+    "GraderKind",
+    "Rubric",
+    "TaskRef",
+    "Trial",
+]

--- a/src/archetype/datasets/definitions.py
+++ b/src/archetype/datasets/definitions.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Vocabulary for the physical-AI dataset & eval domain.
+
+Normative source: ``docs/guide/dataset-eval-ontology.md``. This module is the
+executable mirror of that page's Definitions section: identity and cardinality
+only. Full row schemas (episode contents, sampling metadata) land with the
+dataset readers.
+
+The ``spec`` eval suite asserts this module's shape against the ontology; the
+suite runs inside the required ``evals`` status check, so changes here that
+break the ontology's laws cannot merge.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class GraderKind(StrEnum):
+    """The three kinds of grader a rubric may compose."""
+
+    CHECK = "check"
+    """Mechanical lint: a deterministic predicate over stored state."""
+
+    TEST = "test"
+    """Deterministic behavioral assertion over episode dynamics."""
+
+    JUDGE = "judge"
+    """Model-graded, qualitative scoring. The least reliable kind."""
+
+
+@dataclass(frozen=True)
+class TaskRef:
+    """Identity of a task: a label + instruction inside a benchmark suite."""
+
+    benchmark: str
+    suite: str
+    task_key: str
+
+
+@dataclass(frozen=True)
+class EpisodeRef:
+    """Identity of an episode: dataset coordinates, never runtime ones.
+
+    ``episode_id`` is a zero-based, dataset-scoped integer. Bare
+    ``episode_id`` is not globally unique; the composite key is.
+    """
+
+    benchmark: str
+    episode_id: int
+
+
+@dataclass(frozen=True)
+class Grader:
+    """One scorer of an episode against a task."""
+
+    name: str
+    kind: GraderKind
+
+
+@dataclass(frozen=True)
+class Rubric:
+    """The skeleton of graders that composes an eval."""
+
+    graders: tuple[Grader, ...]
+
+
+@dataclass(frozen=True)
+class Eval:
+    """The grading of exactly one task: the task plus its rubric."""
+
+    task: TaskRef
+    rubric: Rubric
+
+
+@dataclass(frozen=True)
+class Trial:
+    """One seeded assignment of a task to an eval's execution.
+
+    Running a trial produces exactly one episode: the trial is the act, the
+    episode is the evidence. Distinct from the meta-eval harness's internal
+    ``evals.types.TrialResult``.
+    """
+
+    task: TaskRef
+    seed: int
+    episode: EpisodeRef

--- a/tests/datasets/test_definitions.py
+++ b/tests/datasets/test_definitions.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Vocabulary invariants from docs/guide/dataset-eval-ontology.md.
+
+The spec eval suite (evals/suites/spec_contracts.py) is the merge gate for
+these laws; this module keeps them visible in the fast pytest loop too.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from archetype.datasets import (
+    EpisodeRef,
+    Eval,
+    Grader,
+    GraderKind,
+    Rubric,
+    TaskRef,
+    Trial,
+)
+
+
+def _mug_eval() -> Eval:
+    task = TaskRef(benchmark="libero", suite="libero_spatial", task_key="3")
+    rubric = Rubric(
+        graders=(
+            Grader(name="success_flag", kind=GraderKind.CHECK),
+            Grader(name="goal_within_horizon", kind=GraderKind.TEST),
+        )
+    )
+    return Eval(task=task, rubric=rubric)
+
+
+def test_eval_binds_exactly_one_task():
+    ev = _mug_eval()
+    assert isinstance(ev.task, TaskRef)
+
+
+def test_trial_produces_exactly_one_episode():
+    ev = _mug_eval()
+    trial = Trial(task=ev.task, seed=0, episode=EpisodeRef(benchmark="libero", episode_id=0))
+    assert isinstance(trial.episode, EpisodeRef)
+    assert trial.episode.episode_id == 0  # zero-based, dataset-scoped
+
+
+def test_grader_kinds_are_exactly_check_test_judge():
+    assert {kind.value for kind in GraderKind} == {"check", "test", "judge"}
+
+
+def test_vocabulary_is_frozen():
+    ev = _mug_eval()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ev.task = TaskRef(benchmark="droid", suite="default", task_key="0")  # type: ignore[misc]


### PR DESCRIPTION
## What

Adds `docs/guide/dataset-eval-ontology.md` — the normative vocabulary for the physical-AI dataset/eval domain, written **before** the #252 rebase so the rebase inherits the ontology rather than the other way around.

```text
Benchmark 1—N Suite 1—N Task 1—N Episode = 1 Trajectory + 0..N FrameStreams
Trial 1—1 Episode (produces) · Eval 1—1 Task, 1—N Check · EvalSuite ≅ Suite
```

Core laws:
- **Two coordinate systems**: dataset natural keys `(benchmark, suite, task_key, episode_id:int)` vs runtime surrogates `(world_id, run_id, tick)` — never conflated. Composite key `(benchmark, episode_id)` is episode identity.
- **Episode reconciliation**: the dataset episode (int) is distinct from `execution-hierarchy.md`'s runtime episode execution (UUID); a **Trial** bridges them — *datasets are frozen trials*.
- **Symmetry law**: graders never distinguish reader episodes (DROID/EgoDex) from rollout-minted ones (LIBERO); grading is query-backed from stored rows.
- **Suite disambiguation**: a suite is only ever a set of tasks; an eval's graders are *checks*. Since eval↔task is 1:1, eval-suite ≅ task-suite.

Wired into `specification.md`'s contract inventory and the mkdocs Specifications nav.

## Deliberately not armed for auto-merge

Ontology review pending — vocabulary revisions expected before this becomes law. Conformance machinery (vocabulary module, reader conformance suite, spec_contracts entries) lands with the first reader PR / #252 rebase.

## Verification

- `markdownlint-cli2` → 0 errors · `typos` → clean · `uv run --extra docs mkdocs build` → clean, page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)