### PR TITLE
fix(core): empty-row migration guards + sync-stack composition parity

### DIFF
--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -341,7 +341,10 @@ CURRENT GAP:
 - Component addition and removal are archetype moves.
 - The old signature receives a despawn marker.
 - The new signature receives a spawned row built from the latest visible entity
-  state plus the requested mutation.
+  state plus the requested mutation. Latest visible state is the entity's
+  same-tick staged spawn row when one exists, otherwise its last persisted
+  row; a consumed staged row MUST NOT also materialize under the old
+  signature.
 - When migration materializes into an existing DataFrame, staged spawn rows MUST
   be cast or otherwise normalized to the target schema before concat.
 - Adding already-present components or removing already-absent components SHOULD
@@ -357,11 +360,11 @@ CURRENT GAP:
 - Despawn-only signatures MUST still be processed during the next tick, even if
   no active entities remain in that archetype after bookkeeping updates.
 
-CURRENT GAP:
-
-- `AsyncWorld._move_entity()` can currently return an empty row when the old
-  entity is not found in `_live`, and callers do not validate this before
-  staging a spawn. That boundary needs an explicit error or no-op contract.
+- `AsyncWorld._move_entity()` returns an empty row only when the entity has
+  neither a staged row nor a persisted row; `update_entity`,
+  `add_components`, and `remove_components` treat that as a logged no-op and
+  stage nothing. Contract tests:
+  `tests/core/test_same_tick_mutation_composition.py`.
 
 ## Lifecycle Hook Contracts
 
@@ -646,12 +649,10 @@ Required behavior:
   weaker behavior MUST be documented explicitly in user-facing runtime docs and
   examples
 
-CURRENT GAP:
-
-- `UPDATE` followed by `ADD_COMPONENT` for the same entity in one drain cycle
-  does not currently compose intuitively. The second command reads from `_live`
-  rather than from the staged update row, so command order and final
-  materialized state can diverge.
+Resolved: same-tick mutations compose. A later mutation for the same entity
+bases its row on the earlier staged spawn row (consuming it) rather than the
+last persisted tick, so command order and final materialized state agree.
+Contract tests: `tests/core/test_same_tick_mutation_composition.py`.
 
 ### Multi-World Lifetime Contract
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -44,7 +44,7 @@ reason = "Storage write boundary: materialize the incoming frame once for the em
 
 [[entries]]
 path = "src/archetype/core/aio/async_world.py"
-line = 380
+line = 409
 method = "to_pylist"
 reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
 
@@ -56,7 +56,7 @@ reason = "Debug-mode-only logging: materialise so count_rows and df.show emit di
 
 [[entries]]
 path = "src/archetype/core/sync/world.py"
-line = 270
+line = 289
 method = "to_pylist"
 reason = "Cross-archetype entity migration (sync mirror of async_world): extract the latest tick row for component overlay before re-insertion."
 

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -355,6 +355,26 @@ class AsyncWorld(iAsyncWorld):
         self.despawn_cache.pop(sig, None)
         return df.concat(spawns_df) if spawns_df is not None else df
 
+    def _pop_staged_spawn(self, sig: ArchetypeSignature, entity_id: int) -> dict[str, Any] | None:
+        """Remove and return the entity's staged spawn row under ``sig``.
+
+        Multiple staged rows for one entity collapse last-write-wins,
+        matching ``_spawn_frame``'s dedupe rule. Returns ``None`` when
+        nothing is staged.
+        """
+        pending = self.spawn_cache.get(sig)
+        if not pending:
+            return None
+        remaining = [row for row in pending if row["entity_id"] != entity_id]
+        if len(remaining) == len(pending):
+            return None
+        staged = next(row for row in reversed(pending) if row["entity_id"] == entity_id)
+        if remaining:
+            self.spawn_cache[sig] = remaining
+        else:
+            del self.spawn_cache[sig]
+        return staged
+
     async def _move_entity(
         self,
         entity_id: int,
@@ -363,34 +383,42 @@ class AsyncWorld(iAsyncWorld):
         mutated_components: list[Component],
     ) -> dict[str, Any]:
         """
-        Returns a row dict that is valid for the NEW archetype.
-        Any field that is NOT in `mutated_components` is read from the
-        previous most-recent row in the OLD archetype.
+        Returns a row dict that is valid for the NEW archetype, or an empty
+        dict when the entity has no visible state to move (callers treat
+        that as a logged no-op).
+
+        The base row is the entity's latest visible state: a same-tick
+        staged spawn row when one exists (spec C7 — later commands observe
+        earlier staged mutations), otherwise the previous most-recent row in
+        the OLD archetype. A staged row is consumed here so it cannot also
+        materialize under the old signature after the move.
         """
-
-        # 1) fetch *only* the single entity from old archetype's previous tick
-        df = await self.query_archetype(
-            sig=old_sig,
-            run_id=self.run_id,
-            ticks=[self.tick - 1],
-            entity_ids=[entity_id],
-            components=None,
-        )
-
-        row_list = df.to_pylist()
-        if len(row_list) == 0:
-            logger.warning(
-                f"World {self.name} ({self.world_id}): Entity Migration Failed: No entity: {entity_id}"
+        staged = self._pop_staged_spawn(old_sig, entity_id)
+        if staged is not None:
+            row_dict = dict(staged)
+        else:
+            # Fetch *only* the single entity from the old archetype's previous tick
+            df = await self.query_archetype(
+                sig=old_sig,
+                run_id=self.run_id,
+                ticks=[self.tick - 1],
+                entity_ids=[entity_id],
+                components=None,
             )
-            return {}
-        if len(row_list) > 1:
-            logger.warning(
-                f"World {self.name} ({self.world_id}): Entity Migration Failed: Multiple entities: {entity_id}"
-            )
-            return {}
 
-        # We should never have multiple entities with the same entity_id in the same tick.
-        row_dict = row_list[0]
+            row_list = df.to_pylist()
+            if len(row_list) == 0:
+                logger.warning(
+                    f"World {self.name} ({self.world_id}): Entity Migration Failed: No entity: {entity_id}"
+                )
+                return {}
+            if len(row_list) > 1:
+                # We should never have multiple entities with the same entity_id in the same tick.
+                logger.warning(
+                    f"World {self.name} ({self.world_id}): Entity Migration Failed: Multiple entities: {entity_id}"
+                )
+                return {}
+            row_dict = row_list[0]
 
         # 3) overlay components that change with the new ones (skips for remove component with 0 member list)
         for c in mutated_components:
@@ -600,6 +628,9 @@ class AsyncWorld(iAsyncWorld):
             return
 
         row = await self._move_entity(entity_id, old_sig, new_sig, components)
+        if not row:
+            logger.warning("add_components: entity %s has no prior row; no-op", entity_id)
+            return
 
         # 1) mark *old row* inactive
         self.despawn_cache.setdefault(old_sig, []).append(entity_id)
@@ -635,6 +666,9 @@ class AsyncWorld(iAsyncWorld):
         row = await self._move_entity(
             entity_id, old_sig, new_sig, []
         )  # remove ≡ keep remaining columns
+        if not row:
+            logger.warning("remove_components: entity %s has no prior row; no-op", entity_id)
+            return
 
         self.despawn_cache.setdefault(old_sig, []).append(entity_id)
         new_sig = self._intern_sig(new_sig)

--- a/src/archetype/core/sync/world.py
+++ b/src/archetype/core/sync/world.py
@@ -235,6 +235,26 @@ class SyncWorld(iWorld):
         spawns_df = self._spawn_frame(df, sig)
         return df.concat(spawns_df) if spawns_df is not None else df
 
+    def _pop_staged_spawn(self, sig: ArchetypeSignature, entity_id: int) -> dict[str, Any] | None:
+        """Remove and return the entity's staged spawn row under ``sig``.
+
+        Multiple staged rows for one entity collapse last-write-wins,
+        matching ``_spawn_frame``'s dedupe rule. Returns ``None`` when
+        nothing is staged.
+        """
+        pending = self.spawn_cache.get(sig)
+        if not pending:
+            return None
+        remaining = [row for row in pending if row["entity_id"] != entity_id]
+        if len(remaining) == len(pending):
+            return None
+        staged = next(row for row in reversed(pending) if row["entity_id"] == entity_id)
+        if remaining:
+            self.spawn_cache[sig] = remaining
+        else:
+            del self.spawn_cache[sig]
+        return staged
+
     def _move_entity(
         self,
         entity_id: int,
@@ -243,22 +263,21 @@ class SyncWorld(iWorld):
         mutated_components: list[Component],
     ) -> dict[str, Any]:
         """
-        Returns a row dict that is valid for the NEW archetype.
-        Any field that is NOT in `mutated_components` is read from the
-        previous most-recent row in the OLD archetype.
-        """
+        Returns a row dict that is valid for the NEW archetype, or an empty
+        dict when the entity has no visible state to move (callers treat
+        that as a logged no-op).
 
-        # 1) find the most recent row for the entity. Pending spawn rows take
-        # priority because they represent same-tick mutations that haven't yet
-        # been committed to the store; otherwise read the previous-tick row
-        # from durable storage.
+        The base row is the entity's latest visible state: a same-tick
+        staged spawn row when one exists (spec C7 — later commands observe
+        earlier staged mutations), otherwise the previous most-recent row in
+        the OLD archetype. A staged row is consumed here so it cannot also
+        materialize under the old signature after the move.
+        """
         row_dict: dict[str, Any] | None = None
 
-        pending_rows = [
-            row for row in self.spawn_cache.get(old_sig, []) if row.get("entity_id") == entity_id
-        ]
-        if pending_rows:
-            row_dict = dict(pending_rows[-1])
+        staged = self._pop_staged_spawn(old_sig, entity_id)
+        if staged is not None:
+            row_dict = dict(staged)
         else:
             df = self.query_archetype(
                 sig=old_sig,
@@ -425,6 +444,9 @@ class SyncWorld(iWorld):
             return
 
         row = self._move_entity(entity_id, old_sig, new_sig, components)
+        if not row:
+            logger.warning("add_components: entity %s has no prior row; no-op", entity_id)
+            return
 
         # 1) mark *old row* inactive
         self.despawn_cache.setdefault(old_sig, []).append(entity_id)
@@ -455,6 +477,9 @@ class SyncWorld(iWorld):
             return
 
         row = self._move_entity(entity_id, old_sig, new_sig, [])  # remove ≡ keep remaining columns
+        if not row:
+            logger.warning("remove_components: entity %s has no prior row; no-op", entity_id)
+            return
 
         self.despawn_cache.setdefault(old_sig, []).append(entity_id)
         self.spawn_cache.setdefault(new_sig, []).append(row)

--- a/tests/core/test_same_tick_mutation_composition.py
+++ b/tests/core/test_same_tick_mutation_composition.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Same-tick mutation composition (spec C7) and migration no-op contracts.
+
+Issue #193: a later mutation for the same entity in one drain cycle must
+observe the earlier staged mutation — `update_entity` then `add_components`
+composes; the second command bases on the first's staged row, not on the
+last persisted tick, and the staged row must not also materialize under the
+old signature.
+
+Issue #367: migrating an entity with no visible state at all (neither a
+staged row nor a persisted row) must be an observable no-op — no empty row
+staged, no bookkeeping moved.
+"""
+
+import pytest
+
+from archetype.core.archetype import Archetype
+from archetype.core.component import Component
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from tests.conftest import make_world_service
+
+
+class ComposePos(Component):
+    x: float = 0.0
+
+
+class ComposeVel(Component):
+    vx: float = 0.0
+
+
+async def _make_world(ws, tmp_path):
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+    return await ws.create_world(WorldConfig(name="compose"), storage_config=storage)
+
+
+@pytest.mark.asyncio
+async def test_update_then_add_component_composes(tmp_path):
+    """spec C7: ADD_COMPONENT after a same-tick UPDATE keeps the update."""
+    ws = make_world_service()
+    try:
+        world = await _make_world(ws, tmp_path)
+        eid = await world.create_entity([ComposePos(x=1.0)])
+        await world.step(RunConfig())  # x_0 = 1.0 persists @ t0
+
+        await world.update_entity(eid, [ComposePos(x=5.0)])
+        await world.add_components(eid, [ComposeVel(vx=2.0)])
+        await world.step(RunConfig())  # both mutations materialize @ t1
+
+        df = await world.query_archetype(sig=(ComposePos, ComposeVel), ticks=[1])
+        rows = df.to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["composepos__x"] == 5.0, (
+            "add_components based its row on the persisted tick, losing the "
+            "same-tick update (x=5.0) staged before it"
+        )
+        assert rows[0]["composevel__vx"] == 2.0
+
+        live = await world.get_components([ComposePos])
+        live_rows = live.to_pylist()
+        assert len(live_rows) == 1, (
+            f"entity {eid} is active in {len(live_rows)} rows; the update's "
+            "staged row must not also materialize under the old signature"
+        )
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_two_partial_updates_compose(tmp_path):
+    """A second update touching different components keeps the first."""
+    ws = make_world_service()
+    try:
+        world = await _make_world(ws, tmp_path)
+        eid = await world.create_entity([ComposePos(x=1.0), ComposeVel(vx=1.0)])
+        await world.step(RunConfig())
+
+        await world.update_entity(eid, [ComposePos(x=5.0)])
+        await world.update_entity(eid, [ComposeVel(vx=9.0)])
+        await world.step(RunConfig())
+
+        df = await world.query_archetype(sig=(ComposePos, ComposeVel), ticks=[1])
+        rows = df.to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["composepos__x"] == 5.0, "first partial update was lost"
+        assert rows[0]["composevel__vx"] == 9.0
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_spawn_then_add_component_before_first_step(tmp_path):
+    """Migrating a spawned-but-unmaterialized entity uses its staged row."""
+    ws = make_world_service()
+    try:
+        world = await _make_world(ws, tmp_path)
+        eid = await world.create_entity([ComposePos(x=3.0)])
+        await world.add_components(eid, [ComposeVel(vx=4.0)])
+        await world.step(RunConfig())
+
+        df = await world.query_archetype(sig=(ComposePos, ComposeVel), ticks=[0])
+        rows = df.to_pylist()
+        assert len(rows) == 1, (
+            "spawn-then-migrate before the first step must land exactly one "
+            "row under the new signature"
+        )
+        assert rows[0]["entity_id"] == eid
+        assert rows[0]["composepos__x"] == 3.0
+        assert rows[0]["composevel__vx"] == 4.0
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_add_components_without_prior_row_is_noop(tmp_path):
+    """Issue #367: no staged row + no persisted row -> logged no-op."""
+    ws = make_world_service()
+    try:
+        world = await _make_world(ws, tmp_path)
+        # Poison: the registry claims the entity exists, but no row was ever
+        # staged or persisted (state divergence, e.g. a bad replay).
+        sig = Archetype.sig_from_components([ComposePos()])
+        world.entity2sig[77] = sig
+
+        await world.add_components(77, [ComposeVel(vx=1.0)])
+
+        assert world.entity2sig[77] == sig, "no-op must not move the signature"
+        assert not world.spawn_cache, "no-op must not stage a spawn row"
+        assert not world.despawn_cache, "no-op must not stage a despawn"
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_remove_components_without_prior_row_is_noop(tmp_path):
+    """Issue #367: remove_components mirrors the add_components no-op."""
+    ws = make_world_service()
+    try:
+        world = await _make_world(ws, tmp_path)
+        sig = Archetype.sig_from_components([ComposePos(), ComposeVel()])
+        world.entity2sig[77] = sig
+
+        await world.remove_components(77, [ComposeVel])
+
+        assert world.entity2sig[77] == sig, "no-op must not move the signature"
+        assert not world.spawn_cache, "no-op must not stage a spawn row"
+        assert not world.despawn_cache, "no-op must not stage a despawn"
+    finally:
+        await ws.shutdown()

--- a/tests/sync/test_sync_stack_contracts.py
+++ b/tests/sync/test_sync_stack_contracts.py
@@ -554,6 +554,29 @@ def test_sync_world_add_components_before_first_step_uses_pending_spawn_row(tmp_
     assert rows[0]["position__x"] == 1
     assert rows[0]["velocity__vx"] == 5
 
+    # The consumed staged row must not also materialize under the old
+    # signature (issues #193/#367: double-materialize across archetypes).
+    old_sig = Archetype.sig_from_components([Position(x=0, y=0)])
+    stray = _committed_rows(world, old_sig)
+    assert stray == [], (
+        f"entity {entity_id} materialized active under the pre-migration "
+        "signature; the staged spawn row must be consumed by the move"
+    )
+
+
+def test_sync_world_add_components_without_prior_row_is_noop(tmp_path):
+    """Issues #367: no staged row + no persisted row -> logged no-op."""
+    _store, _querier, _updater, _system, world = _make_sync_stack(tmp_path, "world_noop_move")
+    old_sig = Archetype.sig_from_components([Position(x=0, y=0)])
+    world.entity2sig[42] = old_sig
+
+    world.query_archetype = lambda *args, **kwargs: _df_from_rows(old_sig, [])
+    world.add_components(42, [Velocity(vx=1, vy=1)])
+
+    assert world.entity2sig[42] == old_sig, "no-op must not move the signature"
+    assert not world.spawn_cache, "no-op must not stage a spawn row"
+    assert not world.despawn_cache, "no-op must not stage a despawn"
+
 
 def test_sync_world_execute_passes_resources_and_kwargs(tmp_path):
     class ApplyBonus(SyncProcessor):


### PR DESCRIPTION
## Summary
Rescoped after #332 landed (it fixed the async same-drain composition half of #193 — thanks, sibling session). What main still lacked, verified by running this PR's contract tests against main (4 of 5 failed):

- **#367:** `add_components`/`remove_components` staged `_move_entity`'s empty-dict return and moved bookkeeping anyway (async + sync). Both now mirror `update_entity`: logged no-op, nothing staged, signature unchanged.
- **Sync-stack parity:** the sync world read staged rows without consuming them — a spawn-then-migrate left the stale row to materialize *active* under the old signature (double-materialize). Sync now shares the consume-on-move contract; async keeps the composition fix from #332 (folded here as `_pop_staged_spawn`, all-rows LWW consumption).
- **Contract tests:** `tests/core/test_same_tick_mutation_composition.py` (5 tests — the cross-stack pin for spec C7 + the no-op contract) and sync stray-row/no-op assertions in `test_sync_stack_contracts.py`.
- **Spec:** the two CURRENT GAP blocks (Mutation materialization, runtime C7) replaced with the resolved contract + test pointers — #332 didn't touch the spec, so both were stale on main.

## Tests
Full suite: 931 passed, 7 skipped. Lint + audits green.

Closes #367. (#193's async half closed via #332; this pins it cross-stack.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)