### PR TITLE
fix(experiments)!: eval helpers route through the command gateway; @public_api enforced

### DIFF
--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -154,6 +154,29 @@ path described in [Durable Facts](durable-facts.md). Typed facts are scoped to
 the handle's current world and run; fork handles do not inherit ancestor fact
 rows.
 
+### R19 — Public API is gate-addressable, and the machine checks
+
+`@public_api` (top-level export) marks archetype's supported callable surface
+and carries an enforced contract: **a public callable may not accept raw
+services**. Public capability must be expressible through `ArchetypeRuntime`
+and its gated handles, so every mutation carries command-audit provenance —
+a function taking `world_service=`/`simulation_service=` forces callers to
+hand-roll a `ServiceContainer` and bypass the gate (observed twice before
+this rule existed). `scripts/check_api_import_boundaries.py` enforces the
+signature rule and the import scopes (`experiments` may import app *models*
+only; the runtime is the sole public consumer of app). Deprecated
+service-shaped bridge parameters live in the checker's allowlist with a
+removal deadline.
+
+`@archetype.entrypoint()` is the script boundary as a decorator — an
+evolution of the runtime, not a surface beside it: it constructs the runtime
+(env-driven configuration per R16/R17), bridges sync/async, injects the
+runtime as the first argument, and guarantees teardown. Eval helpers
+(`archetype.experiments.eval_rollouts.run_task_eval`,
+`archetype.experiments.instruction_sweep.run_instruction_sweep`) are
+runtime-first: pass `runtime=`; their raw-service keyword forms are
+deprecated bridges removed in v0.6.
+
 ## 3. Ergonomic surface
 
 The full canonical surface, async and sync:

--- a/docs/reference/python/runtime.md
+++ b/docs/reference/python/runtime.md
@@ -7,3 +7,7 @@
 ::: archetype.runtime.ArchetypeRuntime
 
 ::: archetype.runtime.configure_session
+
+::: archetype.runtime.entrypoint.entrypoint
+
+::: archetype._api.public_api

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -128,12 +128,12 @@ reason = "series_to_rows helper: converts each Series parameter to a Python list
 
 [[entries]]
 path = "src/archetype/experiments/eval_rollouts.py"
-line = 228
+line = 413
 method = "collect"
 reason = "grading boundary: latest-tick row per entity from the already-filtered episode query becomes the scalar TaskEvalReport — the analysis edge where eval graders also collect; nothing downstream re-enters the DAG"
 
 [[entries]]
 path = "src/archetype/experiments/eval_rollouts.py"
-line = 228
+line = 413
 method = "to_pylist"
 reason = "same grading-boundary site as the collect above: per-entity terminal rows to Python for success/length aggregation into the report"

--- a/scripts/check_api_import_boundaries.py
+++ b/scripts/check_api_import_boundaries.py
@@ -34,7 +34,7 @@ API_TARGETS = [
     ROOT / "src/archetype/api/deps.py",
     *sorted((ROOT / "src/archetype/api/routes").glob("*.py")),
 ]
-EXPERIMENTS_TARGETS = sorted((ROOT / "src/archetype/experiments").glob("*.py"))
+EXPERIMENTS_TARGETS = sorted((ROOT / "src/archetype/experiments").rglob("*.py"))
 PUBLIC_API_SCAN_TARGETS = sorted((ROOT / "src/archetype").rglob("*.py"))
 
 ALLOWED_APP_IMPORTS_API = {
@@ -112,9 +112,7 @@ def _imported_modules(node: ast.AST) -> list[str]:
     return []
 
 
-def _import_violations(
-    path: Path, allowed: set[str], forbidden: set[str], scope: str
-) -> list[str]:
+def _import_violations(path: Path, allowed: set[str], forbidden: set[str], scope: str) -> list[str]:
     tree = ast.parse(path.read_text(), filename=str(path))
     violations: list[str] = []
     for node in ast.walk(tree):

--- a/scripts/check_api_import_boundaries.py
+++ b/scripts/check_api_import_boundaries.py
@@ -26,6 +26,7 @@ gated handles, so every mutation carries command-audit provenance.
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -133,7 +134,10 @@ def _import_violations(path: Path, allowed: set[str], forbidden: set[str], scope
     return violations
 
 
-def _is_public_api_decorated(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _is_public_api_decorated(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> bool:
     for dec in node.decorator_list:
         target = dec.func if isinstance(dec, ast.Call) else dec
         name = target.attr if isinstance(target, ast.Attribute) else getattr(target, "id", "")
@@ -142,30 +146,56 @@ def _is_public_api_decorated(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bo
     return False
 
 
+def _service_param_violation(param: ast.arg) -> bool:
+    """Whole-token annotation match plus param-name match.
+
+    Tokenizing avoids substring hits (``SimulationServiceConfig`` is not
+    ``SimulationService``). Known limit, held by the param-NAME check as the
+    backstop: an import alias (``import CommandService as Gate``) hides the
+    type token — full resolution would need import walking.
+    """
+    annotation = ast.unparse(param.annotation) if param.annotation else ""
+    tokens = set(_IDENTIFIER.findall(annotation))
+    return bool(tokens & SERVICE_TYPE_NAMES) or param.arg in SERVICE_PARAM_NAMES
+
+
+def _signature_violations(
+    rel: str, qualname: str, fn: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[str]:
+    bridge = PUBLIC_API_BRIDGE_PARAMS.get(f"{rel}::{qualname}", set())
+    params = [*fn.args.posonlyargs, *fn.args.args, *fn.args.kwonlyargs]
+    violations: list[str] = []
+    for param in params:
+        if param.arg in bridge or param.arg in ("self", "cls"):
+            continue
+        if _service_param_violation(param):
+            violations.append(
+                f"{rel}::{qualname} — @public_api callable accepts raw service "
+                f"parameter `{param.arg}`; public capability must be expressible "
+                f"through ArchetypeRuntime (gated, audited). Deprecated bridges "
+                f"belong in PUBLIC_API_BRIDGE_PARAMS with a removal deadline."
+            )
+    return violations
+
+
 def _public_api_violations(path: Path) -> list[str]:
     tree = ast.parse(path.read_text(), filename=str(path))
     rel = str(path.relative_to(ROOT))
     violations: list[str] = []
     for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if not _is_public_api_decorated(node):
-            continue
-        bridge = PUBLIC_API_BRIDGE_PARAMS.get(f"{rel}::{node.name}", set())
-        params = [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
-        for param in params:
-            if param.arg in bridge:
-                continue
-            annotation = ast.unparse(param.annotation) if param.annotation else ""
-            typed_as_service = any(name in annotation for name in SERVICE_TYPE_NAMES)
-            named_as_service = param.arg in SERVICE_PARAM_NAMES
-            if typed_as_service or named_as_service:
-                violations.append(
-                    f"{rel}::{node.name} — @public_api callable accepts raw service "
-                    f"parameter `{param.arg}`; public capability must be expressible "
-                    f"through ArchetypeRuntime (gated, audited). Deprecated bridges "
-                    f"belong in PUBLIC_API_BRIDGE_PARAMS with a removal deadline."
-                )
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _is_public_api_decorated(node):
+                violations += _signature_violations(rel, node.name, node)
+        elif isinstance(node, ast.ClassDef) and _is_public_api_decorated(node):
+            # The marker's contract covers classes too: constructors are the
+            # signature surface, so a @public_api class taking a raw service
+            # in __init__/__new__ is the same bypass in a different costume.
+            for member in node.body:
+                if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)) and member.name in (
+                    "__init__",
+                    "__new__",
+                ):
+                    violations += _signature_violations(rel, f"{node.name}.{member.name}", member)
     return violations
 
 

--- a/scripts/check_api_import_boundaries.py
+++ b/scripts/check_api_import_boundaries.py
@@ -1,10 +1,26 @@
 # Copyright 2025 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Enforce API route import boundaries.
+"""Enforce public-surface boundaries: imports and @public_api signatures.
 
-Route handlers are external entry points and must go through CommandService
-instead of reaching into lower-level app services directly.
+Two rules, one principle — **the runtime is the sole public consumer of app**;
+public capability must be expressible through ``ArchetypeRuntime`` and its
+gated handles, so every mutation carries command-audit provenance.
+
+1. Import scopes (per consumer):
+   - ``api`` route handlers go through CommandService — they may not reach
+     into lower-level app services directly.
+   - ``experiments`` is public surface: it may import app *models* only.
+     Driving services directly from here is how the command-gateway bypass
+     entered ``src/`` (eval_rollouts, 2026-07-17).
+   - ``runtime`` is unrestricted: it hosts the gate.
+
+2. ``@public_api`` signatures: a public callable may not accept raw services
+   (typed or named like one). Deprecated migration bridges are allowlisted
+   HERE, next to the import rules, with a removal deadline — auditable in one
+   place, like the lazy-audit ledger. Quietly adding entries to silence this
+   check is itself a signal the change is evading the gateway; PRs that do so
+   will be reverted at review.
 """
 
 from __future__ import annotations
@@ -13,24 +29,76 @@ import ast
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-TARGETS = [
+
+API_TARGETS = [
     ROOT / "src/archetype/api/deps.py",
     *sorted((ROOT / "src/archetype/api/routes").glob("*.py")),
 ]
+EXPERIMENTS_TARGETS = sorted((ROOT / "src/archetype/experiments").glob("*.py"))
+PUBLIC_API_SCAN_TARGETS = sorted((ROOT / "src/archetype").rglob("*.py"))
 
-ALLOWED_APP_IMPORTS = {
+ALLOWED_APP_IMPORTS_API = {
     "archetype.app.auth.models",
     "archetype.app.command_service",
     "archetype.app.container",
     "archetype.app.models",
 }
 
-FORBIDDEN_APP_IMPORTS = {
+FORBIDDEN_APP_IMPORTS_API = {
     "archetype.app.broker",
     "archetype.app.mutation_service",
     "archetype.app.query_service",
     "archetype.app.simulation_service",
     "archetype.app.world_service",
+}
+
+# Public surface: models only. Anything else must arrive through the runtime.
+ALLOWED_APP_IMPORTS_EXPERIMENTS = {
+    "archetype.app.models",
+}
+
+# Raw-service shapes a @public_api callable may not accept.
+SERVICE_TYPE_NAMES = {
+    "WorldService",
+    "SimulationService",
+    "EvalService",
+    "QueryService",
+    "MutationService",
+    "CommandService",
+    "StorageService",
+    "FactService",
+    "IngestionService",
+    "ServiceContainer",
+    "CommandBroker",
+}
+SERVICE_PARAM_NAMES = {
+    "world_service",
+    "simulation_service",
+    "eval_service",
+    "query_service",
+    "mutation_service",
+    "command_service",
+    "storage_service",
+    "fact_service",
+    "container",
+    "broker",
+}
+
+# Deprecated service-shaped bridge parameters, keyed "relpath::qualname".
+# Every entry carries its removal deadline; delete the entry with the bridge.
+PUBLIC_API_BRIDGE_PARAMS: dict[str, set[str]] = {
+    # remove in v0.6 — pre-runtime callers migrate to runtime=
+    "src/archetype/experiments/eval_rollouts.py::run_task_eval": {
+        "world_service",
+        "simulation_service",
+        "eval_service",
+    },
+    # remove in v0.6 — pre-runtime callers migrate to runtime=
+    "src/archetype/experiments/instruction_sweep.py::run_instruction_sweep": {
+        "world_service",
+        "simulation_service",
+        "eval_service",
+    },
 }
 
 
@@ -44,28 +112,79 @@ def _imported_modules(node: ast.AST) -> list[str]:
     return []
 
 
-def _violations(path: Path) -> list[str]:
+def _import_violations(
+    path: Path, allowed: set[str], forbidden: set[str], scope: str
+) -> list[str]:
     tree = ast.parse(path.read_text(), filename=str(path))
     violations: list[str] = []
     for node in ast.walk(tree):
         for module in _imported_modules(node):
             if not module.startswith("archetype.app"):
                 continue
-            if module in FORBIDDEN_APP_IMPORTS:
-                violations.append(f"{path.relative_to(ROOT)} imports forbidden {module}")
-                continue
-            if module not in ALLOWED_APP_IMPORTS:
+            if module in forbidden:
                 violations.append(
-                    f"{path.relative_to(ROOT)} imports {module}; allowed app imports are "
-                    f"{', '.join(sorted(ALLOWED_APP_IMPORTS))}"
+                    f"{path.relative_to(ROOT)} imports forbidden {module} "
+                    f"({scope}: the runtime is the sole public consumer of app)"
+                )
+                continue
+            if module not in allowed:
+                violations.append(
+                    f"{path.relative_to(ROOT)} imports {module}; allowed app imports "
+                    f"for {scope} are {', '.join(sorted(allowed))}"
+                )
+    return violations
+
+
+def _is_public_api_decorated(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        name = target.attr if isinstance(target, ast.Attribute) else getattr(target, "id", "")
+        if name == "public_api":
+            return True
+    return False
+
+
+def _public_api_violations(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    rel = str(path.relative_to(ROOT))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not _is_public_api_decorated(node):
+            continue
+        bridge = PUBLIC_API_BRIDGE_PARAMS.get(f"{rel}::{node.name}", set())
+        params = [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
+        for param in params:
+            if param.arg in bridge:
+                continue
+            annotation = ast.unparse(param.annotation) if param.annotation else ""
+            typed_as_service = any(name in annotation for name in SERVICE_TYPE_NAMES)
+            named_as_service = param.arg in SERVICE_PARAM_NAMES
+            if typed_as_service or named_as_service:
+                violations.append(
+                    f"{rel}::{node.name} — @public_api callable accepts raw service "
+                    f"parameter `{param.arg}`; public capability must be expressible "
+                    f"through ArchetypeRuntime (gated, audited). Deprecated bridges "
+                    f"belong in PUBLIC_API_BRIDGE_PARAMS with a removal deadline."
                 )
     return violations
 
 
 def main() -> int:
-    violations = [violation for path in TARGETS for violation in _violations(path)]
+    violations = [
+        v
+        for path in API_TARGETS
+        for v in _import_violations(path, ALLOWED_APP_IMPORTS_API, FORBIDDEN_APP_IMPORTS_API, "api")
+    ]
+    violations += [
+        v
+        for path in EXPERIMENTS_TARGETS
+        for v in _import_violations(path, ALLOWED_APP_IMPORTS_EXPERIMENTS, set(), "experiments")
+    ]
+    violations += [v for path in PUBLIC_API_SCAN_TARGETS for v in _public_api_violations(path)]
     if violations:
-        print("API import boundary violations:")
+        print("Public-surface boundary violations:")
         for violation in violations:
             print(f"  - {violation}")
         return 1

--- a/scripts/generate_python_api_docs.py
+++ b/scripts/generate_python_api_docs.py
@@ -35,7 +35,7 @@ PAGES: tuple[ReferencePage, ...] = (
         "Recommended API",
         "Start here for scripts, notebooks, and applications. A runtime owns process-level "
         "services and creates world handles.",
-        ("ArchetypeRuntime", "configure_session"),
+        ("ArchetypeRuntime", "configure_session", "entrypoint", "public_api"),
     ),
     ReferencePage(
         "world-handle",

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -83,6 +83,9 @@ __all__ = [
     "SyncRuntimeWorld",
     "run_sync",
     "configure_session",
+    "entrypoint",
+    # Public-API marker (machine-enforced: no raw-service params)
+    "public_api",
     # Runtime configuration and result types
     "WorldInfo",
     "RunResult",
@@ -154,6 +157,8 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "WorldConfig": ("archetype.core", "WorldConfig"),
     # Runtime
     "ArchetypeRuntime": ("archetype.runtime", "ArchetypeRuntime"),
+    "entrypoint": ("archetype.runtime.entrypoint", "entrypoint"),
+    "public_api": ("archetype._api", "public_api"),
     "RuntimeWorld": ("archetype.runtime", "RuntimeWorld"),
     "SyncArchetypeRuntime": ("archetype.runtime", "SyncArchetypeRuntime"),
     "SyncRuntimeWorld": ("archetype.runtime", "SyncRuntimeWorld"),

--- a/src/archetype/_api.py
+++ b/src/archetype/_api.py
@@ -26,15 +26,9 @@ from __future__ import annotations
 
 from typing import Any
 
-#: Names of callables that declared themselves public, for docs/audit tooling.
-PUBLIC_API_REGISTRY: list[str] = []
-
 
 def public_api[F](obj: F) -> F:
     """Mark a callable or class as archetype public API (see module docstring)."""
-    qualname = getattr(obj, "__qualname__", getattr(obj, "__name__", repr(obj)))
-    module = getattr(obj, "__module__", "?")
-    PUBLIC_API_REGISTRY.append(f"{module}.{qualname}")
     try:
         # setattr keeps the marker invisible to static generics (ty flags a
         # direct attribute write on the TypeVar-bound object).

--- a/src/archetype/_api.py
+++ b/src/archetype/_api.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The public-API marker.
+
+``@public_api`` declares a callable part of archetype's supported surface.
+The marker carries a machine-enforced contract (checked by
+``scripts/check_api_import_boundaries.py``):
+
+    A public callable may not accept raw services. Public capability must be
+    expressible through ``ArchetypeRuntime`` and its gated handles.
+
+Rationale: a public function with ``world_service=`` / ``simulation_service=``
+parameters forces every caller to hand-roll a ``ServiceContainer`` and drive
+services directly — bypassing the command gateway, so worlds mutate with no
+command-audit provenance. That bypass entered ``src/`` twice through exactly
+this signature shape (validate_r2_substrate 2026-07-15; eval_rollouts
+2026-07-17). Convention did not hold; enforcement does.
+
+Deprecated service-shaped parameters that exist only as migration bridges are
+allowlisted (with a removal deadline) in the checker itself, next to
+``ALLOWED_APP_IMPORTS`` — auditable in one place, like the lazy-audit ledger.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Names of callables that declared themselves public, for docs/audit tooling.
+PUBLIC_API_REGISTRY: list[str] = []
+
+
+def public_api[F](obj: F) -> F:
+    """Mark a callable or class as archetype public API (see module docstring)."""
+    qualname = getattr(obj, "__qualname__", getattr(obj, "__name__", repr(obj)))
+    module = getattr(obj, "__module__", "?")
+    PUBLIC_API_REGISTRY.append(f"{module}.{qualname}")
+    try:
+        obj.__archetype_public_api__ = True  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):  # pragma: no cover - exotic callables
+        pass
+    return obj
+
+
+def is_public_api(obj: Any) -> bool:
+    """True when ``obj`` was marked with :func:`public_api`."""
+    return bool(getattr(obj, "__archetype_public_api__", False))

--- a/src/archetype/_api.py
+++ b/src/archetype/_api.py
@@ -36,7 +36,9 @@ def public_api[F](obj: F) -> F:
     module = getattr(obj, "__module__", "?")
     PUBLIC_API_REGISTRY.append(f"{module}.{qualname}")
     try:
-        obj.__archetype_public_api__ = True  # type: ignore[attr-defined]
+        # setattr keeps the marker invisible to static generics (ty flags a
+        # direct attribute write on the TypeVar-bound object).
+        setattr(obj, "__archetype_public_api__", True)  # noqa: B010
     except (AttributeError, TypeError):  # pragma: no cover - exotic callables
         pass
     return obj

--- a/src/archetype/experiments/eval_rollouts.py
+++ b/src/archetype/experiments/eval_rollouts.py
@@ -45,11 +45,13 @@ the orchestration never learns which.
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import uuid_utils as uuid
 
+from archetype._api import public_api
 from archetype.app.models import EpisodeConfig
 from archetype.core.config import StorageConfig, WorldConfig
 from archetype.experiments.manipulation import (
@@ -62,6 +64,9 @@ from archetype.experiments.manipulation import (
     ManipStatus,
     ManipTask,
 )
+
+if TYPE_CHECKING:  # runtime imports app at module scope; keep this edge type-only
+    from archetype.runtime import ArchetypeRuntime
 
 
 @dataclass
@@ -104,11 +109,10 @@ def _instruction_for(env_client: Any, fallback: str) -> str:
     return fallback
 
 
+@public_api
 async def run_task_eval(
+    runtime: ArchetypeRuntime | None = None,
     *,
-    world_service: Any,
-    simulation_service: Any,
-    eval_service: Any,
     env_client: Any,
     policy_client: Any | None = None,
     suite: str,
@@ -118,6 +122,9 @@ async def run_task_eval(
     storage: StorageConfig,
     with_frames: bool = False,
     instruction: str = "reach",
+    world_service: Any | None = None,  # deprecated bridge — remove in v0.6
+    simulation_service: Any | None = None,  # deprecated bridge — remove in v0.6
+    eval_service: Any | None = None,  # deprecated bridge — remove in v0.6
 ) -> TaskEvalReport:
     """Run ``trials`` trials of one task in a single batched world and grade them.
 
@@ -125,11 +132,215 @@ async def run_task_eval(
     manipulation archetype. The policy (priority 1) writes each tick's action
     from the previous observation; ``EnvStepProcessor`` (priority 10) consumes
     it. ``run_episode`` batch-steps them all until every trial's
-    ``ManipStatus.done`` latches (or ``max_steps``), then the eval service
-    grades the persisted rows.
+    ``ManipStatus.done`` latches (or ``max_steps``), then success/length are
+    graded from the persisted rows.
+
+    Pass ``runtime`` (an ``ArchetypeRuntime``): every operation — world
+    creation, spawns, the episode, the grading query — routes through the
+    command gateway with audit rows. The raw-service keyword form is a
+    DEPRECATED bridge (it drives services directly, bypassing the gate) and
+    is removed in v0.6.
     """
+    if runtime is not None:
+        return await _run_task_eval_runtime(
+            runtime,
+            env_client=env_client,
+            policy_client=policy_client,
+            suite=suite,
+            task_id=task_id,
+            trials=trials,
+            max_steps=max_steps,
+            storage=storage,
+            with_frames=with_frames,
+            instruction=instruction,
+        )
+    if world_service is None or simulation_service is None or eval_service is None:
+        raise TypeError(
+            "run_task_eval requires `runtime=ArchetypeRuntime(...)` "
+            "(or, deprecated, all of world_service/simulation_service/eval_service)"
+        )
+    warnings.warn(
+        "run_task_eval(world_service=..., simulation_service=..., eval_service=...) "
+        "bypasses the command gateway and is deprecated; pass runtime= instead. "
+        "The service bridge is removed in v0.6.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return await _run_task_eval_services(
+        world_service=world_service,
+        simulation_service=simulation_service,
+        eval_service=eval_service,
+        env_client=env_client,
+        policy_client=policy_client,
+        suite=suite,
+        task_id=task_id,
+        trials=trials,
+        max_steps=max_steps,
+        storage=storage,
+        with_frames=with_frames,
+        instruction=instruction,
+    )
+
+
+def _trial_components(
+    obs: dict[str, Any],
+    *,
+    suite: str,
+    task_id: int,
+    task_instruction: str,
+    seed: int,
+    env_key: int,
+    with_frames: bool,
+) -> list[Any]:
+    """The manipulation archetype for one trial, seeded from its reset obs."""
+    components: list[Any] = [
+        ManipProprio(
+            eef_pos=list(obs.get("eef_pos", [0.0, 0.0, 0.0])),
+            eef_quat=list(obs.get("eef_quat", [1.0, 0.0, 0.0, 0.0])),
+            gripper=float(obs.get("gripper", 0.0)),
+            gripper_qpos=list(obs.get("gripper_qpos", [0.0, 0.0])),
+        ),
+        ManipAction(values=[0.0] * ACTION_DIM),
+        ManipStatus(),
+        ManipTask(
+            suite=suite,
+            task_id=task_id,
+            instruction=task_instruction,
+            seed=seed,
+            env_key=env_key,
+        ),
+    ]
+    if with_frames:
+        components.append(
+            ManipFrameRef(
+                agentview_ref=str(obs.get("agentview_ref", "")),
+                wrist_ref=str(obs.get("wrist_ref", "")),
+            )
+        )
+    return components
+
+
+def _assemble_report(
+    *,
+    suite: str,
+    task_id: int,
+    task_instruction: str,
+    world_id: str,
+    run_id: str,
+    env_key_by_entity: dict[int, int],
+    seed_by_entity: dict[int, int],
+    final: dict[int, dict],
+) -> TaskEvalReport:
+    report = TaskEvalReport(
+        suite=suite,
+        task_id=task_id,
+        instruction=task_instruction,
+        world_id=world_id,
+        run_id=run_id,
+    )
+    for entity_id, env_key in sorted(env_key_by_entity.items(), key=lambda kv: kv[1]):
+        row = final.get(entity_id, {})
+        report.trials.append(
+            TrialOutcome(
+                trial_idx=env_key,
+                env_key=env_key,
+                seed=seed_by_entity[entity_id],
+                success=bool(row.get("manipstatus__success", False)),
+                episode_length=int(row.get("manipstatus__env_step", 0)),
+            )
+        )
+    return report
+
+
+async def _run_task_eval_runtime(
+    runtime: ArchetypeRuntime,
+    *,
+    env_client: Any,
+    policy_client: Any | None,
+    suite: str,
+    task_id: int,
+    trials: int,
+    max_steps: int,
+    storage: StorageConfig,
+    with_frames: bool,
+    instruction: str,
+) -> TaskEvalReport:
+    """The gated path: every mutation and read is a command with an audit row."""
     # Unique per call: the registry enforces name uniqueness, so a retry / a
     # second variance run on the same (suite, task_id) would otherwise crash.
+    world = runtime.world(name=f"eval:{suite}:t{task_id}:{uuid.uuid7()}", storage=storage)
+    if policy_client is not None:
+        from archetype.experiments.policy import PolicyActionProcessor  # noqa: PLC0415
+
+        await world.add_processor(PolicyActionProcessor(policy_client))
+    processor = FramedEnvStepProcessor(env_client) if with_frames else EnvStepProcessor(env_client)
+    await world.add_processor(processor)
+
+    task_instruction = _instruction_for(env_client, instruction)
+
+    # Reset-then-spawn: each trial's reset obs lands as its raw tick-0 row.
+    env_key_by_entity: dict[int, int] = {}
+    seed_by_entity: dict[int, int] = {}
+    for trial_idx in range(trials):
+        env_key = trial_idx
+        seed = task_id * 1000 + trial_idx
+        obs = env_client.reset(env_key, seed)
+        entity_id = await world.spawn(
+            *_trial_components(
+                obs,
+                suite=suite,
+                task_id=task_id,
+                task_instruction=task_instruction,
+                seed=seed,
+                env_key=env_key,
+                with_frames=with_frames,
+            )
+        )
+        env_key_by_entity[entity_id] = env_key
+        seed_by_entity[entity_id] = seed
+
+    episode = await world.run_episode(
+        EpisodeConfig(
+            max_steps=max_steps,
+            terminal_component=ManipStatus,
+            terminal_field="done",
+            terminal_all=True,
+        )
+    )
+
+    # Grade from the persisted ledger through the gated query (scoped to this
+    # world's run — the run the episode just executed).
+    final = _final_row_per_entity(await world.query(ManipStatus, ManipTask))
+    return _assemble_report(
+        suite=suite,
+        task_id=task_id,
+        task_instruction=task_instruction,
+        world_id=str(world.world_id),
+        run_id=str(episode.run_id),
+        env_key_by_entity=env_key_by_entity,
+        seed_by_entity=seed_by_entity,
+        final=final,
+    )
+
+
+async def _run_task_eval_services(
+    *,
+    world_service: Any,
+    simulation_service: Any,
+    eval_service: Any,
+    env_client: Any,
+    policy_client: Any | None,
+    suite: str,
+    task_id: int,
+    trials: int,
+    max_steps: int,
+    storage: StorageConfig,
+    with_frames: bool,
+    instruction: str,
+) -> TaskEvalReport:
+    """DEPRECATED bridge: drives services directly, bypassing the command
+    gateway (no audit rows). Kept one minor version for callers pinned to the
+    pre-runtime signature; removed in v0.6."""
     world = await world_service.create_world(
         WorldConfig(name=f"eval:{suite}:t{task_id}:{uuid.uuid7()}"), storage
     )
@@ -149,31 +360,17 @@ async def run_task_eval(
         env_key = trial_idx
         seed = task_id * 1000 + trial_idx
         obs = env_client.reset(env_key, seed)
-        components: list[Any] = [
-            ManipProprio(
-                eef_pos=list(obs.get("eef_pos", [0.0, 0.0, 0.0])),
-                eef_quat=list(obs.get("eef_quat", [1.0, 0.0, 0.0, 0.0])),
-                gripper=float(obs.get("gripper", 0.0)),
-                gripper_qpos=list(obs.get("gripper_qpos", [0.0, 0.0])),
-            ),
-            ManipAction(values=[0.0] * ACTION_DIM),
-            ManipStatus(),
-            ManipTask(
+        entity_id = await world.create_entity(
+            _trial_components(
+                obs,
                 suite=suite,
                 task_id=task_id,
-                instruction=task_instruction,
+                task_instruction=task_instruction,
                 seed=seed,
                 env_key=env_key,
-            ),
-        ]
-        if with_frames:
-            components.append(
-                ManipFrameRef(
-                    agentview_ref=str(obs.get("agentview_ref", "")),
-                    wrist_ref=str(obs.get("wrist_ref", "")),
-                )
+                with_frames=with_frames,
             )
-        entity_id = await world.create_entity(components)
+        )
         env_key_by_entity[entity_id] = env_key
         seed_by_entity[entity_id] = seed
 
@@ -188,34 +385,22 @@ async def run_task_eval(
         ),
     )
 
-    # Grade from the persisted ledger — the eval service, not the driver.
     df = await eval_service.query_components(
         [ManipStatus, ManipTask],
         world_id=world.world_id,
         run_id=episode.run_id,
         storage_config=storage,
     )
-    final = _final_row_per_entity(df)
-
-    report = TaskEvalReport(
+    return _assemble_report(
         suite=suite,
         task_id=task_id,
-        instruction=task_instruction,
+        task_instruction=task_instruction,
         world_id=str(world.world_id),
         run_id=str(episode.run_id),
+        env_key_by_entity=env_key_by_entity,
+        seed_by_entity=seed_by_entity,
+        final=_final_row_per_entity(df),
     )
-    for entity_id, env_key in sorted(env_key_by_entity.items(), key=lambda kv: kv[1]):
-        row = final.get(entity_id, {})
-        report.trials.append(
-            TrialOutcome(
-                trial_idx=env_key,
-                env_key=env_key,
-                seed=seed_by_entity[entity_id],
-                success=bool(row.get("manipstatus__success", False)),
-                episode_length=int(row.get("manipstatus__env_step", 0)),
-            )
-        )
-    return report
 
 
 def _final_row_per_entity(df: Any) -> dict[int, dict]:

--- a/src/archetype/experiments/instruction_sweep.py
+++ b/src/archetype/experiments/instruction_sweep.py
@@ -31,22 +31,23 @@ rollout in the world model, no env step — without changing the search.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import uuid_utils as uuid
 
 from archetype.app.models import EpisodeConfig
 from archetype.core.config import StorageConfig, WorldConfig
-from archetype.experiments.eval_rollouts import _final_row_per_entity
+from archetype.experiments.eval_rollouts import _final_row_per_entity, _trial_components
+
+if TYPE_CHECKING:  # runtime imports app at module scope; keep this edge type-only
+    from archetype.runtime import ArchetypeRuntime
+from archetype._api import public_api
 from archetype.experiments.manipulation import (
-    ACTION_DIM,
     EnvStepProcessor,
     FramedEnvStepProcessor,
-    ManipAction,
-    ManipFrameRef,
-    ManipProprio,
     ManipStatus,
     ManipTask,
 )
@@ -116,11 +117,55 @@ def _dedup(items: Sequence[str]) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+class _GatedSweepOps:
+    """Every sweep operation as a gated runtime command (the supported path)."""
+
+    def __init__(self, runtime: ArchetypeRuntime) -> None:
+        self._runtime = runtime
+
+    async def make_world(self, name: str, storage: StorageConfig) -> Any:
+        return self._runtime.world(name=name, storage=storage)
+
+    async def spawn(self, world: Any, components: list[Any]) -> None:
+        await world.spawn(*components)
+
+    async def run_episode(self, world: Any, config: EpisodeConfig) -> Any:
+        return await world.run_episode(config)
+
+    async def query_final(self, world: Any, episode: Any, storage: StorageConfig) -> Any:
+        return await world.query(ManipStatus, ManipTask)
+
+
+class _ServiceSweepOps:
+    """DEPRECATED bridge: raw services, no command gateway. Removed in v0.6."""
+
+    def __init__(self, world_service: Any, simulation_service: Any, eval_service: Any) -> None:
+        self._worlds = world_service
+        self._sim = simulation_service
+        self._eval = eval_service
+
+    async def make_world(self, name: str, storage: StorageConfig) -> Any:
+        return await self._worlds.create_world(WorldConfig(name=name), storage)
+
+    async def spawn(self, world: Any, components: list[Any]) -> None:
+        await world.create_entity(components)
+
+    async def run_episode(self, world: Any, config: EpisodeConfig) -> Any:
+        return await self._sim.run_episode(world.world_id, config)
+
+    async def query_final(self, world: Any, episode: Any, storage: StorageConfig) -> Any:
+        return await self._eval.query_components(
+            [ManipStatus, ManipTask],
+            world_id=world.world_id,
+            run_id=episode.run_id,
+            storage_config=storage,
+        )
+
+
+@public_api
 async def run_instruction_sweep(
+    runtime: ArchetypeRuntime | None = None,
     *,
-    world_service: Any,
-    simulation_service: Any,
-    eval_service: Any,
     env_client: Any,
     policy_client: Any,
     suite: str,
@@ -130,6 +175,9 @@ async def run_instruction_sweep(
     max_steps: int,
     storage: StorageConfig,
     with_frames: bool = False,
+    world_service: Any | None = None,  # deprecated bridge — remove in v0.6
+    simulation_service: Any | None = None,  # deprecated bridge — remove in v0.6
+    eval_service: Any | None = None,  # deprecated bridge — remove in v0.6
 ) -> SweepReport:
     """Run every instruction variant of one task in a single batched world.
 
@@ -146,15 +194,29 @@ async def run_instruction_sweep(
     (tick 0 is the reset observation), so each trial receives ``max_steps - 1``
     control steps. Size it as ``desired_control_steps + 1``.
     """
+    if runtime is not None:
+        ops: Any = _GatedSweepOps(runtime)
+    else:
+        if world_service is None or simulation_service is None or eval_service is None:
+            raise TypeError(
+                "run_instruction_sweep requires `runtime=ArchetypeRuntime(...)` "
+                "(or, deprecated, all of world_service/simulation_service/eval_service)"
+            )
+        warnings.warn(
+            "run_instruction_sweep(world_service=..., ...) bypasses the command "
+            "gateway and is deprecated; pass runtime= instead. Removed in v0.6.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        ops = _ServiceSweepOps(world_service, simulation_service, eval_service)
+
     unique_variants = _dedup(variants)
     if not unique_variants:
         raise ValueError("run_instruction_sweep needs at least one instruction variant")
 
     # Unique per sweep: the optimizer runs many sweeps with the same
     # suite/task_id, and the world registry enforces name uniqueness.
-    world = await world_service.create_world(
-        WorldConfig(name=f"isweep:{suite}:t{task_id}:{uuid.uuid7()}"), storage
-    )
+    world = await ops.make_world(f"isweep:{suite}:t{task_id}:{uuid.uuid7()}", storage)
     await world.add_processor(PolicyActionProcessor(policy_client))
     processor = FramedEnvStepProcessor(env_client) if with_frames else EnvStepProcessor(env_client)
     await world.add_processor(processor)
@@ -179,35 +241,22 @@ async def run_instruction_sweep(
         for seed_slot in range(seeds_per_variant):
             seed = task_id * 1000 + seed_slot
             obs = env_client.reset(env_key, seed)
-            components: list[Any] = [
-                ManipProprio(
-                    eef_pos=list(obs.get("eef_pos", [0.0, 0.0, 0.0])),
-                    eef_quat=list(obs.get("eef_quat", [1.0, 0.0, 0.0, 0.0])),
-                    gripper=float(obs.get("gripper", 0.0)),
-                    gripper_qpos=list(obs.get("gripper_qpos", [0.0, 0.0])),
-                ),
-                ManipAction(values=[0.0] * ACTION_DIM),
-                ManipStatus(),
-                ManipTask(
+            await ops.spawn(
+                world,
+                _trial_components(
+                    obs,
                     suite=suite,
                     task_id=task_id,
-                    instruction=variant,
+                    task_instruction=variant,
                     seed=seed,
                     env_key=env_key,
+                    with_frames=with_frames,
                 ),
-            ]
-            if with_frames:
-                components.append(
-                    ManipFrameRef(
-                        agentview_ref=str(obs.get("agentview_ref", "")),
-                        wrist_ref=str(obs.get("wrist_ref", "")),
-                    )
-                )
-            await world.create_entity(components)
+            )
             env_key += 1
 
-    episode = await simulation_service.run_episode(
-        world.world_id,
+    episode = await ops.run_episode(
+        world,
         EpisodeConfig(
             max_steps=max_steps,
             terminal_component=ManipStatus,
@@ -216,12 +265,7 @@ async def run_instruction_sweep(
         ),
     )
 
-    df = await eval_service.query_components(
-        [ManipStatus, ManipTask],
-        world_id=world.world_id,
-        run_id=episode.run_id,
-        storage_config=storage,
-    )
+    df = await ops.query_final(world, episode, storage)
     final = _final_row_per_entity(df)
 
     # Group the latched final rows by instruction, preserving variant order.

--- a/src/archetype/runtime/entrypoint.py
+++ b/src/archetype/runtime/entrypoint.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``@archetype.entrypoint`` — the script boundary as a decorator.
+
+An evolution of ``ArchetypeRuntime``, not a surface beside it: the decorator
+owns the lifecycle ceremony every script (and every Modal GPU entrypoint) was
+hand-rolling — construct the runtime, bridge sync/async, guarantee teardown —
+and injects the runtime as the wrapped function's first argument.
+
+    @archetype.entrypoint()
+    def main(runtime: SyncArchetypeRuntime, n: int = 3) -> None:
+        world = runtime.world("demo")
+        ...
+
+    @archetype.entrypoint()
+    async def amain(runtime: ArchetypeRuntime, n: int = 3) -> None:
+        world = runtime.world("demo")
+        ...
+
+Async functions run under ``asyncio.run`` inside ``async with
+ArchetypeRuntime()``; sync functions receive the ``SyncArchetypeRuntime``
+facade. Tracing/logging configuration follows the runtime's own env-driven
+selection (R16/R17) — nothing extra to wire per script.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from archetype._api import public_api
+from archetype.runtime.runtime import ArchetypeRuntime
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+@public_api
+def entrypoint(*, log: str | None = None) -> Callable[[_F], Callable[..., Any]]:
+    """Wrap a script's main function with a managed ``ArchetypeRuntime``.
+
+    The wrapped function is called with the runtime prepended to its
+    arguments and may be sync or async. The wrapper itself is always sync
+    (script boundary), returning whatever the function returns.
+    """
+
+    def decorate(fn: _F) -> Callable[..., Any]:
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                async def _run() -> Any:
+                    async with ArchetypeRuntime(log=log) as runtime:
+                        return await fn(runtime, *args, **kwargs)
+
+                return asyncio.run(_run())
+
+            return async_wrapper
+
+        @functools.wraps(fn)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            with ArchetypeRuntime.sync(log=log) as runtime:
+                return fn(runtime, *args, **kwargs)
+
+        return sync_wrapper
+
+    return decorate

--- a/tests/app/test_runtime_entrypoint.py
+++ b/tests/app/test_runtime_entrypoint.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""@archetype.entrypoint — the script boundary as a decorator (R18)."""
+
+from __future__ import annotations
+
+from archetype import ArchetypeRuntime, SyncArchetypeRuntime, entrypoint, public_api
+from archetype._api import is_public_api
+
+
+def test_entrypoint_injects_sync_runtime_and_tears_down():
+    seen: dict = {}
+
+    @entrypoint()
+    def main(runtime: SyncArchetypeRuntime, x: int) -> int:
+        seen["runtime_type"] = type(runtime).__name__
+        return x * 2
+
+    assert main(21) == 42
+    assert seen["runtime_type"] == "SyncArchetypeRuntime"
+
+
+def test_entrypoint_injects_async_runtime():
+    seen: dict = {}
+
+    @entrypoint()
+    async def amain(runtime: ArchetypeRuntime, x: int) -> int:
+        seen["runtime_type"] = type(runtime).__name__
+        seen["open"] = not runtime._closed
+        return x + 1
+
+    assert amain(41) == 42
+    assert seen == {"runtime_type": "ArchetypeRuntime", "open": True}
+
+
+def test_public_api_marker_registers():
+    @public_api
+    def sample() -> None: ...
+
+    assert is_public_api(sample)
+    assert not is_public_api(test_public_api_marker_registers)

--- a/tests/experiments/test_eval_rollouts.py
+++ b/tests/experiments/test_eval_rollouts.py
@@ -120,3 +120,86 @@ async def test_batched_control_plane_eval_is_addressable_and_graded(tmp_path):
         assert len({r["entity_id"] for r in rows}) == 4, "all 4 trials must persist, none orphaned"
     finally:
         await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_runtime_path_matches_replay_and_leaves_command_audit_rows(tmp_path):
+    """The gated path: identical numbers to the service bridge, PLUS command
+    provenance — spawn/run_episode audit rows exist (the gateway-bypass
+    regression this module shipped with, fixed)."""
+    from archetype import ArchetypeRuntime
+
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="evalrt")
+    async with ArchetypeRuntime() as runtime:
+        env = ScriptedReachEnv(targets=TARGETS, tolerance=TOL)
+        policy = ScriptedReachPolicy(targets=TARGETS, gain=GAIN, max_step=MAX_STEP)
+
+        report = await run_task_eval(
+            runtime,
+            env_client=env,
+            policy_client=policy,
+            suite="scripted",
+            task_id=0,
+            trials=4,
+            max_steps=MAX_STEPS,
+            storage=storage,
+        )
+
+        expected = {ek: _simulate(TARGETS[ek], ek) for ek in TARGETS}
+        got = {t.env_key: (t.success, t.episode_length) for t in report.trials}
+        for ek in TARGETS:
+            exp_success, exp_len = expected[ek]
+            assert got[ek][0] == exp_success
+            if exp_success:
+                assert got[ek][1] == exp_len
+        assert report.success_rate == 3 / 4
+
+        # THE contract: every mutation and the episode itself are commands.
+        audit = runtime.attach(report.world_id, storage=storage)
+        rows = (await audit.history(limit=200)).collect().to_pylist()
+        commands = " ".join(str(r) for r in rows)
+        assert "run_episode" in commands, "run_episode must leave a command-audit row"
+        assert "spawn" in commands, "trial spawns must leave command-audit rows"
+
+
+@pytest.mark.asyncio
+async def test_service_bridge_is_deprecated(tmp_path):
+    container = ServiceContainer()
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="evaldep")
+    try:
+        env = ScriptedReachEnv(targets={0: TARGETS[0]}, tolerance=TOL)
+        policy = ScriptedReachPolicy(targets={0: TARGETS[0]}, gain=GAIN, max_step=MAX_STEP)
+        with pytest.warns(DeprecationWarning, match="bypasses the command gateway"):
+            await run_task_eval(
+                world_service=container.world_service,
+                simulation_service=container.simulation_service,
+                eval_service=container.eval_service,
+                env_client=env,
+                policy_client=policy,
+                suite="scripted",
+                task_id=0,
+                trials=1,
+                max_steps=MAX_STEPS,
+                storage=storage,
+            )
+    finally:
+        await container.shutdown()
+
+
+def test_runtime_or_services_required():
+    with pytest.raises(TypeError, match="requires `runtime"):
+        import asyncio
+
+        asyncio.get_event_loop_policy()
+        coro = run_task_eval(
+            env_client=object(),
+            suite="s",
+            task_id=0,
+            trials=1,
+            max_steps=1,
+            storage=StorageConfig(uri="/tmp/x", namespace="x"),
+        )
+        try:
+            coro.send(None)
+        finally:
+            coro.close()

--- a/tests/experiments/test_instruction_sweep.py
+++ b/tests/experiments/test_instruction_sweep.py
@@ -312,3 +312,40 @@ async def test_sweep_resets_policy_state_between_runs(tmp_path):
         assert _SpyPolicy.resets == 2, "each sweep must reset the policy's per-env state"
     finally:
         await container.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_sweep_runtime_path_is_gated_and_matches_service_bridge(tmp_path):
+    """The gated runtime path produces the same per-variant grades as the
+    deprecated service bridge, and leaves run_episode command-audit rows."""
+    from archetype import ArchetypeRuntime
+
+    targets = _targets()
+    variants = ["", "reach red block"]
+
+    async with ArchetypeRuntime() as runtime:
+        env = ScriptedReachEnv(targets=targets, tolerance=TOL)
+        policy = InstructionConditionedReachPolicy(
+            targets=targets, required_keywords=REQUIRED, gain=GAIN, max_step=MAX_STEP
+        )
+        report = await run_instruction_sweep(
+            runtime,
+            env_client=env,
+            policy_client=policy,
+            suite="scripted",
+            task_id=TASK_ID,
+            variants=variants,
+            seeds_per_variant=SEEDS,
+            max_steps=MAX_STEPS,
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="isweeprt"),
+        )
+        for vidx, variant in enumerate(variants):
+            expected = _expected_success_rate(variant, vidx * 3, targets)
+            assert report.variants[vidx].success_rate == expected
+
+        audit = runtime.attach(
+            report.world_id,
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="isweeprt"),
+        )
+        rows = (await audit.history(limit=200)).collect().to_pylist()
+        assert any("run_episode" in str(r) for r in rows)

--- a/tests/test_boundary_checker.py
+++ b/tests/test_boundary_checker.py
@@ -85,3 +85,22 @@ def test_experiments_scope_allows_models(tmp_path, monkeypatch):
         )
         == []
     )
+
+
+def test_experiments_scope_scans_nested_subdirectories(tmp_path, monkeypatch):
+    """Nested experiment modules must not escape the import scan (the reviewer
+    caught the original non-recursive glob)."""
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    nested = tmp_path / "src" / "archetype" / "experiments" / "vla" / "bridge.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("from archetype.app.world_service import WorldService\n")
+    targets = sorted((tmp_path / "src/archetype/experiments").rglob("*.py"))
+    assert nested in targets
+    violations = [
+        v
+        for path in targets
+        for v in checker._import_violations(
+            path, checker.ALLOWED_APP_IMPORTS_EXPERIMENTS, set(), "experiments"
+        )
+    ]
+    assert len(violations) == 1

--- a/tests/test_boundary_checker.py
+++ b/tests/test_boundary_checker.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The public-surface boundary rules must FIRE, not just pass on a clean tree."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_api_import_boundaries",
+    Path(__file__).resolve().parents[1] / "scripts" / "check_api_import_boundaries.py",
+)
+checker = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_api_import_boundaries"] = checker
+_SPEC.loader.exec_module(checker)
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    target = tmp_path / "src" / "archetype" / "experiments" / "sample.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(body)
+    return target
+
+
+def test_public_api_rule_fires_on_service_typed_param(tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        "from archetype._api import public_api\n"
+        "@public_api\n"
+        "async def bad(world_service, x: int = 0): ...\n",
+    )
+    violations = checker._public_api_violations(path)
+    assert len(violations) == 1
+    assert "world_service" in violations[0]
+    assert "ArchetypeRuntime" in violations[0]
+
+
+def test_public_api_rule_fires_on_annotation(tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        "from archetype._api import public_api\n"
+        "@public_api\n"
+        "def bad(svc: 'SimulationService'): ...\n",
+    )
+    assert len(checker._public_api_violations(path)) == 1
+
+
+def test_bridge_allowlist_suppresses_with_deadline(tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        "from archetype._api import public_api\n"
+        "@public_api\n"
+        "async def bridged(world_service=None): ...\n",
+    )
+    monkeypatch.setitem(
+        checker.PUBLIC_API_BRIDGE_PARAMS,
+        "src/archetype/experiments/sample.py::bridged",
+        {"world_service"},
+    )
+    assert checker._public_api_violations(path) == []
+
+
+def test_experiments_scope_blocks_service_imports(tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    path = _write(tmp_path, "from archetype.app.simulation_service import SimulationService\n")
+    violations = checker._import_violations(
+        path, checker.ALLOWED_APP_IMPORTS_EXPERIMENTS, set(), "experiments"
+    )
+    assert len(violations) == 1
+    assert "allowed app imports for experiments" in violations[0]
+
+
+def test_experiments_scope_allows_models(tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    path = _write(tmp_path, "from archetype.app.models import EpisodeConfig\n")
+    assert (
+        checker._import_violations(
+            path, checker.ALLOWED_APP_IMPORTS_EXPERIMENTS, set(), "experiments"
+        )
+        == []
+    )

--- a/tests/test_boundary_checker.py
+++ b/tests/test_boundary_checker.py
@@ -104,3 +104,31 @@ def test_experiments_scope_scans_nested_subdirectories(tmp_path, monkeypatch):
         )
     ]
     assert len(violations) == 1
+
+
+def test_annotation_match_is_whole_token_not_substring(tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        "from archetype._api import public_api\n"
+        "@public_api\n"
+        "def fine(cfg: 'SimulationServiceConfig'): ...\n"
+        "@public_api\n"
+        "def bad(svc: 'SimulationService'): ...\n",
+    )
+    violations = checker._public_api_violations(path)
+    assert len(violations) == 1 and "bad" in violations[0]
+
+
+def test_public_api_class_constructor_is_checked(tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        "from archetype._api import public_api\n"
+        "@public_api\n"
+        "class Bad:\n"
+        "    def __init__(self, world_service): ...\n",
+    )
+    violations = checker._public_api_violations(path)
+    assert len(violations) == 1
+    assert "Bad.__init__" in violations[0]


### PR DESCRIPTION
Closes #363, closes #364, closes #365.

## The violation (found in Everett's robot-evals deep-dive)

`run_task_eval`/`run_instruction_sweep` drove raw services directly — worlds created, trials spawned, episodes run, grades read, with **zero command-audit provenance**. The gated surface already existed (`CommandType.RUN_EPISODE`, gated `RuntimeWorld.run_episode/spawn/query`); the functions bypassed it, and the boundary audit's `ALLOWED_APP_IMPORTS` sanctioned the imports (experiments wasn't even scanned).

## What this PR does

- **Runtime-first eval helpers**: pass `runtime=ArchetypeRuntime(...)` — every operation routes through the gate. Regression tests assert `run_episode` + `spawn` **audit rows exist** and grades match the independent replay oracle exactly. Raw-service kwargs remain as deprecated bridges (warning; removed in v0.6) so robot-evals@0.4.0 keeps working until it migrates.
- **`@public_api`** (top-level export) + machine enforcement: public callables may not accept raw services — signature rule + per-consumer import scopes in `check_api_import_boundaries.py` (`experiments` → app *models* only; runtime is the sole public consumer of app). Bridge params allowlisted in the checker with removal deadlines; self-tests prove all rules fire.
- **`@archetype.entrypoint()`**: script boundary as a decorator — runtime construction, sync/async bridging, injection, teardown. Kills the hand-rolled `ServiceContainer` + `asyncio.run` ceremony (~15 lines × 6 in robot-evals alone).
- `runtime.md` **R19** documents the contract.

## Verdict on the placement hypothesis (from #364)

`ArchetypeRuntime` was already the top-level export — location wasn't the lever; the whitelist teaching service-direct access was. Enforcement stops the recurrence: the same signature shape that caused this twice now fails CI.

Gates: full `make ci` green (tests incl. 7 new: gated-path parity + audit rows, bridge deprecation, entrypoint sync/async, checker rules firing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)