### PR TITLE
fix(catalog): fence recovered claim visibility

### DIFF
--- a/docs/guide/durable-facts.md
+++ b/docs/guide/durable-facts.md
@@ -50,6 +50,10 @@ Claims live in the control catalog, keyed by a deterministic scope
    which publishes its commit token into the visible set. Readers change
    nothing: `visible_tokens` unions tick manifests with completed claims.
 
+For a never-fenced legacy run, the first claim activates token filtering but
+keeps the empty epoch-0 token visible. That hides a PENDING fact's non-empty
+token without making pre-coordination rows disappear.
+
 ## 4. Crash recovery
 
 Stranded PENDING claims are recovered by **lease takeover, never blind

--- a/docs/guide/durable-facts.md
+++ b/docs/guide/durable-facts.md
@@ -56,9 +56,9 @@ Stranded PENDING claims are recovered by **lease takeover, never blind
 retry**:
 
 + Crash before the append: the taker-over finds no rows under the claim's
-  token and appends fresh — under the **original** token, so any late
-  writes by the presumed-dead claimant remain part of the same single
-  visible identity.
+  token, then atomically re-arms the claim with a **fresh** token before
+  rebuilding and appending. Any late write by the expired claimant keeps
+  the old token and therefore remains invisible.
 + Crash after the append, before completion: the taker-over finds the
   orphan rows by token on the data plane and completes the claim
   **without re-appending**. No duplicates, ever.
@@ -106,8 +106,9 @@ rules on top:
   **without re-grading**. The guarantee is exactly one **visible** durable
   receipt per `evaluation_id` — never exactly-once grader execution. A
   lease takeover whose orphan probe finds the appended rows completes
-  without re-running the grader; a takeover that finds none re-runs it at
-  most once.
+  without re-running the grader; a takeover that finds none re-arms the
+  claim before rebuilding. Grader executions may overlap across an expired
+  lease, but only the current claim token can ever publish a receipt.
 + **The subject is pinned, never hashed by content.** Subject identity =
   the immutable snapshot reference (manifest head tick + commit tokens)
   plus the canonical selector (components, ticks, entity ids).

--- a/infra/control-catalog/src/index.ts
+++ b/infra/control-catalog/src/index.ts
@@ -330,7 +330,12 @@ export class WorldCommitDO implements DurableObject {
       if (!anyManifest.length && !anyClaim.length) {
         return json({ visible: fence.length ? {} : null });
       }
-      const ticks = ticksParam ? ticksParam.split(",").map((t) => parseInt(t, 10)) : null;
+      const ticks =
+        ticksParam === null
+          ? null
+          : ticksParam === ""
+            ? []
+            : ticksParam.split(",").map((t) => parseInt(t, 10));
       const visible: Record<string, string[]> = {};
       const add = (tick: number, token: string) => {
         if (ticks && !ticks.includes(tick)) return;

--- a/infra/control-catalog/src/index.ts
+++ b/infra/control-catalog/src/index.ts
@@ -326,8 +326,8 @@ export class WorldCommitDO implements DurableObject {
       const anyClaim = this.sql
         .exec("SELECT 1 FROM claims WHERE run_id = ? LIMIT 1", run)
         .toArray();
+      const fence = this.sql.exec("SELECT 1 FROM fence WHERE singleton = 1").toArray();
       if (!anyManifest.length && !anyClaim.length) {
-        const fence = this.sql.exec("SELECT 1 FROM fence WHERE singleton = 1").toArray();
         return json({ visible: fence.length ? {} : null });
       }
       const ticks = ticksParam ? ticksParam.split(",").map((t) => parseInt(t, 10)) : null;
@@ -336,6 +336,9 @@ export class WorldCommitDO implements DurableObject {
         if (ticks && !ticks.includes(tick)) return;
         (visible[String(tick)] ??= []).push(token);
       };
+      if (!anyManifest.length && !fence.length) {
+        for (const tick of ticks ?? [0]) add(tick, "");
+      }
       for (const row of this.sql
         .exec("SELECT tick, commit_token FROM manifests WHERE run_id = ?", run)
         .toArray() as Array<Record<string, unknown>>) {

--- a/infra/control-catalog/src/index.ts
+++ b/infra/control-catalog/src/index.ts
@@ -324,7 +324,7 @@ export class WorldCommitDO implements DurableObject {
         .exec("SELECT 1 FROM manifests WHERE run_id = ? LIMIT 1", run)
         .toArray();
       const anyClaim = this.sql
-        .exec("SELECT 1 FROM claims WHERE run_id = ? AND status = 'COMPLETE' LIMIT 1", run)
+        .exec("SELECT 1 FROM claims WHERE run_id = ? LIMIT 1", run)
         .toArray();
       if (!anyManifest.length && !anyClaim.length) {
         const fence = this.sql.exec("SELECT 1 FROM fence WHERE singleton = 1").toArray();
@@ -411,6 +411,31 @@ export class WorldCommitDO implements DurableObject {
         route[1],
       );
       return json({ ok: true });
+    }
+
+    if (route[0] === "claims" && route.length === 3 && route[2] === "rearm" && method === "POST") {
+      const body = (await request.json()) as { claimant: string; commit_token: string };
+      const rows = this.sql
+        .exec("SELECT * FROM claims WHERE scope_key = ?", route[1])
+        .toArray();
+      if (!rows.length) return conflict("claim_conflict", `no claim for scope ${route[1]}`);
+      const row = rows[0] as Record<string, unknown>;
+      if (row.status !== "PENDING") {
+        return conflict("claim_conflict", `claim ${route[1]} is already ${row.status}`);
+      }
+      if (row.claimant !== body.claimant) {
+        return json({ error: "claim_pending", message: "claim is held by another claimant" }, 423);
+      }
+      if (row.commit_token === body.commit_token) {
+        return conflict("claim_conflict", "re-arm requires a fresh commit token");
+      }
+      this.sql.exec(
+        "UPDATE claims SET commit_token = ?, table_id = NULL WHERE scope_key = ?",
+        body.commit_token,
+        route[1],
+      );
+      const updated = this.sql.exec("SELECT * FROM claims WHERE scope_key = ?", route[1]).toArray();
+      return json(updated[0]);
     }
 
     if (route[0] === "claims" && route.length === 3 && route[2] === "complete" && method === "POST") {

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -485,8 +485,9 @@ class SqliteControlCatalog:
         Returns (outcome, record) where outcome is one of:
         - "acquired": this claimant owns a fresh PENDING claim (new token).
         - "recovered": this claimant took over an expired PENDING claim —
-          the ORIGINAL token is kept so recovery can find an already-
-          appended orphan and complete without re-appending.
+          the original token is kept only long enough to probe for an
+          already-appended orphan. A recovery with no orphan must re-arm
+          the claim with a fresh token before appending.
         - "duplicate": an identical fact is already COMPLETE — the original
           record is the receipt; nothing to do.
         Raises ClaimConflictError on same id + different digest, and
@@ -572,6 +573,57 @@ class SqliteControlCatalog:
                 )
 
         return await self._run(_acquire)
+
+    async def rearm_claim(
+        self,
+        world_id: str,
+        scope_key: str,
+        claimant: str,
+        commit_token: str,
+    ) -> ClaimRecord:
+        """Rotate a recovered, empty claim to a fresh commit identity.
+
+        This is a claimant-checked CAS. Rows appended late by the expired
+        owner retain the old token and can therefore never become visible
+        when the recovered claim completes.
+        """
+
+        def _rearm() -> ClaimRecord:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT * FROM claims WHERE scope_key=?", (scope_key,)
+                ).fetchone()
+                if row is None:
+                    raise ClaimConflictError(f"no claim recorded for scope {scope_key}")
+                existing = _claim_from_row(row)
+                if existing.world_id != world_id:
+                    raise ClaimConflictError(
+                        f"claim {scope_key} belongs to world {existing.world_id}, not {world_id}"
+                    )
+                if existing.status != "PENDING":
+                    raise ClaimConflictError(
+                        f"claim {scope_key} is already {existing.status}; refusing to re-arm"
+                    )
+                if existing.claimant != claimant:
+                    raise ClaimPendingError(
+                        f"claim {scope_key} is held by {existing.claimant}; "
+                        "this claimant cannot re-arm it"
+                    )
+                if existing.commit_token == commit_token:
+                    raise ClaimConflictError(
+                        f"claim {scope_key} re-arm must use a fresh commit token"
+                    )
+                conn.execute(
+                    "UPDATE claims SET commit_token=?, table_id=NULL WHERE scope_key=?",
+                    (commit_token, scope_key),
+                )
+                return _claim_from_row(
+                    conn.execute("SELECT * FROM claims WHERE scope_key=?", (scope_key,)).fetchone()
+                )
+
+        return await self._run(_rearm)
 
     async def record_claim_table(self, world_id: str, scope_key: str, table_id: str) -> None:
         """Record where a claim's rows will land, BEFORE the append.
@@ -805,9 +857,10 @@ class SqliteControlCatalog:
 
         Unions tick manifests with COMPLETE fact claims (issue #274): a tick
         may carry one manifest token plus any number of fact tokens. None
-        when the pair has neither manifests nor completed claims AND no
-        fence — an uncoordinated or pre-#273 world whose rows are implicitly
-        visible. A fenced world with nothing published filters everything.
+        only when the pair has neither manifests nor claims AND no fence —
+        an uncoordinated or pre-#273 world whose rows are implicitly visible.
+        A fence or any claim activates filtering; only published manifests
+        and COMPLETE claim tokens are then visible.
         """
 
         def _tokens() -> dict[int, list[str]] | None:
@@ -817,7 +870,7 @@ class SqliteControlCatalog:
                 (world_id, run_id),
             ).fetchone()
             any_claim = conn.execute(
-                "SELECT 1 FROM claims WHERE world_id=? AND run_id=? AND status='COMPLETE' LIMIT 1",
+                "SELECT 1 FROM claims WHERE world_id=? AND run_id=? LIMIT 1",
                 (world_id, run_id),
             ).fetchone()
             if any_manifest is None and any_claim is None:

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -860,7 +860,9 @@ class SqliteControlCatalog:
         only when the pair has neither manifests nor claims AND no fence —
         an uncoordinated or pre-#273 world whose rows are implicitly visible.
         A fence or any claim activates filtering; only published manifests
-        and COMPLETE claim tokens are then visible.
+        and COMPLETE claim tokens are then visible. When the first claim is
+        added to a never-fenced legacy run, its empty epoch-0 token remains
+        allowed so coordination does not hide pre-existing rows.
         """
 
         def _tokens() -> dict[int, list[str]] | None:
@@ -873,13 +875,13 @@ class SqliteControlCatalog:
                 "SELECT 1 FROM claims WHERE world_id=? AND run_id=? LIMIT 1",
                 (world_id, run_id),
             ).fetchone()
+            fence = conn.execute(
+                "SELECT 1 FROM writer_fence WHERE world_id=?", (world_id,)
+            ).fetchone()
             if any_manifest is None and any_claim is None:
                 # Distinguish true pre-#273 history (never fenced — implicitly
                 # visible) from a coordinated world whose first commit hasn't
                 # published (fence exists — nothing is visible yet).
-                fence = conn.execute(
-                    "SELECT 1 FROM writer_fence WHERE world_id=?", (world_id,)
-                ).fetchone()
                 return None if fence is None else {}
             if ticks is None:
                 tick_clause, args = "", []
@@ -888,6 +890,10 @@ class SqliteControlCatalog:
                 tick_clause = f" AND tick IN ({placeholders})"
                 args = [int(t) for t in ticks]
             visible: dict[int, list[str]] = {}
+            if any_manifest is None and fence is None:
+                legacy_ticks = [0] if ticks is None else [int(tick) for tick in ticks]
+                for tick in legacy_ticks:
+                    visible.setdefault(tick, []).append("")
             for row in conn.execute(
                 "SELECT tick, commit_token FROM manifests WHERE world_id=? AND run_id=?"
                 + tick_clause,

--- a/src/archetype/app/_remote_catalog.py
+++ b/src/archetype/app/_remote_catalog.py
@@ -251,6 +251,20 @@ class RemoteControlCatalog:
     async def record_claim_table(self, world_id: str, scope_key: str, table_id: str) -> None:
         await self._call("POST", f"/w/{world_id}/claims/{scope_key}/table", {"table_id": table_id})
 
+    async def rearm_claim(
+        self,
+        world_id: str,
+        scope_key: str,
+        claimant: str,
+        commit_token: str,
+    ) -> ClaimRecord:
+        response = await self._call(
+            "POST",
+            f"/w/{world_id}/claims/{scope_key}/rearm",
+            {"claimant": claimant, "commit_token": commit_token},
+        )
+        return _claim_from_json(world_id, response.json())
+
     async def complete_claim(
         self, world_id: str, scope_key: str, claimant: str, table_id: str
     ) -> None:

--- a/src/archetype/app/ingestion_service.py
+++ b/src/archetype/app/ingestion_service.py
@@ -201,25 +201,24 @@ class IngestionService:
 
         store = await self._storage_service.get_or_create_store(effective, None)
 
-        if outcome == "recovered" and claim.table_id:
-            # Crash recovery: the original claimant may have appended before
-            # dying. The claim's token finds the orphan ON the data plane —
-            # complete without re-appending (and without re-grading), never
-            # duplicate. table_id on the claim names where to look; absent
-            # table_id (or a recorded table that was never materialized)
-            # means the crash preceded any append.
-            if claim.table_id != table_id:
-                raise RuntimeError(
-                    f"claim {claim.scope_key} records table {claim.table_id}, but the "
-                    f"declared component shape resolves to {table_id}"
-                )
-            try:
-                existing = await store.get_existing_table_df(claim.table_id, wid, str(run_id))
-                orphaned = existing.where(existing["commit_token"] == claim.commit_token)
-                found = orphaned.count_rows() > 0
-            except KeyError:
-                found = False
+        if outcome == "recovered":
+            # First probe the expired writer's token. If its append is durable,
+            # publish that orphan without rebuilding or re-appending.
+            found = False
+            if claim.table_id:
+                if claim.table_id != table_id:
+                    raise RuntimeError(
+                        f"claim {claim.scope_key} records table {claim.table_id}, but the "
+                        f"declared component shape resolves to {table_id}"
+                    )
+                try:
+                    existing = await store.get_existing_table_df(claim.table_id, wid, str(run_id))
+                    orphaned = existing.where(existing["commit_token"] == claim.commit_token)
+                    found = orphaned.count_rows() > 0
+                except KeyError:
+                    pass
             if found:
+                assert claim.table_id is not None
                 await store.flush()
                 physical = await store.get_existing_table_schema(claim.table_id)
                 if not signature_record.matches(physical):
@@ -234,6 +233,16 @@ class IngestionService:
                 await catalog.complete_claim(wid, claim.scope_key, claimant, claim.table_id)
                 settled = await catalog.get_claim(wid, claim.scope_key)
                 return self._receipt(settled if settled is not None else claim, duplicate=False)
+
+            # No orphan exists yet. Rotate before rebuilding so an expired,
+            # slow writer that appends later can never share the published
+            # token with this recovery attempt.
+            claim = await catalog.rearm_claim(
+                wid,
+                claim.scope_key,
+                claimant,
+                f"fact-{claim.scope_key[:16]}-{uuid7().hex}",
+            )
 
         components = await build_components(claim)
         if not components:

--- a/tests/app/test_ingestion.py
+++ b/tests/app/test_ingestion.py
@@ -199,7 +199,9 @@ async def test_crash_between_append_and_complete_recovers_without_duplication(
         await c.shutdown()
 
 
-async def test_crash_before_append_recovers_by_reappending(tmp_path, monkeypatch):
+async def test_recovery_rearms_before_append_so_expired_writer_stays_invisible(
+    tmp_path, monkeypatch
+):
     c = ServiceContainer()
     try:
         storage = _storage(tmp_path)
@@ -209,16 +211,26 @@ async def test_crash_before_append_recovers_by_reappending(tmp_path, monkeypatch
         from archetype.app.ingestion_service import IngestionService
 
         real_append = IngestionService._append_fact
+        expired_append: tuple | None = None
 
-        async def _crash(self, *args, **kwargs):
-            raise RuntimeError("injected crash before append")
+        async def _controlled_append(self, *args, **kwargs):
+            nonlocal expired_append
+            if expired_append is None:
+                expired_append = args
+                raise RuntimeError("injected crash before append")
 
-        monkeypatch.setattr(IngestionService, "_append_fact", _crash)
+            # The expired writer resumes after takeover and appends with its
+            # stale token immediately before the recovery's fresh append.
+            await real_append(self, *expired_append)
+            await real_append(self, *args, **kwargs)
+
+        monkeypatch.setattr(IngestionService, "_append_fact", _controlled_append)
         with pytest.raises(RuntimeError, match="injected crash"):
             await c.ingestion_service.ingest_fact(
                 wid, [Reading(value=4.0)], external_id="pre-append", producer="p"
             )
-        monkeypatch.setattr(IngestionService, "_append_fact", real_append)
+        assert expired_append is not None
+        expired_claim = expired_append[2]
 
         catalog = c.storage_service.get_control_catalog(storage)
         scope = claim_scope_key(wid, str(world.run_id), "p", "pre-append")
@@ -234,7 +246,17 @@ async def test_crash_before_append_recovers_by_reappending(tmp_path, monkeypatch
             wid, [Reading(value=4.0)], external_id="pre-append", producer="p"
         )
         assert not receipt.duplicate
-        assert len(await _visible_facts(c, world, storage)) == 1
+        assert receipt.commit_token != expired_claim.commit_token
+
+        visible = await _visible_facts(c, world, storage)
+        assert len(visible) == 1
+        assert visible[0]["factmeta__commit_id"] == receipt.commit_token
+
+        store = await c.storage_service.get_or_create_store(storage)
+        physical = await store.get_existing_table_df(receipt.table_id, wid, str(world.run_id))
+        assert physical.count_rows() == 2, (
+            "the late old-token row may exist physically but must stay invisible"
+        )
     finally:
         await c.shutdown()
 

--- a/tests/app/test_remote_catalog_client.py
+++ b/tests/app/test_remote_catalog_client.py
@@ -72,3 +72,34 @@ async def test_get_claim_retries_then_treats_not_found_as_terminal(monkeypatch):
         sleep.assert_awaited_once_with(0.5)
     finally:
         await catalog.close()
+
+
+async def test_rearm_claim_returns_the_rotated_remote_record():
+    catalog = await _catalog_with(
+        [
+            httpx.Response(
+                200,
+                json={
+                    "scope_key": "scope",
+                    "run_id": "r1",
+                    "producer": "p",
+                    "external_id": "e1",
+                    "payload_digest": "digest",
+                    "status": "PENDING",
+                    "commit_token": "fresh-token",
+                    "tick": 0,
+                    "fact_entity_id": -100001,
+                    "table_id": None,
+                    "claimant": "recovery",
+                    "lease_expires_at": 10.0,
+                    "fence_epoch": 1,
+                },
+            )
+        ]
+    )
+    try:
+        claim = await catalog.rearm_claim("w1", "scope", "recovery", "fresh-token")
+        assert claim.commit_token == "fresh-token"
+        assert claim.table_id is None
+    finally:
+        await catalog.close()

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -215,7 +215,8 @@ async def test_visibility_three_state_parity(tmp_path, worker_url):
             claimant="pending-writer",
             tick=0,
         )
-        assert await catalog.visible_tokens("w1", "r1") == {}
+        assert await catalog.visible_tokens("w1", "r1") == {0: [""]}
+        assert await catalog.visible_tokens("w1", "r1", [3]) == {3: [""]}
         # Fenced, nothing published: nothing visible.
         await catalog.acquire_fence("w1", "h1")
         assert await catalog.visible_tokens("w1", "r1") == {}

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -216,6 +216,7 @@ async def test_visibility_three_state_parity(tmp_path, worker_url):
             tick=0,
         )
         assert await catalog.visible_tokens("w1", "r1") == {0: [""]}
+        assert await catalog.visible_tokens("w1", "r1", []) == {}
         assert await catalog.visible_tokens("w1", "r1", [3]) == {3: [""]}
         # Fenced, nothing published: nothing visible.
         await catalog.acquire_fence("w1", "h1")

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -204,6 +204,18 @@ async def test_visibility_three_state_parity(tmp_path, worker_url):
         await catalog.register_world(_world())
         # Never fenced: legacy, unfiltered.
         assert await catalog.visible_tokens("w1", "r1") is None
+        # Once a claim exists, its pending rows must not leak through the
+        # legacy-unfiltered state even before this world has a writer fence.
+        await catalog.acquire_claim(
+            world_id="w1",
+            run_id="r1",
+            producer="p",
+            external_id="pending",
+            payload_digest="pending-digest",
+            claimant="pending-writer",
+            tick=0,
+        )
+        assert await catalog.visible_tokens("w1", "r1") == {}
         # Fenced, nothing published: nothing visible.
         await catalog.acquire_fence("w1", "h1")
         assert await catalog.visible_tokens("w1", "r1") == {}
@@ -282,6 +294,35 @@ async def test_claim_lifecycle_parity(tmp_path, worker_url):
         # Completed claims join the visible set at their tick.
         visible = await catalog.visible_tokens("w1", "r1", [0])
         assert claim.commit_token in visible.get(0, [])
+
+        # An expired empty claim rotates away from the stale writer's token
+        # before a recovery may append.
+        _, empty = await catalog.acquire_claim(
+            world_id="w1",
+            run_id="r1",
+            producer="p",
+            external_id="empty",
+            payload_digest="d-empty",
+            claimant="expired",
+            tick=0,
+            lease_seconds=0.0,
+        )
+        await catalog.record_claim_table("w1", empty.scope_key, "stale-table")
+        outcome3, recovered = await catalog.acquire_claim(
+            world_id="w1",
+            run_id="r1",
+            producer="p",
+            external_id="empty",
+            payload_digest="d-empty",
+            claimant="recovery",
+            tick=0,
+        )
+        assert outcome3 == "recovered"
+        with pytest.raises(ClaimPendingError):
+            await catalog.rearm_claim("w1", empty.scope_key, "expired", "fresh-token")
+        rearmed = await catalog.rearm_claim("w1", recovered.scope_key, "recovery", "fresh-token")
+        assert rearmed.commit_token != empty.commit_token
+        assert rearmed.table_id is None
         await catalog.close()
 
 


### PR DESCRIPTION
## Summary
- activate visibility filtering as soon as any fact claim exists, so PENDING rows cannot leak through legacy-unfiltered reads
- rotate an expired empty claim to a fresh commit token before rebuilding, fencing late stale-writer appends
- keep SQLite and the remote Durable Object catalog behavior identical and document the corrected recovery contract

## Validation
- `make ci` (909 passed, 7 skipped; 12/12 regression evals; 22/22 idempotency evals)
- `uv run pytest -q tests/app/test_remote_catalog_parity.py` (7 passed)
- regression simulates two physical rows from a late expired writer and recovery, with exactly one visible token