### PR TITLE
Harden AutoResearch attempt lifecycle

### DIFF
--- a/docs/guide/autoresearch.md
+++ b/docs/guide/autoresearch.md
@@ -2,7 +2,7 @@
 
 AutoResearch is a pattern for autonomous software optimization: track a single branch head, evaluate candidate commits against it, and advance the head only when a run improves a user-defined metric. The shape — experiment, run, result, keep / discard / crash — follows Andrej Karpathy's framing of autonomous software optimization as a research direction.
 
-**Status: the loop runs on the ledger.** The lifecycle components are implemented, and `AutoResearchService` records its own state as entities in a lab world — the loop is itself an archetype simulation.
+**Status: attempts run on the ledger.** `AutoResearchService` records a `RUNNING` row before candidate preparation or rollout, then records `STOPPED` with an evaluation or `CRASHED` with failure metadata. The loop is itself an archetype simulation.
 
 ## What's Implemented
 
@@ -32,39 +32,102 @@ After ingestion, runs are queryable as entities in the world — filter by `expe
 
 ## The Loop
 
-`AutoResearchService.run(world_id, config, evaluator)` is the controller:
-each iteration forks the base world, runs a rollout, hands the result to
-your evaluator, and advances the head when the score beats the incumbent.
-The service stays scoring-agnostic — the evaluator is yours: scalar,
-Pareto, LLM judge, tournament, human vote.
+`AutoResearchService.run(world_id, config, evaluator)` is the controller. A
+caller supplies a stable `experiment_id`; the human-readable
+`experiment_name` is not used as an identity key. The caller also supplies
+stable evaluator and rollout contract IDs; callable names are recorded only as
+diagnostics, not treated as semantic identities. Each iteration optionally
+prepares a candidate world, runs a rollout from that world, hands the result to
+the caller's evaluator, and advances the head when the finite score beats the
+incumbent.
+
+Evaluators should return `EvaluationResult`, which carries a score, evaluator
+identity, evidence metadata, and optional additional metadata. The result's
+evaluator must equal the config's stable `evaluator_id`, so scores from
+different contracts cannot be compared. Returning a plain `float` remains
+supported and is persisted with the configured evaluator identity.
 
 **The loop's own state lives on the ledger.** Each experiment gets a lab
-world named `autoresearch:{experiment_name}`, sharing the base world's
+world named `autoresearch:{experiment_id}`, sharing the base world's
 storage:
 
-- **tick 0** — genesis: the `Experiment` and a seed `BranchHead`, persisted
-  as raw initial conditions
-- **every subsequent tick** — one iteration: a `Run` row, a `Result` row
-  (score, episode world ids, full provenance), and the `BranchHead`
-  advance when the iteration improved
-- **resume is a read** — a second `run()` of the same experiment reads the
-  incumbent from the latest `BranchHead` row and continues iteration
-  numbering from the lab tick. There is no in-memory loop state to lose.
+- **tick 0** — genesis: the `Experiment`, semantic configuration digest, and a
+  seed `BranchHead`, persisted as raw initial conditions
+- **first attempt tick** — a `Run` in `RUNNING` state, written before candidate
+  preparation or rollout
+- **terminal attempt tick** — the same `Run` transitions to `STOPPED` or
+  `CRASHED`; a stopped attempt adds the typed `Result` and any `BranchHead`
+  advance
+- **resume validates identity** — the stored experiment id, base world, display
+  name, evaluator contract, and semantic configuration must match before
+  another attempt is recorded; `max_iterations` is invocation-local and may
+  change when extending an experiment; an active attempt must be reconciled
+  before resume
 
 ```python
+from archetype.app.autoresearch_service import AutoResearchConfig, EvaluationResult
+
+
+async def prepare_candidate(context):
+    candidate = await container.world_service.fork_world(
+        context.base_world_id,
+        name=f"candidate-{context.iteration}",
+    )
+    # Apply this iteration's candidate changes to the fork here.
+    return candidate.world_id
+
+
+def evaluate(rollout):
+    return EvaluationResult(
+        score=my_score(rollout),
+        evaluator="task-success-v1",
+        evidence={"manifest": "sha256:..."},
+    )
+
+
+config = AutoResearchConfig(
+    experiment_id="exp-2026-001",
+    experiment_name="exp",
+    evaluator_id="task-success-v1",
+    rollout_contract_id="candidate-rollout-v1",
+    max_iterations=10,
+)
 result = await container.autoresearch_service.run(
     base_world_id,
-    AutoResearchConfig(experiment_name="exp", max_iterations=10),
-    evaluator=my_score_fn,
+    config,
+    evaluator=evaluate,
+    prepare_candidate=prepare_candidate,
 )
 
 lab = container.world_service.get_world(result.lab_world_id)
 heads = await lab.query_archetype(sig=(BranchHead,), ticks=[t])  # head at any tick
+
+# Explicitly reattach the same registered lab instead of relying on name lookup.
+resumed = await container.autoresearch_service.run(
+    base_world_id,
+    config,
+    evaluator=evaluate,
+    lab_world_id=result.lab_world_id,
+)
 ```
 
-Because the lab world is an ordinary world, the experiment itself is
-forkable: fork the lab at any tick and replay "what if a different run had
-advanced the head." Contract tests: `tests/app/test_autoresearch_ledger.py`.
+`prepare_candidate` receives a `CandidateContext` with deterministic
+experiment, iteration, and run identities. Returning `None` evaluates the
+original base world. Candidate worlds remain caller-owned.
+
+Because the lab world is an ordinary world, the experiment itself is forkable:
+fork the lab at any tick and replay "what if a different run had advanced the
+head." Contract tests: `tests/app/test_autoresearch_ledger.py`.
+
+### Boundary
+
+This service does not generate candidates, mutate Git, merge or promote a
+winner, coordinate messages, or provide exactly-once/concurrent attempt
+claims. `lab_world_id` reattaches a world already registered with the current
+`WorldService`; it does not reconstruct a destroyed process's world catalog.
+Those are outer orchestration concerns. A float comparison and a
+`BranchHead` update mean only that this caller's configured evaluator selected
+a better recorded result.
 
 ## Why ECS-Native
 

--- a/experiments/cooperative_emergence.py
+++ b/experiments/cooperative_emergence.py
@@ -16,7 +16,6 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-import json
 
 from daft import DataFrame, col
 from daft.functions import when
@@ -26,7 +25,6 @@ from archetype.app.autoresearch_service import AutoResearchConfig
 from archetype.app.models import EpisodeConfig, RolloutResult
 from archetype.core.config import RunConfig
 from archetype.core.hooks import PostTick
-
 
 # ── Components ────────────────────────────────────────────────────────────
 
@@ -102,11 +100,8 @@ class RegrowthProcessor(AsyncProcessor):
     priority = 20
 
     async def process(self, df: DataFrame, **kw) -> DataFrame:
-        regrowth = (
-            col("pool__current")
-            + col("pool__regen_rate")
-            * col("pool__current")
-            * (1.0 - col("pool__current") / col("pool__capacity"))
+        regrowth = col("pool__current") + col("pool__regen_rate") * col("pool__current") * (
+            1.0 - col("pool__current") / col("pool__capacity")
         )
         return df.with_columns(
             {
@@ -252,6 +247,9 @@ async def main():
 
             config = AutoResearchConfig(
                 experiment_name=f"commons-regen-{regen}",
+                experiment_id=f"commons-regen-{regen}",
+                evaluator_id="cooperation-score-v1",
+                rollout_contract_id="commons-dynamics-v1",
                 episode_config=EpisodeConfig(
                     run_config=RunConfig(),
                     max_steps=max_steps,
@@ -314,14 +312,18 @@ async def main():
 
         print()
         if boundary:
-            print(f"Phase boundary detected: between regen={boundary[0]:.2f} and regen={boundary[1]:.2f}")
+            print(
+                f"Phase boundary detected: between regen={boundary[0]:.2f} and regen={boundary[1]:.2f}"
+            )
             print("Cooperation transitions from collapse to sustainability in this range.")
         else:
             all_scores = [s for _, s in sorted_results]
             if all(s >= 0.5 for s in all_scores):
                 print("All parameter points sustained — try lower regen rates to find collapse.")
             else:
-                print("All parameter points collapsed — try higher regen rates to find sustainability.")
+                print(
+                    "All parameter points collapsed — try higher regen rates to find sustainability."
+                )
 
         print()
         print("Done. All results queryable via QueryService (append-only).")

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -74,19 +74,19 @@ reason = "Lineage metadata extract: a fork's ancestor segments (bounded by fork 
 
 [[entries]]
 path = "src/archetype/app/autoresearch_service.py"
-line = 542
+line = 581
 method = "to_pylist"
 reason = "Single-row experiment-contract extract: the persisted identity and JSON configuration digest must enter Python control flow for exact collision rejection before the service records a resumed attempt; this is an imperative lifecycle gate, not a downstream dataframe computation."
 
 [[entries]]
 path = "src/archetype/app/autoresearch_service.py"
-line = 550
+line = 589
 method = "to_pylist"
 reason = "Single-row loop-state extract: the latest BranchHead row must enter Python control flow for incumbent score comparison and entity-id routing of the next append; these values drive imperative orchestration, not a further dataframe computation."
 
 [[entries]]
 path = "src/archetype/app/autoresearch_service.py"
-line = 562
+line = 601
 method = "to_pylist"
 reason = "Bounded control-plane history extract: deterministic Run ids and terminal statuses must enter Python control flow to reject active, corrupt, duplicate, or non-contiguous attempts before resume; the result chooses whether any new work may start rather than feeding a dataframe computation."
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -74,9 +74,21 @@ reason = "Lineage metadata extract: a fork's ancestor segments (bounded by fork 
 
 [[entries]]
 path = "src/archetype/app/autoresearch_service.py"
-line = 313
+line = 542
 method = "to_pylist"
-reason = "Single-row loop-state extract: the latest BranchHead row must enter Python control flow (incumbent score comparison, head entity id for the next update) at the autoresearch loop boundary; the comparison drives imperative orchestration, not a further dataframe computation."
+reason = "Single-row experiment-contract extract: the persisted identity and JSON configuration digest must enter Python control flow for exact collision rejection before the service records a resumed attempt; this is an imperative lifecycle gate, not a downstream dataframe computation."
+
+[[entries]]
+path = "src/archetype/app/autoresearch_service.py"
+line = 550
+method = "to_pylist"
+reason = "Single-row loop-state extract: the latest BranchHead row must enter Python control flow for incumbent score comparison and entity-id routing of the next append; these values drive imperative orchestration, not a further dataframe computation."
+
+[[entries]]
+path = "src/archetype/app/autoresearch_service.py"
+line = 562
+method = "to_pylist"
+reason = "Bounded control-plane history extract: deterministic Run ids and terminal statuses must enter Python control flow to reject active, corrupt, duplicate, or non-contiguous attempts before resume; the result chooses whether any new work may start rather than feeding a dataframe computation."
 
 [[entries]]
 path = "src/archetype/experiments/boundary.py"

--- a/src/archetype/app/autoresearch_service.py
+++ b/src/archetype/app/autoresearch_service.py
@@ -36,6 +36,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
+from pydantic_core import to_jsonable_python
 from uuid_utils import UUID
 
 from archetype.app.models import EpisodeConfig, RolloutConfig, RolloutResult
@@ -208,6 +209,31 @@ def _callable_identity(value: Any) -> str | None:
     return f"{module}.{qualname}"
 
 
+def _jsonable_run_metadata(metadata: dict[str, Any] | None) -> Any:
+    """Normalize run metadata to JSON-native values for identity hashing.
+
+    The digest and its payload are persisted in the Experiment row and
+    compared against their JSON round-trip on resume, so every value must
+    encode deterministically. Types with value-based encodings (stdlib UUID,
+    Path, datetime, ...) are normalized by pydantic; ``uuid_utils`` UUIDs
+    follow the ``JsonUUID`` convention. Anything else fails closed — a
+    ``str()`` fallback would embed memory addresses, making the digest
+    unstable across processes.
+    """
+    if metadata is None:
+        return None
+
+    def reject_unknown(value: Any) -> str:
+        if isinstance(value, UUID):
+            return str(value)
+        raise ValueError(
+            "run metadata is part of the experiment identity and must be "
+            f"JSON-encodable; got {type(value).__module__}.{type(value).__qualname__}"
+        )
+
+    return to_jsonable_python(metadata, fallback=reject_unknown)
+
+
 def _config_identity(config: AutoResearchConfig) -> tuple[str, dict[str, Any]]:
     """Hash semantic loop configuration, excluding invocation-only fields.
 
@@ -230,7 +256,7 @@ def _config_identity(config: AutoResearchConfig) -> tuple[str, dict[str, Any]]:
                 "num_steps": run.num_steps,
                 "debug": run.debug,
                 "show_rows": run.show_rows,
-                "metadata": run.metadata,
+                "metadata": _jsonable_run_metadata(run.metadata),
             },
         },
         "num_episodes": config.num_episodes,
@@ -238,7 +264,14 @@ def _config_identity(config: AutoResearchConfig) -> tuple[str, dict[str, Any]]:
         "improvement_threshold": config.improvement_threshold,
         "destroy_forks_on_complete": config.destroy_forks_on_complete,
     }
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    try:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    except ValueError as exc:
+        # A non-finite float would round-trip as NaN != NaN and poison resume.
+        raise ValueError(
+            "run metadata is part of the experiment identity and must be "
+            f"strict-JSON encodable: {exc}"
+        ) from exc
     return hashlib.sha256(encoded.encode()).hexdigest(), payload
 
 
@@ -311,9 +344,11 @@ class AutoResearchService:
                 world_id, config, lab_world_id=lab_world_id
             )
 
-        # The result baseline is the incumbent at invocation start. This keeps
-        # aggregate ``improved`` semantics correct for both fresh and resumed
-        # runs; the first candidate score is not itself the baseline.
+        # The result baseline is the incumbent at invocation start, keeping
+        # aggregate ``improved`` semantics correct for fresh and resumed
+        # ledger runs alike. Without a ledger there is no incumbent to resume;
+        # the baseline is the first evaluated score, as before the ledger
+        # existed.
         initial_score = incumbent_score
         iterations: list[IterationResult] = []
 
@@ -388,6 +423,8 @@ class AutoResearchService:
                 raise
 
             score = evaluation.score
+            if lab is None and i == start_iteration:
+                initial_score = score
 
             # Compare to incumbent
             improved = score > incumbent_score + config.improvement_threshold
@@ -468,6 +505,16 @@ class AutoResearchService:
         Run ids.  A caller may attach by explicit ``lab_world_id`` instead of
         relying on the process-local name index.
         """
+        # Digest first: a configuration that cannot serve as a stable identity
+        # fails closed before any lab world exists.
+        config_digest, config_payload = _config_identity(config)
+        expected_metadata = {
+            "experiment_id": config.experiment_id,
+            "base_world_id": str(base_world_id),
+            "config_digest": config_digest,
+            "config": config_payload,
+        }
+
         name = f"autoresearch:{config.experiment_id}"
         if lab_world_id is not None:
             lab = self._world_service.get_world(UUID(str(lab_world_id)))
@@ -484,14 +531,6 @@ class AutoResearchService:
             lab = await self._world_service.create_world(
                 WorldConfig(name=name), storage_config, cache_config
             )
-
-        config_digest, config_payload = _config_identity(config)
-        expected_metadata = {
-            "experiment_id": config.experiment_id,
-            "base_world_id": str(base_world_id),
-            "config_digest": config_digest,
-            "config": config_payload,
-        }
 
         if lab.tick == 0:
             await lab.create_entity(

--- a/src/archetype/app/autoresearch_service.py
+++ b/src/archetype/app/autoresearch_service.py
@@ -19,19 +19,22 @@ The loop controller. Reads the current BranchHead, launches a rollout,
 evaluates results, and advances the head on improvement.
 
 The service is deliberately scoring-agnostic: the user provides an
-evaluator callable that takes rollout results and returns a score.
-The service compares scores and advances the BranchHead when the
-new score beats the incumbent.
+evaluator callable that takes rollout results and returns a typed evaluation
+(or a compatibility float). The service compares finite scores and advances
+the BranchHead when the new score beats the incumbent.
 """
 
 from __future__ import annotations
 
+import hashlib
+import inspect
 import json
 import logging
+import math
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from uuid_utils import UUID
 
@@ -55,12 +58,21 @@ logger = logging.getLogger(__name__)
 class AutoResearchConfig:
     """Configuration for one autoresearch loop.
 
-    The evaluator takes a RolloutResult and returns a float score.
-    Higher is better. The loop advances the BranchHead when the
-    new score exceeds the incumbent by at least `improvement_threshold`.
+    Higher scores are better. The loop advances the BranchHead when a finite
+    evaluation score exceeds the incumbent by at least
+    ``improvement_threshold``.
     """
 
     experiment_name: str
+    # Stable caller-supplied identity.  The display name is deliberately not
+    # used as the resume/idempotency key.
+    experiment_id: str
+    # Stable caller-supplied scoring contract. Scores are comparable only
+    # while this identity remains unchanged.
+    evaluator_id: str
+    # Stable caller-supplied identity for episode dynamics, termination, and
+    # rollout interpretation. Callable qualnames alone are not semantic IDs.
+    rollout_contract_id: str
     episode_config: EpisodeConfig = field(default_factory=EpisodeConfig)
     num_episodes: int = 10
     parallel: bool = False
@@ -68,8 +80,62 @@ class AutoResearchConfig:
     improvement_threshold: float = 0.0
     destroy_forks_on_complete: bool = True
     # The loop's own state lives on the ledger: a lab world named
-    # "autoresearch:{experiment_name}" whose ticks are the loop's iterations.
+    # "autoresearch:{experiment_id}" with explicit attempt lifecycle ticks.
     record_to_ledger: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.experiment_id.strip():
+            raise ValueError("experiment_id must be a non-empty caller-supplied identity")
+        if not self.experiment_name.strip():
+            raise ValueError("experiment_name must be non-empty")
+        if not self.evaluator_id.strip():
+            raise ValueError("evaluator_id must be a non-empty scoring contract identity")
+        if not self.rollout_contract_id.strip():
+            raise ValueError("rollout_contract_id must be a non-empty rollout contract identity")
+        if self.num_episodes < 1:
+            raise ValueError("num_episodes must be at least 1")
+        if self.max_iterations < 1:
+            raise ValueError("max_iterations must be at least 1")
+        if self.episode_config.max_steps < 1:
+            raise ValueError("episode_config.max_steps must be at least 1")
+        if not math.isfinite(self.improvement_threshold):
+            raise ValueError("improvement_threshold must be finite")
+        if self.improvement_threshold < 0:
+            raise ValueError("improvement_threshold must be non-negative")
+
+
+@dataclass(frozen=True)
+class CandidateContext:
+    """Stable context passed to a per-iteration candidate preparer."""
+
+    experiment_id: str
+    experiment_name: str
+    iteration: int
+    run_id: str
+    base_world_id: str
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    """Typed evaluator output with explicit evaluator and evidence metadata."""
+
+    score: float
+    evaluator: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        score = float(self.score)
+        if not math.isfinite(score):
+            raise ValueError("evaluation score must be finite")
+        if not self.evaluator.strip():
+            raise ValueError("evaluation evaluator must be non-empty")
+        # Result.make persists these values as JSON.  Validate at the typed
+        # boundary so a terminal STOPPED row cannot be paired with an
+        # unpersistable evaluation.
+        json.dumps(self.evidence)
+        json.dumps(self.metadata)
+        object.__setattr__(self, "score", score)
 
 
 @dataclass(frozen=True)
@@ -79,6 +145,7 @@ class IterationResult:
     iteration: int
     rollout: RolloutResult
     score: float
+    evaluation: EvaluationResult
     improved: bool
     incumbent_score: float
 
@@ -94,7 +161,7 @@ class AutoResearchResult:
     iterations: list[IterationResult] = field(default_factory=list)
     # World id of the experiment's ledger (lab world); "" when recording
     # was disabled. Query it like any other world: Experiment at tick 0,
-    # one tick per iteration, BranchHead history at every tick.
+    # then RUNNING and terminal lifecycle ticks for every attempt.
     lab_world_id: str = ""
 
     @property
@@ -106,9 +173,73 @@ class AutoResearchResult:
 # Evaluator protocol
 # ─────────────────────────────────────────────────────────────────────────────
 
-# An evaluator takes a RolloutResult and returns a score (float).
-# The service doesn't interpret the score beyond comparison.
-Evaluator = Callable[[RolloutResult], float | Awaitable[float]]
+# Float evaluators remain supported for compatibility.  Typed evaluators are
+# preferred because their identity and evidence metadata are persisted beside
+# the score.
+Evaluation = float | EvaluationResult
+Evaluator = Callable[[RolloutResult], Evaluation | Awaitable[Evaluation]]
+CandidatePreparer = Callable[
+    [CandidateContext],
+    str | UUID | None | Awaitable[str | UUID | None],
+]
+
+
+def _normalize_evaluation(value: Evaluation, evaluator_id: str) -> EvaluationResult:
+    if isinstance(value, EvaluationResult):
+        if value.evaluator != evaluator_id:
+            raise ValueError(
+                "evaluation evaluator does not match the configured evaluator_id: "
+                f"{value.evaluator!r} != {evaluator_id!r}"
+            )
+        return value
+    return EvaluationResult(score=float(value), evaluator=evaluator_id)
+
+
+def _callable_identity(value: Any) -> str | None:
+    """Return a diagnostic name for configured callable/type boundaries.
+
+    This is persisted for inspection, not trusted as the semantic contract;
+    callers supply ``rollout_contract_id`` for that purpose.
+    """
+    if value is None:
+        return None
+    module = getattr(value, "__module__", type(value).__module__)
+    qualname = getattr(value, "__qualname__", type(value).__qualname__)
+    return f"{module}.{qualname}"
+
+
+def _config_identity(config: AutoResearchConfig) -> tuple[str, dict[str, Any]]:
+    """Hash semantic loop configuration, excluding invocation-only fields.
+
+    ``max_iterations`` may change when extending a run.  Generated episode and
+    run UUIDs are also excluded; they identify one invocation, not the
+    experiment contract.
+    """
+    episode = config.episode_config
+    run = episode.run_config
+    payload = {
+        "schema_version": 1,
+        "experiment_name": config.experiment_name,
+        "evaluator_id": config.evaluator_id,
+        "rollout_contract_id": config.rollout_contract_id,
+        "episode": {
+            "max_steps": episode.max_steps,
+            "terminal_component": _callable_identity(episode.terminal_component),
+            "termination": _callable_identity(episode.termination),
+            "run": {
+                "num_steps": run.num_steps,
+                "debug": run.debug,
+                "show_rows": run.show_rows,
+                "metadata": run.metadata,
+            },
+        },
+        "num_episodes": config.num_episodes,
+        "parallel": config.parallel,
+        "improvement_threshold": config.improvement_threshold,
+        "destroy_forks_on_complete": config.destroy_forks_on_complete,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode()).hexdigest(), payload
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -138,30 +269,34 @@ class AutoResearchService:
         config: AutoResearchConfig,
         evaluator: Evaluator,
         *,
+        prepare_candidate: CandidatePreparer | None = None,
+        lab_world_id: str | UUID | None = None,
         on_iteration: Callable[[IterationResult], Any] | None = None,
     ) -> AutoResearchResult:
         """Run the autoresearch loop.
 
         1. Get the base world state
         2. For each iteration:
-           a. Run a rollout (N episodes on forks of the base)
-           b. Evaluate the rollout result → score
-           c. If score > incumbent + threshold → advance (record improvement)
-           d. Call on_iteration callback if provided
+           a. Optionally prepare a distinct candidate world
+           b. Run a rollout (N episodes on forks of the candidate)
+           c. Evaluate the rollout result → typed evaluation
+           d. If score > incumbent + threshold → advance (record improvement)
+           e. Call on_iteration callback if provided
         3. Return the aggregate result
 
-        The base world is NOT mutated by the loop. Each iteration forks
-        from the base, runs episodes on the forks, and optionally destroys
-        them. The base world's state is the "seed" for every iteration.
+        The service never mutates the base world. Without ``prepare_candidate``,
+        every iteration evaluates the same base seed. A preparer may return a
+        caller-owned world id so successive iterations evaluate distinct
+        candidates; returning ``None`` selects the base world.
 
         The loop's own state lives on the ledger (unless
         config.record_to_ledger is False): a lab world named
-        "autoresearch:{experiment_name}" whose tick 0 is the genesis
-        (Experiment + seed BranchHead as initial conditions) and whose
-        every subsequent tick is one iteration — a Run row, a Result row,
-        and the BranchHead advance when the iteration improved. The
-        incumbent is read from the ledger, never from memory, so a second
-        run of the same experiment resumes from the last declared best.
+        "autoresearch:{experiment_id}" whose tick 0 is the genesis. Every
+        attempt first appends a RUNNING Run row, then appends a STOPPED or
+        CRASHED transition. Successful attempts also append a Result and any
+        BranchHead advance. ``lab_world_id`` explicitly reattaches a live lab
+        world instead of relying on its name index. Stored experiment identity
+        and configuration must match before resume.
         """
         # Validate the base world exists (raises if not); the loop forks
         # from world_id rather than mutating this instance.
@@ -173,13 +308,17 @@ class AutoResearchService:
         start_iteration = 0
         if config.record_to_ledger:
             lab, head_entity_id, incumbent_score, start_iteration = await self._attach_ledger(
-                world_id, config
+                world_id, config, lab_world_id=lab_world_id
             )
 
-        initial_score = float("-inf")
+        # The result baseline is the incumbent at invocation start. This keeps
+        # aggregate ``improved`` semantics correct for both fresh and resumed
+        # runs; the first candidate score is not itself the baseline.
+        initial_score = incumbent_score
         iterations: list[IterationResult] = []
 
         for i in range(start_iteration, start_iteration + config.max_iterations):
+            run_id = f"{config.experiment_id}:iter{i}"
             # Build rollout config
             rollout_config = RolloutConfig(
                 episode_config=config.episode_config,
@@ -189,18 +328,66 @@ class AutoResearchService:
                 name_prefix=f"{config.experiment_name}:iter{i}",
             )
 
-            # Run the rollout
             started_at_ms = int(time.time() * 1000)
-            rollout_result = await self._simulation_service.run_rollout(world_id, rollout_config)
+            run_entity_id: int | None = None
+            if lab is not None:
+                run_entity_id = await self._record_running(
+                    lab,
+                    config,
+                    run_id=run_id,
+                    started_at_ms=started_at_ms,
+                )
 
-            # Evaluate
-            score = evaluator(rollout_result)
-            if hasattr(score, "__await__"):
-                score = await score  # ty: ignore[invalid-await]  # runtime-checked awaitable
-            score = float(score)
+            candidate_world_id: str | UUID = world_id
+            try:
+                if prepare_candidate is not None:
+                    prepared_value = prepare_candidate(
+                        CandidateContext(
+                            experiment_id=config.experiment_id,
+                            experiment_name=config.experiment_name,
+                            iteration=i,
+                            run_id=run_id,
+                            base_world_id=str(world_id),
+                        )
+                    )
+                    if inspect.isawaitable(prepared_value):
+                        prepared_value = await prepared_value
+                    prepared = cast(str | UUID | None, prepared_value)
+                    if prepared is not None:
+                        candidate_world_id = prepared
 
-            if i == start_iteration:
-                initial_score = score
+                rollout_result = await self._simulation_service.run_rollout(
+                    candidate_world_id, rollout_config
+                )
+
+                evaluation_value = evaluator(rollout_result)
+                if inspect.isawaitable(evaluation_value):
+                    evaluation_value = await evaluation_value
+                evaluation = _normalize_evaluation(
+                    cast(Evaluation, evaluation_value), config.evaluator_id
+                )
+            except BaseException as exc:
+                if lab is not None and run_entity_id is not None:
+                    try:
+                        await self._record_terminal(
+                            lab,
+                            run_entity_id,
+                            head_entity_id,
+                            config,
+                            run_id=run_id,
+                            iteration=i,
+                            status=RunStatus.CRASHED,
+                            started_at_ms=started_at_ms,
+                            candidate_world_id=candidate_world_id,
+                            error=exc,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "failed to persist autoresearch crash transition for %s", run_id
+                        )
+                raise
+
+            score = evaluation.score
 
             # Compare to incumbent
             improved = score > incumbent_score + config.improvement_threshold
@@ -208,21 +395,27 @@ class AutoResearchService:
                 incumbent_score = score
 
             if lab is not None:
-                await self._record_iteration(
+                assert run_entity_id is not None
+                await self._record_terminal(
                     lab,
+                    run_entity_id,
                     head_entity_id,
                     config,
+                    run_id=run_id,
                     iteration=i,
+                    status=RunStatus.STOPPED,
                     rollout=rollout_result,
-                    score=score,
+                    evaluation=evaluation,
                     improved=improved,
                     started_at_ms=started_at_ms,
+                    candidate_world_id=candidate_world_id,
                 )
 
             iteration_result = IterationResult(
                 iteration=i,
                 rollout=rollout_result,
                 score=score,
+                evaluation=evaluation,
                 improved=improved,
                 incumbent_score=incumbent_score,
             )
@@ -240,7 +433,7 @@ class AutoResearchService:
             # Callback
             if on_iteration is not None:
                 result = on_iteration(iteration_result)
-                if hasattr(result, "__await__"):
+                if inspect.isawaitable(result):
                     await result
 
         return AutoResearchResult(
@@ -258,6 +451,8 @@ class AutoResearchService:
         self,
         base_world_id: str | UUID,
         config: AutoResearchConfig,
+        *,
+        lab_world_id: str | UUID | None = None,
     ) -> tuple[Any, int, float, int]:
         """Create or resume the experiment's lab world.
 
@@ -268,14 +463,21 @@ class AutoResearchService:
         lab world inherits the base world's storage — the record lives next
         to the data it is about.
 
-        Resume (existing lab world): the latest BranchHead row IS the
-        incumbent; the next iteration index is derived from the lab tick
-        (one iteration per tick, genesis at tick 0).
+        Resume (existing lab world): validate the stored experiment contract,
+        read the incumbent BranchHead, and derive the next index from recorded
+        Run ids.  A caller may attach by explicit ``lab_world_id`` instead of
+        relying on the process-local name index.
         """
-        name = f"autoresearch:{config.experiment_name}"
-        try:
-            lab = self._world_service.get_world_by_name(name)
-        except KeyError:
+        name = f"autoresearch:{config.experiment_id}"
+        if lab_world_id is not None:
+            lab = self._world_service.get_world(UUID(str(lab_world_id)))
+        else:
+            try:
+                lab = self._world_service.get_world_by_name(name)
+            except KeyError:
+                lab = None
+
+        if lab is None:
             record = self._world_service.storage_record(base_world_id)
             storage_config = record[0] if record is not None else None
             cache_config = record[1] if record is not None else None
@@ -283,14 +485,21 @@ class AutoResearchService:
                 WorldConfig(name=name), storage_config, cache_config
             )
 
-        head_row = await self._read_head(lab)
-        if head_row is None:
+        config_digest, config_payload = _config_identity(config)
+        expected_metadata = {
+            "experiment_id": config.experiment_id,
+            "base_world_id": str(base_world_id),
+            "config_digest": config_digest,
+            "config": config_payload,
+        }
+
+        if lab.tick == 0:
             await lab.create_entity(
                 [
                     Experiment.make(
                         config.experiment_name,
                         "",
-                        metadata={"base_world_id": str(base_world_id)},
+                        metadata=expected_metadata,
                     )
                 ]
             )
@@ -298,12 +507,40 @@ class AutoResearchService:
                 [BranchHead.make(config.experiment_name, "", descriptor={"score": None})]
             )
             await lab.step(RunConfig())  # genesis: initial conditions at tick 0
-            return lab, head_entity_id, float("-inf"), max(lab.tick - 1, 0)
+            return lab, head_entity_id, float("-inf"), 0
 
+        experiment_row = await self._read_experiment(lab)
+        if experiment_row is None:
+            raise ValueError(
+                f"experiment identity collision: lab world {lab.world_id} has no Experiment row"
+            )
+        actual_metadata = json.loads(experiment_row["experiment__metadata_json"])
+        if (
+            experiment_row["experiment__name"] != config.experiment_name
+            or actual_metadata != expected_metadata
+        ):
+            raise ValueError(
+                "experiment identity collision: the requested experiment id, base world, or "
+                "semantic configuration does not match the attached lab"
+            )
+
+        head_row = await self._read_head(lab)
+        if head_row is None:
+            raise ValueError(
+                f"experiment identity collision: lab world {lab.world_id} has no BranchHead row"
+            )
         descriptor = json.loads(head_row["branchhead__descriptor_json"])
         score = descriptor.get("score")
         incumbent = float(score) if score is not None else float("-inf")
-        return lab, int(head_row["entity_id"]), incumbent, max(lab.tick - 1, 0)
+        return lab, int(head_row["entity_id"]), incumbent, await self._next_iteration(lab, config)
+
+    async def _read_experiment(self, lab) -> dict | None:
+        """The active Experiment row, or None when the lab has no genesis."""
+        if lab.tick == 0:
+            return None
+        df = await lab.query_archetype(sig=(Experiment,), ticks=[lab.tick - 1])
+        rows = df.to_pylist()
+        return rows[0] if rows else None
 
     async def _read_head(self, lab) -> dict | None:
         """The latest persisted BranchHead row, or None for a fresh world."""
@@ -313,55 +550,146 @@ class AutoResearchService:
         rows = df.to_pylist()
         return rows[0] if rows else None
 
-    async def _record_iteration(
+    async def _next_iteration(self, lab, config: AutoResearchConfig) -> int:
+        """Return one past the greatest terminal iteration Run id.
+
+        An active row is not silently abandoned: without an explicit lease or
+        reconciliation protocol, starting another attempt could duplicate
+        work and compare a result against an ambiguous incumbent.
+        """
+        if lab.tick == 0:
+            return 0
+        rows = (await lab.query_archetype(sig=(Run,), ticks=[lab.tick - 1])).to_pylist()
+        prefix = f"{config.experiment_id}:iter"
+        indices: list[int] = []
+        for row in rows:
+            run_id = row["run__run_id"]
+            if not run_id.startswith(prefix):
+                raise ValueError(
+                    "experiment identity collision: attached lab contains an unexpected Run id"
+                )
+            suffix = run_id[len(prefix) :]
+            if not suffix.isdigit():
+                raise ValueError(
+                    "experiment identity collision: attached lab contains a malformed Run id"
+                )
+            status = row["run__status"]
+            if RunStatus.is_active(status):
+                raise RuntimeError(
+                    f"experiment has an active attempt {run_id!r}; reconcile it before resuming"
+                )
+            if not RunStatus.is_terminal(status):
+                raise ValueError(
+                    f"experiment history contains an unknown Run status {status!r} for {run_id!r}"
+                )
+            indices.append(int(suffix))
+        ordered_indices = sorted(indices)
+        if ordered_indices != list(range(len(ordered_indices))):
+            raise ValueError(
+                "experiment history contains duplicate or non-contiguous iteration ids"
+            )
+        return len(ordered_indices)
+
+    async def _record_running(
         self,
         lab,
-        head_entity_id: int | None,
         config: AutoResearchConfig,
         *,
-        iteration: int,
-        rollout: RolloutResult,
-        score: float,
-        improved: bool,
+        run_id: str,
         started_at_ms: int,
-    ) -> None:
-        """Append one tick of loop history to the lab world.
-
-        One iteration = one tick: a Run row (the attempt), a Result row
-        (the evaluation), and — when the iteration improved on the
-        incumbent — the BranchHead advance. Every advance is an append;
-        the head's full history stays queryable at every tick.
-        """
-        run_id = f"{config.experiment_name}:iter{iteration}"
-        await lab.create_entity(
+    ) -> int:
+        """Persist RUNNING before candidate preparation or rollout begins."""
+        run_entity_id = await lab.create_entity(
             [
                 Run(
                     run_id=run_id,
                     experiment_name=config.experiment_name,
-                    status=RunStatus.STOPPED.value,
+                    status=RunStatus.RUNNING.value,
+                    task="rollout",
+                    started_at_ms=started_at_ms,
+                )
+            ]
+        )
+        await lab.step(RunConfig())
+        return run_entity_id
+
+    async def _record_terminal(
+        self,
+        lab,
+        run_entity_id: int,
+        head_entity_id: int | None,
+        config: AutoResearchConfig,
+        *,
+        run_id: str,
+        iteration: int,
+        status: RunStatus,
+        started_at_ms: int,
+        rollout: RolloutResult | None = None,
+        evaluation: EvaluationResult | None = None,
+        improved: bool = False,
+        candidate_world_id: str | UUID | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        """Persist a terminal Run transition and its result envelope."""
+        if not RunStatus.is_terminal(status.value):
+            raise ValueError(f"terminal status required, got {status.value}")
+        if status is RunStatus.STOPPED and (rollout is None or evaluation is None):
+            raise ValueError("STOPPED requires rollout and evaluation")
+
+        await lab.update_entity(
+            run_entity_id,
+            [
+                Run(
+                    run_id=run_id,
+                    experiment_name=config.experiment_name,
+                    status=status.value,
                     task="rollout",
                     started_at_ms=started_at_ms,
                     finished_at_ms=int(time.time() * 1000),
                 )
-            ]
+            ],
         )
-        await lab.create_entity(
-            [
-                Result.make(
-                    run_id,
-                    outputs={
-                        "score": score,
-                        "improved": improved,
-                        "iteration": iteration,
-                        "num_episodes": rollout.num_episodes,
-                        "total_duration_steps": rollout.total_duration_steps,
-                        "episode_world_ids": [str(ep.world_id) for ep in rollout.episodes],
-                    },
-                    evaluator="autoresearch",
-                )
-            ]
-        )
-        if improved and head_entity_id is not None:
+
+        if status is RunStatus.STOPPED:
+            assert rollout is not None
+            assert evaluation is not None
+            await lab.create_entity(
+                [
+                    Result.make(
+                        run_id,
+                        outputs={
+                            "score": evaluation.score,
+                            "improved": improved,
+                            "iteration": iteration,
+                            "candidate_world_id": str(candidate_world_id),
+                            "num_episodes": rollout.num_episodes,
+                            "total_duration_steps": rollout.total_duration_steps,
+                            "episode_world_ids": [str(ep.world_id) for ep in rollout.episodes],
+                            "evidence": evaluation.evidence,
+                            "metadata": evaluation.metadata,
+                        },
+                        evaluator=evaluation.evaluator,
+                    )
+                ]
+            )
+        elif error is not None:
+            await lab.create_entity(
+                [
+                    Result.make(
+                        run_id,
+                        outputs={
+                            "iteration": iteration,
+                            "status": RunStatus.CRASHED.value,
+                            "candidate_world_id": str(candidate_world_id),
+                            "error_type": f"{type(error).__module__}.{type(error).__qualname__}",
+                        },
+                        evaluator="autoresearch:lifecycle",
+                    )
+                ]
+            )
+
+        if status is RunStatus.STOPPED and improved and head_entity_id is not None:
+            assert evaluation is not None
             await lab.update_entity(
                 head_entity_id,
                 [
@@ -369,7 +697,12 @@ class AutoResearchService:
                         config.experiment_name,
                         "",
                         run_id=run_id,
-                        descriptor={"score": score, "iteration": iteration},
+                        descriptor={
+                            "score": evaluation.score,
+                            "iteration": iteration,
+                            "evaluator": evaluation.evaluator,
+                            "evidence": evaluation.evidence,
+                        },
                     )
                 ],
             )
@@ -412,12 +745,15 @@ class AutoResearchService:
             # Let the caller configure the fork with these params
             if setup_fn is not None:
                 result = setup_fn(fork.world_id, params)
-                if hasattr(result, "__await__"):
+                if inspect.isawaitable(result):
                     await result
 
             # Run the loop on this fork
             sweep_config = AutoResearchConfig(
                 experiment_name=f"{config.experiment_name}:{combo}",
+                experiment_id=f"{config.experiment_id}:{combo}",
+                evaluator_id=config.evaluator_id,
+                rollout_contract_id=config.rollout_contract_id,
                 episode_config=config.episode_config,
                 num_episodes=config.num_episodes,
                 parallel=config.parallel,

--- a/tests/app/test_autoresearch_ledger.py
+++ b/tests/app/test_autoresearch_ledger.py
@@ -12,8 +12,10 @@ experiment resumes from the last declared best.
 
 import asyncio
 import json
+from pathlib import Path
 
 import pytest
+from uuid_utils import UUID
 
 from archetype.app.autoresearch_service import AutoResearchConfig, EvaluationResult
 from archetype.app.container import ServiceContainer
@@ -194,6 +196,125 @@ async def test_record_to_ledger_opt_out(tmp_path):
         assert result.lab_world_id == ""
         with pytest.raises(KeyError):
             c.world_service.get_world_by_name("autoresearch:ephemeral-id")
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_no_ledger_baseline_is_first_score_not_neg_inf(tmp_path):
+    """Without a ledger the baseline is the first evaluated score: a flat or
+    declining search must not report aggregate improvement."""
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+
+        def config(name: str) -> AutoResearchConfig:
+            return AutoResearchConfig(
+                experiment_name=name,
+                experiment_id=f"{name}-id",
+                evaluator_id="scripted-score-v1",
+                rollout_contract_id="single-step-rollout-v1",
+                episode_config=EpisodeConfig(max_steps=1),
+                max_iterations=2,
+                record_to_ledger=False,
+            )
+
+        flat = await c.autoresearch_service.run(
+            base.world_id, config("flat"), _scripted_evaluator([1.0, 0.5])
+        )
+        assert flat.initial_score == 1.0
+        assert flat.final_score == 1.0
+        assert flat.improved is False, "nothing improved after the first candidate"
+
+        rising = await c.autoresearch_service.run(
+            base.world_id, config("rising"), _scripted_evaluator([1.0, 2.0])
+        )
+        assert rising.initial_score == 1.0
+        assert rising.final_score == 2.0
+        assert rising.improved is True
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_run_metadata_with_uuid_and_path_hashes_and_resumes(tmp_path):
+    """RunConfig metadata with non-JSON-native but value-encodable types
+    (uuid_utils UUID, Path) must hash deterministically and round-trip the
+    persisted identity so an equal-valued config can resume."""
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+
+        def config(max_iterations: int) -> AutoResearchConfig:
+            # Fresh objects each call: identity must be value-based.
+            return AutoResearchConfig(
+                experiment_name="meta",
+                experiment_id="meta-id",
+                evaluator_id="scripted-score-v1",
+                rollout_contract_id="single-step-rollout-v1",
+                episode_config=EpisodeConfig(
+                    max_steps=1,
+                    run_config=RunConfig(
+                        metadata={
+                            "trace_id": UUID("019625d2-6e70-7000-8000-000000000000"),
+                            "artifacts": Path("/tmp/meta-artifacts"),
+                        }
+                    ),
+                ),
+                max_iterations=max_iterations,
+            )
+
+        first = await c.autoresearch_service.run(
+            base.world_id, config(max_iterations=1), _scripted_evaluator([1.0])
+        )
+        lab = c.world_service.get_world(first.lab_world_id)
+        exp_rows = (await lab.query_archetype(sig=(Experiment,), ticks=[0])).to_pylist()
+        stored = json.loads(exp_rows[0]["experiment__metadata_json"])
+        assert stored["config"]["episode"]["run"]["metadata"] == {
+            "trace_id": "019625d2-6e70-7000-8000-000000000000",
+            "artifacts": "/tmp/meta-artifacts",
+        }
+
+        resumed = await c.autoresearch_service.run(
+            base.world_id,
+            config(max_iterations=1),
+            _scripted_evaluator([2.0]),
+            lab_world_id=first.lab_world_id,
+        )
+        assert resumed.iterations[0].iteration == 1, "equal-valued config resumes"
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_run_metadata_that_cannot_identify_the_experiment_fails_closed(tmp_path):
+    """Unknown metadata types and non-finite floats cannot serve as a stable
+    identity; the loop must fail before creating a lab world."""
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+
+        def config(name: str, metadata: dict) -> AutoResearchConfig:
+            return AutoResearchConfig(
+                experiment_name=name,
+                experiment_id=f"{name}-id",
+                evaluator_id="scripted-score-v1",
+                rollout_contract_id="single-step-rollout-v1",
+                episode_config=EpisodeConfig(max_steps=1, run_config=RunConfig(metadata=metadata)),
+                max_iterations=1,
+            )
+
+        with pytest.raises(ValueError, match="JSON-encodable"):
+            await c.autoresearch_service.run(
+                base.world_id, config("opaque", {"handle": object()}), _scripted_evaluator([1.0])
+            )
+        with pytest.raises(ValueError, match="strict-JSON"):
+            await c.autoresearch_service.run(
+                base.world_id, config("nonjson", {"x": float("nan")}), _scripted_evaluator([1.0])
+            )
+        for name in ("opaque", "nonjson"):
+            with pytest.raises(KeyError):
+                c.world_service.get_world_by_name(f"autoresearch:{name}-id")
     finally:
         await c.shutdown()
 

--- a/tests/app/test_autoresearch_ledger.py
+++ b/tests/app/test_autoresearch_ledger.py
@@ -10,16 +10,17 @@ ledger, never from an in-memory float — a second run of the same
 experiment resumes from the last declared best.
 """
 
+import asyncio
 import json
 
 import pytest
 
-from archetype.app.autoresearch_service import AutoResearchConfig
+from archetype.app.autoresearch_service import AutoResearchConfig, EvaluationResult
 from archetype.app.container import ServiceContainer
 from archetype.app.models import EpisodeConfig
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
-from archetype.experiments.components import BranchHead, Experiment, Result, Run
+from archetype.experiments.components import BranchHead, Experiment, Result, Run, RunStatus
 
 
 class Tag(Component):
@@ -30,11 +31,22 @@ def _storage(tmp_path) -> StorageConfig:
     return StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
 
 
-def _config(name: str, max_iterations: int) -> AutoResearchConfig:
+def _config(
+    name: str,
+    max_iterations: int,
+    *,
+    experiment_id: str | None = None,
+    evaluator_id: str = "scripted-score-v1",
+    rollout_contract_id: str = "single-step-rollout-v1",
+    num_episodes: int = 1,
+) -> AutoResearchConfig:
     return AutoResearchConfig(
         experiment_name=name,
+        experiment_id=f"{name}-id" if experiment_id is None else experiment_id,
+        evaluator_id=evaluator_id,
+        rollout_contract_id=rollout_contract_id,
         episode_config=EpisodeConfig(max_steps=1),
-        num_episodes=1,
+        num_episodes=num_episodes,
         max_iterations=max_iterations,
     )
 
@@ -58,8 +70,7 @@ async def _base_world(c: ServiceContainer, tmp_path):
 
 @pytest.mark.asyncio
 async def test_loop_records_genesis_and_iterations(tmp_path):
-    """Tick 0 = Experiment + seed BranchHead (initial conditions); each
-    iteration appends one tick: Run + Result rows and any head advance."""
+    """Each attempt records RUNNING before its terminal lifecycle tick."""
     c = ServiceContainer()
     try:
         base = await _base_world(c, tmp_path)
@@ -71,8 +82,8 @@ async def test_loop_records_genesis_and_iterations(tmp_path):
 
         assert result.lab_world_id, "loop must report its lab world"
         lab = c.world_service.get_world(result.lab_world_id)
-        # genesis tick + one tick per iteration
-        assert lab.tick == 4
+        # genesis + RUNNING/terminal ticks for each iteration
+        assert lab.tick == 7
 
         # Genesis: Experiment row at tick 0, raw initial conditions
         exp_rows = (await lab.query_archetype(sig=(Experiment,), ticks=[0])).to_pylist()
@@ -80,25 +91,39 @@ async def test_loop_records_genesis_and_iterations(tmp_path):
         assert exp_rows[0]["experiment__name"] == "exp"
         metadata = json.loads(exp_rows[0]["experiment__metadata_json"])
         assert metadata["base_world_id"] == str(base.world_id)
+        assert metadata["experiment_id"] == "exp-id"
+        assert metadata["config_digest"]
 
-        # BranchHead history: seed at tick 0, advance on improvement only
+        # RUNNING never advances the head; only a successful terminal tick can.
         head_scores = []
-        for t in range(4):
+        for t in range(7):
             rows = (await lab.query_archetype(sig=(BranchHead,), ticks=[t])).to_pylist()
             assert len(rows) == 1, f"exactly one active head at tick {t}"
             head_scores.append(json.loads(rows[0]["branchhead__descriptor_json"]).get("score"))
-        assert head_scores == [None, 1.0, 1.0, 2.0], (
+        assert head_scores == [None, None, 1.0, 1.0, 1.0, 1.0, 2.0], (
             f"head advances on improvement, holds otherwise: {head_scores}"
         )
 
-        # Run + Result rows: one per iteration, scores preserved
+        # Run rows transition in place from RUNNING to STOPPED.
+        for iteration in range(3):
+            run_id = f"exp-id:iter{iteration}"
+            running_rows = (
+                await lab.query_archetype(sig=(Run,), ticks=[1 + 2 * iteration])
+            ).to_pylist()
+            running = next(r for r in running_rows if r["run__run_id"] == run_id)
+            assert running["run__status"] == RunStatus.RUNNING.value
+
         run_rows = (await lab.query_archetype(sig=(Run,), ticks=[lab.tick - 1])).to_pylist()
         assert sorted(r["run__run_id"] for r in run_rows) == [
-            "exp:iter0",
-            "exp:iter1",
-            "exp:iter2",
+            "exp-id:iter0",
+            "exp-id:iter1",
+            "exp-id:iter2",
         ]
+        assert all(r["run__status"] == RunStatus.STOPPED.value for r in run_rows)
+
+        # Result rows preserve scores and use the configured evaluator id.
         result_rows = (await lab.query_archetype(sig=(Result,), ticks=[lab.tick - 1])).to_pylist()
+        assert {r["result__evaluator"] for r in result_rows} == {"scripted-score-v1"}
         outputs = sorted(
             (json.loads(r["result__outputs_json"]) for r in result_rows),
             key=lambda o: o["iteration"],
@@ -106,6 +131,10 @@ async def test_loop_records_genesis_and_iterations(tmp_path):
         assert [o["score"] for o in outputs] == [1.0, 0.5, 2.0]
         assert [o["improved"] for o in outputs] == [True, False, True]
         assert all(o["episode_world_ids"] for o in outputs), "provenance: episode worlds recorded"
+        assert all(step.evaluation.evaluator == "scripted-score-v1" for step in result.iterations)
+        assert result.initial_score == float("-inf")
+        assert result.final_score == 2.0
+        assert result.improved is True
     finally:
         await c.shutdown()
 
@@ -127,12 +156,16 @@ async def test_loop_resumes_incumbent_from_ledger(tmp_path):
             base.world_id,
             _config("exp", max_iterations=1),
             _scripted_evaluator([1.5]),
+            lab_world_id=(c.world_service.get_world_by_name("autoresearch:exp-id").world_id),
         )
 
         step = resumed.iterations[0]
         assert step.iteration == 3, "iteration numbering continues from the ledger"
         assert step.incumbent_score == 2.0, "incumbent read from the BranchHead row"
         assert step.improved is False, "1.5 does not beat the persisted 2.0"
+        assert resumed.initial_score == 2.0
+        assert resumed.final_score == 2.0
+        assert resumed.improved is False
 
         lab = c.world_service.get_world(resumed.lab_world_id)
         rows = (await lab.query_archetype(sig=(BranchHead,), ticks=[lab.tick - 1])).to_pylist()
@@ -149,6 +182,9 @@ async def test_record_to_ledger_opt_out(tmp_path):
         base = await _base_world(c, tmp_path)
         config = AutoResearchConfig(
             experiment_name="ephemeral",
+            experiment_id="ephemeral-id",
+            evaluator_id="scripted-score-v1",
+            rollout_contract_id="single-step-rollout-v1",
             episode_config=EpisodeConfig(max_steps=1),
             num_episodes=1,
             max_iterations=1,
@@ -157,6 +193,351 @@ async def test_record_to_ledger_opt_out(tmp_path):
         result = await c.autoresearch_service.run(base.world_id, config, _scripted_evaluator([1.0]))
         assert result.lab_world_id == ""
         with pytest.raises(KeyError):
-            c.world_service.get_world_by_name("autoresearch:ephemeral")
+            c.world_service.get_world_by_name("autoresearch:ephemeral-id")
     finally:
         await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_candidate_preparer_can_select_a_distinct_world_per_iteration(tmp_path):
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+        candidate_ids: list[str] = []
+
+        async def prepare(context):
+            candidate = await c.world_service.fork_world(
+                base.world_id,
+                name=f"candidate-{context.iteration}",
+            )
+            candidate_ids.append(str(candidate.world_id))
+            return candidate.world_id
+
+        scores = iter([1.0, 2.0])
+
+        def evaluate(rollout) -> EvaluationResult:
+            return EvaluationResult(
+                score=next(scores),
+                evaluator="candidate-score-v1",
+                evidence={"candidate_world_id": str(rollout.base_world_id)},
+                metadata={"contract": "candidate-world"},
+            )
+
+        result = await c.autoresearch_service.run(
+            base.world_id,
+            _config(
+                "candidate-exp",
+                max_iterations=2,
+                evaluator_id="candidate-score-v1",
+            ),
+            evaluate,
+            prepare_candidate=prepare,
+        )
+
+        assert len(set(candidate_ids)) == 2
+        assert [str(step.rollout.base_world_id) for step in result.iterations] == candidate_ids
+        assert all(step.evaluation.evaluator == "candidate-score-v1" for step in result.iterations)
+
+        lab = c.world_service.get_world(result.lab_world_id)
+        rows = (await lab.query_archetype(sig=(Result,), ticks=[lab.tick - 1])).to_pylist()
+        outputs = [json.loads(row["result__outputs_json"]) for row in rows]
+        assert {row["result__evaluator"] for row in rows} == {"candidate-score-v1"}
+        assert {output["candidate_world_id"] for output in outputs} == set(candidate_ids)
+        assert all(output["evidence"]["candidate_world_id"] in candidate_ids for output in outputs)
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_candidate_preparation_failure_records_crashed_terminal_state(tmp_path):
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+
+        async def fail_preparation(_context):
+            raise RuntimeError("candidate construction failed")
+
+        config = _config("crash-exp", max_iterations=1)
+        with pytest.raises(RuntimeError, match="candidate construction failed"):
+            await c.autoresearch_service.run(
+                base.world_id,
+                config,
+                _scripted_evaluator([1.0]),
+                prepare_candidate=fail_preparation,
+            )
+
+        lab = c.world_service.get_world_by_name("autoresearch:crash-exp-id")
+        assert lab.tick == 3  # genesis, RUNNING, CRASHED
+        running_rows = (await lab.query_archetype(sig=(Run,), ticks=[1])).to_pylist()
+        assert running_rows[0]["run__status"] == RunStatus.RUNNING.value
+        terminal_rows = (await lab.query_archetype(sig=(Run,), ticks=[2])).to_pylist()
+        assert terminal_rows[0]["run__status"] == RunStatus.CRASHED.value
+        result_rows = (await lab.query_archetype(sig=(Result,), ticks=[2])).to_pylist()
+        assert result_rows[0]["result__evaluator"] == "autoresearch:lifecycle"
+        crash = json.loads(result_rows[0]["result__outputs_json"])
+        assert crash["error_type"] == "builtins.RuntimeError"
+        assert crash["candidate_world_id"] == str(base.world_id)
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_failure_after_candidate_selection_records_candidate_provenance(tmp_path):
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+        candidate = await c.world_service.fork_world(base.world_id, name="failing-candidate")
+
+        async def prepare(_context):
+            return candidate.world_id
+
+        def fail_evaluation(_rollout):
+            raise RuntimeError("evaluation failed")
+
+        with pytest.raises(RuntimeError, match="evaluation failed"):
+            await c.autoresearch_service.run(
+                base.world_id,
+                _config("candidate-crash", max_iterations=1),
+                fail_evaluation,
+                prepare_candidate=prepare,
+            )
+
+        lab = c.world_service.get_world_by_name("autoresearch:candidate-crash-id")
+        result_rows = (await lab.query_archetype(sig=(Result,), ticks=[lab.tick - 1])).to_pylist()
+        crash = json.loads(result_rows[0]["result__outputs_json"])
+        assert crash["candidate_world_id"] == str(candidate.world_id)
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("score", [float("nan"), float("inf"), float("-inf")])
+async def test_non_finite_evaluation_is_rejected_and_recorded_as_crashed(tmp_path, score):
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+        config = _config("nonfinite", max_iterations=1)
+
+        with pytest.raises(ValueError, match="score must be finite"):
+            await c.autoresearch_service.run(base.world_id, config, _scripted_evaluator([score]))
+
+        lab = c.world_service.get_world_by_name("autoresearch:nonfinite-id")
+        rows = (await lab.query_archetype(sig=(Run,), ticks=[lab.tick - 1])).to_pylist()
+        assert rows[0]["run__status"] == RunStatus.CRASHED.value
+        heads = (await lab.query_archetype(sig=(BranchHead,), ticks=[lab.tick - 1])).to_pylist()
+        assert json.loads(heads[0]["branchhead__descriptor_json"])["score"] is None
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_experiment_config_identity_collision(tmp_path):
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+        first = await c.autoresearch_service.run(
+            base.world_id,
+            _config("collision", max_iterations=1, num_episodes=1),
+            _scripted_evaluator([1.0]),
+        )
+
+        with pytest.raises(ValueError, match="experiment identity collision"):
+            await c.autoresearch_service.run(
+                base.world_id,
+                _config("collision", max_iterations=1, num_episodes=2),
+                _scripted_evaluator([2.0]),
+                lab_world_id=first.lab_world_id,
+            )
+
+        lab = c.world_service.get_world(first.lab_world_id)
+        rows = (await lab.query_archetype(sig=(Run,), ticks=[lab.tick - 1])).to_pylist()
+        assert len(rows) == 1, "collision must fail before a new attempt is recorded"
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_evaluator_contract_mismatch_crashes_without_advancing_head(tmp_path):
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+
+        def mismatched_evaluator(_rollout) -> EvaluationResult:
+            return EvaluationResult(score=2.0, evaluator="different-score-v2")
+
+        with pytest.raises(ValueError, match="configured evaluator_id"):
+            await c.autoresearch_service.run(
+                base.world_id,
+                _config("evaluator-mismatch", max_iterations=1),
+                mismatched_evaluator,
+            )
+
+        lab = c.world_service.get_world_by_name("autoresearch:evaluator-mismatch-id")
+        runs = (await lab.query_archetype(sig=(Run,), ticks=[lab.tick - 1])).to_pylist()
+        assert runs[0]["run__status"] == RunStatus.CRASHED.value
+        heads = (await lab.query_archetype(sig=(BranchHead,), ticks=[lab.tick - 1])).to_pylist()
+        assert json.loads(heads[0]["branchhead__descriptor_json"])["score"] is None
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_resume_fails_closed_while_an_attempt_is_running(tmp_path):
+    c = ServiceContainer()
+    first_task = None
+    release = asyncio.Event()
+    try:
+        base = await _base_world(c, tmp_path)
+        entered = asyncio.Event()
+        config = _config("active-attempt", max_iterations=1)
+
+        async def block_candidate(_context):
+            entered.set()
+            await release.wait()
+
+        first_task = asyncio.create_task(
+            c.autoresearch_service.run(
+                base.world_id,
+                config,
+                _scripted_evaluator([1.0]),
+                prepare_candidate=block_candidate,
+            )
+        )
+        await entered.wait()
+        lab = c.world_service.get_world_by_name("autoresearch:active-attempt-id")
+
+        with pytest.raises(RuntimeError, match="active attempt"):
+            await c.autoresearch_service.run(
+                base.world_id,
+                config,
+                _scripted_evaluator([2.0]),
+                lab_world_id=lab.world_id,
+            )
+
+        release.set()
+        await first_task
+    finally:
+        release.set()
+        if first_task is not None and not first_task.done():
+            await first_task
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_unknown_run_status(tmp_path):
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+        completed = await c.autoresearch_service.run(
+            base.world_id,
+            _config("unknown-status", max_iterations=1),
+            _scripted_evaluator([1.0]),
+        )
+        lab = c.world_service.get_world(completed.lab_world_id)
+        rows = (await lab.query_archetype(sig=(Run,), ticks=[lab.tick - 1])).to_pylist()
+        await lab.update_entity(
+            int(rows[0]["entity_id"]),
+            [
+                Run(
+                    run_id="unknown-status-id:iter0",
+                    experiment_name="unknown-status",
+                    status="foreign-status",
+                    task="rollout",
+                )
+            ],
+        )
+        await lab.step(RunConfig())
+
+        with pytest.raises(ValueError, match="unknown Run status"):
+            await c.autoresearch_service.run(
+                base.world_id,
+                _config("unknown-status", max_iterations=1),
+                _scripted_evaluator([2.0]),
+                lab_world_id=lab.world_id,
+            )
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_non_contiguous_iteration_history(tmp_path):
+    c = ServiceContainer()
+    try:
+        base = await _base_world(c, tmp_path)
+        completed = await c.autoresearch_service.run(
+            base.world_id,
+            _config("gapped-history", max_iterations=1),
+            _scripted_evaluator([1.0]),
+        )
+        lab = c.world_service.get_world(completed.lab_world_id)
+        await lab.create_entity(
+            [
+                Run(
+                    run_id="gapped-history-id:iter2",
+                    experiment_name="gapped-history",
+                    status=RunStatus.CRASHED.value,
+                    task="rollout",
+                )
+            ]
+        )
+        await lab.step(RunConfig())
+
+        with pytest.raises(ValueError, match="duplicate or non-contiguous"):
+            await c.autoresearch_service.run(
+                base.world_id,
+                _config("gapped-history", max_iterations=1),
+                _scripted_evaluator([2.0]),
+                lab_world_id=lab.world_id,
+            )
+    finally:
+        await c.shutdown()
+
+
+def test_experiment_identity_and_threshold_fail_closed():
+    with pytest.raises(ValueError, match="experiment_id"):
+        _config("invalid", max_iterations=1, experiment_id="")
+
+    with pytest.raises(ValueError, match="improvement_threshold"):
+        AutoResearchConfig(
+            experiment_name="invalid",
+            experiment_id="invalid-id",
+            evaluator_id="scripted-score-v1",
+            rollout_contract_id="single-step-rollout-v1",
+            improvement_threshold=float("nan"),
+        )
+
+    with pytest.raises(ValueError, match="evaluator_id"):
+        AutoResearchConfig(
+            experiment_name="invalid",
+            experiment_id="invalid-id",
+            evaluator_id="",
+            rollout_contract_id="single-step-rollout-v1",
+        )
+
+    with pytest.raises(ValueError, match="rollout_contract_id"):
+        AutoResearchConfig(
+            experiment_name="invalid",
+            experiment_id="invalid-id",
+            evaluator_id="scripted-score-v1",
+            rollout_contract_id="",
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"num_episodes": 0}, "num_episodes"),
+        ({"max_iterations": 0}, "max_iterations"),
+        ({"improvement_threshold": -0.1}, "improvement_threshold"),
+    ],
+)
+def test_empty_or_regressive_search_config_fails_closed(overrides, message):
+    values = {
+        "experiment_name": "invalid",
+        "experiment_id": "invalid-id",
+        "evaluator_id": "scripted-score-v1",
+        "rollout_contract_id": "single-step-rollout-v1",
+    }
+    values.update(overrides)
+    with pytest.raises(ValueError, match=message):
+        AutoResearchConfig(**values)


### PR DESCRIPTION
## Summary

- require stable caller-supplied experiment, evaluator, and rollout contract identities before scores can be resumed or compared
- let each iteration prepare a distinct candidate world and persist typed, finite evaluation evidence
- record deterministic `RUNNING -> STOPPED/CRASHED` attempt transitions, including candidate provenance on failures
- fail closed on empty rollouts, regressive thresholds, evaluator drift, active attempts, corrupt statuses, and ambiguous iteration history
- fix aggregate improvement semantics so resumed runs compare against the persisted incumbent

## Compatibility

`AutoResearchConfig` now requires `experiment_id`, `evaluator_id`, and `rollout_contract_id`. Plain-float evaluators remain supported and are recorded under the configured evaluator identity.

This stays inside Archetype's generic lifecycle boundary: it does not generate candidates, mutate Git, merge winners, coordinate over NATS, or implement company-specific promotion policy. Explicit `lab_world_id` attachment reconnects a world already registered with the current `WorldService`; it is not cross-process catalog reconstruction.

## Lazy-execution exceptions

This PR updates `lazy_audit.toml` for three deliberate control-plane materializations in `AutoResearchService`: the single persisted experiment contract, the single active `BranchHead`, and bounded attempt history. Those rows must enter Python control flow to reject identity collisions, route the head entity update, and fail closed on active or corrupt histories before any new work begins; none feeds a downstream dataframe computation.

## Verification

- `uv run pytest tests/app/test_autoresearch_ledger.py -q` — 18 passed
- `uv run ruff format --check src tests experiments/cooperative_emergence.py`
- `uv run ruff check src tests experiments/cooperative_emergence.py`
- `uvx ty@0.0.48 check --python .venv`
- `uv run python scripts/check_lazy_audit.py` — 12 audited sites accounted for
- `git diff --check`

Opened as a draft so the required-identity API can be reviewed independently from the query-backed eval-service PR.
