### PR TITLE
fix: harden deterministic review completion

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -73,7 +73,7 @@ jobs:
           github_token: ${{ github.token }}
           claude_args: |
             --allowedTools "Read,Grep,Glob"
-            --max-turns 20
+            --max-turns 40
             --json-schema '${{ steps.scope.outputs.schema }}'
           prompt: |
             Review PR #${{ github.event.pull_request.number }} at exact head
@@ -94,6 +94,10 @@ jobs:
             a substantive diff-specific summary, and anchors every finding to
             an actual changed line. An empty findings array is valid only after
             that complete review.
+
+            Use only Read, Grep, and Glob. Do not attempt Bash or any other
+            unavailable tool, and reserve enough turns to return the required
+            structured output.
 
             Do not post comments or reviews. Do not edit files, run repository
             code, run tests, or push commits.
@@ -249,9 +253,20 @@ jobs:
             --finding-count "${FINDING_COUNT}" \
             --digest "${ARTIFACT_DIGEST}"
 
-      - name: Report incomplete review
-        if: failure()
+      - name: Block merge on findings
+        id: finding_gate
+        if: steps.prepare.outputs.finding_count != '0'
         env:
+          FINDING_COUNT: ${{ steps.prepare.outputs.finding_count }}
+        run: |
+          echo "Footgun review reported ${FINDING_COUNT} blocking finding(s)."
+          echo "Resolve the published review threads and push the fix before merging."
+          exit 1
+
+      - name: Report incomplete review
+        if: failure() && steps.finding_gate.outcome != 'failure'
+        env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -93,7 +93,9 @@ jobs:
             partitions every file into a context-relevant reviewed area, gives
             a substantive diff-specific summary, and anchors every finding to
             an actual changed line. An empty findings array is valid only after
-            that complete review.
+            that complete review. Put each changed file in exactly one
+            review_context entry; combine multiple concerns for the same file
+            into that single entry.
 
             Use only Read, Grep, and Glob. Do not attempt Bash or any other
             unavailable tool, and reserve enough turns to return the required


### PR DESCRIPTION
## What changed

- increase the read-only footgun detector budget from 20 to 40 turns
- explicitly keep the detector on its allowed read-only tools
- fail `review-complete` after verified findings are published
- distinguish intentional finding failures from incomplete detector/publisher failures
- make technical failure comments independent of a checked-out repository

## Why

PR #301 demonstrated two important behaviors: the gate correctly failed closed when no structured review existed, but the 20-turn ceiling prevented a 12-file review from completing. Separately, verified findings were published as review threads while `review-complete` could still succeed, leaving thread resolution as the only blocker. This patch makes the required status itself reflect findings.

## Impact

Solo auto-merge remains zero-approval and fast, while exact-head review completion is required. Missing evidence and verified findings both block merge for distinct, contextual reasons.

## Validation

- `make ci`
- 851 tests passed, 6 skipped
- regression evaluation: 12/12
- idempotency evaluation: 22/22
- gate unit tests: 18/18