### PR TITLE
fix(docs): apply navigation fix with cached assets

### DIFF
--- a/docs/overrides/templates/extra_head.html
+++ b/docs/overrides/templates/extra_head.html
@@ -1,0 +1,38 @@
+{# Critical navigation rules live in the document so a browser that still has
+   an older cached theme asset receives the fix on its very next navigation. #}
+<style>
+    @view-transition {
+        navigation: auto;
+    }
+
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+        animation-duration: 120ms;
+        animation-timing-function: ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        ::view-transition-group(*) {
+            animation-duration: 0s;
+        }
+    }
+
+    [data-slot="sidebar"] > .absolute.top-8,
+    [data-slot="sidebar"] > .absolute.top-12 {
+        display: none;
+    }
+</style>
+<script>
+    (() => {
+        const nativeScrollIntoView = Element.prototype.scrollIntoView;
+        Element.prototype.scrollIntoView = function (options) {
+            if (
+                options?.behavior === "smooth" &&
+                this.closest('[data-sidebar="content"]')
+            ) {
+                return;
+            }
+            return nativeScrollIntoView.call(this, options);
+        };
+    })();
+</script>


### PR DESCRIPTION
Delivers the navigation fix inline in the document head as well as through the theme assets, so browsers with a still-fresh cached stylesheet or sidebar script receive the change on their next navigation.

Follow-up to #292.