### PR TITLE
fix(docs): smooth static page navigation

### DIFF
--- a/docs/overrides/js/sidebar.js
+++ b/docs/overrides/js/sidebar.js
@@ -1,0 +1,16 @@
+// Preserve the sidebar's position between document navigations without
+// animating it into a new position on every page load. The upstream script
+// centers the active link with smooth scrolling, which makes static-page
+// navigation look like the sidebar is flashing.
+const sidebar = document.querySelector('[data-sidebar="content"]');
+
+if (sidebar) {
+  const saved = sessionStorage.getItem("sidebar-scroll");
+  if (saved !== null) {
+    sidebar.scrollTop = Number.parseInt(saved, 10);
+  }
+
+  window.addEventListener("pagehide", () => {
+    sessionStorage.setItem("sidebar-scroll", String(sidebar.scrollTop));
+  });
+}

--- a/docs/stylesheets/shadcn.css
+++ b/docs/stylesheets/shadcn.css
@@ -47,11 +47,36 @@ html {
   background: #ffffff;
 }
 
+/* Keep the previous document painted while the next static docs page loads.
+   Browsers without cross-document View Transitions retain normal navigation. */
+@view-transition {
+  navigation: auto;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 120ms;
+  animation-timing-function: ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*) {
+    animation-duration: 0s;
+  }
+}
+
 body {
   background: #ffffff;
   color: #000000;
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
+}
+
+/* The theme adds two absolute gradient overlays to the left sidebar. They
+   obscure the first links and read as a fade during document navigation. */
+[data-slot="sidebar"] > .absolute.top-8,
+[data-slot="sidebar"] > .absolute.top-12 {
+  display: none;
 }
 
 /* The Vangelis mark is 625 × 245, not a square app glyph. */


### PR DESCRIPTION
Removes the remaining sidebar gradient overlays, replaces per-page smooth sidebar centering with passive scroll restoration, and opts into native cross-document View Transitions for same-origin documentation navigation.

Validated with `make docs` and the production-style Wrangler server.