### PR TITLE
feat(obs): vendor-neutral OpenTelemetry; logfire becomes an optional backend

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -54,6 +54,10 @@ jobs:
 
   evals:
     runs-on: ubuntu-latest
+    env:
+      # Real workload jobs report to Logfire when the org token is set;
+      # absent secret -> empty var -> archetype._obs stays vendor-free.
+      LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -138,6 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DO_NOT_TRACK: "1"
+      LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/bench/libero/modal_worker.py
+++ b/bench/libero/modal_worker.py
@@ -89,6 +89,9 @@ image = (
         "easydict",
         "imageio[ffmpeg]",
         "opencv-python-headless",
+        # Worker-side observability: archetype's Modal secret `logfire`
+        # provides LOGFIRE_TOKEN; without it configure is skipped entirely.
+        "logfire",
     )
     # LIBERO's top-level package dir has no __init__.py, so find_packages()
     # produces an empty wheel from a plain `pip install git+...`. The repo's
@@ -119,6 +122,7 @@ app = modal.App("archetype-libero-env", image=image)
     scaledown_window=300,
     max_containers=1,
     volumes={FRAMES_MOUNT: frames_volume},
+    secrets=[modal.Secret.from_name("logfire")],
 )
 class LiberoEnvBatch:
     """A batch of LIBERO envs for one task suite, keyed by env_key.
@@ -142,7 +146,14 @@ class LiberoEnvBatch:
 
     @modal.enter()
     def load_suite(self):
+        import os
+
         from libero.libero import benchmark
+
+        if os.environ.get("LOGFIRE_TOKEN"):
+            import logfire
+
+            logfire.configure(service_name="archetype-libero-env", console=False)
 
         self._envs: dict[int, Any] = {}
         self._suite = benchmark.get_benchmark_dict()[self.suite]()

--- a/bench/libero/modal_worker.py
+++ b/bench/libero/modal_worker.py
@@ -36,6 +36,7 @@ interpreter exit from robosuite's context __del__; harmless.)
 
 # NOTE: no `from __future__ import annotations` here — modal.parameter()
 # validates real annotation objects, and PEP 563 string annotations break it.
+import os
 import uuid
 from typing import Any
 
@@ -109,6 +110,12 @@ image = (
     .env({"MUJOCO_GL": "egl", "PYOPENGL_PLATFORM": "egl"})
 )
 
+# Worker-side observability is opt-out per deployer: the named Modal secret
+# is only referenced when configured (default "logfire", Vangelis' secret).
+# Deploying in a workspace without it: ARCHETYPE_MODAL_LOGFIRE_SECRET= modal deploy ...
+_LOGFIRE_SECRET_NAME = os.environ.get("ARCHETYPE_MODAL_LOGFIRE_SECRET", "logfire")
+_worker_secrets = [modal.Secret.from_name(_LOGFIRE_SECRET_NAME)] if _LOGFIRE_SECRET_NAME else []
+
 app = modal.App("archetype-libero-env", image=image)
 
 
@@ -122,7 +129,7 @@ app = modal.App("archetype-libero-env", image=image)
     scaledown_window=300,
     max_containers=1,
     volumes={FRAMES_MOUNT: frames_volume},
-    secrets=[modal.Secret.from_name("logfire")],
+    secrets=_worker_secrets,
 )
 class LiberoEnvBatch:
     """A batch of LIBERO envs for one task suite, keyed by env_key.

--- a/bench/libero/vla_jepa_worker.py
+++ b/bench/libero/vla_jepa_worker.py
@@ -72,7 +72,7 @@ image = (
     .apt_install("git", "libgl1", "libglib2.0-0")
     .pip_install("torch==2.5.1", "packaging", "ninja", "wheel", "huggingface_hub")
     # Their deployment/ websocket server+client deps are not in requirements.txt.
-    .pip_install("websockets", "msgpack", "msgpack-numpy")
+    .pip_install("websockets", "msgpack", "msgpack-numpy", "logfire")
     # SHA pinned 2026-06-12: git ls-remote VLA-JEPA HEAD → ec8c70f6...
     .run_commands(
         f"git clone {REPO} /opt/VLA-JEPA && git -C /opt/VLA-JEPA checkout {_VLA_JEPA_SHA}",
@@ -99,12 +99,19 @@ ckpt_volume = modal.Volume.from_name("vla-jepa-ckpts", create_if_missing=True)
     timeout=3600,
     scaledown_window=600,
     max_containers=1,
+    secrets=[modal.Secret.from_name("logfire")],
 )
 class VlaJepaPolicy:
     use_bf16: int = modal.parameter(default=1)
 
     @modal.enter()
     def start_server(self):
+        import os as _os
+
+        if _os.environ.get("LOGFIRE_TOKEN"):
+            import logfire
+
+            logfire.configure(service_name="archetype-vla-jepa", console=False)
         # from_pretrained expects the full run directory (config.yaml +
         # dataset_statistics.json beside checkpoints/), not just the .pt.
         # Drop previously-patched config files first so the snapshot always

--- a/bench/libero/vla_jepa_worker.py
+++ b/bench/libero/vla_jepa_worker.py
@@ -44,6 +44,7 @@ L40S. Payload contract confirmed against the live server: batch_images
 # NOTE: no `from __future__ import annotations` — modal.parameter()
 # validates real annotation objects.
 import base64
+import os
 import subprocess
 import time
 from typing import Any
@@ -89,6 +90,12 @@ image = (
     .env({"HF_HOME": f"{CKPT_DIR}/hf-cache", "PYTHONPATH": "/opt/VLA-JEPA"})
 )
 
+# Worker-side observability is opt-out per deployer: the named Modal secret
+# is only referenced when configured (default "logfire", Vangelis' secret).
+# Deploying in a workspace without it: ARCHETYPE_MODAL_LOGFIRE_SECRET= modal deploy ...
+_LOGFIRE_SECRET_NAME = os.environ.get("ARCHETYPE_MODAL_LOGFIRE_SECRET", "logfire")
+_worker_secrets = [modal.Secret.from_name(_LOGFIRE_SECRET_NAME)] if _LOGFIRE_SECRET_NAME else []
+
 app = modal.App("archetype-vla-jepa", image=image)
 ckpt_volume = modal.Volume.from_name("vla-jepa-ckpts", create_if_missing=True)
 
@@ -99,7 +106,7 @@ ckpt_volume = modal.Volume.from_name("vla-jepa-ckpts", create_if_missing=True)
     timeout=3600,
     scaledown_window=600,
     max_containers=1,
-    secrets=[modal.Secret.from_name("logfire")],
+    secrets=_worker_secrets,
 )
 class VlaJepaPolicy:
     use_bf16: int = modal.parameter(default=1)

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -138,6 +138,10 @@ Field access on info objects is sync; the fetch is async (gated). See `world-lif
 
 Scripts own their stdout: no span or log output unless asked. `ARCHETYPE_LOG=debug|info|warning|error` (or `ArchetypeRuntime(log=...)`) wires the stdlib `archetype` logger hierarchy at the runtime boundary; at `debug` it also enables console span output. Every layer *emits* on module loggers — core included, since processor failures and store writes are exactly what debugging needs — but only the runtime *configures* handlers, levels, and sinks. `RunConfig(debug=True)` remains separate: it is per-run dataframe inspection (it materializes frames) and is never switched by an environment variable.
 
+### R17 — Tracing is vendor-neutral OpenTelemetry
+
+Archetype emits spans through the OpenTelemetry *API* only (`archetype._obs`); installing archetype pulls no telemetry vendor. Backend selection happens once, at the runtime boundary, in this order: a provider the host application already registered is respected untouched; `LOGFIRE_TOKEN`/`LOGFIRE_API_KEY`/`LOGFIRE_SEND_TO_LOGFIRE` select Logfire when the `archetype-ecs[logfire]` extra is installed (Logfire is itself an OTel SDK); `OTEL_EXPORTER_OTLP_ENDPOINT` selects the standard OTLP exporter (`archetype-ecs[otlp]`) and works with any collector; `ARCHETYPE_LOG=debug` gets a terse one-line console exporter on stderr with no extras at all; otherwise the no-op OTel API stays and tracing costs nothing. Nothing under `src/` may import `logfire` except the guarded backend selection and `contrib/logfire_observer`.
+
 ## 3. Ergonomic surface
 
 The full canonical surface, async and sync:

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -44,7 +44,7 @@ reason = "Storage write boundary: defensive empty-frame probe before delegating 
 
 [[entries]]
 path = "src/archetype/core/aio/async_world.py"
-line = 335
+line = 332
 method = "to_pylist"
 reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,11 @@ dependencies = [
     "uvicorn[standard]>=0.29",
     "typer>=0.9",
     "httpx>=0.27",
-    "logfire>=4.32.0",
-    "opentelemetry-instrumentation-fastapi>=0.60b1",
-    "opentelemetry-instrumentation-httpx>=0.60b1",
-    "opentelemetry-instrumentation-jinja2>=0.60b1",
-    "opentelemetry-instrumentation-requests>=0.60b1",
-    "opentelemetry-instrumentation-sqlalchemy>=0.60b1",
-    "opentelemetry-instrumentation-sqlite3>=0.60b1",
-    "opentelemetry-instrumentation-urllib>=0.60b1",
+    # Observability is vendor-neutral: archetype emits through the OTel API
+    # only (archetype._obs). The SDK ships so ARCHETYPE_LOG=debug works out
+    # of the box; exporters and vendors are extras.
+    "opentelemetry-api>=1.20",
+    "opentelemetry-sdk>=1.20",
 ]
 
 [project.scripts]
@@ -43,7 +40,8 @@ archetype = "archetype.cli.main:app"
 [project.optional-dependencies]
 benchmark  = ["esper>=2.45"]
 sim        = ["mujoco>=3.2"]
-otel       = ["opentelemetry-api>=1.20", "opentelemetry-sdk>=1.20", "opentelemetry-exporter-otlp-proto-grpc>=1.20"]
+otel       = ["opentelemetry-exporter-otlp-proto-http>=1.20"]
+logfire    = ["logfire[fastapi]>=4.32.0"]
 dev        = [
     "pytest>=8.3", "pytest-asyncio>=0.26", "pytest-cov>=5.0",
     "ruff>=0.15,<0.16",  # pinned: 0.15 introduced I001/B007 rule changes; keep local == CI
@@ -112,6 +110,10 @@ dev = [
     "mutmut>=3.5",
     "mujoco>=3.2",  # physics parity tests (tests/experiments/test_mujoco_rollout.py)
     "pytest-xdist>=3.8.0",
+    # Dev keeps the optional logfire backend installed so CI exercises
+    # contrib/logfire_observer and the api instrumentation path; the
+    # published package depends only on the OTel API + SDK.
+    "logfire[fastapi]>=4.32.0",
 ]
 
 # Mutation testing. Scoped narrowly: mutmut runs each mutation as a full

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ archetype = "archetype.cli.main:app"
 [project.optional-dependencies]
 benchmark  = ["esper>=2.45"]
 sim        = ["mujoco>=3.2"]
-otel       = ["opentelemetry-exporter-otlp-proto-http>=1.20"]
+otlp       = ["opentelemetry-exporter-otlp-proto-http>=1.20"]
 logfire    = ["logfire[fastapi]>=4.32.0"]
 dev        = [
     "pytest>=8.3", "pytest-asyncio>=0.26", "pytest-cov>=5.0",

--- a/src/archetype/_obs.py
+++ b/src/archetype/_obs.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Archetype's observability boundary: vanilla OpenTelemetry, no vendor.
+
+Every span archetype emits goes through this module and the OpenTelemetry
+*API* only. With no SDK configured the API is a no-op, so `import archetype`
+costs nothing and requires no telemetry vendor. Any OTel SDK that registers
+the global tracer provider — the runtime's own setup, a host application's,
+or Logfire's (which is an OTel SDK) — receives the same spans.
+
+Nothing under ``src/`` may import ``logfire``; the only logfire-aware code
+paths are the optional backend selection in :func:`configure_tracing` (via
+importlib, never a hard import) and ``contrib/logfire_observer.py``, which
+is explicitly a Logfire integration.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+import os
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from typing import Any, TypeVar, cast
+
+from opentelemetry import trace
+
+logger = logging.getLogger(__name__)
+
+# The proxy tracer resolves the global provider at span time, so module
+# import order never matters: configure_tracing (or a host SDK) can run
+# before or after any instrumented module is imported.
+_tracer = trace.get_tracer("archetype")
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+# OTel attribute values must be str/bool/int/float or sequences thereof.
+_ATTR_TYPES = (str, bool, int, float)
+
+
+def _attributes(values: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value if isinstance(value, _ATTR_TYPES) else str(value)
+        for key, value in values.items()
+        if value is not None
+    }
+
+
+@contextmanager
+def span(name: str, **attributes: Any) -> Iterator[trace.Span]:
+    """Open one span around a block. No-op without a configured SDK."""
+    with _tracer.start_as_current_span(name, attributes=_attributes(attributes)) as active:
+        yield active
+
+
+def instrument(name: str) -> Callable[[_F], _F]:
+    """Wrap a sync or async callable in one span of the given name."""
+
+    def decorate(fn: _F) -> _F:
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                with _tracer.start_as_current_span(name):
+                    return await fn(*args, **kwargs)
+
+            return cast(_F, async_wrapper)  # wraps preserves the signature
+
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with _tracer.start_as_current_span(name):
+                return fn(*args, **kwargs)
+
+        return cast(_F, wrapper)  # wraps preserves the signature
+
+    return decorate
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Provider setup — called once, by the runtime (the script boundary)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_configured = False
+
+
+def configure_tracing(*, service_name: str, debug_console: bool = False) -> None:
+    """Register a global tracer provider for this process, once.
+
+    Backend selection, in order:
+
+    1. A host application already registered a provider → respect it and do
+       nothing. Archetype is a library; the application owns the pipeline.
+    2. Logfire installed AND explicitly opted into (``LOGFIRE_TOKEN`` /
+       ``LOGFIRE_API_KEY`` / ``LOGFIRE_SEND_TO_LOGFIRE`` truthy) →
+       ``logfire.configure()``. Logfire is an OTel SDK: it registers the
+       global provider and every archetype span lands there.
+    3. ``OTEL_EXPORTER_OTLP_ENDPOINT`` / ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT``
+       set → SDK provider with the standard OTLP/HTTP exporter (which reads
+       the ``OTEL_*`` environment variables itself). Works with any
+       collector: Jaeger, Grafana, Honeycomb, a Logfire endpoint, ...
+    4. ``debug_console`` (ARCHETYPE_LOG=debug) → SDK provider with a terse
+       one-line console exporter on stderr, keeping stdout for the script.
+    5. Otherwise → leave the no-op OTel API in place: zero overhead, zero
+       output.
+    """
+    global _configured
+    if _configured:
+        return
+    _configured = True
+
+    if not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider):
+        return  # path 1: the application already owns the pipeline
+
+    has_token = bool(os.environ.get("LOGFIRE_TOKEN") or os.environ.get("LOGFIRE_API_KEY"))
+    send_env = os.environ.get("LOGFIRE_SEND_TO_LOGFIRE", "").lower()
+    if has_token or send_env in ("1", "true", "yes"):
+        try:
+            import logfire
+
+            logfire.configure(
+                service_name=service_name,
+                send_to_logfire=True,
+                console=None if debug_console else False,
+            )
+            return  # path 2
+        except ImportError:
+            logger.warning(
+                "LOGFIRE_* environment set but logfire is not installed; "
+                "install archetype-ecs[logfire] to send there. Falling back."
+            )
+
+    otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or os.environ.get(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+    )
+    if otlp_endpoint:
+        try:
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+            provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+            provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+            if debug_console:
+                provider.add_span_processor(_console_processor())
+            trace.set_tracer_provider(provider)
+            return  # path 3
+        except ImportError:
+            logger.warning(
+                "OTEL_EXPORTER_OTLP_*ENDPOINT set but no OTLP exporter is "
+                "installed; install archetype-ecs[otlp]. Falling back."
+            )
+
+    if debug_console:
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+
+        provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+        provider.add_span_processor(_console_processor())
+        trace.set_tracer_provider(provider)  # path 4
+    # path 5: no-op API stays
+
+
+def _console_processor():
+    """One line per span on stderr: name, duration, attributes."""
+    import sys
+
+    from opentelemetry.sdk.trace import ReadableSpan
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+    class _OneLineExporter(SpanExporter):
+        def export(self, spans: Any) -> SpanExportResult:
+            for s in spans:
+                assert isinstance(s, ReadableSpan)
+                dur_ms = ((s.end_time or 0) - (s.start_time or 0)) / 1e6
+                attrs = " ".join(f"{k}={v}" for k, v in (s.attributes or {}).items())
+                print(f"· {s.name} {dur_ms:.1f}ms {attrs}".rstrip(), file=sys.stderr)
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self) -> None:
+            return None
+
+    return SimpleSpanProcessor(_OneLineExporter())

--- a/src/archetype/api/app.py
+++ b/src/archetype/api/app.py
@@ -17,20 +17,16 @@
 from contextlib import asynccontextmanager
 from logging import basicConfig
 
-import logfire
 from fastapi import FastAPI
-from logfire.exceptions import LogfireConfigError
 
+from archetype import _obs
 from archetype.api.deps import get_container, set_container
 from archetype.api.routes import commands, entities, query, simulation, worlds
 
-try:
-    logfire.configure(service_name="archetype-ecs")
-except LogfireConfigError:
-    # No Logfire credentials on this machine — degrade to local-only
-    # instrumentation instead of refusing to import.
-    logfire.configure(service_name="archetype-ecs", send_to_logfire=False)
-basicConfig(handlers=[logfire.LogfireLoggingHandler()])
+# Vendor-neutral tracing: backend selection (host provider, LOGFIRE_* opt-in,
+# OTEL_* endpoint, or no-op) lives in archetype._obs. Logfire is optional.
+_obs.configure_tracing(service_name="archetype-ecs")
+basicConfig()
 
 
 @asynccontextmanager
@@ -54,7 +50,14 @@ def create_app() -> FastAPI:
         version="0.1.1",
         lifespan=lifespan,
     )
-    logfire.instrument_fastapi(app)
+    # Route-level tracing is optional: use it when logfire is installed,
+    # skip it otherwise — the gate spans below the routes always exist.
+    try:
+        import logfire
+
+        logfire.instrument_fastapi(app)
+    except ImportError:
+        pass
 
     app.include_router(worlds.router)
     app.include_router(entities.router)

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -30,9 +30,9 @@ import logging
 import math
 from typing import TYPE_CHECKING, Any
 
-import logfire
 from uuid_utils import UUID
 
+from archetype._obs import instrument
 from archetype.app.auth.guard import guardrail_allow
 from archetype.app.models import (
     Command,
@@ -134,7 +134,7 @@ class CommandService:
 
     # ── Mutations (gated, direct) ─────────────────────────────────────────
 
-    @logfire.instrument("gate.create_entity")
+    @instrument("gate.create_entity")
     async def create_entity(
         self,
         ctx: ActorCtx,
@@ -146,7 +146,7 @@ class CommandService:
         await self._emit(ctx, "spawn", world_id)
         return result
 
-    @logfire.instrument("gate.create_entities")
+    @instrument("gate.create_entities")
     async def create_entities(
         self,
         ctx: ActorCtx,
@@ -159,7 +159,7 @@ class CommandService:
         await self._emit(ctx, "spawn_batch", world_id, count=len(entities))
         return result
 
-    @logfire.instrument("gate.reserve_entity_ids")
+    @instrument("gate.reserve_entity_ids")
     def reserve_entity_ids(
         self,
         ctx: ActorCtx,
@@ -170,7 +170,7 @@ class CommandService:
         self._gate(Command(type=CommandType.SPAWN), ctx)
         return self._mutations.reserve_entity_ids(world_id, n)
 
-    @logfire.instrument("gate.spawn_with_reserved_id")
+    @instrument("gate.spawn_with_reserved_id")
     async def spawn_with_reserved_id(
         self,
         ctx: ActorCtx,
@@ -183,7 +183,7 @@ class CommandService:
         await self._mutations.spawn_with_reserved_id(world_id, entity_id, components)
         await self._emit(ctx, "spawn_reserved", world_id, entity_id=entity_id)
 
-    @logfire.instrument("gate.remove_entity")
+    @instrument("gate.remove_entity")
     async def remove_entity(
         self,
         ctx: ActorCtx,
@@ -194,7 +194,7 @@ class CommandService:
         await self._mutations.remove_entity(world_id, entity_id)
         await self._emit(ctx, "despawn", world_id)
 
-    @logfire.instrument("gate.update_entity")
+    @instrument("gate.update_entity")
     async def update_entity(
         self,
         ctx: ActorCtx,
@@ -207,7 +207,7 @@ class CommandService:
         await self._mutations.update_entity(world_id, entity_id, components)
         await self._emit(ctx, "update", world_id)
 
-    @logfire.instrument("gate.add_components")
+    @instrument("gate.add_components")
     async def add_components(
         self,
         ctx: ActorCtx,
@@ -219,7 +219,7 @@ class CommandService:
         await self._mutations.add_components(world_id, entity_id, components)
         await self._emit(ctx, "add_component", world_id)
 
-    @logfire.instrument("gate.remove_components")
+    @instrument("gate.remove_components")
     async def remove_components(
         self,
         ctx: ActorCtx,
@@ -231,7 +231,7 @@ class CommandService:
         await self._mutations.remove_components(world_id, entity_id, component_types)
         await self._emit(ctx, "remove_component", world_id)
 
-    @logfire.instrument("gate.add_processor")
+    @instrument("gate.add_processor")
     async def add_processor(
         self,
         ctx: ActorCtx,
@@ -242,7 +242,7 @@ class CommandService:
         await self._mutations.add_processor(world_id, processor)
         await self._emit(ctx, "add_processor", world_id)
 
-    @logfire.instrument("gate.remove_processor")
+    @instrument("gate.remove_processor")
     async def remove_processor(
         self,
         ctx: ActorCtx,
@@ -255,7 +255,7 @@ class CommandService:
 
     # ── Lifecycle (gated, direct) ─────────────────────────────────────────
 
-    @logfire.instrument("gate.create_world")
+    @instrument("gate.create_world")
     async def create_world(
         self,
         ctx: ActorCtx,
@@ -274,7 +274,7 @@ class CommandService:
         await self._emit(ctx, "create_world", info.world_id)
         return info
 
-    @logfire.instrument("gate.fork_world")
+    @instrument("gate.fork_world")
     async def fork_world(
         self,
         ctx: ActorCtx,
@@ -295,7 +295,7 @@ class CommandService:
         await self._emit(ctx, "fork_world", info.world_id)
         return info
 
-    @logfire.instrument("gate.destroy_world")
+    @instrument("gate.destroy_world")
     async def destroy_world(
         self,
         ctx: ActorCtx,
@@ -308,7 +308,7 @@ class CommandService:
         await self._worlds.destroy_world(world_id)
         await self._emit(ctx, "destroy_world", world_id)
 
-    @logfire.instrument("gate.get_world_info")
+    @instrument("gate.get_world_info")
     async def get_world_info(
         self,
         ctx: ActorCtx,
@@ -341,7 +341,7 @@ class CommandService:
 
     # ── Simulation (gated, direct) ────────────────────────────────────────
 
-    @logfire.instrument("gate.step")
+    @instrument("gate.step")
     async def step(
         self,
         ctx: ActorCtx,
@@ -354,7 +354,7 @@ class CommandService:
         await self._emit(ctx, "step", world_id)
         return commands_applied
 
-    @logfire.instrument("gate.run")
+    @instrument("gate.run")
     async def run(
         self,
         ctx: ActorCtx,
@@ -367,7 +367,7 @@ class CommandService:
         await self._emit(ctx, "run", world_id)
         return result
 
-    @logfire.instrument("gate.run_episode")
+    @instrument("gate.run_episode")
     async def run_episode(
         self,
         ctx: ActorCtx,
@@ -395,7 +395,7 @@ class CommandService:
         )
         return result
 
-    @logfire.instrument("gate.run_rollout")
+    @instrument("gate.run_rollout")
     async def run_rollout(
         self,
         ctx: ActorCtx,
@@ -424,7 +424,7 @@ class CommandService:
         )
         return result
 
-    @logfire.instrument("gate.autoresearch")
+    @instrument("gate.autoresearch")
     async def autoresearch(
         self,
         ctx: ActorCtx,
@@ -488,7 +488,7 @@ class CommandService:
 
     # ── Queries (gated reads) ─────────────────────────────────────────────
 
-    @logfire.instrument("gate.query_components")
+    @instrument("gate.query_components")
     async def query_components(
         self,
         ctx: ActorCtx,
@@ -551,7 +551,7 @@ class CommandService:
             return list(lineage) if lineage else None
         return await self._queries.get_lineage(world_id, run_id, storage_config)
 
-    @logfire.instrument("gate.query_archetype")
+    @instrument("gate.query_archetype")
     async def query_archetype(
         self,
         ctx: ActorCtx,

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -23,6 +23,7 @@ from daft import DataFrame, col
 from daft.functions import when
 from uuid_utils import UUID, uuid7  # noqa: F401 imported for type hints
 
+from archetype import _obs
 from archetype.core.aio.async_querier import UnknownSignatureError, _canonicalize
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
@@ -210,11 +211,9 @@ class AsyncWorld(iAsyncWorld):
     ) -> DataFrame:
         """Build one archetype's tick-N frame. Pure with respect to world
         state: reads the caches without consuming them and writes nothing."""
-        import logfire
-
         sig_name = Archetype.get_name(sig)
 
-        with logfire.span("world.query", sig=sig_name, tick=self.tick):
+        with _obs.span("world.query", sig=sig_name, tick=self.tick):
             df = await self.query_archetype(
                 sig=sig,
                 run_id=self.run_id,
@@ -223,11 +222,11 @@ class AsyncWorld(iAsyncWorld):
                 components=None,
             )
 
-        with logfire.span("world.materialize", sig=sig_name, tick=self.tick):
+        with _obs.span("world.materialize", sig=sig_name, tick=self.tick):
             df = self._apply_despawns(df, sig)
             spawns_df = self._spawn_frame(sig)
 
-        with logfire.span("world.execute", sig=sig_name, tick=self.tick):
+        with _obs.span("world.execute", sig=sig_name, tick=self.tick):
             df = await self.execute(df, sig, tick=self.tick, debug=run_config.debug, **input_kwargs)
 
         # Initial conditions are part of the ledger: a newborn's first row is
@@ -245,9 +244,7 @@ class AsyncWorld(iAsyncWorld):
 
         The updater raises on failed persistence, in which case the caches
         survive for retry."""
-        import logfire
-
-        with logfire.span("world.update", sig=Archetype.get_name(sig), tick=self.tick):
+        with _obs.span("world.update", sig=Archetype.get_name(sig), tick=self.tick):
             df_mat = await self.update(df, sig, run_config)
 
         self.spawn_cache.pop(sig, None)

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -29,6 +29,7 @@ from weakref import WeakSet
 
 from uuid_utils import UUID
 
+from archetype import _obs
 from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
 from archetype.core.config import CacheConfig, StorageConfig
@@ -74,20 +75,6 @@ class ArchetypeRuntime:
     """Process-level runtime. Owns the container and default identity."""
 
     def __init__(self, *, actor_ctx: ActorCtx | None = None, log: str | None = None) -> None:
-        import logfire
-
-        # Never block on an interactive logfire setup prompt.  Send to logfire
-        # only when the user has explicitly configured it via one of:
-        #   - LOGFIRE_TOKEN / LOGFIRE_API_KEY environment variable
-        #   - LOGFIRE_SEND_TO_LOGFIRE=true environment variable
-        # Without explicit opt-in, degrade to local-only instrumentation so
-        # ArchetypeRuntime() works in CI and offline environments without an
-        # EOFError or a blocking interactive prompt.
-        _has_token = bool(os.environ.get("LOGFIRE_TOKEN") or os.environ.get("LOGFIRE_API_KEY"))
-        _send_env = os.environ.get("LOGFIRE_SEND_TO_LOGFIRE", "").lower()
-        _send_explicit = _send_env in ("1", "true", "yes")
-        _send_to_logfire = _has_token or _send_explicit
-
         # One user-facing verbosity flag: ARCHETYPE_LOG=debug|info|warning|error
         # (or ArchetypeRuntime(log=...)). It wires the stdlib "archetype"
         # logger hierarchy, and at debug it also turns on console span output.
@@ -96,12 +83,13 @@ class ArchetypeRuntime:
         level = _resolve_log_level(log)
         if level is not None:
             _configure_archetype_logging(level)
-        console = None if level == logging.DEBUG else False
 
-        logfire.configure(
+        # Tracing is vendor-neutral OpenTelemetry (see archetype._obs):
+        # a host-registered provider is respected, LOGFIRE_*/OTEL_* env vars
+        # select a backend, and with neither the API stays a no-op.
+        _obs.configure_tracing(
             service_name="archetype-runtime",
-            send_to_logfire=_send_to_logfire,
-            console=console,
+            debug_console=level == logging.DEBUG,
         )
 
         self._container = ServiceContainer()

--- a/tests/app/test_obs.py
+++ b/tests/app/test_obs.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Vendor-neutral observability boundary (archetype._obs).
+
+Archetype emits through the OpenTelemetry API only: a no-op without any
+SDK, and any registered provider — bundled, host, or Logfire's — receives
+the same spans. Tests inject a local tracer rather than registering a
+global provider, so no test poisons the process-wide OTel state.
+"""
+
+import asyncio
+import inspect
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from uuid_utils import uuid7
+
+from archetype import _obs
+from archetype.app.auth.models import ActorCtx
+from archetype.app.container import ServiceContainer
+from archetype.core.config import WorldConfig
+
+
+def _capture(monkeypatch) -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(_obs, "_tracer", provider.get_tracer("archetype"))
+    return exporter
+
+
+def test_instrument_is_a_noop_without_any_provider():
+    @_obs.instrument("noop.sync")
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    @_obs.instrument("noop.async")
+    async def mul(a: int, b: int) -> int:
+        return a * b
+
+    assert add(2, 3) == 5
+    assert asyncio.run(mul(2, 3)) == 6
+    assert inspect.iscoroutinefunction(mul), "async-ness must survive instrumentation"
+    assert add.__name__ == "add" and mul.__name__ == "mul"
+
+
+def test_span_coerces_attributes_and_drops_none(monkeypatch):
+    exporter = _capture(monkeypatch)
+
+    class Opaque:
+        def __str__(self) -> str:
+            return "opaque-repr"
+
+    with _obs.span("unit.attrs", sig="a_1", tick=3, obj=Opaque(), skipped=None):
+        pass
+
+    (span,) = exporter.get_finished_spans()
+    assert span.name == "unit.attrs"
+    assert span.attributes == {"sig": "a_1", "tick": 3, "obj": "opaque-repr"}
+
+
+def test_gate_operations_emit_otel_spans(monkeypatch):
+    """The gate's @instrument decorators ride any OTel provider — no vendor."""
+    exporter = _capture(monkeypatch)
+    ctx = ActorCtx(id=uuid7(), roles={"admin"})
+
+    async def drive() -> None:
+        c = ServiceContainer()
+        try:
+            info = await c.command_service.create_world(ctx, WorldConfig(name="obs"), None, None)
+            await c.command_service.get_world_info(ctx, info.world_id)
+        finally:
+            await c.shutdown()
+
+    asyncio.run(drive())
+
+    names = {s.name for s in exporter.get_finished_spans()}
+    assert "gate.create_world" in names
+    assert "gate.get_world_info" in names
+
+
+def test_console_processor_prints_one_line_per_span(monkeypatch, capsys):
+    provider = TracerProvider()
+    provider.add_span_processor(_obs._console_processor())
+    monkeypatch.setattr(_obs, "_tracer", provider.get_tracer("archetype"))
+
+    with _obs.span("debug.line", tick=7):
+        pass
+
+    err = capsys.readouterr().err
+    assert "debug.line" in err and "tick=7" in err
+    assert "\n" == err[-1] and err.count("debug.line") == 1

--- a/tests/app/test_runtime_contracts.py
+++ b/tests/app/test_runtime_contracts.py
@@ -294,26 +294,48 @@ class TestPreActivationHookRaises:
                 await world.add_hook(PreTick, handler)
 
 
-# ── Logfire degradation ──────────────────────────────────────────────────
+# ── Observability vendor neutrality ──────────────────────────────────────
 
 
-class TestLogfireDegradation:
-    """ArchetypeRuntime must construct without Logfire credentials."""
+class TestVendorNeutralObservability:
+    """ArchetypeRuntime must construct with no telemetry vendor configured.
 
-    def test_runtime_constructs_when_logfire_unauthenticated(self, monkeypatch):
-        import logfire
-        from logfire.exceptions import LogfireConfigError
+    Without LOGFIRE_*/OTEL_* opt-in the runtime never touches logfire (it
+    may not even be installed for package consumers); spans ride the no-op
+    OTel API.
+    """
+
+    def test_runtime_never_calls_logfire_without_opt_in(self, monkeypatch):
+        logfire = pytest.importorskip("logfire")
+        for var in (
+            "LOGFIRE_TOKEN",
+            "LOGFIRE_API_KEY",
+            "LOGFIRE_SEND_TO_LOGFIRE",
+            "ARCHETYPE_LOG",
+        ):
+            monkeypatch.delenv(var, raising=False)
 
         calls: list[dict] = []
-
-        def fake_configure(**kwargs):
-            calls.append(kwargs)
-            if "send_to_logfire" not in kwargs:
-                raise LogfireConfigError("You are not logged into Logfire.")
-
-        monkeypatch.setattr(logfire, "configure", fake_configure)
+        monkeypatch.setattr(logfire, "configure", lambda **kw: calls.append(kw))
 
         runtime = ArchetypeRuntime()
         asyncio.run(runtime.shutdown())
 
-        assert calls[-1]["send_to_logfire"] is False
+        assert calls == [], "no vendor SDK configuration without explicit opt-in"
+
+    def test_runtime_uses_logfire_when_opted_in(self, monkeypatch):
+        logfire = pytest.importorskip("logfire")
+        from archetype import _obs
+
+        monkeypatch.setattr(_obs, "_configured", False)
+        monkeypatch.setenv("LOGFIRE_SEND_TO_LOGFIRE", "1")
+        monkeypatch.delenv("ARCHETYPE_LOG", raising=False)
+
+        calls: list[dict] = []
+        monkeypatch.setattr(logfire, "configure", lambda **kw: calls.append(kw))
+
+        runtime = ArchetypeRuntime()
+        asyncio.run(runtime.shutdown())
+
+        assert calls and calls[-1]["send_to_logfire"] is True
+        assert calls[-1]["console"] is False, "console verbosity belongs to ARCHETYPE_LOG"

--- a/tests/core/test_footgun_fixes.py
+++ b/tests/core/test_footgun_fixes.py
@@ -234,33 +234,27 @@ def test_runtime_construction_non_interactive_repeated(monkeypatch):
 
 
 def test_runtime_send_to_logfire_with_token_env(monkeypatch):
-    """When LOGFIRE_TOKEN is set, the runtime should attempt to send to logfire.
+    """When LOGFIRE_TOKEN is set (and logfire is installed), the first runtime
+    of the process routes tracing to logfire with send_to_logfire=True.
 
-    We can't actually connect in CI, but we verify the path through the code
-    that inspects the env var — no EOFError is the passing criterion here too,
-    since the actual send would fail at network level, not at init time.
+    Backend selection runs once per process (archetype._obs.configure_tracing),
+    so the guard is reset here to simulate being that first runtime; logfire
+    is imported inside the selection path, so monkeypatching logfire.configure
+    needs no module reload.
     """
+    logfire = pytest.importorskip("logfire")
+
+    from archetype import _obs
+
     monkeypatch.setenv("LOGFIRE_TOKEN", "test-fake-token-for-unit-test")
     monkeypatch.delenv("LOGFIRE_API_KEY", raising=False)
     monkeypatch.delenv("LOGFIRE_SEND_TO_LOGFIRE", raising=False)
+    monkeypatch.delenv("ARCHETYPE_LOG", raising=False)
+    monkeypatch.setattr(_obs, "_configured", False)
 
-    import logfire
-
-    # Patch logfire.configure so we can observe the call arguments without
-    # actually connecting to logfire's API.
     captured: dict = {}
+    monkeypatch.setattr(logfire, "configure", lambda **kwargs: captured.update(kwargs))
 
-    def fake_configure(**kwargs):
-        captured.update(kwargs)
-
-    monkeypatch.setattr(logfire, "configure", fake_configure)
-
-    import importlib
-
-    from archetype.runtime import runtime as rt_module
-
-    # Force re-import so monkeypatched logfire.configure is used.
-    importlib.reload(rt_module)
     from archetype.runtime.runtime import ArchetypeRuntime
 
     ArchetypeRuntime()

--- a/uv.lock
+++ b/uv.lock
@@ -68,14 +68,8 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "lancedb" },
-    { name = "logfire" },
-    { name = "opentelemetry-instrumentation-fastapi" },
-    { name = "opentelemetry-instrumentation-httpx" },
-    { name = "opentelemetry-instrumentation-jinja2" },
-    { name = "opentelemetry-instrumentation-requests" },
-    { name = "opentelemetry-instrumentation-sqlalchemy" },
-    { name = "opentelemetry-instrumentation-sqlite3" },
-    { name = "opentelemetry-instrumentation-urllib" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pyiceberg", extra = ["daft", "sql-sqlite"] },
@@ -105,10 +99,11 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pymdown-extensions" },
 ]
+logfire = [
+    { name = "logfire", extra = ["fastapi"] },
+]
 otel = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
 sim = [
     { name = "mujoco" },
@@ -117,6 +112,7 @@ sim = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "logfire", extra = ["fastapi"] },
     { name = "mujoco" },
     { name = "mutmut" },
     { name = "pre-commit" },
@@ -136,23 +132,16 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "lancedb", specifier = ">=0.22.0" },
-    { name = "logfire", specifier = ">=4.32.0" },
+    { name = "logfire", extras = ["fastapi"], marker = "extra == 'logfire'", specifier = ">=4.32.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.9" },
     { name = "mkdocs-mermaid2-plugin", marker = "extra == 'docs'" },
     { name = "mkdocs-shadcn", marker = "extra == 'docs'" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27" },
     { name = "mujoco", marker = "extra == 'sim'", specifier = ">=3.2" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.5" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.20" },
-    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.60b1" },
-    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.60b1" },
-    { name = "opentelemetry-instrumentation-jinja2", specifier = ">=0.60b1" },
-    { name = "opentelemetry-instrumentation-requests", specifier = ">=0.60b1" },
-    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.60b1" },
-    { name = "opentelemetry-instrumentation-sqlite3", specifier = ">=0.60b1" },
-    { name = "opentelemetry-instrumentation-urllib", specifier = ">=0.60b1" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20" },
+    { name = "opentelemetry-api", specifier = ">=1.20" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.20" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyiceberg", extras = ["daft", "sql-sqlite"] },
@@ -166,11 +155,12 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29" },
     { name = "viztracer", marker = "extra == 'dev'", specifier = ">=1.0.4" },
 ]
-provides-extras = ["benchmark", "sim", "otel", "dev", "docs"]
+provides-extras = ["benchmark", "sim", "otel", "logfire", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27" },
+    { name = "logfire", extras = ["fastapi"], specifier = ">=4.32.0" },
     { name = "mujoco", specifier = ">=3.2" },
     { name = "mutmut", specifier = ">=3.5" },
     { name = "pre-commit", specifier = ">=4.0" },
@@ -929,47 +919,6 @@ wheels = [
 ]
 
 [[package]]
-name = "grpcio"
-version = "1.80.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
-    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
-    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
-    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
-    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
-    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
-    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
-    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1484,6 +1433,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/64/f927d4f9de1f1371047b9016adba1ec2e08258301708d548d41f86f27772/logfire-4.32.0.tar.gz", hash = "sha256:f1dc9d756a4b28f0483645244aaf3ea8535b8e2ae5a1068442a968ca0c746304", size = 1088575, upload-time = "2026-04-10T19:36:54.172Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/33/81b13e1f2044b5fe0112068a2494526db9cfdf784030a2ea57688279360a/logfire-4.32.0-py3-none-any.whl", hash = "sha256:d9cff51c3c093c4161ece87a65e6ac6e2d862258b62494c30d93d713e9858758", size = 312412, upload-time = "2026-04-10T19:36:50.97Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "opentelemetry-instrumentation-fastapi" },
 ]
 
 [[package]]
@@ -2050,24 +2004,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
-]
-
-[[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2117,21 +2053,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation-dbapi"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/b5/1e1f0642892a2abb6e75b7009ccee946e801cded88caac3d803cf46c8c73/opentelemetry_instrumentation_dbapi-0.60b1.tar.gz", hash = "sha256:a239d328249b86fba5e42900b98bf31ee99c07092530feca18afde92c600f901", size = 16311, upload-time = "2025-12-11T13:36:55.654Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/08/d4c78b6e317d9975d473dd98f7854f5731ff4a1d470c65d2630fa68a1484/opentelemetry_instrumentation_dbapi-0.60b1-py3-none-any.whl", hash = "sha256:5577189f678de5b9828c930c8fb72e8f1999b304131777b60099e5c4b3948193", size = 13968, upload-time = "2025-12-11T13:35:56.316Z" },
-]
-
-[[package]]
 name = "opentelemetry-instrumentation-fastapi"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
@@ -2145,96 +2066,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-httpx"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/08/11208bcfcab4fc2023252c3f322aa397fd9ad948355fea60f5fc98648603/opentelemetry_instrumentation_httpx-0.60b1.tar.gz", hash = "sha256:a506ebaf28c60112cbe70ad4f0338f8603f148938cb7b6794ce1051cd2b270ae", size = 20611, upload-time = "2025-12-11T13:37:01.661Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/59/b98e84eebf745ffc75397eaad4763795bff8a30cbf2373a50ed4e70646c5/opentelemetry_instrumentation_httpx-0.60b1-py3-none-any.whl", hash = "sha256:f37636dd742ad2af83d896ba69601ed28da51fa4e25d1ab62fde89ce413e275b", size = 15701, upload-time = "2025-12-11T13:36:04.56Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-jinja2"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/81/6de9361e30855d773c293a3c8321515b1774a7f5271c9488ef76042af600/opentelemetry_instrumentation_jinja2-0.60b1.tar.gz", hash = "sha256:0255d0c09415a1ac2d5ee2bacb3b696c08b7c1bac9e4cbdf7f6983f20257b695", size = 8455, upload-time = "2025-12-11T13:37:02.729Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/a0/fac0489ee2e002e439f94a40078e4facb832b3534dc2a9bb70e81604f611/opentelemetry_instrumentation_jinja2-0.60b1-py3-none-any.whl", hash = "sha256:a33423fde73d089500c0e1723f0fa998277b873acad0c777d195ea1bcf249f99", size = 9424, upload-time = "2025-12-11T13:36:05.766Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-requests"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/4a/bb9d47d7424fc33aeba75275256ae6e6031f44b6a9a3f778d611c0c3ac27/opentelemetry_instrumentation_requests-0.60b1.tar.gz", hash = "sha256:9a1063c16c44a3ba6e81870c4fa42a0fac3ecef5a4d60a11d0976eec9046f3d4", size = 16366, upload-time = "2025-12-11T13:37:12.456Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/7f/969b59a5acccb4c35317421843d63d7853ad7a18078ca3a9b80c248be448/opentelemetry_instrumentation_requests-0.60b1-py3-none-any.whl", hash = "sha256:eec9fac3fab84737f663a2e08b12cb095b4bd67643b24587a8ecfa3cf4d0ca4c", size = 13141, upload-time = "2025-12-11T13:36:23.696Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-sqlalchemy"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/16/6a4cbff1b7cd86d1e58ffd100255f6da781a88f4a2affdcc3721880191c9/opentelemetry_instrumentation_sqlalchemy-0.60b1.tar.gz", hash = "sha256:b614e874a7c0a692838a0da613d1654e81a0612867836a1f0765e40e9c8cc49b", size = 15317, upload-time = "2025-12-11T13:37:13.089Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/b7/2234bc761c197c7f099f30cad5d50efd8286c59b5b8f45cfd6ba6ebe7d5e/opentelemetry_instrumentation_sqlalchemy-0.60b1-py3-none-any.whl", hash = "sha256:486a5f264d264c44e07e0320e33fd19d09cecd2fd4b99c1064046e77a27d9f9f", size = 14529, upload-time = "2025-12-11T13:36:24.964Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-sqlite3"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-dbapi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/44/33/fafa354b529a7e9b5a5dc4155953bae1ff71622334a420d19f7e1d65e7cc/opentelemetry_instrumentation_sqlite3-0.60b1.tar.gz", hash = "sha256:d716b9d89d31dc426ccedefcdbf96cba1897dfe020d21e5e5ea82a782d03e1d6", size = 7922, upload-time = "2025-12-11T13:37:13.655Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/64/be1c8a6d17cf2860f41206828cbabe39b71345cc95626b91c84f48e96066/opentelemetry_instrumentation_sqlite3-0.60b1-py3-none-any.whl", hash = "sha256:7666853b9df186b81e587320aaa03da3f1ce46ba9277b62d8ea20a745886031c", size = 9338, upload-time = "2025-12-11T13:36:25.854Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-urllib"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/1d/b1ac334f36a3e7e5bf73cd26f5dde7b23909fe9a068316f9cd29388a245e/opentelemetry_instrumentation_urllib-0.60b1.tar.gz", hash = "sha256:7d6c56e45551bdbf21efc11bd463e10862e8fd04ed4a94b5695325a56440b13e", size = 13930, upload-time = "2025-12-11T13:37:18.507Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/70/b4c7b3bc17081725cf4bfa09286fd87e1d3a0d0589b12b35efba5db8da34/opentelemetry_instrumentation_urllib-0.60b1-py3-none-any.whl", hash = "sha256:bf36188d684ca6454b7162492a66749181955011e0cc47a2324cbe66e7f13e81", size = 12674, upload-time = "2025-12-11T13:36:31.33Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -102,7 +102,7 @@ docs = [
 logfire = [
     { name = "logfire", extra = ["fastapi"] },
 ]
-otel = [
+otlp = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
 sim = [
@@ -140,7 +140,7 @@ requires-dist = [
     { name = "mujoco", marker = "extra == 'sim'", specifier = ">=3.2" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "opentelemetry-api", specifier = ">=1.20" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.20" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otlp'", specifier = ">=1.20" },
     { name = "opentelemetry-sdk", specifier = ">=1.20" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -155,7 +155,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29" },
     { name = "viztracer", marker = "extra == 'dev'", specifier = ">=1.0.4" },
 ]
-provides-extras = ["benchmark", "sim", "otel", "logfire", "dev", "docs"]
+provides-extras = ["benchmark", "sim", "otlp", "logfire", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

The larger requirement: **neither archetype nor any future user or installer is locked into Logfire.**

- `archetype._obs` is the observability boundary: every span emits through the OpenTelemetry **API** only. No SDK configured → true no-op, zero output, zero vendor. Nothing under `src/` imports logfire (the only logfire-aware code is the guarded backend selection and `contrib/logfire_observer`, which is a Logfire integration by definition).
- Backend selection, once, at the runtime boundary (`runtime.md` **R17**):
  1. host application already registered a provider → respected untouched
  2. `LOGFIRE_TOKEN`/`LOGFIRE_API_KEY`/`LOGFIRE_SEND_TO_LOGFIRE` + `[logfire]` extra → Logfire (it *is* an OTel SDK — same spans, zero migration for existing users)
  3. `OTEL_EXPORTER_OTLP_ENDPOINT` + `[otlp]` extra → standard OTLP/HTTP, any collector (Jaeger, Grafana, Honeycomb, a Logfire endpoint, …)
  4. `ARCHETYPE_LOG=debug` → terse one-line console spans on stderr, no extras needed
  5. otherwise → no-op API stays
- Dependencies: hard deps drop `logfire` **and seven unused `opentelemetry-instrumentation-*` packages**, gaining `opentelemetry-api`/`sdk` (already transitive). New extras: `[logfire]`, `[otlp]`. The dev group keeps `logfire[fastapi]` so CI keeps testing the contrib observer and FastAPI instrumentation.
- Call sites rewired: 21 gate `@instrument` decorators, 4 world-step spans, runtime + API configure.

## Operational wiring (Vangelis keeps Logfire as *our* backend)

- `evals` and `examples` CI jobs pass `LOGFIRE_TOKEN` through from repo secrets (set today) — this PR's own run is the live test of driver-side reporting. Empty secret is safe: the vendor path is skipped.
- Both Modal workers (`archetype-libero-env`, `archetype-vla-jepa`) attach the pre-existing `logfire` Modal secret, install logfire in their images, and configure it at container start when the token is present.

## Verification

- **Logfire physically uninstalled**: import, `ArchetypeRuntime`, world ops, API factory, quiet stdout, and the vendor-free debug console (`· gate.create_world 68.5ms`) all verified working.
- New `tests/app/test_obs.py`: no-op without a provider, async/sync instrument, attribute coercion, gate ops captured by a local `InMemorySpanExporter` (tests inject a local tracer — no test registers a global provider), console one-liner format.
- Runtime contract tests updated: logfire is never called without explicit opt-in; opted-in path passes `send_to_logfire=True, console=False`.
- Parallel suite: 767/768 (the one failure is the pre-existing timing-sensitive cached-store idle-flush test, untouched here and green 3× in isolation — a candidate for the deferred adversarial isolation audit).
- ruff, ty, lazy audit, lock-check, typos, markdownlint — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)