### PR TITLE
release: v0.2.0 — Daft 0.7.19, Python 3.13, positioning and docs refresh

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -25,7 +28,7 @@ jobs:
         run: uv sync --group dev
 
       - name: Run tests
-        run: uv run pytest tests/ -v --tb=short
+        run: uv run pytest tests/ -q --tb=short -n auto --dist loadgroup
 
   build:
     needs: test

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ composable, declarative, and data-centric.**
 Archetype is a state machine that uses big-data technology to run itself,
 built for the AI-native world.
 
+It is built the way game engines are built — entities, components,
+processors, ticks, save states — because an operation run by agents and
+humans together *is* a real-time simulation, and its record deserves
+engine-grade physics. Archetype is the physics and the history: what
+happened, in order, forever. What the record *means*, and what is allowed
+to happen next, belongs to the layers you build on top of it — Archetype
+records; your policy decides.
+
 - **Composable** — two primitives only: components (data) and processors
   (behavior). Archetypes, worlds, and forks are compositions of them.
 - **Declarative** — you declare shapes and transforms; the engine derives
@@ -76,6 +84,9 @@ What you get for keeping everything:
 - **The engine's own operation is data** — every gated command lands in an
   append-only audit table on the same substrate that stores world state:
   consistent, partitioned, queryable, trainable
+- **Any altitude is a query** — the same ledger renders the whole
+  operation at command level or a single actor's first-person timeline;
+  views are projections over rows, never separate state to reconcile
 
 ## Built for agents
 
@@ -106,6 +117,10 @@ trust the result by reviewing code, not by re-running it:
   order. The audit trail this produces is the raw material for
   auto-research loops — the engine improving things that run on the
   engine.
+- **Humans and agents are the same `Actor`.** Both act through the same
+  gate under capability bindings (`viewer`/`player`/`operator`/`admin`);
+  a person can drop into a world with exactly one worker's capabilities,
+  and any elevation is explicit and lands in the audit trail.
 
 The design is meant to scale with its user. The more capable the model,
 the more it can do with two orthogonal primitives — richer components,
@@ -157,7 +172,7 @@ async def main():
         await world.run(steps=3)
 
         df = await world.query(Position)  # full append-only history
-        print(df.collect().to_pylist())
+        print(df.to_pylist())
 
 
 asyncio.run(main())
@@ -208,16 +223,30 @@ uv run python examples/04_messaging.py
 uv run python examples/05_llm_agents.py
 uv run python examples/06_trajectory_analysis.py
 uv run python examples/07_hooks.py
+uv run python examples/08_htn_resolution.py
+uv run python examples/09_cloud_storage.py
+uv run python examples/10_autoresearch.py     # save-state optimization on the ledger
 ```
 
 `examples/05_llm_agents.py` and parts of `examples/06_trajectory_analysis.py`
-require `OPENAI_API_KEY`.
+require `OPENAI_API_KEY`. Everything else runs credential-free (and does, in CI).
 
 ## Observability
 
-[Logfire](https://pydantic.dev/logfire) spans on every gated call and every
-tick phase (query / materialize / execute / update), plus opt-in
-per-tick/per-entity hooks:
+Quiet by default: your script's stdout is yours. One flag turns the
+machinery visible, and tracing is vendor-neutral OpenTelemetry — installing
+archetype pulls no telemetry vendor.
+
+```bash
+ARCHETYPE_LOG=debug uv run python your_script.py   # logs + one-line spans
+```
+
+Every gated call and tick phase (query / materialize / execute / update)
+emits OTel spans. Point them anywhere: a host app's provider is respected
+as-is; `OTEL_EXPORTER_OTLP_ENDPOINT` sends to any collector
+(`pip install archetype-ecs[otlp]`); `LOGFIRE_TOKEN` sends to
+[Logfire](https://pydantic.dev/logfire) (`pip install archetype-ecs[logfire]`),
+which also unlocks the opt-in per-tick/per-entity hooks:
 
 ```python
 from archetype.contrib.logfire_observer import logfire_hooks

--- a/docs/guide/autoresearch.md
+++ b/docs/guide/autoresearch.md
@@ -160,61 +160,33 @@ Modeling experiments as ECS state means:
 
 Experiment state gets the same operational properties as any other simulation in Archetype, without a parallel storage layer.
 
-## LIBERO Eval Driver
+## LIBERO on the ledger
 
-The same lab-world pattern extends to robotics benchmarks. `bench/libero/eval_driver.py`
-orchestrates LIBERO suite × task × trial sweeps on the Archetype ledger:
+The same lab-world pattern extends to robotics benchmarks. `bench/libero/eval_run.py`
+runs batched LIBERO evals the Archetype-native way:
 
-- One `Experiment` + `Run` entity per eval run as tick-0 initial conditions (genesis tick)
-- One `EvalTrialResult` entity per trial (suite, task, trial index, seed, success, episode length)
-- `bench/libero/report.py` reads the lab world and emits a markdown report with per-task
-  success rates, mean episode lengths, wall-clock timing, and the **provenance-tax headline**
-  (ledger overhead per tick as % of mean step latency)
+- **One control-plane world per task, N trial entities** keyed by `env_key`. The env
+  client batches by `env_key`, so one tick steps every live trial at once; finished
+  trials freeze on the ledger (`done` latches). Every trial's trajectory is addressable
+  by the single `(world_id, run_id)` and sliced by `ManipTask`.
+- Termination is the value-based "all entities done" contract
+  (`EpisodeConfig(terminal_component=ManipStatus, terminal_field="done")`) — no
+  hand-rolled episode loop.
+- Success and episode length are **graded from raw `ManipStatus` rows by the eval
+  service**, not computed in the driver, so there is no summary component to drift
+  from the ledger. (The old `eval_driver.py` / `EvalTrialResult` stack had exactly
+  that drift problem and was removed.)
+- `bench/libero/in_process.py` runs LIBERO envs in-process (no Modal required);
+  `bench/libero/instruction_sweep.py` layers instruction optimization on top, and
+  `bench/libero/in_process_policy.py` colocates a VLA policy with the env.
 
-The provenance-tax figure is sourced from `bench/mujoco/rollout_overhead.py` (measured 7 ms
-per tick); re-wire when a fresh measurement is available.
-
-### Running a smoke eval (1 task × 2 trials)
-
-```bash
-# Scripted env — CI-safe, no Modal or GPU required:
-uv run python bench/libero/eval_driver.py \
-    --suite libero_spatial --task-ids 0 \
-    --trials 2 --max-steps 80 \
-    --env-client scripted --no-policy \
-    --out /tmp/libero_smoke
-
-# Generate the markdown report:
-uv run python bench/libero/report.py --lab-dir /tmp/libero_smoke
-```
-
-The full 2,000-episode benchmark sweep (`--trials 50 --max-steps 600` over all 4 × 10
-task combinations) is **a user-triggered action** (GPU cost); never run it in CI.
-
-### `EvalTrialResult` component
-
-```python
-from archetype.experiments import EvalTrialResult
-
-result = EvalTrialResult.make(
-    suite="libero_spatial",
-    task_id=0,
-    trial_idx=2,
-    seed=2,
-    env_key=2,
-    success=True,
-    episode_length=74,
-    wall_s=28.3,
-    run_id="my-eval-run",
-)
-```
-
-Contract tests: `tests/experiments/test_eval_driver.py`.
+`docs/guide/libero-recipe.md` is the full recipe. The large benchmark sweeps are
+**user-triggered actions** (GPU cost); never run them in CI.
 
 ## References
 
 - Andrej Karpathy's framing of autonomous software optimization and branch-frontier agent workflows
 - `src/archetype/experiments/` — the current component implementations
 - `archetype-runner` — the agent-in-VM runner whose registry feeds this schema
-- `bench/libero/eval_driver.py` — LIBERO eval driver (suites × tasks × trials)
-- `bench/libero/report.py` — markdown report generator with provenance-tax headline
+- `bench/libero/eval_run.py` — batched control-plane LIBERO eval
+- `docs/guide/libero-recipe.md` — the end-to-end LIBERO recipe

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Agent Evaluation:
       - Trajectories: guide/trajectories.md
       - AutoResearch: guide/autoresearch.md
+      - LIBERO Recipe: guide/libero-recipe.md
       - Tragedy of the Commons: experiments/tragedy-of-the-commons.md
   - Core Architecture:
       - Overview: guide/architecture.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-ecs"
-version = "0.1.1"
+version = "0.2.0"
 description = "Dataframe-first, append-only ECS runtime for simulations and AI agents. Built on Daft with LanceDB time-travel storage."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -14,10 +14,11 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 dependencies = [
-    "daft[openai,lance,iceberg]>=0.7.15",
+    "daft[openai,lance,iceberg]>=0.7.19",
     "lancedb>=0.22.0",
     "pyiceberg[daft,sql-sqlite]",
     "uuid-utils>=0.11.0",
@@ -148,6 +149,11 @@ do_not_mutate = [
 # Supply-chain guard: refuse packages released after this date (7-day quarantine).
 # Bump this manually as needed; uv 0.8.x doesn't support relative durations.
 exclude-newer = "2026-06-12T00:00:00Z"
+# Surgical exceptions to the freeze — one package, one dated ceiling, so the
+# quarantine holds for everything else. daft 0.7.19 released 2026-07-10;
+# admitted explicitly (Everett, 2026-07-14) for the 0.2.0 release.
+[tool.uv.exclude-newer-package]
+daft = "2026-07-11T00:00:00Z"
 
 [tool.ruff]
 target-version = "py312"

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -51,7 +51,7 @@ from typing import Any
 # `setdefault` honors an explicit `DO_NOT_TRACK=0` if a user wants telemetry on.
 os.environ.setdefault("DO_NOT_TRACK", "1")
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     # Core types

--- a/src/archetype/api/app.py
+++ b/src/archetype/api/app.py
@@ -47,7 +47,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="Archetype ECS",
         description="Dataframe-first ECS runtime for simulations and AI agents.",
-        version="0.1.1",
+        version="0.2.0",
         lifespan=lifespan,
     )
     # Route-level tracing is optional: use it when logfire is installed,
@@ -67,7 +67,7 @@ def create_app() -> FastAPI:
 
     @app.get("/")
     async def root():
-        return {"name": "archetype-ecs", "version": "0.1.1"}
+        return {"name": "archetype-ecs", "version": "0.2.0"}
 
     @app.get("/healthz")
     async def healthz():

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
 [options]
 exclude-newer = "2026-06-12T00:00:00Z"
 
+[options.exclude-newer-package]
+daft = "2026-07-11T00:00:00Z"
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -61,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "archetype-ecs"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "daft", extra = ["iceberg", "lance", "openai"] },
@@ -125,7 +128,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "daft", extras = ["openai", "lance", "iceberg"], specifier = ">=0.7.15" },
+    { name = "daft", extras = ["openai", "lance", "iceberg"], specifier = ">=0.7.19" },
     { name = "esper", marker = "extra == 'benchmark'", specifier = ">=2.45" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", specifier = ">=0.27" },
@@ -559,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "daft"
-version = "0.7.15"
+version = "0.7.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec" },
@@ -567,13 +570,12 @@ dependencies = [
     { name = "pyarrow" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/54/5553c78dfaa0b387bbc2795d36832ad57901e45eed55594b553a4efa48fc/daft-0.7.15.tar.gz", hash = "sha256:f7c7bfd5714eb5729cf9ce3362834cae2a8759a97bd7423b69ba2bfbba203bf5", size = 3317832, upload-time = "2026-06-07T03:05:56.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/eb/201ecf2f3ed4ea709e0692716f29ddd7aedc1c38fb0e2a5a8429c352a6de/daft-0.7.15-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b893e732db49020daeab500f636842d271eaa8d0a210e9b1a68e4b178da1e419", size = 61756120, upload-time = "2026-06-07T03:05:26.8Z" },
-    { url = "https://files.pythonhosted.org/packages/06/8e/7b7298def7412f85fa00cca00b7cea619252257efe236423f7524b41659b/daft-0.7.15-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:6f192c9e090a27f121855f2a4a4f5781569d7fe7f158a0ad3d8f161b50f92c08", size = 57299676, upload-time = "2026-06-07T03:05:30.624Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/53/f94fa83a0c3808e045556ad057e78eb85659299a32ce7f78358632673cbb/daft-0.7.15-cp310-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:e4231a0d2512fa6a7a74eca1b8f5c1be3fba75901f3ab32f34914f020403f930", size = 59881693, upload-time = "2026-06-07T03:05:34.806Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b1/e98c641b9197285cfc6d29b5794ec683478747a4845e63e46368740ff8fe/daft-0.7.15-cp310-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:70fac4183d2d68be8eed7e57534189fc35da269f231cba66ed1212d5907abf60", size = 62193072, upload-time = "2026-06-07T03:05:38.617Z" },
-    { url = "https://files.pythonhosted.org/packages/24/64/5672db6574314ea21d8ce62a458668981c9d3d01205cda3b5fc8bf2a65f9/daft-0.7.15-cp310-abi3-win_amd64.whl", hash = "sha256:789a05490748befea2cb585b0b0527eb130a0b5888b73fbc8dcc93ce2112da0f", size = 62969464, upload-time = "2026-06-07T03:05:42.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cb/4165cee0dcb8110c37064abfe67d14bf503eb3378ad3b98e059a4e920fa6/daft-0.7.19-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7862b017a33c7d7259ece90daf4b2f16e46677774c974bf3c491477476783aab", size = 55673370, upload-time = "2026-07-10T02:35:42.985Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/6699fceee675e292ba7a3e3be18ec7dd6e813623660011082e486e586b6a/daft-0.7.19-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3b928b7af90b02fd460d96e3b524fe8bee3aaafa53c8ad0c54706f20808819c0", size = 51508723, upload-time = "2026-07-10T02:35:46.999Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7e/d2723e52fee17d7ad73af3ebda9867aa5fd89e5f2ebf422d53523752ada1/daft-0.7.19-cp310-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:0e5af435aca282c6a54a2ff9f3ac452be219a9abd2572888f595aa5eb4dcccaa", size = 53833418, upload-time = "2026-07-10T02:35:50.659Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0e/ce9d740e25fe592a7ac87f4704499229e7356e1bdaa4597ac28d5caab75a/daft-0.7.19-cp310-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:6f1d343b231814158061ab108546513c3314fcdb2a3d4530289ea1b781822d0a", size = 56020515, upload-time = "2026-07-10T02:35:54.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ce/f22368e38de6fa757e9598a63838723f28bd1ceaada7a5661268df8319da/daft-0.7.19-cp310-abi3-win_amd64.whl", hash = "sha256:d3e5267bf437321f36858ab30ebf2e86974b1ee1cdb4506fbc783e171119e09f", size = 55181842, upload-time = "2026-07-10T02:35:58.308Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Release prep for v0.2.0.

- **Daft 0.7.15 → 0.7.19** via `[tool.uv.exclude-newer-package]` — one package, one dated ceiling (2026-07-11), so the 2026-06-12 supply-chain freeze holds for every other dependency. Override approved by Everett for this release.
- **Python 3.13 support, proven**: full suite run locally on 3.12 and 3.13 against Daft 0.7.19 — **768/768 on each**. Classifier added; `ci` and release `test` jobs now run a `["3.12", "3.13"]` matrix. (`ci (3.13)` starts advisory; adding it to the required checks once green here.)
- **v0.2.0** across all version sites. Minor-bump rationale: new runtime APIs (`world.autoresearch`, `runtime.attach`, `world.grade`, `ARCHETYPE_LOG`), required autoresearch identities + `destroy_forks_on_complete` default flip, and the observability de-vendoring — `logfire` moved from hard dependency to `[logfire]` extra, which 0.1.1 consumers should read as the upgrade note.
- **README**: positioning refinement (game-engine construction, physics-and-history, any-altitude-is-a-query, humans-and-agents-as-one-Actor), examples list completed through `10_autoresearch.py`, observability section rewritten to the vendor-neutral posture, quickstart double-materialization fixed.
- **Docs**: autoresearch guide rewritten off the removed `eval_driver`/`EvalTrialResult` stack onto the current `eval_run`/trajectory-grading path; LIBERO recipe added to the nav.

## Verification

- 3.12: 768 passed (9:22) · 3.13: 768 passed (10:17), fresh `UV_PROJECT_ENVIRONMENT`
- ruff, ty, lazy audit (12 sites), lock-check, typos, markdownlint — clean
- Release pipeline unchanged in shape: tag `v0.2.0` → test matrix → build → PyPI trusted publishing → GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)