### PR TITLE
fix(catalog): fail closed and preserve commit authority

### DIFF
--- a/docs/guide/atomic-visibility.md
+++ b/docs/guide/atomic-visibility.md
@@ -127,7 +127,8 @@ is what makes maintenance safe:
   execution is queryable up to its last published tick, not resumable
   mid-physics.
 - Cross-host fencing requires the remote control catalog
-  (``ARCHETYPE_CONTROL_CATALOG_URL``, issue #281): with it configured,
+  (``ARCHETYPE_CONTROL_CATALOG_URL`` plus
+  ``ARCHETYPE_CONTROL_CATALOG_TOKEN``, issue #281): with it configured,
   discovery, fencing, and visibility hold across hosts; the default local
   SQLite catalog remains single-host authority.
 - Mutable cold resume is delivered on top of this contract — see

--- a/docs/guide/durable-discovery.md
+++ b/docs/guide/durable-discovery.md
@@ -20,8 +20,9 @@ storage identity, with no shared memory and no live world object.
 
 Each storage identity gets one control catalog — local SQLite by default,
 or the remote Durable Objects catalog when
-``ARCHETYPE_CONTROL_CATALOG_URL`` is configured (issue #281), which lifts
-the single-host limit. The catalog is
+``ARCHETYPE_CONTROL_CATALOG_URL`` and
+``ARCHETYPE_CONTROL_CATALOG_TOKEN`` are configured (issue #281), which
+lifts the single-host limit. The catalog is
 **authoritative for world identity** and **advisory for progress**:
 
 | Recorded | Authority |

--- a/docs/guide/durable-facts.md
+++ b/docs/guide/durable-facts.md
@@ -91,8 +91,8 @@ receipt = await world.ingest(
 The receipt is the durable outcome: commit token, fact entity id, tick,
 table, digest, and whether this call deduplicated against an existing
 visible fact. Ingestion works against live worlds and cold (catalog-
-recorded) ones; facts land at the world's last visible tick and never
-advance it.
+recorded) ones; facts land at the latest manifest tick, falling back to the
+recorded fork/genesis head before the first manifest, and never advance it.
 
 ## 7. Evaluation receipts: claim-before-grade
 

--- a/infra/control-catalog/README.md
+++ b/infra/control-catalog/README.md
@@ -28,7 +28,9 @@ export ARCHETYPE_CONTROL_CATALOG_TOKEN=<the secret>
 ```
 
 Every coordinated world in that process now fences, publishes, and claims
-through the worker. Parity with the SQLite reference is enforced by
-`tests/app/test_remote_catalog_parity.py` (runs the worker under
-`wrangler dev`); the owner-facing end-to-end proof is
-`scripts/validate_r2_substrate.py`.
+through the worker. The Worker returns a configuration error when
+`CATALOG_TOKEN` is absent, and the Python host fails during catalog setup
+when the URL is configured without the matching token. Parity with the
+SQLite reference is enforced by `tests/app/test_remote_catalog_parity.py`
+(runs the worker under `wrangler dev`); the owner-facing end-to-end proof
+is `scripts/validate_r2_substrate.py`.

--- a/infra/control-catalog/src/index.ts
+++ b/infra/control-catalog/src/index.ts
@@ -35,11 +35,15 @@ function conflict(kind: string, message: string): Response {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    if (env.CATALOG_TOKEN) {
-      const auth = request.headers.get("authorization") ?? "";
-      if (auth !== `Bearer ${env.CATALOG_TOKEN}`) {
-        return json({ error: "unauthorized" }, 401);
-      }
+    if (!env.CATALOG_TOKEN) {
+      return json(
+        { error: "misconfigured", message: "CATALOG_TOKEN is not set" },
+        500,
+      );
+    }
+    const auth = request.headers.get("authorization") ?? "";
+    if (auth !== `Bearer ${env.CATALOG_TOKEN}`) {
+      return json({ error: "unauthorized" }, 401);
     }
     const url = new URL(request.url);
     const parts = url.pathname.split("/").filter(Boolean);
@@ -63,13 +67,20 @@ export default {
         const response = await stub.fetch(request);
         if (response.ok && typeof body.tick === "number") {
           const directory = env.DIRECTORY.get(env.DIRECTORY.idFromName(namespace));
-          await directory.fetch(
-            new Request(`${url.origin}/ns/${namespace}/worlds/${worldId}`, {
-              method: "PATCH",
-              headers: JSON_HEADERS,
-              body: JSON.stringify({ tick_head: body.tick }),
-            }),
-          );
+          try {
+            const headResponse = await directory.fetch(
+              new Request(`${url.origin}/ns/${namespace}/worlds/${worldId}`, {
+                method: "PATCH",
+                headers: JSON_HEADERS,
+                body: JSON.stringify({ tick_head: body.tick }),
+              }),
+            );
+            if (!headResponse.ok) {
+              console.error("directory tick_head advance failed", headResponse.status);
+            }
+          } catch (error) {
+            console.error("directory tick_head advance failed", error);
+          }
         }
         return response;
       }
@@ -283,7 +294,7 @@ export class WorldCommitDO implements DurableObject {
         m.tick,
         m.commit_token,
         m.writer_epoch,
-        JSON.stringify(m.table_ids ?? []),
+        JSON.stringify([...((m.table_ids as string[] | undefined) ?? [])].sort()),
         now,
       );
       return json({ ok: true });

--- a/infra/control-catalog/src/index.ts
+++ b/infra/control-catalog/src/index.ts
@@ -269,6 +269,15 @@ export class WorldCommitDO implements DurableObject {
       return json({ epoch: rows.length ? Number((rows[0] as Record<string, unknown>).epoch) : null });
     }
 
+    if (route[0] === "manifest-head" && method === "GET") {
+      const run = url.searchParams.get("run") ?? "";
+      const rows = this.sql
+        .exec("SELECT MAX(tick) AS tick FROM manifests WHERE run_id = ?", run)
+        .toArray();
+      const tick = rows.length ? (rows[0] as Record<string, unknown>).tick : null;
+      return json({ tick: tick === null ? null : Number(tick) });
+    }
+
     if (route[0] === "manifests" && method === "POST") {
       const m = (await request.json()) as Record<string, unknown>;
       const fence = this.sql.exec("SELECT epoch FROM fence WHERE singleton = 1").toArray();

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -271,6 +271,7 @@ class ControlCatalog(Protocol):
     async def list_worlds(self) -> list[WorldRecord]: ...
     async def register_signature(self, record: SignatureRecord) -> None: ...
     async def list_signatures(self) -> list[SignatureRecord]: ...
+    async def max_manifest_tick(self, world_id: str, run_id: str) -> int | None: ...
     async def close(self) -> None: ...
 
 
@@ -717,6 +718,20 @@ class SqliteControlCatalog:
                 "SELECT epoch FROM writer_fence WHERE world_id=?", (world_id,)
             ).fetchone()
             return int(row["epoch"]) if row is not None else None
+
+        return await self._run(_get)
+
+    async def max_manifest_tick(self, world_id: str, run_id: str) -> int | None:
+        def _get() -> int | None:
+            row = (
+                self._connect_sync()
+                .execute(
+                    "SELECT MAX(tick) AS tick FROM manifests WHERE world_id=? AND run_id=?",
+                    (world_id, run_id),
+                )
+                .fetchone()
+            )
+            return int(row["tick"]) if row is not None and row["tick"] is not None else None
 
         return await self._run(_get)
 

--- a/src/archetype/app/_remote_catalog.py
+++ b/src/archetype/app/_remote_catalog.py
@@ -160,6 +160,11 @@ class RemoteControlCatalog:
         epoch = response.json().get("epoch")
         return int(epoch) if epoch is not None else None
 
+    async def max_manifest_tick(self, world_id: str, run_id: str) -> int | None:
+        response = await self._call("GET", f"/w/{world_id}/manifest-head?run={run_id}")
+        tick = response.json().get("tick")
+        return int(tick) if tick is not None else None
+
     async def publish_manifest(
         self,
         world_id: str,

--- a/src/archetype/app/ingestion_service.py
+++ b/src/archetype/app/ingestion_service.py
@@ -165,6 +165,8 @@ class IngestionService:
         run_id = record.run_id
         if not run_id:
             raise RuntimeError(f"world {wid} has no recorded run; nothing to attach facts to")
+        manifest_tick = await catalog.max_manifest_tick(wid, str(run_id))
+        claim_tick = record.tick_head if manifest_tick is None else manifest_tick
         sig, table_id, signature_record = self._signature(component_types)
 
         claimant = f"{socket.gethostname()}:{os.getpid()}:{uuid7().hex[:8]}"
@@ -179,7 +181,7 @@ class IngestionService:
                     external_id=external_id,
                     payload_digest=payload_digest,
                     claimant=claimant,
-                    tick=record.tick_head,
+                    tick=claim_tick,
                     lease_seconds=lease_seconds,
                 )
             except ClaimPendingError:

--- a/src/archetype/app/storage_service.py
+++ b/src/archetype/app/storage_service.py
@@ -151,7 +151,7 @@ class StorageService:
 
         Default: the local SQLite catalog (the reference implementation,
         single-host authority). Setting ``ARCHETYPE_CONTROL_CATALOG_URL``
-        (+ optional ``ARCHETYPE_CONTROL_CATALOG_TOKEN``) selects the remote
+        and ``ARCHETYPE_CONTROL_CATALOG_TOKEN`` selects the remote
         Durable Objects catalog (issue #281), namespaced by the storage
         fingerprint — the same identity key both implementations pool by,
         so a config resolves to ONE catalog whichever backend serves it.
@@ -161,6 +161,12 @@ class StorageService:
             from archetype.app._catalog import storage_fingerprint
             from archetype.app._remote_catalog import RemoteControlCatalog
 
+            token = os.environ.get("ARCHETYPE_CONTROL_CATALOG_TOKEN", "").strip()
+            if not token:
+                raise RuntimeError(
+                    "ARCHETYPE_CONTROL_CATALOG_TOKEN is required when "
+                    "ARCHETYPE_CONTROL_CATALOG_URL is configured"
+                )
             namespace = storage_fingerprint(storage_config)[:24]
             key = f"{remote_url}::{namespace}"
             catalog = self._catalogs.get(key)
@@ -168,7 +174,7 @@ class StorageService:
                 catalog = RemoteControlCatalog(
                     remote_url,
                     namespace,
-                    token=os.environ.get("ARCHETYPE_CONTROL_CATALOG_TOKEN") or None,
+                    token=token,
                 )
                 self._catalogs[key] = catalog
             return catalog

--- a/tests/app/test_ingestion.py
+++ b/tests/app/test_ingestion.py
@@ -10,6 +10,7 @@ a fact is visible iff its claim is COMPLETE.
 """
 
 import asyncio
+from dataclasses import replace
 
 import pytest
 
@@ -72,6 +73,32 @@ async def test_ingest_appends_visible_fact_with_external_key_on_rows(tmp_path):
         assert rows[0]["factmeta__commit_id"] == receipt.commit_token, (
             "the external key and commit id ride the data plane"
         )
+    finally:
+        await c.shutdown()
+
+
+async def test_fact_tick_uses_manifest_head_when_directory_head_lags(tmp_path, monkeypatch):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await _world(c, storage)
+        await c.simulation_service.step(world.world_id, RunConfig())
+        catalog = c.storage_service.get_control_catalog(storage)
+        real_get_world = catalog.get_world
+
+        async def stale_get_world(world_id):
+            record = await real_get_world(world_id)
+            return replace(record, tick_head=0) if record is not None else None
+
+        monkeypatch.setattr(catalog, "get_world", stale_get_world)
+        receipt = await c.ingestion_service.ingest_fact(
+            str(world.world_id),
+            [Reading(value=21.5, unit="C")],
+            external_id="after-derived-head-failure",
+            producer="sensor-001",
+        )
+
+        assert receipt.tick == 1
     finally:
         await c.shutdown()
 

--- a/tests/app/test_remote_catalog_client.py
+++ b/tests/app/test_remote_catalog_client.py
@@ -10,6 +10,8 @@ import pytest
 
 from archetype.app import _remote_catalog
 from archetype.app._remote_catalog import RemoteControlCatalog
+from archetype.app.storage_service import StorageService
+from archetype.core.config import StorageConfig
 
 pytestmark = pytest.mark.asyncio
 
@@ -23,6 +25,15 @@ async def _catalog_with(responses: list[httpx.Response]) -> RemoteControlCatalog
 
     catalog._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     return catalog
+
+
+async def test_remote_catalog_configuration_requires_token(monkeypatch):
+    monkeypatch.setenv("ARCHETYPE_CONTROL_CATALOG_URL", "https://catalog.invalid")
+    monkeypatch.delenv("ARCHETYPE_CONTROL_CATALOG_TOKEN", raising=False)
+
+    service = StorageService()
+    with pytest.raises(RuntimeError, match="ARCHETYPE_CONTROL_CATALOG_TOKEN is required"):
+        service.get_control_catalog(StorageConfig())
 
 
 async def test_get_world_retries_transient_server_errors(monkeypatch):

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -37,6 +37,7 @@ from archetype.core.interfaces import StaleWriterError
 pytestmark = pytest.mark.asyncio
 
 WORKER_DIR = Path(__file__).resolve().parents[2] / "infra" / "control-catalog"
+WORKER_TOKEN = "archetype-parity-token"
 
 
 def _free_port() -> int:
@@ -51,7 +52,17 @@ def worker_url():
         pytest.skip("npx unavailable; wrangler dev harness skipped")
     port = _free_port()
     proc = subprocess.Popen(
-        ["npx", "--yes", "wrangler", "dev", "--local", "--port", str(port)],
+        [
+            "npx",
+            "--yes",
+            "wrangler",
+            "dev",
+            "--local",
+            "--port",
+            str(port),
+            "--var",
+            f"CATALOG_TOKEN:{WORKER_TOKEN}",
+        ],
         cwd=WORKER_DIR,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -67,7 +78,11 @@ def worker_url():
                 out = proc.stdout.read() if proc.stdout else ""
                 pytest.skip(f"wrangler dev exited early: {out[-400:]}")
             try:
-                response = httpx.get(f"{url}/ns/probe/worlds", timeout=2.0)
+                response = httpx.get(
+                    f"{url}/ns/probe/worlds",
+                    headers={"authorization": f"Bearer {WORKER_TOKEN}"},
+                    timeout=2.0,
+                )
                 if response.status_code == 200:
                     break
             except Exception:
@@ -88,7 +103,11 @@ def _remote(worker_url: str):
     from archetype.app._remote_catalog import RemoteControlCatalog
 
     # Fresh namespace per catalog instance: parity runs are independent.
-    return RemoteControlCatalog(worker_url, f"parity-{uuid.uuid4().hex[:12]}")
+    return RemoteControlCatalog(
+        worker_url,
+        f"parity-{uuid.uuid4().hex[:12]}",
+        token=WORKER_TOKEN,
+    )
 
 
 def _sqlite(tmp_path) -> SqliteControlCatalog:
@@ -105,6 +124,13 @@ def _world(wid: str = "w1", **overrides) -> WorldRecord:
 
 async def _both(tmp_path, worker_url):
     return _sqlite(tmp_path), _remote(worker_url)
+
+
+async def test_worker_requires_bearer_token(worker_url):
+    import httpx
+
+    response = httpx.get(f"{worker_url}/ns/probe/worlds")
+    assert response.status_code == 401
 
 
 async def test_world_registration_parity(tmp_path, worker_url):
@@ -157,10 +183,11 @@ async def test_fence_and_manifest_parity(tmp_path, worker_url):
         await catalog.publish_manifest("w1", "r1", 0, "tok-a", 2, ["t1"])
         with pytest.raises(CatalogConflictError):
             await catalog.publish_manifest("w1", "r1", 0, "tok-b", 2, ["t1"])
-        await catalog.publish_manifest("w1", "r1", 1, "tok-c", 2, ["t1", "t2"])
+        await catalog.publish_manifest("w1", "r1", 1, "tok-c", 2, ["t2", "t1"])
 
         manifests = await catalog.list_manifests("w1", "r1")
         assert [(m.tick, m.commit_token) for m in manifests] == [(0, "tok-a"), (1, "tok-c")]
+        assert manifests[1].table_ids == ("t1", "t2")
         # Publication advances the durable head on both backends.
         assert (await catalog.get_world("w1")).tick_head == 1
         await catalog.close()
@@ -256,6 +283,7 @@ async def test_service_stack_runs_against_remote_catalog(tmp_path, worker_url, m
     """The integration proof: coordinator + ingestion + receipts through the
     remote catalog with zero changes above the protocol."""
     monkeypatch.setenv("ARCHETYPE_CONTROL_CATALOG_URL", worker_url)
+    monkeypatch.setenv("ARCHETYPE_CONTROL_CATALOG_TOKEN", WORKER_TOKEN)
 
     from archetype.app.container import ServiceContainer
     from archetype.core.component import Component

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -18,6 +18,7 @@ receipts — against the remote catalog via ARCHETYPE_CONTROL_CATALOG_URL.
 import shutil
 import socket
 import subprocess
+import tempfile
 import time
 import uuid
 from pathlib import Path
@@ -51,6 +52,7 @@ def worker_url():
     if shutil.which("npx") is None:
         pytest.skip("npx unavailable; wrangler dev harness skipped")
     port = _free_port()
+    worker_log = tempfile.TemporaryFile(mode="w+")
     proc = subprocess.Popen(
         [
             "npx",
@@ -64,7 +66,7 @@ def worker_url():
             f"CATALOG_TOKEN:{WORKER_TOKEN}",
         ],
         cwd=WORKER_DIR,
-        stdout=subprocess.PIPE,
+        stdout=worker_log,
         stderr=subprocess.STDOUT,
         text=True,
     )
@@ -75,7 +77,8 @@ def worker_url():
         deadline = time.time() + 120
         while time.time() < deadline:
             if proc.poll() is not None:
-                out = proc.stdout.read() if proc.stdout else ""
+                worker_log.seek(0)
+                out = worker_log.read()
                 pytest.skip(f"wrangler dev exited early: {out[-400:]}")
             try:
                 response = httpx.get(
@@ -97,6 +100,7 @@ def worker_url():
             proc.wait(timeout=10)
         except subprocess.TimeoutExpired:
             proc.kill()
+        worker_log.close()
 
 
 def _remote(worker_url: str):

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -174,6 +174,7 @@ async def test_fence_and_manifest_parity(tmp_path, worker_url):
         assert await catalog.acquire_fence("w1", "h1") == 1
         assert await catalog.acquire_fence("w1", "h2") == 2
         assert await catalog.current_fence_epoch("w1") == 2
+        assert await catalog.max_manifest_tick("w1", "r1") is None
 
         # Stale epoch fails closed.
         with pytest.raises(StaleWriterError):
@@ -188,6 +189,7 @@ async def test_fence_and_manifest_parity(tmp_path, worker_url):
         manifests = await catalog.list_manifests("w1", "r1")
         assert [(m.tick, m.commit_token) for m in manifests] == [(0, "tok-a"), (1, "tok-c")]
         assert manifests[1].table_ids == ("t1", "t2")
+        assert await catalog.max_manifest_tick("w1", "r1") == 1
         # Publication advances the durable head on both backends.
         assert (await catalog.get_world("w1")).tick_head == 1
         await catalog.close()


### PR DESCRIPTION
## Summary

- require the remote catalog bearer token in both the Worker and host configuration
- keep a successful manifest publication authoritative when the derived directory-head update fails
- canonicalize manifest table IDs to match the SQLite reference

## Validation

- `make ci` — 904 passed, 6 skipped; regression 12/12; idempotency 22/22
- `uv run pytest tests/app/test_remote_catalog_parity.py -q` — 7 passed
- `npx --yes wrangler deploy --dry-run` — passed

Addresses the three unresolved Footgun threads on #291.