### PR TITLE
docs: align contributor guidance with current contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,36 @@ Roles (flat, not hierarchical):
 | `operator` | schema, processors, hooks, resources, simulation, fork, destroy |
 | `admin` | All commands |
 
+## Change-safety quick reference
+
+- Keep dependencies pointing downward: runtime/API/CLI → app → core. Runtime
+  and API calls go through `CommandService`; do not leak `AsyncWorld` or
+  lower-level services past that gate.
+- Treat `src/archetype/core/` as invariant-owned. Prefer an app or runtime
+  extension when it can meet the requirement; discuss any core behavior change
+  before implementing it.
+- Preserve the lazy Daft DAG. Prefer expressions and DataFrame transforms;
+  `.collect()` or `.to_pylist()` in `src/` needs a documented
+  `lazy_audit.toml` exception at a real execution boundary.
+- A tick is a commit boundary: compute all archetypes before persistence, and
+  do not consume staged mutations or advance the tick until durable visibility
+  is published. Failed ticks must remain retryable.
+- Keep runtime and world lifetimes distinct. Handles are lazy and actor-bound;
+  world shutdown is local, while runtime teardown owns shared services.
+- When changing behavior, update the focused contract test (and the
+  specification if the contract itself changes), not only a happy-path test.
+
+### Contract-first issue loop
+
+For non-trivial work, capture the behavior, owning layer, normative source,
+executable oracle, invariants at risk, validation, and affected docs in the
+issue. Use focused normative specs first, then executable contracts, then the
+umbrella specification, with guides and examples as teaching material. If
+those sources disagree, surface the mismatch instead of choosing silently.
+Split adjacent drift into separate issues, implement the smallest layer-correct
+change, and report the exact validation that ran. See
+`docs/guide/contributing.md` for the full workflow and documentation register.
+
 ## Conventions
 
 ### Components

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -649,19 +649,45 @@ for entry in history:
 
 ---
 
-## Single Process, Single Event Loop (Apr 2026)
+## Process and Coordination Boundaries (Apr 2026, updated Jul 2026)
 
-Archetype runs as **one `archetype serve` process**. This is a hard architectural constraint — do not design for multi-process or multi-server deployments. Daft owns the cores — it manages thread pools, memory, and parallelism internally. `SimulationService.run_all` drives all worlds concurrently via `asyncio.gather` in a single event loop. `AsyncWorld.step` parallelizes across archetypes the same way.
+One `ArchetypeRuntime` or `archetype serve` process owns its live world objects,
+service container, and event loop. Daft owns data-plane parallelism inside that
+process: it manages worker pools and executes lazy processor plans across rows
+and archetypes. Two server processes do not share an in-memory world registry,
+so a request that needs a particular live world must reach the process hosting
+that world.
+
+That live-process boundary is not the durability boundary. Persisted worlds can
+be discovered and queried from a fresh process. Mutable cold resume reconstructs
+a world from visible rows and manifests, then acquires a writer fence. The local
+SQLite control catalog coordinates processes on one host; deployments that need
+cross-host fencing use the remote control catalog. One live writer per world is
+the invariant, not one process for the whole deployment. See
+`docs/guide/durable-discovery.md`, `docs/guide/atomic-visibility.md`, and
+`docs/guide/world-lifecycle.md` for the normative contracts.
 
 **Consequences:**
 
-- **The CLI is a thin HTTP client.** Every command (except `serve`) is an `httpx` call to the running server. The CLI never instantiates a `ServiceContainer` — that would create an isolated, ephemeral process that can't participate in the server's event loop or share world state.
-- **Never spin up a second server.** There is no multi-node or multi-process coordination layer. If you need more compute, scale the Daft cluster, not the server count.
-- **World lifecycle mutations route through the CommandBroker.** `CREATE_WORLD`, `DESTROY_WORLD`, `FORK_WORLD` go through `CommandService.submit()` → broker lock → `apply_world_lifecycle()`. This gives RBAC, audit history, and serialized writes for free. Use `tick=0` for immediate execution (not tick-scheduled).
+- **The CLI is a thin HTTP client.** Every command except `serve` is an HTTP
+  call to a running server. The CLI does not instantiate its own
+  `ServiceContainer`, because that would create an unrelated live-world scope.
+- **Scale simulation work through Daft.** Adding an API process does not split
+  one live world's in-memory execution. Multi-process discovery, cold reads,
+  and fenced resume are control-plane capabilities, not a replacement for
+  Daft's data-plane execution model.
+- **World lifecycle operations are direct gated calls.** `create_world`,
+  `fork_world`, and `destroy_world` flow through `iCommandService` for RBAC and
+  audit, then delegate to `iWorldService`. The `CommandBroker` queues
+  tick-deferred commands; it is not the lifecycle or authorization boundary.
 
 **State across restarts:**
 
-A `WorldRegistry` (JSON file at `./archetype_data/archetype_registry.json`) catalogs world metadata (id, name, storage URI, namespace, tick). The server calls `discover_worlds()` on startup to rehydrate. This is a **boot catalog**, not a coordination mechanism — single writer, no locking needed.
+The control catalog attached to a storage identity records durable world
+metadata, signatures, writer fences, and tick manifests. `discover_worlds()`
+reads that catalog without constructing live worlds; `resume_world()` rebuilds
+a mutable world and acquires its fence. There is no JSON boot registry in the
+current architecture.
 
 ---
 

--- a/docs/guide/archetype.md
+++ b/docs/guide/archetype.md
@@ -7,12 +7,18 @@ An archetype is the fundamental grouping mechanism in the ECS.
 
 ```python
 class Archetype:
-    BASE_SCHEMA = pa.schema([
+    LEGACY_BASE_SCHEMA = pa.schema([
         pa.field("world_id", pa.string(), nullable=False),
         pa.field("run_id", pa.string(), nullable=False),
         pa.field("entity_id", pa.int32(), nullable=False),
         pa.field("tick", pa.int32(), nullable=False),
         pa.field("is_active", pa.bool_(), nullable=False),
+    ])
+
+    BASE_SCHEMA = pa.schema([
+        *LEGACY_BASE_SCHEMA,
+        pa.field("commit_token", pa.string(), nullable=False),
+        pa.field("writer_epoch", pa.int64(), nullable=False),
     ])
     PARTITION_KEYS = ["world_id", "run_id", "tick"]
 
@@ -48,6 +54,7 @@ class Archetype:
         row_dict = {
             "world_id": str(world_id), "run_id": str(run_id),
             "entity_id": entity_id, "tick": tick, "is_active": True,
+            "commit_token": "", "writer_epoch": 0,
         }
         for c in components:
             row_dict.update({c.get_prefix() + k: v for k, v in c.model_dump().items()})
@@ -82,7 +89,12 @@ a_2c_s9f3a1b2c4d5e6f7
 +--------- "a" prefix (archetype)
 ```
 
-Names are stable -- the same set of component types always produces the same name, regardless of component order. This allows multiple simulations and runs to share the same catalog.
+Names are stable within a schema generation -- the same set of component types
+and storage metadata produces the same name, regardless of component order.
+Because the schema hash includes the base columns, adding commit identity in
+v0.3 produced new table ids instead of mutating v0.2 tables in place. Stores
+may read a legacy table through its old schema-derived name, but new writes use
+the current name.
 
 ```python
 name = Archetype.get_name(sig)  # "a_2c_s9f3a1b2c4d5e6f7"
@@ -105,14 +117,22 @@ schema = Archetype.get_archetype_schema(sig)
 | `entity_id` | `int32` | Unique entity identifier |
 | `tick` | `int32` | Simulation tick when this row was written |
 | `is_active` | `bool` | Whether the entity is alive |
+| `commit_token` | `string` | Identity of the tick-commit attempt that wrote the row |
+| `writer_epoch` | `int64` | Fenced writer epoch for that attempt |
 
 **Component columns** are prefixed with the lowercase class name. A `Position(x=5, y=10)` component adds columns `position__x` and `position__y`.
 
 The full schema for an archetype with `(Health, Position)` would be:
 
 ```text
-world_id    | run_id | entity_id | tick | is_active | health__current | health__max_hp | position__x | position__y
+world_id | run_id | entity_id | tick | is_active | commit_token | writer_epoch | health__current | health__max_hp | position__x | position__y
 ```
+
+The commit columns are raw ledger metadata. Raw archetype reads expose them so
+visibility can be inspected; component projections omit them and return the
+five legacy housekeeping columns plus the requested component fields. A tick
+is visible only when its commit token appears in a published manifest. See
+[Atomic Tick Visibility](atomic-visibility.md).
 
 ## Partition Keys
 
@@ -152,12 +172,18 @@ row = Archetype.to_row_dict(
 #     "entity_id": 1,
 #     "tick": 0,
 #     "is_active": True,
+#     "commit_token": "",
+#     "writer_epoch": 0,
 #     "position__x": 5.0,
 #     "position__y": 10.0,
 #     "velocity__vx": 1.0,
 #     "velocity__vy": 0.0,
 # }
 ```
+
+`to_row_dict()` uses the uncoordinated epoch-0 placeholders shown above. During
+a coordinated tick, the updater replaces them with the tick's real commit
+token and writer epoch before append.
 
 ## Entities
 
@@ -171,6 +197,7 @@ When you add or remove components from an entity, it migrates to a different arc
 - [System Execution](system-execution.md) -- how signatures drive the subset rule for processor matching
 - [Worlds](worlds.md) -- tick lifecycle, spawn/despawn caches, entity migration
 - [Stores](stores.md) -- how archetype tables are persisted
+- [Atomic Tick Visibility](atomic-visibility.md) -- commit identity, manifests, and fencing
 
 ## Source Reference
 

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -1,19 +1,54 @@
 # Contributing
 
-Most changes to this repo are written as issues first and implemented in a branch with a PR. The intent is to keep work explicit, reviewable, and grounded in the contracts the repo is trying to preserve. Direct commits are fine for typo fixes and small docs edits.
+Archetype changes are contract work. A good contribution states the behavior it
+is preserving or changing, lands in the layer that owns that behavior, and
+leaves behind an executable reason to believe the result.
 
-## Recommended Workflow
+Most changes begin as issues and are implemented in a dedicated branch or
+workspace. The issue is a compact decision surface, not paperwork: it records
+the problem, the relevant contract, the likely owner, and what will count as
+done. Direct commits remain appropriate for typo fixes and small documentation
+edits whose behavior is not in question.
 
-If you want to contribute, the recommended path is:
+## Source of Truth
 
-1. Open an issue that describes the work as a prompt.
-2. Include scope, acceptance criteria, and any contract constraints.
-3. Have an agent work the issue in a dedicated workspace or branch.
-4. Review the resulting PR as you would review any other engineering change.
+When repository sources disagree, use this order:
 
-For simple typo fixes or small docs changes, you can still contribute directly.
-For runtime, service-layer, or engine behavior changes, issue-first is the
-recommended default.
+1. The focused normative specification for the affected behavior.
+2. Executable contract tests and evals.
+3. The umbrella [Specification](specification.md).
+4. Teaching material: guides, README, examples, and `LEARNINGS.md`.
+
+This order is a way to locate authority, not permission to ignore a conflict.
+If a focused specification and its executable oracle disagree, stop and surface
+that mismatch explicitly. Decide which contract is intended before changing
+behavior. A stale teaching example should become its own documentation fix
+rather than quietly steering an unrelated implementation.
+
+## Contract-First Issue Loop
+
+Use this loop for bugs, features, refactors, and contract clarifications:
+
+1. **Orient.** Read the focused specification, the nearest executable contract,
+   and the implementation seam that owns the behavior.
+2. **State the contract.** Describe what callers should observe, including the
+   behavior that must remain unchanged.
+3. **Reconcile the evidence.** Compare specification, tests, implementation,
+   and teaching docs. Record contradictions instead of resolving them silently.
+4. **Split the work.** Open separate issues for drift that is real but not
+   required by the current change. Keep one patch responsible for one decision.
+5. **Choose the oracle.** Identify the boundary test that will prove the change.
+   Add one when the contract has no executable witness.
+6. **Implement narrowly.** Change the lowest safe layer that owns the behavior.
+   Prefer app or runtime composition when a core change is unnecessary.
+7. **Validate proportionally.** Start with the closest test, then run the static
+   audits and broader suites appropriate to the risk.
+8. **Close the loop.** Report the resulting behavior and exact validation. Close
+   the issue only when the published change is merged, not merely when a local
+   patch exists.
+
+The loop should make small changes faster by removing ambiguity. It should not
+turn a typo into an architecture exercise.
 
 ## Read These First
 
@@ -32,7 +67,10 @@ These documents are the current orientation pack for contributors:
 | [Architecture](architecture.md) | High-level ECS and service-layer design |
 | [Quickstart](quickstart.md) | Fastest way to get oriented with the current API surface |
 
-If you skip one document, do not skip `LEARNINGS.md`.
+For a behavior change, do not skip the focused specification that owns it.
+Before writing processors or Daft UDFs, `LEARNINGS.md` is also mandatory; it
+records execution-model footguns that are too implementation-specific for the
+normative contracts.
 
 ## Contribution Policy
 
@@ -96,23 +134,33 @@ behavior is intentional.
 
 ## Issue Template Guidance
 
-The best issues are written as implementation prompts.
+The best issues are usable implementation prompts. For non-trivial work, add a
+contract card:
 
-A good issue should include:
+```text
+Behavior:
+Owning layer:
+Normative source:
+Existing executable oracle:
+Invariants at risk:
+Required validation:
+Documentation affected:
+```
 
-- the user-facing or system-facing problem
-- the affected layer
-  for example `core`, `app`, `api`, `cli`, `docs`, or `examples`
-- whether this is a bug fix, contract clarification, feature, or refactor
-- acceptance criteria
-- any relevant specification or requirements references
-- test expectations
+Keep each field concrete. "Owning layer: app/CommandService" is useful;
+"backend" is not. "Invariants at risk: failed commands must not debit quota or
+enter the broker" gives a reviewer something to verify. Empty fields are useful
+signals too: if no executable oracle exists, the issue has identified a test
+that needs to be written.
 
 Good examples:
 
 - "Make `SimulationService.run()` preserve one logical `run_id` across the full run and add regression coverage."
 - "Document the world-local shutdown contract for the sugar runtime and add smoke tests."
 - "Fix `QueryService` so it either implements real reads or is clearly documented as provisional."
+
+Do not force a contract card onto a spelling fix. Use it when implementation
+choices, public behavior, or architectural ownership could reasonably diverge.
 
 ## Development Workflow
 
@@ -136,13 +184,19 @@ uv run mkdocs build
 
 ### Before you open a PR
 
-At minimum:
+Validation follows risk rather than patch size alone:
 
-- run `make test`
-- run `make check` or the relevant lint/format commands
-- run `uv run mkdocs build` if you touched docs
+| Change | Expected validation |
+|---|---|
+| Typo or prose-only documentation | `git diff --check`; build the affected docs when navigation, links, or rendering may change |
+| Executable example or public snippet | Run the example or snippet path, then build the docs |
+| API, CLI, runtime, or app behavior | Closest contract/regression tests, then `make check`; use `make ci` when behavior crosses service or lifecycle boundaries |
+| Core, storage, concurrency, or durability | Prior contract discussion, focused failure/race coverage, `make ci`, and the relevant eval or infrastructure gate |
+| Dependency or release metadata | Lock check plus the workflow-specific build or release validation |
 
-For broad changes, prefer `make ci`.
+Report the commands that actually ran and their outcomes. Do not write "tests
+pass" when only one test ran; that one test may be exactly the right evidence,
+but name it. Warnings should be identified as new, pre-existing, or unrelated.
 
 ## How to Structure Changes
 
@@ -158,14 +212,36 @@ Keep the work narrow and contract-driven.
 - If a proposed ergonomic change weakens a contract, document the tradeoff and
   get agreement before implementing it.
 
+## Documentation Register
+
+Write documentation in the same register the architecture expects from code:
+
+- Lead with the observable behavior or decision.
+- Name ownership and lifecycle boundaries directly.
+- Explain why an invariant exists when that reason changes how someone should
+  extend the system.
+- Distinguish normative requirements, current gaps, compatibility behavior,
+  and historical lessons. Do not present an obsolete implementation as a hard
+  architectural law.
+- Prefer the recommended runtime surface in beginner material. Use service and
+  core APIs only when the document is explicitly teaching those lower layers.
+- Keep examples executable in spirit and syntax. If a snippet is intentionally
+  abbreviated, say what was omitted.
+- Link to the focused specification instead of reproducing a second, subtly
+  different contract.
+
+The goal is calm precision: enough context to make the right change, without
+turning implementation history into ceremony.
+
 ## Pull Requests
 
 PRs should explain:
 
-- what changed
-- why the change is needed
-- what contract it preserves, introduces, or modifies
-- how it was validated
+- the behavior that changed
+- the owning layer and why it is the right seam
+- the contract preserved, introduced, or modified
+- the executable oracle and exact validation results
+- any adjacent drift deliberately left to a separate issue
 
 If behavior changed, include the test that proves it.
 

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -24,6 +24,13 @@ The runtime module imports from `archetype.app` ONLY:
 - `archetype.app.container`
 - `archetype.app.models`
 - `archetype.app.auth.models`
+- `archetype.app.autoresearch_service` inside `TYPE_CHECKING` only
+- `archetype.app.eval_service` inside `TYPE_CHECKING` only
+
+The two type-only modules supply public callback and result annotations for
+`world.autoresearch()` and `world.grade()`. They do not provide an operational
+path around the gate; both operations still route through the authorized
+runtime surface.
 
 Imports from `archetype.app.{mutation_service, simulation_service, query_service, world_service, broker}` are forbidden. Any such import is a spec violation; the gate is leaking.
 

--- a/docs/guide/updater.md
+++ b/docs/guide/updater.md
@@ -1,6 +1,8 @@
 # Updater
 
-`AsyncUpdateManager` is the write facade to the store. It stamps housekeeping columns onto processed DataFrames and delegates the append to the store.
+`AsyncUpdateManager` is the write facade to the store. It stamps housekeeping
+and commit-identity columns onto processed DataFrames and delegates the append
+to the store.
 
 ```python
 class AsyncUpdateManager(iAsyncUpdateManager):
@@ -9,7 +11,13 @@ class AsyncUpdateManager(iAsyncUpdateManager):
         self.validate_flag = validate_flag
 
     async def update(
-        self, df: DataFrame, sig: ArchetypeSignature, tick: int, world_id: str, run_id: str
+        self,
+        df: DataFrame,
+        sig: ArchetypeSignature,
+        tick: int,
+        world_id: str,
+        run_id: str,
+        commit: CommitContext | None = None,
     ) -> DataFrame:
         df = df.with_columns(
             {
@@ -17,6 +25,10 @@ class AsyncUpdateManager(iAsyncUpdateManager):
                 "world_id": lit(str(world_id)),
                 "run_id": lit(str(run_id)),
                 "entity_id": col("entity_id").cast(daft.DataType.int32()),
+                "commit_token": lit(commit.commit_token if commit else ""),
+                "writer_epoch": lit(commit.writer_epoch if commit else 0).cast(
+                    daft.DataType.int64()
+                ),
             }
         )
 
@@ -40,20 +52,31 @@ Every DataFrame returned by processor execution passes through the updater befor
 
 ## What It Does
 
-The `update()` method applies four housekeeping mutations before appending:
+The `update()` method applies six metadata mutations before appending:
 
 ```python
-df = await updater.update(df, sig, tick=5, world_id="abc", run_id="run-1")
+df = await updater.update(
+    df,
+    sig,
+    tick=5,
+    world_id="abc",
+    run_id="run-1",
+    commit=commit_context,
+)
 ```
 
 1. **Stamp `tick`** -- overwrite with the current tick as `int32`
 2. **Stamp `world_id`** -- overwrite with the world's ID as `string`
 3. **Stamp `run_id`** -- overwrite with the current run's ID as `string`
 4. **Cast `entity_id`** -- ensure `int32` type for schema consistency
+5. **Stamp `commit_token`** -- identify the coordinated tick attempt
+6. **Stamp `writer_epoch`** -- identify the fenced writer as `int64`
 
 These stamps ensure every row in storage has correct, consistent metadata regardless of what processors may have done to the DataFrame.
 
 After stamping, the updater calls `store.append(sig, df)` and logs the duration.
+Without a commit context, it stamps `""` and `0`, the implicit epoch-0 identity
+used by uncoordinated core worlds.
 
 ## Why Stamping Matters
 
@@ -62,13 +85,35 @@ Processors receive DataFrames and return DataFrames. They can add columns, modif
 - **Spawned entities** arrive with placeholder `run_id=""` from the spawn cache. The updater stamps the real `run_id`.
 - **Forked worlds** re-stamp `world_id` so cloned rows are attributed to the new world.
 - **Type safety** -- `entity_id` is cast to `int32` to match the base schema, preventing schema mismatches in union operations.
+- **Coordinated visibility** -- every archetype written for one tick receives the same commit token and writer epoch.
+
+## Append Is Not Visibility
+
+For an uncoordinated core world, a successful append retains the legacy
+epoch-0 behavior and is immediately readable. For a world created through the
+service layer, the updater's successful append is only one phase of the tick
+commit:
+
+```text
+compute every archetype
+    -> append every stamped frame
+    -> flush staged rows
+    -> publish one tick manifest
+    -> consume mutation caches and advance the tick
+```
+
+Readers admit current-generation rows only when their commit token is published
+for that tick. If append, flush, or manifest publication fails, the tick does
+not advance and its staged mutations remain available for retry. Physical rows
+from an unpublished attempt may remain in storage, but they are invisible.
+See [Atomic Tick Visibility](atomic-visibility.md) for the normative protocol.
 
 ## World Facade
 
 Most code goes through the world:
 
 ```python
-# Internally calls updater.update() with world_id and run_config.run_id
+# Internally passes the world's pinned run_id and current tick commit context
 df = await world.update(df, sig, run_config)
 ```
 
@@ -77,6 +122,7 @@ df = await world.update(df, sig, run_config)
 - [Data Flow](data-flow.md) -- how the updater fits into the write path and command pipeline
 - [Querier](querier.md) -- the read counterpart to the updater
 - [Stores](stores.md) -- the storage backends the updater appends to
+- [Atomic Tick Visibility](atomic-visibility.md) -- the coordinated visibility boundary
 
 ## Source Reference
 


### PR DESCRIPTION
## Behavior

- codifies a contract-first issue loop, source-of-truth precedence, contract cards, proportional validation, and the documentation register
- corrects obsolete single-process, lifecycle-routing, and restart guidance in `LEARNINGS.md`
- updates archetype and updater guides for commit-token / writer-epoch visibility
- aligns the runtime R1 import boundary with its executable contract
- mirrors the operational rules in `AGENTS.md`

## Why

The focused specifications and executable contracts had moved ahead of several teaching documents. That drift made old implementation history look normative and left contributors without a compact way to connect an issue to its owning layer, invariant, executable oracle, and validation.

This PR dogfoods the documented workflow: each independent discrepancy was captured as a focused issue, then implemented as one cohesive documentation convergence pass.

## Impact

No runtime behavior changes. Contributors and agents get one explicit source hierarchy and a repeatable, risk-proportional issue workflow. Core/storage readers now see the coordinated visibility model rather than the pre-v0.3 append model.

## Validation

- `uv run pytest -q tests/app/test_import_boundaries.py tests/spec_contracts/test_spec_contract_evals.py` — 6 passed
- `make check` — formatting, lint, lazy audit, API boundary audit, and idempotency audit passed
- `uv run --extra docs mkdocs build` — passed
- `git diff --check` — passed

The docs build retains two pre-existing warnings: Material's MkDocs 2.0 notice and Griffe's missing annotation warning for `async_system.py::**input_kwargs`.

Closes #335
Closes #336
Closes #337
Closes #366