### PR TITLE
ci: restrict deterministic review to maintainer-authored PRs

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -3,6 +3,10 @@ name: Deterministic Review Gate
 on:
   # zizmor: ignore[dangerous-triggers] Base stays at the workspace root; the
   # candidate is data-only, and the detector job has no write permissions.
+  # Reviews are further restricted to maintainer-authored PRs: everyone else
+  # fails closed in the first step, before any checkout, API call, or model
+  # spend. (A failing step, not a job-level `if` — skipped required checks
+  # count as satisfied, which would fail open.)
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -25,6 +29,13 @@ jobs:
       REVIEW_DIR: ${{ github.workspace }}/.footgun-review-output
       SCOPE_FILE: ${{ github.workspace }}/.footgun-review-scope.json
     steps:
+      - name: Restrict to maintainer PRs
+        if: github.event.pull_request.user.login != 'everettVT'
+        run: |
+          echo "Deterministic footgun review only runs for PRs authored by everettVT."
+          echo "This PR fails closed: no review ran and merge stays blocked."
+          exit 1
+
       - name: Checkout trusted base
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -266,7 +277,9 @@ jobs:
           exit 1
 
       - name: Report incomplete review
-        if: failure() && steps.finding_gate.outcome != 'failure'
+        if: >-
+          failure() && steps.finding_gate.outcome != 'failure' &&
+          github.event.pull_request.user.login == 'everettVT'
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

`deterministic-review.yml` fires on `pull_request_target` for **any** PR, including forks from any GitHub account. Injection was already contained (Read/Grep/Glob only, trusted-base checkout, diff as inert data), but every external push burned a Claude run against `CLAUDE_CODE_OAUTH_TOKEN` — a subscription quota, so a push-spammer throttles the maintainer's own dev sessions.

## Fix

Reviews now run only for PRs authored by `everettVT`; everyone else **fails closed**.

Two deliberate mechanics:

- **Failing first step, not a job-level `if`.** GitHub treats a skipped required check as satisfied — a job-level condition would have silently waived the review requirement for exactly the untrusted PRs. The failing step keeps `footgun-review`/`review-complete` red, so merge stays blocked, and it runs before any checkout, `gh api` call, or model invocation (external cost ≈ two 5-second runner jobs).
- **Author-guarded incomplete-review comment.** Without it, every external push would post a misleading "review incomplete" bot comment — a spam channel.

## Consequences

- External contributions are unmergeable until adopted by the maintainer (e.g. re-pushed under their authorship) or until an explicit opt-in path (an `ok-to-review` label gate) is added later. Given automerge and `claude.yml` are already `everettVT`-gated, this matches the repo's actual trust model.
- Note `pull_request_target` runs the **base** branch's workflow, so this PR's own gate run still uses the old rules; the restriction takes effect for PRs opened after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)