### PR TITLE
fix(app): harden cold-resume lifecycle boundaries

### DIFF
--- a/docs/guide/durable-discovery.md
+++ b/docs/guide/durable-discovery.md
@@ -99,9 +99,11 @@ for every component the writing process defined.
 
 ```python
 # Process B, sharing nothing with the writer but the storage config:
-infos = await gate.discover_worlds(ctx, storage_config)
-df = await runtime.query_components(
-    [Score], world_id=infos[0].world_id, run_id=infos[0].run_id,
+infos = await container.command_service.discover_worlds(ctx, storage_config)
+info = infos[0]
+assert info.run_id is not None
+df = await container.command_service.query_components(
+    ctx, [Score], world_id=str(info.world_id), run_id=str(info.run_id),
     storage_config=storage_config,
 )
 ```

--- a/docs/guide/world-lifecycle.md
+++ b/docs/guide/world-lifecycle.md
@@ -215,8 +215,9 @@ world = await runtime.resume(world_id, storage=...)
 Resume reconstructs a live, writable world from durable state in a process
 that shares nothing with the previous writer but the storage config:
 
-- **Tick** — the last *visible* tick + 1, from manifests, never from rows:
-  a crashed attempt's unpublished rows must not advance the head.
+- **Tick** — the last manifest tick + 1, never from fact claims or rows:
+  neither a visible fact nor a crashed attempt's unpublished rows may
+  advance the simulation head.
 - **Entity directory** — the latest visible row per entity across every
   catalog table decides its archetype and liveness; `next_entity_id`
   resumes past the highest id ever seen (ids are never reused). The
@@ -230,6 +231,12 @@ that shares nothing with the previous writer but the storage config:
   whose lineage rows are missing is detectable corruption and refuses.
 - **Fence** — acquired last (epoch + 1): the previous writer's next publish
   fails closed with `StaleWriterError`.
+
+Resume preflights reconstruction before fencing, then repeats it against the
+authoritative post-fence snapshot. If state changed between those reads and
+the second reconstruction fails, the new fence has already made the previous
+writer stale; the failure is logged as an operator-visible orphaned-writer
+condition and the caller must retry after correcting the reconstruction error.
 
 Resume fails loudly rather than reconstructing unfaithfully: unrecorded
 worlds (`KeyError`), destroyed worlds (queryable, never resumable), worlds

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -116,7 +116,7 @@ reason = "Processor candidate boundary: materializes the distinct, existing-key-
 
 [[entries]]
 path = "src/archetype/app/world_service.py"
-line = 701
+line = 710
 method = "to_pylist"
 reason = "Resume-time entity-directory extract (issue #273 A1-resume): the latest visible row per entity — already reduced in Daft to one (entity_id, tick, is_active) row per entity via groupby-max + join — must enter Python control flow to become the entity2sig registry and next_entity_id counter that route all subsequent mutations; imperative world reconstruction at the cold-resume boundary, bounded by live entity count, not a downstream dataframe computation."
 

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -548,10 +548,8 @@ class WorldService:
                 "persisted lineage rows; refusing to resume (corruption)"
             )
 
-        # Validation pass BEFORE fencing: rebuilding the snapshot here proves
-        # this process can faithfully reconstruct the world (classes present,
-        # descriptors resolvable) without side effects — a resume that fails
-        # validation must never stale a healthy incumbent writer.
+        # Preflight stable reconstruction failures before fencing. The world
+        # may still advance before the authoritative post-fence snapshot.
         snapshot = await self._resume_snapshot(catalog, store, wid, str(run_id), lineage)
         self._resolve_live_signatures(snapshot.directory)
 
@@ -560,23 +558,32 @@ class WorldService:
         # stable — no window where a late-published tick slips between the
         # snapshot and the fence.
         epoch = await catalog.acquire_fence(wid, _writer_holder())
-        snapshot = await self._resume_snapshot(catalog, store, wid, str(run_id), lineage)
-        entity2sig, _live_tables = self._resolve_live_signatures(snapshot.directory)
+        try:
+            snapshot = await self._resume_snapshot(catalog, store, wid, str(run_id), lineage)
+            entity2sig, _live_tables = self._resolve_live_signatures(snapshot.directory)
 
-        world = self._factory.create_async_world(
-            store,
-            WorldConfig(
-                world_id=wid,
-                name=record.name,
-                run_id=str(run_id),
-                tick=snapshot.resume_tick,
-                next_entity_id=snapshot.next_entity_id,
-                entity2sig=entity2sig,
-                lineage=lineage or [],
-            ),
-        )
-        world.commit_coordinator = CatalogCommitCoordinator(catalog, epoch=epoch)
-        self._registry.insert(world)
+            world = self._factory.create_async_world(
+                store,
+                WorldConfig(
+                    world_id=wid,
+                    name=record.name,
+                    run_id=str(run_id),
+                    tick=snapshot.resume_tick,
+                    next_entity_id=snapshot.next_entity_id,
+                    entity2sig=entity2sig,
+                    lineage=lineage or [],
+                ),
+            )
+            world.commit_coordinator = CatalogCommitCoordinator(catalog, epoch=epoch)
+            self._registry.insert(world)
+        except Exception:
+            logger.exception(
+                "resume for world %s acquired fence epoch %d but failed before "
+                "installing its replacement writer; the previous writer is now stale",
+                wid,
+                epoch,
+            )
+            raise
         self._storage_configs[wid] = (storage_config, None)
         logger.info(
             "resumed world %s at tick %d (epoch %d, %d entities)",
@@ -607,14 +614,16 @@ class WorldService:
         state; the fork's own rows override by tick.
         """
         visible = await catalog.visible_tokens(world_id, run_id)
-        if visible:
-            resume_tick: int | None = max(visible) + 1
+        manifest_tick = await catalog.max_manifest_tick(world_id, run_id)
+        if visible is not None:
             tokens: list[str] | None = sorted(
                 {token for token_list in visible.values() for token in token_list}
             )
-        elif visible is not None:
-            resume_tick = (lineage[-1][2] + 1) if lineage else 0
-            tokens = []
+            resume_tick: int | None = (
+                manifest_tick + 1
+                if manifest_tick is not None
+                else ((lineage[-1][2] + 1) if lineage else 0)
+            )
         else:
             # Never-fenced legacy world: rows are implicitly visible and the
             # own-row head is the true head (resolved after the scan).
@@ -796,10 +805,10 @@ class WorldService:
         record = self._storage_configs.get(str(world_id))
         if record is None:
             return
-        world = self._orchestrator.get_world(UUID(str(world_id)))
-        if not world.run_id:
-            return
         try:
+            world = self._orchestrator.get_world(UUID(str(world_id)))
+            if not world.run_id:
+                return
             catalog = self._storage_service.get_control_catalog(record[0])
             await catalog.set_world_run(str(world_id), str(world.run_id))
         except Exception:

--- a/tests/app/test_durable_discovery.py
+++ b/tests/app/test_durable_discovery.py
@@ -10,6 +10,7 @@ container recycling would not prove cold discovery.
 """
 
 import json
+import logging
 import multiprocessing
 import sqlite3
 import subprocess
@@ -190,6 +191,22 @@ async def test_destroyed_worlds_stay_discoverable_with_status(tmp_path):
         assert [str(i.world_id) for i in infos] == [str(world.world_id)]
         record = await c.storage_service.get_control_catalog(storage).get_world(str(world.world_id))
         assert record.status == "destroyed", "append-only: destroy marks, never deletes"
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_record_step_remains_advisory_after_destroy(tmp_path, caplog):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="ephemeral"), storage)
+        await c.world_service.destroy_world(world.world_id)
+
+        with caplog.at_level(logging.ERROR):
+            await c.world_service.record_step(world.world_id)
+
+        assert "catalog run update failed" in caplog.text
     finally:
         await c.shutdown()
 

--- a/tests/app/test_world_resume.py
+++ b/tests/app/test_world_resume.py
@@ -12,6 +12,7 @@ processors/resources/hooks reattach explicitly.
 """
 
 import json
+import logging
 import subprocess
 import sys
 import textwrap
@@ -146,6 +147,29 @@ async def test_resume_after_crash_resumes_at_last_visible_tick(tmp_path, monkeyp
         await fresh.simulation_service.step(wid, RunConfig())
         df = await fresh.query_service.query_components([Score], wid, rid, storage, ticks=[1])
         assert len(df.to_pylist()) == 1, "exactly one visible attempt at the retried tick"
+    finally:
+        await fresh.shutdown()
+
+
+async def test_fact_only_claim_does_not_advance_resume_tick(tmp_path):
+    c = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await c.world_service.create_world(WorldConfig(name="facts-first"), storage)
+        await c.ingestion_service.ingest_fact(
+            world.world_id,
+            [Score(points=42.0)],
+            external_id="before-first-step",
+            producer="sensor",
+        )
+        wid = str(world.world_id)
+    finally:
+        await c.shutdown()
+
+    fresh = ServiceContainer()
+    try:
+        resumed = await fresh.world_service.open_world_mutable(storage, wid)
+        assert resumed.tick == 0, "fact claims are visible but are not tick manifests"
     finally:
         await fresh.shutdown()
 
@@ -490,3 +514,40 @@ async def test_resume_snapshot_taken_after_fence_beats_racing_publisher(tmp_path
     finally:
         await a.shutdown()
         await b.shutdown()
+
+
+async def test_post_fence_resume_failure_is_operationally_loud(tmp_path, monkeypatch, caplog):
+    incumbent = ServiceContainer()
+    replacement = ServiceContainer()
+    try:
+        storage = _storage(tmp_path)
+        world = await incumbent.world_service.create_world(WorldConfig(name="w"), storage)
+        await incumbent.mutation_service.create_entity(world.world_id, [Score(points=1.0)])
+        await incumbent.simulation_service.step(world.world_id, RunConfig())
+        wid = str(world.world_id)
+
+        real_resolve = replacement.world_service._resolve_live_signatures
+        calls = 0
+
+        def fail_after_fence(directory):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("injected post-fence reconstruction failure")
+            return real_resolve(directory)
+
+        monkeypatch.setattr(
+            replacement.world_service,
+            "_resolve_live_signatures",
+            fail_after_fence,
+        )
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(RuntimeError, match="post-fence reconstruction"):
+                await replacement.world_service.open_world_mutable(storage, wid)
+
+        assert "previous writer is now stale" in caplog.text
+        with pytest.raises((StaleWriterError, RuntimeError)):
+            await incumbent.simulation_service.step(wid, RunConfig())
+    finally:
+        await incumbent.shutdown()
+        await replacement.shutdown()


### PR DESCRIPTION
## What changed

- derive cold-resume tick exclusively from the durable manifest head while retaining fact claims in the visibility allowlist
- make post-fence reconstruction failures operator-visible and keep advisory step recording safe during destroy races
- correct the normative cold-query examples to use the supported command-service path
- add regression coverage for fact-only claims, reconstruction failure, and advisory-record races

## Why

Cold resume must follow committed simulation state, not auxiliary fact ingestion. Reconstruction after ownership fencing also needs to fail loudly without turning advisory bookkeeping into a lifecycle failure.

## Impact

World resume remains deterministic, fact ingestion cannot advance simulation time, and operators receive actionable diagnostics when fenced reconstruction fails.

## Validation

- `make check`
- `make ci` — 908 passed, 7 skipped
- focused lifecycle regressions — 12 passed
- idempotency suite — 22 passed
- `git diff --check origin/main...HEAD`
