### PR TITLE
feat(app): atomic tick visibility — manifests, fenced writers, epoch-0 legacy (A2, #273)

### DIFF
--- a/docs/guide/atomic-visibility.md
+++ b/docs/guide/atomic-visibility.md
@@ -82,6 +82,12 @@ The allowlist matches manifests across history, not the head epoch alone: a
 stale writer may append old-epoch rows at an already-visible tick, and those
 rows carry an unpublished token, so they never surface.
 
+A corrupt or unreadable catalog fails coordinated reads closed — the error
+propagates; it never degrades to unfiltered visibility. (Degraded discovery
+returns less data; degraded visibility would return rows no manifest
+authorized.) A merely missing catalog is not an error: connecting creates an
+empty one, which reports the legacy-unfiltered case.
+
 ## 5. Writer fencing
 
 One live writer per world, enforced by catalog CAS: acquiring the fence

--- a/docs/guide/atomic-visibility.md
+++ b/docs/guide/atomic-visibility.md
@@ -1,0 +1,125 @@
+# Atomic Tick Visibility
+
+**Document type:** Normative.
+**Scope:** Commit identity, manifests, writer fencing, append receipts, legacy epoch-0 semantics. Issue #273 (v0.3.0 slice A2). Amends the storage base schema defined in the umbrella specification.
+
+## 1. The visibility rule
+
+A tick is visible if and only if its manifest is published in the control
+catalog. Everything else follows from this one rule:
+
+- A crash during a tick's appends leaves rows on disk but no manifest —
+  the tick did not happen, and no reader ever sees the partial write.
+- A crash after appends but before publish: same outcome. The retried tick
+  recomputes from the last visible tick and re-appends under a fresh commit
+  token; only the attempt that published is ever visible. Exactly one
+  visible attempt per tick, even with multiple physical attempts on disk.
+- A stale writer (one that lost the fence) fails at publish, atomically,
+  and its rows stay invisible — including rows it appends late at a tick
+  that is already visible.
+
+## 2. Commit identity columns
+
+The storage base schema carries two commit-identity columns on every row:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `commit_token` | string | Names the tick-commit attempt that wrote the row. |
+| `writer_epoch` | int64 | The fenced writer epoch the attempt ran under. |
+
+Schema-is-identity is preserved: schemas never evolve on tables, so these
+columns join the base schema of **new-generation tables** — the table id is
+a hash of the full schema, and the new columns produce new ids. v0.2 tables
+keep their old ids and are read through a legacy-name fallback as **implicit
+epoch-0** history: always visible, token filtering never applies to them,
+and nothing ever writes to a legacy table id again.
+
+Component projections (`query_components`, `query_archetype` with a
+`components` argument) exclude the commit columns — they are storage
+metadata, not part of the component shape. Raw `query_archetype` reads
+expose them: commit identity is in the ledger and queryable like everything
+else.
+
+## 3. The tick commit protocol
+
+Coordinated worlds (every world created through the service layer) commit a
+tick in this order:
+
+1. **Compute** every archetype's frame. No writes, no cache consumption.
+2. **Mint** one `CommitContext` (fresh `commit_token`, the writer's epoch)
+   for the whole tick.
+3. **Append** every frame, stamped with the tick's commit identity. Appends
+   return `AppendReceipt`s (row counts, staged/durable, an auxiliary backend
+   reference such as a Lance version — never the visibility mechanism).
+4. **Flush** the store. A caching store drains its memtables; a manifest
+   must never claim RAM-only rows are durable.
+5. **Publish** the manifest — one catalog transaction that (a) verifies the
+   writer still holds the fence, (b) put-if-absent inserts the manifest row
+   `(world, run, tick, commit_token, writer_epoch, table_ids)`, and (c)
+   advances the world's durable tick head. Stale epoch →
+   `StaleWriterError`; a different already-published attempt →
+   `CatalogConflictError`; the identical attempt → idempotent no-op.
+6. **Consume** spawn/despawn caches — only now. Failure at any earlier
+   point leaves mutations intact for the retried tick.
+
+Worlds constructed without a coordinator (bare core usage, the sync stack)
+run uncoordinated: rows stamp the implicit epoch-0 identity (`""`/`0`), no
+manifests are written, and nothing is filtered — v0.2 semantics, unchanged.
+
+## 4. Reader-side allowlist
+
+Readers resolve a token allowlist per `(world, run)` segment — fork lineage
+segments each resolve against their own ancestor's manifests:
+
+- No manifests and no writer fence → pre-#273 or uncoordinated history:
+  unfiltered (implicitly visible).
+- A writer fence exists but no manifests → a coordinated world whose first
+  commit has not published: nothing current-generation is visible.
+- Manifests exist → rows must match the published token for their tick.
+  Legacy epoch-0 rows are always admitted.
+
+The allowlist matches manifests across history, not the head epoch alone: a
+stale writer may append old-epoch rows at an already-visible tick, and those
+rows carry an unpublished token, so they never surface.
+
+## 5. Writer fencing
+
+One live writer per world, enforced by catalog CAS: acquiring the fence
+increments the epoch and stales every earlier holder. `create_world` and
+`fork_world` acquire the fence; fenced mutable resume (A1-resume) acquires
+it cold. Publication verifies the epoch inside the manifest transaction, so
+fencing has no window: either the manifest lands under the live epoch or
+the writer learns it is stale and stops (its world never advances).
+
+## 6. Fork lineage under commit identity
+
+`persist_lineage` writes the fork's full ancestor chain as **one append**,
+which is atomic on both backends — a crash leaves either the whole chain or
+nothing. Lineage rows are world metadata (negative entity ids, epoch-0
+stamped, never token-filtered). The catalog's world record carries the
+authoritative `parent_world_id`; a fork record whose lineage rows are
+missing is detectable corruption, and fenced resume must refuse it loudly.
+
+## 7. Retention, optimize, and GC
+
+Visibility is column-and-manifest based, never backend-version based. That
+is what makes maintenance safe:
+
+- `optimize()`/compaction may rewrite fragments freely — rows keep their
+  commit columns, manifests keep matching them.
+- Backend version pruning is safe: no reader ever pins a Lance/Iceberg
+  version to decide visibility (versions appear only as auxiliary
+  diagnostics in receipts).
+- Append-only holds: no maintenance operation deletes rows. Unmanifested
+  rows from crashed attempts are dead weight, not dangerous weight; a
+  future vacuum contract may reclaim them, and MUST key on "token absent
+  from manifests", never on age or version.
+
+## 8. What A2 does not do
+
+- No physical resumability: a crashed MuJoCo (or any external-process)
+  execution is queryable up to its last published tick, not resumable
+  mid-physics.
+- No cross-host fencing: the catalog is single-host authority in v0.3.
+- Mutable cold resume (restoring a live world from rows + manifests) is
+  A1-resume, specified separately and gated on this contract.

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -21,6 +21,7 @@ The current contract set is split across design docs and executable tests.
 | [Execution Hierarchy](execution-hierarchy.md) | Step/run/episode/rollout | Simulation levels and rollout fork semantics. |
 | [World Lifecycle](world-lifecycle.md) | Create/fork/destroy | Append-only lifecycle, info-class downgrade, fork sharing/copy rules. |
 | [Durable Discovery](durable-discovery.md) | Control catalog and cold reads | Catalog authority, `discover_worlds`/`open_world_readonly`, fail-closed cold queries. |
+| [Atomic Visibility](atomic-visibility.md) | Tick commit identity | Manifest-published ticks, commit tokens, writer fencing, epoch-0 legacy reads. |
 | [Audit Log](audit-log.md) | Audit rows | Append-only audit history and query contract. |
 | [`tests/app/test_runtime_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_contracts.py) | Executable runtime contracts | Enforces activation single-flight, runtime-vs-world lifetime, fork isolation, spawn visibility, governance, and smoke paths. |
 | [`tests/app/test_runtime_fork_storage.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_fork_storage.py) | Runtime fork storage contracts | Enforces fork storage inheritance through the runtime layer, lineage reads on fork handles, fork run_id minting, and gate-side storage resolution. |
@@ -129,7 +130,12 @@ Each layer may depend downward. No lower layer may depend upward.
 - Signature identity is order-invariant. `(A, B)` and `(B, A)` describe the
   same archetype.
 - The base persisted columns for every archetype row are:
-  `world_id`, `run_id`, `entity_id`, `tick`, and `is_active`.
+  `world_id`, `run_id`, `entity_id`, `tick`, `is_active`, and — since the
+  atomic-visibility amendment ([Atomic Visibility](atomic-visibility.md)) —
+  `commit_token` and `writer_epoch`. v0.2 tables without the commit columns
+  remain readable as implicit epoch-0 history under their legacy table ids.
+- Component projections exclude the commit columns; raw archetype reads
+  expose them.
 
 ## Store Contracts
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -38,13 +38,13 @@ reason = "HTTP JSON response boundary: convert the already-collected Daft result
 
 [[entries]]
 path = "src/archetype/core/aio/async_store.py"
-line = 198
+line = 276
 method = "collect"
 reason = "Storage write boundary: defensive empty-frame probe before delegating to the backing table writer; cannot be expressed as a Daft predicate because count_rows requires materialised state."
 
 [[entries]]
 path = "src/archetype/core/aio/async_world.py"
-line = 332
+line = 382
 method = "to_pylist"
 reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -44,7 +44,7 @@ reason = "Storage write boundary: defensive empty-frame probe before delegating 
 
 [[entries]]
 path = "src/archetype/core/aio/async_world.py"
-line = 382
+line = 383
 method = "to_pylist"
 reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -38,7 +38,7 @@ reason = "HTTP JSON response boundary: convert the already-collected Daft result
 
 [[entries]]
 path = "src/archetype/core/aio/async_store.py"
-line = 276
+line = 279
 method = "collect"
 reason = "Storage write boundary: defensive empty-frame probe before delegating to the backing table writer; cannot be expressed as a Daft predicate because count_rows requires materialised state."
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - Execution Hierarchy: guide/execution-hierarchy.md
       - World Lifecycle: guide/world-lifecycle.md
       - Durable Discovery: guide/durable-discovery.md
+      - Atomic Visibility: guide/atomic-visibility.md
       - Audit Log: guide/audit-log.md
   - Building:
       - Building Simulations: guide/building-simulations.md

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -55,10 +55,11 @@ from urllib.parse import urlparse
 import pyarrow as pa
 
 from archetype.core.config import StorageConfig
+from archetype.core.interfaces import StaleWriterError
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 _DIGEST_DOMAIN = "archetype.catalog.v1"
 
 
@@ -196,6 +197,25 @@ class WorldRecord:
 
 
 @dataclass(frozen=True)
+class ManifestRecord:
+    """One published tick commit: the visibility authority (issue #273).
+
+    A tick is visible iff its manifest row exists. Compact by contract:
+    world, run, tick, the commit token that names the winning attempt, the
+    fenced writer epoch, and the table ids touched — never entity
+    directories or state snapshots.
+    """
+
+    world_id: str
+    run_id: str
+    tick: int
+    commit_token: str
+    writer_epoch: int
+    table_ids: tuple[str, ...]
+    created_at: str
+
+
+@dataclass(frozen=True)
 class SignatureRecord:
     """Compact durable pointer to one archetype table."""
 
@@ -213,7 +233,7 @@ class ControlCatalog(Protocol):
 
     async def register_world(self, record: WorldRecord) -> None: ...
     async def set_world_status(self, world_id: str, status: str) -> None: ...
-    async def set_tick_head(self, world_id: str, tick_head: int, run_id: str | None) -> None: ...
+    async def set_world_run(self, world_id: str, run_id: str) -> None: ...
     async def get_world(self, world_id: str) -> WorldRecord | None: ...
     async def list_worlds(self) -> list[WorldRecord]: ...
     async def register_signature(self, record: SignatureRecord) -> None: ...
@@ -243,6 +263,22 @@ CREATE TABLE IF NOT EXISTS signatures (
     component_names TEXT NOT NULL,
     schema_json TEXT NOT NULL,
     fingerprint TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS manifests (
+    world_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    tick INTEGER NOT NULL,
+    commit_token TEXT NOT NULL,
+    writer_epoch INTEGER NOT NULL,
+    tables_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (world_id, run_id, tick)
+);
+CREATE TABLE IF NOT EXISTS writer_fence (
+    world_id TEXT PRIMARY KEY,
+    epoch INTEGER NOT NULL,
+    holder TEXT NOT NULL,
+    acquired_at TEXT NOT NULL
 );
 INSERT OR IGNORE INTO catalog_meta (key, value) VALUES ('schema_version', '{_SCHEMA_VERSION}');
 """
@@ -274,13 +310,20 @@ class SqliteControlCatalog:
             logger.warning("catalog %s: journal_mode=%s (WAL unavailable)", self.path, journal)
         conn.execute("PRAGMA synchronous=FULL")
         conn.executescript(_DDL)
-        version = conn.execute(
-            "SELECT value FROM catalog_meta WHERE key='schema_version'"
-        ).fetchone()[0]
-        if int(version) != _SCHEMA_VERSION:
+        version = int(
+            conn.execute("SELECT value FROM catalog_meta WHERE key='schema_version'").fetchone()[0]
+        )
+        if version > _SCHEMA_VERSION:
             raise CatalogConflictError(
                 f"catalog {self.path} has schema_version={version}, "
                 f"this build expects {_SCHEMA_VERSION}"
+            )
+        if version < _SCHEMA_VERSION:
+            # Upgrades are strictly additive (the DDL above already created
+            # any missing tables); record the new version.
+            conn.execute(
+                "UPDATE catalog_meta SET value=? WHERE key='schema_version'",
+                (str(_SCHEMA_VERSION),),
             )
         conn.commit()
         self._conn = conn
@@ -345,20 +388,13 @@ class SqliteControlCatalog:
 
         await self._run(_set)
 
-    async def set_tick_head(self, world_id: str, tick_head: int, run_id: str | None) -> None:
+    async def set_world_run(self, world_id: str, run_id: str) -> None:
+        """Track the world's current run (manifests own the tick head)."""
+
         def _set() -> None:
             conn = self._connect_sync()
             with conn:
-                if run_id is None:
-                    conn.execute(
-                        "UPDATE worlds SET tick_head=? WHERE world_id=?",
-                        (tick_head, world_id),
-                    )
-                else:
-                    conn.execute(
-                        "UPDATE worlds SET tick_head=?, run_id=? WHERE world_id=?",
-                        (tick_head, run_id, world_id),
-                    )
+                conn.execute("UPDATE worlds SET run_id=? WHERE world_id=?", (run_id, world_id))
 
         await self._run(_set)
 
@@ -425,6 +461,188 @@ class SqliteControlCatalog:
             ]
 
         return await self._run(_list)
+
+    # ── commit identity: writer fence + manifests (issue #273) ──────────────
+
+    async def acquire_fence(self, world_id: str, holder: str) -> int:
+        """CAS-acquire the world's writer fence; returns the new epoch.
+
+        Every acquisition increments the epoch, so exactly one writer holds
+        the live epoch and every earlier writer becomes stale. Publishing
+        verifies the epoch inside the same transaction — a stale writer
+        fails closed rather than splitting history.
+        """
+
+        def _acquire() -> int:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT epoch FROM writer_fence WHERE world_id=?", (world_id,)
+                ).fetchone()
+                epoch = (int(row["epoch"]) if row is not None else 0) + 1
+                conn.execute(
+                    "INSERT INTO writer_fence (world_id, epoch, holder, acquired_at) "
+                    "VALUES (?, ?, ?, ?) "
+                    "ON CONFLICT(world_id) DO UPDATE SET "
+                    "epoch=excluded.epoch, holder=excluded.holder, "
+                    "acquired_at=excluded.acquired_at",
+                    (world_id, epoch, holder, _utcnow()),
+                )
+                return epoch
+
+        return await self._run(_acquire)
+
+    async def current_fence_epoch(self, world_id: str) -> int | None:
+        def _get() -> int | None:
+            conn = self._connect_sync()
+            row = conn.execute(
+                "SELECT epoch FROM writer_fence WHERE world_id=?", (world_id,)
+            ).fetchone()
+            return int(row["epoch"]) if row is not None else None
+
+        return await self._run(_get)
+
+    async def publish_manifest(
+        self,
+        world_id: str,
+        run_id: str,
+        tick: int,
+        commit_token: str,
+        writer_epoch: int,
+        table_ids: list[str],
+    ) -> None:
+        """Publish one tick's manifest — the LAST step of a tick commit.
+
+        One transaction: verify the caller still holds the fence, put-if-
+        absent the manifest row, and advance the world's tick head. A stale
+        epoch raises StaleWriterError; a different already-published attempt
+        for the same tick raises CatalogConflictError. Re-publishing the
+        identical attempt is a no-op (idempotent retry).
+        """
+
+        def _publish() -> None:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                fence = conn.execute(
+                    "SELECT epoch FROM writer_fence WHERE world_id=?", (world_id,)
+                ).fetchone()
+                if fence is None or int(fence["epoch"]) != writer_epoch:
+                    live = None if fence is None else int(fence["epoch"])
+                    raise StaleWriterError(
+                        f"writer epoch {writer_epoch} for world {world_id} is not the "
+                        f"live fence epoch ({live}); refusing to publish tick {tick}"
+                    )
+                row = conn.execute(
+                    "SELECT commit_token FROM manifests WHERE world_id=? AND run_id=? AND tick=?",
+                    (world_id, run_id, tick),
+                ).fetchone()
+                if row is not None:
+                    if row["commit_token"] == commit_token:
+                        return
+                    raise CatalogConflictError(
+                        f"tick {tick} of world {world_id} already has a published "
+                        f"manifest from a different commit attempt"
+                    )
+                conn.execute(
+                    "INSERT INTO manifests "
+                    "(world_id, run_id, tick, commit_token, writer_epoch, tables_json, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        world_id,
+                        run_id,
+                        tick,
+                        commit_token,
+                        writer_epoch,
+                        json.dumps(sorted(table_ids)),
+                        _utcnow(),
+                    ),
+                )
+                conn.execute(
+                    "UPDATE worlds SET tick_head=MAX(tick_head, ?) WHERE world_id=?",
+                    (tick, world_id),
+                )
+
+        await self._run(_publish)
+
+    async def visible_tokens(
+        self, world_id: str, run_id: str, ticks: list[int] | None = None
+    ) -> dict[int, str] | None:
+        """The reader-side visibility map for one (world, run).
+
+        None when the pair has no manifests at all — an uncoordinated or
+        pre-#273 world whose rows are implicitly visible. Otherwise a
+        {tick: commit_token} map covering the requested ticks; a tick with
+        no entry is invisible (its commit never finished).
+        """
+
+        def _tokens() -> dict[int, str] | None:
+            conn = self._connect_sync()
+            any_row = conn.execute(
+                "SELECT 1 FROM manifests WHERE world_id=? AND run_id=? LIMIT 1",
+                (world_id, run_id),
+            ).fetchone()
+            if any_row is None:
+                # No manifests: distinguish true pre-#273 history (never
+                # fenced — implicitly visible) from a coordinated world whose
+                # first commit hasn't published (fence exists — nothing is
+                # visible yet; a crashed first tick must not surface).
+                fence = conn.execute(
+                    "SELECT 1 FROM writer_fence WHERE world_id=?", (world_id,)
+                ).fetchone()
+                return None if fence is None else {}
+            if ticks is None:
+                rows = conn.execute(
+                    "SELECT tick, commit_token FROM manifests WHERE world_id=? AND run_id=?",
+                    (world_id, run_id),
+                ).fetchall()
+            else:
+                placeholders = ",".join("?" for _ in ticks)
+                rows = conn.execute(
+                    "SELECT tick, commit_token FROM manifests "
+                    f"WHERE world_id=? AND run_id=? AND tick IN ({placeholders})",
+                    (world_id, run_id, *[int(t) for t in ticks]),
+                ).fetchall()
+            return {int(r["tick"]): r["commit_token"] for r in rows}
+
+        return await self._run(_tokens)
+
+    async def list_manifests(
+        self, world_id: str, run_id: str | None = None
+    ) -> list[ManifestRecord]:
+        def _list() -> list[ManifestRecord]:
+            conn = self._connect_sync()
+            if run_id is None:
+                rows = conn.execute(
+                    "SELECT * FROM manifests WHERE world_id=? ORDER BY run_id, tick",
+                    (world_id,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM manifests WHERE world_id=? AND run_id=? ORDER BY tick",
+                    (world_id, run_id),
+                ).fetchall()
+            return [
+                ManifestRecord(
+                    world_id=r["world_id"],
+                    run_id=r["run_id"],
+                    tick=int(r["tick"]),
+                    commit_token=r["commit_token"],
+                    writer_epoch=int(r["writer_epoch"]),
+                    table_ids=tuple(json.loads(r["tables_json"])),
+                    created_at=r["created_at"],
+                )
+                for r in rows
+            ]
+
+        return await self._run(_list)
+
+
+def _utcnow() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
 
 
 def _world_from_row(row: sqlite3.Row) -> WorldRecord:

--- a/src/archetype/app/_commit.py
+++ b/src/archetype/app/_commit.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Catalog-backed commit coordinator (issue #273).
+
+Implements the core ``iCommitCoordinator`` protocol over the SQLite control
+catalog: one fenced writer epoch per world, one commit token per tick
+attempt, manifest published LAST. Core never imports this module — the
+coordinator is injected into worlds by WorldService, the same way stores are.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from uuid_utils import uuid7
+
+from archetype.core.interfaces import CommitContext
+
+if TYPE_CHECKING:
+    from archetype.app._catalog import SqliteControlCatalog
+
+
+class CatalogCommitCoordinator:
+    """One coordinator per (world, fence acquisition).
+
+    The epoch is acquired once — at world creation, fork, or (later) fenced
+    resume — and every tick this writer commits carries it. begin_tick is
+    pure token minting (no catalog I/O); publish_tick is the single catalog
+    transaction per tick and fails closed on a lost fence.
+    """
+
+    def __init__(self, catalog: SqliteControlCatalog, *, epoch: int) -> None:
+        self._catalog = catalog
+        self._epoch = epoch
+
+    @property
+    def epoch(self) -> int:
+        return self._epoch
+
+    async def begin_tick(self, world_id: str, run_id: str, tick: int) -> CommitContext:
+        return CommitContext(commit_token=uuid7().hex, writer_epoch=self._epoch)
+
+    async def publish_tick(
+        self,
+        world_id: str,
+        run_id: str,
+        tick: int,
+        ctx: CommitContext,
+        table_ids: list[str],
+    ) -> None:
+        await self._catalog.publish_manifest(
+            world_id,
+            run_id,
+            tick,
+            commit_token=ctx.commit_token,
+            writer_epoch=ctx.writer_epoch,
+            table_ids=table_ids,
+        )
+
+    async def visible_tokens(
+        self, world_id: str, run_id: str, ticks: list[int] | None = None
+    ) -> dict[int, str] | None:
+        return await self._catalog.visible_tokens(world_id, run_id, ticks)

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -158,15 +158,18 @@ class QueryService:
         """Reader-side commit-token allowlist for one (world, run) segment.
 
         None = unfiltered (no manifests recorded: uncoordinated or pre-#273
-        history — implicit epoch-0). Catalog unavailability degrades to
-        unfiltered reads, matching _catalog_candidates' failure posture.
+        history — implicit epoch-0).
+
+        Catalog errors PROPAGATE — the opposite posture from
+        _catalog_candidates, deliberately. Degraded discovery returns less
+        data; a degraded visibility check would return MORE (rows from
+        crashed or stale commit attempts that no manifest authorized), so a
+        corrupt or unreadable catalog fails the read closed. A missing
+        catalog is not an error: connecting creates an empty one, which
+        reports no manifests and no fence — the legacy-unfiltered case.
         """
-        try:
-            catalog = self._storage_service.get_control_catalog(storage_config)
-            visible = await catalog.visible_tokens(str(world_id), str(run_id), ticks)
-        except Exception:
-            logger.exception("control catalog unavailable for %s", storage_config.uri)
-            return None
+        catalog = self._storage_service.get_control_catalog(storage_config)
+        visible = await catalog.visible_tokens(str(world_id), str(run_id), ticks)
         if visible is None:
             return None
         if ticks is None:

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 
-from daft import DataFrame, col
+from daft import DataFrame, col, lit
 
 from archetype.app.models import Command, CommandType
 from archetype.app.storage_service import StorageService
@@ -70,18 +70,12 @@ class QueryService:
         When `lineage` is provided (a fork's ancestor segments), pre-fork
         ticks are read from the owning ancestor's run and unioned in.
         """
-        store = await self._storage_service.get_or_create_store(storage_config or StorageConfig())
+        effective_config = storage_config or StorageConfig()
+        store = await self._storage_service.get_or_create_store(effective_config)
         querier = AsyncQueryManager(store=store)
-        result = await querier.query_archetype(
-            sig=sig,
-            world_id=world_id,
-            run_id=run_id,
-            ticks=ticks,
-            entity_ids=entity_ids,
-            components=components,
-        )
 
         async def _segment(seg_world: str, seg_run: str, seg_ticks: list[int] | None):
+            tokens = await self._visible_tokens(effective_config, seg_world, seg_run, seg_ticks)
             return await querier.query_archetype(
                 sig=sig,
                 world_id=seg_world,
@@ -89,8 +83,10 @@ class QueryService:
                 ticks=seg_ticks,
                 entity_ids=entity_ids,
                 components=components,
+                commit_tokens=tokens,
             )
 
+        result = await _segment(world_id, run_id, ticks)
         return await self._union_lineage(result, lineage, ticks, _segment)
 
     async def query_components(
@@ -118,6 +114,7 @@ class QueryService:
         catalog_records = await self._catalog_candidates(effective_config, components)
 
         async def _read(seg_world: str, seg_run: str, seg_ticks: list[int] | None):
+            tokens = await self._visible_tokens(effective_config, seg_world, seg_run, seg_ticks)
             return await self._components_frame(
                 querier,
                 store,
@@ -127,6 +124,7 @@ class QueryService:
                 seg_run,
                 ticks=seg_ticks,
                 entity_ids=entity_ids,
+                commit_tokens=tokens,
             )
 
         result = await _read(world_id, run_id, ticks)
@@ -150,6 +148,31 @@ class QueryService:
             return []
         return [r for r in records if requested.issubset(set(r.component_names))]
 
+    async def _visible_tokens(
+        self,
+        storage_config: StorageConfig,
+        world_id: str,
+        run_id: str,
+        ticks: list[int] | None,
+    ) -> list[str] | None:
+        """Reader-side commit-token allowlist for one (world, run) segment.
+
+        None = unfiltered (no manifests recorded: uncoordinated or pre-#273
+        history — implicit epoch-0). Catalog unavailability degrades to
+        unfiltered reads, matching _catalog_candidates' failure posture.
+        """
+        try:
+            catalog = self._storage_service.get_control_catalog(storage_config)
+            visible = await catalog.visible_tokens(str(world_id), str(run_id), ticks)
+        except Exception:
+            logger.exception("control catalog unavailable for %s", storage_config.uri)
+            return None
+        if visible is None:
+            return None
+        if ticks is None:
+            return sorted(set(visible.values()))
+        return sorted({visible[t] for t in ticks if t in visible})
+
     async def _components_frame(
         self,
         querier: AsyncQueryManager,
@@ -161,6 +184,7 @@ class QueryService:
         *,
         ticks: list[int] | None,
         entity_ids: list[int] | None,
+        commit_tokens: list[str] | None = None,
     ) -> DataFrame:
         """Live subset query unioned with catalog-discovered tables.
 
@@ -176,8 +200,9 @@ class QueryService:
         from archetype.app._catalog import CatalogSchemaMismatchError, schema_fingerprint
 
         output_sig = tuple(sorted(components, key=lambda t: t.__name__))
-        schema = Archetype.get_archetype_schema(output_sig)
-        proj_cols = schema.names
+        proj_cols = Archetype.projection_columns(list(output_sig))
+        full_schema = Archetype.get_archetype_schema(output_sig)
+        schema = pa.schema([full_schema.field(name) for name in proj_cols])
 
         live_sigs = await querier.list_signatures()
         live_tables = {Archetype.get_name(sig) for sig in live_sigs}
@@ -190,6 +215,7 @@ class QueryService:
                 run_id=run_id,
                 ticks=ticks,
                 entity_ids=entity_ids,
+                commit_tokens=commit_tokens,
             )
         except KeyError:
             # The live registry has signatures but none satisfy the request.
@@ -214,6 +240,10 @@ class QueryService:
                 entity_ids=entity_ids,
                 active_only=True,
             )
+            if commit_tokens is not None and "commit_token" in df.column_names:
+                # (Daft stubs Expression methods as bool; these are Expressions.)
+                visible = df["commit_token"].is_in(commit_tokens) if commit_tokens else lit(False)
+                df = df.where(visible)
             result = result.concat(df.select(*proj_cols))
 
         return result

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import socket
 from typing import TYPE_CHECKING
 
 from uuid_utils import UUID, uuid7
@@ -35,6 +37,7 @@ from archetype.app._catalog import (
     arrow_schema_descriptor,
     schema_fingerprint,
 )
+from archetype.app._commit import CatalogCommitCoordinator
 from archetype.app.models import WorldInfo
 from archetype.app.storage_service import StorageService
 from archetype.core.aio import (
@@ -54,6 +57,11 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+
+def _writer_holder() -> str:
+    """Diagnostic fence-holder label; the epoch is the actual authority."""
+    return f"{socket.gethostname()}:{os.getpid()}"
 
 
 def _world_info_from_record(record: WorldRecord) -> WorldInfo:
@@ -317,8 +325,9 @@ class WorldService:
         # fails the create, loudly — a world the catalog cannot describe would
         # be undiscoverable after this process exits. Unwind the registry so
         # the failed create leaves no live, mutable world behind.
+        catalog = self._storage_service.get_control_catalog(storage_config)
         try:
-            await self._storage_service.get_control_catalog(storage_config).register_world(
+            await catalog.register_world(
                 WorldRecord(
                     world_id=str(world.world_id),
                     name=world.name,
@@ -328,9 +337,13 @@ class WorldService:
                     tick_head=world.tick,
                 )
             )
+            # Fenced writer (issue #273): this process is the world's one live
+            # writer; every tick it commits publishes under this epoch.
+            epoch = await catalog.acquire_fence(str(world.world_id), _writer_holder())
         except Exception:
             self._registry.remove(world.world_id)
             raise
+        world.commit_coordinator = CatalogCommitCoordinator(catalog, epoch=epoch)
         self._storage_configs[str(world.world_id)] = (storage_config, cache_config)
         return world
 
@@ -394,8 +407,9 @@ class WorldService:
         fork = self._orchestrator.fork_world(store, source_world_id, name=name)
         # Same authoritative-identity contract as create_world: a fork the
         # catalog cannot describe must not survive as a live world.
+        catalog = self._storage_service.get_control_catalog(storage_config)
         try:
-            await self._storage_service.get_control_catalog(storage_config).register_world(
+            await catalog.register_world(
                 WorldRecord(
                     world_id=str(fork.world_id),
                     name=fork.name,
@@ -405,9 +419,11 @@ class WorldService:
                     tick_head=fork.tick,
                 )
             )
+            epoch = await catalog.acquire_fence(str(fork.world_id), _writer_holder())
         except Exception:
             self._registry.remove(fork.world_id)
             raise
+        fork.commit_coordinator = CatalogCommitCoordinator(catalog, epoch=epoch)
         self._storage_configs[str(fork.world_id)] = (storage_config, cache_config)
         # Persist the fork's ancestor chain (append-only): provenance must
         # survive the fork being destroyed or the process restarting.
@@ -467,12 +483,12 @@ class WorldService:
     async def record_step(self, world_id: str | UUID) -> None:
         """Advance the world's advisory catalog head after a step.
 
-        Called by SimulationService post-step. Advisory in A1-read (the
-        cached store may not have flushed; the true durable head arrives
-        with A2 manifests), so failures log loudly rather than failing a
-        tick whose data-plane writes already succeeded. New signatures are
-        registered once (process-local memo keeps the hot loop at one
-        catalog transaction per step).
+        Called by SimulationService post-step. Since #273, the durable tick
+        head is maintained transactionally by manifest publication inside
+        world.step — this hook only registers new signatures (once, via a
+        process-local memo) and refreshes the world's current run_id.
+        Failures log loudly rather than failing a tick whose data-plane
+        writes and manifest already succeeded.
         """
         record = self._storage_configs.get(str(world_id))
         if record is None:
@@ -495,11 +511,10 @@ class WorldService:
                     )
                 )
                 registered.add(table_id)
-            await catalog.set_tick_head(
-                str(world_id), world.tick, str(world.run_id) if world.run_id else None
-            )
+            if world.run_id:
+                await catalog.set_world_run(str(world_id), str(world.run_id))
         except Exception:
-            logger.exception("catalog head update failed for world %s", world_id)
+            logger.exception("catalog signature registration failed for world %s", world_id)
 
     async def add_resource(self, world_id: str | UUID, resource: object) -> None:
         """Attach a resource to a world's Resources container."""

--- a/src/archetype/core/aio/async_cached_store.py
+++ b/src/archetype/core/aio/async_cached_store.py
@@ -28,7 +28,7 @@ from archetype.core.archetype import Archetype
 from archetype.core.config import CacheConfig
 
 # Internals
-from archetype.core.interfaces import ArchetypeSignature, iAsyncStore
+from archetype.core.interfaces import AppendReceipt, ArchetypeSignature, iAsyncStore
 
 logger = getLogger(__name__)
 
@@ -146,13 +146,16 @@ class AsyncCachedStore(iAsyncStore):
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
         active_only: bool = False,
+        commit_tokens: list[str] | None = None,
     ) -> DataFrame:
         """
         Get all archetypes that contain all of the specified component types.
 
         Reads are a union of already-flushed rows on disk and unflushed rows
         still in the memtable so that callers always see a coherent view of
-        the sig's full history regardless of flush state.
+        the sig's full history regardless of flush state. The commit-token
+        allowlist (issue #273) applies to both layers: staged rows are no
+        more visible than durable ones.
         """
         disk_df = await self._inner.get_archetype_df(
             sig,
@@ -161,6 +164,7 @@ class AsyncCachedStore(iAsyncStore):
             ticks=ticks,
             entity_ids=entity_ids,
             active_only=active_only,
+            commit_tokens=commit_tokens,
         )
 
         mt = self._mem.get(sig)
@@ -184,6 +188,12 @@ class AsyncCachedStore(iAsyncStore):
         if entity_ids is not None:
             mem_df = mem_df.where(mem_df["entity_id"].is_in(entity_ids))
 
+        if commit_tokens is not None:
+            visible = (
+                mem_df["commit_token"].is_in(commit_tokens) if commit_tokens else daft.lit(False)
+            )
+            mem_df = mem_df.where(visible)  # ty: ignore[invalid-argument-type]
+
         return disk_df.concat(mem_df)
 
     async def list_signatures(self) -> list[ArchetypeSignature]:
@@ -196,17 +206,27 @@ class AsyncCachedStore(iAsyncStore):
             return await self._inner.list_committed_signatures()
         return await self._inner.list_signatures()
 
-    async def append(self, sig: ArchetypeSignature, df: DataFrame) -> None:
+    async def append(self, sig: ArchetypeSignature, df: DataFrame) -> AppendReceipt:
         """
         Cache driven append with built in flush logic to underlying storage (super) a table with a new dataframe.
+
+        The receipt is staged (durable=False) unless this append tripped a
+        flush: rows become durable at flush()/threshold/idle/shutdown. A
+        commit coordinator must call flush() before publishing a manifest
+        head — a head must never claim RAM-only rows are durable.
         """
         # 1) convert the tiny incoming Daft DataFrame slice → RecordBatch
         added_bytes = 0
+        added_rows = 0
         for batch in df.to_arrow_iter():
             self._mem.setdefault(sig, MemTable()).append(batch)
             added_bytes += batch.nbytes
+            added_rows += batch.num_rows
 
         self._update_total_bytes(added_bytes)
+
+        if added_rows == 0:
+            return AppendReceipt(table_id=Archetype.get_name(sig), rows=0, durable=True)
 
         # cheap in‑mem stats
         needs_flush = (
@@ -217,6 +237,21 @@ class AsyncCachedStore(iAsyncStore):
 
         if needs_flush:
             await self._background_flush_sig(sig)
+
+        return AppendReceipt(
+            table_id=Archetype.get_name(sig), rows=added_rows, durable=needs_flush
+        )
+
+    async def flush(self) -> None:
+        """Drain every memtable to the inner store (issue #273).
+
+        Called by the commit coordinator's owner before a manifest head is
+        published, so visibility never outruns durability.
+        """
+        for sig, mt in list(self._mem.items()):
+            if mt.rows:
+                await self._background_flush_sig(sig)
+        await self._inner.flush()
 
     async def shutdown(self) -> None:
         """

--- a/src/archetype/core/aio/async_cached_store.py
+++ b/src/archetype/core/aio/async_cached_store.py
@@ -192,7 +192,7 @@ class AsyncCachedStore(iAsyncStore):
             visible = (
                 mem_df["commit_token"].is_in(commit_tokens) if commit_tokens else daft.lit(False)
             )
-            mem_df = mem_df.where(visible)  # ty: ignore[invalid-argument-type]
+            mem_df = mem_df.where(visible)
 
         return disk_df.concat(mem_df)
 
@@ -238,9 +238,7 @@ class AsyncCachedStore(iAsyncStore):
         if needs_flush:
             await self._background_flush_sig(sig)
 
-        return AppendReceipt(
-            table_id=Archetype.get_name(sig), rows=added_rows, durable=needs_flush
-        )
+        return AppendReceipt(table_id=Archetype.get_name(sig), rows=added_rows, durable=needs_flush)
 
     async def flush(self) -> None:
         """Drain every memtable to the inner store (issue #273).

--- a/src/archetype/core/aio/async_lancedb_store.py
+++ b/src/archetype/core/aio/async_lancedb_store.py
@@ -20,11 +20,11 @@ from typing import Any, Protocol
 
 import daft
 import lancedb
-from daft import DataFrame
+from daft import DataFrame, lit
 from lancedb.index import Bitmap, BTree
 
 from archetype.core.archetype import Archetype
-from archetype.core.interfaces import ArchetypeSignature, iAsyncStore
+from archetype.core.interfaces import AppendReceipt, ArchetypeSignature, iAsyncStore
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +66,9 @@ class AsyncLancedbStore(iAsyncStore):
         # ~100s of it). A LanceDB handle always reads the current version, so
         # reusing it is safe — appends and queries see the latest data.
         self._tables: dict[str, Any] = {}
+        # Memoized presence of v0.2 legacy tables per legacy table id — frozen
+        # history, checked once (see _legacy_df).
+        self._legacy_present: dict[str, bool] = {}
 
     async def _ensure_table(self, sig):
         table_name = Archetype.get_name(sig)
@@ -193,6 +196,44 @@ class AsyncLancedbStore(iAsyncStore):
 
         return list(await self.lancedb.table_names())
 
+    @staticmethod
+    def _where(
+        world_id: str,
+        run_id: str,
+        *,
+        ticks: list[int] | None,
+        entity_ids: list[int] | None,
+        active_only: bool,
+        commit_tokens: list[str] | None = None,
+    ) -> str:
+        safe_world = str(world_id).replace("'", "''")
+        safe_run = str(run_id).replace("'", "''")
+        clauses = [
+            f"world_id = '{safe_world}'",
+            f"run_id = '{safe_run}'",
+        ]
+
+        if active_only:
+            clauses.append("is_active = true")
+
+        if ticks is not None:
+            tick_list = ", ".join(str(int(t)) for t in ticks)
+            clauses.append(f"tick IN ({tick_list})")
+
+        if entity_ids is not None:
+            id_list = ", ".join(str(int(eid)) for eid in entity_ids)
+            clauses.append(f"entity_id IN ({id_list})")
+
+        if commit_tokens is not None:
+            if commit_tokens:
+                token_list = ", ".join("'{}'".format(t.replace("'", "''")) for t in commit_tokens)
+                clauses.append(f"commit_token IN ({token_list})")
+            else:
+                # An empty allowlist means no current-generation row is visible.
+                clauses.append("false")
+
+        return " AND ".join(clauses)
+
     async def get_archetype_df(
         self,
         sig,
@@ -202,30 +243,27 @@ class AsyncLancedbStore(iAsyncStore):
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
         active_only: bool = False,
+        commit_tokens: list[str] | None = None,
     ) -> DataFrame:
+        """Read one archetype's rows.
+
+        ``commit_tokens`` is the reader-side visibility allowlist (issue #273):
+        current-generation rows must match a published manifest token. Legacy
+        (v0.2) rows carry no commit identity and are implicitly epoch-0
+        visible — the allowlist never applies to them.
+        """
         table_name = Archetype.get_name(sig)
         async_table = await self._ensure_table(sig)
 
         try:
-            safe_world = str(world_id).replace("'", "''")
-            safe_run = str(run_id).replace("'", "''")
-            clauses = [
-                f"world_id = '{safe_world}'",
-                f"run_id = '{safe_run}'",
-            ]
-
-            if active_only:
-                clauses.append("is_active = true")
-
-            if ticks is not None:
-                tick_list = ", ".join(str(int(t)) for t in ticks)
-                clauses.append(f"tick IN ({tick_list})")
-
-            if entity_ids is not None:
-                id_list = ", ".join(str(int(eid)) for eid in entity_ids)
-                clauses.append(f"entity_id IN ({id_list})")
-
-            where_str = " AND ".join(clauses)
+            where_str = self._where(
+                world_id,
+                run_id,
+                ticks=ticks,
+                entity_ids=entity_ids,
+                active_only=active_only,
+                commit_tokens=commit_tokens,
+            )
             filtered_arrow = await async_table.query().where(where_str).to_arrow()
             df = daft.from_arrow(filtered_arrow)
 
@@ -233,7 +271,52 @@ class AsyncLancedbStore(iAsyncStore):
             logger.error(f"Error reading archetype table {table_name}: {e}")
             raise e
 
+        legacy_df = await self._legacy_df(
+            sig, world_id, run_id, ticks=ticks, entity_ids=entity_ids, active_only=active_only
+        )
+        if legacy_df is not None:
+            df = df.concat(legacy_df)
+
         return df
+
+    async def _legacy_df(
+        self,
+        sig,
+        world_id: str,
+        run_id: str,
+        *,
+        ticks: list[int] | None,
+        entity_ids: list[int] | None,
+        active_only: bool,
+    ) -> DataFrame | None:
+        """Rows persisted by v0.2 under the legacy table id, if any.
+
+        Presence is memoized per legacy table id: legacy tables are frozen
+        history (nothing writes them after #273), so one existence check
+        suffices. Rows are stamped with the epoch-0 identity and aligned to
+        the current schema so callers see one uniform shape.
+        """
+        legacy_name = Archetype.get_legacy_name(sig)
+        known = self._legacy_present.get(legacy_name)
+        if known is None:
+            await self._connect()
+            known = legacy_name in await self._list_table_names()
+            self._legacy_present[legacy_name] = known
+        if not known:
+            return None
+
+        table = await self._open_existing_table(legacy_name)
+        where_str = self._where(
+            world_id, run_id, ticks=ticks, entity_ids=entity_ids, active_only=active_only
+        )
+        arrow = await table.query().where(where_str).to_arrow()
+        df = daft.from_arrow(arrow).with_columns(
+            {
+                "commit_token": lit(""),
+                "writer_epoch": lit(0).cast(daft.DataType.int64()),
+            }
+        )
+        return df.select(*Archetype.get_archetype_schema(sig).names)
 
     async def list_signatures(self) -> list[ArchetypeSignature]:
         return list(self._known_sigs.values())
@@ -246,28 +329,38 @@ class AsyncLancedbStore(iAsyncStore):
         """
         return [sig for key, sig in self._known_sigs.items() if key in self._committed_sigs]
 
-    async def append(self, sig, df: DataFrame) -> None:
+    async def append(self, sig, df: DataFrame) -> AppendReceipt:
         # ONE materialization. Lance rejects zero-row / schemaless frames, so the
         # empty guard stays — but the row count comes free from the Arrow table we
         # must build anyway. A separate df.collect() + df.count_rows() re-ran the
         # Daft plan twice for nothing; this redundancy is a recurring rewrite
         # regression (perf-fixed before in the predecessor stores) — keep it lean.
+        table_id = Archetype.get_name(sig)
         if not df.column_names:
-            logger.info(
-                f"Append skipped (lancedb): archetype={Archetype.get_name(sig)} empty schema"
-            )
-            return
+            logger.info(f"Append skipped (lancedb): archetype={table_id} empty schema")
+            return AppendReceipt(table_id=table_id, rows=0, durable=True)
         arrow_table = df.to_arrow()
         if arrow_table.num_rows == 0:
-            logger.info(f"Append skipped (lancedb): archetype={Archetype.get_name(sig)} rows=0")
-            return
+            logger.info(f"Append skipped (lancedb): archetype={table_id} rows=0")
+            return AppendReceipt(table_id=table_id, rows=0, durable=True)
 
         async_table = await self._ensure_table(sig)
         # Record this sig as durably committed for list_committed_signatures().
-        self._committed_sigs.add(Archetype.get_name(sig))
+        self._committed_sigs.add(table_id)
         # No local try/except: AsyncUpdateManager.update already logs + re-raises
         # (the "loud failures" contract), so wrapping here would only double-log.
-        await async_table.add(arrow_table, mode="append")
+        result = await async_table.add(arrow_table, mode="append")
+        # Backend version is an auxiliary diagnostic, never the visibility mechanism.
+        version = getattr(result, "version", None)
+        return AppendReceipt(
+            table_id=table_id,
+            rows=arrow_table.num_rows,
+            durable=True,
+            backend_ref=str(version) if version is not None else None,
+        )
+
+    async def flush(self) -> None:
+        """No-op: appends write through to LanceDB."""
 
     async def shutdown(self) -> None:
         if self.lancedb is not None:

--- a/src/archetype/core/aio/async_querier.py
+++ b/src/archetype/core/aio/async_querier.py
@@ -54,6 +54,7 @@ class AsyncQueryManager(iAsyncQueryManager):
         entity_ids: list[int] | None = None,
         components: list[type["Component"]] | None = None,
         run_id: str | None = None,
+        commit_tokens: list[str] | None = None,
         **kwargs,  # absorbs world-internal keys (e.g. run_config, _world_validated)
     ) -> DataFrame:
         """Query active entities for the provided archetype signature.
@@ -120,6 +121,7 @@ class AsyncQueryManager(iAsyncQueryManager):
             ticks=ticks,
             entity_ids=entity_ids,
             active_only=True,
+            commit_tokens=commit_tokens,
         )
 
         if components:
@@ -135,6 +137,7 @@ class AsyncQueryManager(iAsyncQueryManager):
         *,
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
+        commit_tokens: list[str] | None = None,
     ) -> DataFrame:
         """Query all entities that contain the requested component types.
 
@@ -207,6 +210,7 @@ class AsyncQueryManager(iAsyncQueryManager):
                 ticks=ticks,
                 entity_ids=entity_ids,
                 active_only=True,
+                commit_tokens=commit_tokens,
             )
             result = result.concat(df.select(*proj_cols))
 

--- a/src/archetype/core/aio/async_querier.py
+++ b/src/archetype/core/aio/async_querier.py
@@ -154,10 +154,13 @@ class AsyncQueryManager(iAsyncQueryManager):
 
         required = set(components)
 
-        # Build the output schema from the requested components
+        # Build the output schema from the requested components. Component
+        # projections exclude commit-identity columns (they are storage
+        # metadata; raw query_archetype reads still expose them).
         output_sig = tuple(sorted(components, key=lambda t: t.__name__))
-        schema = Archetype.get_archetype_schema(output_sig)
-        proj_cols = schema.names
+        proj_cols = Archetype.projection_columns(list(output_sig))
+        full_schema = Archetype.get_archetype_schema(output_sig)
+        schema = pa.schema([full_schema.field(name) for name in proj_cols])
 
         # Find all sigs that contain the required types
         all_sigs = await self.list_signatures()

--- a/src/archetype/core/aio/async_store.py
+++ b/src/archetype/core/aio/async_store.py
@@ -130,7 +130,7 @@ class AsyncStore(iAsyncStore):
         if commit_tokens is not None:
             # (Daft stubs Expression.__and__ etc. as bool; these are Expressions.)
             visible = df["commit_token"].is_in(commit_tokens) if commit_tokens else lit(False)
-            df = df.where(visible)  # ty: ignore[invalid-argument-type]
+            df = df.where(visible)
 
         legacy_df = self._legacy_df(
             sig, world_id, run_id, ticks=ticks, entity_ids=entity_ids, active_only=active_only
@@ -186,7 +186,10 @@ class AsyncStore(iAsyncStore):
         legacy_name = Archetype.get_legacy_name(sig)
         known = self._legacy_present.get(legacy_name)
         if known is None:
-            known = self.session.has_table(legacy_name)
+            # The ctor accepts Session-like duck types (test fakes); one that
+            # cannot answer has_table has no legacy tables to offer.
+            has_table = getattr(self.session, "has_table", None)
+            known = bool(has_table(legacy_name)) if callable(has_table) else False
             self._legacy_present[legacy_name] = known
         if not known:
             return None
@@ -276,9 +279,7 @@ class AsyncStore(iAsyncStore):
             df.collect()
             rows = df.count_rows()
             if rows == 0 or not df.column_names:
-                logger.info(
-                    f"Append skipped (store): archetype={table_id} rows=0 or empty schema"
-                )
+                logger.info(f"Append skipped (store): archetype={table_id} rows=0 or empty schema")
                 return AppendReceipt(table_id=table_id, rows=0, durable=True)
         except Exception as e:
             # A frame that cannot materialize cannot be persisted; the caller

--- a/src/archetype/core/aio/async_store.py
+++ b/src/archetype/core/aio/async_store.py
@@ -17,14 +17,15 @@ from logging import getLogger
 from typing import cast
 
 # Technologies
-from daft import DataFrame, Schema, read_iceberg
+import daft
+from daft import DataFrame, Schema, lit, read_iceberg
 from daft.catalog import Table
 from daft.io import IOConfig
 from daft.session import Session
 
 # Internals
 from archetype.core.archetype import Archetype
-from archetype.core.interfaces import ArchetypeSignature, iAsyncStore
+from archetype.core.interfaces import AppendReceipt, ArchetypeSignature, iAsyncStore
 
 # Logger
 logger = getLogger(__name__)
@@ -57,6 +58,9 @@ class AsyncStore(iAsyncStore):
         # This lets query_archetype distinguish an unknown sig (never committed)
         # from an empty-but-known sig (committed with zero active rows).
         self._committed_sigs: set[str] = set()
+        # Memoized presence of v0.2 legacy tables per legacy table id — frozen
+        # history, checked once (see _legacy_df).
+        self._legacy_present: dict[str, bool] = {}
 
     def _ensure_table(self, sig: ArchetypeSignature) -> Table:
         """
@@ -108,13 +112,44 @@ class AsyncStore(iAsyncStore):
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
         active_only: bool = False,
+        commit_tokens: list[str] | None = None,
     ) -> DataFrame:
         """
         Get all archetypes that contain all of the specified component types.
+
+        ``commit_tokens`` is the reader-side visibility allowlist (issue #273):
+        current-generation rows must match a published manifest token. Legacy
+        (v0.2) rows carry no commit identity and are implicitly epoch-0
+        visible — the allowlist never applies to them.
         """
         table: Table = self._ensure_table(sig)
         df: DataFrame = self._read_table(table)  # Cheap, Lazy
+        df = self._filter(
+            df, world_id, run_id, ticks=ticks, entity_ids=entity_ids, active_only=active_only
+        )
+        if commit_tokens is not None:
+            # (Daft stubs Expression.__and__ etc. as bool; these are Expressions.)
+            visible = df["commit_token"].is_in(commit_tokens) if commit_tokens else lit(False)
+            df = df.where(visible)  # ty: ignore[invalid-argument-type]
 
+        legacy_df = self._legacy_df(
+            sig, world_id, run_id, ticks=ticks, entity_ids=entity_ids, active_only=active_only
+        )
+        if legacy_df is not None:
+            df = df.concat(legacy_df)
+
+        return df
+
+    def _filter(
+        self,
+        df: DataFrame,
+        world_id: str,
+        run_id: str,
+        *,
+        ticks: list[int] | None,
+        entity_ids: list[int] | None,
+        active_only: bool,
+    ) -> DataFrame:
         # stored as strings; ensure filter values are strings
         # (Daft stubs type Expression.__eq__ as bool; these are Expressions.)
         df = df.where(df["world_id"] == str(world_id))  # ty: ignore[invalid-argument-type]
@@ -130,6 +165,48 @@ class AsyncStore(iAsyncStore):
             df = df.where(df["entity_id"].is_in(entity_ids))
 
         return df
+
+    def _legacy_df(
+        self,
+        sig: ArchetypeSignature,
+        world_id: str,
+        run_id: str,
+        *,
+        ticks: list[int] | None,
+        entity_ids: list[int] | None,
+        active_only: bool,
+    ) -> DataFrame | None:
+        """Rows persisted by v0.2 under the legacy table id, if any.
+
+        Presence is memoized per signature: legacy tables are frozen history
+        (nothing writes them after #273), so one existence check suffices.
+        Rows are stamped with the epoch-0 identity and aligned to the current
+        schema so callers see one uniform shape.
+        """
+        legacy_name = Archetype.get_legacy_name(sig)
+        known = self._legacy_present.get(legacy_name)
+        if known is None:
+            known = self.session.has_table(legacy_name)
+            self._legacy_present[legacy_name] = known
+        if not known:
+            return None
+
+        table = self.session.get_table(legacy_name)
+        df = self._filter(
+            self._read_table(table),
+            world_id,
+            run_id,
+            ticks=ticks,
+            entity_ids=entity_ids,
+            active_only=active_only,
+        )
+        df = df.with_columns(
+            {
+                "commit_token": lit(""),
+                "writer_epoch": lit(0).cast(daft.DataType.int64()),
+            }
+        )
+        return df.select(*Archetype.get_archetype_schema(sig).names)
 
     # ── Durable-discovery seam (issue #272) ─────────────────────────────────
     # Open-never-create reads by persisted physical table identity, so a cold
@@ -189,32 +266,51 @@ class AsyncStore(iAsyncStore):
         """
         return [sig for key, sig in self._known_sigs.items() if key in self._committed_sigs]
 
-    async def append(self, sig: ArchetypeSignature, df: DataFrame) -> None:
+    async def append(self, sig: ArchetypeSignature, df: DataFrame) -> AppendReceipt:
         """
-        Append a table with a new dataframe.
+        Append a table with a new dataframe. Returns the durable batch receipt.
         """
+        table_id = Archetype.get_name(sig)
         # Defensive: skip zero-row or empty-schema appends to protect backends
         try:
             df.collect()
-            if df.count_rows() == 0 or not df.column_names:
+            rows = df.count_rows()
+            if rows == 0 or not df.column_names:
                 logger.info(
-                    f"Append skipped (store): archetype={Archetype.get_name(sig)} rows=0 or empty schema"
+                    f"Append skipped (store): archetype={table_id} rows=0 or empty schema"
                 )
-                return
+                return AppendReceipt(table_id=table_id, rows=0, durable=True)
         except Exception as e:
             # A frame that cannot materialize cannot be persisted; the caller
             # must see that, not a silent no-op.
-            logger.error(f"Append collect failed for {Archetype.get_name(sig)}: {e}")
+            logger.error(f"Append collect failed for {table_id}: {e}")
             raise
 
         table = self._ensure_table(sig)
         # Record that this sig has been durably committed (not just auto-created
         # by a read).  list_committed_signatures() uses this to give callers a
         # reliable "was this sig ever written?" answer.
-        self._committed_sigs.add(Archetype.get_name(sig))
+        self._committed_sigs.add(table_id)
 
         # Daft's Table.append is synchronous; do not await
         self._append_table(table, df)
+        return AppendReceipt(
+            table_id=table_id, rows=rows, durable=True, backend_ref=self._snapshot_ref(table)
+        )
+
+    @staticmethod
+    def _snapshot_ref(table: Table) -> str | None:
+        """Auxiliary diagnostic only — never the visibility mechanism."""
+        inner = getattr(table, "_inner", None)
+        current = getattr(inner, "current_snapshot", None)
+        try:
+            snapshot = current() if callable(current) else None
+        except Exception:
+            return None
+        return str(snapshot.snapshot_id) if snapshot is not None else None
+
+    async def flush(self) -> None:
+        """No-op: appends write through to Iceberg."""
 
     async def shutdown(self) -> None:
         """

--- a/src/archetype/core/aio/async_updater.py
+++ b/src/archetype/core/aio/async_updater.py
@@ -19,7 +19,12 @@ import daft
 from daft import DataFrame, col, lit
 
 from archetype.core.archetype import Archetype
-from archetype.core.interfaces import ArchetypeSignature, iAsyncStore, iAsyncUpdateManager
+from archetype.core.interfaces import (
+    ArchetypeSignature,
+    CommitContext,
+    iAsyncStore,
+    iAsyncUpdateManager,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +35,13 @@ class AsyncUpdateManager(iAsyncUpdateManager):
         self.validate_flag = validate_flag
 
     async def update(
-        self, df: DataFrame, sig: ArchetypeSignature, tick: int, world_id: str, run_id: str
+        self,
+        df: DataFrame,
+        sig: ArchetypeSignature,
+        tick: int,
+        world_id: str,
+        run_id: str,
+        commit: CommitContext | None = None,
     ) -> DataFrame:
         # A schemaless frame (no columns) cannot be stamped and carries
         # nothing to persist — a legitimate no-op, distinct from a failure.
@@ -45,6 +56,13 @@ class AsyncUpdateManager(iAsyncUpdateManager):
                     "world_id": lit(str(world_id)),
                     "run_id": lit(str(run_id)),
                     "entity_id": col("entity_id").cast(daft.DataType.int32()),
+                    # Commit identity (issue #273). Uncoordinated worlds stamp
+                    # the implicit epoch-0 identity: no manifests exist, so
+                    # every row stays visible — v0.2 semantics, new schema.
+                    "commit_token": lit(commit.commit_token if commit else ""),
+                    "writer_epoch": lit(commit.writer_epoch if commit else 0).cast(
+                        daft.DataType.int64()
+                    ),
                 }
             )
 

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -113,6 +113,7 @@ class AsyncWorld(iAsyncWorld):
         self.commit_coordinator = commit_coordinator
         self._commit_ctx: CommitContext | None = None
         self._updater_takes_commit: bool | None = None
+        self._querier_caps: dict[str, bool] | None = None
 
     @property
     def _entity2sig(self):
@@ -710,34 +711,38 @@ class AsyncWorld(iAsyncWorld):
                 )
 
         async def _query_one(target_world: str, target_run: str, target_ticks: list[int]):
-            # Prefer to pass run_config if the querier supports it (instrumented);
-            # otherwise omit.  Also pass _world_validated=True so that the
-            # querier's own existence check is bypassed — the world-level guard
-            # above has already verified the sig against live + store sigs,
-            # including sigs that are in the spawn cache but not yet committed.
+            # Querier capability is resolved by signature inspection, NOT by
+            # TypeError probing: a retry-on-TypeError fallback that omits
+            # commit_tokens would silently fail OPEN — surfacing rows no
+            # manifest authorized — the exact failure the atomic-visibility
+            # amendment forbids (same reasoning as update()'s commit param).
             tokens = await self._visible_tokens(target_world, target_run, target_ticks)
-            try:
-                return await self.querier.query_archetype(
-                    sig=sig,
-                    world_id=target_world,
-                    run_id=target_run,
-                    ticks=target_ticks,
-                    entity_ids=entity_ids,
-                    components=components,
-                    commit_tokens=tokens,  # ty: ignore[unknown-argument]  # absorbed by **kwargs
-                    run_config=run_config,  # ty: ignore[unknown-argument]  # probed; TypeError-guarded below
-                    _world_validated=True,  # ty: ignore[unknown-argument]  # absorbed by **kwargs
-                )
-            except TypeError:
-                return await self.querier.query_archetype(
-                    sig=sig,
-                    world_id=target_world,
-                    run_id=target_run,
-                    ticks=target_ticks,
-                    entity_ids=entity_ids,
-                    components=components,
-                    _world_validated=True,  # ty: ignore[unknown-argument]  # absorbed by **kwargs
-                )
+            caps = self._querier_query_caps()
+            kwargs: dict[str, Any] = {}
+            if caps["_world_validated"]:
+                # Bypass the querier's own existence check — the world-level
+                # guard above already verified the sig against live + store
+                # sigs, including uncommitted spawn-cache sigs.
+                kwargs["_world_validated"] = True
+            if caps["run_config"] and run_config is not None:
+                kwargs["run_config"] = run_config
+            if tokens is not None:
+                if not caps["commit_tokens"]:
+                    raise RuntimeError(
+                        f"querier {type(self.querier).__name__} does not accept "
+                        "commit_tokens; refusing an unfiltered read of a "
+                        "coordinated world (fail closed)"
+                    )
+                kwargs["commit_tokens"] = tokens
+            return await self.querier.query_archetype(
+                sig=sig,
+                world_id=target_world,
+                run_id=target_run,
+                ticks=target_ticks,
+                entity_ids=entity_ids,
+                components=components,
+                **kwargs,
+            )
 
         requested_ticks = ticks or [self.tick]
         if not self.lineage:
@@ -768,6 +773,22 @@ class AsyncWorld(iAsyncWorld):
             if tick <= up_to_tick:
                 return str(ancestor_world), str(ancestor_run)
         return str(self.world_id), str(own_run_id or self.run_id or "")
+
+    def _querier_query_caps(self) -> dict[str, bool]:
+        """Which optional kwargs this querier's query_archetype accepts.
+
+        Inspected once and memoized. A parameter is accepted if it is named
+        in the signature or the signature takes **kwargs (the core querier
+        absorbs world-internal keys that way).
+        """
+        if self._querier_caps is None:
+            params = inspect.signature(self.querier.query_archetype).parameters
+            var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+            self._querier_caps = {
+                name: var_kw or name in params
+                for name in ("commit_tokens", "run_config", "_world_validated")
+            }
+        return self._querier_caps
 
     async def _visible_tokens(
         self, world_id: str, run_id: str, ticks: list[int] | None

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import inspect
 import json
 from logging import getLogger
 from typing import Any, TypeVar, cast
@@ -42,12 +43,14 @@ from archetype.core.hooks import (
 )
 from archetype.core.interfaces import (
     ArchetypeSignature,
+    CommitContext,
     iAsyncHookBus,
     iAsyncProcessor,
     iAsyncQueryManager,
     iAsyncSystem,
     iAsyncUpdateManager,
     iAsyncWorld,
+    iCommitCoordinator,
     iResourceContainer,
 )
 
@@ -74,6 +77,7 @@ class AsyncWorld(iAsyncWorld):
         spawn_cache: dict[ArchetypeSignature, list[dict[str, Any]]] | None = None,
         despawn_cache: dict[ArchetypeSignature, list[int]] | None = None,
         lineage: list[tuple[str, str, int]] | None = None,
+        commit_coordinator: iCommitCoordinator | None = None,
     ):
         """
         Initialize the fully parallel async world.
@@ -100,6 +104,15 @@ class AsyncWorld(iAsyncWorld):
         # Rows for ticks <= up_to_tick live under that ancestor's run; the
         # store is append-only, so those rows are immutable history.
         self.lineage = list(lineage) if lineage else []
+
+        # Commit identity (issue #273). Coordinated worlds mint a commit
+        # context per tick attempt and publish the tick's manifest LAST;
+        # readers admit only manifest-matched rows. Uncoordinated worlds
+        # (coordinator=None) keep implicit epoch-0 semantics: rows stamp
+        # token ""/epoch 0 and nothing is filtered.
+        self.commit_coordinator = commit_coordinator
+        self._commit_ctx: CommitContext | None = None
+        self._updater_takes_commit: bool | None = None
 
     @property
     def _entity2sig(self):
@@ -170,6 +183,16 @@ class AsyncWorld(iAsyncWorld):
             # so a store failure preserves exactly the uncommitted mutations.
             # The guard above propagated/raised every exception, so each
             # remaining result is a computed DataFrame.
+            #
+            # Coordinated worlds (issue #273) mint one commit context for the
+            # whole tick; every append this tick stamps it. The manifest is
+            # published LAST, after a forced flush — a crash or stale-writer
+            # failure anywhere before publish leaves this tick's rows
+            # unmanifested and therefore invisible to every reader.
+            if self.commit_coordinator is not None:
+                self._commit_ctx = await self.commit_coordinator.begin_tick(
+                    str(self.world_id), str(self.run_id), self.tick
+                )
             frames = cast("list[DataFrame]", results)
             commits = [
                 self._commit_archetype(sig, df, run_config)
@@ -195,6 +218,21 @@ class AsyncWorld(iAsyncWorld):
                 for sig, r in zip(sigs, committed, strict=False)
                 if not isinstance(r, BaseException)
             }
+
+            if self.commit_coordinator is not None and self._commit_ctx is not None:
+                # Visibility must never outrun durability: staged (cached)
+                # rows flush before the head claims them.
+                store = getattr(self.updater, "store", None)
+                if store is not None:
+                    await store.flush()
+                await self.commit_coordinator.publish_tick(
+                    str(self.world_id),
+                    str(self.run_id),
+                    self.tick,
+                    self._commit_ctx,
+                    [Archetype.get_name(sig) for sig in sigs],
+                )
+            self._commit_ctx = None
 
             self.tick += 1
 
@@ -665,6 +703,7 @@ class AsyncWorld(iAsyncWorld):
             # querier's own existence check is bypassed — the world-level guard
             # above has already verified the sig against live + store sigs,
             # including sigs that are in the spawn cache but not yet committed.
+            tokens = await self._visible_tokens(target_world, target_run, target_ticks)
             try:
                 return await self.querier.query_archetype(
                     sig=sig,
@@ -673,6 +712,7 @@ class AsyncWorld(iAsyncWorld):
                     ticks=target_ticks,
                     entity_ids=entity_ids,
                     components=components,
+                    commit_tokens=tokens,  # ty: ignore[unknown-argument]  # absorbed by **kwargs
                     run_config=run_config,  # ty: ignore[unknown-argument]  # probed; TypeError-guarded below
                     _world_validated=True,  # ty: ignore[unknown-argument]  # absorbed by **kwargs
                 )
@@ -717,6 +757,25 @@ class AsyncWorld(iAsyncWorld):
                 return str(ancestor_world), str(ancestor_run)
         return str(self.world_id), str(own_run_id or self.run_id or "")
 
+    async def _visible_tokens(
+        self, world_id: str, run_id: str, ticks: list[int] | None
+    ) -> list[str] | None:
+        """Reader-side commit-token allowlist for one (world, run) segment.
+
+        None means unfiltered: either this world is uncoordinated, or the
+        target segment has no manifests at all (pre-#273 legacy history).
+        An empty list means manifests exist but none cover the requested
+        ticks — nothing current-generation is visible there.
+        """
+        if self.commit_coordinator is None:
+            return None
+        visible = await self.commit_coordinator.visible_tokens(str(world_id), str(run_id), ticks)
+        if visible is None:
+            return None
+        if ticks is None:
+            return sorted(set(visible.values()))
+        return sorted({visible[t] for t in ticks if t in visible})
+
     async def get_components(
         self,
         components: list[type[Component]],
@@ -728,12 +787,22 @@ class AsyncWorld(iAsyncWorld):
         """
         read_tick = max(self.tick - 1, 0)
         source_world, source_run = self._tick_source(read_tick)
+        tokens = await self._visible_tokens(source_world, source_run, [read_tick])
+        if tokens is None:
+            return await self.querier.query_components(
+                components=components,
+                world_id=source_world,
+                run_id=source_run,
+                ticks=[read_tick],
+                entity_ids=entity_ids,
+            )
         return await self.querier.query_components(
             components=components,
             world_id=source_world,
             run_id=source_run,
             ticks=[read_tick],
             entity_ids=entity_ids,
+            commit_tokens=tokens,  # ty: ignore[unknown-argument]  # coordinated queriers accept it
         )
 
     async def execute(self, df: DataFrame, sig: ArchetypeSignature, **input_kwargs) -> DataFrame:
@@ -749,9 +818,26 @@ class AsyncWorld(iAsyncWorld):
         run_config: RunConfig,
         tick: int | None = None,
     ) -> DataFrame:
-        """Update the store with the given archetypes."""
-        df = await self.updater.update(df, sig, tick or self.tick, self.world_id, self.run_id)
-        return df
+        """Update the store with the given archetypes.
+
+        Stamps the tick's commit context when one is active (issue #273).
+        Updater capability is resolved by signature inspection, NOT by
+        TypeError probing — a retry-on-TypeError around a write could
+        double-append rows the first call already persisted.
+        """
+        if self._updater_takes_commit is None:
+            params = inspect.signature(self.updater.update).parameters
+            self._updater_takes_commit = "commit" in params
+        if self._updater_takes_commit:
+            return await self.updater.update(
+                df,
+                sig,
+                tick or self.tick,
+                self.world_id,
+                self.run_id,
+                commit=self._commit_ctx,  # ty: ignore[unknown-argument]  # presence checked above
+            )
+        return await self.updater.update(df, sig, tick or self.tick, self.world_id, self.run_id)
 
     # -------------------------------------------------------------------------
     # Hooks: Typed lifecycle callbacks for observability

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -232,6 +232,15 @@ class AsyncWorld(iAsyncWorld):
                     self._commit_ctx,
                     [Archetype.get_name(sig) for sig in sigs],
                 )
+                # Mutations are consumed only now, after the manifest exists.
+                # A crash or stale-writer failure at ANY earlier point leaves
+                # the caches intact, so the retried tick recomputes and
+                # re-appends under a fresh token — the failed attempt's rows
+                # stay unmanifested and invisible; exactly one attempt per
+                # tick ever becomes visible.
+                for sig in sigs:
+                    self.spawn_cache.pop(sig, None)
+                    self.despawn_cache.pop(sig, None)
             self._commit_ctx = None
 
             self.tick += 1
@@ -278,15 +287,18 @@ class AsyncWorld(iAsyncWorld):
     async def _commit_archetype(
         self, sig: ArchetypeSignature, df: DataFrame, run_config: RunConfig
     ) -> DataFrame:
-        """Append one archetype's computed frame and consume its caches.
+        """Append one archetype's computed frame; consume caches (uncoordinated).
 
         The updater raises on failed persistence, in which case the caches
-        survive for retry."""
+        survive for retry. Coordinated worlds defer cache consumption to
+        after manifest publish (see step): durability alone is not enough
+        once visibility requires the published head."""
         with _obs.span("world.update", sig=Archetype.get_name(sig), tick=self.tick):
             df_mat = await self.update(df, sig, run_config)
 
-        self.spawn_cache.pop(sig, None)
-        self.despawn_cache.pop(sig, None)
+        if self.commit_coordinator is None:
+            self.spawn_cache.pop(sig, None)
+            self.despawn_cache.pop(sig, None)
         return df_mat
 
     # ---------------------------------------------------------------------
@@ -835,7 +847,7 @@ class AsyncWorld(iAsyncWorld):
                 tick or self.tick,
                 self.world_id,
                 self.run_id,
-                commit=self._commit_ctx,  # ty: ignore[unknown-argument]  # presence checked above
+                commit=self._commit_ctx,
             )
         return await self.updater.update(df, sig, tick or self.tick, self.world_id, self.run_id)
 

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -113,7 +113,7 @@ class AsyncWorld(iAsyncWorld):
         self.commit_coordinator = commit_coordinator
         self._commit_ctx: CommitContext | None = None
         self._updater_takes_commit: bool | None = None
-        self._querier_caps: dict[str, bool] | None = None
+        self._querier_caps: dict[str, dict[str, bool]] | None = None
 
     @property
     def _entity2sig(self):
@@ -717,7 +717,7 @@ class AsyncWorld(iAsyncWorld):
             # manifest authorized — the exact failure the atomic-visibility
             # amendment forbids (same reasoning as update()'s commit param).
             tokens = await self._visible_tokens(target_world, target_run, target_ticks)
-            caps = self._querier_query_caps()
+            caps = self._querier_caps_for("query_archetype")
             kwargs: dict[str, Any] = {}
             if caps["_world_validated"]:
                 # Bypass the querier's own existence check — the world-level
@@ -774,21 +774,27 @@ class AsyncWorld(iAsyncWorld):
                 return str(ancestor_world), str(ancestor_run)
         return str(self.world_id), str(own_run_id or self.run_id or "")
 
-    def _querier_query_caps(self) -> dict[str, bool]:
-        """Which optional kwargs this querier's query_archetype accepts.
+    def _querier_caps_for(self, method: str) -> dict[str, bool]:
+        """Which optional kwargs a querier method accepts (memoized per method).
 
-        Inspected once and memoized. A parameter is accepted if it is named
-        in the signature or the signature takes **kwargs (the core querier
-        absorbs world-internal keys that way).
+        A parameter is accepted if it is named in the signature or the
+        signature takes **kwargs (the core querier absorbs world-internal
+        keys that way). Per the iAsyncQueryManager contract, a querier that
+        accepts commit_tokens MUST filter by it — coordinated worlds refuse
+        queriers that cannot accept it at all (fail closed).
         """
         if self._querier_caps is None:
-            params = inspect.signature(self.querier.query_archetype).parameters
+            self._querier_caps = {}
+        caps = self._querier_caps.get(method)
+        if caps is None:
+            params = inspect.signature(getattr(self.querier, method)).parameters
             var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
-            self._querier_caps = {
+            caps = {
                 name: var_kw or name in params
                 for name in ("commit_tokens", "run_config", "_world_validated")
             }
-        return self._querier_caps
+            self._querier_caps[method] = caps
+        return caps
 
     async def _visible_tokens(
         self, world_id: str, run_id: str, ticks: list[int] | None
@@ -821,21 +827,24 @@ class AsyncWorld(iAsyncWorld):
         read_tick = max(self.tick - 1, 0)
         source_world, source_run = self._tick_source(read_tick)
         tokens = await self._visible_tokens(source_world, source_run, [read_tick])
-        if tokens is None:
-            return await self.querier.query_components(
-                components=components,
-                world_id=source_world,
-                run_id=source_run,
-                ticks=[read_tick],
-                entity_ids=entity_ids,
-            )
+        kwargs: dict[str, Any] = {}
+        if tokens is not None:
+            # Same fail-closed guard as query_archetype: a querier that
+            # cannot accept the allowlist must not serve a coordinated read.
+            if not self._querier_caps_for("query_components")["commit_tokens"]:
+                raise RuntimeError(
+                    f"querier {type(self.querier).__name__} does not accept "
+                    "commit_tokens; refusing an unfiltered read of a "
+                    "coordinated world (fail closed)"
+                )
+            kwargs["commit_tokens"] = tokens
         return await self.querier.query_components(
             components=components,
             world_id=source_world,
             run_id=source_run,
             ticks=[read_tick],
             entity_ids=entity_ids,
-            commit_tokens=tokens,  # ty: ignore[unknown-argument]  # coordinated queriers accept it
+            **kwargs,
         )
 
     async def execute(self, df: DataFrame, sig: ArchetypeSignature, **input_kwargs) -> DataFrame:

--- a/src/archetype/core/archetype.py
+++ b/src/archetype/core/archetype.py
@@ -24,13 +24,28 @@ from archetype.core.interfaces import ArchetypeSignature
 class Archetype:
     """Convenience handler for archetype operations"""
 
-    BASE_SCHEMA = pa.schema(
+    # v0.2 base schema. Kept verbatim: legacy tables are named by the hash of
+    # this shape and remain readable as implicit epoch-0 history (issue #273).
+    LEGACY_BASE_SCHEMA = pa.schema(
         [
             pa.field("world_id", pa.string(), nullable=False),
             pa.field("run_id", pa.string(), nullable=False),
             pa.field("entity_id", pa.int32(), nullable=False),
             pa.field("tick", pa.int32(), nullable=False),
             pa.field("is_active", pa.bool_(), nullable=False),
+        ]
+    )
+
+    # Commit identity (issue #273): a tick is visible iff its manifest is
+    # published; rows carry the commit token + writer epoch that name the
+    # attempt. Schema-is-identity means these columns produce NEW table ids
+    # via get_name's schema hash — v0.2 tables never evolve in place.
+    COMMIT_FIELD_NAMES = ("commit_token", "writer_epoch")
+    BASE_SCHEMA = pa.schema(
+        [
+            *LEGACY_BASE_SCHEMA,
+            pa.field("commit_token", pa.string(), nullable=False),
+            pa.field("writer_epoch", pa.int64(), nullable=False),
         ]
     )
     PARTITION_KEYS = ["world_id", "run_id", "tick"]
@@ -60,9 +75,17 @@ class Archetype:
         Projection is type-level — only the schema matters — so this accepts
         component types directly. Instances are accepted for back-compat and
         normalized to their types.
+
+        Commit-identity columns are excluded: they are storage metadata the
+        read layer filters on, not part of the user-facing shape — and legacy
+        epoch-0 tables do not have them, so projections must not ask.
         """
         component_types = tuple({c if isinstance(c, type) else type(c) for c in components})
-        return list(Archetype.get_archetype_schema(component_types).names)
+        return [
+            name
+            for name in Archetype.get_archetype_schema(component_types).names
+            if name not in Archetype.COMMIT_FIELD_NAMES
+        ]
 
     @staticmethod
     def add_components(
@@ -89,16 +112,27 @@ class Archetype:
         Generate a compact, filesystem-safe name for an archetype.
         We avoid extremely long identifiers by using only a short descriptor and
         a schema hash. This ensures stable uniqueness without exceeding path limits.
-        """
-        # Schema hash part: hash of the combined PyArrow schema
-        combined_schema = Archetype.get_archetype_schema(sig)
-        # Convert PyArrow schema to a JSON string for consistent hashing
-        schema_json = str(combined_schema)
-        schema_hash = hashlib.sha256(schema_json.encode()).hexdigest()[:16]  # 16-char suffix
 
-        # Compact descriptor: number of components
-        num_components = len(sig)
-        return f"a_{num_components}c_s{schema_hash}"
+        The hash covers the FULL storage schema, commit columns included —
+        schema-is-identity is what turns the commit-identity amendment into
+        new-generation table ids instead of in-place evolution.
+        """
+        return Archetype._name_for_schema(sig, Archetype.get_archetype_schema(sig))
+
+    @staticmethod
+    def get_legacy_name(sig: ArchetypeSignature) -> str:
+        """The v0.2 table id for a signature (base schema without commit columns).
+
+        Read-only fallback: stores resolve this name when the current-generation
+        table does not exist, so pre-#273 history stays queryable. Nothing ever
+        writes to a legacy table id.
+        """
+        return Archetype._name_for_schema(sig, Archetype.get_legacy_schema(sig))
+
+    @staticmethod
+    def _name_for_schema(sig: ArchetypeSignature, schema: pa.Schema) -> str:
+        schema_hash = hashlib.sha256(str(schema).encode()).hexdigest()[:16]
+        return f"a_{len(sig)}c_s{schema_hash}"
 
     @staticmethod
     def get_archetype_schema(sig: ArchetypeSignature) -> pa.Schema:
@@ -106,6 +140,15 @@ class Archetype:
         Get the schema for an archetype from a list of component types.
         Combines the base archetype schema with prefixed component schemas.
         """
+        return Archetype._schema_from_base(sig, Archetype.BASE_SCHEMA)
+
+    @staticmethod
+    def get_legacy_schema(sig: ArchetypeSignature) -> pa.Schema:
+        """The v0.2 storage schema for a signature (no commit columns)."""
+        return Archetype._schema_from_base(sig, Archetype.LEGACY_BASE_SCHEMA)
+
+    @staticmethod
+    def _schema_from_base(sig: ArchetypeSignature, base: pa.Schema) -> pa.Schema:
         seen: dict[str, type[Component]] = {}
         for component_type in sig:
             prefix = component_type.get_prefix()
@@ -120,7 +163,7 @@ class Archetype:
                 )
             seen[prefix] = component_type
 
-        archetype_schema = Archetype.BASE_SCHEMA
+        archetype_schema = base
         for component_type in sig:
             component_schema = component_type.get_prefixed_schema()
             archetype_schema = pa.unify_schemas([archetype_schema, component_schema])
@@ -150,6 +193,10 @@ class Archetype:
             "entity_id": entity_id,
             "tick": tick,
             "is_active": True,
+            # Placeholders satisfying the non-nullable storage schema; the
+            # updater stamps the real commit identity at append time.
+            "commit_token": "",
+            "writer_epoch": 0,
         }
 
         seen_prefixes: dict[str, type[Component]] = {}

--- a/src/archetype/core/interfaces.py
+++ b/src/archetype/core/interfaces.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 import pyarrow as pa
@@ -330,6 +331,68 @@ class iWorld(Protocol):
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# COMMIT IDENTITY (issue #273, spec amendment approved 2026-07-14)
+# ═══════════════════════════════════════════════════════════════════════════════
+# A tick is visible iff its manifest is published. Rows carry a commit token
+# and writer epoch; readers admit only rows whose token matches the published
+# manifest for that tick, so crashed partial writes and stale-writer appends
+# are invisible by construction. The coordinator lives above core (the control
+# catalog implements it); core defines the protocol and runs uncoordinated —
+# with implicit epoch-0, everything-visible semantics — when none is injected.
+
+
+@dataclass(frozen=True)
+class CommitContext:
+    """Identity of one tick-commit attempt by one fenced writer."""
+
+    commit_token: str
+    writer_epoch: int
+
+
+@dataclass(frozen=True)
+class AppendReceipt:
+    """Durable batch receipt for one append (spec: append returns receipts).
+
+    ``durable`` is False for staged writes (e.g. a caching store's memtable);
+    such rows become durable at flush. ``backend_ref`` is an auxiliary
+    diagnostic (e.g. a Lance version or Iceberg snapshot id) — never the
+    visibility mechanism.
+    """
+
+    table_id: str
+    rows: int | None
+    durable: bool
+    backend_ref: str | None = None
+
+
+class StaleWriterError(RuntimeError):
+    """A writer whose epoch lost the fence attempted to publish; fail closed."""
+
+
+class iCommitCoordinator(Protocol):
+    """Fenced tick-commit protocol (spec §273 amendment).
+
+    begin_tick mints the commit identity for a tick attempt; publish_tick
+    CAS-publishes the manifest LAST, verifying the writer still holds the
+    fence in the same transaction; visible_tokens answers the reader-side
+    allowlist (None: no manifests recorded — legacy world, nothing filtered).
+    """
+
+    async def begin_tick(self, world_id: str, run_id: str, tick: int) -> CommitContext: ...
+    async def publish_tick(
+        self,
+        world_id: str,
+        run_id: str,
+        tick: int,
+        ctx: CommitContext,
+        table_ids: list[str],
+    ) -> None: ...
+    async def visible_tokens(
+        self, world_id: str, run_id: str, ticks: list[int] | None = None
+    ) -> dict[int, str] | None: ...
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # ASYNCHRONOUS INTERFACES
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -367,6 +430,7 @@ class iAsyncStore(Protocol):
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
         active_only: bool = False,
+        commit_tokens: list[str] | None = None,
     ) -> DataFrame: ...
     async def list_signatures(self) -> list[ArchetypeSignature]: ...
     async def list_committed_signatures(self) -> list[ArchetypeSignature]:
@@ -374,7 +438,13 @@ class iAsyncStore(Protocol):
         read tables. Used by the querier's UnknownSignatureError existence check."""
         ...
 
-    async def append(self, sig: ArchetypeSignature, df: DataFrame) -> None: ...
+    async def append(self, sig: ArchetypeSignature, df: DataFrame) -> AppendReceipt: ...
+    async def flush(self) -> None:
+        """Force staged rows durable. No-op for stores that write through;
+        caching stores drain their memtables. A commit coordinator's manifest
+        head must never be published while its tick's rows are staged-only."""
+        ...
+
     async def shutdown(self) -> None: ...
 
     # ── Durable-discovery seam (issue #272, approved 2026-07-14) ──────────
@@ -428,7 +498,13 @@ class iAsyncUpdateManager(Protocol):
     """Async write facade; returns the persisted-shape DataFrame (spec §181)."""
 
     async def update(
-        self, df: DataFrame, sig: ArchetypeSignature, tick: int, world_id: str, run_id: str
+        self,
+        df: DataFrame,
+        sig: ArchetypeSignature,
+        tick: int,
+        world_id: str,
+        run_id: str,
+        commit: CommitContext | None = None,
     ) -> DataFrame: ...
 
 

--- a/src/archetype/core/interfaces.py
+++ b/src/archetype/core/interfaces.py
@@ -468,7 +468,14 @@ class iAsyncStore(Protocol):
 
 
 class iAsyncQueryManager(Protocol):
-    """Async active-state read facade (spec §159–§173)."""
+    """Async active-state read facade (spec §159–§173).
+
+    ``commit_tokens`` (issue #273) is the reader-side visibility allowlist.
+    An implementation that accepts it MUST filter current-generation rows to
+    the allowlisted tokens — accepting and ignoring it silently fails open,
+    which the atomic-visibility amendment forbids. Coordinated worlds refuse
+    queriers whose signatures cannot accept it (fail closed).
+    """
 
     async def get_archetype(
         self, sig: ArchetypeSignature, world_id: str, run_id: str
@@ -481,6 +488,7 @@ class iAsyncQueryManager(Protocol):
         entity_ids: list[int] | None = None,
         components: list[type[Component]] | None = None,
         run_id: str | None = None,
+        commit_tokens: list[str] | None = None,
     ) -> DataFrame: ...
     async def query_components(
         self,
@@ -490,6 +498,7 @@ class iAsyncQueryManager(Protocol):
         *,
         ticks: list[int] | None = None,
         entity_ids: list[int] | None = None,
+        commit_tokens: list[str] | None = None,
     ) -> DataFrame: ...
     async def list_signatures(self) -> list[ArchetypeSignature]: ...
 

--- a/src/archetype/core/sync/updater.py
+++ b/src/archetype/core/sync/updater.py
@@ -45,6 +45,11 @@ class UpdateManager(iUpdateManager):
                 "world_id": lit(str(world_id)),
                 "run_id": lit(str(run_id)),
                 "entity_id": col("entity_id").cast(daft.DataType.uint32()),
+                # The sync stack runs uncoordinated: implicit epoch-0 commit
+                # identity, everything visible (issue #273). The async stack
+                # is the coordinated path.
+                "commit_token": lit(""),
+                "writer_epoch": lit(0).cast(daft.DataType.int64()),
             }
         )
         try:

--- a/tests/aio/test_async_query_updater.py
+++ b/tests/aio/test_async_query_updater.py
@@ -102,7 +102,8 @@ async def test_update_stamps_and_query_filters(store_backend):
         run_id=run_id,
     )
     cols = set(df_proj.collect().column_names)
-    base_cols = set(Archetype.BASE_SCHEMA.names)
+    # Projections exclude commit-identity columns (issue #273).
+    base_cols = set(Archetype.LEGACY_BASE_SCHEMA.names)
     comp_cols = set(Position.get_prefixed_schema().names)
     assert base_cols.issubset(cols)
     assert comp_cols.issubset(cols)

--- a/tests/aio/test_async_world_querying.py
+++ b/tests/aio/test_async_world_querying.py
@@ -86,7 +86,8 @@ async def test_query_archetype_with_filters_and_projection(world):
     cols = set(df_proj.collect().column_names)
     from archetype.core.archetype import Archetype as A
 
-    base_cols = set(A.BASE_SCHEMA.names)
+    # Projections exclude commit-identity columns (issue #273).
+    base_cols = set(A.LEGACY_BASE_SCHEMA.names)
     comp_cols = set(Position.get_prefixed_schema().names)
     assert base_cols.issubset(cols) and comp_cols.issubset(cols)
 

--- a/tests/app/test_atomic_visibility.py
+++ b/tests/app/test_atomic_visibility.py
@@ -312,6 +312,27 @@ async def test_v1_catalog_upgrades_additively(tmp_path):
     await catalog.close()
 
 
+async def test_catalog_failure_fails_reads_closed_not_open(tmp_path, monkeypatch):
+    """A broken control catalog must fail coordinated reads, never widen
+    them: returning 'no allowlist' on error would surface rows from crashed
+    or stale commit attempts that no manifest authorized (Codex P1, #280)."""
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="w"), storage)
+        await _spawn_and_step(c, world)
+        assert len(await _visible_rows(c, world, storage, ticks=[0])) == 1
+
+        async def _broken(self, *args, **kwargs):
+            raise RuntimeError("catalog corrupt")
+
+        monkeypatch.setattr(SqliteControlCatalog, "visible_tokens", _broken)
+        with pytest.raises(RuntimeError, match="catalog corrupt"):
+            await _visible_rows(c, world, storage, ticks=[0])
+    finally:
+        await c.shutdown()
+
+
 async def test_coordinator_epoch_and_manifest_roundtrip(tmp_path):
     catalog = SqliteControlCatalog(tmp_path / "cat.db")
     epoch = await catalog.acquire_fence("w", "h1")

--- a/tests/app/test_atomic_visibility.py
+++ b/tests/app/test_atomic_visibility.py
@@ -1,0 +1,334 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Atomic tick visibility (issue #273, A2).
+
+The contract under test: a tick is visible iff its manifest is published.
+Crashed partial writes, failed publishes, and stale-writer appends leave
+rows on disk but never in a manifest — invisible by construction. Exactly
+one commit attempt per tick ever becomes visible.
+"""
+
+import pytest
+
+from archetype.app._catalog import SqliteControlCatalog
+from archetype.app._commit import CatalogCommitCoordinator
+from archetype.app.container import ServiceContainer
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.interfaces import StaleWriterError
+
+pytestmark = pytest.mark.asyncio
+
+
+class Counter(Component):
+    value: float = 0.0
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+
+
+async def _spawn_and_step(c: ServiceContainer, world, n_steps: int = 1) -> None:
+    await c.mutation_service.create_entity(world.world_id, [Counter(value=1.0)])
+    for _ in range(n_steps):
+        await c.simulation_service.step(world.world_id, RunConfig())
+
+
+async def _visible_rows(c: ServiceContainer, world, storage, ticks=None) -> list[dict]:
+    df = await c.query_service.query_components(
+        [Counter], str(world.world_id), str(world.run_id), storage, ticks=ticks
+    )
+    return df.to_pylist()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P0: crash injection at every boundary
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def test_service_worlds_publish_manifests_per_tick(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="w"), storage)
+        assert world.commit_coordinator is not None, "service worlds are coordinated"
+        await _spawn_and_step(c, world, n_steps=2)
+
+        catalog = c.storage_service.get_control_catalog(storage)
+        manifests = await catalog.list_manifests(str(world.world_id))
+        assert [m.tick for m in manifests] == [0, 1]
+        assert all(m.writer_epoch == 1 for m in manifests)
+        assert (await catalog.get_world(str(world.world_id))).tick_head == 1
+    finally:
+        await c.shutdown()
+
+
+async def test_failed_publish_leaves_tick_invisible_and_retry_wins(tmp_path, monkeypatch):
+    """Crash between appends and head publish: rows exist, tick invisible.
+
+    The retried tick recomputes (caches intact), appends under a fresh
+    token, and publishes — exactly one attempt visible, no lost spawns,
+    no duplicate visible rows.
+    """
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="w"), storage)
+        await c.mutation_service.create_entity(world.world_id, [Counter(value=1.0)])
+
+        real_publish = SqliteControlCatalog.publish_manifest
+
+        async def _crash(self, *args, **kwargs):
+            raise RuntimeError("injected crash before head publish")
+
+        monkeypatch.setattr(SqliteControlCatalog, "publish_manifest", _crash)
+        with pytest.raises(RuntimeError, match="injected crash"):
+            await c.simulation_service.step(world.world_id, RunConfig())
+
+        assert world.tick == 0, "a tick that did not publish did not happen"
+        assert await _visible_rows(c, world, storage) == [], "unmanifested rows must be invisible"
+
+        # Recovery: the same writer retries the tick.
+        monkeypatch.setattr(SqliteControlCatalog, "publish_manifest", real_publish)
+        await c.simulation_service.step(world.world_id, RunConfig())
+
+        rows = await _visible_rows(c, world, storage, ticks=[0])
+        assert len(rows) == 1, (
+            f"exactly one visible row despite two physical attempts, saw {len(rows)}"
+        )
+        assert rows[0]["counter__value"] == 1.0
+    finally:
+        await c.shutdown()
+
+
+async def test_cache_enabled_head_never_claims_ram_only_rows(tmp_path):
+    """With the caching store, flush is forced before publish: after a step,
+    a cold reader over the same storage (fresh container, no memtables)
+    sees every manifested row."""
+    from archetype.core.config import CacheConfig
+
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        cache = CacheConfig(flush_rows=1_000_000, flush_mb=1_000, idle_sec=3600)
+        world = await c.world_service.create_world(WorldConfig(name="w"), storage, cache)
+        await _spawn_and_step(c, world, n_steps=2)
+        wid, rid = str(world.world_id), str(world.run_id)
+    finally:
+        await c.shutdown()
+
+    cold = ServiceContainer()
+    try:
+        df = await cold.query_service.query_components([Counter], wid, rid, storage)
+        rows = df.to_pylist()
+        assert {r["tick"] for r in rows} == {0, 1}, (
+            "every published tick must be durably readable cold"
+        )
+    finally:
+        await cold.shutdown()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P0: fencing and stale writers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def test_second_fence_acquisition_stales_first_writer(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="w"), storage)
+        await _spawn_and_step(c, world)
+
+        # A second writer (e.g. another process resuming this world) takes
+        # the fence. The first writer's next publish must fail closed.
+        catalog = c.storage_service.get_control_catalog(storage)
+        await catalog.acquire_fence(str(world.world_id), "intruder:999")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await c.simulation_service.step(world.world_id, RunConfig())
+        assert "StaleWriter" in type(exc_info.value).__name__ or "not the" in str(exc_info.value)
+        assert world.tick == 1, "stale writer must not advance"
+        rows = await _visible_rows(c, world, storage)
+        assert {r["tick"] for r in rows} == {0}, "stale attempt stays invisible"
+    finally:
+        await c.shutdown()
+
+
+async def test_stale_epoch_rows_at_visible_tick_are_excluded(tmp_path):
+    """A stale writer appending at an ALREADY-VISIBLE tick is excluded by the
+    token allowlist — this is why readers match manifests, not epochs-at-head."""
+    import daft
+    import pyarrow as pa
+
+    from archetype.core.archetype import Archetype
+
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="w"), storage)
+        await _spawn_and_step(c, world)
+        assert len(await _visible_rows(c, world, storage, ticks=[0])) == 1
+
+        # Forge a late, unmanifested append at the visible tick 0.
+        sig = (Counter,)
+        schema = Archetype.get_archetype_schema(sig)
+        store = await c.storage_service.get_or_create_store(storage)
+        forged = {
+            "world_id": str(world.world_id),
+            "run_id": str(world.run_id),
+            "entity_id": 999,
+            "tick": 0,
+            "is_active": True,
+            "commit_token": "stale-attempt",
+            "writer_epoch": 0,
+            "counter__value": 666.0,
+        }
+        await store.append(sig, daft.from_arrow(pa.Table.from_pylist([forged], schema=schema)))
+
+        rows = await _visible_rows(c, world, storage, ticks=[0])
+        assert len(rows) == 1 and rows[0]["counter__value"] == 1.0, (
+            "unmanifested stale-epoch rows at a visible tick must not surface"
+        )
+    finally:
+        await c.shutdown()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P0: receipts, legacy readability, catalog upgrade
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def test_append_returns_durable_receipts(tmp_path):
+    import daft
+    import pyarrow as pa
+
+    from archetype.core.aio import AsyncLancedbStore
+    from archetype.core.archetype import Archetype
+
+    sig = (Counter,)
+    schema = Archetype.get_archetype_schema(sig)
+    row = {
+        "world_id": "w",
+        "run_id": "r",
+        "entity_id": 1,
+        "tick": 0,
+        "is_active": True,
+        "commit_token": "t",
+        "writer_epoch": 1,
+        "counter__value": 2.0,
+    }
+    store = AsyncLancedbStore(uri=str(tmp_path), namespace="ns")
+    try:
+        receipt = await store.append(
+            sig, daft.from_arrow(pa.Table.from_pylist([row], schema=schema))
+        )
+        assert receipt.durable and receipt.rows == 1
+        assert receipt.table_id == Archetype.get_name(sig)
+    finally:
+        await store.shutdown()
+
+
+async def test_legacy_v02_tables_stay_readable(tmp_path):
+    """A table written under the v0.2 schema/name (no commit columns) reads
+    through the same paths as implicit epoch-0 history."""
+    import lancedb
+    import pyarrow as pa
+
+    from archetype.core.aio import AsyncLancedbStore
+    from archetype.core.archetype import Archetype
+
+    sig = (Counter,)
+    legacy_schema = Archetype.get_legacy_schema(sig)
+    legacy_name = Archetype.get_legacy_name(sig)
+    assert legacy_name != Archetype.get_name(sig), "generations must not collide"
+
+    # Write the legacy table the way v0.2 did: directly under the legacy id.
+    db = await lancedb.connect_async(str(tmp_path / "ns" / "lance"))
+    legacy_row = {
+        "world_id": "w",
+        "run_id": "r",
+        "entity_id": 7,
+        "tick": 3,
+        "is_active": True,
+        "counter__value": 9.0,
+    }
+    table = await db.create_table(
+        name=legacy_name,
+        schema=legacy_schema,
+        exist_ok=True,
+    )
+    await table.add(pa.Table.from_pylist([legacy_row], schema=legacy_schema))
+
+    store = AsyncLancedbStore(uri=str(tmp_path), namespace="ns")
+    try:
+        df = await store.get_archetype_df(sig, "w", "r", active_only=True)
+        rows = df.to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["counter__value"] == 9.0
+        assert rows[0]["commit_token"] == "" and rows[0]["writer_epoch"] == 0, (
+            "legacy rows surface as implicit epoch-0"
+        )
+
+        # The allowlist never applies to legacy rows.
+        df = await store.get_archetype_df(
+            sig, "w", "r", active_only=True, commit_tokens=["only-this-token"]
+        )
+        assert len(df.to_pylist()) == 1, "epoch-0 legacy history is always visible"
+    finally:
+        await store.shutdown()
+
+
+async def test_v1_catalog_upgrades_additively(tmp_path):
+    import sqlite3
+
+    path = tmp_path / "cat.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE catalog_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE worlds (
+            world_id TEXT PRIMARY KEY, name TEXT, run_id TEXT,
+            parent_world_id TEXT, status TEXT NOT NULL,
+            tick_head INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE signatures (
+            table_id TEXT PRIMARY KEY, component_names TEXT NOT NULL,
+            schema_json TEXT NOT NULL, fingerprint TEXT NOT NULL
+        );
+        INSERT INTO catalog_meta (key, value) VALUES ('schema_version', '1');
+        INSERT INTO worlds VALUES ('w1', 'alpha', 'r1', NULL, 'active', 5);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    catalog = SqliteControlCatalog(path)
+    record = await catalog.get_world("w1")
+    assert record is not None and record.tick_head == 5, "v1 data survives"
+    epoch = await catalog.acquire_fence("w1", "h")
+    assert epoch == 1, "v2 tables exist after additive upgrade"
+    await catalog.close()
+
+
+async def test_coordinator_epoch_and_manifest_roundtrip(tmp_path):
+    catalog = SqliteControlCatalog(tmp_path / "cat.db")
+    epoch = await catalog.acquire_fence("w", "h1")
+    coordinator = CatalogCommitCoordinator(catalog, epoch=epoch)
+
+    ctx = await coordinator.begin_tick("w", "r", 0)
+    assert ctx.writer_epoch == epoch and ctx.commit_token
+
+    await coordinator.publish_tick("w", "r", 0, ctx, ["t1"])
+    await coordinator.publish_tick("w", "r", 0, ctx, ["t1"])  # idempotent retry
+
+    visible = await coordinator.visible_tokens("w", "r", [0, 1])
+    assert visible == {0: ctx.commit_token}
+
+    # A newer fence stales this coordinator.
+    await catalog.acquire_fence("w", "h2")
+    ctx2 = await coordinator.begin_tick("w", "r", 1)
+    with pytest.raises(StaleWriterError):
+        await coordinator.publish_tick("w", "r", 1, ctx2, ["t1"])
+    await catalog.close()

--- a/tests/app/test_atomic_visibility.py
+++ b/tests/app/test_atomic_visibility.py
@@ -333,6 +333,40 @@ async def test_catalog_failure_fails_reads_closed_not_open(tmp_path, monkeypatch
         await c.shutdown()
 
 
+async def test_querier_without_commit_tokens_support_fails_closed(tmp_path):
+    """A querier whose signature cannot accept the visibility allowlist must
+    refuse coordinated reads — never silently retry unfiltered (footgun
+    finding on #280: the old TypeError fallback dropped commit_tokens)."""
+    from archetype.core.aio import AsyncWorld
+
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="w"), storage)
+        await _spawn_and_step(c, world)
+
+        class NoTokenQuerier:
+            def __init__(self, inner):
+                self._inner = inner
+
+            async def list_signatures(self):
+                return await self._inner.list_signatures()
+
+            async def query_archetype(
+                self, sig, world_id, ticks=None, entity_ids=None, components=None, run_id=None
+            ):
+                raise AssertionError("must not be reached for a coordinated world")
+
+        assert isinstance(world, AsyncWorld)
+        world.querier = NoTokenQuerier(world.querier)
+        world._querier_caps = None  # re-inspect the replaced querier
+
+        with pytest.raises(RuntimeError, match="commit_tokens.*fail closed"):
+            await world.query_archetype((Counter,), ticks=[0])
+    finally:
+        await c.shutdown()
+
+
 async def test_coordinator_epoch_and_manifest_roundtrip(tmp_path):
     catalog = SqliteControlCatalog(tmp_path / "cat.db")
     epoch = await catalog.acquire_fence("w", "h1")

--- a/tests/app/test_atomic_visibility.py
+++ b/tests/app/test_atomic_visibility.py
@@ -357,12 +357,19 @@ async def test_querier_without_commit_tokens_support_fails_closed(tmp_path):
             ):
                 raise AssertionError("must not be reached for a coordinated world")
 
+            async def query_components(
+                self, components, world_id, run_id, *, ticks=None, entity_ids=None
+            ):
+                raise AssertionError("must not be reached for a coordinated world")
+
         assert isinstance(world, AsyncWorld)
         world.querier = NoTokenQuerier(world.querier)
         world._querier_caps = None  # re-inspect the replaced querier
 
         with pytest.raises(RuntimeError, match="commit_tokens.*fail closed"):
             await world.query_archetype((Counter,), ticks=[0])
+        with pytest.raises(RuntimeError, match="commit_tokens.*fail closed"):
+            await world.get_components([Counter])
     finally:
         await c.shutdown()
 

--- a/tests/app/test_durable_discovery.py
+++ b/tests/app/test_durable_discovery.py
@@ -433,6 +433,8 @@ async def test_iceberg_seam_reads_existing_tables_only(tmp_path):
             "entity_id": 1,
             "tick": 0,
             "is_active": True,
+            "commit_token": "",
+            "writer_epoch": 0,
             "score__points": 3.0,
         }
         await writer.append(sig, daft.from_arrow(pa.Table.from_pylist([row], schema=schema)))

--- a/tests/core/test_archetype_core_signatures.py
+++ b/tests/core/test_archetype_core_signatures.py
@@ -40,15 +40,29 @@ def test_add_and_remove_components_are_set_like_and_sorted():
 
 
 def test_base_schema_and_partition_keys_are_stable():
-    """Core base schema and partition keys should remain stable over time (API contract)."""
-    # Names only (types covered elsewhere); keep invariant stable
+    """Core base schema and partition keys should remain stable over time (API contract).
+
+    Amended by issue #273 (approved spec amendment): the storage base schema
+    carries the commit identity; the v0.2 shape is frozen as LEGACY_BASE_SCHEMA
+    and names the read-only legacy tables.
+    """
     assert set(Archetype.BASE_SCHEMA.names) == {
         "world_id",
         "run_id",
         "entity_id",
         "tick",
         "is_active",
+        "commit_token",
+        "writer_epoch",
     }
+    assert set(Archetype.LEGACY_BASE_SCHEMA.names) == {
+        "world_id",
+        "run_id",
+        "entity_id",
+        "tick",
+        "is_active",
+    }
+    assert Archetype.COMMIT_FIELD_NAMES == ("commit_token", "writer_epoch")
     assert Archetype.PARTITION_KEYS == ["world_id", "run_id", "tick"]
 
 

--- a/tests/core/test_async_store_updater_failures.py
+++ b/tests/core/test_async_store_updater_failures.py
@@ -101,6 +101,8 @@ async def test_async_updater_raises_on_store_failure(tmp_path, caplog):
                     "entity_id": 1,
                     "tick": 0,
                     "is_active": True,
+                    "commit_token": "",
+                    "writer_epoch": 0,
                     "demo__v": 1,
                 }
             ],

--- a/tests/storage/test_lancedb_store_core.py
+++ b/tests/storage/test_lancedb_store_core.py
@@ -97,6 +97,8 @@ async def test_lancedb_store_creates_opens_and_appends(monkeypatch, tmp_path):
                 "entity_id": 1,
                 "tick": 0,
                 "is_active": True,
+                "commit_token": "",
+                "writer_epoch": 0,
                 "demo__v": 7,
             }
         ],

--- a/tests/storage/test_lancedb_store_errors.py
+++ b/tests/storage/test_lancedb_store_errors.py
@@ -108,6 +108,8 @@ async def test_lancedb_store_append_failure_raises(monkeypatch, tmp_path):
                 "entity_id": 1,
                 "tick": 0,
                 "is_active": True,
+                "commit_token": "",
+                "writer_epoch": 0,
                 "demo__v": 1,
             }
         ],

--- a/tests/storage/test_lancedb_store_open_and_optimize.py
+++ b/tests/storage/test_lancedb_store_open_and_optimize.py
@@ -92,6 +92,8 @@ async def test_lancedb_open_path_no_create_called(monkeypatch, tmp_path):
                 "entity_id": 1,
                 "tick": 0,
                 "is_active": True,
+                "commit_token": "",
+                "writer_epoch": 0,
                 "demo__v": 5,
             }
         ],

--- a/tests/sync/test_sync_stack_contracts.py
+++ b/tests/sync/test_sync_stack_contracts.py
@@ -235,6 +235,8 @@ def test_sync_update_manager_appends_stamped_rows_to_store():
             "entity_id": 5,
             "tick": 9,
             "is_active": True,
+            "commit_token": "",
+            "writer_epoch": 0,
             "position__x": 7,
             "position__y": 8,
         }
@@ -335,6 +337,8 @@ def test_sync_query_manager_filters_active_ticks_and_entities():
             "entity_id": 2,
             "tick": 1,
             "is_active": True,
+            "commit_token": "",
+            "writer_epoch": 0,
             "position__x": 2,
             "position__y": 2,
             "velocity__vx": 20,
@@ -429,6 +433,8 @@ def test_sync_world_materialize_mutations_prefers_latest_spawn_for_same_entity(t
             "entity_id": 7,
             "tick": 0,
             "is_active": True,
+            "commit_token": "",
+            "writer_epoch": 0,
             "position__x": 9,
             "position__y": 9,
         }
@@ -464,6 +470,8 @@ def test_sync_world_materialize_mutations_marks_despawned_entities_inactive(tmp_
             "entity_id": 4,
             "tick": 0,
             "is_active": False,
+            "commit_token": "",
+            "writer_epoch": 0,
             "position__x": 1,
             "position__y": 2,
         }


### PR DESCRIPTION
Implements the A2 core of #273 per the approved spec amendment: **a tick is visible iff its manifest is published**. Crashed partial writes, failed publishes, and stale-writer appends leave rows on disk but never in a manifest — invisible by construction, with exactly one visible commit attempt per tick.

A1-resume (fenced mutable cold resume + AutoResearch subprocess-resume acceptance) is the follow-up PR, per the plan's slice order; #273 stays open until it lands.

## Mechanism

- **Commit identity columns**: `commit_token` (string) + `writer_epoch` (int64) join `BASE_SCHEMA`. Schema-is-identity does the generational work: table ids hash the full schema, so the new columns yield **new-generation table ids** with zero in-place evolution. v0.2 tables keep their ids (`Archetype.get_legacy_name`/`get_legacy_schema`) and read through a memoized open-never-write fallback as **implicit epoch-0** history, stamped `""`/`0` and aligned to the current shape. The token allowlist never applies to them.
- **Tick commit protocol** (coordinated worlds — everything created through the service layer): compute all → mint one `CommitContext` → append all (stamped) → `flush()` (cached store drains memtables; a head must never claim RAM-only rows) → **publish manifest LAST** via one catalog CAS transaction that verifies the fence epoch, put-if-absent inserts the manifest, and advances the durable tick head → only then consume spawn/despawn caches. Failure anywhere earlier leaves mutations intact; the retried tick re-appends under a fresh token and only the published attempt is ever visible.
- **Writer fencing**: catalog CAS epoch per world, acquired at create/fork. A stale writer fails closed at publish (`StaleWriterError`) inside the same transaction — no fencing window.
- **Reader-side allowlist**: per (world, run) segment — fork lineage segments resolve against their own ancestor's manifests. Three-state semantics: no manifests + no fence → legacy, unfiltered; fence but no manifests → coordinated world whose first commit never published, nothing visible; manifests → rows must match their tick's published token. Matching is across manifest history, not head-epoch comparison, so stale-epoch rows appended late at an already-visible tick never surface.
- **Receipts**: `append()` returns `AppendReceipt` (rows, staged/durable, auxiliary backend ref — Lance version / Iceberg snapshot; never the visibility mechanism). Cached appends return staged receipts.
- **Uncoordinated worlds** (bare core, sync stack) stamp epoch-0 identity and skip manifests entirely — v0.2 behavior preserved, verified by the existing suites.

## Catalog v2

`manifests` + `writer_fence` tables; strictly additive v1→v2 upgrade (older catalogs upgrade in place; newer-than-build fails loudly). `publish_manifest` is the single new per-tick catalog transaction. `record_step` slims to signature registration (+ current run tracking): manifests now own the durable tick head transactionally (`set_tick_head` removed).

## Design notes for review

- **Cache consumption moved after publish** for coordinated worlds. The v0.2 per-append pop would lose spawns when the publish (not the append) fails — caught by the crash-injection test.
- **Updater capability by `inspect.signature`, not TypeError-probing**: a retry-on-TypeError around a *write* can double-append rows the first call already persisted.
- **Component projections exclude commit columns** (`projection_columns`, `query_components`); raw `query_archetype` reads expose them. Keeps user shape stable and legacy/g2 unions uniform.
- **Lineage under commit identity**: the fork's ancestor chain writes as ONE append (atomic on both backends) of epoch-0 metadata rows; the catalog's `parent_world_id` is the authority, so a fork record with missing lineage is detectable corruption. Fenced resume (next PR) must refuse it loudly. No second manifest keyspace.
- **GC/optimize**: visibility is column+manifest based, never backend-version based — compaction and version pruning stay safe. Spec page §7.
- **Per-tick durability cost**: coordinated worlds flush the cached store every tick before publish. That is the amendment's price; CacheConfig still batches within a tick, and uncoordinated bare-core worlds keep full caching semantics.

## Acceptance (P0) → tests

`tests/app/test_atomic_visibility.py` (9 tests): crash injection before publish with exactly-one-visible retry; manifests per tick + transactional tick head; cache-enabled cold read after flush-before-publish; two-writer fence contention (loser stops, stays invisible); stale-epoch rows at an already-visible tick excluded; durable receipts; legacy v0.2 tables readable throughout (including under an active allowlist); v1→v2 catalog upgrade; coordinator epoch/manifest roundtrip incl. idempotent re-publish.

## Verification

Full fast suite: **790 passed** (9 pre-existing tests updated: fixture rows gained the two stamped columns; projection assertions moved to `LEGACY_BASE_SCHEMA` per the projection contract). Gates: ruff/format, lazy-audit (12 sites, two line-shift re-keys, no new materializations), API import boundary, ty (0 diagnostics), spec-contracts 6/6, markdownlint. Examples 01–03 (mutations, fork counterfactual, time travel) run clean under coordination.

Docs: normative `docs/guide/atomic-visibility.md` + spec index/nav + base-columns amendment in the umbrella spec.

Part of #273 · milestone v0.3.0 — durable substrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
