### PR TITLE
chore: cleanliness + durability posture (closes #278, #276)

### DIFF
--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -881,7 +881,6 @@ coherent engine contract:
 8. Resolve or explicitly codify same-entity same-tick mutation composition so
    broker command order and final materialized state cannot diverge silently.
 
-
 ## Durability Posture (v0.3, issue #276)
 
 The durable substrate (#272–#275) gives each remaining self-assessment an

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -881,6 +881,24 @@ coherent engine contract:
 8. Resolve or explicitly codify same-entity same-tick mutation composition so
    broker command order and final materialized state cannot diverge silently.
 
+
+## Durability Posture (v0.3, issue #276)
+
+The durable substrate (#272–#275) gives each remaining self-assessment an
+explicit contract. Every subsystem below is either durable by mechanism or
+deliberately advisory with the durable alternative named — none is an
+undocumented gap.
+
+| Subsystem | Contract |
+|---|---|
+| CommandBroker | **Advisory by contract**: tick-boundary batching for live worlds; in-memory, non-deduplicating, drain failures log. Durable, deduplicating delivery of external events is `ingest_fact` ([Durable Facts](durable-facts.md)) — routing durability requirements through the broker is a misuse, not a gap. |
+| AuditLog | **Advisory durability class** in v0.3: `_emit` never raises (an audit failure must not fail the gated operation). The upgrade path is the control catalog's transactional substrate; until then, audit rows are operational telemetry, and durable evidence belongs in fact/receipt rows. |
+| Mutation idempotency | **Simulation mutations stay non-idempotent by design** — `create_entity` twice is two entities, because spawns are simulation events, not external ones. External events with retry semantics carry an external identity through `ingest_fact` (exactly-once-visible). Deterministic replays use reserved entity ids. |
+| API auth | **Development-grade by contract**: the default admin `ActorCtx` is for the reference deployment. A production front must inject authenticated `ActorCtx` (roles resolved by the deployment's identity layer) and never expose the default. |
+| RBAC quota state | **Process-local and advisory** in v0.3 (daily token budgets reset on restart). Durable quota accounting is a control-catalog follow-up; deployments needing hard budgets enforce them at the identity layer above. |
+
+Receipts and facts carry no authority (enforced by `spec.receipt_authority_firewall`); the audit log records who asked, the ledger records what happened, and every durable guarantee in this table traces to the visibility contract in [Atomic Visibility](atomic-visibility.md).
+
 ## Acceptance Criteria
 
 This specification should be considered satisfied only when tests demonstrate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,8 +111,8 @@ dev = [
     "mutmut>=3.5",
     "mujoco>=3.2",  # physics parity tests (tests/experiments/test_mujoco_rollout.py)
     "pytest-xdist>=3.8.0",
-    # Dev keeps the optional logfire backend installed so CI exercises
-    # contrib/logfire_observer and the api instrumentation path; the
+    # Dev keeps the optional logfire backend installed so CI can exercise
+    # contrib/logfire_observer (tests/contrib) and the api instrumentation path; the
     # published package depends only on the OTel API + SDK.
     "logfire[fastapi]>=4.32.0",
 ]

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -175,6 +175,24 @@ _EXPORTS: dict[str, tuple[str, str]] = {
 }
 
 
+# Sync-engine exports are the educational tier (issue #278): stable, kept,
+# and deprecated at the TOP-LEVEL alias only. `archetype.core.sync` imports
+# stay silent — the tier is for reading and teaching; the async stack (and
+# the Rust core beyond it) is the performance path.
+_SYNC_TIER_DEPRECATED = frozenset(
+    {
+        "World",
+        "Processor",
+        "System",
+        "Store",
+        "SyncWorld",
+        "SyncProcessor",
+        "SyncSystem",
+        "SyncStore",
+    }
+)
+
+
 def __getattr__(name: str) -> Any:
     """
     Lazy public API loader.
@@ -183,6 +201,16 @@ def __getattr__(name: str) -> Any:
     the entire world at `import archetype` time so small utilities can run in
     minimal environments.
     """
+    if name in _SYNC_TIER_DEPRECATED:
+        import warnings
+
+        warnings.warn(
+            f"archetype.{name} is the educational sync tier: stable but frozen. "
+            "New code should use ArchetypeRuntime (or the Async* classes); see "
+            "docs/guide/runtime.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     target = _EXPORTS.get(name)
     if not target:

--- a/src/archetype/app/storage_service.py
+++ b/src/archetype/app/storage_service.py
@@ -32,7 +32,6 @@ from archetype.app._catalog import SqliteControlCatalog, catalog_path_for
 from archetype.core.aio import AsyncCachedStore, AsyncLancedbStore, AsyncStore
 from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
 from archetype.core.interfaces import iAsyncStore
-from archetype.core.sync import SyncStore
 
 logger = logging.getLogger(__name__)
 
@@ -77,21 +76,6 @@ def create_async_store(
         store = AsyncCachedStore(async_store=store, cache_config=cache_config)
 
     return store
-
-
-def create_sync_store(
-    config: StorageConfig,
-    session: Session | None = None,
-) -> SyncStore:
-    """Create a sync store from a StorageConfig."""
-    uri = _resolve_uri(str(config.uri))
-    if config.backend == StorageBackend.ICEBERG:
-        from archetype.runtime.session import configure_session
-
-        sess = configure_session(config, session or Session())
-    else:
-        sess = session or Session()
-    return SyncStore(uri, sess, io_config=config.io_config)
 
 
 class StorageService:

--- a/src/archetype/core/sync/__init__.py
+++ b/src/archetype/core/sync/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""EDUCATIONAL TIER (deprecated at the top-level API, kept stable here)."""
+
 from .processor import SyncProcessor
 from .querier import QueryManager
 from .store import SyncStore

--- a/src/archetype/htn/__init__.py
+++ b/src/archetype/htn/__init__.py
@@ -15,6 +15,10 @@
 """
 Archetype HTN — Hierarchical Task Network plan resolution as a formal ECS pattern.
 
+**EXPERIMENTAL** (issue #278): never production-dogfooded; the API and the
+row shapes may change without deprecation. Use for exploration, not as a
+dependency surface.
+
 Plan resolution is a single-world, ``plan_id``-tagged AND/OR forest. Every live
 branch is ONE row of ONE ``(Branch,)`` archetype carrying, co-located:
 

--- a/tests/app/test_world_resume.py
+++ b/tests/app/test_world_resume.py
@@ -354,7 +354,8 @@ async def test_autoresearch_continues_across_processes(tmp_path):
         [sys.executable, "-c", script, uri],
         capture_output=True,
         text=True,
-        timeout=300,
+        timeout=600,  # the child runs a real 2-iteration autoresearch loop; a
+        # loaded machine (xdist peers) has pushed it past 300s (observed).
     )
     assert proc.returncode == 0, proc.stderr
     child = json.loads(proc.stdout.strip().splitlines()[-1])

--- a/tests/contrib/test_logfire_observer.py
+++ b/tests/contrib/test_logfire_observer.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke coverage for contrib/logfire_observer (issue #278).
+
+Runs only when the optional ``[logfire]`` extra is installed — the dev
+group carries it so CI exercises this path; a bare install skips cleanly.
+"""
+
+import pytest
+
+logfire = pytest.importorskip("logfire")
+
+from archetype.contrib.logfire_observer import _tick_spans, logfire_hooks  # noqa: E402
+from archetype.core.component import Component  # noqa: E402
+
+
+class Blip(Component):
+    x: float = 0.0
+
+
+def test_logfire_hooks_shape():
+    """One (event_type, handler) pair per lifecycle event, all coroutine fns."""
+    import inspect
+
+    from archetype.core.hooks import HookEvent
+
+    hooks = logfire_hooks()
+    assert hooks, "the observer must register at least the tick span pair"
+    for event_type, handler in hooks:
+        assert issubclass(event_type, HookEvent)
+        assert inspect.iscoroutinefunction(handler)
+
+
+@pytest.mark.asyncio
+async def test_observer_rides_a_real_world_without_sending(monkeypatch, tmp_path):
+    """Attach the hooks to a real runtime world, step it, and verify the
+    span bookkeeping opens and closes — with network sending disabled."""
+    monkeypatch.setenv("LOGFIRE_SEND_TO_LOGFIRE", "false")
+
+    from archetype import ArchetypeRuntime
+    from archetype.core.config import StorageConfig
+
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "observed",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns"),
+            hooks=logfire_hooks(),
+        )
+        await world.spawn(Blip(x=1.0))
+        await world.run(steps=2)
+        assert _tick_spans == {}, "every PreTick span must be closed by PostTick"


### PR DESCRIPTION
Closes #278. Closes #276. The two milestone-closing issues: code hygiene per the approved cleanliness decisions, and the durability-posture contracts that resolve the spec's honest self-assessments now that the substrate (#272–#275) exists.

## Cleanliness (#278, all per the 2026-07-14 maintainer decisions)

- **Sync engine = educational tier**: `DeprecationWarning` on the top-level aliases (`World`, `Processor`, `System`, `Store`, and the `Sync*` names) via the lazy-export hook — direct `archetype.core.sync` imports stay silent (the tier is for reading and teaching). Banner in the package docstring. Removed the dead `storage_service.create_sync_store` factory (zero callers).
- **HTN labeled EXPERIMENTAL** in the module docstring: never production-dogfooded; API and row shapes may change without deprecation.
- **contrib/logfire_observer**: first tests (`tests/contrib/`, behind `pytest.importorskip("logfire")`): hook-shape check + a real runtime world stepped with the observer attached, asserting every PreTick span closes and nothing sends (`LOGFIRE_SEND_TO_LOGFIRE=false`). The pyproject dev-group comment now tells the truth.
- **CLI audit**: concluded satisfied — `docs/reference/cli.md` (docs overhaul) documents every command against the thin-HTTP-client reference story; no dead handlers found worth removing this cycle.
- **experiments exports**: verified — every `__all__` name imports (the stale-file claim from the design review does not reproduce on main).

## Durability posture (#276)

`specification.md` gains a **Durability Posture** table giving each self-assessment an explicit contract instead of an open gap:

- **CommandBroker** — advisory by contract (tick-boundary batching); durable deduplicating delivery IS `ingest_fact`. Routing durability requirements through the broker is a misuse, not a gap.
- **AuditLog** — advisory durability class (an audit failure must not fail the gated operation); durable evidence belongs in fact/receipt rows; catalog substrate named as the upgrade path.
- **Mutation idempotency** — simulation mutations stay non-idempotent by design (spawns are simulation events); external events with retry semantics carry external identity through `ingest_fact`.
- **API auth** — development-grade by contract; production fronts inject authenticated `ActorCtx`.
- **RBAC quota state** — process-local and advisory in v0.3; durable accounting is a control-catalog follow-up.

Every line traces to the visibility contract in `atomic-visibility.md`; none is an undocumented gap anymore, which was #276's exit criterion ("hardening PR or an explicit documented contract").

## Verification

Affected suites green under xdist; gates: ruff/format, lazy-audit (13 sites), API import boundary, ty (0 diagnostics), spec-contracts 7/7, markdownlint. Deprecation behavior verified: sync aliases warn once with the runtime pointer; `Async*` paths never warn.

Closes #278 · Closes #276 · milestone v0.3.0 — durable substrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
