### PR TITLE
Add query-backed EvalService

### DIFF
--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -12,19 +12,13 @@ The gate (`iCommandService`) sits in front of the other services and applies aut
 ## 2. Service dependency graph
 
 ```text
-iStorageService                                                   (leaf)
-    ↑             ↑                              ↑
-iWorldService     iQueryService           iAuditLog               (storage)
-    ↑               ↑                              ↑
-iMutationService    iSimulationService            (worlds)
-    ↑               ↑              ↑              ↑
-    └───────────────┴──────────────┴──────────────┘
-                          ↑
-                   iCommandBroker  (queue, no service deps)
-                          ↑
-                   iCommandService (the gate — ActorCtx-aware,
-                                    delegates to all of the above,
-                                    emits audit rows)
+iStorageService -> iWorldService -> iMutationService
+                              +---> iSimulationService
+                -> iQueryService -> iEvalService
+                -> iAuditLog
+
+iWorldService + iMutationService + iSimulationService + iQueryService
+    + iAuditLog + iCommandBroker -> iCommandService (the ActorCtx-aware gate)
 ```
 
 A tier MUST depend only on tiers strictly below it. Circular dependencies are forbidden.
@@ -98,9 +92,40 @@ Direct read path to storage. Independent of `iWorldService`.
 
 ```python
 async def query_archetype(sig, world_id, run_id, storage_config=None,
-                           *, ticks=None, entity_ids=None, components=None) -> DataFrame
+                           *, ticks=None, entity_ids=None, components=None,
+                           lineage=None) -> DataFrame
+async def query_components(components, world_id, run_id, storage_config=None,
+                           *, ticks=None, entity_ids=None, lineage=None) -> DataFrame
 async def list_signatures(storage_config=None) -> list[ArchetypeSignature]
 ```
+
+### `iEvalService`
+
+Dataframe-first evaluation over rows already persisted by Archetype. It
+depends only on `iQueryService`: it does not run simulations, own experiment
+lifecycle, choose a scoring schema, or persist scores on the caller's behalf.
+
+```python
+async def query_components(components, *, world_id, run_id,
+                           storage_config=None, ticks=None,
+                           entity_ids=None, lineage=None) -> DataFrame
+async def query_episode(episode, *, components, run_id=None,
+                        storage_config=None, entity_ids=None,
+                        lineage=None) -> DataFrame
+async def query_trajectory_component(component, *, world_id, run_id,
+                                     trajectory_ids=None, episode_ids=None,
+                                     rollout_ids=None, task_ids=None,
+                                     trial_idxs=None, **query_options) -> DataFrame
+async def run_graders(df, graders) -> list[object]
+async def grade_trajectory_component(component, *, world_id, run_id,
+                                     graders, **query_options) -> list[object]
+```
+
+`run_graders` MUST reject an empty grader set and any grader that returns no
+outputs. Such an evaluation is undefined; it must not be representable as a
+vacuous success through Python's `all([])` behavior. Grader outputs are returned
+to the caller and remain opaque to Archetype. If a score should be durable, the
+caller writes it as a component.
 
 ### `iCommandBroker`
 
@@ -269,6 +294,7 @@ class ServiceContainer:
         self.mutation_service = MutationService(self.world_service)
         self.simulation_service = SimulationService(self.world_service)
         self.query_service = QueryService(self.storage_service)
+        self.eval_service = EvalService(self.query_service)
         self.command_service = CommandService(
             mutations=self.mutation_service,
             worlds=self.world_service,

--- a/src/archetype/app/__init__.py
+++ b/src/archetype/app/__init__.py
@@ -24,12 +24,14 @@ Services:
 - CommandService: Auth routing + command dispatch
 - SimulationService: Execution (step/run with broker drain)
 - QueryService: Time-travel reads
+- EvalService: Query-backed evaluation over persisted components
 - ServiceContainer: Wires everything together
 """
 
 from archetype.app.broker import CommandBroker
 from archetype.app.command_service import CommandService
 from archetype.app.container import ServiceContainer
+from archetype.app.eval_service import EvalService
 from archetype.app.models import (
     AuditRow,
     Command,
@@ -54,6 +56,7 @@ __all__ = [
     "WorldService",
     "SimulationService",
     "QueryService",
+    "EvalService",
     "StorageService",
     "ServiceContainer",
     # Infrastructure

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -372,6 +372,8 @@ class CommandService:
             payload_json=json.dumps(
                 {
                     "episode_id": str(result.episode_id),
+                    "run_id": str(result.run_id) if result.run_id is not None else None,
+                    "start_tick": result.start_tick,
                     "final_tick": result.final_tick,
                     "terminated": result.terminated,
                     "duration_steps": result.duration_steps,

--- a/src/archetype/app/container.py
+++ b/src/archetype/app/container.py
@@ -24,6 +24,7 @@ from archetype.app.audit_log import AuditLog
 from archetype.app.autoresearch_service import AutoResearchService
 from archetype.app.broker import CommandBroker
 from archetype.app.command_service import CommandService
+from archetype.app.eval_service import EvalService
 from archetype.app.mutation_service import MutationService
 from archetype.app.query_service import QueryService
 from archetype.app.simulation_service import SimulationService
@@ -55,6 +56,7 @@ class ServiceContainer:
         self.world_service = WorldService(self.storage_service)
         self.audit_log = AuditLog(self.storage_service)
         self.query_service = QueryService(self.storage_service, self.audit_log)
+        self.eval_service = EvalService(self.query_service)
 
         # Services that depend on WorldService
         self.mutation_service = MutationService(self.world_service)

--- a/src/archetype/app/eval_service.py
+++ b/src/archetype/app/eval_service.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dataframe-first evaluation over persisted component rows.
+
+``EvalService`` does not own simulation, experiment lifecycle, or a durable
+scoring schema. It finds persisted rows through ``QueryService`` and runs
+caller-provided graders over Daft DataFrames.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from inspect import isawaitable
+from typing import Any
+
+from daft import DataFrame, col
+from uuid_utils import UUID
+
+from archetype.app.models import EpisodeResult
+from archetype.app.query_service import QueryService
+from archetype.core.component import Component
+from archetype.core.config import StorageConfig
+from archetype.experiments.trajectories import Trajectory
+
+GraderOutput = object
+GraderReturn = GraderOutput | Sequence[GraderOutput]
+TrajectoryGrader = Callable[[DataFrame], GraderReturn | Awaitable[GraderReturn]]
+
+
+class EvalService:
+    """Query persisted rows and execute graders over DataFrames.
+
+    The returned analysis surface is a Daft DataFrame. Durable scores remain
+    components written by the caller when a score should persist.
+    """
+
+    def __init__(self, query_service: QueryService) -> None:
+        self._query_service = query_service
+
+    async def query_components(
+        self,
+        components: Sequence[type[Component]],
+        *,
+        world_id: str | UUID,
+        run_id: str | UUID,
+        storage_config: StorageConfig | None = None,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+    ) -> DataFrame:
+        """Return persisted component rows as a Daft DataFrame."""
+        return await self._query_service.query_components(
+            list(components),
+            world_id=str(world_id),
+            run_id=str(run_id),
+            storage_config=storage_config,
+            ticks=ticks,
+            entity_ids=entity_ids,
+            lineage=lineage,
+        )
+
+    async def query_episode(
+        self,
+        episode: EpisodeResult,
+        *,
+        components: Sequence[type[Component]],
+        run_id: str | UUID | None = None,
+        storage_config: StorageConfig | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+    ) -> DataFrame:
+        """Return component rows produced during one episode."""
+        active_run_id = run_id or episode.run_id
+        if active_run_id is None:
+            raise ValueError("query_episode requires episode.run_id or run_id")
+        return await self.query_components(
+            components,
+            world_id=episode.world_id,
+            run_id=active_run_id,
+            storage_config=storage_config,
+            ticks=list(range(int(episode.start_tick), int(episode.final_tick))),
+            entity_ids=entity_ids,
+            lineage=lineage,
+        )
+
+    async def query_trajectory_component(
+        self,
+        component: type[Component] = Trajectory,
+        *,
+        world_id: str | UUID,
+        run_id: str | UUID,
+        storage_config: StorageConfig | None = None,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+        trajectory_ids: Sequence[str] | None = None,
+        episode_ids: Sequence[str] | None = None,
+        rollout_ids: Sequence[str] | None = None,
+        task_ids: Sequence[str] | None = None,
+        trial_idxs: Sequence[int] | None = None,
+    ) -> DataFrame:
+        """Return one typed trajectory component filtered by target fields.
+
+        Components such as ``Trajectory``, ``TrajectoryReward``, and
+        ``TrajectoryObservation`` each have their own table shape. A grader
+        needing several trajectory tables should request each DataFrame.
+        """
+        df = await self.query_components(
+            [component],
+            world_id=world_id,
+            run_id=run_id,
+            storage_config=storage_config,
+            ticks=ticks,
+            entity_ids=entity_ids,
+            lineage=lineage,
+        )
+        filters = {
+            "trajectory_id": trajectory_ids,
+            "episode_id": episode_ids,
+            "rollout_id": rollout_ids,
+            "task_id": task_ids,
+            "trial_idx": trial_idxs,
+        }
+        return _filter_component_rows(df, component, filters)
+
+    async def run_graders(
+        self,
+        df: DataFrame,
+        graders: Sequence[TrajectoryGrader],
+    ) -> list[GraderOutput]:
+        """Execute graders and flatten their non-empty outputs.
+
+        An evaluation with no graders or no grader outputs is undefined, not a
+        passing evaluation. Reject both cases here so callers cannot turn an
+        empty result into a vacuous success via ``all([])``.
+        """
+        if not graders:
+            raise ValueError("run_graders requires at least one grader")
+
+        results: list[GraderOutput] = []
+        for grader in graders:
+            raw = grader(df)
+            output = await raw if isawaitable(raw) else raw
+            if isinstance(output, Sequence) and not isinstance(output, str | bytes):
+                if not output:
+                    name = getattr(grader, "__name__", type(grader).__name__)
+                    raise ValueError(f"grader {name!r} returned no outputs")
+                results.extend(output)
+            else:
+                results.append(output)
+        return results
+
+    async def grade_trajectory_component(
+        self,
+        component: type[Component] = Trajectory,
+        *,
+        world_id: str | UUID,
+        run_id: str | UUID,
+        graders: Sequence[TrajectoryGrader],
+        storage_config: StorageConfig | None = None,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+        trajectory_ids: Sequence[str] | None = None,
+        episode_ids: Sequence[str] | None = None,
+        rollout_ids: Sequence[str] | None = None,
+        task_ids: Sequence[str] | None = None,
+        trial_idxs: Sequence[int] | None = None,
+    ) -> list[GraderOutput]:
+        """Query one trajectory component and execute graders over it."""
+        df = await self.query_trajectory_component(
+            component,
+            world_id=world_id,
+            run_id=run_id,
+            storage_config=storage_config,
+            ticks=ticks,
+            entity_ids=entity_ids,
+            lineage=lineage,
+            trajectory_ids=trajectory_ids,
+            episode_ids=episode_ids,
+            rollout_ids=rollout_ids,
+            task_ids=task_ids,
+            trial_idxs=trial_idxs,
+        )
+        return await self.run_graders(df, graders)
+
+
+def _filter_component_rows(
+    df: DataFrame,
+    component: type[Component],
+    filters: dict[str, Sequence[Any] | None],
+) -> DataFrame:
+    prefix = component.get_prefix()
+    model_fields = getattr(component, "model_fields", {})
+    for field_name, values in filters.items():
+        if values is None or field_name not in model_fields:
+            continue
+        df = df.where(col(f"{prefix}{field_name}").is_in(list(values)))
+    return df

--- a/src/archetype/app/interfaces.py
+++ b/src/archetype/app/interfaces.py
@@ -18,23 +18,20 @@ Every protocol here represents a service boundary visible to the
 ``ServiceContainer``.  Internal composition (factories, registries,
 orchestrators) lives in the implementation modules, not here.
 
-Service dependency graph::
+Service dependency graph (providers point to consumers)::
 
-    iStorageService                                    (leaf)
-        ↑             ↑                 ↑
-    iWorldService     iQueryService     iAuditLog      (storage-backed)
-        ↑
-    iMutationService  iSimulationService               (worlds)
-        ↑               ↑         ↑         ↑
-        └───────────────┴─────────┴─────────┘
-                        ↑
-                 iCommandBroker                         (queue)
-                        ↑
-                 iCommandService                        (the gate)
+    iStorageService -> iWorldService -> iMutationService
+                                  +---> iSimulationService
+                    -> iQueryService -> iEvalService
+                    -> iAuditLog
+
+    iWorldService + iMutationService + iSimulationService + iQueryService
+        + iAuditLog + iCommandBroker -> iCommandService (the gate)
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Protocol
 
 from daft import DataFrame
@@ -193,11 +190,97 @@ class iQueryService(Protocol):
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
         components: list[type[Component]] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+    ) -> DataFrame: ...
+
+    async def query_components(
+        self,
+        components: list[type[Component]],
+        world_id: str,
+        run_id: str,
+        storage_config: StorageConfig | None = None,
+        *,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
     ) -> DataFrame: ...
 
     async def list_signatures(
         self, storage_config: StorageConfig | None = None
     ) -> list[ArchetypeSignature]: ...
+
+
+class iEvalService(Protocol):
+    """Dataframe-first evaluation over persisted component rows.
+
+    Depends on: ``iQueryService``
+    """
+
+    def __init__(self, query_service: iQueryService) -> None: ...
+
+    async def query_components(
+        self,
+        components: Sequence[type[Component]],
+        *,
+        world_id: str | UUID,
+        run_id: str | UUID,
+        storage_config: StorageConfig | None = None,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+    ) -> DataFrame: ...
+
+    async def query_episode(
+        self,
+        episode: EpisodeResult,
+        *,
+        components: Sequence[type[Component]],
+        run_id: str | UUID | None = None,
+        storage_config: StorageConfig | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+    ) -> DataFrame: ...
+
+    async def query_trajectory_component(
+        self,
+        component: type[Component],
+        *,
+        world_id: str | UUID,
+        run_id: str | UUID,
+        storage_config: StorageConfig | None = None,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+        trajectory_ids: Sequence[str] | None = None,
+        episode_ids: Sequence[str] | None = None,
+        rollout_ids: Sequence[str] | None = None,
+        task_ids: Sequence[str] | None = None,
+        trial_idxs: Sequence[int] | None = None,
+    ) -> DataFrame: ...
+
+    async def run_graders(
+        self,
+        df: DataFrame,
+        graders: Sequence[Callable[[DataFrame], object]],
+    ) -> list[object]: ...
+
+    async def grade_trajectory_component(
+        self,
+        component: type[Component],
+        *,
+        world_id: str | UUID,
+        run_id: str | UUID,
+        graders: Sequence[Callable[[DataFrame], object]],
+        storage_config: StorageConfig | None = None,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        lineage: list[tuple[str, str, int]] | None = None,
+        trajectory_ids: Sequence[str] | None = None,
+        episode_ids: Sequence[str] | None = None,
+        rollout_ids: Sequence[str] | None = None,
+        task_ids: Sequence[str] | None = None,
+        trial_idxs: Sequence[int] | None = None,
+    ) -> list[object]: ...
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/archetype/app/models.py
+++ b/src/archetype/app/models.py
@@ -197,6 +197,8 @@ class EpisodeResult(BaseModel):
     model_config = dict(frozen=True, arbitrary_types_allowed=True)
     episode_id: str | JsonUUID
     world_id: str | JsonUUID
+    run_id: str | JsonUUID | None = None
+    start_tick: int = 0
     final_tick: int = 0
     terminated: bool = False
     duration_steps: int = 0

--- a/src/archetype/app/simulation_service.py
+++ b/src/archetype/app/simulation_service.py
@@ -119,6 +119,9 @@ class SimulationService:
         if not isinstance(world, AsyncWorld):
             raise TypeError("run_episode requires AsyncWorld")
 
+        if not world.run_id:
+            world.run_id = str(config.run_config.run_id)
+
         start_tick = world.tick
         terminated = False
         step_count = 0
@@ -144,6 +147,8 @@ class SimulationService:
         return EpisodeResult(
             episode_id=config.episode_id,
             world_id=world_id,
+            run_id=world.run_id,
+            start_tick=start_tick,
             final_tick=world.tick,
             terminated=terminated,
             duration_steps=world.tick - start_tick,

--- a/tests/app/test_eval_service.py
+++ b/tests/app/test_eval_service.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EvalService contracts."""
+
+from __future__ import annotations
+
+import daft
+import pytest
+from daft import DataFrame, col
+
+from archetype.app.container import ServiceContainer
+from archetype.app.eval_service import EvalService
+from archetype.app.models import EpisodeConfig
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.experiments.trajectories import Trajectory, TrajectoryReward
+from evals.graders import exact_match, state_check
+from evals.types import GraderResult
+
+
+class Score(Component):
+    value: int = 0
+
+
+class IncrementScore(AsyncProcessor):
+    components = (Score,)
+    priority = 10
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        return df.with_column("score__value", col("score__value") + 1)
+
+
+def _score_rows(df: DataFrame) -> list[dict]:
+    return df.collect().to_pylist()
+
+
+@pytest.mark.asyncio
+async def test_container_wires_eval_service():
+    container = ServiceContainer()
+    try:
+        assert isinstance(container.eval_service, EvalService)
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_eval_service_queries_explicit_component_window(tmp_path):
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="eval")
+        world = await container.world_service.create_world(WorldConfig(name="scores"), storage)
+        await world.add_processor(IncrementScore())
+        await world.create_entity([Score(value=1)])
+
+        run = await container.simulation_service.run(world.world_id, RunConfig(num_steps=3))
+        df = await container.eval_service.query_components(
+            [Score],
+            world_id=world.world_id,
+            run_id=run.run_id,
+            ticks=[0, 1, 2],
+            storage_config=storage,
+        )
+
+        assert isinstance(df, DataFrame)
+        assert [row["score__value"] for row in _score_rows(df)] == [1, 2, 3]
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_eval_service_queries_episode_dataframe(tmp_path):
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="eval_episode")
+        world = await container.world_service.create_world(WorldConfig(name="episode"), storage)
+        await world.add_processor(IncrementScore())
+        await world.create_entity([Score(value=5)])
+        await container.simulation_service.run(world.world_id, RunConfig(num_steps=1))
+
+        episode = await container.simulation_service.run_episode(
+            world.world_id,
+            EpisodeConfig(max_steps=2),
+        )
+
+        df = await container.eval_service.query_episode(
+            episode,
+            components=[Score],
+            storage_config=storage,
+        )
+
+        rows = _score_rows(df)
+        assert episode.start_tick == 1
+        assert [row["tick"] for row in rows] == [1, 2]
+        assert [row["score__value"] for row in rows] == [6, 7]
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_eval_service_filters_trajectory_component_and_runs_graders(tmp_path):
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="eval_trajectory")
+        world = await container.world_service.create_world(WorldConfig(name="trajectory"), storage)
+        await world.create_entity(
+            [
+                Trajectory(
+                    trajectory_id="traj-a",
+                    run_id="run-a",
+                    episode_id="episode-a",
+                    task_id="reach",
+                    trial_idx=0,
+                    terminal=True,
+                    outcome="success",
+                )
+            ]
+        )
+        await world.create_entity(
+            [
+                Trajectory(
+                    trajectory_id="traj-b",
+                    run_id="run-a",
+                    episode_id="episode-b",
+                    task_id="reach",
+                    trial_idx=1,
+                    terminal=True,
+                    outcome="failure",
+                )
+            ]
+        )
+
+        run = await container.simulation_service.run(world.world_id, RunConfig(num_steps=1))
+        df = await container.eval_service.query_trajectory_component(
+            Trajectory,
+            world_id=world.world_id,
+            run_id=run.run_id,
+            task_ids=["reach"],
+            trial_idxs=[1],
+            storage_config=storage,
+        )
+
+        rows = _score_rows(df)
+        assert [row["trajectory__trajectory_id"] for row in rows] == ["traj-b"]
+
+        def grade_failure(frame: DataFrame) -> GraderResult:
+            graded_rows = frame.collect().to_pylist()
+            return state_check(
+                {
+                    "one_row": len(graded_rows) == 1,
+                    "selected_failure": graded_rows[0]["trajectory__outcome"] == "failure",
+                },
+                name="selected_trajectory",
+            )
+
+        results = await container.eval_service.run_graders(df, [grade_failure])
+
+        assert len(results) == 1
+        assert isinstance(results[0], GraderResult)
+        assert results[0].passed is True
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_eval_service_grades_trajectory_component_with_custom_sampling(tmp_path):
+    container = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="eval_rewards")
+        world = await container.world_service.create_world(WorldConfig(name="rewards"), storage)
+        await world.create_entity([TrajectoryReward(trajectory_id="traj-a", seq=0, reward=0.25)])
+        await world.create_entity([TrajectoryReward(trajectory_id="traj-a", seq=1, reward=1.0)])
+        await world.create_entity([TrajectoryReward(trajectory_id="traj-b", seq=0, reward=-1.0)])
+
+        run = await container.simulation_service.run(world.world_id, RunConfig(num_steps=1))
+
+        def grade_total_reward(frame: DataFrame) -> list[GraderResult]:
+            rows = frame.collect().to_pylist()
+            total_reward = sum(row["trajectoryreward__reward"] for row in rows)
+            return [
+                exact_match(len(rows), 2, name="sample_count"),
+                exact_match(total_reward, 1.25, name="total_reward"),
+            ]
+
+        results = await container.eval_service.grade_trajectory_component(
+            TrajectoryReward,
+            world_id=world.world_id,
+            run_id=run.run_id,
+            trajectory_ids=["traj-a"],
+            graders=[grade_total_reward],
+            storage_config=storage,
+        )
+
+        assert [result.passed for result in results] == [True, True]
+        assert [result.grader_name for result in results] == ["sample_count", "total_reward"]
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_eval_service_rejects_vacuous_grader_sets():
+    container = ServiceContainer()
+    try:
+        df = daft.from_pydict({"value": [1]})
+
+        with pytest.raises(ValueError, match="at least one grader"):
+            await container.eval_service.run_graders(df, [])
+
+        def no_results(_frame: DataFrame) -> list[object]:
+            return []
+
+        with pytest.raises(ValueError, match="returned no outputs"):
+            await container.eval_service.run_graders(df, [no_results])
+    finally:
+        await container.shutdown()

--- a/tests/integration/test_episode_rollout.py
+++ b/tests/integration/test_episode_rollout.py
@@ -98,6 +98,8 @@ class TestEpisode:
             result = await container.simulation_service.run_episode(world.world_id, config)
 
             assert result.duration_steps == 10
+            assert result.run_id == world.run_id
+            assert result.start_tick == 0
             assert result.final_tick == 10
         finally:
             await container.shutdown()
@@ -114,6 +116,7 @@ class TestEpisode:
             result = await container.simulation_service.run_episode(world.world_id, config)
 
             assert str(result.world_id) == str(wid_before)
+            assert result.run_id is not None
         finally:
             await container.shutdown()
 


### PR DESCRIPTION
## Summary

Adds a narrowly scoped, dataframe-first `EvalService` over persisted Archetype rows.

- Queries component and trajectory rows by explicit `(world_id, run_id)` identity.
- Queries the exact tick window produced by an `EpisodeResult`.
- Runs synchronous or asynchronous caller-provided graders without owning a scoring schema.
- Rejects empty grader sets and empty grader outputs so undefined evaluation cannot become a vacuous `all([])` success.
- Wires the service into `ServiceContainer` and documents the normative protocol.
- Adds `run_id` and `start_tick` to episode results so evaluations do not reconstruct provenance from ambient runtime state.

This supersedes the core EvalService portion of #252. It intentionally excludes the app-directory reorganization, LIBERO/VLA work, benchmark changes, performance changes, and autoresearch hardening from that draft. AutoResearch improvements will follow as a separate review unit.

## Why

Evaluation should be able to read raw persisted component rows through Archetype's existing query boundary. The service remains scoring-agnostic: callers decide grader types and persist domain scores as components when needed.

## Validation

- `make test` — 704 passed
- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uvx ty@0.0.48 check --python .venv`
- focused EvalService and episode integration tests — 16 passed
- lazy-evaluation and API-boundary audits — passed
- Markdown lint — passed
- `git diff --check`

