### PR TITLE
chore: release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-ecs"
-version = "0.3.0"
+version = "0.4.0"
 description = "Dataframe-first, append-only ECS runtime for simulations and AI agents. Built on Daft with LanceDB time-travel storage."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -38,7 +38,7 @@ from typing import Any
 # `setdefault` honors an explicit `DO_NOT_TRACK=0` if a user wants telemetry on.
 os.environ.setdefault("DO_NOT_TRACK", "1")
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     # Core types

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "archetype-ecs"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "daft", extra = ["iceberg", "lance", "openai"] },


### PR DESCRIPTION
Version bump for v0.4.0. Highlights since v0.3.0:

- **Remote control catalog on Durable Objects** (#297) — cross-host world discovery, writer fencing, and claims through the deployed Cloudflare worker; single-host limit lifted.
- **Eval rollout machinery graduated into the package** (#303) — `archetype.experiments.eval_rollouts` (one world, N trial entities, ledger-graded) and `archetype.experiments.instruction_sweep`; proven at libero_spatial 99/100 the day it landed.
- **LIBERO/VLA-JEPA harness extracted** to `everettVT/robot-evals` (#333), which consumes `archetype-ecs` as a package dependency — the dogfood now runs through the front door.
- Idempotency eval suite (#249); CI/security hardening incl. footgun-review rebuild, least-privilege workflow permissions, dependabot clears (#299–#331).

On merge: tag `v0.4.0`, release workflow builds the 3.12+3.13 matrix, publish to PyPI via trusted publishing (release-pypi approval per standing precedent), then robot-evals swaps its git-pin to `archetype-ecs>=0.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)