### PR TITLE
ci: Claude workflows authenticate via CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)

--- a/.github/workflows/daily-security-audit.yml
+++ b/.github/workflows/daily-security-audit.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Generate daily security report with Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
           prompt: |
             Produce today's Archetype security audit report.

--- a/.github/workflows/footgun-review.yml
+++ b/.github/workflows/footgun-review.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   footgun:
-    # Skip PRs from forks — they don't get access to ANTHROPIC_API_KEY.
+    # Skip PRs from forks — they don't get access to CLAUDE_CODE_OAUTH_TOKEN.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +29,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
           prompt: |
             You are running in CI on PR #${{ github.event.pull_request.number }}.


### PR DESCRIPTION
## Summary

Revives the three Claude-backed workflows. The `ANTHROPIC_API_KEY` secret (June 2025) was dead and has been removed from the repo: every `claude-code-action` invocation failed on its first API call (~386ms, `total_cost_usd: 0`, `num_turns: 1`) — meaning the footgun reviewer has **never** completed a review; every PR got only the "did not complete" advisory notice. `footgun-review`, `claude`, and `daily-security-audit` now authenticate with `CLAUDE_CODE_OAUTH_TOKEN` (minted via `claude setup-token`, added to repo secrets today).

## Verification

This PR is its own live test: it triggers `footgun-review` under the new token. Success = a real footgun review lands (inline threads per the #267 rewiring, or the "No notes" comment) instead of "Footgun review did not complete."

🤖 Generated with [Claude Code](https://claude.com/claude-code)