### PR TITLE
fix(eval): reject unsupported trajectory filters

### DIFF
--- a/src/archetype/app/eval_service.py
+++ b/src/archetype/app/eval_service.py
@@ -204,8 +204,14 @@ def _filter_component_rows(
 ) -> DataFrame:
     prefix = component.get_prefix()
     model_fields = getattr(component, "model_fields", {})
-    for field_name, values in filters.items():
-        if values is None or field_name not in model_fields:
-            continue
+    requested = {field_name: values for field_name, values in filters.items() if values is not None}
+    unsupported = sorted(set(requested) - set(model_fields))
+    if unsupported:
+        names = ", ".join(unsupported)
+        raise ValueError(
+            f"{component.__name__} does not store requested trajectory filter field(s): "
+            f"{names}; filter the Trajectory header or use fields stored on this component"
+        )
+    for field_name, values in requested.items():
         df = df.where(col(f"{prefix}{field_name}").is_in(list(values)))
     return df

--- a/tests/app/test_eval_service.py
+++ b/tests/app/test_eval_service.py
@@ -194,6 +194,18 @@ async def test_eval_service_grades_trajectory_component_with_custom_sampling(tmp
 
         assert [result.passed for result in results] == [True, True]
         assert [result.grader_name for result in results] == ["sample_count", "total_reward"]
+
+        with pytest.raises(
+            ValueError,
+            match=r"TrajectoryReward does not store requested trajectory filter field\(s\): task_id",
+        ):
+            await container.eval_service.query_trajectory_component(
+                TrajectoryReward,
+                world_id=world.world_id,
+                run_id=run.run_id,
+                task_ids=["reach"],
+                storage_config=storage,
+            )
     finally:
         await container.shutdown()
 


### PR DESCRIPTION
## Summary
- reject trajectory filter fields that the selected component table does not store
- direct callers to filter the `Trajectory` header instead of silently widening a child-table query
- cover the `TrajectoryReward` + `task_ids` regression from the unresolved #260 review

## Validation
- `make ci` (910 passed, 5 skipped; 12/12 regression evals; 22/22 idempotency evals)
- `uv run pytest -q tests/app/test_eval_service.py` (6 passed)