### PR TITLE
fix(htn): enforce depth cap before primitive effects

### DIFF
--- a/src/archetype/htn/processors.py
+++ b/src/archetype/htn/processors.py
@@ -146,6 +146,8 @@ class EffectProcessor(AsyncProcessor):
                 col("branch__status"),
                 col("branch__fail_reason"),
                 col("branch__pre_state_sig"),
+                col("branch__depth"),
+                col("branch__max_depth"),
                 col("branch__ready_kind"),
                 col("branch__ready_node_id"),
                 col("branch__ready_op_name"),

--- a/src/archetype/htn/udfs.py
+++ b/src/archetype/htn/udfs.py
@@ -216,6 +216,8 @@ def apply_effect(
     status: str,
     fail_reason: str,
     pre_state_sig: str,
+    depth: int,
+    max_depth: int,
     ready_kind: str,
     ready_node_id: int,
     ready_op_name: str,
@@ -227,7 +229,8 @@ def apply_effect(
 ) -> dict:
     """Guarded, self-recording STRIPS application for the ready node (Inv HTN-V2.3/2.4).
 
-    Acts ONLY when the branch is live and its ready node is a PRIMITIVE. Re-checks
+    Enforces the mandatory depth cap before any mutation, then acts ONLY when
+    the branch is live and its ready node is a PRIMITIVE. Re-checks
     applicability against the CURRENT (pre-mutation) atoms in-row — never trusting a
     possibly-stale ``applicable`` column. On success: records the witness ``pre_state_sig``
     from the pre-mutation atoms, appends the plan step (``seq = len(plan)`` — derived, so it
@@ -245,6 +248,8 @@ def apply_effect(
         "fail_reason": fail_reason,
         "applicable": False,
     }
+    if status == "live" and depth > max_depth:
+        return {**unchanged, "status": "failed", "fail_reason": "depth_exceeded"}
     if ready_kind != "primitive" or status != "live":
         return unchanged
 

--- a/tests/htn/test_htn_contract.py
+++ b/tests/htn/test_htn_contract.py
@@ -18,6 +18,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 # The runtime auto-configures Logfire; keep it offline and non-interactive in tests.
 os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
 os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
@@ -25,6 +27,8 @@ os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
 from archetype import ArchetypeRuntime  # noqa: E402
 from archetype.core.config import StorageConfig  # noqa: E402
 from archetype.htn import (  # noqa: E402
+    Branch,
+    EffectProcessor,
     HtnDomain,
     MethodSpec,
     OperatorSpec,
@@ -147,6 +151,35 @@ class TestUDFs:
             .to_pydict()["sig"]
         )
         assert sigs[0] != sigs[1]
+
+
+class TestProcessors:
+    @pytest.mark.asyncio
+    async def test_effect_processor_checks_depth_before_applying_primitive(self):
+        """Inv HTN-V2.11: a branch over the cap cannot mutate state first."""
+        import daft
+
+        branch = Branch(
+            atoms_json=json.dumps(["before"]),
+            network_json=json.dumps([{"node_id": 7, "name": "mutate", "status": "open"}]),
+            depth=1,
+            max_depth=0,
+            ready_node_id=7,
+            ready_kind="primitive",
+            ready_op_name="mutate",
+            ready_args_json="[]",
+            pre_pos_json=json.dumps(["before"]),
+            add_json=json.dumps(["after"]),
+            del_json=json.dumps(["before"]),
+        )
+
+        out = await EffectProcessor().process(daft.from_pylist([branch.to_row_dict()]))
+        row = out.collect().to_pylist()[0]
+
+        assert row["branch__status"] == "failed"
+        assert row["branch__fail_reason"] == "depth_exceeded"
+        assert json.loads(row["branch__atoms_json"]) == ["before"]
+        assert json.loads(row["branch__plan_json"]) == []
 
 
 # ── domain build / decomposition ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #344.

## What changed

- pass `depth` and `max_depth` into the existing consolidated HTN effect UDF
- fail an over-depth live branch before mutating atoms, its plan, or its task network
- add a focused processor contract proving that the failed branch remains unchanged

## Root cause and MRE

`TerminationProcessor` enforced the mandatory depth cap after `EffectProcessor`
had already applied a ready primitive. On exact current `main`
(`d1dcbbdc48d79f35cc0716432550595601550602`), the canonical #344 MRE shows
the invalid branch failing only after it appends `act` to the plan and adds the
`effect` atom.

The same MRE passes on candidate head
`97886e216b1e57fb455d98c0ea332e40cddcb5c0`: the branch fails with
`depth_exceeded` and its atoms, plan, and task network remain unchanged.

The guard stays inside the existing atomic effect boundary. It adds no
processor, eager materialization, or core/service wiring.

## Validation

- exact issue MRE on current `main`: failed as expected
- exact issue MRE plus all HTN contracts on candidate: 11 passed
- `make ci`: 1,047 passed, 5 skipped
- regression evals: 12/12 passed
- infrastructure idempotency audit: 23/23 passed
- `git diff --check`
