### PR TITLE
ci: arm auto-merge automatically on maintainer PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,35 @@
+# Arm auto-merge (squash) on maintainer PRs the moment they open or leave
+# draft. The merge itself still waits on every required check and on
+# review-conversation resolution — this only removes the manual
+# `gh pr merge --auto --squash` step.
+#
+# Token note: if AUTOMERGE_PAT (a fine-grained PAT with contents:write +
+# pull-requests:write) is present, it is preferred. With the default
+# GITHUB_TOKEN the merge is attributed to github-actions, and pushes made
+# by GITHUB_TOKEN do not trigger `on: push` workflows — the docs deploy to
+# Cloudflare Pages on main would be skipped for auto-merged PRs.
+
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  arm:
+    name: Arm auto-merge for maintainer PRs
+    if: >-
+      github.event.pull_request.user.login == 'everettVT' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Arms `gh pr merge --auto --squash` by workflow on every PR authored by `everettVT` (same-repo, non-draft, on open or ready-for-review). The merge itself still waits on all required checks and review-conversation resolution — this only removes the manual arming step.

## Token caveat

The workflow prefers a repo secret `AUTOMERGE_PAT` (fine-grained PAT, this repo only, `contents: write` + `pull-requests: write`) and falls back to `GITHUB_TOKEN`. With the fallback, the eventual merge is attributed to `github-actions`, and pushes made by `GITHUB_TOKEN` do not trigger `on: push` workflows — so the docs deploy to Cloudflare Pages on main would not fire for auto-merged PRs. Adding the PAT restores user-attributed merges and keeps the docs deploy firing.

## Verification

- YAML parses; conditions mirror the ruleset assumptions (8 required checks strict, approvals=0, conversation resolution required).
- First real exercise will be the next PR opened after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)