### PR TITLE
feat(runtime): expose autoresearch and evals through ArchetypeRuntime

### DIFF
--- a/docs/guide/autoresearch.md
+++ b/docs/guide/autoresearch.md
@@ -4,6 +4,26 @@ AutoResearch is a pattern for autonomous software optimization: track a single b
 
 **Status: attempts run on the ledger.** `AutoResearchService` records a `RUNNING` row before candidate preparation or rollout, then records `STOPPED` with an evaluation or `CRASHED` with failure metadata. The loop is itself an archetype simulation.
 
+## Runtime quick path
+
+Think of worlds as save states. `world.autoresearch(...)` replays candidate lines from a base save, scores each one, and keeps the best route; every attempt — including crashes — lands on the experiment's own ledger. Episode worlds are kept by default so you can load any of them afterward and inspect what actually happened.
+
+```python
+from archetype import ArchetypeRuntime, AutoResearchConfig, EvaluationResult
+
+async with ArchetypeRuntime() as runtime:
+    base = runtime.world("base", storage="./data")
+    # ... spawn initial state, run once ...
+
+    result = await base.autoresearch(config, evaluate, prepare_candidate=prepare)
+
+    lab = runtime.attach(result.lab_world_id)     # the experiment's ledger
+    episode = runtime.attach(result.iterations[0].rollout.episodes[0].world_id)
+    outputs = await episode.grade(MyComponent, graders=[my_grader])
+```
+
+`examples/10_autoresearch.py` is the full runnable version. `ServiceContainer.autoresearch_service` remains the lower-level interface; the runtime path routes through the command gate (`CommandType.AUTORESEARCH`, operator+) and emits one audit row per loop.
+
 ## What's Implemented
 
 `archetype.experiments` models the lifecycle state as ordinary Components, so runs become entities in an archetype world — forkable, time-travelable, and queryable with the same tools as any other simulation state.

--- a/docs/guide/command-gate.md
+++ b/docs/guide/command-gate.md
@@ -87,6 +87,7 @@ Processors define behavior. Hooks observe lifecycle. Resources hold shared state
 | `run` | — | — | ✓ | ✓ |
 | `run_episode` | — | — | ✓ | ✓ |
 | `run_rollout` | — | — | ✓ | ✓ |
+| `autoresearch` | — | — | ✓ | ✓ |
 
 A `player` does not advance the world — they participate in the world that something else is advancing.
 
@@ -153,6 +154,7 @@ _OPERATOR_ADDS = frozenset({
     CommandType.RUN,
     CommandType.RUN_EPISODE,
     CommandType.RUN_ROLLOUT,
+    CommandType.AUTORESEARCH,
     CommandType.FORK_WORLD,
     CommandType.DESTROY_WORLD,
 })
@@ -250,6 +252,8 @@ tracked as audit-log hardening.)
 Multi-step gate methods (e.g. `destroy_world` orchestrating broker.clear + audit.flush + world_service.destroy_world) emit ONE audit row, not one per step. The row's `payload_json` captures sub-operation outcomes.
 
 `run_rollout` emits ONE row, not one per fork. The row's payload captures the fork world_ids and aggregate stats.
+
+`autoresearch` emits ONE row for the whole loop. The experiment's lab world is the fine-grained record: every attempt appends `RUNNING` and terminal lifecycle ticks there, so per-iteration provenance is queryable simulation state rather than audit noise.
 
 ## 7. Migration from earlier role sets
 

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -125,6 +125,15 @@ Field access on info objects is sync; the fetch is async (gated). See `world-lif
 - `world.fork(name?)` returns a new world handle bound to the same `ActorCtx`. Fork goes through `iCommandService.fork_world`. The new handle is registered for shutdown.
 - `world.destroy()` calls `iCommandService.destroy_world`. The handle becomes invalid; subsequent operations raise. Storage and audit rows are NEVER deleted.
 
+### R14 — Attached handles do not own their world
+
+`runtime.attach(world_id)` returns a handle for a world that already exists in this runtime — an episode world left behind by a rollout, an autoresearch lab world, or any world created elsewhere in the process. The id is validated on first operation. Shutting the handle down never destroys the world; only an explicit, gated `destroy()` can. Reads resolve the world's recorded storage through the gate, so an attached handle finds rows wherever the world actually wrote them.
+
+### R15 — AutoResearch and grading route through the gate
+
+- `world.autoresearch(config, evaluator, ...)` is gated as `CommandType.AUTORESEARCH` (operator+) and emits one loop-level audit row; per-attempt provenance lives on the experiment's lab world. The base world is never mutated. The handle's op lock is held only for activation, so `evaluator`, `prepare_candidate`, and `on_iteration` may call back into runtime handles (`query`, `attach`, `grade`) without deadlocking.
+- `world.grade(*components, graders=[...])` composes the gated, lineage-resolved `query` with `EvalService.run_graders`. Graders receive one lazy Daft DataFrame of the full append-only history and decide what to compute; the runtime materializes nothing. Empty grader lists and empty grader outputs are rejected, never vacuous successes.
+
 ## 3. Ergonomic surface
 
 The full canonical surface, async and sync:
@@ -132,6 +141,7 @@ The full canonical surface, async and sync:
 ```python
 # Construction (factory on runtime)
 world = runtime.world(name, storage=..., cache=..., processors=..., resources=..., hooks=...)
+world = runtime.attach(world_id)   # handle for an existing world (episode/lab worlds)
 
 # Mutations
 eid = await world.spawn(Position(x=0), Velocity(dx=1))
@@ -153,6 +163,7 @@ await world.run(steps=10)
 await world.run(config=RunConfig(...))
 await world.run_episode(EpisodeConfig(...))
 await world.run_rollout(RolloutConfig(...))
+await world.autoresearch(AutoResearchConfig(...), evaluator)  # optimization loop
 
 # Lifecycle
 await world.fork(name="branch_a")                        # → new handle
@@ -160,6 +171,7 @@ await world.destroy()                                    # in-memory only
 
 # Reads
 df = await world.query(Position, Velocity)
+outs = await world.grade(Position, graders=[my_grader])  # query + graders
 info = await world.info()                                # WorldInfo snapshot
 df = await world.history(limit=100)
 procs = await world.list_processors()

--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -102,6 +102,10 @@ _RUNTIME_ALLOWED_APP_IMPORTS = frozenset(
         "archetype.app.container",
         "archetype.app.models",
         "archetype.app.auth.models",
+        # Type-only signature references; the operations themselves route
+        # through the gate (CommandType.AUTORESEARCH, QUERY_WORLD).
+        "archetype.app.autoresearch_service",
+        "archetype.app.eval_service",
     }
 )
 
@@ -161,6 +165,7 @@ _EXPECTED_ROLE_MATRIX: dict[str, frozenset[CommandType]] = {
             CommandType.RUN,
             CommandType.RUN_EPISODE,
             CommandType.RUN_ROLLOUT,
+            CommandType.AUTORESEARCH,
             CommandType.FORK_WORLD,
             CommandType.DESTROY_WORLD,
         }
@@ -185,6 +190,7 @@ _COMMAND_GATE_MAP: dict[str, CommandType] = {
     "run": CommandType.RUN,
     "run_episode": CommandType.RUN_EPISODE,
     "run_rollout": CommandType.RUN_ROLLOUT,
+    "autoresearch": CommandType.AUTORESEARCH,
     "query_components": CommandType.QUERY_WORLD,
     "query_archetype": CommandType.QUERY_WORLD,
     "list_signatures": CommandType.LIST_SIGNATURES,

--- a/examples/10_autoresearch.py
+++ b/examples/10_autoresearch.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+AutoResearch: Save-State Optimization
+======================================
+
+Worlds are save states. This example tunes a parameter by replaying
+candidate lines from one base save:
+
+1. Fork the base world and set a candidate value (prepare)
+2. Roll the candidate forward (rollout)
+3. Score it by loading the episode save and grading what happened (evaluate)
+4. Keep the best route on the experiment's ledger (BranchHead)
+
+Every attempt — including crashes — is recorded on the experiment's own
+lab world, so the search itself is a queryable archetype simulation.
+Rerunning with the same experiment_id resumes from the persisted best.
+
+No external dependencies — runs entirely in-process.
+
+Usage:
+    uv run python examples/10_autoresearch.py
+"""
+
+import asyncio
+
+from daft import col
+
+from archetype import ArchetypeRuntime, AutoResearchConfig, EvaluationResult
+from archetype.app.models import EpisodeConfig
+from archetype.core.component import Component
+from archetype.core.config import StorageConfig
+from archetype.experiments.components import Run
+
+TARGET = 3.0
+
+
+class Knob(Component):
+    x: float = 0.0
+
+
+async def main():
+    storage = StorageConfig(uri="./archetype_data", namespace="autoresearch_demo")
+
+    async with ArchetypeRuntime() as runtime:
+        base = runtime.world("knob-base", storage=storage)
+        await base.spawn(Knob(x=0.0))
+        await base.run(steps=1)
+        print(f"Base save state: {base.world_id}\n")
+
+        async def prepare(ctx):
+            """Fork the base save and try x = iteration index."""
+            fork = await base.fork(f"candidate-x{ctx.iteration}")
+            rows = (await fork.query(Knob)).to_pylist()
+            await fork.update(int(rows[0]["entity_id"]), Knob(x=float(ctx.iteration)))
+            await fork.run(steps=1)
+            return fork.world_id
+
+        async def evaluate(rollout) -> EvaluationResult:
+            """Load each episode save and score its final Knob state."""
+            xs = []
+            for ep in rollout.episodes:
+                episode = runtime.attach(ep.world_id, name="episode")
+                final_tick = (await episode.info()).tick - 1
+
+                def final_x(df, t=final_tick):
+                    latest = df.where(col("tick") == t)
+                    return latest.agg(col("knob__x").mean().alias("x")).to_pylist()[0]["x"]
+
+                outputs = await episode.grade(Knob, graders=[final_x])
+                xs.append(outputs[0])
+            dist = sum((x - TARGET) ** 2 for x in xs) / len(xs)
+            score = -dist if dist else 0.0
+            return EvaluationResult(
+                score=score,
+                evaluator="knob-distance-v1",
+                evidence={"xs": xs, "target": TARGET},
+            )
+
+        config = AutoResearchConfig(
+            experiment_name="knob-tuning",
+            experiment_id="knob-tuning-demo",
+            evaluator_id="knob-distance-v1",
+            rollout_contract_id="knob-1ep-1step-v1",
+            episode_config=EpisodeConfig(max_steps=1),
+            num_episodes=1,
+            max_iterations=4,
+        )
+
+        result = await base.autoresearch(config, evaluate, prepare_candidate=prepare)
+
+        for it in result.iterations:
+            marker = "ADVANCE" if it.improved else "hold"
+            print(
+                f"iter {it.iteration}: x={float(it.iteration):.0f} "
+                f"score={it.score:+.1f} -> {marker} (best={it.incumbent_score:+.1f})"
+            )
+        print(f"\nBest score {result.final_score:+.1f} at x={TARGET:.0f}, ", end="")
+        print(f"improved={result.improved}")
+
+        # The search itself is a simulation: load the ledger save and audit it.
+        lab = runtime.attach(result.lab_world_id, name="lab")
+        attempts = await lab.query(Run)
+        info = await lab.info()
+        latest = attempts.where(col("tick") == info.tick - 1)
+        print(f"\nExperiment ledger ({result.lab_world_id}), attempts at final tick:")
+        latest.select("run__run_id", "run__status").show()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -74,19 +74,19 @@ reason = "Lineage metadata extract: a fork's ancestor segments (bounded by fork 
 
 [[entries]]
 path = "src/archetype/app/autoresearch_service.py"
-line = 581
+line = 584
 method = "to_pylist"
 reason = "Single-row experiment-contract extract: the persisted identity and JSON configuration digest must enter Python control flow for exact collision rejection before the service records a resumed attempt; this is an imperative lifecycle gate, not a downstream dataframe computation."
 
 [[entries]]
 path = "src/archetype/app/autoresearch_service.py"
-line = 589
+line = 592
 method = "to_pylist"
 reason = "Single-row loop-state extract: the latest BranchHead row must enter Python control flow for incumbent score comparison and entity-id routing of the next append; these values drive imperative orchestration, not a further dataframe computation."
 
 [[entries]]
 path = "src/archetype/app/autoresearch_service.py"
-line = 601
+line = 604
 method = "to_pylist"
 reason = "Bounded control-plane history extract: deterministic Run ids and terminal statuses must enter Python control flow to reject active, corrupt, duplicate, or non-contiguous attempts before resume; the result chooses whether any new work may start rather than feeding a dataframe computation."
 

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -98,6 +98,11 @@ __all__ = [
     # Models
     "Command",
     "CommandType",
+    # AutoResearch
+    "AutoResearchConfig",
+    "AutoResearchResult",
+    "CandidateContext",
+    "EvaluationResult",
 ]
 
 _EXPORTS: dict[str, tuple[str, str]] = {
@@ -153,6 +158,11 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "ServiceContainer": ("archetype.app", "ServiceContainer"),
     "Command": ("archetype.app", "Command"),
     "CommandType": ("archetype.app", "CommandType"),
+    # AutoResearch
+    "AutoResearchConfig": ("archetype.app.autoresearch_service", "AutoResearchConfig"),
+    "AutoResearchResult": ("archetype.app.autoresearch_service", "AutoResearchResult"),
+    "CandidateContext": ("archetype.app.autoresearch_service", "CandidateContext"),
+    "EvaluationResult": ("archetype.app.autoresearch_service", "EvaluationResult"),
 }
 
 

--- a/src/archetype/app/auth/guard.py
+++ b/src/archetype/app/auth/guard.py
@@ -50,6 +50,7 @@ _TOKEN_COSTS: dict[str, int] = {
     "destroy_world": 10,
     "fork_world": 100,
     "run_rollout": 200,
+    "autoresearch": 200,  # per iteration; see estimate_token_cost
     "run_episode": 500,
     "run": 50,
     "step": 10,
@@ -77,8 +78,18 @@ _last_reset_date: date = datetime.now(UTC).date()
 
 
 def estimate_token_cost(cmd: Command) -> int:
-    """Estimate token cost for a command."""
-    return _TOKEN_COSTS.get(cmd.type.value, 10)
+    """Estimate token cost for a command.
+
+    ``autoresearch`` is one command that performs up to ``max_iterations``
+    rollouts (the loop's internal rollouts are not gated individually), so
+    it is charged at the rollout rate per iteration rather than as one
+    flat command.
+    """
+    cost = _TOKEN_COSTS.get(cmd.type.value, 10)
+    if cmd.type.value == "autoresearch":
+        iterations = cmd.payload.get("max_iterations", 1)
+        cost *= max(int(iterations), 1)
+    return cost
 
 
 def guardrail_check(

--- a/src/archetype/app/auth/permissions.py
+++ b/src/archetype/app/auth/permissions.py
@@ -67,6 +67,7 @@ _OPERATOR_ADDS = frozenset(
         CommandType.RUN,
         CommandType.RUN_EPISODE,
         CommandType.RUN_ROLLOUT,
+        CommandType.AUTORESEARCH,
         CommandType.FORK_WORLD,
         CommandType.DESTROY_WORLD,
     }

--- a/src/archetype/app/autoresearch_service.py
+++ b/src/archetype/app/autoresearch_service.py
@@ -79,7 +79,10 @@ class AutoResearchConfig:
     parallel: bool = False
     max_iterations: int = 100
     improvement_threshold: float = 0.0
-    destroy_forks_on_complete: bool = True
+    # Episode worlds are save states: keep them by default so evaluators and
+    # post-hoc analysis can query what actually happened. Opt in to destruction
+    # when fork volume is a real constraint.
+    destroy_forks_on_complete: bool = False
     # The loop's own state lives on the ledger: a lab world named
     # "autoresearch:{experiment_id}" with explicit attempt lifecycle ticks.
     record_to_ledger: bool = True

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -444,7 +444,18 @@ class CommandService:
         """
         if self._autoresearch is None:
             raise RuntimeError("CommandService was constructed without an AutoResearchService")
-        self._gate(Command(type=CommandType.AUTORESEARCH), ctx)
+        # The payload drives quota accounting: the loop is charged per
+        # iteration at the rollout rate (see guard.estimate_token_cost).
+        self._gate(
+            Command(
+                type=CommandType.AUTORESEARCH,
+                payload={
+                    "max_iterations": config.max_iterations,
+                    "num_episodes": config.num_episodes,
+                },
+            ),
+            ctx,
+        )
         result = await self._autoresearch.run(
             world_id,
             config,

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -27,7 +27,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+import math
+from typing import TYPE_CHECKING, Any
 
 import logfire
 from uuid_utils import UUID
@@ -43,10 +44,20 @@ from archetype.app.models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from daft import DataFrame
 
     from archetype.app.audit_log import AuditLog
     from archetype.app.auth.models import ActorCtx
+    from archetype.app.autoresearch_service import (
+        AutoResearchConfig,
+        AutoResearchResult,
+        AutoResearchService,
+        CandidatePreparer,
+        Evaluator,
+        IterationResult,
+    )
     from archetype.app.broker import CommandBroker
     from archetype.app.models import (
         EpisodeConfig,
@@ -82,6 +93,7 @@ class CommandService:
         queries: QueryService,
         broker: CommandBroker,
         audit: AuditLog | None = None,
+        autoresearch: AutoResearchService | None = None,
     ) -> None:
         self._mutations = mutations
         self._worlds = worlds
@@ -89,6 +101,7 @@ class CommandService:
         self._queries = queries
         self._broker = broker
         self._audit = audit
+        self._autoresearch = autoresearch
 
     def _gate(self, cmd: Command, ctx: ActorCtx) -> None:
         """RBAC + quota check. Raises GuardrailError if denied."""
@@ -406,6 +419,57 @@ class CommandService:
                     "num_episodes": result.num_episodes,
                     "total_duration_steps": result.total_duration_steps,
                     "episode_world_ids": [str(ep.world_id) for ep in result.episodes],
+                }
+            ),
+        )
+        return result
+
+    @logfire.instrument("gate.autoresearch")
+    async def autoresearch(
+        self,
+        ctx: ActorCtx,
+        world_id: str | UUID,
+        config: AutoResearchConfig,
+        evaluator: Evaluator,
+        *,
+        prepare_candidate: CandidatePreparer | None = None,
+        lab_world_id: str | UUID | None = None,
+        on_iteration: Callable[[IterationResult], Any] | None = None,
+    ) -> AutoResearchResult:
+        """Gate, then delegate to AutoResearchService.run.
+
+        Emits ONE loop-level audit row. Candidate forks, rollouts, and
+        lab-world lifecycle ticks are AutoResearchService's mechanics; the
+        experiment's own ledger is the fine-grained record of every attempt.
+        """
+        if self._autoresearch is None:
+            raise RuntimeError("CommandService was constructed without an AutoResearchService")
+        self._gate(Command(type=CommandType.AUTORESEARCH), ctx)
+        result = await self._autoresearch.run(
+            world_id,
+            config,
+            evaluator,
+            prepare_candidate=prepare_candidate,
+            lab_world_id=lab_world_id,
+            on_iteration=on_iteration,
+        )
+        await self._emit(
+            ctx,
+            "autoresearch",
+            world_id,
+            payload_json=json.dumps(
+                {
+                    "experiment_id": config.experiment_id,
+                    "iterations_completed": result.iterations_completed,
+                    # -inf baselines (fresh ledger) are not JSON values.
+                    "initial_score": (
+                        result.initial_score if math.isfinite(result.initial_score) else None
+                    ),
+                    "final_score": (
+                        result.final_score if math.isfinite(result.final_score) else None
+                    ),
+                    "improved": result.improved,
+                    "lab_world_id": result.lab_world_id,
                 }
             ),
         )

--- a/src/archetype/app/container.py
+++ b/src/archetype/app/container.py
@@ -62,6 +62,9 @@ class ServiceContainer:
         self.mutation_service = MutationService(self.world_service)
         self.simulation_service = SimulationService(self.world_service)
 
+        # AutoResearch — depends on WorldService + SimulationService
+        self.autoresearch_service = AutoResearchService(self.world_service, self.simulation_service)
+
         # The gate — depends on everything
         self.command_service = CommandService(
             mutations=self.mutation_service,
@@ -70,11 +73,9 @@ class ServiceContainer:
             queries=self.query_service,
             broker=self.broker,
             audit=self.audit_log,
+            autoresearch=self.autoresearch_service,
         )
         self.simulation_service.set_command_drain(self.command_service.drain_and_apply)
-
-        # AutoResearch — depends on WorldService + SimulationService
-        self.autoresearch_service = AutoResearchService(self.world_service, self.simulation_service)
 
     async def shutdown(self) -> None:
         """Gracefully shut down all services."""

--- a/src/archetype/app/models.py
+++ b/src/archetype/app/models.py
@@ -59,6 +59,7 @@ class CommandType(StrEnum):
     RUN = "run"
     RUN_ROLLOUT = "run_rollout"
     RUN_EPISODE = "run_episode"
+    AUTORESEARCH = "autoresearch"  # Optimization loop over rollouts
 
     # Reads / introspection
     QUERY_WORLD = "query_world"

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -25,6 +25,8 @@ from pathlib import Path
 from typing import Any
 from weakref import WeakSet
 
+from uuid_utils import UUID
+
 from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
 from archetype.core.config import CacheConfig, StorageConfig
@@ -120,6 +122,36 @@ class ArchetypeRuntime:
         self._handles.add(handle)
         return handle
 
+    def attach(self, world_id: str | UUID, *, name: str = "attached") -> RuntimeWorld:
+        """Return a handle for a world that already exists in this runtime.
+
+        The save-slot loader: episode worlds left behind by a rollout, an
+        autoresearch lab world, or any world created outside this handle's
+        scope can be queried and driven through the same gated surface. The
+        id is validated on first operation, and the handle does not own the
+        world — shutting it down never destroys the world (``destroy()``
+        still can, explicitly).
+        """
+        if self._closed:
+            raise RuntimeError("ArchetypeRuntime is closed")
+
+        state = _RuntimeWorldState(
+            runtime=self,
+            name=name,
+            # None → the gate resolves the world's recorded storage on read.
+            storage_config=None,
+            cache_config=None,
+            init_processors=[],
+            init_resources=[],
+            init_hooks=[],
+            world_id=world_id,
+            owns_world=False,
+        )
+        handle = RuntimeWorld(state=state, actor_ctx=self._actor_ctx)
+        state.aliases.add(handle)
+        self._handles.add(handle)
+        return handle
+
     @classmethod
     def sync(cls, *, actor_ctx: ActorCtx | None = None) -> SyncArchetypeRuntime:
         """Factory for the synchronous runtime facade."""
@@ -180,6 +212,10 @@ class SyncArchetypeRuntime:
             hooks=hooks,
         )
         return SyncRuntimeWorld(rw, self)
+
+    def attach(self, world_id, *, name: str = "attached") -> SyncRuntimeWorld:
+        """Handle for an existing world. See ArchetypeRuntime.attach."""
+        return SyncRuntimeWorld(self._runtime.attach(world_id, name=name), self)
 
 
 def run_sync(coro) -> Any:

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -193,6 +193,30 @@ class SyncArchetypeRuntime:
             raise RuntimeError("SyncArchetypeRuntime is not active")
         return self._runner
 
+    def _dispatch(self, coro) -> Any:
+        """Run *coro* to completion from any thread.
+
+        Sync autoresearch executes user callbacks in a worker thread while
+        the runner's loop keeps running in the owning thread; sync handle
+        methods called from those callbacks must schedule onto the running
+        loop instead of re-entering Runner.run.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            coro.close()
+            raise RuntimeError(
+                "sync handle methods cannot be called from the event-loop thread; "
+                "use async handles (ArchetypeRuntime) inside async callbacks"
+            )
+        runner = self._require_runner()
+        loop = runner.get_loop()
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return runner.run(coro)
+
     def world(
         self,
         name: str = "world",

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -39,6 +39,16 @@ from archetype.core.config import CacheConfig, RunConfig, StorageConfig, WorldCo
 from archetype.core.hooks import HookEvent
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from archetype.app.autoresearch_service import (
+        AutoResearchConfig,
+        AutoResearchResult,
+        CandidatePreparer,
+        Evaluator,
+        IterationResult,
+    )
+    from archetype.app.eval_service import GraderOutput, TrajectoryGrader
     from archetype.runtime.runtime import ArchetypeRuntime, SyncArchetypeRuntime
 
 _FireMode = Any  # Literal["blocking", "spawn"] — kept loose for forward compat
@@ -94,6 +104,9 @@ class _RuntimeWorldState:
         init_hooks: list[tuple[type[HookEvent], Any]],
         # Pre-activated fork state (set when forking from an existing world)
         world_id: str | UUID | None = None,
+        # Attached handles (runtime.attach) reference a world they did not
+        # create; shutdown must not destroy it.
+        owns_world: bool = True,
     ) -> None:
         self.runtime = runtime
         self.name = name
@@ -102,6 +115,7 @@ class _RuntimeWorldState:
         self.init_processors = init_processors
         self.init_resources = init_resources
         self.init_hooks = init_hooks
+        self.owns_world = owns_world
 
         self.world_id: str | UUID | None = world_id
         self.initialized: bool = world_id is not None
@@ -154,7 +168,7 @@ class _RuntimeWorldState:
             return
         self.closed = True
 
-        if not from_runtime and self.initialized and self.world_id is not None:
+        if not from_runtime and self.owns_world and self.initialized and self.world_id is not None:
             gate = self.runtime._container.command_service
             # Use a default admin ctx for shutdown
             from archetype.runtime._actor import default_actor_ctx
@@ -348,6 +362,57 @@ class RuntimeWorld:
         async with self._state.op_lock:
             wid = await self._ensure_id()
             return await self._gate.run_rollout(self._ctx, wid, config, **kw)
+
+    async def autoresearch(
+        self,
+        config: AutoResearchConfig,
+        evaluator: Evaluator,
+        *,
+        prepare_candidate: CandidatePreparer | None = None,
+        lab_world_id: str | UUID | None = None,
+        on_iteration: Callable[[IterationResult], Any] | None = None,
+    ) -> AutoResearchResult:
+        """Run an autoresearch loop with this world as the base save state.
+
+        Each iteration optionally prepares a candidate world (a fork of this
+        one), runs a rollout, scores it with ``evaluator``, and advances the
+        experiment's BranchHead on improvement. This world is never mutated.
+        Loop state lives on the experiment's lab world, so rerunning with the
+        same ``config.experiment_id`` resumes from the persisted incumbent.
+        Episode worlds are kept by default — load them with
+        ``runtime.attach`` to inspect or grade what happened.
+
+        The op lock is held only for activation: ``evaluator``,
+        ``prepare_candidate``, and ``on_iteration`` may call back into this
+        handle (e.g. ``query``) without deadlocking.
+        """
+        async with self._state.op_lock:
+            wid = await self._ensure_id()
+        return await self._gate.autoresearch(
+            self._ctx,
+            wid,
+            config,
+            evaluator,
+            prepare_candidate=prepare_candidate,
+            lab_world_id=lab_world_id,
+            on_iteration=on_iteration,
+        )
+
+    async def grade(
+        self,
+        *component_types: type[Component],
+        graders: Sequence[TrajectoryGrader],
+        entity_ids: list[int] | None = None,
+    ) -> list[GraderOutput]:
+        """Query this world's rows and execute graders over the result.
+
+        The query is gated and lineage-resolved exactly like ``query``;
+        graders receive one lazy Daft DataFrame of the full append-only
+        history and decide what to compute. Durable scores remain components
+        the caller writes back.
+        """
+        df = await self.query(*component_types, entity_ids=entity_ids)
+        return await self._state.runtime._container.eval_service.run_graders(df, graders)
 
     # ── Lifecycle ─────────────────────────────────────────────────────────
 
@@ -560,6 +625,35 @@ class SyncRuntimeWorld:
 
     def run_rollout(self, config: RolloutConfig, **kw) -> RolloutResult:
         return self._run(lambda: self._world.run_rollout(config, **kw))
+
+    def autoresearch(
+        self,
+        config: AutoResearchConfig,
+        evaluator: Evaluator,
+        *,
+        prepare_candidate: CandidatePreparer | None = None,
+        lab_world_id: str | UUID | None = None,
+        on_iteration: Callable[[IterationResult], Any] | None = None,
+    ) -> AutoResearchResult:
+        return self._run(
+            lambda: self._world.autoresearch(
+                config,
+                evaluator,
+                prepare_candidate=prepare_candidate,
+                lab_world_id=lab_world_id,
+                on_iteration=on_iteration,
+            )
+        )
+
+    def grade(
+        self,
+        *component_types: type[Component],
+        graders: Sequence[TrajectoryGrader],
+        entity_ids: list[int] | None = None,
+    ) -> list[GraderOutput]:
+        return self._run(
+            lambda: self._world.grade(*component_types, graders=graders, entity_ids=entity_ids)
+        )
 
     def info(self) -> WorldInfo:
         return self._run(lambda: self._world.info())

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -20,6 +20,7 @@ Holds world_id (not iWorld). Routes every operation through iCommandService.
 from __future__ import annotations
 
 import asyncio
+import inspect
 from typing import TYPE_CHECKING, Any
 from weakref import WeakSet
 
@@ -559,6 +560,22 @@ class RuntimeWorld:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def _callback_in_thread(fn):
+    """Adapt a sync user callback to run off the event-loop thread.
+
+    Sync callbacks re-enter sync handle methods; running them on the loop
+    thread would deadlock the dispatch that schedules onto the running
+    loop. Async callbacks pass through untouched.
+    """
+    if fn is None or inspect.iscoroutinefunction(fn):
+        return fn
+
+    async def _in_thread(arg):
+        return await asyncio.to_thread(fn, arg)
+
+    return _in_thread
+
+
 class SyncRuntimeWorld:
     """Synchronous facade. Mirrors RuntimeWorld without await."""
 
@@ -567,7 +584,7 @@ class SyncRuntimeWorld:
         self._runtime = runtime
 
     def _run(self, factory) -> Any:
-        return self._runtime._require_runner().run(factory())
+        return self._runtime._dispatch(factory())
 
     @property
     def world_id(self):
@@ -635,13 +652,19 @@ class SyncRuntimeWorld:
         lab_world_id: str | UUID | None = None,
         on_iteration: Callable[[IterationResult], Any] | None = None,
     ) -> AutoResearchResult:
+        """Sync mirror of RuntimeWorld.autoresearch.
+
+        Sync callbacks are executed in a worker thread so they may call
+        sync handle methods (attach, grade, query) while the loop runs;
+        async callbacks are passed through and must use async handles.
+        """
         return self._run(
             lambda: self._world.autoresearch(
                 config,
-                evaluator,
-                prepare_candidate=prepare_candidate,
+                _callback_in_thread(evaluator),
+                prepare_candidate=_callback_in_thread(prepare_candidate),
                 lab_world_id=lab_world_id,
-                on_iteration=on_iteration,
+                on_iteration=_callback_in_thread(on_iteration),
             )
         )
 

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -109,3 +109,29 @@ class TestActorCtx:
     def test_default_roles(self):
         ctx = ActorCtx(id=uuid7())
         assert "viewer" in ctx.roles
+
+
+class TestAutoresearchTokenCost:
+    """One autoresearch command performs max_iterations rollouts; the budget
+    must charge it accordingly, not as one flat command."""
+
+    def test_cost_scales_with_iterations(self):
+        flat = Command(type=CommandType.AUTORESEARCH, payload={})
+        assert _guard.estimate_token_cost(flat) == _guard._TOKEN_COSTS["autoresearch"]
+
+        loop = Command(type=CommandType.AUTORESEARCH, payload={"max_iterations": 100})
+        assert _guard.estimate_token_cost(loop) == _guard._TOKEN_COSTS["run_rollout"] * 100, (
+            "the loop is charged at the rollout rate per iteration"
+        )
+
+    def test_large_loop_exceeds_budget_where_one_rollout_would_not(self):
+        ctx = ActorCtx(id=uuid7(), roles={"operator"})
+        _guard._daily_tokens[ctx.id] = MAX_TOKENS_PER_DAY - 300
+
+        guardrail_allow(Command(type=CommandType.RUN_ROLLOUT, payload={}), ctx)
+
+        with pytest.raises(GuardrailError, match="daily token budget"):
+            guardrail_allow(
+                Command(type=CommandType.AUTORESEARCH, payload={"max_iterations": 100}),
+                ctx,
+            )

--- a/tests/app/test_import_boundaries.py
+++ b/tests/app/test_import_boundaries.py
@@ -27,6 +27,10 @@ _RUNTIME_ALLOWED_APP = frozenset(
         "archetype.app.container",
         "archetype.app.models",
         "archetype.app.auth.models",
+        # Type-only signature references for world.autoresearch / world.grade;
+        # the operations themselves route through the gate.
+        "archetype.app.autoresearch_service",
+        "archetype.app.eval_service",
     }
 )
 

--- a/tests/app/test_runtime_autoresearch.py
+++ b/tests/app/test_runtime_autoresearch.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime exposure of autoresearch and evals.
+
+The beginner path: ``world.autoresearch`` runs the gated optimization loop,
+``runtime.attach`` loads existing worlds (episode saves, the lab ledger),
+and ``world.grade`` composes the gated query with grader execution. All of
+it routes through the command gate with the handle's ActorCtx.
+"""
+
+import pytest
+from daft import col
+from uuid_utils import uuid7
+
+from archetype import ArchetypeRuntime, AutoResearchConfig, EvaluationResult
+from archetype.app.auth.errors import GuardrailError
+from archetype.app.auth.models import ActorCtx
+from archetype.app.models import EpisodeConfig
+from archetype.core.component import Component
+from archetype.core.config import StorageConfig
+from archetype.experiments.components import Run, RunStatus
+
+TARGET = 3.0
+
+
+class Knob(Component):
+    x: float = 0.0
+
+
+def _config(name: str, max_iterations: int) -> AutoResearchConfig:
+    return AutoResearchConfig(
+        experiment_name=name,
+        experiment_id=f"{name}-id",
+        evaluator_id="knob-distance-v1",
+        rollout_contract_id="knob-1ep-1step-v1",
+        episode_config=EpisodeConfig(max_steps=1),
+        num_episodes=1,
+        max_iterations=max_iterations,
+    )
+
+
+@pytest.mark.asyncio
+async def test_world_autoresearch_optimizes_and_ledgers(tmp_path):
+    """Full runtime path: prepare forks candidates, evaluate loads episode
+    saves via attach and grades their final state, the loop advances the
+    head, and the lab world is attachable for audit."""
+    async with ArchetypeRuntime() as runtime:
+        base = runtime.world(
+            "base", storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        )
+        await base.spawn(Knob(x=0.0))
+        await base.run(steps=1)
+
+        async def prepare(ctx):
+            fork = await base.fork(f"candidate-{ctx.iteration}")
+            rows = (await fork.query(Knob)).to_pylist()
+            await fork.update(int(rows[0]["entity_id"]), Knob(x=float(ctx.iteration)))
+            await fork.run(steps=1)
+            return fork.world_id
+
+        async def evaluate(rollout) -> EvaluationResult:
+            xs = []
+            for ep in rollout.episodes:
+                episode = runtime.attach(ep.world_id)
+                final_tick = (await episode.info()).tick - 1
+
+                def final_x(df, t=final_tick):
+                    latest = df.where(col("tick") == t)
+                    return latest.agg(col("knob__x").mean().alias("x")).to_pylist()[0]["x"]
+
+                xs.append((await episode.grade(Knob, graders=[final_x]))[0])
+            score = -sum((x - TARGET) ** 2 for x in xs) / len(xs)
+            return EvaluationResult(score=score, evaluator="knob-distance-v1", evidence={"xs": xs})
+
+        result = await base.autoresearch(
+            _config("runtime-exp", max_iterations=4), evaluate, prepare_candidate=prepare
+        )
+
+        assert [it.score for it in result.iterations] == [-9.0, -4.0, -1.0, 0.0]
+        assert result.final_score == 0.0
+        assert result.improved
+
+        # Episode worlds are kept by default (destroy_forks_on_complete=False):
+        # the evaluator above could only have graded live saves.
+        lab = runtime.attach(result.lab_world_id, name="lab")
+        info = await lab.info()
+        assert info.tick == 9, "genesis + RUNNING/terminal ticks for 4 attempts"
+        attempts = (await lab.query(Run)).where(col("tick") == info.tick - 1).to_pylist()
+        assert sorted(r["run__run_id"] for r in attempts) == [
+            f"runtime-exp-id:iter{i}" for i in range(4)
+        ]
+        assert all(r["run__status"] == RunStatus.STOPPED.value for r in attempts)
+
+
+@pytest.mark.asyncio
+async def test_world_autoresearch_denied_below_operator(tmp_path):
+    async with ArchetypeRuntime() as runtime:
+        base = runtime.world(
+            "base", storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        )
+        await base.spawn(Knob(x=0.0))
+        await base.run(steps=1)
+
+        for role in ("viewer", "player"):
+            handle = base.as_actor(ActorCtx(id=uuid7(), roles={role}))
+            with pytest.raises(GuardrailError):
+                await handle.autoresearch(
+                    _config(f"denied-{role}", max_iterations=1), lambda _r: 1.0
+                )
+
+
+@pytest.mark.asyncio
+async def test_attach_shutdown_does_not_destroy_the_world(tmp_path):
+    async with ArchetypeRuntime() as runtime:
+        base = runtime.world(
+            "base", storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        )
+        await base.spawn(Knob(x=1.0))
+        await base.run(steps=1)
+
+        attached = runtime.attach(base.world_id, name="alias")
+        assert (await attached.info()).tick == 1
+        await attached.shutdown()
+
+        # The world survives: the attached handle never owned it.
+        assert (await base.info()).tick == 1
+        again = runtime.attach(base.world_id)
+        assert (await again.info()).tick == 1
+
+
+@pytest.mark.asyncio
+async def test_grade_rejects_empty_graders(tmp_path):
+    async with ArchetypeRuntime() as runtime:
+        base = runtime.world(
+            "base", storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        )
+        await base.spawn(Knob(x=1.0))
+        await base.run(steps=1)
+
+        with pytest.raises(ValueError, match="at least one grader"):
+            await base.grade(Knob, graders=[])
+
+
+@pytest.mark.asyncio
+async def test_attach_unknown_world_fails_on_first_operation():
+    async with ArchetypeRuntime() as runtime:
+        ghost = runtime.attach(uuid7(), name="ghost")
+        with pytest.raises(LookupError):
+            await ghost.info()

--- a/tests/app/test_runtime_autoresearch.py
+++ b/tests/app/test_runtime_autoresearch.py
@@ -148,3 +148,46 @@ async def test_attach_unknown_world_fails_on_first_operation():
         ghost = runtime.attach(uuid7(), name="ghost")
         with pytest.raises(LookupError):
             await ghost.info()
+
+
+def test_sync_autoresearch_callbacks_reenter_sync_handles(tmp_path):
+    """Sync parity: a sync evaluator may attach episode saves and grade them
+    with sync handle methods while the loop is running (callbacks execute in
+    a worker thread; handle calls schedule onto the running loop)."""
+    from archetype import ArchetypeRuntime as _RT
+
+    with _RT.sync() as runtime:
+        base = runtime.world(
+            "base", storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        )
+        base.spawn(Knob(x=0.0))
+        base.run(steps=1)
+
+        def prepare(ctx):
+            fork = base.fork(f"candidate-{ctx.iteration}")
+            rows = fork.query(Knob).to_pylist()
+            fork.update(int(rows[0]["entity_id"]), Knob(x=float(ctx.iteration)))
+            fork.run(steps=1)
+            return fork.world_id
+
+        def evaluate(rollout) -> EvaluationResult:
+            xs = []
+            for ep in rollout.episodes:
+                episode = runtime.attach(ep.world_id)
+                final_tick = episode.info().tick - 1
+
+                def final_x(df, t=final_tick):
+                    latest = df.where(col("tick") == t)
+                    return latest.agg(col("knob__x").mean().alias("x")).to_pylist()[0]["x"]
+
+                xs.append(episode.grade(Knob, graders=[final_x])[0])
+            score = -sum((x - TARGET) ** 2 for x in xs) / len(xs)
+            return EvaluationResult(score=score, evaluator="knob-distance-v1", evidence={"xs": xs})
+
+        result = base.autoresearch(
+            _config("sync-exp", max_iterations=4), evaluate, prepare_candidate=prepare
+        )
+
+        assert [it.score for it in result.iterations] == [-9.0, -4.0, -1.0, 0.0]
+        assert result.final_score == 0.0
+        assert result.improved


### PR DESCRIPTION
## Summary

The beginner-facing path for autoresearch, indexed on the save-state mental model:

- `world.autoresearch(config, evaluator, ...)` — run the optimization loop with this world as the base save state. Gated as `CommandType.AUTORESEARCH` (operator+), one loop-level audit row; per-attempt provenance stays on the experiment's lab world.
- `runtime.attach(world_id)` — the save-slot loader: get a gated handle for any world that already exists in the runtime (episode worlds a rollout left behind, the autoresearch lab ledger). Attached handles do not own their world — shutdown never destroys it.
- `world.grade(*components, graders=[...])` — the gated, lineage-resolved query composed with `EvalService.run_graders`. Graders receive one lazy DataFrame and decide what to compute; empty grader lists/outputs are rejected, never vacuous successes.
- Top-level exports: `AutoResearchConfig`, `AutoResearchResult`, `CandidateContext`, `EvaluationResult`.
- Sync facades mirror all three verbs.

## Behavior change

`AutoResearchConfig.destroy_forks_on_complete` now defaults to **False**: episode worlds are save states, and evaluators that score what actually happened need them alive (this was the one usage wart the PR #261 dogfood surfaced). Configs that relied on the old default get a different identity digest, so resuming such an experiment fails closed with an identity collision instead of silently comparing across different rollout semantics.

## Spec alignment

RBAC matrix (`operator` gains `autoresearch`), `docs/guide/command-gate.md`, the executable spec contracts (`evals/suites/spec_contracts.py`: role matrix, runtime→app import allowlist, command-gate map), and the import-boundary test were all updated together. Runtime imports of `autoresearch_service`/`eval_service` are type-only; operations route through the gate. `docs/guide/runtime.md` adds R14 (attached handles don't own worlds) and R15 (autoresearch/grade gate routing; op lock held only for activation so callbacks can re-enter handles without deadlock).

## Lazy-execution exceptions

None added. `lazy_audit.toml` re-keys the three existing autoresearch entries to their shifted lines.

## Verification

- `make test` — full suite green (731 passed after spec-contract updates)
- `uv run pytest tests/app/test_runtime_autoresearch.py` — 5 new tests: end-to-end optimization via the runtime (finds the optimum, ledger audited via attach), viewer/player denied by the gate, attach shutdown non-destructive, empty graders rejected, unknown world id fails on first op
- `uv run python examples/10_autoresearch.py` — runs credential-free, converges to the target, prints the experiment ledger (picked up automatically by the examples CI glob)
- ruff format/check, ty 0.0.48, lazy audit, typos, markdownlint-cli2 — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)