### PR TITLE
docs: reconcile hardening register with current contracts

### DIFF
--- a/docs/guide/run-config.md
+++ b/docs/guide/run-config.md
@@ -4,20 +4,29 @@ Archetype uses Pydantic models for all configuration. There are four config type
 
 ## RunConfig
 
-`RunConfig` controls the behavior of `step` and `run`. Each run gets a unique `run_id` (UUID7) for storage isolation.
+`RunConfig` describes one bounded sequence of ticks. Its generated `run_id`
+seeds a world's active run identity on first execution; after that identity is
+pinned, later steps and runs keep the world's existing `run_id` so state stays
+continuous.
 
 ```python
 from archetype.core.config import RunConfig
 
 config = RunConfig(num_steps=10, debug=True)
-await world.run(config)
+await world.run(config=config)
 ```
 
 ### Contract
 
-- A `RunConfig` identifies a run — one `run_id` shared by every tick in the run.
-- `SimulationService.step()` and `world.step()` **require** an explicit `RunConfig`. They MUST NOT mint one per call. Callers driving a multi-tick run reuse the same `RunConfig` across every step so persisted rows stay addressable by `run_id`.
-- `SimulationService.run()` and `world.run()` thread the caller's `RunConfig` into every internal `step()` call.
+- A `RunConfig` carries one candidate `run_id` shared by every tick in that
+  bounded call. It initializes a new world's active run identity but does not
+  replace an identity already pinned to that world.
+- `SimulationService.step()` and the lower-level `AsyncWorld.step()` require an
+  explicit `RunConfig`; callers driving multiple individual steps reuse one
+  config. `RuntimeWorld.step()` creates the ordinary one-step config when the
+  public caller omits it.
+- `SimulationService.run()` and the world implementations thread the caller's
+  `RunConfig` into every internal `step()` call.
 - `EpisodeConfig` wraps `RunConfig` with termination semantics.
 - `RolloutConfig` wraps `EpisodeConfig` with fork-and-aggregate semantics.
 
@@ -25,27 +34,13 @@ await world.run(config)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `run_id` | `UUID` | auto (uuid7) | Unique identifier for this run sequence |
+| `run_id` | `str \| UUID` | auto (uuid7) | Candidate identifier used when the world has no active run |
 | `num_steps` | `int` | `1` | Number of ticks to execute |
-| `debug` | `bool` | `False` | Emit structured debug events (tick start/end, entity counts) |
-| `enable_validation` | `bool` | `False` | Enable schema validation checks during processing |
-| `show_rows` | `int` | `3` | Max rows in debug DataFrame snapshots (0 disables) |
-| `explain` | `bool` | `False` | Render DataFrame logical plans in debug panels |
-| `prefer_live_reads` | `bool` | `False` | Read from in-memory `_live` cache instead of store |
-| `suite` | `str?` | `None` | Optional label for grouping runs (benchmarks, ensembles) |
-| `trial` | `int?` | `None` | Optional trial index for ensemble/grid runs |
-| `metadata` | `dict?` | `None` | Arbitrary metadata for experiment tracking |
+| `debug` | `bool` | `False` | Emit per-tick diagnostic panels |
+| `show_rows` | `int` | `8` | Maximum rows in each debug snapshot; `0` disables snapshots |
+| `metadata` | `dict?` | `None` | Optional metadata recorded with the run |
 
 `RunConfig` is frozen (immutable after construction).
-
-### prefer_live_reads
-
-Controls how `_run_archetype` fetches previous state at the start of each tick:
-
-- **`False` (default):** Reads from the store via the querier. Suitable for single-step runs, validation, and benchmarks where you want to verify that persisted state round-trips correctly.
-- **`True`:** Reads from the in-memory `_live` cache. Avoids redundant store reads between consecutive ticks. Required for multi-step runs where each step's `run_id` differs from the persisted rows.
-
-In practice, `_live` is always used after tick 0 regardless of this flag -- the core tick loop falls back to `_live` when it is populated for a given signature. This flag controls the intent at the `RunConfig` level; the actual behavior is governed by the `_live` cache population logic in `AsyncWorld._run_archetype`.
 
 ### Named Constructors
 
@@ -53,29 +48,25 @@ In practice, `_live` is always used after tick 0 regardless of this flag -- the 
 
 #### RunConfig.dev()
 
-Interactive development. Debug output on, live reads enabled, higher row display limit.
+Interactive development with debug output and a five-row display limit by
+default.
 
 ```python
 config = RunConfig.dev(steps=5)
-# debug=True, prefer_live_reads=True, show_rows=5
+# debug=True, show_rows=5
 ```
 
 #### RunConfig.benchmark()
 
-Performance measurement. Debug off, no row display, optional suite/trial labels for organizing results.
+Performance measurement with debug output and row snapshots disabled. Put
+experiment labels in `metadata` when needed.
 
 ```python
-config = RunConfig.benchmark(steps=100, suite="latency", trial=0)
-# debug=False, show_rows=0, suite="benchmark"
-```
-
-#### RunConfig.validate()
-
-Schema and invariant checking. Validation enabled, debug on, reads from store to verify persistence.
-
-```python
-config = RunConfig.validate(steps=3)
-# enable_validation=True, debug=True, prefer_live_reads=False, suite="validate"
+config = RunConfig.benchmark(
+    steps=100,
+    metadata={"suite": "latency", "trial": 0},
+)
+# debug=False, show_rows=0
 ```
 
 ## WorldConfig

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -306,12 +306,6 @@ One tick MUST follow this order:
 - Store-backed reads are the durability path.
 - `get_components()` is a live-snapshot API, not a historical store query.
 
-CURRENT GAP:
-
-- `RunConfig.prefer_live_reads` exists, but current async world behavior
-  effectively prefers `_live` whenever it is available. The config flag should
-  either be enforced or removed.
-
 ### Run contract
 
 - A `RunConfig` describes a sequence of steps that share one `run_id`.
@@ -360,8 +354,9 @@ CURRENT GAP:
 CURRENT GAP:
 
 - `AsyncWorld._move_entity()` can currently return an empty row when the old
-  entity is not found in `_live`, and callers do not validate this before
-  staging a spawn. That boundary needs an explicit error or no-op contract.
+  entity is not found. `update_entity()` guards that return, but
+  `add_components()` and `remove_components()` still stage it. Those two paths
+  need an explicit error or no-op contract.
 
 ## Lifecycle Hook Contracts
 
@@ -417,17 +412,18 @@ CURRENT GAP:
 - `create_world()` MUST be idempotent by explicit `world_id`.
 - Name lookup is a convenience index; names are unique, but they are not the
   idempotency key.
+- Duplicate-name validation MUST happen before a new world is inserted into the
+  live registry. A rejected create MUST leave both the ID and name indexes
+  unchanged.
+- If durable catalog registration or writer-fence acquisition fails after
+  construction, `create_world()` MUST remove the new live world before
+  propagating the failure.
 - Broker injection into world resources is an app-layer responsibility.
 - `destroy_world()` SHOULD be safe to call on a missing world.
 - `fork_world()` MUST create a new `world_id`, clone the source world's visible
   state, and let source and fork diverge independently.
 - Forking MUST transfer pending spawn/despawn caches so spawn-then-fork before
   the next tick materializes in both worlds.
-
-CURRENT GAP:
-
-- `create_world()` currently inserts the world into `_worlds` before duplicate
-  name validation, which can leave behind an unintended cached world on error.
 
 ### CommandBroker
 
@@ -480,16 +476,17 @@ CURRENT GAPS:
 
 - `QueryService` is the internal read facade below the gate.
 - External reads go through `iCommandService`.
-- Read behavior SHOULD be consistent with the underlying core world and querier
-  contracts.
-- Query methods SHOULD either validate world existence consistently or
-  intentionally document which routes are world-agnostic.
-
-CURRENT GAP:
-
-- Most read methods are currently stubs that echo metadata rather than querying
-  actual world state.
+- Archetype and component reads MUST resolve storage per call and query durable
+  rows by `world_id` and `run_id`; they do not require the world to be live in
+  the process registry.
+- Coordinated reads MUST restrict results to catalog-published commit tokens.
+- Fork-aware reads MUST compose persisted lineage segments with the fork's own
+  rows without requiring a live source world.
+- `get_lineage()` reads persisted ancestry, and `list_signatures()` reads the
+  selected store's registered archetypes.
 - Audit history is served by `iAuditLog` through `iCommandService`.
+  `QueryService.get_command_history()` remains a compatibility read over queued
+  audit rows, not an in-memory broker-history contract.
 
 ### ServiceContainer and runtime lifetime
 
@@ -511,12 +508,11 @@ CURRENT GAP:
 - A fork shares runtime infrastructure, but not world identity.
 - Shutting down or destroying one world MUST NOT invalidate sibling worlds that
   share the same runtime.
-
-CURRENT GAP:
-
-- `destroy_world()` only removes the world from the world catalog and registry.
-  It does not explicitly clear per-world broker state or provide true
-  world-local shutdown semantics.
+- The gated `CommandService.destroy_world()` path MUST clear the target world's
+  pending and historical broker state before delegating world removal.
+- World removal MUST preserve durable rows, lineage, audit history, shared
+  storage backends, and sibling-world state. The durable catalog records the
+  world as destroyed rather than deleting its identity.
 
 ## Top-Level Runtime Contracts
 
@@ -926,24 +922,20 @@ I/O and commit visibility, not the Cloudflare Data Catalog control plane.
 
 ## Required Hardening Work
 
-The following items should be treated as implementation requirements for a
-coherent engine contract:
+This register retains stable item numbers used by issues and tests. `Open`
+means the contract is not yet implemented; `Resolved` requires both shipped
+behavior and an executable oracle.
 
-1. Make updater durability failures explicit instead of log-only.
-2. Define and implement world-lifecycle command ack semantics so API create,
-   destroy, and fork are not left in ambiguous broker state.
-3. ~~Decide whether command submission to an unknown world is allowed; if not,
-   reject at submit time.~~ Resolved: `CommandService.submit*` raise
-   `archetype.app.errors.WorldNotFoundError` before any side effect.
-4. Fix `WorldService.create_world()` duplicate-name failure ordering so failed
-   creation does not cache a hidden world.
-5. Align hook documentation and implementation for spawn/despawn lifecycle
-   events.
-6. Give `QueryService` a real read contract or clearly mark it as provisional.
-7. Define world-local teardown semantics that do not leak broker or shared
-   runtime state.
-8. Resolve or explicitly codify same-entity same-tick mutation composition so
-   broker command order and final materialized state cannot diverge silently.
+| Item | Status | Contract or remaining work | Oracle or tracking |
+|---|---|---|---|
+| 1 | Resolved | Async and sync updater/store failures raise instead of returning a stamped-but-uncommitted frame. | `tests/core/test_async_store_updater_failures.py`; `tests/sync/test_sync_stack_contracts.py` |
+| 2 | Open | Define truthful ack semantics for world-lifecycle command types submitted through the tick-deferred broker. | Issue #368 |
+| 3 | Resolved | `CommandService.submit*` reject an unknown world with `WorldNotFoundError` before quota, enqueue, or audit side effects. | `tests/integration/test_command_flow.py::test_submit_to_unknown_world_rejected` |
+| 4 | Resolved | Duplicate-name and catalog-registration failures leave no hidden live world. | `tests/core/test_orchestrator_errors_and_instrumentation.py`; `tests/app/test_durable_discovery.py::test_failed_catalog_registration_leaves_no_live_world` |
+| 5 | Resolved | Spawn, despawn, and component migration hooks fire from their public mutation paths with the documented queue-time semantics. | `tests/core/test_resources_hooks_messaging.py`; `tests/core/test_batch_spawn_contract.py`; `tests/sync/test_sync_world.py` |
+| 6 | Resolved | `QueryService` performs durable archetype, component, lineage, signature, and audit-backed history reads. | `tests/app/test_atomic_visibility.py`; `tests/app/test_runtime_fork_storage.py`; `tests/app/test_audit_contracts.py` |
+| 7 | Resolved | Gated destroy clears only the target world's broker state and preserves shared runtime and durable state. | `tests/integration/test_fork_destroy_contracts.py` |
+| 8 | Open | Make same-entity, same-tick mutations compose in broker order or explicitly codify weaker behavior. | Issue #193 |
 
 ## Durability Posture (v0.3, issue #276)
 

--- a/docs/guide/trajectories.md
+++ b/docs/guide/trajectories.md
@@ -143,7 +143,7 @@ async with ArchetypeRuntime() as runtime:
             label = Label(technique=technique, description=description)
             await world.spawn(trajectory, label)
 
-    await world.step(config=RunConfig(num_steps=1, prefer_live_reads=True))
+    await world.step(config=RunConfig(num_steps=1))
 
     df = await world.query(Trajectory, Label)
     rows = df.collect().to_pylist()
@@ -158,7 +158,7 @@ fork = await world.fork(
     "strict-eval",
     storage=StorageConfig(uri="./trajectory_data", namespace="trajectories"),
 )
-await fork.step(config=RunConfig(num_steps=1, prefer_live_reads=True))
+await fork.step(config=RunConfig(num_steps=1))
 ```
 
 Forks share resource instances by default. For a strict-vs-lenient comparison, stage distinct resources on separate worlds or attach replacement resources through the gated resource-management path before running the fork.

--- a/tests/integration/test_fork_destroy_contracts.py
+++ b/tests/integration/test_fork_destroy_contracts.py
@@ -19,6 +19,7 @@ from uuid_utils import uuid7
 from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
 from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
+from archetype.app.models import Command, CommandType
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 from archetype.core.hooks import PostTick
@@ -216,7 +217,43 @@ async def test_destroy_audit_row_preservation(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 5. 10-world destroy stress test
+# 5. Destroy clears only the target world's broker state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gated_destroy_clears_only_target_world_broker_state(tmp_path):
+    """Gated destroy removes the target queue/history without touching a sibling."""
+    c = ServiceContainer()
+    storage = _storage(tmp_path)
+    ctx = _admin_ctx()
+    try:
+        target = await c.command_service.create_world(ctx, WorldConfig(name="target"), storage)
+        sibling = await c.command_service.create_world(ctx, WorldConfig(name="sibling"), storage)
+
+        target_command = Command(type=CommandType.CUSTOM)
+        sibling_command = Command(type=CommandType.CUSTOM)
+        await c.command_service.submit(ctx, target.world_id, target_command)
+        await c.command_service.submit(ctx, sibling.world_id, sibling_command)
+
+        assert await c.broker.get_pending_count(target.world_id) == 1
+        assert await c.broker.get_pending_count(sibling.world_id) == 1
+
+        await c.command_service.destroy_world(ctx, target.world_id)
+
+        assert await c.broker.get_pending_count(target.world_id) == 0
+        assert await c.broker.get_history(target.world_id) == []
+        assert await c.broker.get_pending_count(sibling.world_id) == 1
+        assert [command.id for command in await c.broker.get_history(sibling.world_id)] == [
+            sibling_command.id
+        ]
+        assert c.world_service.get_world(sibling.world_id).world_id == sibling.world_id
+    finally:
+        await c.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# 6. 10-world destroy stress test
 # ---------------------------------------------------------------------------
 
 
@@ -264,7 +301,7 @@ async def test_10_world_destroy_stress(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 6. Audit row monotonicity
+# 7. Audit row monotonicity
 # ---------------------------------------------------------------------------
 
 
@@ -305,7 +342,7 @@ async def test_audit_row_monotonicity(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 7. Fork inherits source's storage by default
+# 8. Fork inherits source's storage by default
 # ---------------------------------------------------------------------------
 
 
@@ -411,7 +448,7 @@ async def test_fork_explicit_storage_override(tmp_path):
 
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
-# 8. Fork lineage: pre-fork ticks readable through ancestry
+# 9. Fork lineage: pre-fork ticks readable through ancestry
 # ---------------------------------------------------------------------------
 
 
@@ -571,7 +608,7 @@ async def test_unstepped_fork_has_no_lineage_segment(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 9. Persisted lineage: ancestry survives dead worlds
+# 10. Persisted lineage: ancestry survives dead worlds
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- replace stale CURRENT GAP markers with the shipped contracts for live reads, create rollback, durable query reads, and world-local teardown
- turn the numbered hardening list into a status register that preserves stable references and names an executable oracle for every resolved item
- align the RunConfig guide and trajectory examples with the live five-field model and its two supported named constructors
- add a focused contract proving gated destroy clears only the target world's broker queue/history while preserving a sibling

## Why

The specification is used as both contributor guidance and a planning input. Fixed behavior was still labeled incomplete, while the RunConfig guide taught fields and a constructor that no longer exist. That makes the harness's signals less trustworthy and sends contributors toward obsolete APIs.

The stale `apply_world_lifecycle()` reference named in #371 was already removed by #372; this pass verifies no references remain.

## Impact

No runtime behavior changes. The public documentation now matches current code, and the existing teardown behavior gains an executable regression contract.

## Validation

- `uv run pytest -q ...` — 33 focused contract tests passed
- `uv run pytest -q tests/spec_contracts/test_spec_contract_evals.py` — 2 passed
- `make check`
- `uv run --extra docs mkdocs build`
- `npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"`
- `git diff --check`
- direct RunConfig model/constructor smoke assertion

Closes #371