### PR TITLE
feat(runtime): quiet observability by default; ARCHETYPE_LOG turns it up

### DIFF
--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -134,6 +134,10 @@ Field access on info objects is sync; the fetch is async (gated). See `world-lif
 - `world.autoresearch(config, evaluator, ...)` is gated as `CommandType.AUTORESEARCH` (operator+) and emits one loop-level audit row; per-attempt provenance lives on the experiment's lab world. The base world is never mutated. The handle's op lock is held only for activation, so `evaluator`, `prepare_candidate`, and `on_iteration` may call back into runtime handles (`query`, `attach`, `grade`) without deadlocking.
 - `world.grade(*components, graders=[...])` composes the gated, lineage-resolved `query` with `EvalService.run_graders`. Graders receive one lazy Daft DataFrame of the full append-only history and decide what to compute; the runtime materializes nothing. Empty grader lists and empty grader outputs are rejected, never vacuous successes.
 
+### R16 — Observability is quiet by default, one flag turns it up
+
+Scripts own their stdout: no span or log output unless asked. `ARCHETYPE_LOG=debug|info|warning|error` (or `ArchetypeRuntime(log=...)`) wires the stdlib `archetype` logger hierarchy at the runtime boundary; at `debug` it also enables console span output. Every layer *emits* on module loggers — core included, since processor failures and store writes are exactly what debugging needs — but only the runtime *configures* handlers, levels, and sinks. `RunConfig(debug=True)` remains separate: it is per-run dataframe inspection (it materializes frames) and is never switched by an environment variable.
+
 ## 3. Ergonomic surface
 
 The full canonical surface, async and sync:

--- a/examples/01_world_mutations.py
+++ b/examples/01_world_mutations.py
@@ -13,6 +13,10 @@ No external dependencies — runs entirely in-process.
 
 Usage:
     uv run python examples/01_world_mutations.py
+
+The script's own narration is all you see by default. To watch the
+machinery underneath (gated ops, world steps, store writes), set:
+    ARCHETYPE_LOG=debug uv run python examples/01_world_mutations.py
 """
 
 import asyncio

--- a/examples/06_trajectory_analysis.py
+++ b/examples/06_trajectory_analysis.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import sys
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -21,6 +21,8 @@ that route every operation through iCommandService.
 from __future__ import annotations
 
 import asyncio
+import logging
+import os
 from pathlib import Path
 from typing import Any
 from weakref import WeakSet
@@ -35,13 +37,39 @@ from archetype.runtime._actor import default_actor_ctx
 from archetype.runtime._config import coerce_cache, coerce_storage
 from archetype.runtime.world import RuntimeWorld, SyncRuntimeWorld, _RuntimeWorldState
 
+_LOG_LEVELS = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+}
+
+
+def _resolve_log_level(env: str | None = None) -> int | None:
+    """Map ARCHETYPE_LOG (or an explicit override) to a stdlib level."""
+    value = (env if env is not None else os.environ.get("ARCHETYPE_LOG", "")).strip().lower()
+    return _LOG_LEVELS.get(value)
+
+
+def _configure_archetype_logging(level: int) -> None:
+    """Wire the ``archetype`` logger hierarchy at the script boundary.
+
+    Every layer emits on module loggers and never configures handlers; the
+    runtime is the application boundary, so the one user-facing flag lives
+    here. Root logging is left untouched.
+    """
+    pkg_logger = logging.getLogger("archetype")
+    pkg_logger.setLevel(level)
+    if not pkg_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(levelname).1s %(name)s: %(message)s"))
+        pkg_logger.addHandler(handler)
+
 
 class ArchetypeRuntime:
     """Process-level runtime. Owns the container and default identity."""
 
-    def __init__(self, *, actor_ctx: ActorCtx | None = None) -> None:
-        import os
-
+    def __init__(self, *, actor_ctx: ActorCtx | None = None, log: str | None = None) -> None:
         import logfire
 
         # Never block on an interactive logfire setup prompt.  Send to logfire
@@ -56,7 +84,21 @@ class ArchetypeRuntime:
         _send_explicit = _send_env in ("1", "true", "yes")
         _send_to_logfire = _has_token or _send_explicit
 
-        logfire.configure(service_name="archetype-runtime", send_to_logfire=_send_to_logfire)
+        # One user-facing verbosity flag: ARCHETYPE_LOG=debug|info|warning|error
+        # (or ArchetypeRuntime(log=...)). It wires the stdlib "archetype"
+        # logger hierarchy, and at debug it also turns on console span output.
+        # Quiet is the default: span walls interleave with script output and
+        # drown the program's own voice — legibility of the script wins.
+        level = _resolve_log_level(log)
+        if level is not None:
+            _configure_archetype_logging(level)
+        console = None if level == logging.DEBUG else False
+
+        logfire.configure(
+            service_name="archetype-runtime",
+            send_to_logfire=_send_to_logfire,
+            console=console,
+        )
 
         self._container = ServiceContainer()
         self._actor_ctx = actor_ctx or default_actor_ctx()
@@ -153,9 +195,11 @@ class ArchetypeRuntime:
         return handle
 
     @classmethod
-    def sync(cls, *, actor_ctx: ActorCtx | None = None) -> SyncArchetypeRuntime:
+    def sync(
+        cls, *, actor_ctx: ActorCtx | None = None, log: str | None = None
+    ) -> SyncArchetypeRuntime:
         """Factory for the synchronous runtime facade."""
-        return SyncArchetypeRuntime(actor_ctx=actor_ctx)
+        return SyncArchetypeRuntime(actor_ctx=actor_ctx, log=log)
 
     def _register_handle(self, handle: RuntimeWorld) -> None:
         self._handles.add(handle)
@@ -171,8 +215,8 @@ class ArchetypeRuntime:
 class SyncArchetypeRuntime:
     """Synchronous facade. Owns its own asyncio.Runner (R6, OQ6)."""
 
-    def __init__(self, *, actor_ctx: ActorCtx | None = None) -> None:
-        self._runtime = ArchetypeRuntime(actor_ctx=actor_ctx)
+    def __init__(self, *, actor_ctx: ActorCtx | None = None, log: str | None = None) -> None:
+        self._runtime = ArchetypeRuntime(actor_ctx=actor_ctx, log=log)
         self._runner: asyncio.Runner | None = None
 
     def __enter__(self) -> SyncArchetypeRuntime:

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -64,6 +64,10 @@ def _configure_archetype_logging(level: int) -> None:
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter("%(levelname).1s %(name)s: %(message)s"))
         pkg_logger.addHandler(handler)
+        # This handler now owns archetype records. Without this, a host that
+        # configured root logging (basicConfig, a Logfire root handler, ...)
+        # would emit every record a second time through the root sinks.
+        pkg_logger.propagate = False
 
 
 class ArchetypeRuntime:

--- a/tests/app/test_runtime_observability.py
+++ b/tests/app/test_runtime_observability.py
@@ -41,12 +41,17 @@ def test_configure_wires_package_logger_idempotently():
     pkg = logging.getLogger("archetype")
     before_handlers = list(pkg.handlers)
     before_level = pkg.level
+    before_propagate = pkg.propagate
     try:
         _configure_archetype_logging(logging.INFO)
         _configure_archetype_logging(logging.DEBUG)
         added = [h for h in pkg.handlers if h not in before_handlers]
         assert len(added) <= 1, "repeat configuration must not stack handlers"
         assert pkg.level == logging.DEBUG
+        if added:
+            # Our handler owns the records: without stopping propagation, a
+            # host with root logging configured would double-emit every line.
+            assert pkg.propagate is False
         # Root logging stays untouched: libraries and the runtime never
         # reconfigure logging that isn't theirs.
         assert logging.getLogger().level == logging.WARNING or not logging.getLogger().handlers
@@ -54,3 +59,4 @@ def test_configure_wires_package_logger_idempotently():
         for h in [h for h in pkg.handlers if h not in before_handlers]:
             pkg.removeHandler(h)
         pkg.setLevel(before_level)
+        pkg.propagate = before_propagate

--- a/tests/app/test_runtime_observability.py
+++ b/tests/app/test_runtime_observability.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime observability contract (runtime.md R16).
+
+Scripts own their stdout: the runtime configures nothing unless asked, and
+one flag — ARCHETYPE_LOG / ArchetypeRuntime(log=...) — wires the stdlib
+``archetype`` hierarchy at the script boundary.
+"""
+
+import logging
+
+import pytest
+
+from archetype.runtime.runtime import _configure_archetype_logging, _resolve_log_level
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("debug", logging.DEBUG),
+        ("INFO", logging.INFO),
+        (" warning ", logging.WARNING),
+        ("error", logging.ERROR),
+        ("", None),
+        ("verbose", None),
+    ],
+)
+def test_resolve_log_level(value, expected):
+    assert _resolve_log_level(value) == expected
+
+
+def test_env_var_is_the_default_source(monkeypatch):
+    monkeypatch.setenv("ARCHETYPE_LOG", "info")
+    assert _resolve_log_level() == logging.INFO
+    monkeypatch.delenv("ARCHETYPE_LOG")
+    assert _resolve_log_level() is None
+
+
+def test_configure_wires_package_logger_idempotently():
+    pkg = logging.getLogger("archetype")
+    before_handlers = list(pkg.handlers)
+    before_level = pkg.level
+    try:
+        _configure_archetype_logging(logging.INFO)
+        _configure_archetype_logging(logging.DEBUG)
+        added = [h for h in pkg.handlers if h not in before_handlers]
+        assert len(added) <= 1, "repeat configuration must not stack handlers"
+        assert pkg.level == logging.DEBUG
+        # Root logging stays untouched: libraries and the runtime never
+        # reconfigure logging that isn't theirs.
+        assert logging.getLogger().level == logging.WARNING or not logging.getLogger().handlers
+    finally:
+        for h in [h for h in pkg.handlers if h not in before_handlers]:
+            pkg.removeHandler(h)
+        pkg.setLevel(before_level)


### PR DESCRIPTION
## Summary

Legibility fix for scripts and examples: the runtime stops printing console spans by default, so a script's own narration is all you see. One flag lights the machinery up:

- `ARCHETYPE_LOG=debug|info|warning|error` (or `ArchetypeRuntime(log=...)`, mirrored on the sync facade) wires the stdlib `archetype` logger hierarchy — level plus one stderr handler, root logging untouched, idempotent.
- At `debug`, console span output (gate.*, world.*) comes back on.
- Emission is unchanged at every layer — core keeps logging processor failures, store writes, migrations on module loggers; only the runtime configures handlers/sinks. Documented as runtime.md R16.
- `RunConfig(debug=True)` deliberately stays separate: it materializes frames for inspection (lazy-audit-exempted diagnostics) and must remain per-run opt-in, never env-switched.
- `examples/01_world_mutations.py` docstring points at the flag; example output is now pure narrative (verified: no span lines on stdout by default; spans visible under `ARCHETYPE_LOG=debug`).

## Follow-up (not in this PR)

OTel-agnostic emission: logfire is already an OpenTelemetry SDK (its spans are OTel spans, exported as standard OTLP), so the migration path is a thin internal shim replacing `logfire.span`/`@logfire.instrument` at ~38 call sites (gate 22, async_world 6, api 6, runtime configure) with the vanilla `opentelemetry.trace` API, leaving Logfire as just one OTLP backend and `contrib/logfire_observer` as the only logfire-branded surface.

## Verification

- New tests: `tests/app/test_runtime_observability.py` (level resolution, env source, idempotent handler wiring, root untouched)
- Behavior verified end-to-end: quiet default (no span output during spawn/run), debug mode shows spans + stdlib logs
- ruff format/check, ty, markdownlint on runtime.md — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)