### PR TITLE
refactor(storage): make Daft session the managed catalog boundary

### DIFF
--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -31,7 +31,13 @@ Each entry below is a one-line summary. The full signatures live in `app/interfa
 
 ### `iStorageService`
 
-Creates and pools async stores. Multiton on `(uri, namespace, backend, cache)`. Leaf service — no required dependencies.
+Creates and pools async stores. Multiton on
+`(uri, namespace, backend, IOConfig identity, cache)` within one process.
+The built-in Iceberg factory is a concrete local SQLite-catalog lakehouse.
+Managed or remote Iceberg enters through a caller-configured Daft `Session`;
+`IOConfig` passes directly to Daft data I/O. Leaf service — no required
+dependencies. One injected session serves one storage URI and namespace;
+mismatches fail closed.
 
 ```python
 async def get_or_create_store(storage_config, cache_config=None) -> iAsyncStore
@@ -292,9 +298,11 @@ Pattern: pydantic `BaseModel` with `frozen=True`. Carry only metadata that's saf
 
 ```python
 class ServiceContainer:
-    def __init__(self):
+    def __init__(self, storage_service: StorageService | None = None):
         self.broker = CommandBroker()
-        self.storage_service = StorageService()
+        self.storage_service = (
+            storage_service if storage_service is not None else StorageService()
+        )
         self.audit = AuditLog(self.storage_service)
         self.world_service = WorldService(self.storage_service)
         self.mutation_service = MutationService(self.world_service)

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -300,6 +300,7 @@ Pattern: pydantic `BaseModel` with `frozen=True`. Carry only metadata that's saf
 class ServiceContainer:
     def __init__(self, storage_service: StorageService | None = None):
         self.broker = CommandBroker()
+        self._owns_storage_service = storage_service is None
         self.storage_service = (
             storage_service if storage_service is not None else StorageService()
         )
@@ -322,10 +323,13 @@ class ServiceContainer:
         await self.broker.clear()
         await self.audit.flush()
         await self.audit.shutdown()
-        await self.world_service.shutdown()
+        if self._owns_storage_service:
+            await self.world_service.shutdown()
 ```
 
-Shutdown order matters: clear pending broker work; flush + close audit (write any buffered rows to permanent storage); close stores last.
+Shutdown order matters: clear pending broker work; flush + close audit; close
+container-owned stores last. An injected `StorageService` is caller-owned and
+remains open.
 
 ## 6. Companion specs
 

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -32,7 +32,7 @@ Each entry below is a one-line summary. The full signatures live in `app/interfa
 ### `iStorageService`
 
 Creates and pools async stores. Multiton on
-`(uri, namespace, backend, IOConfig identity, cache)` within one process.
+`(uri, namespace, backend, Daft IOConfig fingerprint, cache)` within one process.
 The built-in Iceberg factory is a concrete local SQLite-catalog lakehouse.
 Managed or remote Iceberg enters through a caller-configured Daft `Session`;
 `IOConfig` passes directly to Daft data I/O. Leaf service — no required

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -142,6 +142,12 @@ Each layer may depend downward. No lower layer may depend upward.
 
 - The store MUST be append-only. Updating a world means appending new rows, not
   mutating prior rows in place.
+- Archetype's built-in Iceberg factory MUST create only its concrete local
+  SQLite-catalog lakehouse. It MUST NOT pair remote data with a hidden
+  host-local metadata catalog.
+- Remote or managed Iceberg MUST enter through a caller-configured Daft
+  `Session`. `StorageConfig.io_config` is passed directly to Daft data I/O and
+  MUST NOT be translated into catalog credential properties.
 - A store MUST create archetype tables on demand from the signature schema.
 - Store reads MUST be scoped by `world_id` and `run_id`.
 - Store writes MUST resolve through the same table identity as reads for the
@@ -369,7 +375,8 @@ CURRENT GAP:
 - `StorageService` is the multiton owner for backend triplets:
   `(store, querier, updater)`.
 - Worlds sharing the same effective storage pool key `(uri, namespace, backend,
-  cache config)` MUST reuse the same backend triplet.
+  in-process IOConfig identity, cache config)` MUST reuse the same backend
+  triplet.
 - Concurrent backend acquisition for the same key MUST single-flight so only
   one backend is built.
 - Backend selection and storage-resource construction are app/runtime
@@ -378,6 +385,11 @@ CURRENT GAP:
   storage context.
 - The default catalog-backed path MAY construct a Daft `Session` and Daft
   `Catalog` through `StorageService`.
+- A caller-configured `Session` MUST pass through unchanged; its attached
+  catalog, namespace, and catalog credentials are authoritative.
+- One injected `Session` MUST be bound to one storage URI and namespace.
+  `StorageService` MUST reject a mismatched config rather than mutate the
+  shared session namespace or silently route tables to the wrong namespace.
 - When `StorageConfig.io_config` is provided for catalog-backed storage, it
   MUST be bound to the store and passed explicitly to Daft Iceberg
   read/write operations.
@@ -841,7 +853,7 @@ the constraints that any acceptable design must satisfy.
 
 | Operation | Expected contract |
 |---|---|
-| `StorageService.get_or_create_store(key)` | Idempotent per `(uri, namespace, backend, cache config)` within one service instance |
+| `StorageService.get_or_create_store(key)` | Idempotent per `(uri, namespace, backend, in-process IOConfig identity, cache config)` within one service instance |
 | `WorldService.create_world(world_id=X)` | Idempotent by explicit `world_id` |
 | `WorldService.destroy_world(missing)` | Safe no-op |
 | `AsyncCachedStore.shutdown()` | Idempotent |

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -488,12 +488,13 @@ CURRENT GAP:
 ### ServiceContainer and runtime lifetime
 
 - `ServiceContainer` is the process-scoped composition root.
-- It owns one shared `StorageService`, one shared `CommandBroker`, one
-  append-only audit log, and the world, mutation, command, simulation, and
-  query services built on top of them.
+- It owns one shared `CommandBroker`, one append-only audit log, and the world,
+  mutation, command, simulation, and query services built on top of them. It
+  owns a `StorageService` that it creates and borrows one supplied by a caller.
 - Container shutdown MUST be explicit and distinct from per-world removal.
 - Container shutdown order MUST clear broker state, flush/shut down audit, and
-  then shut down world and storage services.
+  then shut down storage the container owns. An injected `StorageService` MUST
+  remain open for its caller to manage.
 
 ## Multi-World Contracts
 

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -375,7 +375,7 @@ CURRENT GAP:
 - `StorageService` is the multiton owner for backend triplets:
   `(store, querier, updater)`.
 - Worlds sharing the same effective storage pool key `(uri, namespace, backend,
-  in-process IOConfig identity, cache config)` MUST reuse the same backend
+  Daft IOConfig fingerprint, cache config)` MUST reuse the same backend
   triplet.
 - Concurrent backend acquisition for the same key MUST single-flight so only
   one backend is built.
@@ -853,7 +853,7 @@ the constraints that any acceptable design must satisfy.
 
 | Operation | Expected contract |
 |---|---|
-| `StorageService.get_or_create_store(key)` | Idempotent per `(uri, namespace, backend, in-process IOConfig identity, cache config)` within one service instance |
+| `StorageService.get_or_create_store(key)` | Idempotent per `(uri, namespace, backend, Daft IOConfig fingerprint, cache config)` within one service instance |
 | `WorldService.create_world(world_id=X)` | Idempotent by explicit `world_id` |
 | `WorldService.destroy_world(missing)` | Safe no-op |
 | `AsyncCachedStore.shutdown()` | Idempotent |

--- a/docs/guide/stores.md
+++ b/docs/guide/stores.md
@@ -16,22 +16,22 @@ Each archetype signature maps to a single table, named by the archetype's determ
 
 `StorageService` owns the conversion from user-facing `StorageConfig` into
 backend-native core store inputs. The core stores do not interpret
-`StorageConfig` themselves.
+`StorageConfig` themselves. Archetype supplies one concrete catalog factory:
+a local Iceberg warehouse with SQLite metadata.
 
 ```python
 from archetype.core.config import StorageConfig, StorageBackend
 from archetype.app.storage_service import StorageService
 
-config = StorageConfig(
+storage = StorageConfig(
     uri="./my_data",
     namespace="experiment_1",
     backend=StorageBackend.ICEBERG,
 )
-session = StorageService.build_session(config)
+storage_service = StorageService()
 ```
 
-`StorageService.build_session()` is the default convenience path for catalog-backed
-storage. It initializes:
+On first use, the local path initializes:
 
 1. An **Iceberg SqlCatalog** backed by SQLite for metadata
 2. A **Daft Session** attached to the catalog
@@ -41,21 +41,42 @@ For LanceDB, `StorageService` passes the resolved storage URI and namespace
 directly to `AsyncLancedbStore`. It does not build a Daft session/catalog for
 the LanceDB backend.
 
-### Local vs Remote Storage
+### Managed and remote Iceberg
 
-| URI scheme | Warehouse | Metadata |
-|------------|-----------|----------|
-| `./path` or `file://` | Local filesystem | SQLite in `path/catalog.db` |
-| `s3://bucket` or `gs://bucket` | Remote object store | SQLite in `.archetype_meta/catalog.db` |
+Archetype does not infer a remote catalog from environment variables and does
+not pair remote object data with hidden local metadata. Configure the catalog,
+namespace, and catalog credentials directly in a Daft `Session`, then inject
+that session at the composition root:
 
-Remote warehouses store data in the cloud but keep catalog metadata locally in a `.archetype_meta/` directory.
+```python
+from daft.session import Session
+from archetype.app.container import ServiceContainer
+from archetype.app.storage_service import StorageService
+
+session = Session()
+session.attach_catalog(configured_catalog)
+session.set_namespace("experiment_1")
+
+services = ServiceContainer(storage_service=StorageService(session=session))
+```
+
+`configured_catalog` may wrap a managed PyIceberg catalog or another catalog
+already supported by Daft. That attached catalog and namespace are
+authoritative. `StorageConfig.io_config` remains the single explicit entry
+point for object-data credentials passed to Daft reads and writes; Archetype
+does not translate it into catalog properties.
+
+An injected session is bound to one configured storage URI and namespace.
+Create a separate `Session` and `StorageService` for another namespace;
+Archetype rejects a mismatch instead of mutating shared session state.
 
 ## Cloud Provider Banners
 
-Cloud storage uses the same Archetype API as local storage:
+The provider snippets below show `IOConfig` data-plane configuration. They are
+used with a caller-configured catalog session as shown above; a remote
+`StorageConfig` by itself intentionally fails closed.
 
 ```python
-from archetype import ArchetypeRuntime
 from archetype.core.config import StorageBackend, StorageConfig
 
 storage = StorageConfig(
@@ -65,8 +86,8 @@ storage = StorageConfig(
     io_config=io_config,
 )
 
-async with ArchetypeRuntime() as runtime:
-    world = runtime.world("cloud-demo", storage=storage)
+# Pass this storage config through the ServiceContainer backed by the
+# preconfigured session above.
 ```
 
 The full runnable catalog is in
@@ -255,28 +276,29 @@ LanceDB stores data in Lance format on the local filesystem. It is the default b
 
 ### Iceberg
 
-The Iceberg backend uses Daft's native Iceberg integration with a SQLite-backed PyIceberg SQL catalog. It writes Parquet files and supports:
+The Iceberg backend uses Daft's native Iceberg integration and writes Parquet
+files. The built-in path uses a local SQLite-backed PyIceberg SQL catalog;
+managed deployments inject their configured Daft session. It supports:
 
-- Cloud object stores (S3, GCS) via `StorageConfig.io_config`, passed explicitly to Daft Iceberg reads/writes
+- Cloud object stores via the injected catalog plus `StorageConfig.io_config`
 - Catalog-level namespace isolation
 - Compatibility with the broader Iceberg ecosystem
 
 ### Backend Selection
 
-`StorageService._create_backend()` checks `storage_config.use_lancedb` (derived from the `backend` enum) to pick the store class. Both are wrapped identically by `AsyncQueryManager` and `AsyncUpdateManager`:
+`create_async_store()` selects the backend enum and then applies the optional
+write-behind cache:
 
 ```text
-StorageService._create_backend(config, cache_config)
+create_async_store(config, session, cache_config)
     |
-    +-- config.use_lancedb? --> StorageService.resolve_location(config)
-    |                         --> AsyncLancedbStore(uri, namespace)
-    +-- else                --> StorageService.build_session(config)
-                              --> AsyncStore(session)
+    +-- LANCEDB --> AsyncLancedbStore(uri, namespace)
+    +-- ICEBERG + supplied session --> AsyncStore(session)
+    +-- ICEBERG + no session --> configure_session(config)
+                                 --> local SQLite catalog
+                                 --> AsyncStore(session)
     |
-    +-- cache_config?     --> AsyncCachedStore(store, cache_config)
-    |
-    +-- AsyncQueryManager(store)
-    +-- AsyncUpdateManager(store)
+    +-- cache_config? --> AsyncCachedStore(store, cache_config)
 ```
 
 ## Write-Behind Cache

--- a/docs/guide/stores.md
+++ b/docs/guide/stores.md
@@ -66,6 +66,10 @@ authoritative. `StorageConfig.io_config` remains the single explicit entry
 point for object-data credentials passed to Daft reads and writes; Archetype
 does not translate it into catalog properties.
 
+An injected `StorageService` remains caller-owned. Container shutdown leaves
+it open so another container or host service can continue using it; the caller
+closes it after its final consumer stops.
+
 An injected session is bound to one configured storage URI and namespace.
 Create a separate `Session` and `StorageService` for another namespace;
 Archetype rejects a mismatch instead of mutating shared session state.

--- a/evals/suites/idempotency.py
+++ b/evals/suites/idempotency.py
@@ -77,7 +77,7 @@ IDEMPOTENCY_CASES: tuple[IdempotencyCase, ...] = (
     IdempotencyCase(
         operation="`StorageService.get_or_create_store(key)`",
         expected_contract=(
-            "Idempotent per `(uri, namespace, backend, in-process IOConfig identity, cache config)` "
+            "Idempotent per `(uri, namespace, backend, Daft IOConfig fingerprint, cache config)` "
             "within one service instance"
         ),
         task_id="idempotency.storage_pooling_and_shutdown",
@@ -367,7 +367,8 @@ async def _task_storage_pooling_and_shutdown() -> list[GraderResult]:
         io_config = IOConfig()
         storage = base_storage.model_copy(update={"io_config": io_config})
         other_namespace = storage.model_copy(update={"namespace": "idem_other"})
-        other_io = storage.model_copy(update={"io_config": IOConfig()})
+        equivalent_io = storage.model_copy(update={"io_config": IOConfig()})
+        other_io = storage.model_copy(update={"io_config": IOConfig(disable_suffix_range=True)})
         cache = CacheConfig(flush_rows=10_000, flush_mb=10_000, global_mb=10_000, idle_sec=3600)
         try:
             plain_a = await service.get_or_create_store(storage)
@@ -379,6 +380,7 @@ async def _task_storage_pooling_and_shutdown() -> list[GraderResult]:
                 other_namespace_rejected = False
             except ValueError:
                 other_namespace_rejected = True
+            equivalent_credentials = await service.get_or_create_store(equivalent_io)
             different_credentials = await service.get_or_create_store(other_io)
 
             # The cached store itself owns an idempotent shutdown contract.
@@ -396,7 +398,8 @@ async def _task_storage_pooling_and_shutdown() -> list[GraderResult]:
                         "same_cache_config_reuses_cached_store": cached_a is cached_b,
                         "cache_config_is_part_of_pool_key": plain_a is not cached_a,
                         "injected_session_rejects_other_namespace": (other_namespace_rejected),
-                        "io_config_identity_is_part_of_pool_key": (
+                        "equivalent_io_config_reuses_store": (plain_a is equivalent_credentials),
+                        "io_config_fingerprint_is_part_of_pool_key": (
                             plain_a is not different_credentials
                         ),
                     },

--- a/evals/suites/idempotency.py
+++ b/evals/suites/idempotency.py
@@ -20,6 +20,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from daft.io import IOConfig
 from uuid_utils import uuid7
 
 from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
@@ -30,7 +31,13 @@ from archetype.app.models import Command, CommandType
 from archetype.app.storage_service import StorageService
 from archetype.app.world_service import WorldService
 from archetype.core.component import Component
-from archetype.core.config import CacheConfig, RunConfig, StorageConfig, WorldConfig
+from archetype.core.config import (
+    CacheConfig,
+    RunConfig,
+    StorageBackend,
+    StorageConfig,
+    WorldConfig,
+)
 from archetype.core.hooks import OnComponentAdded, OnComponentRemoved
 from archetype.core.sync import QueryManager, SyncStore, UpdateManager
 from archetype.runtime.session import configure_session
@@ -70,7 +77,8 @@ IDEMPOTENCY_CASES: tuple[IdempotencyCase, ...] = (
     IdempotencyCase(
         operation="`StorageService.get_or_create_store(key)`",
         expected_contract=(
-            "Idempotent per `(uri, namespace, backend, cache config)` within one service instance"
+            "Idempotent per `(uri, namespace, backend, in-process IOConfig identity, cache config)` "
+            "within one service instance"
         ),
         task_id="idempotency.storage_pooling_and_shutdown",
     ),
@@ -350,16 +358,28 @@ def task_storage_pooling_and_shutdown() -> list[GraderResult]:
 
 async def _task_storage_pooling_and_shutdown() -> list[GraderResult]:
     with tempfile.TemporaryDirectory() as tmp:
-        service = StorageService()
-        storage = StorageConfig(uri=f"{tmp}/store", namespace="idem")
+        base_storage = StorageConfig(
+            uri=f"{tmp}/store",
+            namespace="idem",
+            backend=StorageBackend.ICEBERG,
+        )
+        service = StorageService(session=configure_session(base_storage))
+        io_config = IOConfig()
+        storage = base_storage.model_copy(update={"io_config": io_config})
         other_namespace = storage.model_copy(update={"namespace": "idem_other"})
+        other_io = storage.model_copy(update={"io_config": IOConfig()})
         cache = CacheConfig(flush_rows=10_000, flush_mb=10_000, global_mb=10_000, idle_sec=3600)
         try:
             plain_a = await service.get_or_create_store(storage)
             plain_b = await service.get_or_create_store(storage)
             cached_a = await service.get_or_create_store(storage, cache)
             cached_b = await service.get_or_create_store(storage, cache)
-            other = await service.get_or_create_store(other_namespace)
+            try:
+                await service.get_or_create_store(other_namespace)
+                other_namespace_rejected = False
+            except ValueError:
+                other_namespace_rejected = True
+            different_credentials = await service.get_or_create_store(other_io)
 
             # The cached store itself owns an idempotent shutdown contract.
             await cached_a.shutdown()
@@ -375,7 +395,10 @@ async def _task_storage_pooling_and_shutdown() -> list[GraderResult]:
                         "same_config_reuses_plain_store": plain_a is plain_b,
                         "same_cache_config_reuses_cached_store": cached_a is cached_b,
                         "cache_config_is_part_of_pool_key": plain_a is not cached_a,
-                        "namespace_is_part_of_pool_key": plain_a is not other,
+                        "injected_session_rejects_other_namespace": (other_namespace_rejected),
+                        "io_config_identity_is_part_of_pool_key": (
+                            plain_a is not different_credentials
+                        ),
                     },
                     name="storage_pooling_contract",
                 )

--- a/src/archetype/app/container.py
+++ b/src/archetype/app/container.py
@@ -52,6 +52,7 @@ class ServiceContainer:
         self.broker = CommandBroker()
 
         # Leaf services
+        self._owns_storage_service = storage_service is None
         self.storage_service = storage_service if storage_service is not None else StorageService()
 
         # Storage-backed services
@@ -90,4 +91,5 @@ class ServiceContainer:
         """Gracefully shut down all services."""
         await self.audit_log.shutdown()
         await self.broker.clear()
-        await self.world_service.shutdown()
+        if self._owns_storage_service:
+            await self.world_service.shutdown()

--- a/src/archetype/app/container.py
+++ b/src/archetype/app/container.py
@@ -47,12 +47,12 @@ class ServiceContainer:
         await container.simulation_service.step(world.world_id, run_config)
     """
 
-    def __init__(self):
+    def __init__(self, storage_service: StorageService | None = None):
         # Infrastructure
         self.broker = CommandBroker()
 
         # Leaf services
-        self.storage_service = StorageService()
+        self.storage_service = storage_service if storage_service is not None else StorageService()
 
         # Storage-backed services
         self.world_service = WorldService(self.storage_service)

--- a/src/archetype/app/storage_service.py
+++ b/src/archetype/app/storage_service.py
@@ -16,7 +16,7 @@
 Storage Service
 
 Resolves StorageConfig → concrete store. Pools instances by config key.
-Session configuration is handled at the runtime level (see runtime/session.py).
+Caller-configured Daft sessions are the extension point for managed Iceberg.
 """
 
 from __future__ import annotations
@@ -35,6 +35,18 @@ from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
 from archetype.core.interfaces import iAsyncStore
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_session_namespace(session: Session, config: StorageConfig) -> None:
+    """Fail before a shared session can route a store into the wrong namespace."""
+    current = session.current_namespace()
+    if current is None:
+        raise ValueError("injected Daft Session must have a current namespace")
+    if str(current) != config.namespace:
+        raise ValueError(
+            "injected Daft Session namespace mismatch: "
+            f"current={current}, requested={config.namespace}"
+        )
 
 
 def _resolve_uri(uri: str) -> str:
@@ -58,7 +70,9 @@ def create_async_store(
     """Create an async store from a StorageConfig.
 
     For LanceDB: uses resolved uri + namespace directly.
-    For Iceberg: uses the Daft session (global if not provided).
+    For Iceberg without a session: builds Archetype's concrete local
+    SQLite-catalog lakehouse. A supplied session is already authoritative for
+    catalog, namespace, and credentials and passes through unchanged.
     """
     store: iAsyncStore
     if config.backend == StorageBackend.LANCEDB:
@@ -67,7 +81,11 @@ def create_async_store(
     else:
         from archetype.runtime.session import configure_session
 
-        sess = configure_session(config, session or Session())
+        if session is not None:
+            _validate_session_namespace(session, config)
+            sess = session
+        else:
+            sess = configure_session(config)
         store = AsyncStore(sess, io_config=config.io_config)
 
     if isinstance(cache_config, bool):
@@ -82,12 +100,14 @@ def create_async_store(
 class StorageService:
     """Creates and pools async stores. Manages storage lifecycle.
 
-    Multiton semantics: for any (uri, namespace, backend, cache) tuple,
-    only one store instance is created and reused.
+    Multiton semantics: stores with the same location, backend, cache, and
+    in-process ``IOConfig`` identity share one instance.
     """
 
     def __init__(self, session: Session | None = None) -> None:
+        """Create a pool around an optional caller-configured Daft session."""
         self._session = session
+        self._session_identity: tuple[str, str] | None = None
         self._instances: dict[str, iAsyncStore] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         # Control catalogs, pooled by resolved catalog path (issue #272).
@@ -136,7 +156,7 @@ class StorageService:
         storage_config: StorageConfig,
         cache_config: CacheConfig | None,
     ) -> str:
-        """Build a pool key covering uri, namespace, backend, and cache_config."""
+        """Build a pool key without serializing credential-bearing I/O config."""
         if isinstance(cache_config, bool):
             effective_cache = CacheConfig() if cache_config else None
         else:
@@ -151,10 +171,18 @@ class StorageService:
                 f"idle={effective_cache.idle_sec}"
             )
 
+        io_config_part = (
+            f"identity={id(storage_config.io_config)}"
+            if storage_config.backend == StorageBackend.ICEBERG
+            and storage_config.io_config is not None
+            else "none"
+        )
+
         return (
             f"{storage_config.uri}"
             f"::{storage_config.namespace}"
             f"::backend={storage_config.backend.value}"
+            f"::io_config({io_config_part})"
             f"::cache({cache_part})"
         )
 
@@ -168,6 +196,7 @@ class StorageService:
         Creates the store on first call for a given config key.
         Subsequent calls with the same config return the cached instance.
         """
+        self._bind_injected_session(storage_config)
         key = self._pool_key(storage_config, cache_config)
 
         if key not in self._instances:
@@ -181,6 +210,21 @@ class StorageService:
                     )
 
         return self._instances[key]
+
+    def _bind_injected_session(self, storage_config: StorageConfig) -> None:
+        """Bind one injected session to one Iceberg location and namespace."""
+        if self._session is None or storage_config.backend != StorageBackend.ICEBERG:
+            return
+        _validate_session_namespace(self._session, storage_config)
+        requested = (str(storage_config.uri), storage_config.namespace)
+        if self._session_identity is None:
+            self._session_identity = requested
+        elif requested != self._session_identity:
+            raise ValueError(
+                "one injected Daft Session cannot serve multiple storage identities; "
+                f"bound={self._session_identity}, requested={requested}. "
+                "Use a separate StorageService and Session."
+            )
 
     async def shutdown(self):
         """Gracefully shuts down all managed storage backends."""

--- a/src/archetype/app/storage_service.py
+++ b/src/archetype/app/storage_service.py
@@ -101,13 +101,14 @@ class StorageService:
     """Creates and pools async stores. Manages storage lifecycle.
 
     Multiton semantics: stores with the same location, backend, cache, and
-    in-process ``IOConfig`` identity share one instance.
+    effective Daft ``IOConfig`` share one instance.
     """
 
     def __init__(self, session: Session | None = None) -> None:
         """Create a pool around an optional caller-configured Daft session."""
         self._session = session
         self._session_identity: tuple[str, str] | None = None
+        self._session_lock = asyncio.Lock()
         self._instances: dict[str, iAsyncStore] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         # Control catalogs, pooled by resolved catalog path (issue #272).
@@ -172,7 +173,7 @@ class StorageService:
             )
 
         io_config_part = (
-            f"identity={id(storage_config.io_config)}"
+            f"fingerprint={hash(storage_config.io_config)}"
             if storage_config.backend == StorageBackend.ICEBERG
             and storage_config.io_config is not None
             else "none"
@@ -196,8 +197,11 @@ class StorageService:
         Creates the store on first call for a given config key.
         Subsequent calls with the same config return the cached instance.
         """
-        self._bind_injected_session(storage_config)
         key = self._pool_key(storage_config, cache_config)
+
+        if self._session is not None and storage_config.backend == StorageBackend.ICEBERG:
+            async with self._session_lock:
+                return self._get_or_create_injected_store(key, storage_config, cache_config)
 
         if key not in self._instances:
             if key not in self._locks:
@@ -211,20 +215,29 @@ class StorageService:
 
         return self._instances[key]
 
-    def _bind_injected_session(self, storage_config: StorageConfig) -> None:
-        """Bind one injected session to one Iceberg location and namespace."""
-        if self._session is None or storage_config.backend != StorageBackend.ICEBERG:
-            return
+    def _get_or_create_injected_store(
+        self,
+        key: str,
+        storage_config: StorageConfig,
+        cache_config: CacheConfig | None,
+    ) -> iAsyncStore:
+        """Create successfully before committing an injected session binding."""
+        assert self._session is not None
         _validate_session_namespace(self._session, storage_config)
         requested = (str(storage_config.uri), storage_config.namespace)
-        if self._session_identity is None:
-            self._session_identity = requested
-        elif requested != self._session_identity:
+        if self._session_identity is not None and requested != self._session_identity:
             raise ValueError(
                 "one injected Daft Session cannot serve multiple storage identities; "
                 f"bound={self._session_identity}, requested={requested}. "
                 "Use a separate StorageService and Session."
             )
+
+        store = self._instances.get(key)
+        if store is None:
+            store = create_async_store(storage_config, self._session, cache_config)
+            self._instances[key] = store
+            self._session_identity = requested
+        return store
 
     async def shutdown(self):
         """Gracefully shuts down all managed storage backends."""

--- a/src/archetype/app/wiring.md
+++ b/src/archetype/app/wiring.md
@@ -84,7 +84,9 @@ Annotated excerpt from `ServiceContainer.__init__` — param names match `interf
 
 ```python
 self.broker = CommandBroker()                          # → iCommandBroker
-self.storage_service = StorageService()                # → iStorageService
+self.storage_service = (                               # → iStorageService
+    storage_service if storage_service is not None else StorageService()
+)
 
 self.world_service = WorldService(                     # → iWorldService
     self.storage_service,                              #   storage_service: iStorageService
@@ -155,7 +157,7 @@ Hosts (`ArchetypeRuntime`, FastAPI) hold a `ServiceContainer` and call **`iComma
 |------|------|----------|
 | `ArchetypeRuntime` | `runtime/runtime.py` | `iCommandService` |
 | FastAPI | `api/deps.py` | `iCommandService` |
-| Tests / lower-level scripts | `ServiceContainer()` | any protocol, as needed |
+| Tests / lower-level scripts | `ServiceContainer(storage_service=...)` | any protocol, as needed |
 
 `iEvalService` and `AutoResearchService` sit on the container but **outside** the gate — callers use them directly for grading loops and experiment orchestration.
 

--- a/src/archetype/app/wiring.md
+++ b/src/archetype/app/wiring.md
@@ -84,6 +84,7 @@ Annotated excerpt from `ServiceContainer.__init__` — param names match `interf
 
 ```python
 self.broker = CommandBroker()                          # → iCommandBroker
+self._owns_storage_service = storage_service is None
 self.storage_service = (                               # → iStorageService
     storage_service if storage_service is not None else StorageService()
 )
@@ -253,7 +254,7 @@ Only `iCommandService` accepts `ActorCtx` on its public surface. All other proto
 
 1. `iAuditLog.shutdown()` — flush pending rows
 2. `iCommandBroker.clear()` — drop queued commands
-3. `iWorldService.shutdown()` — destroy live worlds, then `iStorageService.shutdown()` on pooled stores
+3. `iWorldService.shutdown()` — close pooled stores only when the container created the `StorageService`; injected storage remains caller-owned
 
 ---
 

--- a/src/archetype/runtime/session.py
+++ b/src/archetype/runtime/session.py
@@ -47,34 +47,35 @@ def configure_session(
     config: StorageConfig,
     session: Session | None = None,
 ) -> Session:
-    """Configure a Daft session for Archetype's Iceberg storage backend.
+    """Build Archetype's concrete local SQLite-catalog Iceberg session.
 
-    Uses the global default session if none is provided.
-    Resolves the URI, creates the Iceberg catalog, attaches it, and sets the namespace.
+    Remote and managed catalogs are caller-owned. They enter through an
+    already-configured ``Session`` passed to ``StorageService`` rather than
+    being reconstructed from storage fields or environment variables.
 
     Args:
         config: Storage configuration with uri and namespace.
-        session: Optional explicit session. Defaults to the global Daft session.
+        session: Optional session to configure for backward-compatible local
+            construction. Managed sessions should instead be injected through
+            ``StorageService`` and are not reconfigured by Archetype.
 
     Returns:
         The configured session.
     """
     from pyiceberg.catalog.sql import SqlCatalog
 
-    if session is None:
-        session = Session()
-
     resolved_uri, is_remote = _resolve_storage_uri(str(config.uri))
-
     if is_remote:
-        local_meta_dir = pathlib.Path(".archetype_meta")
-        local_meta_dir.mkdir(parents=True, exist_ok=True)
-        sqlite_db_path = local_meta_dir / "catalog.db"
-        warehouse_uri = str(config.uri)
-    else:
-        base_path = pathlib.Path(resolved_uri)
-        sqlite_db_path = base_path / "catalog.db"
-        warehouse_uri = f"file://{base_path}"
+        raise ValueError(
+            "Archetype's built-in Iceberg factory supports local paths only; "
+            "inject a preconfigured Daft Session through StorageService for "
+            "remote or managed catalogs"
+        )
+
+    session = session if session is not None else Session()
+    base_path = pathlib.Path(resolved_uri)
+    sqlite_db_path = base_path / "catalog.db"
+    warehouse_uri = f"file://{base_path}"
 
     catalog = Catalog.from_iceberg(
         SqlCatalog(

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -41,6 +41,13 @@ class TestServiceContainer:
         assert isinstance(container.simulation_service, SimulationService)
         assert isinstance(container.query_service, QueryService)
 
+    def test_container_uses_injected_storage_service(self):
+        storage_service = StorageService()
+
+        container = ServiceContainer(storage_service=storage_service)
+
+        assert container.storage_service is storage_service
+
     @pytest.mark.asyncio
     async def test_container_shutdown(self):
         container = ServiceContainer()

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -41,12 +41,30 @@ class TestServiceContainer:
         assert isinstance(container.simulation_service, SimulationService)
         assert isinstance(container.query_service, QueryService)
 
-    def test_container_uses_injected_storage_service(self):
-        storage_service = StorageService()
+    @pytest.mark.asyncio
+    async def test_containers_borrow_shared_storage_service(self):
+        class TrackedStorageService(StorageService):
+            def __init__(self):
+                super().__init__()
+                self.shutdown_calls = 0
 
-        container = ServiceContainer(storage_service=storage_service)
+            async def shutdown(self):
+                self.shutdown_calls += 1
+                await super().shutdown()
 
-        assert container.storage_service is storage_service
+        storage_service = TrackedStorageService()
+
+        first = ServiceContainer(storage_service=storage_service)
+        second = ServiceContainer(storage_service=storage_service)
+
+        assert first.storage_service is storage_service
+        assert second.storage_service is storage_service
+        await first.shutdown()
+        await second.shutdown()
+        assert storage_service.shutdown_calls == 0
+
+        await storage_service.shutdown()
+        assert storage_service.shutdown_calls == 1
 
     @pytest.mark.asyncio
     async def test_container_shutdown(self):

--- a/tests/core/test_resources_manager.py
+++ b/tests/core/test_resources_manager.py
@@ -173,8 +173,8 @@ def test_iceberg_backend_passes_io_config_to_async_store(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_iceberg_pool_distinguishes_io_config_identity(tmp_path):
-    """Explicit I/O credentials must not be replaced by an earlier caller's config."""
+async def test_iceberg_pool_uses_daft_io_config_fingerprint(tmp_path):
+    """Equivalent Daft I/O configs pool while distinct credentials stay isolated."""
     from daft.io import IOConfig
 
     svc = make_storage_service()
@@ -184,16 +184,17 @@ async def test_iceberg_pool_distinguishes_io_config_identity(tmp_path):
         backend=StorageBackend.ICEBERG,
     )
     first_io = IOConfig()
-    second_io = IOConfig()
+    equivalent_io = IOConfig()
+    distinct_io = IOConfig(disable_suffix_range=True)
     try:
         first = await svc.get_or_create_store(StorageConfig(**shared, io_config=first_io))
-        same = await svc.get_or_create_store(StorageConfig(**shared, io_config=first_io))
-        second = await svc.get_or_create_store(StorageConfig(**shared, io_config=second_io))
+        equivalent = await svc.get_or_create_store(StorageConfig(**shared, io_config=equivalent_io))
+        distinct = await svc.get_or_create_store(StorageConfig(**shared, io_config=distinct_io))
 
-        assert first is same
-        assert first is not second
+        assert first is equivalent
+        assert first is not distinct
         assert first.io_config is first_io
-        assert second.io_config is second_io
+        assert distinct.io_config is distinct_io
     finally:
         await svc.shutdown()
 
@@ -241,6 +242,43 @@ async def test_injected_session_rejects_external_namespace_drift(tmp_path):
 
         with pytest.raises(ValueError, match="namespace mismatch"):
             await service.get_or_create_store(config)
+    finally:
+        await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_failed_store_creation_does_not_bind_injected_session(tmp_path, monkeypatch):
+    from archetype.app import storage_service
+    from archetype.app.storage_service import StorageService
+    from archetype.runtime.session import configure_session
+
+    first = StorageConfig(
+        uri=str(tmp_path / "first"),
+        namespace="managed",
+        backend=StorageBackend.ICEBERG,
+    )
+    corrected = first.model_copy(update={"uri": str(tmp_path / "corrected")})
+    session = configure_session(first)
+    service = StorageService(session=session)
+    real_create = storage_service.create_async_store
+    calls = 0
+
+    def fail_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("catalog unavailable")
+        return real_create(*args, **kwargs)
+
+    monkeypatch.setattr(storage_service, "create_async_store", fail_once)
+    try:
+        with pytest.raises(RuntimeError, match="catalog unavailable"):
+            await service.get_or_create_store(first)
+
+        store = await service.get_or_create_store(corrected)
+
+        assert isinstance(store, AsyncStore)
+        assert service._session_identity == (str(corrected.uri), corrected.namespace)
     finally:
         await service.shutdown()
 

--- a/tests/core/test_resources_manager.py
+++ b/tests/core/test_resources_manager.py
@@ -145,10 +145,17 @@ async def test_lancedb_backend_does_not_construct_daft_iceberg_session(tmp_path,
 
 def test_iceberg_backend_passes_io_config_to_async_store(tmp_path, monkeypatch):
     from daft.io import IOConfig
-    from daft.session import Session
+
+    from archetype.runtime.session import configure_session
 
     io_config = IOConfig()
-    session = Session()
+    cfg = StorageConfig(
+        uri=str(tmp_path / "store"),
+        namespace="ns",
+        backend=StorageBackend.ICEBERG,
+        io_config=io_config,
+    )
+    session = configure_session(cfg)
     seen = {}
 
     class FakeStore:
@@ -158,18 +165,84 @@ def test_iceberg_backend_passes_io_config_to_async_store(tmp_path, monkeypatch):
 
     monkeypatch.setattr("archetype.app.storage_service.AsyncStore", FakeStore)
 
-    cfg = StorageConfig(
-        uri=str(tmp_path / "store"),
-        namespace="ns",
-        backend=StorageBackend.ICEBERG,
-        io_config=io_config,
-    )
-
     store = create_async_store(cfg, session=session, cache_config=None)
 
     assert isinstance(store, FakeStore)
     assert seen["session"] is session
     assert seen["io_config"] is io_config
+
+
+@pytest.mark.asyncio
+async def test_iceberg_pool_distinguishes_io_config_identity(tmp_path):
+    """Explicit I/O credentials must not be replaced by an earlier caller's config."""
+    from daft.io import IOConfig
+
+    svc = make_storage_service()
+    shared = dict(
+        uri=str(tmp_path / "store"),
+        namespace="ns",
+        backend=StorageBackend.ICEBERG,
+    )
+    first_io = IOConfig()
+    second_io = IOConfig()
+    try:
+        first = await svc.get_or_create_store(StorageConfig(**shared, io_config=first_io))
+        same = await svc.get_or_create_store(StorageConfig(**shared, io_config=first_io))
+        second = await svc.get_or_create_store(StorageConfig(**shared, io_config=second_io))
+
+        assert first is same
+        assert first is not second
+        assert first.io_config is first_io
+        assert second.io_config is second_io
+    finally:
+        await svc.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_injected_session_rejects_second_storage_identity(tmp_path):
+    from archetype.app.storage_service import StorageService
+    from archetype.runtime.session import configure_session
+
+    first = StorageConfig(
+        uri=str(tmp_path / "store"),
+        namespace="first",
+        backend=StorageBackend.ICEBERG,
+    )
+    service = StorageService(session=configure_session(first))
+    try:
+        await service.get_or_create_store(first)
+
+        with pytest.raises(ValueError, match="namespace mismatch"):
+            await service.get_or_create_store(first.model_copy(update={"namespace": "second"}))
+        with pytest.raises(ValueError, match="cannot serve multiple storage identities"):
+            await service.get_or_create_store(
+                first.model_copy(update={"uri": str(tmp_path / "other")})
+            )
+    finally:
+        await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_injected_session_rejects_external_namespace_drift(tmp_path):
+    from archetype.app.storage_service import StorageService
+    from archetype.runtime.session import configure_session
+
+    config = StorageConfig(
+        uri=str(tmp_path / "store"),
+        namespace="first",
+        backend=StorageBackend.ICEBERG,
+    )
+    session = configure_session(config)
+    service = StorageService(session=session)
+    try:
+        await service.get_or_create_store(config)
+        session.create_namespace_if_not_exists("second")
+        session.set_namespace("second")
+
+        with pytest.raises(ValueError, match="namespace mismatch"):
+            await service.get_or_create_store(config)
+    finally:
+        await service.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_storage_context_factory.py
+++ b/tests/core/test_storage_context_factory.py
@@ -26,3 +26,13 @@ def test_configure_session_builds_local_and_creates_dirs(tmp_path):
     assert isinstance(session, Session)
     # io_config stays on the config, not the session
     assert cfg.io_config is None
+
+
+def test_configure_session_preserves_public_local_session_argument(tmp_path):
+    """The exported helper still configures and returns a supplied local session."""
+    supplied = Session()
+    cfg = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+
+    configured = configure_session(cfg, supplied)
+
+    assert configured is supplied

--- a/tests/core/test_storage_context_remote_uc.py
+++ b/tests/core/test_storage_context_remote_uc.py
@@ -1,42 +1,48 @@
-import pathlib
-import shutil
+from pathlib import Path
 
 import pytest
-from daft.session import Session
+from daft.io import IOConfig, UnityConfig
 
-from archetype.core.config import StorageConfig
+from archetype.app.storage_service import create_async_store
+from archetype.core.aio import AsyncStore
+from archetype.core.config import StorageBackend, StorageConfig
 from archetype.runtime.session import configure_session
 
-# These tests mutate the repository-relative .archetype_meta/catalog.db; under
-# xdist they must share one worker (--dist loadgroup in the Makefile) so they
-# serialize against each other instead of racing on the shared catalog.
-pytestmark = pytest.mark.xdist_group("archetype-meta")
+
+def test_builtin_iceberg_factory_rejects_remote_uri(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = StorageConfig(
+        uri="s3://bucket/prefix",
+        namespace="ns",
+        backend=StorageBackend.ICEBERG,
+    )
+
+    with pytest.raises(ValueError, match="preconfigured Daft Session"):
+        configure_session(config)
+
+    assert not Path(".archetype_meta").exists()
 
 
-def test_configure_session_remote_uri_uses_meta_dir(tmp_path):
-    """Remote URIs should not be created locally; local sqlite catalog should be under .archetype_meta."""
-    remote_uri = "s3://bucket/prefix"
-    # Ensure we start clean
-    meta_dir = pathlib.Path(".archetype_meta")
-    if meta_dir.exists():
-        shutil.rmtree(meta_dir)
+def test_preconfigured_session_and_io_config_pass_through_for_remote_iceberg(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    io_config = IOConfig(unity=UnityConfig(endpoint="https://example", token="t"))
+    session = configure_session(
+        StorageConfig(
+            uri=str(tmp_path / "catalog"),
+            namespace="managed",
+            backend=StorageBackend.ICEBERG,
+        )
+    )
+    config = StorageConfig(
+        uri="s3://bucket/prefix",
+        namespace="managed",
+        backend=StorageBackend.ICEBERG,
+        io_config=io_config,
+    )
 
-    cfg = StorageConfig(uri=remote_uri, namespace="ns")
-    session = configure_session(cfg)
-    # Local meta dir created
-    assert pathlib.Path(".archetype_meta").exists()
-    # Session returned successfully
-    assert isinstance(session, Session)
+    store = create_async_store(config, session=session)
 
-
-def test_configure_session_preserves_io_config_on_storage_config():
-    """StorageConfig.io_config stays available for explicit Daft Iceberg read/write calls."""
-    from daft.io import IOConfig, UnityConfig
-
-    io = IOConfig(unity=UnityConfig(endpoint="https://example", token="t"))
-
-    cfg = StorageConfig(uri="s3://bucket/prefix", namespace="ns", io_config=io)
-    session = configure_session(cfg)
-    assert isinstance(session, Session)
-    # io_config is on the config object, not consumed by configure_session
-    assert cfg.io_config is io
+    assert isinstance(store, AsyncStore)
+    assert store.session is session
+    assert store.io_config is io_config
+    assert not (tmp_path / ".archetype_meta").exists()


### PR DESCRIPTION
## Summary

- keep Archetype's built-in Iceberg factory concrete and local: SQLite catalog plus local warehouse
- make an injected Daft `Session` authoritative for managed and remote catalogs
- pass Daft `IOConfig` through unchanged instead of translating credentials or creating hidden local metadata
- allow `ServiceContainer` to receive the configured `StorageService` at the composition root

## Verification

- `uvx ty@0.0.48 check --python .venv`
- `make ci` (852 passed, 6 skipped; 12/12 regression and 22/22 idempotency evals)
