### PR TITLE
feat(app): evaluation receipts — claim-before-grade (C, closes #275)

### DIFF
--- a/docs/guide/command-gate.md
+++ b/docs/guide/command-gate.md
@@ -99,6 +99,7 @@ A `player` does not advance the world — they participate in the world that som
 | `fork_world` | — | — | ✓ | ✓ |
 | `destroy_world` | — | — | ✓ | ✓ |
 | `ingest_fact` | — | — | ✓ | ✓ |
+| `evaluate` | — | — | ✓ | ✓ |
 
 The asymmetry is intentional. `create_world` establishes new platform-level identity → admin-only. `fork_world` and `destroy_world` are operator-territory because operators routinely fork (rollouts) and destroy (cleanup). Forks and destroys never delete persistent data (append-only invariant), so this is safe.
 

--- a/docs/guide/durable-facts.md
+++ b/docs/guide/durable-facts.md
@@ -1,7 +1,7 @@
 # Durable Facts
 
 **Document type:** Normative.
-**Scope:** `IngestionService`, fact claims, exactly-once visibility, asset references. Issue #274 (v0.3.0 slice B). Builds on [Atomic Visibility](atomic-visibility.md).
+**Scope:** `IngestionService`, fact claims, exactly-once visibility, asset references, evaluation receipts. Issues #274 and #275 (v0.3.0 slices B and C). Builds on [Atomic Visibility](atomic-visibility.md).
 
 ## 1. What a fact is
 
@@ -93,3 +93,41 @@ table, digest, and whether this call deduplicated against an existing
 visible fact. Ingestion works against live worlds and cold (catalog-
 recorded) ones; facts land at the world's last visible tick and never
 advance it.
+
+## 7. Evaluation receipts: claim-before-grade
+
+A receipt records that ONE grader ran under ONE pinned contract against ONE
+pinned subject, and what it concluded. Receipts ride the fact machinery —
+same claims, same visibility, same crash recovery — with three identity
+rules on top:
+
++ **The claim precedes the grader.** `evaluate` acquires the claim before
+  any grading runs; a matching COMPLETE claim returns the persisted receipt
+  **without re-grading**. The guarantee is exactly one **visible** durable
+  receipt per `evaluation_id` — never exactly-once grader execution. A
+  lease takeover whose orphan probe finds the appended rows completes
+  without re-running the grader; a takeover that finds none re-runs it at
+  most once.
++ **The subject is pinned, never hashed by content.** Subject identity =
+  the immutable snapshot reference (manifest head tick + commit tokens)
+  plus the canonical selector (components, ticks, entity ids).
+  Materializing a trajectory to hash its rows would break the lazy
+  contract; the snapshot reference makes the receipt recomputable and
+  attributable without it. Asset references inside subjects bind content
+  digests, never path strings.
++ **The contract is versioned or the receipt is refused.** A
+  `GraderContract` (stable grader id, implementation/prompt/model version,
+  config, thresholds, seed) is required; bare callables get no digest and
+  no persisted receipt — `world.grade` remains the ephemeral path. The
+  `evaluation_id` is deliberately distinct from subject + contract:
+  repeated trials of nondeterministic graders are a feature, and each
+  trial is its own id. Same id with a different subject or contract is a
+  loud conflict.
+
+Outcomes are typed — pass, fail, invalid, or inconclusive, with an optional
+finite score — and empty outcome sets fail closed.
+
+**Receipts are evidence, never authority.** A receipt carries no authority
+fields — no accepted, no promote, no approved, no allowed_next_action —
+enforced by the spec-contract eval suite. A PASS means one grader passed
+under one pinned contract; the layer above owns what that means.

--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -87,6 +87,12 @@ SPEC_CASES: tuple[SpecCase, ...] = (
         task_id="spec.info_class_downgrades",
     ),
     SpecCase(
+        spec_id="durable-facts.7",
+        source="durable-facts.md",
+        anchors=("evidence, never authority", "no authority"),
+        task_id="spec.receipt_authority_firewall",
+    ),
+    SpecCase(
         spec_id="audit-log.2",
         source="audit-log.md",
         anchors=("Append-only invariant", "no `drop_*` or `delete_*` methods"),
@@ -169,6 +175,7 @@ _EXPECTED_ROLE_MATRIX: dict[str, frozenset[CommandType]] = {
             CommandType.FORK_WORLD,
             CommandType.DESTROY_WORLD,
             CommandType.INGEST_FACT,
+            CommandType.EVALUATE,
         }
     ),
     "admin": frozenset(CommandType),
@@ -191,6 +198,7 @@ _COMMAND_GATE_MAP: dict[str, CommandType] = {
     "open_world_readonly": CommandType.GET_WORLD_INFO,
     "resume_world": CommandType.CREATE_WORLD,
     "ingest_fact": CommandType.INGEST_FACT,
+    "evaluate": CommandType.EVALUATE,
     "step": CommandType.STEP,
     "run": CommandType.RUN,
     "run_episode": CommandType.RUN_EPISODE,
@@ -581,6 +589,35 @@ def _registered_task_ids() -> list[str]:
     return [task_id for task_id, _, _, _ in harness._tasks]
 
 
+def task_receipt_authority_firewall() -> list[GraderResult]:
+    """Receipt and fact components carry evidence, never authority.
+
+    The non-negotiable boundary (issue #275): no field on a persisted
+    receipt/fact component may name an authority decision. A PASS means one
+    grader passed under one pinned contract — the layer above owns meaning.
+    """
+    from archetype.app.facts import AssetRef, FactMeta
+    from archetype.experiments.receipts import EvalReceipt
+
+    forbidden = {
+        "accepted",
+        "accept",
+        "approved",
+        "approve",
+        "promote",
+        "promoted",
+        "allowed_next_action",
+        "authorized",
+        "authorize",
+        "permitted",
+    }
+    checks = {}
+    for component in (EvalReceipt, FactMeta, AssetRef):
+        fields = {name.lower() for name in component.model_fields}
+        checks[f"{component.__name__}_carries_no_authority"] = not (fields & forbidden)
+    return [state_check(checks, name="receipt_authority_firewall")]
+
+
 def register(harness: EvalHarness) -> None:
     harness.add(
         "spec.manifest_traceability",
@@ -611,6 +648,12 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_append_only_protocols,
         desc="Storage and audit protocols expose no destructive delete/drop methods.",
+    )
+    harness.add(
+        "spec.receipt_authority_firewall",
+        suite=SUITE,
+        fn=task_receipt_authority_firewall,
+        desc="Receipt/fact components carry no authority fields (evidence only).",
     )
     harness.add(
         "spec.info_class_downgrades",

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -97,12 +97,6 @@ method = "to_pylist"
 reason = "Resume-time entity-directory extract (issue #273 A1-resume): the latest visible row per entity — already reduced in Daft to one (entity_id, tick, is_active) row per entity via groupby-max + join — must enter Python control flow to become the entity2sig registry and next_entity_id counter that route all subsequent mutations; imperative world reconstruction at the cold-resume boundary, bounded by live entity count, not a downstream dataframe computation."
 
 [[entries]]
-path = "src/archetype/app/ingestion_service.py"
-line = 136
-method = "to_pylist"
-reason = "Crash-recovery orphan probe (issue #274): a lease takeover must learn whether the presumed-dead claimant already appended this ONE fact (rows filtered to a single commit token, bounded to one fact's rows) so it can complete-without-append instead of duplicating; the append/skip decision is imperative claim-lifecycle control flow, not a dataframe computation."
-
-[[entries]]
 path = "src/archetype/experiments/boundary.py"
 line = 119
 method = "to_pylist"

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -572,6 +572,23 @@ class SqliteControlCatalog:
 
         return await self._run(_acquire)
 
+    async def record_claim_table(self, scope_key: str, table_id: str) -> None:
+        """Record where a claim's rows will land, BEFORE the append.
+
+        Lets lease-takeover recovery probe the exact table for orphan rows
+        by commit token — and complete without re-running the payload
+        builder (for evaluations: without re-grading)."""
+
+        def _record() -> None:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute(
+                    "UPDATE claims SET table_id=? WHERE scope_key=? AND status='PENDING'",
+                    (table_id, scope_key),
+                )
+
+        await self._run(_record)
+
     async def complete_claim(self, scope_key: str, claimant: str, table_id: str) -> None:
         """Publish the fact's visibility and complete the claim — one CAS.
 

--- a/src/archetype/app/auth/permissions.py
+++ b/src/archetype/app/auth/permissions.py
@@ -71,6 +71,7 @@ _OPERATOR_ADDS = frozenset(
         CommandType.FORK_WORLD,
         CommandType.DESTROY_WORLD,
         CommandType.INGEST_FACT,
+        CommandType.EVALUATE,
     }
 )
 

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         IterationResult,
     )
     from archetype.app.broker import CommandBroker
+    from archetype.app.eval_service import EvalService
     from archetype.app.ingestion_service import IngestionService
     from archetype.app.models import (
         EpisodeConfig,
@@ -96,6 +97,7 @@ class CommandService:
         audit: AuditLog | None = None,
         autoresearch: AutoResearchService | None = None,
         ingestion: IngestionService | None = None,
+        evals: EvalService | None = None,
     ) -> None:
         self._mutations = mutations
         self._worlds = worlds
@@ -105,6 +107,7 @@ class CommandService:
         self._audit = audit
         self._autoresearch = autoresearch
         self._ingestion = ingestion
+        self._evals = evals
 
     def _gate(self, cmd: Command, ctx: ActorCtx) -> None:
         """RBAC + quota check. Raises GuardrailError if denied."""
@@ -399,6 +402,128 @@ class CommandService:
             storage_config=storage_config,
         )
         await self._emit(ctx, "ingest_fact", world_id)
+        return receipt
+
+    @instrument("gate.evaluate")
+    async def evaluate(
+        self,
+        ctx: ActorCtx,
+        world_id: str | UUID,
+        components: list[type[Component]],
+        *,
+        contract,
+        grader,
+        evaluation_id: str,
+        producer: str = "evals",
+        storage_config: StorageConfig | None = None,
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+    ):
+        """Claim-before-grade (issue #275): one visible receipt per evaluation_id.
+
+        The claim is acquired BEFORE the grader runs; a matching COMPLETE
+        claim returns the persisted receipt without re-grading. The subject
+        is pinned by snapshot reference (manifest head + tokens) + canonical
+        selector — never row-content hashing. A versioned GraderContract is
+        required: bare callables get no digest. The receipt is evidence,
+        never authority.
+
+        Composition lives here by design: EvalService stays QueryService-
+        only, IngestionService never grades — the gate wires them together.
+        """
+        import time as _time
+
+        from pydantic_core import to_jsonable_python as _to_jsonable
+
+        from archetype.experiments.receipts import (
+            EvalReceipt,
+            GraderContract,
+            Outcome,
+            evaluation_identity_digest,
+            subject_digest,
+        )
+
+        self._gate(Command(type=CommandType.EVALUATE), ctx)
+        if self._ingestion is None or self._evals is None:
+            raise RuntimeError("evaluation requires the ingestion and eval services wired")
+        ingestion, evals = self._ingestion, self._evals
+        if not isinstance(contract, GraderContract):
+            raise ValueError(
+                "persisted receipts require a GraderContract descriptor — bare "
+                "callables get no digest (use world.grade for ephemeral scoring)"
+            )
+
+        wid = str(world_id)
+        run_id, snap_tick, snap_tokens, effective = await ingestion.snapshot_ref(
+            wid, storage_config
+        )
+        subject = subject_digest(
+            wid,
+            run_id,
+            snapshot_tick=snap_tick,
+            snapshot_tokens=snap_tokens,
+            component_names=[c.__name__ for c in components],
+            ticks=ticks,
+            entity_ids=entity_ids,
+        )
+        contract_digest = contract.digest()
+        identity = evaluation_identity_digest(subject, contract_digest)
+
+        async def _grade_and_build(_claim) -> list:
+            df = await self._queries.query_components(
+                components,
+                wid,
+                run_id,
+                effective,
+                ticks=ticks,
+                entity_ids=entity_ids,
+            )
+            outputs = await evals.run_graders(df, [grader])
+            typed = [o for o in outputs if isinstance(o, Outcome)]
+            if len(typed) != len(outputs):
+                raise ValueError(
+                    "persisted receipts require typed Outcome results "
+                    "(pass/fail/invalid/inconclusive + optional finite score)"
+                )
+            if len(typed) != 1:
+                raise ValueError(
+                    "a persisted evaluation is one trial: the grader must return "
+                    "exactly one Outcome (run more trials under new evaluation_ids)"
+                )
+            outcome = typed[0]
+            return [
+                EvalReceipt(
+                    evaluation_id=evaluation_id,
+                    subject_digest=subject,
+                    contract_digest=contract_digest,
+                    grader_id=contract.grader_id,
+                    outcome=outcome.status,
+                    score=outcome.score,
+                    graded_at_ms=int(_time.time() * 1000),
+                    evidence_json=json.dumps(_to_jsonable(outcome.evidence)),
+                )
+            ]
+
+        receipt = await ingestion.ingest_evaluated(
+            wid,
+            evaluation_id=evaluation_id,
+            producer=producer,
+            identity_digest=identity,
+            build_components=_grade_and_build,
+            storage_config=storage_config,
+        )
+        await self._emit(
+            ctx,
+            "evaluate",
+            world_id,
+            payload_json=json.dumps(
+                {
+                    "evaluation_id": evaluation_id,
+                    "duplicate": receipt.duplicate,
+                    "grader_id": contract.grader_id,
+                }
+            ),
+        )
         return receipt
 
     @instrument("gate.resume_world")

--- a/src/archetype/app/container.py
+++ b/src/archetype/app/container.py
@@ -79,6 +79,7 @@ class ServiceContainer:
             broker=self.broker,
             audit=self.audit_log,
             ingestion=self.ingestion_service,
+            evals=self.eval_service,
             autoresearch=self.autoresearch_service,
         )
         self.simulation_service.set_command_drain(self.command_service.drain_and_apply)

--- a/src/archetype/app/ingestion_service.py
+++ b/src/archetype/app/ingestion_service.py
@@ -75,10 +75,67 @@ class IngestionService:
         in the catalog). Concurrent identical submissions converge: one
         caller appends, the rest receive the original receipt.
         """
-        if not external_id.strip():
-            raise ValueError("external_id must be a non-empty producer-scoped identity")
         if not components:
             raise ValueError("a fact needs at least one component")
+
+        async def _ready(_claim: ClaimRecord) -> list[Component]:
+            return components
+
+        return await self._ingest(
+            world_id,
+            external_id=external_id,
+            producer=producer,
+            payload_digest=fact_payload_digest(components),
+            build_components=_ready,
+            storage_config=storage_config,
+            lease_seconds=lease_seconds,
+        )
+
+    async def ingest_evaluated(
+        self,
+        world_id: str,
+        *,
+        evaluation_id: str,
+        producer: str,
+        identity_digest: str,
+        build_components,
+        storage_config: StorageConfig | None = None,
+        lease_seconds: float = 30.0,
+    ) -> FactReceipt:
+        """Claim-BEFORE-grade (issue #275): the payload is built only after
+        this claimant owns the claim.
+
+        ``identity_digest`` names what the evaluation is OF (subject +
+        contract), never the graded outcome — trials of nondeterministic
+        graders share it while concluding differently. ``build_components``
+        (the grader, composed by the gate layer) runs at most once per
+        completed claim: a duplicate returns the persisted receipt without
+        re-grading, and a lease takeover that finds the orphan rows
+        completes without re-running.
+        """
+        return await self._ingest(
+            world_id,
+            external_id=evaluation_id,
+            producer=producer,
+            payload_digest=identity_digest,
+            build_components=build_components,
+            storage_config=storage_config,
+            lease_seconds=lease_seconds,
+        )
+
+    async def _ingest(
+        self,
+        world_id: str,
+        *,
+        external_id: str,
+        producer: str,
+        payload_digest: str,
+        build_components,
+        storage_config: StorageConfig | None,
+        lease_seconds: float,
+    ) -> FactReceipt:
+        if not external_id.strip():
+            raise ValueError("external_id must be a non-empty producer-scoped identity")
 
         wid = str(world_id)
         effective = self._resolve_storage(wid, storage_config)
@@ -90,7 +147,6 @@ class IngestionService:
         if not run_id:
             raise RuntimeError(f"world {wid} has no recorded run; nothing to attach facts to")
 
-        digest = fact_payload_digest(components)
         claimant = f"{socket.gethostname()}:{os.getpid()}:{uuid7().hex[:8]}"
         deadline = time.monotonic() + max(lease_seconds, 1.0) * 2
 
@@ -101,7 +157,7 @@ class IngestionService:
                     run_id=str(run_id),
                     producer=producer,
                     external_id=external_id,
-                    payload_digest=digest,
+                    payload_digest=payload_digest,
                     claimant=claimant,
                     tick=record.tick_head,
                     lease_seconds=lease_seconds,
@@ -122,21 +178,37 @@ class IngestionService:
             return self._receipt(claim, duplicate=True)
 
         store = await self._storage_service.get_or_create_store(effective, None)
-        sig = tuple(sorted({*(type(c) for c in components), FactMeta}, key=lambda t: t.__name__))
-        table_id = Archetype.get_name(sig)
 
-        appended = False
-        if outcome == "recovered":
+        if outcome == "recovered" and claim.table_id:
             # Crash recovery: the original claimant may have appended before
             # dying. The claim's token finds the orphan ON the data plane —
-            # complete without re-appending, never duplicate.
-            existing = await store.get_archetype_df(
-                sig, wid, str(run_id), commit_tokens=[claim.commit_token]
-            )
-            appended = bool(existing.to_pylist())
+            # complete without re-appending (and without re-grading), never
+            # duplicate. table_id on the claim names where to look; absent
+            # table_id (or a recorded table that was never materialized)
+            # means the crash preceded any append.
+            try:
+                existing = await store.get_existing_table_df(claim.table_id, wid, str(run_id))
+                orphaned = existing.where(
+                    existing["commit_token"]  # ty: ignore[invalid-argument-type]
+                    == claim.commit_token
+                )
+                found = orphaned.count_rows() > 0
+            except KeyError:
+                found = False
+            if found:
+                await store.flush()
+                await catalog.complete_claim(claim.scope_key, claimant, claim.table_id)
+                settled = await catalog.get_claim(claim.scope_key)
+                return self._receipt(settled if settled is not None else claim, duplicate=False)
 
-        if not appended:
-            await self._append_fact(store, sig, claim, components, wid, str(run_id))
+        components = await build_components(claim)
+        if not components:
+            raise ValueError("a fact needs at least one component")
+        sig = tuple(sorted({*(type(c) for c in components), FactMeta}, key=lambda t: t.__name__))
+        table_id = Archetype.get_name(sig)
+        await catalog.record_claim_table(claim.scope_key, table_id)
+
+        await self._append_fact(store, sig, claim, components, wid, str(run_id))
 
         # Facts are discoverable like everything else.
         schema = Archetype.get_archetype_schema(sig)
@@ -154,6 +226,38 @@ class IngestionService:
         await catalog.complete_claim(claim.scope_key, claimant, table_id)
         settled = await catalog.get_claim(claim.scope_key)
         return self._receipt(settled if settled is not None else claim, duplicate=False)
+
+    async def snapshot_ref(
+        self, world_id: str, storage_config: StorageConfig | None = None
+    ) -> tuple[str, int, list[str], StorageConfig]:
+        """The world's pinned snapshot reference: (run_id, head tick, tokens
+        at that tick, effective storage).
+
+        Persisted receipts require a pinned subject (issue #275); a world
+        with no published visibility has nothing immutable to pin — fail
+        closed rather than hash a moving target.
+        """
+        wid = str(world_id)
+        effective = self._resolve_storage(wid, storage_config)
+        catalog = self._storage_service.get_control_catalog(effective)
+        record = await catalog.get_world(wid)
+        if record is None:
+            raise KeyError(f"world {wid} is not recorded in catalog for {effective.uri}")
+        if not record.run_id:
+            raise RuntimeError(f"world {wid} has no recorded run; nothing to pin")
+        # Manifests ONLY: the subject is the simulation snapshot. Fact and
+        # receipt tokens are evidence ATTACHED to that snapshot — including
+        # them would let every completed receipt perturb the identity of the
+        # subject it was graded against.
+        manifests = await catalog.list_manifests(wid, str(record.run_id))
+        if not manifests:
+            raise RuntimeError(
+                f"world {wid} has no published visibility to pin a subject against "
+                "(step it at least once before evaluating)"
+            )
+        head = max(m.tick for m in manifests)
+        tokens = sorted(m.commit_token for m in manifests if m.tick == head)
+        return str(record.run_id), head, tokens, effective
 
     # ── internals ────────────────────────────────────────────────────────────
 

--- a/src/archetype/app/models.py
+++ b/src/archetype/app/models.py
@@ -40,6 +40,7 @@ class CommandType(StrEnum):
 
     # Entity-level commands
     INGEST_FACT = "ingest_fact"  # Durable external fact, exactly-once-visible
+    EVALUATE = "evaluate"  # Claim-before-grade: one visible receipt per evaluation_id
     SPAWN = "spawn"
     DESPAWN = "despawn"
     UPDATE = "update"

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -48,6 +48,18 @@ class QueryService:
         self._storage_service = storage_service
         self._audit = audit
 
+    async def _querier_for(self, storage_config: StorageConfig | None):
+        """Resolve (config, store, querier) for one call.
+
+        The store is per-call state — every method takes a storage_config so
+        any historical location is reachable — and the pool inside
+        StorageService makes repeated resolution a dict lookup. The querier
+        is a stateless facade; constructing one per call is deliberate.
+        """
+        effective = storage_config or StorageConfig()
+        store = await self._storage_service.get_or_create_store(effective, None)
+        return effective, store, AsyncQueryManager(store=store)
+
     async def query_archetype(
         self,
         sig: ArchetypeSignature,
@@ -70,9 +82,7 @@ class QueryService:
         When `lineage` is provided (a fork's ancestor segments), pre-fork
         ticks are read from the owning ancestor's run and unioned in.
         """
-        effective_config = storage_config or StorageConfig()
-        store = await self._storage_service.get_or_create_store(effective_config)
-        querier = AsyncQueryManager(store=store)
+        effective_config, _store, querier = await self._querier_for(storage_config)
 
         async def _segment(seg_world: str, seg_run: str, seg_ticks: list[int] | None):
             tokens = await self._visible_tokens(effective_config, seg_world, seg_run, seg_ticks)
@@ -108,9 +118,7 @@ class QueryService:
         When `lineage` is provided (a fork's ancestor segments), pre-fork
         ticks are read from the owning ancestor's run and unioned in.
         """
-        effective_config = storage_config or StorageConfig()
-        store = await self._storage_service.get_or_create_store(effective_config, None)
-        querier = AsyncQueryManager(store=store)
+        effective_config, store, querier = await self._querier_for(storage_config)
         catalog_records = await self._catalog_candidates(effective_config, components)
 
         async def _read(seg_world: str, seg_run: str, seg_ticks: list[int] | None):
@@ -289,7 +297,7 @@ class QueryService:
         Lineage rows are append-only, so this works for destroyed worlds.
         Returns None for root worlds (nothing was recorded at fork time).
         """
-        store = await self._storage_service.get_or_create_store(storage_config or StorageConfig())
+        _config, store, _querier = await self._querier_for(storage_config)
         return await load_lineage(store, world_id=world_id, run_id=run_id)
 
     async def list_signatures(
@@ -297,8 +305,7 @@ class QueryService:
         storage_config: StorageConfig | None = None,
     ) -> list[ArchetypeSignature]:
         """List all archetype signatures in a store."""
-        store = await self._storage_service.get_or_create_store(storage_config or StorageConfig())
-        querier = AsyncQueryManager(store=store)
+        _config, _store, querier = await self._querier_for(storage_config)
         return await querier.list_signatures()
 
     async def get_command_history(

--- a/src/archetype/experiments/receipts.py
+++ b/src/archetype/experiments/receipts.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluation receipts (issue #275): identity envelopes and the receipt row.
+
+A receipt records that ONE grader ran under ONE pinned contract against ONE
+pinned subject snapshot, and what it concluded. Receipts carry no authority:
+no accepted/promote/approved/allowed_next_action fields, ever — a PASS means
+one grader passed under one contract, nothing more. The layer above decides
+what that means.
+
+Identity is three digests:
+
+- subject: the immutable snapshot reference (manifest head + tokens) plus
+  the canonical selector. Never row-content hashing — materializing a
+  10k-entity x 600-tick trajectory to hash it would break the lazy contract.
+- contract: the versioned grader descriptor. Bare callables get no digest;
+  persisted receipts REQUIRE a contract.
+- evaluation_id: caller-supplied trial identity, deliberately DISTINCT from
+  subject+contract — repeated trials of nondeterministic graders are a
+  feature, not a replay bug.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+
+from pydantic_core import to_jsonable_python
+
+from archetype.core.component import Component
+
+_RECEIPT_DIGEST_DOMAIN = "archetype.receipt.v1"
+
+OUTCOME_STATUSES = frozenset({"pass", "fail", "invalid", "inconclusive"})
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """A typed grading conclusion. Persisted receipts accept nothing looser.
+
+    ``status`` must be one of pass/fail/invalid/inconclusive; ``score`` is
+    optional but must be finite when present. Constructed by grader code —
+    validation is explicit because the values feed durable evidence.
+    """
+
+    status: str
+    score: float | None = None
+    evidence: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.status not in OUTCOME_STATUSES:
+            raise ValueError(
+                f"outcome status {self.status!r} is not one of {sorted(OUTCOME_STATUSES)}"
+            )
+        if self.score is not None and not math.isfinite(self.score):
+            raise ValueError("outcome score must be finite when present")
+
+
+@dataclass(frozen=True)
+class GraderContract:
+    """Versioned grader identity. Required for every persisted receipt.
+
+    A dataclass (not pydantic) by the repo's boundary rule variant for
+    configs that participate in digest identity: no coercion, explicit
+    validation, canonical JSON digest. Two receipts are comparable only
+    when their contract digests match.
+    """
+
+    grader_id: str
+    implementation_version: str
+    config: dict = field(default_factory=dict)
+    thresholds: dict = field(default_factory=dict)
+    seed: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.grader_id.strip():
+            raise ValueError("grader_id must be a non-empty stable identity")
+        if not self.implementation_version.strip():
+            raise ValueError(
+                "implementation_version must name the grader implementation "
+                "(code version, prompt hash, or model id)"
+            )
+
+    def digest(self) -> str:
+        payload = json.dumps(
+            {
+                "domain": _RECEIPT_DIGEST_DOMAIN,
+                "kind": "grader-contract",
+                "grader_id": self.grader_id,
+                "implementation_version": self.implementation_version,
+                "config": to_jsonable_python(self.config),
+                "thresholds": to_jsonable_python(self.thresholds),
+                "seed": self.seed,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def subject_digest(
+    world_id: str,
+    run_id: str,
+    *,
+    snapshot_tick: int,
+    snapshot_tokens: list[str],
+    component_names: list[str],
+    ticks: list[int] | None = None,
+    entity_ids: list[int] | None = None,
+) -> str:
+    """The pinned-subject identity: snapshot reference + canonical selector.
+
+    The snapshot reference is the manifest head (tick + its commit tokens)
+    from the control catalog — immutable by the atomic-visibility contract.
+    The selector is what was asked of that snapshot. Together they make a
+    receipt recomputable and attributable without hashing row content.
+    """
+    payload = json.dumps(
+        {
+            "domain": _RECEIPT_DIGEST_DOMAIN,
+            "kind": "subject",
+            "world_id": str(world_id),
+            "run_id": str(run_id),
+            "snapshot": {"tick": snapshot_tick, "tokens": sorted(snapshot_tokens)},
+            "selector": {
+                "components": sorted(component_names),
+                "ticks": sorted(int(t) for t in ticks) if ticks is not None else None,
+                "entity_ids": sorted(int(e) for e in entity_ids)
+                if entity_ids is not None
+                else None,
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def evaluation_identity_digest(subject: str, contract: str) -> str:
+    """The claim's payload digest: what this evaluation is OF.
+
+    Deliberately excludes the graded outcome — two trials of a
+    nondeterministic grader share subject+contract while concluding
+    differently. Same evaluation_id + different identity digest is a loud
+    conflict; same identity under a new evaluation_id is a fresh trial.
+    """
+    payload = json.dumps(
+        {
+            "domain": _RECEIPT_DIGEST_DOMAIN,
+            "kind": "evaluation-identity",
+            "subject": subject,
+            "contract": contract,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class EvalReceipt(Component):
+    """The persisted receipt row: evidence, never authority.
+
+    Non-processable by construction — receipts persist through the durable
+    fact path (issue #274), so they live in the negative id band, never join
+    active simulation, and never re-append per tick.
+    """
+
+    evaluation_id: str = ""
+    subject_digest: str = ""
+    contract_digest: str = ""
+    grader_id: str = ""
+    outcome: str = ""
+    score: float | None = None
+    graded_at_ms: int = 0
+    evidence_json: str = "{}"

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -435,6 +435,39 @@ class RuntimeWorld:
         df = await self.query(*component_types, entity_ids=entity_ids)
         return await self._state.runtime._container.eval_service.run_graders(df, graders)
 
+    async def evaluate(
+        self,
+        *component_types: type[Component],
+        contract,
+        grader: TrajectoryGrader,
+        evaluation_id: str,
+        producer: str = "evals",
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+    ):
+        """Claim-before-grade (issue #275): one visible receipt per evaluation_id.
+
+        Unlike ``grade`` (ephemeral scores), this persists a durable
+        EvalReceipt pinned to the world's current snapshot and a versioned
+        GraderContract. Replaying the same evaluation_id returns the
+        original receipt without re-grading; new trials of nondeterministic
+        graders use new evaluation_ids. Receipts are evidence, never
+        authority.
+        """
+        async with self._state.op_lock:
+            wid = await self._ensure_id()
+            return await self._gate.evaluate(
+                self._ctx,
+                wid,
+                list(component_types),
+                contract=contract,
+                grader=grader,
+                evaluation_id=evaluation_id,
+                producer=producer,
+                ticks=ticks,
+                entity_ids=entity_ids,
+            )
+
     # ── Lifecycle ─────────────────────────────────────────────────────────
 
     async def info(self) -> WorldInfo:
@@ -702,6 +735,29 @@ class SyncRuntimeWorld:
     ) -> list[GraderOutput]:
         return self._run(
             lambda: self._world.grade(*component_types, graders=graders, entity_ids=entity_ids)
+        )
+
+    def evaluate(
+        self,
+        *component_types: type[Component],
+        contract,
+        grader: TrajectoryGrader,
+        evaluation_id: str,
+        producer: str = "evals",
+        ticks: list[int] | None = None,
+        entity_ids: list[int] | None = None,
+    ):
+        """See RuntimeWorld.evaluate (claim-before-grade receipts)."""
+        return self._run(
+            lambda: self._world.evaluate(
+                *component_types,
+                contract=contract,
+                grader=grader,
+                evaluation_id=evaluation_id,
+                producer=producer,
+                ticks=ticks,
+                entity_ids=entity_ids,
+            )
         )
 
     def info(self) -> WorldInfo:

--- a/tests/app/test_eval_receipts.py
+++ b/tests/app/test_eval_receipts.py
@@ -1,0 +1,378 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluation receipts (issue #275, C): claim-before-grade.
+
+Exactly one VISIBLE durable receipt per evaluation_id — never exactly-once
+grader execution. The claim precedes the grader; replay returns the
+persisted receipt without re-grading; the subject is pinned by snapshot
+reference, never row-content hashing; receipts are evidence, never
+authority.
+"""
+
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+from uuid_utils import uuid7
+
+from archetype.app._catalog import ClaimConflictError, SqliteControlCatalog, claim_scope_key
+from archetype.app.auth.models import ActorCtx
+from archetype.app.container import ServiceContainer
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.experiments.receipts import (
+    EvalReceipt,
+    GraderContract,
+    Outcome,
+    subject_digest,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class Telemetry(Component):
+    reading: float = 0.0
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+
+
+def _ctx(role: str = "operator") -> ActorCtx:
+    return ActorCtx(id=uuid7(), roles={role})
+
+
+def _contract(**overrides) -> GraderContract:
+    base = dict(
+        grader_id="mean-reading-v1",
+        implementation_version="2026.07.15",
+        thresholds={"min": 0.5},
+    )
+    base.update(overrides)
+    return GraderContract(**base)
+
+
+async def _seeded_world(c: ServiceContainer, storage):
+    world = await c.world_service.create_world(WorldConfig(name="w"), storage)
+    await c.mutation_service.create_entity(world.world_id, [Telemetry(reading=0.8)])
+    await c.simulation_service.step(world.world_id, RunConfig())
+    return world
+
+
+def _counting_grader(calls: list[int], outcome: Outcome):
+    def grader(df):
+        calls.append(1)
+        rows = df.to_pylist()
+        assert rows, "the pinned subject must have rows"
+        return outcome
+
+    return grader
+
+
+async def test_replay_returns_original_receipt_without_regrading(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await _seeded_world(c, storage)
+        calls: list[int] = []
+        grader = _counting_grader(calls, Outcome(status="pass", score=0.8))
+
+        first = await c.command_service.evaluate(
+            _ctx(),
+            world.world_id,
+            [Telemetry],
+            contract=_contract(),
+            grader=grader,
+            evaluation_id="trial-1",
+        )
+        assert not first.duplicate and len(calls) == 1
+
+        replay = await c.command_service.evaluate(
+            _ctx(),
+            world.world_id,
+            [Telemetry],
+            contract=_contract(),
+            grader=grader,
+            evaluation_id="trial-1",
+        )
+        assert replay.duplicate and replay.commit_token == first.commit_token
+        assert len(calls) == 1, "replay must not re-run the grader"
+
+        # The persisted receipt row is queryable evidence.
+        df = await c.query_service.query_components(
+            [EvalReceipt], str(world.world_id), str(world.run_id), storage
+        )
+        rows = df.to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["evalreceipt__outcome"] == "pass"
+        assert rows[0]["evalreceipt__evaluation_id"] == "trial-1"
+    finally:
+        await c.shutdown()
+
+
+async def test_new_trials_of_nondeterministic_graders_are_new_receipts(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await _seeded_world(c, storage)
+        calls: list[int] = []
+
+        for i, status in enumerate(("pass", "fail")):
+            receipt = await c.command_service.evaluate(
+                _ctx(),
+                world.world_id,
+                [Telemetry],
+                contract=_contract(),
+                grader=_counting_grader(calls, Outcome(status=status)),
+                evaluation_id=f"trial-{i}",
+            )
+            assert not receipt.duplicate
+        assert len(calls) == 2, "each trial grades once — trials are a feature"
+
+        df = await c.query_service.query_components(
+            [EvalReceipt], str(world.world_id), str(world.run_id), storage
+        )
+        outcomes = sorted(r["evalreceipt__outcome"] for r in df.to_pylist())
+        assert outcomes == ["fail", "pass"], "both trials visible, distinct ids"
+    finally:
+        await c.shutdown()
+
+
+async def test_same_id_different_contract_conflicts_loudly(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await _seeded_world(c, storage)
+        grader = _counting_grader([], Outcome(status="pass"))
+
+        await c.command_service.evaluate(
+            _ctx(),
+            world.world_id,
+            [Telemetry],
+            contract=_contract(),
+            grader=grader,
+            evaluation_id="trial-x",
+        )
+        with pytest.raises(ClaimConflictError):
+            await c.command_service.evaluate(
+                _ctx(),
+                world.world_id,
+                [Telemetry],
+                contract=_contract(implementation_version="2026.08.01"),
+                grader=grader,
+                evaluation_id="trial-x",
+            )
+    finally:
+        await c.shutdown()
+
+
+async def test_crash_after_grade_before_persist_reruns_at_most_once(tmp_path, monkeypatch):
+    """Crash between complete-side steps: takeover finds the orphan by token
+    and completes WITHOUT re-grading (the claim-before-grade payoff)."""
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await _seeded_world(c, storage)
+        wid = str(world.world_id)
+        calls: list[int] = []
+        grader = _counting_grader(calls, Outcome(status="pass", score=1.0))
+
+        real_complete = SqliteControlCatalog.complete_claim
+
+        async def _crash(self, *args, **kwargs):
+            raise RuntimeError("injected crash after grade+append, before complete")
+
+        monkeypatch.setattr(SqliteControlCatalog, "complete_claim", _crash)
+        with pytest.raises(RuntimeError, match="injected crash"):
+            await c.command_service.evaluate(
+                _ctx(),
+                wid,
+                [Telemetry],
+                contract=_contract(),
+                grader=grader,
+                evaluation_id="crashy",
+            )
+        monkeypatch.setattr(SqliteControlCatalog, "complete_claim", real_complete)
+        assert len(calls) == 1
+
+        # Expire the lease: the owner is presumed dead.
+        catalog = c.storage_service.get_control_catalog(storage)
+        scope = claim_scope_key(wid, str(world.run_id), "evals", "crashy")
+
+        def _expire():
+            conn = catalog._connect_sync()
+            with conn:
+                conn.execute("UPDATE claims SET lease_expires_at=0 WHERE scope_key=?", (scope,))
+
+        await catalog._run(_expire)
+
+        receipt = await c.command_service.evaluate(
+            _ctx(),
+            wid,
+            [Telemetry],
+            contract=_contract(),
+            grader=grader,
+            evaluation_id="crashy",
+        )
+        assert not receipt.duplicate
+        assert len(calls) == 1, "orphan found by token: the grader must NOT re-run"
+
+        df = await c.query_service.query_components([EvalReceipt], wid, str(world.run_id), storage)
+        assert len(df.to_pylist()) == 1, "exactly one visible receipt"
+    finally:
+        await c.shutdown()
+
+
+async def test_fail_closed_inputs(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await _seeded_world(c, storage)
+
+        # Bare callable without a contract descriptor.
+        with pytest.raises(ValueError, match="GraderContract"):
+            await c.command_service.evaluate(
+                _ctx(),
+                world.world_id,
+                [Telemetry],
+                contract=None,
+                grader=lambda df: Outcome(status="pass"),
+                evaluation_id="t",
+            )
+
+        # Untyped grader output.
+        with pytest.raises(ValueError, match="typed Outcome"):
+            await c.command_service.evaluate(
+                _ctx(),
+                world.world_id,
+                [Telemetry],
+                contract=_contract(),
+                grader=lambda df: 0.9,
+                evaluation_id="t2",
+            )
+
+        # A world with no published visibility has nothing to pin.
+        bare = await c.world_service.create_world(WorldConfig(name="unstepped"), storage)
+        with pytest.raises(RuntimeError, match="no published visibility"):
+            await c.command_service.evaluate(
+                _ctx(),
+                bare.world_id,
+                [Telemetry],
+                contract=_contract(),
+                grader=lambda df: Outcome(status="pass"),
+                evaluation_id="t3",
+            )
+
+        # Invalid outcome statuses and non-finite scores refuse at construction.
+        with pytest.raises(ValueError):
+            Outcome(status="maybe")
+        with pytest.raises(ValueError):
+            Outcome(status="pass", score=float("inf"))
+    finally:
+        await c.shutdown()
+
+
+async def test_receipt_is_attributable_from_the_pinned_snapshot(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await _seeded_world(c, storage)
+        wid, rid = str(world.world_id), str(world.run_id)
+        contract = _contract()
+
+        await c.command_service.evaluate(
+            _ctx(),
+            wid,
+            [Telemetry],
+            contract=contract,
+            grader=lambda df: Outcome(status="pass", score=0.8),
+            evaluation_id="attrib",
+        )
+
+        df = await c.query_service.query_components([EvalReceipt], wid, rid, storage)
+        row = df.to_pylist()[0]
+
+        # Recompute the subject digest from the catalog's pinned snapshot —
+        # manifests only: receipts attach to a snapshot without perturbing it.
+        catalog = c.storage_service.get_control_catalog(storage)
+        manifests = await catalog.list_manifests(wid, rid)
+        head = max(m.tick for m in manifests)
+        recomputed = subject_digest(
+            wid,
+            rid,
+            snapshot_tick=head,
+            snapshot_tokens=sorted(m.commit_token for m in manifests if m.tick == head),
+            component_names=[Telemetry.__name__],
+        )
+        assert row["evalreceipt__subject_digest"] == recomputed
+        assert row["evalreceipt__contract_digest"] == contract.digest()
+    finally:
+        await c.shutdown()
+
+
+async def test_flagship_worker_writes_then_cold_process_grades(tmp_path):
+    """The physical-AI flow: a worker subprocess writes trajectories; a
+    separate process cold-discovers the world and grades it — one visible
+    receipt, no live world, no shared memory."""
+    script = textwrap.dedent(
+        """
+        import asyncio, json, sys
+
+        from archetype.app.container import ServiceContainer
+        from archetype.core.component import Component
+        from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+
+        class Telemetry(Component):
+            reading: float = 0.0
+
+        async def main(uri):
+            c = ServiceContainer()
+            try:
+                storage = StorageConfig(uri=uri, namespace="ns")
+                world = await c.world_service.create_world(WorldConfig(name="gpu"), storage)
+                await c.mutation_service.create_entity(world.world_id, [Telemetry(reading=0.9)])
+                for _ in range(3):
+                    await c.simulation_service.step(world.world_id, RunConfig())
+                print(json.dumps({"world_id": str(world.world_id), "run_id": str(world.run_id)}))
+            finally:
+                await c.shutdown()
+
+        asyncio.run(main(sys.argv[1]))
+        """
+    )
+    uri = str(tmp_path / "store")
+    proc = subprocess.run(
+        [sys.executable, "-c", script, uri],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode == 0, proc.stderr
+    info = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    cold = ServiceContainer()
+    try:
+        storage = StorageConfig(uri=uri, namespace="ns")
+        receipt = await cold.command_service.evaluate(
+            _ctx(),
+            info["world_id"],
+            [Telemetry],
+            contract=_contract(),
+            grader=lambda df: Outcome(
+                status="pass", score=float(df.to_pylist()[-1]["telemetry__reading"])
+            ),
+            evaluation_id="cold-grade-1",
+            storage_config=storage,
+        )
+        assert not receipt.duplicate
+
+        df = await cold.query_service.query_components(
+            [EvalReceipt], info["world_id"], info["run_id"], storage
+        )
+        rows = df.to_pylist()
+        assert len(rows) == 1 and rows[0]["evalreceipt__outcome"] == "pass"
+    finally:
+        await cold.shutdown()


### PR DESCRIPTION
Closes #275. The final durability slice: **evaluation receipts, claim-before-grade** — exactly one **visible** durable receipt per `evaluation_id`, never exactly-once grader execution. Receipts ride B's claim machinery (#287) end to end; C adds identity envelopes, typed outcomes, and one composition entrypoint. No new service, per the locked design.

## What lands

- **Identity envelopes** (`experiments/receipts.py`):
  - `GraderContract` — versioned grader identity (stable id, implementation/prompt/model version, config, thresholds, seed) with a canonical digest. **Bare callables get no digest and no persisted receipt** — `world.grade` remains the ephemeral path.
  - `subject_digest` — the pinned subject: immutable snapshot reference (**manifest head tick + commit tokens**) + canonical selector. Row-content hashing rejected by design (materializing a 10k-entity × 600-tick trajectory would break the lazy contract). Manifests **only**: fact/receipt tokens attach evidence to a snapshot without perturbing its identity — the test matrix caught that a receipt's own completion token would otherwise change the digest it was graded against.
  - `evaluation_identity_digest` — subject + contract, deliberately excluding the outcome: repeated trials of nondeterministic graders are a feature; each trial is its own `evaluation_id`. Same id + different subject/contract → loud conflict.
  - `Outcome` — typed conclusions (pass/fail/invalid/inconclusive + optional finite score); untyped grader outputs and empty outcome sets fail closed.
  - `EvalReceipt` — the persisted row. **Evidence, never authority**: no accepted/promote/approved/allowed_next_action fields, enforced by a new spec-contract eval task (`spec.receipt_authority_firewall`) covering EvalReceipt, FactMeta, and AssetRef.
- **Claim-before-grade**: `IngestionService.ingest_evaluated` — the claim is acquired before any grading; a matching COMPLETE claim returns the persisted receipt **without re-grading**. The B spine was refactored so both entrypoints share it, and claims now record their `table_id` **before** the append — takeover recovery probes the exact table by token through the open-never-create seam, completing without re-grading when orphan rows exist and re-running at most once when they don't.
- **Composition at the gate** (`CommandService.evaluate`, gated as new `CommandType.EVALUATE`, operator+): snapshot pinning → digests → grade → persist. `EvalService` stays QueryService-only; `IngestionService` never grades — the gate wires them, exactly per the dependency ruling from the adversarial design pass. Runtime: `world.evaluate(...)` + sync mirror, alongside the unchanged ephemeral `world.grade`.
- Also folded in: the `QueryService._querier_for` de-duplication (four methods shared the resolve-config → pool-store → wrap-querier preamble; maintainer nit, same file).

## Acceptance (issue P0) → tests

`tests/app/test_eval_receipts.py` (7):

- Replay with the same `evaluation_id` returns the original receipt with **zero re-grading** (call-count spy); the receipt row is queryable evidence.
- New trials of nondeterministic graders are new receipts under new ids — both visible, each graded once.
- Same id + different contract → `ClaimConflictError`.
- Crash after grade+append, before complete: lease takeover finds the orphan by token and completes **without re-running the grader**; exactly one visible receipt.
- Fail-closed matrix: bare callable without contract; untyped grader output; unpinnable world (no published visibility); invalid outcome statuses; non-finite scores.
- Receipt attributable: subject digest recomputed from the catalog's pinned manifests matches the persisted row; contract digest matches the descriptor.
- **Flagship physical-AI flow**: a worker subprocess writes trajectories → a separate process cold-discovers the world and grades it via explicit storage config — no live world, no shared memory, one visible receipt.

## Verification

Full fast suite: **823 passed**. Gates: ruff/format, lazy-audit (13 sites — B's orphan-probe entry retired by the seam-based probe, net −1), API import boundary, ty (0 diagnostics), **spec-contracts 7/7** (new firewall task; traceability enforced the docs anchors), markdownlint. Docs: `durable-facts.md` §7 + command-gate matrix row.

Closes #275 · milestone v0.3.0 — durable substrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
