### PR TITLE
ci: ignore unrendered docs templates in link checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -36,4 +36,6 @@ exclude_path = [
     "node_modules",
     ".venv",
     "uv.lock",
+    # Jinja templates contain URLs resolved only by MkDocs at build time.
+    "docs/overrides/templates",
 ]


### PR DESCRIPTION
The documentation link checker was interpreting Jinja expressions in the custom MkDocs templates as local paths. Exclude the template source directory; rendered documentation remains covered by the docs build.

This is a follow-up to #282.