### PR TITLE
[codex] Refine sidebar navigation rhythm

### DIFF
--- a/docs/stylesheets/vangelis.css
+++ b/docs/stylesheets/vangelis.css
@@ -122,6 +122,44 @@ body {
   font-weight: 700;
 }
 
+/* Give the desktop documentation rail a clearer section rhythm. */
+@media screen and (min-width: 76.25em) {
+  .md-nav--primary > .md-nav__list > .md-nav__item--section {
+    margin: 0 0 1.6rem;
+  }
+
+  .md-nav--primary > .md-nav__list > .md-nav__item--section > .md-nav__link {
+    color: #000000;
+    font-size: 0.66rem;
+    font-weight: 700;
+    letter-spacing: 0.09em;
+    line-height: 1.2;
+    margin-bottom: 0.55rem;
+    text-transform: uppercase;
+  }
+
+  .md-nav--primary
+    > .md-nav__list
+    > .md-nav__item--section
+    > .md-nav
+    > .md-nav__list
+    > .md-nav__item
+    > .md-nav__link {
+    line-height: 1.45;
+    margin-top: 0.5rem;
+  }
+
+  .md-nav--primary
+    > .md-nav__list
+    > .md-nav__item--section
+    > .md-nav
+    > .md-nav__list
+    > .md-nav__item:first-child
+    > .md-nav__link {
+    margin-top: 0;
+  }
+}
+
 .md-typeset {
   color: #171717;
   font-size: 0.82rem;


### PR DESCRIPTION
## Why

The left documentation rail gave section labels and page links nearly the same visual weight. With five large groups and several long page lists, the navigation read as one crowded block instead of a hierarchy.

## What changed

- Render the five top-level desktop sidebar section labels in uppercase with restrained letter spacing.
- Add more separation between major navigation groups.
- Give child links slightly more line height and vertical spacing.
- Keep the mobile drawer, nested page groups, and right-hand table of contents unchanged.

## Validation

- `make check`
- `make docs`
- `npx --yes prettier --check docs/stylesheets/vangelis.css`
- Verified the assembled local Pages route returns `200` without a redirect and serves the updated stylesheet.

The in-app browser was unavailable in this workspace, so validation used the generated navigation DOM and the locally served production artifact.
