### PR TITLE
fix(rust): make tick preparation failure-atomic

### DIFF
--- a/crates/archetype-core/src/aio/async_store.rs
+++ b/crates/archetype-core/src/aio/async_store.rs
@@ -14,6 +14,7 @@ pub struct ReadFilter {
 
 #[async_trait]
 pub trait Store: Send + Sync {
+    /// Atomically publish one table batch: `Err` must leave the batch invisible.
     async fn append(&self, table_name: &str, batch: &RecordBatch) -> Result<()>;
 
     async fn read_table(&self, table_name: &str, filter: ReadFilter) -> Result<Vec<RecordBatch>>;

--- a/crates/archetype-core/src/aio/async_world.rs
+++ b/crates/archetype-core/src/aio/async_world.rs
@@ -105,6 +105,7 @@ pub struct WorldState {
     next_entity_id: EntityId,
     entity2table: HashMap<EntityId, String>,
     mutations: MutationBuffer,
+    partial_failure: Option<PartialTickFailure>,
 }
 
 impl WorldState {
@@ -116,6 +117,7 @@ impl WorldState {
             next_entity_id: 1,
             entity2table: HashMap::new(),
             mutations: MutationBuffer::default(),
+            partial_failure: None,
         }
     }
 
@@ -150,6 +152,7 @@ impl WorldState {
         table_schema: SchemaRef,
         component_batch: RecordBatch,
     ) -> Result<Vec<EntityId>> {
+        self.ensure_healthy()?;
         let table_name = table_name.into();
         let rows = component_batch.num_rows();
         let entity_ids = (0..rows)
@@ -172,6 +175,7 @@ impl WorldState {
         component_batch: RecordBatch,
         entity_ids: &[EntityId],
     ) -> Result<()> {
+        self.ensure_healthy()?;
         let table_name = table_name.into();
         let spawn = stamp_spawn_batch(
             table_schema,
@@ -209,6 +213,7 @@ impl WorldState {
         component_batch: RecordBatch,
         entity_ids: &[EntityId],
     ) -> Result<()> {
+        self.ensure_healthy()?;
         let table_name = table_name.into();
         let spawn = stamp_spawn_batch(
             table_schema,
@@ -268,6 +273,7 @@ impl WorldState {
     }
 
     pub fn queue_despawn(&mut self, entity_id: EntityId) -> Result<()> {
+        self.ensure_healthy()?;
         let table_name = self
             .entity2table
             .get(&entity_id)
@@ -315,6 +321,7 @@ impl WorldState {
         table_schema: SchemaRef,
         prior: RecordBatch,
     ) -> Result<RecordBatch> {
+        self.ensure_healthy()?;
         let materialized = self.staged_despawns_to_prior(table_name, table_schema, prior)?;
         self.mutations.despawns.remove(table_name);
         Ok(materialized)
@@ -349,6 +356,7 @@ impl WorldState {
     /// first-seen insertion order — matching the Python dict-based spawn
     /// dedupe.  Returns an empty `Vec` if nothing was queued.
     pub fn drain_spawn_frames(&mut self, table_name: &str) -> Result<Vec<RecordBatch>> {
+        self.ensure_healthy()?;
         let frames = self.staged_spawn_frames(table_name)?;
         self.mutations.spawns.remove(table_name);
         Ok(frames)
@@ -411,6 +419,7 @@ impl WorldState {
         table_schema: SchemaRef,
         prior: RecordBatch,
     ) -> Result<RecordBatch> {
+        self.ensure_healthy()?;
         let processor_input =
             self.staged_despawns_to_prior(table_name, table_schema.clone(), prior)?;
         let spawn_frames = self.staged_spawn_frames(table_name)?;
@@ -421,8 +430,21 @@ impl WorldState {
         Ok(materialized)
     }
 
-    pub fn advance_tick(&mut self) {
+    pub fn advance_tick(&mut self) -> Result<()> {
+        self.ensure_healthy()?;
         self.tick += 1;
+        Ok(())
+    }
+
+    fn poison(&mut self, failure: PartialTickFailure) {
+        self.partial_failure = Some(failure);
+    }
+
+    fn ensure_healthy(&self) -> Result<()> {
+        match &self.partial_failure {
+            Some(failure) => Err(failure.as_error()),
+            None => Ok(()),
+        }
     }
 }
 
@@ -435,7 +457,6 @@ where
     system: AsyncSystem,
     tables: HashMap<String, SchemaRef>,
     live_tables: HashMap<String, RecordBatch>,
-    partial_failure: Option<PartialTickFailure>,
 }
 
 impl<S> AsyncWorld<S>
@@ -449,7 +470,6 @@ where
             system,
             tables: HashMap::new(),
             live_tables: HashMap::new(),
-            partial_failure: None,
         }
     }
 
@@ -563,7 +583,7 @@ where
                         cause: error.to_string(),
                     };
                     let error = failure.as_error();
-                    self.partial_failure = Some(failure);
+                    self.state.poison(failure);
                     return Err(error);
                 }
             }
@@ -573,7 +593,7 @@ where
             .into_iter()
             .map(|table| self.finalize_prepared_table(table).1)
             .collect();
-        self.state.advance_tick();
+        self.state.advance_tick()?;
         Ok(StepProfile {
             tick,
             tables,
@@ -611,7 +631,7 @@ where
         let mut prepared = self.prepare_table_profiled(table_name).await?;
         self.append_prepared_table(&mut prepared).await?;
         let completed = self.finalize_prepared_table(prepared);
-        self.state.advance_tick();
+        self.state.advance_tick()?;
         Ok(completed)
     }
 
@@ -701,10 +721,7 @@ where
     }
 
     fn ensure_healthy(&self) -> Result<()> {
-        match &self.partial_failure {
-            Some(failure) => Err(failure.as_error()),
-            None => Ok(()),
-        }
+        self.state.ensure_healthy()
     }
 
     pub async fn query_table(

--- a/crates/archetype-core/src/aio/async_world.rs
+++ b/crates/archetype-core/src/aio/async_world.rs
@@ -3,19 +3,24 @@
 //! ```text
 //! Tick N:
 //!   1. Read prior active rows (live snapshot from tick N-1, or store).
-//!   2. Apply despawns: drain despawn buffer, tombstone matching rows in prior.
+//!   2. Apply staged despawns: tombstone matching rows in prior.
 //!      Result = processor_input (only previously-live rows, with despawned ones
 //!      marked is_active=false).
 //!   3. Execute processors over processor_input.  Spawns queued this tick are NOT
 //!      visible to processors — they land raw.
-//!   4. Drain spawn buffer: deduplicate (last-write-wins, first-seen order), concat
+//!   4. Read staged spawns: deduplicate (last-write-wins, first-seen order), concat
 //!      raw spawn rows AFTER processor output.
 //!      Invariant: x₀ is the raw spawn value; x_{t+1} = f(x_t).
 //!   5. Stamp tick/world/run metadata on the full concatenated batch.
 //!   6. Persist the stamped batch.
-//!   7. Update live snapshot = active_snapshot(stamped), which includes raw spawn
+//!   7. Consume that table's mutations and update its live snapshot. The snapshot
+//!      is active_snapshot(stamped), which includes raw spawn
 //!      rows (is_active=true) so they are transformed for the first time on tick N+1.
 //! ```
+//!
+//! A world prepares every active table before the first append. Store appends
+//! are atomic per table, not across tables; failure after an earlier table was
+//! published poisons the world so tick N cannot be retried and duplicated.
 //!
 //! Same-tick spawn-cancel (despawn while spawn is still pending) removes the
 //! spawn row entirely without writing a tombstone — the entity is never observed.
@@ -58,6 +63,29 @@ pub struct StepProfile {
     pub tick: i32,
     pub tables: Vec<TableStepProfile>,
     pub tick_sec: f64,
+}
+
+struct PreparedTableStep {
+    batch: RecordBatch,
+    live_snapshot: RecordBatch,
+    profile: TableStepProfile,
+}
+
+#[derive(Debug, Clone)]
+struct PartialTickFailure {
+    tick: i32,
+    committed_tables: usize,
+    cause: String,
+}
+
+impl PartialTickFailure {
+    fn as_error(&self) -> ArchetypeCoreError {
+        ArchetypeCoreError::PartialTick {
+            tick: self.tick,
+            committed_tables: self.committed_tables,
+            cause: self.cause.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -150,6 +178,16 @@ impl WorldState {
             &self.world_id,
             &self.run_id,
         )?;
+        self.queue_stamped_spawn_batch(table_name, spawn, entity_ids);
+        Ok(())
+    }
+
+    fn queue_stamped_spawn_batch(
+        &mut self,
+        table_name: String,
+        spawn: RecordBatch,
+        entity_ids: &[EntityId],
+    ) {
         for entity_id in entity_ids {
             self.entity2table.insert(*entity_id, table_name.clone());
             self.next_entity_id = self.next_entity_id.max(*entity_id + 1);
@@ -159,17 +197,82 @@ impl WorldState {
             .entry(table_name)
             .or_default()
             .push(spawn);
+    }
+
+    fn queue_migration_batch(
+        &mut self,
+        table_name: impl Into<String>,
+        table_schema: SchemaRef,
+        component_batch: RecordBatch,
+        entity_ids: &[EntityId],
+    ) -> Result<()> {
+        let table_name = table_name.into();
+        let spawn = stamp_spawn_batch(
+            table_schema,
+            component_batch,
+            entity_ids,
+            self.tick,
+            &self.world_id,
+            &self.run_id,
+        )?;
+
+        let mut source_entities = HashMap::<String, Vec<EntityId>>::new();
+        for entity_id in entity_ids {
+            let source = self
+                .entity2table
+                .get(entity_id)
+                .ok_or(ArchetypeCoreError::UnknownEntity(*entity_id))?;
+            source_entities
+                .entry(source.clone())
+                .or_default()
+                .push(*entity_id);
+        }
+
+        let mut retained_spawns = HashMap::new();
+        let mut cancelled_spawns = HashSet::new();
+        for (source, ids) in &source_entities {
+            let Some(batches) = self.mutations.spawns.get(source) else {
+                continue;
+            };
+            let targets = ids.iter().copied().collect::<HashSet<_>>();
+            let (retained, removed) = remove_entities_from_spawn_batches(batches, &targets)?;
+            retained_spawns.insert(source.clone(), retained);
+            cancelled_spawns.extend(removed);
+        }
+
+        for (source, retained) in retained_spawns {
+            if retained.is_empty() {
+                self.mutations.spawns.remove(&source);
+            } else {
+                self.mutations.spawns.insert(source, retained);
+            }
+        }
+        for (source, ids) in source_entities {
+            let tombstones = ids
+                .into_iter()
+                .filter(|entity_id| !cancelled_spawns.contains(entity_id))
+                .collect::<Vec<_>>();
+            if !tombstones.is_empty() {
+                self.mutations
+                    .despawns
+                    .entry(source)
+                    .or_default()
+                    .extend(tombstones);
+            }
+        }
+        self.queue_stamped_spawn_batch(table_name, spawn, entity_ids);
         Ok(())
     }
 
     pub fn queue_despawn(&mut self, entity_id: EntityId) -> Result<()> {
         let table_name = self
             .entity2table
-            .remove(&entity_id)
+            .get(&entity_id)
+            .cloned()
             .ok_or(ArchetypeCoreError::UnknownEntity(entity_id))?;
-        // A despawn in the same tick as the spawn cancels the pending spawn
-        // instead of queueing a tombstone, matching AsyncWorld.remove_entity.
-        if self.cancel_pending_spawn(&table_name, entity_id)? {
+        let cancelled = self.cancel_pending_spawn(&table_name, entity_id)?;
+        self.entity2table.remove(&entity_id);
+        if cancelled {
             return Ok(());
         }
         self.mutations
@@ -181,32 +284,19 @@ impl WorldState {
     }
 
     fn cancel_pending_spawn(&mut self, table_name: &str, entity_id: EntityId) -> Result<bool> {
-        let Some(batches) = self.mutations.spawns.get_mut(table_name) else {
+        let Some(batches) = self.mutations.spawns.get(table_name) else {
             return Ok(false);
         };
-
-        let mut cancelled = false;
-        let mut kept = Vec::with_capacity(batches.len());
-        for batch in batches.drain(..) {
-            let entities = entity_column(&batch)?;
-            let keep = BooleanArray::from_iter(
-                (0..batch.num_rows()).map(|idx| Some(entities.value(idx) != entity_id)),
-            );
-            if keep.true_count() == batch.num_rows() {
-                kept.push(batch);
-            } else {
-                cancelled = true;
-                let filtered = filter_record_batch(&batch, &keep)?;
-                if filtered.num_rows() > 0 {
-                    kept.push(filtered);
-                }
-            }
-        }
-        *batches = kept;
-        if batches.is_empty() {
+        let targets = HashSet::from([entity_id]);
+        let (retained, removed) = remove_entities_from_spawn_batches(batches, &targets)?;
+        if retained.is_empty() {
             self.mutations.spawns.remove(table_name);
+        } else {
+            self.mutations
+                .spawns
+                .insert(table_name.to_string(), retained);
         }
-        Ok(cancelled)
+        Ok(removed.contains(&entity_id))
     }
 
     /// Phase 1 of the tick lifecycle: apply queued despawns to `prior` and
@@ -222,20 +312,29 @@ impl WorldState {
         table_schema: SchemaRef,
         prior: RecordBatch,
     ) -> Result<RecordBatch> {
+        let materialized = self.staged_despawns_to_prior(table_name, table_schema, prior)?;
+        self.mutations.despawns.remove(table_name);
+        Ok(materialized)
+    }
+
+    fn staged_despawns_to_prior(
+        &self,
+        table_name: &str,
+        table_schema: SchemaRef,
+        prior: RecordBatch,
+    ) -> Result<RecordBatch> {
         if prior.schema().fields() != table_schema.fields() {
             return Err(ArchetypeCoreError::SchemaMismatch {
                 table_name: table_name.to_string(),
             });
         }
-        let despawns = self
-            .mutations
-            .despawns
-            .remove(table_name)
-            .unwrap_or_default();
+        let Some(despawns) = self.mutations.despawns.get(table_name) else {
+            return Ok(prior);
+        };
         if despawns.is_empty() {
             Ok(prior)
         } else {
-            apply_despawns(prior, &despawns)
+            apply_despawns(prior, despawns)
         }
     }
 
@@ -247,14 +346,20 @@ impl WorldState {
     /// first-seen insertion order — matching the Python dict-based spawn
     /// dedupe.  Returns an empty `Vec` if nothing was queued.
     pub fn drain_spawn_frames(&mut self, table_name: &str) -> Result<Vec<RecordBatch>> {
-        let Some(spawns) = self.mutations.spawns.remove(table_name) else {
+        let frames = self.staged_spawn_frames(table_name)?;
+        self.mutations.spawns.remove(table_name);
+        Ok(frames)
+    }
+
+    fn staged_spawn_frames(&self, table_name: &str) -> Result<Vec<RecordBatch>> {
+        let Some(spawns) = self.mutations.spawns.get(table_name) else {
             return Ok(Vec::new());
         };
         // Dedupe: last-write-wins for duplicate entity IDs, first-seen order.
         let mut order = Vec::<EntityId>::new();
         let mut latest_by_entity = HashMap::<EntityId, RecordBatchRow>::new();
         let mut total_rows = 0usize;
-        for batch in &spawns {
+        for batch in spawns {
             let entities = entity_column(batch)?;
             for row_idx in 0..batch.num_rows() {
                 let entity_id = entities.value(row_idx);
@@ -274,7 +379,7 @@ impl WorldState {
             }
         }
         if latest_by_entity.len() == total_rows {
-            Ok(spawns)
+            Ok(spawns.clone())
         } else {
             order
                 .into_iter()
@@ -284,6 +389,11 @@ impl WorldState {
                 })
                 .collect()
         }
+    }
+
+    fn consume_table_mutations(&mut self, table_name: &str) {
+        self.mutations.spawns.remove(table_name);
+        self.mutations.despawns.remove(table_name);
     }
 
     /// Convenience wrapper used by unit tests and migration helpers: applies
@@ -299,11 +409,13 @@ impl WorldState {
         prior: RecordBatch,
     ) -> Result<RecordBatch> {
         let processor_input =
-            self.apply_despawns_to_prior(table_name, table_schema.clone(), prior)?;
-        let spawn_frames = self.drain_spawn_frames(table_name)?;
+            self.staged_despawns_to_prior(table_name, table_schema.clone(), prior)?;
+        let spawn_frames = self.staged_spawn_frames(table_name)?;
         let mut batches = vec![processor_input];
         batches.extend(spawn_frames);
-        concat_batches(&table_schema, &batches).map_err(Into::into)
+        let materialized = concat_batches(&table_schema, &batches)?;
+        self.consume_table_mutations(table_name);
+        Ok(materialized)
     }
 
     pub fn advance_tick(&mut self) {
@@ -320,6 +432,7 @@ where
     system: AsyncSystem,
     tables: HashMap<String, SchemaRef>,
     live_tables: HashMap<String, RecordBatch>,
+    partial_failure: Option<PartialTickFailure>,
 }
 
 impl<S> AsyncWorld<S>
@@ -333,6 +446,7 @@ where
             system,
             tables: HashMap::new(),
             live_tables: HashMap::new(),
+            partial_failure: None,
         }
     }
 
@@ -371,9 +485,12 @@ where
         table: &ArchetypeTable,
         component_batch: RecordBatch,
     ) -> Result<Vec<EntityId>> {
+        self.ensure_healthy()?;
+        let entity_ids =
+            self.state
+                .queue_spawn_batch(table.table_name(), table.schema(), component_batch)?;
         self.register_table(table);
-        self.state
-            .queue_spawn_batch(table.table_name(), table.schema(), component_batch)
+        Ok(entity_ids)
     }
 
     pub fn queue_spawn_batch_with_entity_ids(
@@ -382,16 +499,19 @@ where
         component_batch: RecordBatch,
         entity_ids: &[EntityId],
     ) -> Result<()> {
-        self.register_table(table);
+        self.ensure_healthy()?;
         self.state.queue_spawn_batch_with_entity_ids(
             table.table_name(),
             table.schema(),
             component_batch,
             entity_ids,
-        )
+        )?;
+        self.register_table(table);
+        Ok(())
     }
 
     pub fn queue_despawn(&mut self, entity_id: EntityId) -> Result<()> {
+        self.ensure_healthy()?;
         self.state.queue_despawn(entity_id)
     }
 
@@ -401,16 +521,15 @@ where
         entity_ids: &[EntityId],
         new_component_batch: RecordBatch,
     ) -> Result<()> {
-        self.register_table(new_table);
-        for entity_id in entity_ids {
-            self.state.queue_despawn(*entity_id)?;
-        }
-        self.state.queue_spawn_batch_with_entity_ids(
+        self.ensure_healthy()?;
+        self.state.queue_migration_batch(
             new_table.table_name(),
             new_table.schema(),
             new_component_batch,
             entity_ids,
-        )
+        )?;
+        self.register_table(new_table);
+        Ok(())
     }
 
     pub async fn step(&mut self) -> Result<()> {
@@ -418,17 +537,39 @@ where
     }
 
     pub async fn step_profiled(&mut self) -> Result<StepProfile> {
+        self.ensure_healthy()?;
         let tick_start = Instant::now();
         let tick = self.state.tick();
         let mut table_names = self.state.active_tables().into_iter().collect::<Vec<_>>();
         table_names.sort();
 
-        let mut tables = Vec::with_capacity(table_names.len());
-        for table_name in table_names {
-            let (_batch, profile) = self.step_table_profiled(&table_name).await?;
-            tables.push(profile);
+        let mut prepared = Vec::with_capacity(table_names.len());
+        for table_name in &table_names {
+            prepared.push(self.prepare_table_profiled(table_name).await?);
         }
 
+        let mut committed_tables = 0;
+        for table in &mut prepared {
+            match self.append_prepared_table(table).await {
+                Ok(()) => committed_tables += usize::from(table.batch.num_rows() > 0),
+                Err(error) if committed_tables == 0 => return Err(error),
+                Err(error) => {
+                    let failure = PartialTickFailure {
+                        tick,
+                        committed_tables,
+                        cause: error.to_string(),
+                    };
+                    let error = failure.as_error();
+                    self.partial_failure = Some(failure);
+                    return Err(error);
+                }
+            }
+        }
+
+        let tables = prepared
+            .into_iter()
+            .map(|table| self.finalize_prepared_table(table).1)
+            .collect();
         self.state.advance_tick();
         Ok(StepProfile {
             tick,
@@ -454,16 +595,13 @@ where
         &mut self,
         table_name: &str,
     ) -> Result<(RecordBatch, TableStepProfile)> {
-        // ── Tick lifecycle for one table ─────────────────────────────────────
-        // See module-level docs for the full ordered description.
-        //
-        // Phase 1: read prior active rows.
-        // Phase 2: apply despawns (tombstone in prior, not in spawns).
-        // Phase 3: execute processors over the despawn-filtered prior.
-        //           Spawns queued this tick are NOT visible here.
-        // Phase 4: drain spawn buffer; concat raw spawn rows AFTER processed.
-        //           Invariant: x₀ lands raw, f applied first on tick N+1.
-        // Phase 5: stamp metadata, persist, update live snapshot.
+        self.ensure_healthy()?;
+        let mut prepared = self.prepare_table_profiled(table_name).await?;
+        self.append_prepared_table(&mut prepared).await?;
+        Ok(self.finalize_prepared_table(prepared))
+    }
+
+    async fn prepare_table_profiled(&self, table_name: &str) -> Result<PreparedTableStep> {
         let table_start = Instant::now();
         let schema = self
             .tables
@@ -471,19 +609,16 @@ where
             .cloned()
             .ok_or_else(|| ArchetypeCoreError::UnknownTable(table_name.to_string()))?;
 
-        // Phase 1 — read prior
         let read_prior_start = Instant::now();
         let prior = self.read_prior_table(table_name, schema.clone()).await?;
         let read_prior_sec = read_prior_start.elapsed().as_secs_f64();
 
-        // Phase 2 — apply despawns (pre-processor)
         let materialize_start = Instant::now();
         let processor_input =
             self.state
-                .apply_despawns_to_prior(table_name, schema.clone(), prior)?;
+                .staged_despawns_to_prior(table_name, schema.clone(), prior)?;
         let materialize_sec = materialize_start.elapsed().as_secs_f64();
 
-        // Phase 3 — run processors over the despawn-filtered prior rows
         let process_start = Instant::now();
         let processed = self.system.execute(
             processor_input,
@@ -495,8 +630,7 @@ where
         )?;
         let process_sec = process_start.elapsed().as_secs_f64();
 
-        // Phase 4 — drain spawn buffer, concat raw spawn rows after processed
-        let spawn_frames = self.state.drain_spawn_frames(table_name)?;
+        let spawn_frames = self.state.staged_spawn_frames(table_name)?;
         let combined = if spawn_frames.is_empty() {
             processed
         } else {
@@ -505,32 +639,58 @@ where
             concat_batches(&schema, &batches)?
         };
 
-        // Phase 5 — stamp, persist, update live snapshot
         let stamped = stamp_batch_metadata(
             combined,
             self.state.tick(),
             self.state.world_id(),
             self.state.run_id(),
         )?;
-        let append_start = Instant::now();
-        if stamped.num_rows() > 0 {
-            self.store.append(table_name, &stamped).await?;
-        }
-        let append_sec = append_start.elapsed().as_secs_f64();
         let live_snapshot_start = Instant::now();
-        self.live_tables
-            .insert(table_name.to_string(), active_snapshot(&stamped)?);
+        let live_snapshot = active_snapshot(&stamped)?;
         let live_snapshot_sec = live_snapshot_start.elapsed().as_secs_f64();
         let profile = TableStepProfile {
             table_name: table_name.to_string(),
             read_prior_sec,
             materialize_sec,
             process_sec,
-            append_sec,
+            append_sec: 0.0,
             live_snapshot_sec,
             table_sec: table_start.elapsed().as_secs_f64(),
         };
-        Ok((stamped, profile))
+        Ok(PreparedTableStep {
+            batch: stamped,
+            live_snapshot,
+            profile,
+        })
+    }
+
+    async fn append_prepared_table(&self, prepared: &mut PreparedTableStep) -> Result<()> {
+        let append_start = Instant::now();
+        if prepared.batch.num_rows() > 0 {
+            self.store
+                .append(&prepared.profile.table_name, &prepared.batch)
+                .await?;
+        }
+        prepared.profile.append_sec = append_start.elapsed().as_secs_f64();
+        prepared.profile.table_sec += prepared.profile.append_sec;
+        Ok(())
+    }
+
+    fn finalize_prepared_table(
+        &mut self,
+        prepared: PreparedTableStep,
+    ) -> (RecordBatch, TableStepProfile) {
+        let table_name = prepared.profile.table_name.clone();
+        self.state.consume_table_mutations(&table_name);
+        self.live_tables.insert(table_name, prepared.live_snapshot);
+        (prepared.batch, prepared.profile)
+    }
+
+    fn ensure_healthy(&self) -> Result<()> {
+        match &self.partial_failure {
+            Some(failure) => Err(failure.as_error()),
+            None => Ok(()),
+        }
     }
 
     pub async fn query_table(
@@ -579,6 +739,34 @@ where
 struct RecordBatchRow {
     batch: RecordBatch,
     row_idx: usize,
+}
+
+fn remove_entities_from_spawn_batches(
+    batches: &[RecordBatch],
+    targets: &HashSet<EntityId>,
+) -> Result<(Vec<RecordBatch>, HashSet<EntityId>)> {
+    let mut retained = Vec::with_capacity(batches.len());
+    let mut removed = HashSet::new();
+    for batch in batches {
+        let entities = entity_column(batch)?;
+        let keep = BooleanArray::from_iter((0..batch.num_rows()).map(|idx| {
+            let entity_id = entities.value(idx);
+            let remove = targets.contains(&entity_id);
+            if remove {
+                removed.insert(entity_id);
+            }
+            Some(!remove)
+        }));
+        if keep.true_count() == batch.num_rows() {
+            retained.push(batch.clone());
+        } else {
+            let filtered = filter_record_batch(batch, &keep)?;
+            if filtered.num_rows() > 0 {
+                retained.push(filtered);
+            }
+        }
+    }
+    Ok((retained, removed))
 }
 
 fn stamp_spawn_batch(

--- a/crates/archetype-core/src/aio/async_world.rs
+++ b/crates/archetype-core/src/aio/async_world.rs
@@ -1,4 +1,4 @@
-//! Tick lifecycle (per table, per `step_table_profiled` call):
+//! Tick lifecycle (per table within one `step_profiled` call):
 //!
 //! ```text
 //! Tick N:
@@ -21,6 +21,9 @@
 //! A world prepares every active table before the first append. Store appends
 //! are atomic per table, not across tables; failure after an earlier table was
 //! published poisons the world so tick N cannot be retried and duplicated.
+//! `step_table` and `step_table_profiled` are complete-tick conveniences for
+//! single-table worlds only: they reject multi-table use before any append and
+//! advance the shared tick after a successful append.
 //!
 //! Same-tick spawn-cancel (despawn while spawn is still pending) removes the
 //! spawn row entirely without writing a tombstone — the entity is never observed.
@@ -399,7 +402,7 @@ impl WorldState {
     /// Convenience wrapper used by unit tests and migration helpers: applies
     /// despawns then drains spawns into a single concatenated batch.
     ///
-    /// In the full tick path (`step_table_profiled`) these two phases are
+    /// In the full tick path (`prepare_table_profiled`) these two phases are
     /// called separately so that processors run only on prior rows and spawns
     /// land raw after processor output.
     pub fn materialize_table(
@@ -596,9 +599,20 @@ where
         table_name: &str,
     ) -> Result<(RecordBatch, TableStepProfile)> {
         self.ensure_healthy()?;
+        let mut active_tables = self.state.active_tables().into_iter().collect::<Vec<_>>();
+        active_tables.sort();
+        if active_tables.len() != 1 || active_tables[0] != table_name {
+            return Err(ArchetypeCoreError::InvalidTableStep {
+                table_name: table_name.to_string(),
+                active_tables,
+            });
+        }
+
         let mut prepared = self.prepare_table_profiled(table_name).await?;
         self.append_prepared_table(&mut prepared).await?;
-        Ok(self.finalize_prepared_table(prepared))
+        let completed = self.finalize_prepared_table(prepared);
+        self.state.advance_tick();
+        Ok(completed)
     }
 
     async fn prepare_table_profiled(&self, table_name: &str) -> Result<PreparedTableStep> {

--- a/crates/archetype-core/src/error.rs
+++ b/crates/archetype-core/src/error.rs
@@ -28,6 +28,15 @@ pub enum ArchetypeCoreError {
     UnknownEntity(i32),
 
     #[error(
+        "per-table step for {table_name} requires it to be the only active table; \
+         active tables: {active_tables:?}; use step or step_profiled for multi-table ticks"
+    )]
+    InvalidTableStep {
+        table_name: String,
+        active_tables: Vec<String>,
+    },
+
+    #[error(
         "tick {tick} partially committed after {committed_tables} table(s): {cause}; \
          this world is not safe to retry"
     )]

--- a/crates/archetype-core/src/error.rs
+++ b/crates/archetype-core/src/error.rs
@@ -27,6 +27,16 @@ pub enum ArchetypeCoreError {
     #[error("entity {0} is not registered in this world")]
     UnknownEntity(i32),
 
+    #[error(
+        "tick {tick} partially committed after {committed_tables} table(s): {cause}; \
+         this world is not safe to retry"
+    )]
+    PartialTick {
+        tick: i32,
+        committed_tables: usize,
+        cause: String,
+    },
+
     #[error("arrow error: {0}")]
     Arrow(#[from] ArrowError),
 

--- a/crates/archetype-core/tests/failure_atomicity.rs
+++ b/crates/archetype-core/tests/failure_atomicity.rs
@@ -135,6 +135,18 @@ async fn later_append_failure_poisons_partial_tick_against_retry() {
         world.queue_despawn(position_ids[0]).unwrap_err(),
         ArchetypeCoreError::PartialTick { tick: 0, .. }
     ));
+    assert!(matches!(
+        world
+            .state_mut()
+            .queue_despawn(position_ids[0])
+            .unwrap_err(),
+        ArchetypeCoreError::PartialTick { tick: 0, .. }
+    ));
+    assert!(matches!(
+        world.state_mut().advance_tick().unwrap_err(),
+        ArchetypeCoreError::PartialTick { tick: 0, .. }
+    ));
+    assert_eq!(world.state().tick(), 0);
 }
 
 struct FailVelocity {

--- a/crates/archetype-core/tests/failure_atomicity.rs
+++ b/crates/archetype-core/tests/failure_atomicity.rs
@@ -1,0 +1,267 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use archetype_core::archetype::IS_ACTIVE;
+use archetype_core::{
+    ArchetypeCoreError, ArchetypeTable, AsyncSystem, AsyncWorld, Processor, ProcessorContext,
+    ReadFilter, Result, Store,
+};
+use arrow_array::{BooleanArray, Float64Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use async_trait::async_trait;
+
+fn position_table() -> ArchetypeTable {
+    ArchetypeTable::new(
+        "position",
+        Arc::new(Schema::new(vec![Field::new(
+            "position__x",
+            DataType::Float64,
+            false,
+        )])),
+    )
+    .unwrap()
+}
+
+fn position_velocity_table() -> ArchetypeTable {
+    ArchetypeTable::new(
+        "position_velocity",
+        Arc::new(Schema::new(vec![
+            Field::new("position__x", DataType::Float64, false),
+            Field::new("velocity__dx", DataType::Float64, false),
+        ])),
+    )
+    .unwrap()
+}
+
+fn position_batch(value: f64) -> RecordBatch {
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "position__x",
+            DataType::Float64,
+            false,
+        )])),
+        vec![Arc::new(Float64Array::from(vec![value]))],
+    )
+    .unwrap()
+}
+
+fn position_velocity_batch(position: f64, velocity: f64) -> RecordBatch {
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("position__x", DataType::Float64, false),
+            Field::new("velocity__dx", DataType::Float64, false),
+        ])),
+        vec![
+            Arc::new(Float64Array::from(vec![position])),
+            Arc::new(Float64Array::from(vec![velocity])),
+        ],
+    )
+    .unwrap()
+}
+
+#[derive(Clone, Default)]
+struct ControlledStore {
+    appends: Arc<Mutex<Vec<(String, RecordBatch)>>>,
+    fail_next: Arc<AtomicBool>,
+    fail_table: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl Store for ControlledStore {
+    async fn append(&self, table_name: &str, batch: &RecordBatch) -> Result<()> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(ArchetypeCoreError::Store("injected append failure".into()));
+        }
+        let should_fail = {
+            let mut fail_table = self.fail_table.lock().unwrap();
+            let matches = fail_table.as_deref() == Some(table_name);
+            if matches {
+                fail_table.take();
+            }
+            matches
+        };
+        if should_fail {
+            return Err(ArchetypeCoreError::Store("injected append failure".into()));
+        }
+        self.appends
+            .lock()
+            .unwrap()
+            .push((table_name.to_string(), batch.clone()));
+        Ok(())
+    }
+
+    async fn read_table(&self, _table_name: &str, _filter: ReadFilter) -> Result<Vec<RecordBatch>> {
+        Ok(Vec::new())
+    }
+}
+
+#[tokio::test]
+async fn later_append_failure_poisons_partial_tick_against_retry() {
+    let position = position_table();
+    let position_velocity = position_velocity_table();
+    let store = ControlledStore::default();
+    let appends = store.appends.clone();
+    *store.fail_table.lock().unwrap() = Some(position_velocity.table_name().to_string());
+    let mut world = AsyncWorld::from_ids("world-a", "run-a", store, AsyncSystem::new());
+    let position_ids = world
+        .queue_spawn_batch(&position, position_batch(1.5))
+        .unwrap();
+    world
+        .queue_spawn_batch(&position_velocity, position_velocity_batch(2.5, 3.5))
+        .unwrap();
+
+    let error = world.step().await.unwrap_err();
+    assert!(matches!(
+        error,
+        ArchetypeCoreError::PartialTick {
+            tick: 0,
+            committed_tables: 1,
+            ..
+        }
+    ));
+    assert_eq!(world.state().tick(), 0);
+    assert_eq!(appends.lock().unwrap().len(), 1);
+
+    assert!(matches!(
+        world.step().await.unwrap_err(),
+        ArchetypeCoreError::PartialTick {
+            tick: 0,
+            committed_tables: 1,
+            ..
+        }
+    ));
+    assert_eq!(appends.lock().unwrap().len(), 1);
+    assert!(matches!(
+        world.queue_despawn(position_ids[0]).unwrap_err(),
+        ArchetypeCoreError::PartialTick { tick: 0, .. }
+    ));
+}
+
+struct FailVelocity {
+    enabled: Arc<AtomicBool>,
+}
+
+impl Processor for FailVelocity {
+    fn name(&self) -> &str {
+        "fail_velocity"
+    }
+
+    fn required_columns(&self) -> &[&'static str] {
+        &["velocity__dx"]
+    }
+
+    fn process(&self, batch: RecordBatch, _ctx: &ProcessorContext) -> Result<RecordBatch> {
+        if self.enabled.load(Ordering::SeqCst) {
+            Err(ArchetypeCoreError::Store(
+                "injected processor failure".into(),
+            ))
+        } else {
+            Ok(batch)
+        }
+    }
+}
+
+#[tokio::test]
+async fn processor_failure_prevents_every_table_append_and_preserves_retry() {
+    let position = position_table();
+    let position_velocity = position_velocity_table();
+    let store = ControlledStore::default();
+    let appends = store.appends.clone();
+    let failure = Arc::new(AtomicBool::new(true));
+    let mut system = AsyncSystem::new();
+    system.add_processor(FailVelocity {
+        enabled: failure.clone(),
+    });
+    let mut world = AsyncWorld::from_ids("world-a", "run-a", store, system);
+    world
+        .queue_spawn_batch(&position, position_batch(1.5))
+        .unwrap();
+    world
+        .queue_spawn_batch(&position_velocity, position_velocity_batch(2.5, 3.5))
+        .unwrap();
+
+    let error = world.step().await.unwrap_err();
+    assert!(
+        matches!(error, ArchetypeCoreError::Store(message) if message == "injected processor failure")
+    );
+    assert_eq!(world.state().tick(), 0);
+    assert!(appends.lock().unwrap().is_empty());
+
+    failure.store(false, Ordering::SeqCst);
+    world.step().await.unwrap();
+    assert_eq!(world.state().tick(), 1);
+    assert_eq!(appends.lock().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn append_failure_preserves_spawn_and_despawn_for_retry() {
+    let table = position_table();
+    let store = ControlledStore::default();
+    let appends = store.appends.clone();
+    let fail_next = store.fail_next.clone();
+    let mut world = AsyncWorld::from_ids("world-a", "run-a", store, AsyncSystem::new());
+    let ids = world
+        .queue_spawn_batch(&table, position_batch(1.5))
+        .unwrap();
+
+    fail_next.store(true, Ordering::SeqCst);
+    assert!(world.step().await.is_err());
+    assert_eq!(world.state().tick(), 0);
+    assert!(appends.lock().unwrap().is_empty());
+
+    world.step().await.unwrap();
+    assert_eq!(world.state().tick(), 1);
+    assert_eq!(appends.lock().unwrap().len(), 1);
+
+    world.queue_despawn(ids[0]).unwrap();
+    fail_next.store(true, Ordering::SeqCst);
+    assert!(world.step().await.is_err());
+    assert_eq!(world.state().tick(), 1);
+    assert_eq!(appends.lock().unwrap().len(), 1);
+
+    world.step().await.unwrap();
+    let appended = appends.lock().unwrap();
+    assert_eq!(world.state().tick(), 2);
+    assert_eq!(appended.len(), 2);
+    let active = appended[1]
+        .1
+        .column(appended[1].1.schema().index_of(IS_ACTIVE).unwrap())
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .unwrap();
+    assert!(!active.value(0));
+}
+
+#[tokio::test]
+async fn rejected_migration_leaves_pending_source_entity_unchanged() {
+    let old_table = position_table();
+    let new_table = position_velocity_table();
+    let invalid = RecordBatch::new_empty(Arc::new(Schema::new(vec![
+        Field::new("position__x", DataType::Float64, false),
+        Field::new("velocity__dx", DataType::Float64, false),
+    ])));
+    let store = ControlledStore::default();
+    let appends = store.appends.clone();
+    let mut world = AsyncWorld::from_ids("world-a", "run-a", store, AsyncSystem::new());
+    let ids = world
+        .queue_spawn_batch(&old_table, position_batch(1.5))
+        .unwrap();
+
+    let error = world
+        .queue_migration_batch(&new_table, &ids, invalid)
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        ArchetypeCoreError::InvalidRowCount {
+            expected: 1,
+            actual: 0
+        }
+    ));
+
+    world.step().await.unwrap();
+    let appended = appends.lock().unwrap();
+    assert_eq!(appended.len(), 1);
+    assert_eq!(appended[0].0, old_table.table_name());
+    assert_eq!(appended[0].1.num_rows(), 1);
+    assert!(appended[0].1.schema().index_of("velocity__dx").is_err());
+}

--- a/crates/archetype-core/tests/failure_atomicity.rs
+++ b/crates/archetype-core/tests/failure_atomicity.rs
@@ -233,6 +233,58 @@ async fn append_failure_preserves_spawn_and_despawn_for_retry() {
 }
 
 #[tokio::test]
+async fn per_table_step_rejects_multi_table_ticks_before_any_append() {
+    let position = position_table();
+    let position_velocity = position_velocity_table();
+    let store = ControlledStore::default();
+    let appends = store.appends.clone();
+    let mut world = AsyncWorld::from_ids("world-a", "run-a", store, AsyncSystem::new());
+    world
+        .queue_spawn_batch(&position, position_batch(1.5))
+        .unwrap();
+    world
+        .queue_spawn_batch(&position_velocity, position_velocity_batch(2.5, 3.5))
+        .unwrap();
+
+    let error = world.step_table(position.table_name()).await.unwrap_err();
+    assert!(matches!(
+        error,
+        ArchetypeCoreError::InvalidTableStep {
+            table_name,
+            active_tables,
+        } if table_name == position.table_name() && active_tables.len() == 2
+    ));
+    assert_eq!(world.state().tick(), 0);
+    assert!(appends.lock().unwrap().is_empty());
+
+    world.step().await.unwrap();
+    assert_eq!(world.state().tick(), 1);
+    assert_eq!(appends.lock().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn per_table_step_is_a_complete_retryable_single_table_tick() {
+    let table = position_table();
+    let store = ControlledStore::default();
+    let appends = store.appends.clone();
+    let fail_next = store.fail_next.clone();
+    let mut world = AsyncWorld::from_ids("world-a", "run-a", store, AsyncSystem::new());
+    world
+        .queue_spawn_batch(&table, position_batch(1.5))
+        .unwrap();
+
+    fail_next.store(true, Ordering::SeqCst);
+    assert!(world.step_table(table.table_name()).await.is_err());
+    assert_eq!(world.state().tick(), 0);
+    assert!(appends.lock().unwrap().is_empty());
+
+    let batch = world.step_table(table.table_name()).await.unwrap();
+    assert_eq!(batch.num_rows(), 1);
+    assert_eq!(world.state().tick(), 1);
+    assert_eq!(appends.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
 async fn rejected_migration_leaves_pending_source_entity_unchanged() {
     let old_table = position_table();
     let new_table = position_velocity_table();

--- a/crates/archetype-parquet/src/lib.rs
+++ b/crates/archetype-parquet/src/lib.rs
@@ -28,9 +28,13 @@ impl ParquetStore {
         self.root.join(&self.namespace).join(table_name)
     }
 
-    fn part_path(&self, table_name: &str) -> PathBuf {
-        self.table_dir(table_name)
-            .join(format!("part-{}.parquet", Uuid::now_v7()))
+    fn part_paths(&self, table_name: &str) -> (PathBuf, PathBuf) {
+        let id = Uuid::now_v7();
+        let table_dir = self.table_dir(table_name);
+        (
+            table_dir.join(format!("part-{id}.parquet")),
+            table_dir.join(format!("part-{id}.parquet.tmp")),
+        )
     }
 }
 
@@ -40,17 +44,13 @@ impl Store for ParquetStore {
         let table_dir = self.table_dir(table_name);
         fs::create_dir_all(&table_dir).map_err(|err| ArchetypeCoreError::Store(err.to_string()))?;
 
-        let path = self.part_path(table_name);
-        let file = File::create(path).map_err(|err| ArchetypeCoreError::Store(err.to_string()))?;
-        let mut writer = ArrowWriter::try_new(file, batch.schema(), None)
-            .map_err(|err| ArchetypeCoreError::Store(err.to_string()))?;
-        writer
-            .write(batch)
-            .map_err(|err| ArchetypeCoreError::Store(err.to_string()))?;
-        writer
-            .close()
-            .map_err(|err| ArchetypeCoreError::Store(err.to_string()))?;
-        Ok(())
+        let (path, staging_path) = self.part_paths(table_name);
+        let result = write_part(&staging_path, batch)
+            .and_then(|()| fs::rename(&staging_path, path).map_err(store_error));
+        if result.is_err() {
+            let _ = fs::remove_file(staging_path);
+        }
+        result
     }
 
     async fn read_table(&self, table_name: &str, filter: ReadFilter) -> Result<Vec<RecordBatch>> {
@@ -80,6 +80,18 @@ impl Store for ParquetStore {
         let merged = concat_batches(&schema, &batches).map_err(ArchetypeCoreError::from)?;
         Ok(vec![merged])
     }
+}
+
+fn write_part(path: &Path, batch: &RecordBatch) -> Result<()> {
+    let file = File::create(path).map_err(store_error)?;
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).map_err(store_error)?;
+    writer.write(batch).map_err(store_error)?;
+    writer.close().map_err(store_error)?;
+    Ok(())
+}
+
+fn store_error(error: impl std::fmt::Display) -> ArchetypeCoreError {
+    ArchetypeCoreError::Store(error.to_string())
 }
 
 fn read_part(path: &Path, filter: &ReadFilter) -> Result<Vec<RecordBatch>> {


### PR DESCRIPTION
## What changed

- prepare every table's processor output and durable batch before the first append
- retain staged spawn, despawn, and migration mutations until persistence succeeds
- validate migrations before mutating their pending source state
- make each Parquet append publish through a staged temporary file and atomic rename
- poison a world with a typed `PartialTick` error when a later table append fails after an earlier table has already committed
- add regression coverage for processor failure, first-append retry, later-append poisoning, and rejected migrations

## Why

The prior step path interleaved preparation, mutation consumption, and persistence. A failure could therefore discard pending mutations or make retry duplicate data. The storage contract is atomic per table—not transactionally atomic across every table in a tick—so an unavoidable later-table failure must be explicit and non-retryable.

## Impact

Preparation failures perform no appends, first-append failures preserve mutations for a clean retry, rejected migrations leave source state intact, and cross-table partial commits cannot be silently retried.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check origin/main...HEAD`
