### PR TITLE
docs(claude): stop claiming skills auto-fire on file paths

### DIFF
--- a/.claude/skills/archetype-components/SKILL.md
+++ b/.claude/skills/archetype-components/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: archetype-components
-description: Enforces correct Component definitions. Auto-triggers when creating or editing Component subclasses, ECS entities, or archetype schema code.
-paths: "src/**/*.py,tests/**/*.py,examples/**/*.py"
+description: Enforces correct Component definitions. Use when creating or editing Component subclasses, ECS entities, or archetype schema code — anywhere under src/, tests/, or examples/.
+user_invocable: true
 ---
 
 ## Rules

--- a/.claude/skills/archetype-processors/SKILL.md
+++ b/.claude/skills/archetype-processors/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: archetype-processors
-description: Enforces correct Processor implementation. Auto-triggers when creating or editing AsyncProcessor subclasses, process methods, or pipeline stages.
-paths: "src/**/*.py,tests/**/*.py,examples/**/*.py"
+description: Enforces correct Processor implementation. Use when creating or editing AsyncProcessor subclasses, process methods, or pipeline stages — anywhere under src/, tests/, or examples/.
+user_invocable: true
 ---
 
 ## Rules

--- a/.claude/skills/daft-patterns/SKILL.md
+++ b/.claude/skills/daft-patterns/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daft-patterns
-description: Enforces correct Daft DataFrame patterns. Auto-triggers when writing or editing Python files that use Daft, DataFrames, UDFs, or column expressions.
-paths: "src/**/*.py,tests/**/*.py,examples/**/*.py"
+description: Enforces correct Daft DataFrame patterns. Use when writing or editing Python that touches Daft, DataFrames, UDFs, or column expressions — anywhere under src/, tests/, or examples/.
+user_invocable: true
 ---
 
 ## Daft built-ins to reach for first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,16 +6,16 @@ Read these before doing anything:
 - `LEARNINGS.md` — Daft 0.7.x patterns, UDF rules, serialization. **Mandatory before writing a processor.**
 - `AGENTS.md` — Architecture, service layer, RBAC, conventions, dev workflow.
 
-Skills in `.claude/skills/` enforce framework rules automatically. They fire based on file paths — you don't need to invoke them manually.
+Skills in `.claude/skills/` are the framework rulebooks. Nothing fires on file paths alone: a skill loads when you invoke it by name or when the agent matches its description to the task at hand. Before editing Python under `src/`, `tests/`, or `examples/`, load the relevant skill — the deterministic footgun gate in CI reviews every PR against the same rules, so skipping them locally just moves the failure to review.
 
 ## Skills index
 
-| Skill | How it fires | What it enforces |
+| Skill | How it loads | What it enforces |
 |-------|--------------|------------------|
-| `daft-patterns` | auto (Python files) | Daft built-in functions to reach for first, UDF decision tree, lazy DAG rules |
-| `archetype-components` | auto (Python files) | Component definitions, Arrow serialization, field conventions |
-| `archetype-processors` | auto (Python files) | AsyncProcessor patterns, priority ordering, resource access |
-| `footgun-detector` | `/footgun` | Scans the current diff for archetype-specific runtime bugs across three perspectives: actor (code), observed (data), observer (review) |
+| `daft-patterns` | `/daft-patterns`, or model-invoked for Daft/DataFrame/UDF code | Daft built-in functions to reach for first, UDF decision tree, lazy DAG rules |
+| `archetype-components` | `/archetype-components`, or model-invoked for Component/schema code | Component definitions, Arrow serialization, field conventions |
+| `archetype-processors` | `/archetype-processors`, or model-invoked for processor/pipeline code | AsyncProcessor patterns, priority ordering, resource access |
+| `footgun-detector` | `/footgun-detector` | Scans the current diff for archetype-specific runtime bugs across three perspectives: actor (code), observed (data), observer (review) |
 
 ## Agents
 


### PR DESCRIPTION
## Problem

CLAUDE.md tells every agent session: *"Skills fire based on file paths — you don't need to invoke them manually."* That claim is false in the current harness: `paths:` is not a recognized SKILL.md frontmatter key, and no path-based auto-fire mechanism exists. Skills load two ways only — explicit `/name` invocation, or the model matching their description to the task. An agent that believes the doc assumes rule coverage it doesn't have and skips loading the rulebooks.

## Fix

- **CLAUDE.md** — describe how skills actually load (invoked by name, or model-matched on description), instruct agents to load the relevant skill before editing Python under `src/`/`tests/`/`examples/`, and name the deterministic CI footgun gate as the enforcement backstop. Also fixes the stale `/footgun` → `/footgun-detector` reference in the skills table.
- **Three SKILL.md files** — drop the dead `paths:` key, add `user_invocable: true` (mirroring the footgun-detector skill) so the `/daft-patterns`-style invocations the CLAUDE.md table now documents are actually exposed, and rephrase descriptions from "Auto-triggers when…" (a false metadata claim) to "Use when…" trigger language with the path scope folded in — the description being the surface that actually drives model invocation.

## Alternative considered

Wiring a PostToolUse hook that injects skill reminders on Python edits. Rejected: it re-states what CLAUDE.md already puts in every session's context, adds per-edit noise plus session-state bookkeeping, and the deterministic review gate already provides the hard enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)