### PR TITLE
feat(app): durable world discovery via SQLite control catalog (A1-read, #272)

### DIFF
--- a/docs/guide/durable-discovery.md
+++ b/docs/guide/durable-discovery.md
@@ -1,0 +1,133 @@
+# Durable Discovery
+
+**Document type:** Normative.
+**Scope:** The control catalog, `discover_worlds`, `open_world_readonly`, cold subset queries. Issue #272 (v0.3.0 slice A1-read).
+
+## 1. The problem this solves
+
+Every store keeps a process-local registry of the worlds and archetype
+signatures it has seen. That registry dies with the process. The data does
+not: archetype tables are append-only and survive on disk or in object
+storage. Before durable discovery, a fresh process pointed at existing
+storage could read tables only if it already knew — from Python code — which
+worlds and component classes had been written there.
+
+Durable discovery closes that gap. A world written by one process is
+discoverable and queryable from any later process pointed at the same
+storage identity, with no shared memory and no live world object.
+
+## 2. The control catalog
+
+Each storage identity gets one SQLite control catalog. The catalog is
+**authoritative for world identity** and **advisory for progress**:
+
+| Recorded | Authority |
+|---|---|
+| World identity (`world_id`, `name`, `run_id`, `parent_world_id`) | Authoritative. Registration failure fails `create_world`/`fork_world`. |
+| World status (`active`, `destroyed`) | Authoritative for catalog state; destroyed worlds stay discoverable (their rows are still queryable; append-only). |
+| Tick head | Advisory until A2 manifests land. Post-step updates log loudly on failure but never fail a tick whose data-plane writes succeeded. |
+| Archetype signatures (component names, schema descriptor, fingerprint) | Authoritative descriptor for cold reads; guarded by fingerprint check (section 5). |
+
+### Catalog location is a pure function of the storage URI
+
+The same `StorageConfig` always resolves to the same catalog file, so
+restarts and crashes converge on one catalog with no coordination:
+
+- Local URIs: `<uri>/<namespace>/.archetype-catalog.db`, beside the data it
+  describes.
+- Remote URIs (e.g. `s3://`): `~/.archetype/catalogs/<fingerprint>.db`,
+  where the fingerprint hashes the normalized storage identity. Override the
+  directory with `ARCHETYPE_CATALOG_DIR`.
+
+The catalog opens with WAL journaling, `synchronous=FULL`, a busy timeout,
+and `BEGIN IMMEDIATE` transactions. Concurrent processes racing to register
+the same world converge on exactly one row: identical re-registration is a
+no-op; a differing record for the same `world_id` raises
+`CatalogConflictError`.
+
+## 3. Gated discovery API
+
+Two read-gated operations on `iCommandService`:
+
+```python
+async def discover_worlds(
+    ctx: ActorCtx, storage_config: StorageConfig
+) -> list[WorldInfo]: ...
+
+async def open_world_readonly(
+    ctx: ActorCtx, storage_config: StorageConfig, world_id: str | UUID
+) -> WorldInfo: ...
+```
+
+- `discover_worlds` is gated as `LIST_WORLDS`. Unlike `list_worlds` (live
+  process registry), it answers from the catalog: a fresh process sees every
+  world ever registered against that storage identity, including destroyed
+  ones.
+- `open_world_readonly` is gated as `GET_WORLD_INFO`. It returns the world's
+  durable descriptor as the existing `WorldInfo` boundary type and raises
+  `KeyError` for unrecorded worlds. It never constructs a live mutable
+  world — fenced mutable resume is a separate, A2-gated capability.
+
+Both operations respect the info-class downgrade: callers get `WorldInfo`,
+never a world handle.
+
+## 4. Cold subset queries
+
+`query_components` unions two sources:
+
+1. The live querier path (unchanged): signatures registered in this process.
+2. Catalog-discovered tables: signature records whose component sets cover
+   the request and whose tables are not already live.
+
+Catalog tables are read through a dedicated store seam —
+`get_existing_table_schema` / `get_existing_table_df` — that **opens and
+never creates**. Read paths cannot allocate tables, on either backend
+(LanceDB, Iceberg). Projection uses the durable schema descriptor, so a cold
+process needs Python classes only for the components it is asking about, not
+for every component the writing process defined.
+
+```python
+# Process B, sharing nothing with the writer but the storage config:
+infos = await gate.discover_worlds(ctx, storage_config)
+df = await runtime.query_components(
+    [Score], world_id=infos[0].world_id, run_id=infos[0].run_id,
+    storage_config=storage_config,
+)
+```
+
+## 5. Fail-closed schema check
+
+Before reading a catalog-discovered table, the physical table schema is
+fingerprinted and compared to the catalog record. A mismatch raises
+`CatalogSchemaMismatchError` — the read fails closed rather than returning
+rows whose shape the descriptor no longer describes.
+
+The fingerprint hashes the schema's *logical* shape: field names and
+normalized logical types, in order. It deliberately excludes nullability and
+physical encoding variants (`large_string` vs `string`), because backends
+legitimately normalize those on round-trip — Iceberg stores `string` as
+`large_string` and forces fields nullable. Renames, reorders, added or
+removed columns, and retypes all mismatch.
+
+Schemas never evolve in place: a changed component set is a new archetype
+signature and a new table. The stored descriptor for an existing table is
+therefore immutable, and a fingerprint mismatch means corruption or
+out-of-band interference, not drift.
+
+## 6. What is and is not guaranteed (A1-read)
+
+Guaranteed:
+
+- Worlds registered at create/fork time are discoverable from any process,
+  for the life of the storage, including after `destroy_world`.
+- Exactly one catalog row per world identity under concurrent registration.
+- Cold reads never create tables and fail closed on descriptor mismatch.
+- Catalog unavailability degrades reads to live-registry behavior (logged);
+  it never corrupts the data plane.
+
+Not guaranteed until A2 (issue #273):
+
+- The catalog tick head is advisory. The durable, atomic tick-visibility
+  boundary (commit tokens, writer epochs) is A2's contract.
+- No fenced mutable resume of a discovered world. Opens are read-only.
+- Crashed physical executions are queryable, not resumable.

--- a/docs/guide/durable-discovery.md
+++ b/docs/guide/durable-discovery.md
@@ -33,11 +33,17 @@ Each storage identity gets one SQLite control catalog. The catalog is
 The same `StorageConfig` always resolves to the same catalog file, so
 restarts and crashes converge on one catalog with no coordination:
 
-- Local URIs: `<uri>/<namespace>/.archetype-catalog.db`, beside the data it
-  describes.
+- Local URIs: `<uri>/<namespace>/.archetype-catalog-<backend>.db`, beside
+  the data it describes.
 - Remote URIs (e.g. `s3://`): `~/.archetype/catalogs/<fingerprint>.db`,
   where the fingerprint hashes the normalized storage identity. Override the
   directory with `ARCHETYPE_CATALOG_DIR`.
+
+The storage identity is uri + namespace + backend — the same key
+`StorageService` pools stores by. Two configs that resolve to different
+stores (LanceDB vs Iceberg on the same uri and namespace) never share a
+catalog, so one backend cannot discover descriptors whose rows live in the
+other.
 
 The catalog opens with WAL journaling, `synchronous=FULL`, a busy timeout,
 and `BEGIN IMMEDIATE` transactions. Concurrent processes racing to register

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -20,6 +20,7 @@ The current contract set is split across design docs and executable tests.
 | [Command Gate](command-gate.md) | Authorization and roles | Four-role model, permissions matrix, audit emission shape. |
 | [Execution Hierarchy](execution-hierarchy.md) | Step/run/episode/rollout | Simulation levels and rollout fork semantics. |
 | [World Lifecycle](world-lifecycle.md) | Create/fork/destroy | Append-only lifecycle, info-class downgrade, fork sharing/copy rules. |
+| [Durable Discovery](durable-discovery.md) | Control catalog and cold reads | Catalog authority, `discover_worlds`/`open_world_readonly`, fail-closed cold queries. |
 | [Audit Log](audit-log.md) | Audit rows | Append-only audit history and query contract. |
 | [`tests/app/test_runtime_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_contracts.py) | Executable runtime contracts | Enforces activation single-flight, runtime-vs-world lifetime, fork isolation, spawn visibility, governance, and smoke paths. |
 | [`tests/app/test_runtime_fork_storage.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_fork_storage.py) | Runtime fork storage contracts | Enforces fork storage inheritance through the runtime layer, lineage reads on fork handles, fork run_id minting, and gate-side storage resolution. |

--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -186,6 +186,8 @@ _COMMAND_GATE_MAP: dict[str, CommandType] = {
     "destroy_world": CommandType.DESTROY_WORLD,
     "get_world_info": CommandType.GET_WORLD_INFO,
     "list_worlds": CommandType.LIST_WORLDS,
+    "discover_worlds": CommandType.LIST_WORLDS,
+    "open_world_readonly": CommandType.GET_WORLD_INFO,
     "step": CommandType.STEP,
     "run": CommandType.RUN,
     "run_episode": CommandType.RUN_EPISODE,

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -38,7 +38,7 @@ reason = "HTTP JSON response boundary: convert the already-collected Daft result
 
 [[entries]]
 path = "src/archetype/core/aio/async_store.py"
-line = 156
+line = 198
 method = "collect"
 reason = "Storage write boundary: defensive empty-frame probe before delegating to the backing table writer; cannot be expressed as a Daft predicate because count_rows requires materialised state."
 
@@ -86,7 +86,7 @@ reason = "Bounded control-plane history extract: deterministic Run ids and termi
 
 [[entries]]
 path = "src/archetype/app/simulation_service.py"
-line = 216
+line = 221
 method = "to_pylist"
 reason = "Episode-termination boundary: the value-based 'all entities done' check is reduced in Daft to a single (n_done, n_total) row, then materialized so the all/any decision can enter Python control flow and break the run_episode loop; a Python bool cannot remain a lazy Daft expression."
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - Command Gate: guide/command-gate.md
       - Execution Hierarchy: guide/execution-hierarchy.md
       - World Lifecycle: guide/world-lifecycle.md
+      - Durable Discovery: guide/durable-discovery.md
       - Audit Log: guide/audit-log.md
   - Building:
       - Building Simulations: guide/building-simulations.md

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -129,13 +129,20 @@ def schema_fingerprint(schema: pa.Schema) -> str:
 
 
 def storage_fingerprint(config: StorageConfig) -> str:
-    """Stable identity for a storage location (credential-free)."""
+    """Stable identity for a storage location (credential-free).
+
+    Keyed by uri + namespace + backend, matching StorageService's pool
+    identity: two configs that resolve to different stores (LanceDB vs
+    Iceberg on the same uri/namespace) must never share a catalog, or one
+    backend would discover descriptors whose rows live in the other.
+    """
     payload = json.dumps(
         {
             "domain": _DIGEST_DOMAIN,
             "kind": "storage",
             "uri": _normalized_uri(config),
             "namespace": config.namespace,
+            "backend": config.backend.value,
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -156,16 +163,17 @@ def catalog_path_for(config: StorageConfig) -> Path:
     """The catalog location as a pure function of the storage identity.
 
     Local stores keep the record beside the data it is about
-    (``<uri>/<namespace>/.archetype-catalog.db``). Remote stores get a
-    deterministic host-local path keyed by the storage fingerprint —
+    (``<uri>/<namespace>/.archetype-catalog-<backend>.db``). Remote stores
+    get a deterministic host-local path keyed by the storage fingerprint —
     the same config always resolves the same catalog on this host
-    (single-host authority is the documented v0.3 limit).
+    (single-host authority is the documented v0.3 limit). The backend is
+    part of the identity in both forms, mirroring storage_fingerprint.
     """
     uri = str(config.uri)
     parsed = urlparse(uri)
     if parsed.scheme in ("", "file"):
         base = Path(parsed.path if parsed.scheme == "file" else uri).expanduser()
-        return base / config.namespace / ".archetype-catalog.db"
+        return base / config.namespace / f".archetype-catalog-{config.backend.value}.db"
     root = Path(os.environ.get("ARCHETYPE_CATALOG_DIR", "~/.archetype/catalogs")).expanduser()
     return root / f"{storage_fingerprint(config)[:24]}.db"
 

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -1,0 +1,430 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Durable control catalog — private implementation resource of StorageService.
+
+The catalog makes Archetype's *existing* registries durable: which worlds live
+in a store, and which archetype tables (signatures) hold their rows. It is the
+authority for discovery; the process-local registries in WorldService and the
+stores remain what they always were — caches.
+
+Design rules (issue #272, design review 2026-07-14):
+
+- The catalog location is a **pure function of the storage identity**: the
+  same StorageConfig always resolves the same catalog, across processes,
+  restarts, and crashes.
+- Records are compact pointers (a world row, a signature row with its stored
+  Arrow schema). Never operational state: no entity directories, no lineage
+  copies (``core/lineage`` is already durable), no manifest snapshots.
+- Append-only in spirit: worlds transition status; nothing is deleted.
+- Same identity + same content → idempotent no-op. Same identity + different
+  content → loud ``CatalogConflictError``. Fail closed, never fail quiet.
+- SQLite is the control plane (LanceDB ``merge_insert`` is proven non-CAS
+  under concurrency). Single-host authority in v0.3; the protocol leaves room
+  for a shared backend later.
+
+This module is deliberately not a service: it has no distinct authority or
+gate surface (``docs/guide/service-protocols.md`` § new-service bar). A2 will
+extend it with manifest heads and claims.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import urlparse
+
+import pyarrow as pa
+
+from archetype.core.config import StorageConfig
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = 1
+_DIGEST_DOMAIN = "archetype.catalog.v1"
+
+
+class CatalogConflictError(RuntimeError):
+    """Same identity registered with different content — never silently resolved."""
+
+
+class CatalogSchemaMismatchError(RuntimeError):
+    """A stored signature descriptor disagrees with the physical table schema."""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Canonical schema fingerprints (salvaged, trimmed, from the A1 draft branch)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def arrow_schema_descriptor(schema: pa.Schema) -> dict[str, object]:
+    """A JSON-native, order-preserving description of an Arrow schema.
+
+    Field type identity uses ``str(field.type)``; cross-PyArrow-version
+    stability of that string is a documented hypothesis (design review pass 2)
+    — the fingerprint guards read-time safety, not archival identity.
+    """
+    return {
+        "fields": [
+            {
+                "name": field.name,
+                "type": str(field.type),
+                "nullable": bool(field.nullable),
+            }
+            for field in schema
+        ],
+    }
+
+
+_TYPE_NORMALIZATION = {
+    "large_string": "string",
+    "large_binary": "binary",
+}
+
+
+def _normalized_type(type_str: str) -> str:
+    for physical, logical in _TYPE_NORMALIZATION.items():
+        type_str = type_str.replace(physical, logical)
+    return type_str
+
+
+def schema_fingerprint(schema: pa.Schema) -> str:
+    """Domain-separated SHA-256 over the schema's *logical* shape.
+
+    Backends normalize physical encodings — Iceberg round-trips
+    ``string`` as ``large_string`` and forces every field nullable — so
+    the fingerprint hashes field names and normalized logical types, in
+    order, and deliberately excludes nullability and large/small encoding
+    variants. Its job is read-safety ("is this table what the descriptor
+    claims"), which must hold across backend representations of the same
+    declared schema. Renames, reorders, and retypes still mismatch.
+    """
+    value = [[field.name, _normalized_type(str(field.type))] for field in schema]
+    payload = json.dumps(
+        {"domain": _DIGEST_DOMAIN, "kind": "arrow-schema", "value": value},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def storage_fingerprint(config: StorageConfig) -> str:
+    """Stable identity for a storage location (credential-free)."""
+    payload = json.dumps(
+        {
+            "domain": _DIGEST_DOMAIN,
+            "kind": "storage",
+            "uri": _normalized_uri(config),
+            "namespace": config.namespace,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _normalized_uri(config: StorageConfig) -> str:
+    uri = str(config.uri)
+    parsed = urlparse(uri)
+    if parsed.scheme in ("", "file"):
+        path = parsed.path if parsed.scheme == "file" else uri
+        return str(Path(path).expanduser().resolve())
+    return uri.rstrip("/")
+
+
+def catalog_path_for(config: StorageConfig) -> Path:
+    """The catalog location as a pure function of the storage identity.
+
+    Local stores keep the record beside the data it is about
+    (``<uri>/<namespace>/.archetype-catalog.db``). Remote stores get a
+    deterministic host-local path keyed by the storage fingerprint —
+    the same config always resolves the same catalog on this host
+    (single-host authority is the documented v0.3 limit).
+    """
+    uri = str(config.uri)
+    parsed = urlparse(uri)
+    if parsed.scheme in ("", "file"):
+        base = Path(parsed.path if parsed.scheme == "file" else uri).expanduser()
+        return base / config.namespace / ".archetype-catalog.db"
+    root = Path(os.environ.get("ARCHETYPE_CATALOG_DIR", "~/.archetype/catalogs")).expanduser()
+    return root / f"{storage_fingerprint(config)[:24]}.db"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Records
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class WorldRecord:
+    """Compact durable pointer to a world in one store."""
+
+    world_id: str
+    name: str | None
+    run_id: str | None
+    parent_world_id: str | None
+    status: str  # "active" | "destroyed"
+    tick_head: int  # advisory until A2 manifests land
+
+
+@dataclass(frozen=True)
+class SignatureRecord:
+    """Compact durable pointer to one archetype table."""
+
+    table_id: str
+    component_names: tuple[str, ...]
+    schema_json: str  # canonical arrow_schema_descriptor, JSON-encoded
+    fingerprint: str
+
+    def matches(self, schema: pa.Schema) -> bool:
+        return self.fingerprint == schema_fingerprint(schema)
+
+
+class ControlCatalog(Protocol):
+    """What StorageService exposes to the app layer. A2 extends this."""
+
+    async def register_world(self, record: WorldRecord) -> None: ...
+    async def set_world_status(self, world_id: str, status: str) -> None: ...
+    async def set_tick_head(self, world_id: str, tick_head: int, run_id: str | None) -> None: ...
+    async def get_world(self, world_id: str) -> WorldRecord | None: ...
+    async def list_worlds(self) -> list[WorldRecord]: ...
+    async def register_signature(self, record: SignatureRecord) -> None: ...
+    async def list_signatures(self) -> list[SignatureRecord]: ...
+    async def close(self) -> None: ...
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SQLite implementation
+# ─────────────────────────────────────────────────────────────────────────────
+
+_DDL = f"""
+CREATE TABLE IF NOT EXISTS catalog_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS worlds (
+    world_id TEXT PRIMARY KEY,
+    name TEXT,
+    run_id TEXT,
+    parent_world_id TEXT,
+    status TEXT NOT NULL,
+    tick_head INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS signatures (
+    table_id TEXT PRIMARY KEY,
+    component_names TEXT NOT NULL,
+    schema_json TEXT NOT NULL,
+    fingerprint TEXT NOT NULL
+);
+INSERT OR IGNORE INTO catalog_meta (key, value) VALUES ('schema_version', '{_SCHEMA_VERSION}');
+"""
+
+
+class SqliteControlCatalog:
+    """Hardened per the proven A1-draft settings: WAL, synchronous=FULL,
+    busy timeout, BEGIN IMMEDIATE for read-modify-write. All sqlite work runs
+    in a worker thread; one connection per catalog instance, serialized by an
+    asyncio lock (SQLite write transactions are single-writer anyway)."""
+
+    def __init__(self, path: Path, *, busy_timeout_ms: int = 5000) -> None:
+        self.path = path
+        self._busy_timeout_ms = busy_timeout_ms
+        self._conn: sqlite3.Connection | None = None
+        self._lock = asyncio.Lock()
+
+    # ── connection ─────────────────────────────────────────────────────────
+
+    def _connect_sync(self) -> sqlite3.Connection:
+        if self._conn is not None:
+            return self._conn
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute(f"PRAGMA busy_timeout={self._busy_timeout_ms}")
+        journal = str(conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]).upper()
+        if journal != "WAL":
+            logger.warning("catalog %s: journal_mode=%s (WAL unavailable)", self.path, journal)
+        conn.execute("PRAGMA synchronous=FULL")
+        conn.executescript(_DDL)
+        version = conn.execute(
+            "SELECT value FROM catalog_meta WHERE key='schema_version'"
+        ).fetchone()[0]
+        if int(version) != _SCHEMA_VERSION:
+            raise CatalogConflictError(
+                f"catalog {self.path} has schema_version={version}, "
+                f"this build expects {_SCHEMA_VERSION}"
+            )
+        conn.commit()
+        self._conn = conn
+        return conn
+
+    async def _run(self, fn, *args):
+        async with self._lock:
+            return await asyncio.to_thread(fn, *args)
+
+    async def close(self) -> None:
+        def _close() -> None:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+        await self._run(_close)
+
+    # ── worlds ───────────────────────────────────────────────────────────────
+
+    async def register_world(self, record: WorldRecord) -> None:
+        def _register() -> None:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT * FROM worlds WHERE world_id=?", (record.world_id,)
+                ).fetchone()
+                if row is not None:
+                    existing = _world_from_row(row)
+                    # Identity fields must agree; status/tick may have advanced.
+                    if (existing.name, existing.run_id, existing.parent_world_id) != (
+                        record.name,
+                        record.run_id,
+                        record.parent_world_id,
+                    ):
+                        raise CatalogConflictError(
+                            f"world {record.world_id} already registered with "
+                            f"different identity in catalog {self.path}"
+                        )
+                    return
+                conn.execute(
+                    "INSERT INTO worlds "
+                    "(world_id, name, run_id, parent_world_id, status, tick_head) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        record.world_id,
+                        record.name,
+                        record.run_id,
+                        record.parent_world_id,
+                        record.status,
+                        record.tick_head,
+                    ),
+                )
+
+        await self._run(_register)
+
+    async def set_world_status(self, world_id: str, status: str) -> None:
+        def _set() -> None:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("UPDATE worlds SET status=? WHERE world_id=?", (status, world_id))
+
+        await self._run(_set)
+
+    async def set_tick_head(self, world_id: str, tick_head: int, run_id: str | None) -> None:
+        def _set() -> None:
+            conn = self._connect_sync()
+            with conn:
+                if run_id is None:
+                    conn.execute(
+                        "UPDATE worlds SET tick_head=? WHERE world_id=?",
+                        (tick_head, world_id),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE worlds SET tick_head=?, run_id=? WHERE world_id=?",
+                        (tick_head, run_id, world_id),
+                    )
+
+        await self._run(_set)
+
+    async def get_world(self, world_id: str) -> WorldRecord | None:
+        def _get() -> WorldRecord | None:
+            conn = self._connect_sync()
+            row = conn.execute("SELECT * FROM worlds WHERE world_id=?", (world_id,)).fetchone()
+            return _world_from_row(row) if row is not None else None
+
+        return await self._run(_get)
+
+    async def list_worlds(self) -> list[WorldRecord]:
+        def _list() -> list[WorldRecord]:
+            conn = self._connect_sync()
+            rows = conn.execute("SELECT * FROM worlds ORDER BY world_id").fetchall()
+            return [_world_from_row(row) for row in rows]
+
+        return await self._run(_list)
+
+    # ── signatures ───────────────────────────────────────────────────────────
+
+    async def register_signature(self, record: SignatureRecord) -> None:
+        def _register() -> None:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT fingerprint FROM signatures WHERE table_id=?",
+                    (record.table_id,),
+                ).fetchone()
+                if row is not None:
+                    if row["fingerprint"] != record.fingerprint:
+                        raise CatalogConflictError(
+                            f"signature {record.table_id} already registered with a "
+                            f"different schema fingerprint in catalog {self.path}"
+                        )
+                    return
+                conn.execute(
+                    "INSERT INTO signatures "
+                    "(table_id, component_names, schema_json, fingerprint) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        record.table_id,
+                        json.dumps(list(record.component_names)),
+                        record.schema_json,
+                        record.fingerprint,
+                    ),
+                )
+
+        await self._run(_register)
+
+    async def list_signatures(self) -> list[SignatureRecord]:
+        def _list() -> list[SignatureRecord]:
+            conn = self._connect_sync()
+            rows = conn.execute("SELECT * FROM signatures ORDER BY table_id").fetchall()
+            return [
+                SignatureRecord(
+                    table_id=row["table_id"],
+                    component_names=tuple(json.loads(row["component_names"])),
+                    schema_json=row["schema_json"],
+                    fingerprint=row["fingerprint"],
+                )
+                for row in rows
+            ]
+
+        return await self._run(_list)
+
+
+def _world_from_row(row: sqlite3.Row) -> WorldRecord:
+    return WorldRecord(
+        world_id=row["world_id"],
+        name=row["name"],
+        run_id=row["run_id"],
+        parent_world_id=row["parent_world_id"],
+        status=row["status"],
+        tick_head=int(row["tick_head"]),
+    )

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -339,6 +339,35 @@ class CommandService:
         await self._emit(ctx, "list_worlds")
         return worlds
 
+    @instrument("gate.discover_worlds")
+    async def discover_worlds(
+        self, ctx: ActorCtx, storage_config: StorageConfig
+    ) -> list[WorldInfo]:
+        """Durable discovery (issue #272): worlds recorded in a store's catalog.
+
+        Unlike list_worlds (live registry), this answers cold — a fresh
+        process pointed at the same storage identity sees every world ever
+        registered there. Read-gated as LIST_WORLDS.
+        """
+        self._gate(Command(type=CommandType.LIST_WORLDS), ctx)
+        infos = await self._worlds.discover_worlds(storage_config)
+        await self._emit(ctx, "discover_worlds")
+        return infos
+
+    @instrument("gate.open_world_readonly")
+    async def open_world_readonly(
+        self, ctx: ActorCtx, storage_config: StorageConfig, world_id: str | UUID
+    ) -> WorldInfo:
+        """Cold read-only open (issue #272): the world's durable descriptor.
+
+        Never constructs a live mutable world; queryability flows through
+        the ordinary gated query path. Read-gated as GET_WORLD_INFO.
+        """
+        self._gate(Command(type=CommandType.GET_WORLD_INFO), ctx)
+        info = await self._worlds.open_world_readonly(storage_config, world_id)
+        await self._emit(ctx, "open_world_readonly", world_id)
+        return info
+
     # ── Simulation (gated, direct) ────────────────────────────────────────
 
     @instrument("gate.step")

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -21,15 +21,20 @@ including worlds that no longer exist in memory.
 
 from __future__ import annotations
 
+import logging
+
 from daft import DataFrame, col
 
 from archetype.app.models import Command, CommandType
 from archetype.app.storage_service import StorageService
 from archetype.core.aio import AsyncQueryManager
+from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import StorageConfig
 from archetype.core.interfaces import ArchetypeSignature
 from archetype.core.lineage import load_lineage
+
+logger = logging.getLogger(__name__)
 
 
 class QueryService:
@@ -107,26 +112,111 @@ class QueryService:
         When `lineage` is provided (a fork's ancestor segments), pre-fork
         ticks are read from the owning ancestor's run and unioned in.
         """
-        store = await self._storage_service.get_or_create_store(storage_config or StorageConfig())
+        effective_config = storage_config or StorageConfig()
+        store = await self._storage_service.get_or_create_store(effective_config, None)
         querier = AsyncQueryManager(store=store)
-        result = await querier.query_components(
-            components=components,
-            world_id=world_id,
-            run_id=run_id,
-            ticks=ticks,
-            entity_ids=entity_ids,
-        )
+        catalog_records = await self._catalog_candidates(effective_config, components)
 
-        async def _segment(seg_world: str, seg_run: str, seg_ticks: list[int] | None):
-            return await querier.query_components(
-                components=components,
-                world_id=seg_world,
-                run_id=seg_run,
+        async def _read(seg_world: str, seg_run: str, seg_ticks: list[int] | None):
+            return await self._components_frame(
+                querier,
+                store,
+                catalog_records,
+                components,
+                seg_world,
+                seg_run,
                 ticks=seg_ticks,
                 entity_ids=entity_ids,
             )
 
-        return await self._union_lineage(result, lineage, ticks, _segment)
+        result = await _read(world_id, run_id, ticks)
+        return await self._union_lineage(result, lineage, ticks, _read)
+
+    async def _catalog_candidates(
+        self, storage_config: StorageConfig, components: list[type[Component]]
+    ):
+        """Durable signature records whose component sets cover the request.
+
+        The control catalog (issue #272) is the durable complement to the
+        store's process-local signature registry: a fresh process discovers
+        every table ever committed against this storage identity.
+        """
+        requested = {c.__name__ for c in components}
+        try:
+            catalog = self._storage_service.get_control_catalog(storage_config)
+            records = await catalog.list_signatures()
+        except Exception:
+            logger.exception("control catalog unavailable for %s", storage_config.uri)
+            return []
+        return [r for r in records if requested.issubset(set(r.component_names))]
+
+    async def _components_frame(
+        self,
+        querier: AsyncQueryManager,
+        store,
+        catalog_records,
+        components: list[type[Component]],
+        world_id: str,
+        run_id: str,
+        *,
+        ticks: list[int] | None,
+        entity_ids: list[int] | None,
+    ) -> DataFrame:
+        """Live subset query unioned with catalog-discovered tables.
+
+        The live path is unchanged. Catalog tables not already covered by a
+        live signature are read through the open-never-create store seam and
+        projected from their durable schema — no Python classes required
+        beyond the ones the caller asked for. A fingerprint mismatch between
+        the catalog descriptor and the physical table fails closed.
+        """
+        import daft
+        import pyarrow as pa
+
+        from archetype.app._catalog import CatalogSchemaMismatchError, schema_fingerprint
+
+        output_sig = tuple(sorted(components, key=lambda t: t.__name__))
+        schema = Archetype.get_archetype_schema(output_sig)
+        proj_cols = schema.names
+
+        live_sigs = await querier.list_signatures()
+        live_tables = {Archetype.get_name(sig) for sig in live_sigs}
+        extra_records = [r for r in catalog_records if r.table_id not in live_tables]
+
+        try:
+            result = await querier.query_components(
+                components=components,
+                world_id=world_id,
+                run_id=run_id,
+                ticks=ticks,
+                entity_ids=entity_ids,
+            )
+        except KeyError:
+            # The live registry has signatures but none satisfy the request.
+            # Durable tables may still: fall through to the catalog union,
+            # re-raising only when the catalog cannot help either.
+            if not extra_records:
+                raise
+            result = daft.from_arrow(pa.Table.from_batches([], schema=schema))
+
+        for record in extra_records:
+            physical = await store.get_existing_table_schema(record.table_id)
+            if record.fingerprint != schema_fingerprint(physical):
+                raise CatalogSchemaMismatchError(
+                    f"catalog descriptor for table {record.table_id} does not match "
+                    "the physical schema; refusing to read (fail closed)"
+                )
+            df = await store.get_existing_table_df(
+                record.table_id,
+                world_id,
+                run_id,
+                ticks=ticks,
+                entity_ids=entity_ids,
+                active_only=True,
+            )
+            result = result.concat(df.select(*proj_cols))
+
+        return result
 
     @staticmethod
     async def _union_lineage(result, lineage, ticks, segment_query) -> DataFrame:

--- a/src/archetype/app/simulation_service.py
+++ b/src/archetype/app/simulation_service.py
@@ -89,6 +89,11 @@ class SimulationService:
             commands_applied = len(applied) if isinstance(applied, Sized) else 0
         if isinstance(world, AsyncWorld):
             await world.step(run_config, **input_kwargs)
+            # Advance the world's advisory catalog head + register any new
+            # signatures (issue #272). One catalog transaction per tick;
+            # advisory until A2 manifests, so failures log, never fail a
+            # tick whose data-plane writes already committed.
+            await self._world_service.record_step(world_id)
         return commands_applied
 
     async def run(

--- a/src/archetype/app/storage_service.py
+++ b/src/archetype/app/storage_service.py
@@ -28,6 +28,7 @@ from urllib.parse import urlparse
 
 from daft.session import Session
 
+from archetype.app._catalog import SqliteControlCatalog, catalog_path_for
 from archetype.core.aio import AsyncCachedStore, AsyncLancedbStore, AsyncStore
 from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
 from archetype.core.interfaces import iAsyncStore
@@ -104,6 +105,21 @@ class StorageService:
         self._session = session
         self._instances: dict[str, iAsyncStore] = {}
         self._locks: dict[str, asyncio.Lock] = {}
+        # Control catalogs, pooled by resolved catalog path (issue #272).
+        # The catalog is an implementation resource of this service — it is
+        # authoritative for discovery, and its location is a pure function
+        # of the storage identity (see app/_catalog.py).
+        self._catalogs: dict[str, SqliteControlCatalog] = {}
+
+    def get_control_catalog(self, storage_config: StorageConfig) -> SqliteControlCatalog:
+        """The durable control catalog for a storage location (pooled)."""
+        path = catalog_path_for(storage_config)
+        key = str(path)
+        catalog = self._catalogs.get(key)
+        if catalog is None:
+            catalog = SqliteControlCatalog(path)
+            self._catalogs[key] = catalog
+        return catalog
 
     @staticmethod
     def _pool_key(
@@ -171,8 +187,16 @@ class StorageService:
                 logger.exception("Failed to shut down store %r", store)
                 errors.append(e)
 
+        for catalog in self._catalogs.values():
+            try:
+                await catalog.close()
+            except Exception as e:
+                logger.exception("Failed to close control catalog %r", catalog.path)
+                errors.append(e)
+
         self._instances.clear()
         self._locks.clear()
+        self._catalogs.clear()
 
         if errors:
             raise RuntimeError(

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -23,11 +23,19 @@ WorldService  — facade (bridges StorageService into the orchestrator)
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING
 
 from uuid_utils import UUID, uuid7
 
+from archetype.app._catalog import (
+    SignatureRecord,
+    WorldRecord,
+    arrow_schema_descriptor,
+    schema_fingerprint,
+)
+from archetype.app.models import WorldInfo
 from archetype.app.storage_service import StorageService
 from archetype.core.aio import (
     AsyncQueryManager,
@@ -35,6 +43,7 @@ from archetype.core.aio import (
     AsyncUpdateManager,
     AsyncWorld,
 )
+from archetype.core.archetype import Archetype
 from archetype.core.config import CacheConfig, StorageConfig, WorldConfig
 from archetype.core.hooks import HookRegistry
 from archetype.core.interfaces import iAsyncStore, iAsyncSystem
@@ -45,6 +54,16 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+
+def _world_info_from_record(record: WorldRecord) -> WorldInfo:
+    """Catalog record → the existing gate boundary descriptor."""
+    return WorldInfo(
+        world_id=record.world_id,
+        name=record.name,
+        tick=record.tick_head,
+        run_id=record.run_id,
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -277,6 +296,9 @@ class WorldService:
         # Records the storage/cache config that backs each world so fork_world
         # can default to "same store as source" per world-lifecycle.md § 4.5.
         self._storage_configs: dict[str, tuple[StorageConfig, CacheConfig | None]] = {}
+        # Per-world memo of signature table_ids already registered in the
+        # catalog, keeping record_step at one catalog transaction per tick.
+        self._registered_sigs: dict[str, set[str]] = {}
 
     async def create_world(
         self,
@@ -292,6 +314,19 @@ class WorldService:
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
         world = self._orchestrator.create_world(store, config, system=system)
         self._storage_configs[str(world.world_id)] = (storage_config, cache_config)
+        # Durable identity is authoritative (issue #272): registration failure
+        # fails the create, loudly — a world the catalog cannot describe would
+        # be undiscoverable after this process exits.
+        await self._storage_service.get_control_catalog(storage_config).register_world(
+            WorldRecord(
+                world_id=str(world.world_id),
+                name=world.name,
+                run_id=str(world.run_id) if world.run_id else None,
+                parent_world_id=None,
+                status="active",
+                tick_head=world.tick,
+            )
+        )
         return world
 
     def get_world(self, world_id: UUID) -> AsyncWorld:
@@ -353,6 +388,16 @@ class WorldService:
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
         fork = self._orchestrator.fork_world(store, source_world_id, name=name)
         self._storage_configs[str(fork.world_id)] = (storage_config, cache_config)
+        await self._storage_service.get_control_catalog(storage_config).register_world(
+            WorldRecord(
+                world_id=str(fork.world_id),
+                name=fork.name,
+                run_id=str(fork.run_id) if fork.run_id else None,
+                parent_world_id=str(source_world_id),
+                status="active",
+                tick_head=fork.tick,
+            )
+        )
         # Persist the fork's ancestor chain (append-only): provenance must
         # survive the fork being destroyed or the process restarting.
         await persist_lineage(
@@ -369,9 +414,81 @@ class WorldService:
 
         The storage record is retained: destroyed worlds' rows are still in
         the store (append-only), and readers resolve them through
-        storage_record().
+        storage_record(). The catalog marks status — append-only holds in
+        the control plane too; nothing is deleted.
         """
         await self._orchestrator.destroy_world(world_id)
+        record = self._storage_configs.get(str(world_id))
+        if record is not None:
+            catalog = self._storage_service.get_control_catalog(record[0])
+            await catalog.set_world_status(str(world_id), "destroyed")
+
+    # ── Durable discovery (issue #272) ───────────────────────────────────────
+
+    async def discover_worlds(self, storage_config: StorageConfig) -> list[WorldInfo]:
+        """Worlds recorded in a store's control catalog — works cold.
+
+        Unlike ``list_worlds`` (live process registry), this answers from the
+        durable catalog: a fresh process pointed at the same storage identity
+        sees every world ever registered there, including destroyed ones
+        (their rows are still queryable; append-only).
+        """
+        catalog = self._storage_service.get_control_catalog(storage_config)
+        return [_world_info_from_record(record) for record in await catalog.list_worlds()]
+
+    async def open_world_readonly(
+        self, storage_config: StorageConfig, world_id: str | UUID
+    ) -> WorldInfo:
+        """Cold, read-only open: the world's durable descriptor.
+
+        Returns the existing ``WorldInfo`` boundary type — identity, name,
+        run, and (advisory until A2 manifests) tick head. Queryability comes
+        through the ordinary gated query path with this info plus the same
+        ``storage_config``. This never constructs a live mutable world:
+        fenced mutable resume is a separate, A2-gated capability.
+        """
+        catalog = self._storage_service.get_control_catalog(storage_config)
+        record = await catalog.get_world(str(world_id))
+        if record is None:
+            raise KeyError(f"world {world_id} is not recorded in catalog for {storage_config.uri}")
+        return _world_info_from_record(record)
+
+    async def record_step(self, world_id: str | UUID) -> None:
+        """Advance the world's advisory catalog head after a step.
+
+        Called by SimulationService post-step. Advisory in A1-read (the
+        cached store may not have flushed; the true durable head arrives
+        with A2 manifests), so failures log loudly rather than failing a
+        tick whose data-plane writes already succeeded. New signatures are
+        registered once (process-local memo keeps the hot loop at one
+        catalog transaction per step).
+        """
+        record = self._storage_configs.get(str(world_id))
+        if record is None:
+            return
+        world = self._orchestrator.get_world(UUID(str(world_id)))
+        catalog = self._storage_service.get_control_catalog(record[0])
+        try:
+            registered = self._registered_sigs.setdefault(str(world_id), set())
+            for sig in set(world.entity2sig.values()):
+                table_id = Archetype.get_name(sig)
+                if table_id in registered:
+                    continue
+                schema = Archetype.get_archetype_schema(sig)
+                await catalog.register_signature(
+                    SignatureRecord(
+                        table_id=table_id,
+                        component_names=tuple(c.__name__ for c in sig),
+                        schema_json=json.dumps(arrow_schema_descriptor(schema)),
+                        fingerprint=schema_fingerprint(schema),
+                    )
+                )
+                registered.add(table_id)
+            await catalog.set_tick_head(
+                str(world_id), world.tick, str(world.run_id) if world.run_id else None
+            )
+        except Exception:
+            logger.exception("catalog head update failed for world %s", world_id)
 
     async def add_resource(self, world_id: str | UUID, resource: object) -> None:
         """Attach a resource to a world's Resources container."""

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -313,20 +313,25 @@ class WorldService:
 
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
         world = self._orchestrator.create_world(store, config, system=system)
-        self._storage_configs[str(world.world_id)] = (storage_config, cache_config)
         # Durable identity is authoritative (issue #272): registration failure
         # fails the create, loudly — a world the catalog cannot describe would
-        # be undiscoverable after this process exits.
-        await self._storage_service.get_control_catalog(storage_config).register_world(
-            WorldRecord(
-                world_id=str(world.world_id),
-                name=world.name,
-                run_id=str(world.run_id) if world.run_id else None,
-                parent_world_id=None,
-                status="active",
-                tick_head=world.tick,
+        # be undiscoverable after this process exits. Unwind the registry so
+        # the failed create leaves no live, mutable world behind.
+        try:
+            await self._storage_service.get_control_catalog(storage_config).register_world(
+                WorldRecord(
+                    world_id=str(world.world_id),
+                    name=world.name,
+                    run_id=str(world.run_id) if world.run_id else None,
+                    parent_world_id=None,
+                    status="active",
+                    tick_head=world.tick,
+                )
             )
-        )
+        except Exception:
+            self._registry.remove(world.world_id)
+            raise
+        self._storage_configs[str(world.world_id)] = (storage_config, cache_config)
         return world
 
     def get_world(self, world_id: UUID) -> AsyncWorld:
@@ -387,17 +392,23 @@ class WorldService:
                 )
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
         fork = self._orchestrator.fork_world(store, source_world_id, name=name)
-        self._storage_configs[str(fork.world_id)] = (storage_config, cache_config)
-        await self._storage_service.get_control_catalog(storage_config).register_world(
-            WorldRecord(
-                world_id=str(fork.world_id),
-                name=fork.name,
-                run_id=str(fork.run_id) if fork.run_id else None,
-                parent_world_id=str(source_world_id),
-                status="active",
-                tick_head=fork.tick,
+        # Same authoritative-identity contract as create_world: a fork the
+        # catalog cannot describe must not survive as a live world.
+        try:
+            await self._storage_service.get_control_catalog(storage_config).register_world(
+                WorldRecord(
+                    world_id=str(fork.world_id),
+                    name=fork.name,
+                    run_id=str(fork.run_id) if fork.run_id else None,
+                    parent_world_id=str(source_world_id),
+                    status="active",
+                    tick_head=fork.tick,
+                )
             )
-        )
+        except Exception:
+            self._registry.remove(fork.world_id)
+            raise
+        self._storage_configs[str(fork.world_id)] = (storage_config, cache_config)
         # Persist the fork's ancestor chain (append-only): provenance must
         # survive the fork being destroyed or the process restarting.
         await persist_lineage(

--- a/src/archetype/core/aio/async_lancedb_store.py
+++ b/src/archetype/core/aio/async_lancedb_store.py
@@ -78,15 +78,11 @@ class AsyncLancedbStore(iAsyncStore):
 
         pyarrow_schema = Archetype.get_archetype_schema(sig)
 
-        if self.lancedb is None:
-            subdir = os.environ.get("ARCT_LANCEDB_SUBDIR", "lance")
-            self.lancedb = await lancedb.connect_async(
-                os.path.join(self.uri, self.namespace, subdir)
-            )
+        connection = await self._connect()
 
         if table_name in await self._list_table_names():
             try:
-                async_table = await self.lancedb.open_table(table_name)
+                async_table = await connection.open_table(table_name)
             except Exception as e:
                 raise RuntimeError(f"Error opening LanceDB table {table_name}: {e}") from e
 
@@ -95,7 +91,7 @@ class AsyncLancedbStore(iAsyncStore):
             return async_table
 
         try:
-            async_table = await self.lancedb.create_table(
+            async_table = await connection.create_table(
                 name=table_name,
                 schema=pyarrow_schema,
                 exist_ok=True,
@@ -115,6 +111,74 @@ class AsyncLancedbStore(iAsyncStore):
         self._known_sigs[table_name] = sig
         self._tables[table_name] = async_table
         return async_table
+
+    async def _connect(self):
+        """Open the database connection without creating any user table.
+
+        Connecting may create the database *directory*; it never creates or
+        registers an archetype table, so read paths stay create-free.
+        """
+        if self.lancedb is None:
+            subdir = os.environ.get("ARCT_LANCEDB_SUBDIR", "lance")
+            self.lancedb = await lancedb.connect_async(
+                os.path.join(self.uri, self.namespace, subdir)
+            )
+        return self.lancedb
+
+    # ── Durable-discovery seam (issue #272) ─────────────────────────────────
+    # Salvaged from the A1 draft branch: open-never-create reads by persisted
+    # physical table identity. Deliberately does not touch _known_sigs /
+    # _committed_sigs — those stay process-local caches, never discovery
+    # authority — and does not populate the mutable _tables handle cache.
+
+    async def _open_existing_table(self, table_id: str):
+        db = await self._connect()
+        if table_id not in await self._list_table_names():
+            raise KeyError(f"LanceDB table {table_id!r} does not exist")
+        try:
+            return await db.open_table(table_id)
+        except Exception as exc:
+            raise RuntimeError(f"Error opening LanceDB table {table_id}: {exc}") from exc
+
+    async def get_existing_table_schema(self, table_id: str):
+        """Return an existing table's Arrow schema without creating it."""
+        table = await self._open_existing_table(table_id)
+        return await table.schema()
+
+    async def get_existing_table_df(
+        self,
+        table_id: str,
+        world_id: str,
+        run_id: str,
+        *,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        active_only: bool = False,
+    ) -> DataFrame:
+        """Read an existing table by durable physical identity.
+
+        Unlike ``get_archetype_df``, this never calls ``_ensure_table`` and
+        therefore cannot turn a read into a committed-looking table.
+        """
+        table = await self._open_existing_table(table_id)
+        safe_world = str(world_id).replace("'", "''")
+        safe_run = str(run_id).replace("'", "''")
+        clauses = [f"world_id = '{safe_world}'", f"run_id = '{safe_run}'"]
+        if active_only:
+            clauses.append("is_active = true")
+        if ticks is not None:
+            tick_list = ", ".join(str(int(t)) for t in ticks)
+            clauses.append(f"tick IN ({tick_list})" if ticks else "false")
+        if entity_ids is not None:
+            id_list = ", ".join(str(int(eid)) for eid in entity_ids)
+            clauses.append(f"entity_id IN ({id_list})" if entity_ids else "false")
+        where_str = " AND ".join(clauses)
+        try:
+            arrow = await table.query().where(where_str).to_arrow()
+        except Exception as exc:
+            logger.error("Error reading existing table %s: %s", table_id, exc)
+            raise
+        return daft.from_arrow(arrow)
 
     async def _list_table_names(self) -> list[str]:
         if self.lancedb is None:

--- a/src/archetype/core/aio/async_store.py
+++ b/src/archetype/core/aio/async_store.py
@@ -131,6 +131,48 @@ class AsyncStore(iAsyncStore):
 
         return df
 
+    # ── Durable-discovery seam (issue #272) ─────────────────────────────────
+    # Open-never-create reads by persisted physical table identity, so a cold
+    # process holding a catalog descriptor can read without Python component
+    # classes. Signature caches are untouched: they remain caches, not
+    # discovery authority.
+
+    def _get_existing_table(self, table_id: str) -> Table:
+        if not self.session.has_table(table_id):
+            raise KeyError(f"Iceberg table {table_id!r} does not exist")
+        try:
+            return self.session.get_table(table_id)
+        except Exception as exc:
+            raise RuntimeError(f"Error opening Iceberg table {table_id}: {exc}") from exc
+
+    async def get_existing_table_schema(self, table_id: str):
+        """Return an existing table's Arrow schema without creating it."""
+        table = self._get_existing_table(table_id)
+        return self._read_table(table).schema().to_pyarrow_schema()
+
+    async def get_existing_table_df(
+        self,
+        table_id: str,
+        world_id: str,
+        run_id: str,
+        *,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        active_only: bool = False,
+    ) -> DataFrame:
+        """Read an existing table by durable physical identity (never creates)."""
+        table = self._get_existing_table(table_id)
+        df = self._read_table(table)
+        df = df.where(df["world_id"] == str(world_id))  # ty: ignore[invalid-argument-type]
+        df = df.where(df["run_id"] == str(run_id))  # ty: ignore[invalid-argument-type]
+        if active_only:
+            df = df.where(df["is_active"])
+        if ticks is not None:
+            df = df.where(df["tick"].is_in(ticks))
+        if entity_ids is not None:
+            df = df.where(df["entity_id"].is_in(entity_ids))
+        return df
+
     async def list_signatures(self) -> list[ArchetypeSignature]:
         """
         List all archetype signatures that have been registered via _ensure_table.

--- a/src/archetype/core/interfaces.py
+++ b/src/archetype/core/interfaces.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Iterable
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
+import pyarrow as pa
 from daft import DataFrame  # type: ignore[import-not-found]
 
 from .component import Component
@@ -375,6 +376,25 @@ class iAsyncStore(Protocol):
 
     async def append(self, sig: ArchetypeSignature, df: DataFrame) -> None: ...
     async def shutdown(self) -> None: ...
+
+    # ── Durable-discovery seam (issue #272, approved 2026-07-14) ──────────
+    # Reads by persisted physical table identity, for processes that hold a
+    # catalog descriptor but not the Python component classes. Both methods
+    # are open-never-create: a missing table raises KeyError; no read path
+    # may materialize a table (the create-on-read of get_archetype_df is
+    # exactly what these exist to avoid).
+
+    async def get_existing_table_schema(self, table_id: str) -> pa.Schema: ...
+    async def get_existing_table_df(
+        self,
+        table_id: str,
+        world_id: str,
+        run_id: str,
+        *,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+        active_only: bool = False,
+    ) -> DataFrame: ...
 
 
 class iAsyncQueryManager(Protocol):

--- a/tests/app/test_durable_discovery.py
+++ b/tests/app/test_durable_discovery.py
@@ -50,9 +50,11 @@ def _storage(tmp_path) -> StorageConfig:
 
 
 def test_catalog_path_is_a_pure_function_of_storage_identity(tmp_path):
+    from archetype.core.config import StorageBackend
+
     local = StorageConfig(uri=str(tmp_path / "s"), namespace="ns")
     assert catalog_path_for(local) == catalog_path_for(local)
-    assert catalog_path_for(local).name == ".archetype-catalog.db"
+    assert catalog_path_for(local).name == f".archetype-catalog-{local.backend.value}.db"
     assert str(tmp_path / "s" / "ns") in str(catalog_path_for(local))
 
     remote = StorageConfig(uri="s3://bucket/prefix", namespace="ns")
@@ -62,6 +64,43 @@ def test_catalog_path_is_a_pure_function_of_storage_identity(tmp_path):
 
     other = StorageConfig(uri="s3://bucket/other", namespace="ns")
     assert catalog_path_for(other) != a
+
+    # The backend is part of the storage identity (it selects a different
+    # physical store): same uri/namespace, different backend → different
+    # catalog, locally and remotely.
+    for cfg in (local, remote):
+        pairs = {
+            catalog_path_for(StorageConfig(uri=cfg.uri, namespace=cfg.namespace, backend=backend))
+            for backend in (StorageBackend.LANCEDB, StorageBackend.ICEBERG)
+        }
+        assert len(pairs) == 2, "backends must never share a catalog"
+
+
+@pytest.mark.asyncio
+async def test_failed_catalog_registration_leaves_no_live_world(tmp_path, monkeypatch):
+    """Identity is authoritative both ways: a world the catalog cannot
+    describe must not survive as a live, mutable world (create or fork)."""
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        source = await c.world_service.create_world(WorldConfig(name="src"), storage)
+
+        async def _boom(self, record):
+            raise CatalogConflictError("injected registration failure")
+
+        monkeypatch.setattr(SqliteControlCatalog, "register_world", _boom)
+
+        with pytest.raises(CatalogConflictError):
+            await c.world_service.create_world(WorldConfig(name="orphan"), storage)
+        with pytest.raises(CatalogConflictError):
+            await c.world_service.fork_world(source.world_id, name="orphan-fork")
+
+        live = {w.name for w in c.world_service.list_worlds()}
+        assert live == {"src"}, f"failed registrations must unwind, saw {live}"
+        with pytest.raises(KeyError):
+            c.world_service.get_world_by_name("orphan")
+    finally:
+        await c.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_durable_discovery.py
+++ b/tests/app/test_durable_discovery.py
@@ -1,0 +1,415 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Durable discovery (issue #272, A1-read).
+
+The control catalog makes the existing registries durable: a fresh process
+pointed at the same storage identity discovers every world and signature ever
+committed there. P0 tests use true subprocess restarts — same-process
+container recycling would not prove cold discovery.
+"""
+
+import json
+import multiprocessing
+import sqlite3
+import subprocess
+import sys
+import textwrap
+
+import pytest
+from uuid_utils import uuid7
+
+from archetype.app._catalog import (
+    CatalogConflictError,
+    SignatureRecord,
+    SqliteControlCatalog,
+    WorldRecord,
+    catalog_path_for,
+    schema_fingerprint,
+)
+from archetype.app.container import ServiceContainer
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+
+
+class Score(Component):
+    points: float = 0.0
+
+
+class Flag(Component):
+    label: str = ""
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Catalog unit behavior
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_catalog_path_is_a_pure_function_of_storage_identity(tmp_path):
+    local = StorageConfig(uri=str(tmp_path / "s"), namespace="ns")
+    assert catalog_path_for(local) == catalog_path_for(local)
+    assert catalog_path_for(local).name == ".archetype-catalog.db"
+    assert str(tmp_path / "s" / "ns") in str(catalog_path_for(local))
+
+    remote = StorageConfig(uri="s3://bucket/prefix", namespace="ns")
+    a, b = catalog_path_for(remote), catalog_path_for(remote)
+    assert a == b, "remote catalogs must resolve deterministically"
+    assert str(tmp_path) not in str(a), "remote catalog lives in the host-local root"
+
+    other = StorageConfig(uri="s3://bucket/other", namespace="ns")
+    assert catalog_path_for(other) != a
+
+
+@pytest.mark.asyncio
+async def test_register_world_is_idempotent_and_conflicts_loudly(tmp_path):
+    catalog = SqliteControlCatalog(tmp_path / "cat.db")
+    record = WorldRecord(
+        world_id="w1", name="alpha", run_id="r1", parent_world_id=None, status="active", tick_head=0
+    )
+    await catalog.register_world(record)
+    await catalog.register_world(record)  # same identity + content → no-op
+    assert (await catalog.get_world("w1")).name == "alpha"
+
+    with pytest.raises(CatalogConflictError):
+        await catalog.register_world(
+            WorldRecord(
+                world_id="w1",
+                name="impostor",
+                run_id="r1",
+                parent_world_id=None,
+                status="active",
+                tick_head=0,
+            )
+        )
+    await catalog.close()
+
+
+def _register_world_proc(path: str, result_queue) -> None:
+    import asyncio
+
+    from archetype.app._catalog import SqliteControlCatalog, WorldRecord
+
+    async def go():
+        catalog = SqliteControlCatalog.__new__(SqliteControlCatalog)
+        catalog.__init__(__import__("pathlib").Path(path))
+        await catalog.register_world(
+            WorldRecord(
+                world_id="race",
+                name="same",
+                run_id="r",
+                parent_world_id=None,
+                status="active",
+                tick_head=0,
+            )
+        )
+        await catalog.close()
+
+    try:
+        asyncio.run(go())
+        result_queue.put("ok")
+    except Exception as exc:  # pragma: no cover - failure reporting
+        result_queue.put(f"error: {exc}")
+
+
+def test_concurrent_identical_registration_yields_one_row(tmp_path):
+    """Multi-process put-if-absent: the SQLite control plane, not wishful dedup."""
+    path = tmp_path / "race.db"
+    ctx = multiprocessing.get_context("spawn")
+    queue = ctx.Queue()
+    procs = [ctx.Process(target=_register_world_proc, args=(str(path), queue)) for _ in range(8)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+    results = [queue.get(timeout=5) for _ in procs]
+    assert all(r == "ok" for r in results), results
+
+    rows = sqlite3.connect(path).execute("SELECT COUNT(*) FROM worlds").fetchone()[0]
+    assert rows == 1, "eight identical registrations must produce exactly one row"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Service integration
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_destroyed_worlds_stay_discoverable_with_status(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="ephemeral"), storage)
+        await c.world_service.destroy_world(world.world_id)
+
+        infos = await c.world_service.discover_worlds(storage)
+        assert [str(i.world_id) for i in infos] == [str(world.world_id)]
+        record = await c.storage_service.get_control_catalog(storage).get_world(str(world.world_id))
+        assert record.status == "destroyed", "append-only: destroy marks, never deletes"
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_fork_records_parent_world(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        base = await c.world_service.create_world(WorldConfig(name="base"), storage)
+        await c.mutation_service.create_entity(base.world_id, [Score(points=1.0)])
+        await c.simulation_service.step(base.world_id, RunConfig())
+        fork = await c.world_service.fork_world(base.world_id, name="branch")
+
+        record = await c.storage_service.get_control_catalog(storage).get_world(str(fork.world_id))
+        assert record.parent_world_id == str(base.world_id)
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_readonly_open_never_constructs_a_live_world(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="cold"), storage)
+        wid = str(world.world_id)
+    finally:
+        await c.shutdown()
+
+    fresh = ServiceContainer()
+    try:
+        info = await fresh.world_service.open_world_readonly(storage, wid)
+        assert str(info.world_id) == wid
+        assert not fresh.world_service.has_world(wid), (
+            "read-only open must not register a live world"
+        )
+        with pytest.raises(KeyError):
+            await fresh.world_service.open_world_readonly(storage, str(uuid7()))
+    finally:
+        await fresh.shutdown()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P0: true cold restart
+# ─────────────────────────────────────────────────────────────────────────────
+
+_CHILD = textwrap.dedent(
+    """
+    import asyncio, sys
+    from archetype.app.container import ServiceContainer
+    from archetype.core.component import Component
+    from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+
+    class Score(Component):
+        points: float = 0.0
+
+    class Flag(Component):
+        label: str = ""
+
+    async def main():
+        c = ServiceContainer()
+        try:
+            w = await c.world_service.create_world(
+                WorldConfig(name="cold"), StorageConfig(uri=sys.argv[1], namespace="ns")
+            )
+            # Two archetypes: (Score,) and (Score, Flag) — the subset query
+            # must union both, cold.
+            await c.mutation_service.create_entity(w.world_id, [Score(points=7.5)])
+            await c.mutation_service.create_entity(
+                w.world_id, [Score(points=2.5), Flag(label="x")]
+            )
+            await c.simulation_service.step(w.world_id, RunConfig())
+            print(w.world_id)
+        finally:
+            await c.shutdown()
+
+    asyncio.run(main())
+    """
+)
+
+
+@pytest.mark.asyncio
+async def test_p0_cold_subset_query_across_process_boundary(tmp_path):
+    """The reproduced bug, as a release gate: write in a child process, then a
+    fresh process discovers the world and a typed subset query unions rows
+    from every archetype containing the requested component."""
+    storage = _storage(tmp_path)
+    result = subprocess.run(
+        [sys.executable, "-c", _CHILD, storage.uri],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    world_id = result.stdout.strip().splitlines()[-1]
+
+    c = ServiceContainer()
+    try:
+        infos = await c.world_service.discover_worlds(storage)
+        assert [str(i.world_id) for i in infos] == [world_id]
+        info = await c.world_service.open_world_readonly(storage, world_id)
+
+        df = await c.query_service.query_components([Score], world_id, str(info.run_id), storage)
+        points = sorted(row["score__points"] for row in df.to_pylist())
+        assert points == [2.5, 7.5], "subset query must union both archetypes, cold"
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_p0_stale_descriptor_fails_closed(tmp_path):
+    """A catalog descriptor whose fingerprint disagrees with the physical
+    table must refuse to read — never an empty frame, never a created table."""
+    from archetype.app._catalog import CatalogSchemaMismatchError
+
+    storage = _storage(tmp_path)
+    result = subprocess.run(
+        [sys.executable, "-c", _CHILD, storage.uri],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    world_id = result.stdout.strip().splitlines()[-1]
+
+    # Corrupt one signature fingerprint directly in the catalog.
+    conn = sqlite3.connect(catalog_path_for(storage))
+    conn.execute("UPDATE signatures SET fingerprint='deadbeef'")
+    conn.commit()
+    conn.close()
+
+    c = ServiceContainer()
+    try:
+        info = await c.world_service.open_world_readonly(storage, world_id)
+        with pytest.raises(CatalogSchemaMismatchError):
+            await c.query_service.query_components([Score], world_id, str(info.run_id), storage)
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_reads_never_create_tables(tmp_path):
+    """Open-never-create: the seam raises KeyError for missing tables and a
+    failed read leaves the store's physical table list unchanged."""
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="w"), storage)
+        await c.mutation_service.create_entity(world.world_id, [Score(points=1.0)])
+        await c.simulation_service.step(world.world_id, RunConfig())
+
+        store = await c.storage_service.get_or_create_store(storage, None)
+        before = sorted(await store._list_table_names())
+
+        with pytest.raises(KeyError):
+            await store.get_existing_table_schema("a_nonexistent_table")
+        with pytest.raises(KeyError):
+            await store.get_existing_table_df("a_nonexistent_table", "w", "r")
+
+        assert sorted(await store._list_table_names()) == before
+    finally:
+        await c.shutdown()
+
+
+def test_schema_fingerprint_is_order_and_content_sensitive():
+    import pyarrow as pa
+
+    a = pa.schema([("x", pa.int64()), ("y", pa.float64())])
+    same = pa.schema([("x", pa.int64()), ("y", pa.float64())])
+    reordered = pa.schema([("y", pa.float64()), ("x", pa.int64())])
+    retyped = pa.schema([("x", pa.int32()), ("y", pa.float64())])
+
+    assert schema_fingerprint(a) == schema_fingerprint(same)
+    assert schema_fingerprint(a) != schema_fingerprint(reordered)
+    assert schema_fingerprint(a) != schema_fingerprint(retyped)
+
+    # Physical encoding variants are the SAME logical schema: Iceberg
+    # round-trips string as large_string and forces nullability.
+    s1 = pa.schema([pa.field("n", pa.string(), nullable=False)])
+    s2 = pa.schema([pa.field("n", pa.large_string(), nullable=True)])
+    assert schema_fingerprint(s1) == schema_fingerprint(s2)
+
+
+@pytest.mark.asyncio
+async def test_signature_record_roundtrip(tmp_path):
+    import pyarrow as pa
+
+    from archetype.app._catalog import arrow_schema_descriptor
+
+    catalog = SqliteControlCatalog(tmp_path / "cat.db")
+    schema = pa.schema([("score__points", pa.float64())])
+    record = SignatureRecord(
+        table_id="t1",
+        component_names=("Score",),
+        schema_json=json.dumps(arrow_schema_descriptor(schema)),
+        fingerprint=schema_fingerprint(schema),
+    )
+    await catalog.register_signature(record)
+    await catalog.register_signature(record)  # idempotent
+    (loaded,) = await catalog.list_signatures()
+    assert loaded == record
+    assert loaded.matches(schema)
+
+    with pytest.raises(CatalogConflictError):
+        await catalog.register_signature(
+            SignatureRecord(
+                table_id="t1",
+                component_names=("Score",),
+                schema_json=record.schema_json,
+                fingerprint="different",
+            )
+        )
+    await catalog.close()
+
+
+@pytest.mark.asyncio
+async def test_iceberg_seam_reads_existing_tables_only(tmp_path):
+    """The durable-discovery seam holds on the Iceberg backend too:
+    open-never-create reads by table id, KeyError for missing tables.
+
+    The seam reads go through a FRESH session and store — nothing shared
+    with the writer but the storage config — so this is a true cold read.
+    """
+    import daft
+    import pyarrow as pa
+
+    from archetype.core.aio import AsyncStore
+    from archetype.core.archetype import Archetype
+    from archetype.core.config import StorageBackend
+    from archetype.runtime.session import configure_session
+
+    storage = StorageConfig(uri=str(tmp_path), namespace="ns", backend=StorageBackend.ICEBERG)
+    sig = (Score,)
+    schema = Archetype.get_archetype_schema(sig)
+    table_id = Archetype.get_name(sig)
+
+    writer = AsyncStore(configure_session(storage), io_config=storage.io_config)
+    try:
+        row = {
+            "world_id": "w",
+            "run_id": "r",
+            "entity_id": 1,
+            "tick": 0,
+            "is_active": True,
+            "score__points": 3.0,
+        }
+        await writer.append(sig, daft.from_arrow(pa.Table.from_pylist([row], schema=schema)))
+    finally:
+        await writer.shutdown()
+
+    cold = AsyncStore(configure_session(storage), io_config=storage.io_config)
+    try:
+        physical = await cold.get_existing_table_schema(table_id)
+        assert schema_fingerprint(physical) == schema_fingerprint(schema)
+
+        df = await cold.get_existing_table_df(table_id, "w", "r", active_only=True)
+        rows = df.to_pylist()
+        assert len(rows) == 1 and rows[0]["score__points"] == 3.0
+
+        with pytest.raises(KeyError):
+            await cold.get_existing_table_schema("no_such_table")
+    finally:
+        await cold.shutdown()


### PR DESCRIPTION
Implements #272 (v0.3.0 slice A1-read) per the locked design plan: durability as an implementation of the existing StorageService → WorldService → QueryService authorities. No new service, no new public package — `app/_catalog.py` is the only new module.

## What lands

- **SQLite control catalog** — authoritative for world identity, advisory for tick head. Location is a pure function of the storage URI (local: `<uri>/<namespace>/.archetype-catalog.db`; remote: `~/.archetype/catalogs/<fingerprint>.db`, `ARCHETYPE_CATALOG_DIR` override), so restarts and crashes converge on one catalog with zero coordination. WAL + `synchronous=FULL` + `BEGIN IMMEDIATE`; identical re-registration is a no-op, a conflicting record raises `CatalogConflictError`.
- **One approved core seam, both backends** — `iAsyncStore.get_existing_table_schema` / `get_existing_table_df`, open-never-create, on `AsyncLancedbStore` and `AsyncStore` (Iceberg). Read paths cannot allocate tables. Salvaged from #264's draft where proven.
- **Existing owners grow** — `StorageService.get_control_catalog` (pooled, closed at shutdown); `WorldService` registers WorldRecords at create/fork (registration failure fails the command — identity is authoritative), marks destroy status append-only, gains `discover_worlds` + read-only `open_world_readonly` returning the existing `WorldInfo` descriptor; post-step advisory tick head + one-time signature registration (one catalog transaction per step, failures log loudly and never fail a tick whose data-plane writes succeeded). `storage_record`/`get_world_by_name`/`has_world` unchanged.
- **Cold subset queries** — `QueryService.query_components` unions catalog-discovered tables, projecting from stored schema descriptors; only the queried component classes need to exist in the reading process.
- **Fail closed** — physical-vs-descriptor fingerprint mismatch raises `CatalogSchemaMismatchError`, never an empty result and never a created table.
- **Gate** — `discover_worlds` gated as `LIST_WORLDS`, `open_world_readonly` as `GET_WORLD_INFO`; spec-contracts gate map extended.
- **Docs** — normative `docs/guide/durable-discovery.md` (+ spec index, nav).

## Acceptance (P0) → tests

All in `tests/app/test_durable_discovery.py` (12 tests):

- True subprocess restart: child process writes two archetypes; fresh parent container runs `discover_worlds` + typed subset `query_components` and gets rows from both tables.
- Corrupt/stale descriptor fails closed (fingerprint tampered in SQLite → `CatalogSchemaMismatchError`).
- Reads never create tables (missing table id → `KeyError`, store table set unchanged).
- Both backends: LanceDB end-to-end; Iceberg seam exercised through a fresh session + store sharing nothing with the writer but the config.
- 8-process registration race converges on exactly one world row; destroyed worlds stay discoverable; forks record parentage; read-only opens never register live worlds.

## Design notes for review

- **Schema fingerprint hashes logical shape** (field names + normalized types, order-sensitive) and deliberately excludes nullability and `large_string`/`string` encoding variants: Iceberg legitimately normalizes both on round-trip. Renames, reorders, adds/drops, and retypes still mismatch. The stored `schema_json` descriptor keeps full declared fidelity for projection. Schemas never evolve in place (a changed component set is a new signature), so a mismatch means corruption, not drift.
- **Deviation from the issue sketch**: `WorldRecord` carries no storage-fingerprint column — the storage identity is encoded in *which catalog file* the record lives in (path = pure function of the URI), which is strictly simpler and equivalent.
- **lazy_audit.toml**: no new materialization entries; two existing entries re-keyed for line shifts only (`async_store.py` 156→198, `simulation_service.py` 216→221).

## Out of scope (per issue)

Mutable cold resume (A1-resume, gated on #273's manifests); durable atomic tick visibility (A2). `tick_head` here is advisory only.

## Verification

Full fast suite: **780 passed**. Gates: ruff/format, lazy-audit (12 sites), API import boundary, ty (0 diagnostics), spec-contracts 6/6, markdownlint on the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
