### PR TITLE
fix(docs): preserve published shortcut redirects

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Verify Cloudflare Pages files
         run: |
-          for f in _headers index.html 404.html docs/index.html; do
+          for f in _headers _redirects index.html 404.html docs/index.html; do
             if [ ! -f "site/$f" ]; then
               echo "::error::site/$f missing from the production artifact"
               exit 1

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,0 +1,11 @@
+# Published shortcut URLs. MkDocs copies this file under site/docs; the
+# assembly step promotes it to the Cloudflare Pages artifact root.
+/api              /docs/reference/rest-api/       301
+/cli              /docs/reference/cli/            301
+/python           /docs/reference/python-api/     301
+/quickstart       /docs/guide/quickstart/          301
+/start            /docs/guide/quickstart/          301
+/architecture     /docs/guide/architecture/        301
+/examples         /docs/guide/examples/            301
+/contributing     /docs/guide/contributing/        301
+/docs             /docs/                           301

--- a/scripts/assemble_docs_site.py
+++ b/scripts/assemble_docs_site.py
@@ -12,18 +12,20 @@ NOT_FOUND_SOURCE = ROOT / "scripts" / "docs_404.html"
 
 def main() -> None:
     docs_index = DOCS / "index.html"
-    headers = DOCS / "_headers"
+    root_files = ("_headers", "_redirects")
 
     if not docs_index.is_file():
         msg = "Expected MkDocs output at site/docs/index.html before assembly."
         raise SystemExit(msg)
-    if not headers.is_file():
-        msg = "Expected docs/_headers to be copied into the MkDocs output."
-        raise SystemExit(msg)
+    for name in root_files:
+        if not (DOCS / name).is_file():
+            msg = f"Expected docs/{name} to be copied into the MkDocs output."
+            raise SystemExit(msg)
 
     (SITE / "index.html").write_text(LANDING_SOURCE.read_text(), encoding="utf-8")
     (SITE / "404.html").write_text(NOT_FOUND_SOURCE.read_text(), encoding="utf-8")
-    shutil.move(headers, SITE / "_headers")
+    for name in root_files:
+        shutil.move(DOCS / name, SITE / name)
 
     print("Assembled Cloudflare Pages artifact: / landing page, /docs documentation.")
 

--- a/tests/scripts/test_assemble_docs_site.py
+++ b/tests/scripts/test_assemble_docs_site.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for the Cloudflare Pages artifact assembly."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import assemble_docs_site as assembly  # noqa: E402
+
+
+def _configure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    site = tmp_path / "site"
+    docs = site / "docs"
+    docs.mkdir(parents=True)
+    landing = tmp_path / "landing.html"
+    not_found = tmp_path / "404.html"
+    landing.write_text("landing", encoding="utf-8")
+    not_found.write_text("missing", encoding="utf-8")
+    monkeypatch.setattr(assembly, "SITE", site)
+    monkeypatch.setattr(assembly, "DOCS", docs)
+    monkeypatch.setattr(assembly, "LANDING_SOURCE", landing)
+    monkeypatch.setattr(assembly, "NOT_FOUND_SOURCE", not_found)
+    return site, docs
+
+
+def test_assembly_promotes_cloudflare_control_files(tmp_path, monkeypatch):
+    site, docs = _configure(tmp_path, monkeypatch)
+    (docs / "index.html").write_text("docs", encoding="utf-8")
+    (docs / "_headers").write_text("headers", encoding="utf-8")
+    (docs / "_redirects").write_text("redirects", encoding="utf-8")
+
+    assembly.main()
+
+    assert (site / "index.html").read_text(encoding="utf-8") == "landing"
+    assert (site / "404.html").read_text(encoding="utf-8") == "missing"
+    assert (site / "_headers").read_text(encoding="utf-8") == "headers"
+    assert (site / "_redirects").read_text(encoding="utf-8") == "redirects"
+    assert not (docs / "_headers").exists()
+    assert not (docs / "_redirects").exists()
+
+
+def test_assembly_fails_when_redirect_rules_are_missing(tmp_path, monkeypatch):
+    _, docs = _configure(tmp_path, monkeypatch)
+    (docs / "index.html").write_text("docs", encoding="utf-8")
+    (docs / "_headers").write_text("headers", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match=r"docs/_redirects"):
+        assembly.main()


### PR DESCRIPTION
## Summary
- restore the public `/api`, `/python`, `/quickstart`, and related shortcut redirects under the new `/docs/` site layout
- promote `_redirects` from MkDocs output to the Cloudflare Pages artifact root alongside `_headers`
- make both unit tests and the deployment workflow fail if the redirect artifact disappears

## Validation
- `uv run pytest -q tests/scripts/test_assemble_docs_site.py` (2 passed)
- `make docs`
- verified every redirect destination exists in the generated site
- `make check`