### PR TITLE
fix(security): containment checks for storage/catalog paths (CodeQL path-injection)

### DIFF
--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -116,11 +116,7 @@ reason = "Processor candidate boundary: materializes the distinct, existing-key-
 
 [[entries]]
 path = "src/archetype/app/world_service.py"
-<<<<<<< HEAD
-line = 713
-=======
-line = 721
->>>>>>> origin/main
+line = 724
 method = "to_pylist"
 reason = "Resume-time entity-directory extract (issue #273 A1-resume): the latest visible row per entity — already reduced in Daft to one (entity_id, tick, is_active) row per entity via groupby-max + join — must enter Python control flow to become the entity2sig registry and next_entity_id counter that route all subsequent mutations; imperative world reconstruction at the cold-resume boundary, bounded by live entity count, not a downstream dataframe computation."
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -116,7 +116,7 @@ reason = "Processor candidate boundary: materializes the distinct, existing-key-
 
 [[entries]]
 path = "src/archetype/app/world_service.py"
-line = 712
+line = 713
 method = "to_pylist"
 reason = "Resume-time entity-directory extract (issue #273 A1-resume): the latest visible row per entity — already reduced in Daft to one (entity_id, tick, is_active) row per entity via groupby-max + join — must enter Python control flow to become the entity2sig registry and next_entity_id counter that route all subsequent mutations; imperative world reconstruction at the cold-resume boundary, bounded by live entity count, not a downstream dataframe computation."
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -116,7 +116,7 @@ reason = "Processor candidate boundary: materializes the distinct, existing-key-
 
 [[entries]]
 path = "src/archetype/app/world_service.py"
-line = 710
+line = 712
 method = "to_pylist"
 reason = "Resume-time entity-directory extract (issue #273 A1-resume): the latest visible row per entity — already reduced in Daft to one (entity_id, tick, is_active) row per entity via groupby-max + join — must enter Python control flow to become the entity2sig registry and next_entity_id counter that route all subsequent mutations; imperative world reconstruction at the cold-resume boundary, bounded by live entity count, not a downstream dataframe computation."
 

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -57,6 +57,7 @@ import pyarrow as pa
 
 from archetype.core.config import StorageConfig
 from archetype.core.interfaces import StaleWriterError
+from archetype.core.paths import require_safe_namespace, resolve_local_root
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +158,7 @@ def _normalized_uri(config: StorageConfig) -> str:
     parsed = urlparse(uri)
     if parsed.scheme in ("", "file"):
         path = parsed.path if parsed.scheme == "file" else uri
-        return str(Path(path).expanduser().resolve())
+        return str(resolve_local_root(path))
     return uri.rstrip("/")
 
 
@@ -173,10 +174,15 @@ def catalog_path_for(config: StorageConfig) -> Path:
     """
     uri = str(config.uri)
     parsed = urlparse(uri)
+    namespace = require_safe_namespace(config.namespace)
     if parsed.scheme in ("", "file"):
-        base = Path(parsed.path if parsed.scheme == "file" else uri).expanduser()
-        return base / config.namespace / f".archetype-catalog-{config.backend.value}.db"
+        base = resolve_local_root(parsed.path if parsed.scheme == "file" else uri)
+        candidate = base / namespace / f".archetype-catalog-{config.backend.value}.db"
+        if not candidate.resolve().is_relative_to(base):
+            raise ValueError(f"catalog path {candidate} escapes storage root {base} (fail closed)")
+        return candidate
     root = Path(os.environ.get("ARCHETYPE_CATALOG_DIR", "~/.archetype/catalogs")).expanduser()
+    # The remote-form filename is fingerprint-derived hex, never request data.
     return root / f"{storage_fingerprint(config)[:24]}.db"
 
 

--- a/src/archetype/app/storage_service.py
+++ b/src/archetype/app/storage_service.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import pathlib
 from urllib.parse import urlparse
 
 from daft.session import Session
@@ -34,6 +33,7 @@ from archetype.app.iceberg import IcebergCatalogContext
 from archetype.core.aio import AsyncCachedStore, AsyncLancedbStore, AsyncStore
 from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
 from archetype.core.interfaces import iAsyncStore
+from archetype.core.paths import require_safe_namespace, resolve_local_root
 
 logger = logging.getLogger(__name__)
 
@@ -51,14 +51,17 @@ def _validate_session_namespace(session: Session, config: StorageConfig) -> None
 
 
 def _resolve_uri(uri: str) -> str:
-    """Resolve local storage paths to absolute. Remote URIs pass through."""
-    scheme = urlparse(uri).scheme.lower()
+    """Resolve local storage paths to absolute. Remote URIs pass through.
+
+    Local paths route through ``resolve_local_root`` (issue #327): NUL bytes
+    are rejected and, when ``ARCHETYPE_DATA_ROOT`` is set, escapes fail closed.
+    """
+    parsed = urlparse(uri)
+    scheme = parsed.scheme.lower()
     if scheme not in ("", "file"):
         return uri
 
-    base_path = pathlib.Path(uri)
-    if not base_path.is_absolute():
-        base_path = pathlib.Path.cwd() / base_path
+    base_path = resolve_local_root(parsed.path if scheme == "file" else uri)
     base_path.mkdir(parents=True, exist_ok=True)
     return str(base_path)
 
@@ -78,7 +81,7 @@ def create_async_store(
     store: iAsyncStore
     if config.backend == StorageBackend.LANCEDB:
         uri = _resolve_uri(str(config.uri))
-        store = AsyncLancedbStore(uri, config.namespace)
+        store = AsyncLancedbStore(uri, require_safe_namespace(config.namespace))
     else:
         from archetype.runtime.session import configure_session
 

--- a/src/archetype/app/storage_service.py
+++ b/src/archetype/app/storage_service.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from pathlib import Path
 from urllib.parse import urlparse
 
 from daft.session import Session
@@ -79,9 +80,18 @@ def create_async_store(
     catalog, namespace, and credentials and passes through unchanged.
     """
     store: iAsyncStore
+    # Unconditional: the injected-session Iceberg branch must reject an unsafe
+    # namespace here too, before any world can bind to the store — the catalog
+    # path derived from the same config validates it either way (issue #327).
+    namespace = require_safe_namespace(config.namespace)
     if config.backend == StorageBackend.LANCEDB:
         uri = _resolve_uri(str(config.uri))
-        store = AsyncLancedbStore(uri, require_safe_namespace(config.namespace))
+        if urlparse(str(config.uri)).scheme.lower() in ("", "file"):
+            # A pre-planted symlink at <uri>/<namespace> could redirect writes
+            # outside ARCHETYPE_DATA_ROOT even with a safe segment name;
+            # resolve the namespace directory under the same containment rule.
+            resolve_local_root(str(Path(uri) / namespace))
+        store = AsyncLancedbStore(uri, namespace)
     else:
         from archetype.runtime.session import configure_session
 

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -346,9 +346,11 @@ class WorldService:
         # Durable identity is authoritative (issue #272): registration failure
         # fails the create, loudly — a world the catalog cannot describe would
         # be undiscoverable after this process exits. Unwind the registry so
-        # the failed create leaves no live, mutable world behind.
-        catalog = self._storage_service.get_control_catalog(storage_config)
+        # the failed create leaves no live, mutable world behind. Catalog
+        # acquisition sits inside the unwind: path/namespace resolution can
+        # raise too (issue #327), and that failure must not orphan the world.
         try:
+            catalog = self._storage_service.get_control_catalog(storage_config)
             await catalog.register_world(
                 WorldRecord(
                     world_id=str(world.world_id),

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -430,9 +430,10 @@ class WorldService:
         store = await self._storage_service.get_or_create_store(storage_config, cache_config)
         fork = self._orchestrator.fork_world(store, source_world_id, name=name)
         # Same authoritative-identity contract as create_world: a fork the
-        # catalog cannot describe must not survive as a live world.
-        catalog = self._storage_service.get_control_catalog(storage_config)
+        # catalog cannot describe must not survive as a live world. Catalog
+        # acquisition sits inside the unwind for the same reason (issue #327).
         try:
+            catalog = self._storage_service.get_control_catalog(storage_config)
             await catalog.register_world(
                 WorldRecord(
                     world_id=str(fork.world_id),

--- a/src/archetype/core/paths.py
+++ b/src/archetype/core/paths.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Path safety for user-influenced storage locations (issue #327).
+
+Storage URIs and catalog namespaces arrive from the API and CLI, then flow
+into filesystem paths (lance directories, SQLite catalog files, Iceberg
+warehouses). Every local path normalizes through :func:`resolve_local_root`
+so one containment rule applies everywhere, and a namespace must pass
+:func:`require_safe_namespace` before it may join a path.
+
+``ARCHETYPE_DATA_ROOT`` is the deployment containment control: when set,
+every local storage path must resolve inside it, and escapes fail closed.
+Unset — the local-development default — paths resolve unconstrained,
+matching the development-grade API-auth posture documented in the
+specification's durability table.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+_NAMESPACE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+
+def require_safe_namespace(namespace: str) -> str:
+    """Return *namespace* when it is a single separator-free path segment.
+
+    Raises:
+        ValueError: If the namespace contains path separators, starts with a
+            dot, or is otherwise able to traverse a directory when joined
+            into a filesystem path.
+    """
+    if not _NAMESPACE_RE.fullmatch(namespace):
+        raise ValueError(
+            f"namespace {namespace!r} is not a safe catalog namespace: expected a "
+            "single segment matching [A-Za-z0-9][A-Za-z0-9_.-]* (no path separators)"
+        )
+    return namespace
+
+
+def resolve_local_root(path_like: str) -> Path:
+    """Resolve a local storage path to an absolute, symlink-free path.
+
+    Raises:
+        ValueError: On an embedded NUL byte, or when ``ARCHETYPE_DATA_ROOT``
+            is set and the resolved path escapes it (fail closed).
+    """
+    if "\x00" in path_like:
+        raise ValueError("storage path contains a NUL byte")
+    base = Path(path_like).expanduser()
+    if not base.is_absolute():
+        base = Path.cwd() / base
+    base = base.resolve()
+    root = os.environ.get("ARCHETYPE_DATA_ROOT", "").strip()
+    if root:
+        root_path = Path(root).expanduser().resolve()
+        if not base.is_relative_to(root_path):
+            raise ValueError(
+                f"storage path {base} escapes ARCHETYPE_DATA_ROOT {root_path} (fail closed)"
+            )
+    return base

--- a/src/archetype/runtime/session.py
+++ b/src/archetype/runtime/session.py
@@ -23,22 +23,22 @@ from daft.catalog import Catalog
 from daft.session import Session
 
 from archetype.core.config import StorageConfig
+from archetype.core.paths import require_safe_namespace, resolve_local_root
 
 
 def _resolve_storage_uri(uri: str) -> tuple[str, bool]:
     """Resolve local storage paths while preserving remote object-store URIs.
 
-    Returns (resolved_uri, is_remote).
+    Returns (resolved_uri, is_remote). Local paths route through
+    ``resolve_local_root`` (issue #327): NUL bytes are rejected and, when
+    ``ARCHETYPE_DATA_ROOT`` is set, escapes fail closed.
     """
-    scheme = urlparse(uri).scheme.lower()
-    is_remote = scheme not in ("", "file")
-
-    if is_remote:
+    parsed = urlparse(uri)
+    scheme = parsed.scheme.lower()
+    if scheme not in ("", "file"):
         return uri, True
 
-    base_path = pathlib.Path(uri)
-    if not base_path.is_absolute():
-        base_path = pathlib.Path.cwd() / base_path
+    base_path = resolve_local_root(parsed.path if scheme == "file" else uri)
     base_path.mkdir(parents=True, exist_ok=True)
     return str(base_path), False
 
@@ -71,6 +71,8 @@ def configure_session(
             "inject a preconfigured Daft Session through StorageService for "
             "remote or managed catalogs"
         )
+    # The namespace becomes warehouse directory names under base_path.
+    require_safe_namespace(config.namespace)
 
     session = session if session is not None else Session()
     base_path = pathlib.Path(resolved_uri)

--- a/src/archetype/runtime/session.py
+++ b/src/archetype/runtime/session.py
@@ -71,8 +71,13 @@ def configure_session(
             "inject a preconfigured Daft Session through StorageService for "
             "remote or managed catalogs"
         )
-    # The namespace becomes warehouse directory names under base_path.
+    # The namespace becomes a warehouse directory under base_path
+    # (pyiceberg Hive convention: <warehouse>/<namespace>.db/<table>).
     require_safe_namespace(config.namespace)
+    # Same symlink-escape probe as the LanceDB branch: a pre-planted symlink
+    # at the namespace directory must not redirect writes outside
+    # ARCHETYPE_DATA_ROOT.
+    resolve_local_root(str(pathlib.Path(resolved_uri) / f"{config.namespace}.db"))
 
     session = session if session is not None else Session()
     base_path = pathlib.Path(resolved_uri)

--- a/tests/app/test_path_safety.py
+++ b/tests/app/test_path_safety.py
@@ -196,6 +196,33 @@ class TestCreateWorldUnwind:
         finally:
             await ws.shutdown()
 
+    @pytest.mark.asyncio
+    async def test_catalog_failure_unwinds_fork_registry(self, tmp_path, monkeypatch):
+        """fork_world shares create_world's unwind contract: a raise from
+        catalog acquisition must not leave the fork live in the registry."""
+        from archetype.core.config import WorldConfig
+        from tests.conftest import make_world_service
+
+        ws = make_world_service()
+        try:
+            config = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+            source = await ws.create_world(WorldConfig(name="source"), config)
+
+            def boom(storage_config):
+                raise ValueError("catalog path rejected")
+
+            monkeypatch.setattr(ws._storage_service, "get_control_catalog", boom)
+
+            with pytest.raises(ValueError, match="catalog path rejected"):
+                await ws.fork_world(source.world_id)
+
+            live = {str(w.world_id) for w in ws.list_worlds()}
+            assert live == {str(source.world_id)}, (
+                "failed fork left a live, mutable world in the registry"
+            )
+        finally:
+            await ws.shutdown()
+
 
 class TestApiSurface:
     def test_create_world_with_traversal_namespace_is_client_error(self, tmp_path):

--- a/tests/app/test_path_safety.py
+++ b/tests/app/test_path_safety.py
@@ -116,6 +116,68 @@ class TestStoreConstructionGuards:
         resolved, is_remote = _resolve_storage_uri("s3://bucket/prefix")
         assert is_remote and resolved == "s3://bucket/prefix"
 
+    def test_injected_session_branch_rejects_traversal_namespace(self, tmp_path):
+        """Footgun-review finding: the injected-session Iceberg branch skipped
+        every namespace check, deferring the raise past world registration."""
+        from unittest.mock import Mock
+
+        config = StorageConfig(
+            uri=str(tmp_path / "store"),
+            namespace="../../evil",
+            backend=StorageBackend.ICEBERG,
+        )
+        session = Mock()
+        with pytest.raises(ValueError, match="namespace"):
+            create_async_store(config, session=session)
+        session.current_namespace.assert_not_called()
+
+    def test_lance_namespace_symlink_escape_rejected(self, tmp_path, monkeypatch):
+        """A pre-planted symlink at <uri>/<namespace> must not redirect writes
+        outside ARCHETYPE_DATA_ROOT (Codex P2 on PR #379)."""
+        root = tmp_path / "root"
+        outside = tmp_path / "outside"
+        store_dir = root / "store"
+        store_dir.mkdir(parents=True)
+        outside.mkdir()
+        (store_dir / "ns").symlink_to(outside)
+        monkeypatch.setenv("ARCHETYPE_DATA_ROOT", str(root))
+
+        config = StorageConfig(uri=str(store_dir), namespace="ns", backend=StorageBackend.LANCEDB)
+        with pytest.raises(ValueError, match="escapes ARCHETYPE_DATA_ROOT"):
+            create_async_store(config)
+
+        # Without the symlink the same config constructs fine.
+        (store_dir / "ns").unlink()
+        assert create_async_store(config) is not None
+
+
+class TestCreateWorldUnwind:
+    @pytest.mark.asyncio
+    async def test_catalog_failure_unwinds_registry(self, tmp_path, monkeypatch):
+        """Footgun-review finding on PR #379: a raise from control-catalog
+        acquisition (path/namespace resolution) after the orchestrator inserted
+        the world must unwind the registry — no live orphan world."""
+        from archetype.core.config import WorldConfig
+        from tests.conftest import make_world_service
+
+        ws = make_world_service()
+        try:
+
+            def boom(storage_config):
+                raise ValueError("catalog path rejected")
+
+            monkeypatch.setattr(ws._storage_service, "get_control_catalog", boom)
+            config = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+
+            with pytest.raises(ValueError, match="catalog path rejected"):
+                await ws.create_world(WorldConfig(name="orphan"), config)
+
+            assert ws.list_worlds() == [], (
+                "failed create left a live, mutable world in the registry"
+            )
+        finally:
+            await ws.shutdown()
+
 
 class TestApiSurface:
     def test_create_world_with_traversal_namespace_is_client_error(self, tmp_path):

--- a/tests/app/test_path_safety.py
+++ b/tests/app/test_path_safety.py
@@ -150,6 +150,24 @@ class TestStoreConstructionGuards:
         (store_dir / "ns").unlink()
         assert create_async_store(config) is not None
 
+    def test_iceberg_namespace_symlink_escape_rejected(self, tmp_path, monkeypatch):
+        """The Iceberg warehouse namespace dir (<base>/<ns>.db) gets the same
+        symlink-escape probe as LanceDB (footgun-review on PR #379)."""
+        root = tmp_path / "root"
+        outside = tmp_path / "outside"
+        store_dir = root / "store"
+        store_dir.mkdir(parents=True)
+        outside.mkdir()
+        (store_dir / "ns.db").symlink_to(outside)
+        monkeypatch.setenv("ARCHETYPE_DATA_ROOT", str(root))
+
+        config = StorageConfig(uri=str(store_dir), namespace="ns", backend=StorageBackend.ICEBERG)
+        with pytest.raises(ValueError, match="escapes ARCHETYPE_DATA_ROOT"):
+            configure_session(config)
+
+        (store_dir / "ns.db").unlink()
+        assert configure_session(config) is not None
+
 
 class TestCreateWorldUnwind:
     @pytest.mark.asyncio

--- a/tests/app/test_path_safety.py
+++ b/tests/app/test_path_safety.py
@@ -16,7 +16,7 @@ from archetype.app._catalog import catalog_path_for
 from archetype.app.storage_service import _resolve_uri, create_async_store
 from archetype.core.config import StorageBackend, StorageConfig
 from archetype.core.paths import require_safe_namespace, resolve_local_root
-from archetype.runtime.session import _resolve_storage_uri, configure_session
+from archetype.runtime.session import configure_session
 
 BAD_NAMESPACES = ["../up", "a/b", "a\\b", ".hidden", "..", "", "/abs", "a b", "a\x00b"]
 GOOD_NAMESPACES = ["ecs", "ns_1", "a.b", "A-2", "audit"]
@@ -102,19 +102,23 @@ class TestStoreConstructionGuards:
         with pytest.raises(ValueError, match="escapes ARCHETYPE_DATA_ROOT"):
             _resolve_uri(str(tmp_path.parent / "escape"))
 
-    def test_session_resolve_respects_data_root(self, tmp_path, monkeypatch):
+    def test_configure_session_respects_data_root(self, tmp_path, monkeypatch):
         monkeypatch.setenv("ARCHETYPE_DATA_ROOT", str(tmp_path))
-        resolved, is_remote = _resolve_storage_uri(str(tmp_path / "store"))
-        assert not is_remote
-        assert Path(resolved).is_relative_to(tmp_path.resolve())
-
+        config = StorageConfig(
+            uri=str(tmp_path.parent / "escape"),
+            namespace="ns",
+            backend=StorageBackend.ICEBERG,
+        )
         with pytest.raises(ValueError, match="escapes ARCHETYPE_DATA_ROOT"):
-            _resolve_storage_uri(str(tmp_path.parent / "escape"))
+            configure_session(config)
+
+        inside = StorageConfig(
+            uri=str(tmp_path / "store"), namespace="ns", backend=StorageBackend.ICEBERG
+        )
+        assert configure_session(inside) is not None
 
     def test_remote_uris_pass_through_untouched(self):
         assert _resolve_uri("s3://bucket/prefix") == "s3://bucket/prefix"
-        resolved, is_remote = _resolve_storage_uri("s3://bucket/prefix")
-        assert is_remote and resolved == "s3://bucket/prefix"
 
     def test_injected_session_branch_rejects_traversal_namespace(self, tmp_path):
         """Footgun-review finding: the injected-session Iceberg branch skipped

--- a/tests/app/test_path_safety.py
+++ b/tests/app/test_path_safety.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Path-safety contracts for user-influenced storage locations (issue #327).
+
+Storage URIs and namespaces arrive from the API/CLI and flow into filesystem
+paths. Namespaces must be single separator-free segments; local storage paths
+must stay inside ``ARCHETYPE_DATA_ROOT`` when a deployment sets it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from archetype.app._catalog import catalog_path_for
+from archetype.app.storage_service import _resolve_uri, create_async_store
+from archetype.core.config import StorageBackend, StorageConfig
+from archetype.core.paths import require_safe_namespace, resolve_local_root
+from archetype.runtime.session import _resolve_storage_uri, configure_session
+
+BAD_NAMESPACES = ["../up", "a/b", "a\\b", ".hidden", "..", "", "/abs", "a b", "a\x00b"]
+GOOD_NAMESPACES = ["ecs", "ns_1", "a.b", "A-2", "audit"]
+
+
+class TestRequireSafeNamespace:
+    @pytest.mark.parametrize("namespace", BAD_NAMESPACES)
+    def test_rejects_traversal_and_separators(self, namespace):
+        with pytest.raises(ValueError, match="namespace"):
+            require_safe_namespace(namespace)
+
+    @pytest.mark.parametrize("namespace", GOOD_NAMESPACES)
+    def test_accepts_identifiers(self, namespace):
+        assert require_safe_namespace(namespace) == namespace
+
+
+class TestResolveLocalRoot:
+    def test_rejects_nul_byte(self):
+        with pytest.raises(ValueError, match="NUL"):
+            resolve_local_root("data\x00dir")
+
+    def test_resolves_relative_to_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert resolve_local_root("store") == (tmp_path / "store").resolve()
+
+    def test_data_root_containment(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ARCHETYPE_DATA_ROOT", str(tmp_path))
+        inside = resolve_local_root(str(tmp_path / "worlds" / "a"))
+        assert inside.is_relative_to(tmp_path.resolve())
+
+        outside = tmp_path.parent / "escape"
+        with pytest.raises(ValueError, match="escapes ARCHETYPE_DATA_ROOT"):
+            resolve_local_root(str(outside))
+
+    def test_data_root_blocks_dotdot_escape(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ARCHETYPE_DATA_ROOT", str(tmp_path))
+        with pytest.raises(ValueError, match="escapes ARCHETYPE_DATA_ROOT"):
+            resolve_local_root(str(tmp_path / "worlds" / ".." / ".." / "escape"))
+
+
+class TestCatalogPathContainment:
+    def test_catalog_path_stays_under_store_root(self, tmp_path):
+        config = StorageConfig(
+            uri=str(tmp_path / "store"), namespace="ns", backend=StorageBackend.ICEBERG
+        )
+        path = catalog_path_for(config)
+        assert path.is_relative_to((tmp_path / "store").resolve())
+        assert path.name == ".archetype-catalog-iceberg.db"
+
+    @pytest.mark.parametrize("namespace", ["../evil", "a/b"])
+    def test_catalog_path_rejects_traversal_namespace(self, tmp_path, namespace):
+        config = StorageConfig(
+            uri=str(tmp_path / "store"), namespace=namespace, backend=StorageBackend.ICEBERG
+        )
+        with pytest.raises(ValueError, match="namespace"):
+            catalog_path_for(config)
+
+
+class TestStoreConstructionGuards:
+    def test_create_async_store_rejects_traversal_namespace(self, tmp_path):
+        config = StorageConfig(
+            uri=str(tmp_path / "store"),
+            namespace="../../evil",
+            backend=StorageBackend.LANCEDB,
+        )
+        with pytest.raises(ValueError, match="namespace"):
+            create_async_store(config)
+
+    def test_configure_session_rejects_traversal_namespace(self, tmp_path):
+        config = StorageConfig(
+            uri=str(tmp_path / "store"),
+            namespace="../../evil",
+            backend=StorageBackend.ICEBERG,
+        )
+        with pytest.raises(ValueError, match="namespace"):
+            configure_session(config)
+
+    def test_resolve_uri_respects_data_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ARCHETYPE_DATA_ROOT", str(tmp_path))
+        resolved = _resolve_uri(str(tmp_path / "store"))
+        assert Path(resolved).is_relative_to(tmp_path.resolve())
+
+        with pytest.raises(ValueError, match="escapes ARCHETYPE_DATA_ROOT"):
+            _resolve_uri(str(tmp_path.parent / "escape"))
+
+    def test_session_resolve_respects_data_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ARCHETYPE_DATA_ROOT", str(tmp_path))
+        resolved, is_remote = _resolve_storage_uri(str(tmp_path / "store"))
+        assert not is_remote
+        assert Path(resolved).is_relative_to(tmp_path.resolve())
+
+        with pytest.raises(ValueError, match="escapes ARCHETYPE_DATA_ROOT"):
+            _resolve_storage_uri(str(tmp_path.parent / "escape"))
+
+    def test_remote_uris_pass_through_untouched(self):
+        assert _resolve_uri("s3://bucket/prefix") == "s3://bucket/prefix"
+        resolved, is_remote = _resolve_storage_uri("s3://bucket/prefix")
+        assert is_remote and resolved == "s3://bucket/prefix"
+
+
+class TestApiSurface:
+    def test_create_world_with_traversal_namespace_is_client_error(self, tmp_path):
+        """The HTTP body is the taint source CodeQL traced; prove it 4xxs."""
+        pytest.importorskip("httpx")
+        from fastapi.testclient import TestClient
+
+        from archetype.api.app import create_app
+        from archetype.api.deps import set_container
+        from archetype.app.container import ServiceContainer
+
+        set_container(ServiceContainer())
+        try:
+            with TestClient(create_app()) as client:
+                resp = client.post(
+                    "/worlds",
+                    json={
+                        "name": "evil",
+                        "storage_uri": str(tmp_path / "store"),
+                        "namespace": "../../evil",
+                    },
+                )
+                assert 400 <= resp.status_code < 500, resp.text
+        finally:
+            set_container(None)


### PR DESCRIPTION
## Summary
Fixes the four HIGH `py/path-injection` alerts (#12, #13, #17, #18) — user-influenced values (`storage_uri`, `namespace` from the HTTP body/CLI) flowing into filesystem paths.

- New `archetype.core.paths` (additive core module, importable from both app/ and runtime/):
  - `require_safe_namespace` — namespace must match `[A-Za-z0-9][A-Za-z0-9_.-]*`: a single separator-free path segment that cannot traverse. Every existing namespace in the repo already conforms.
  - `resolve_local_root` — one resolver for local storage paths: expanduser + resolve, NUL bytes rejected, and **`ARCHETYPE_DATA_ROOT`** (new opt-in deployment control) enforces fail-closed containment when set. Unset = unconstrained local-dev default, matching the documented dev-grade auth posture.
- Sites guarded: `_catalog._normalized_uri` (#17), `catalog_path_for` (#18 — namespace validated + explicit `is_relative_to` containment under the store root), `storage_service._resolve_uri` (#13), `runtime/session._resolve_storage_uri` (#12) + namespace validated in `create_async_store` and `configure_session`.
- Latent bug fixed en route: `file://` URIs were treated as relative paths (mkdir'd a literal `file:` directory); both resolvers now use the parsed path component, aligning store identity with `storage_fingerprint`'s normalization.

## Tests
- `tests/app/test_path_safety.py`: 27 tests — namespace fuzz set, NUL/containment/dotdot escapes, catalog containment, store/session construction guards, remote pass-through, and an end-to-end `POST /worlds` with a traversal namespace returning 4xx (the exact taint path CodeQL traced).
- Full suite 919 passed; ty strict clean.

If any alert survives the next scan (the data-root barrier is conditional by design), the remainder is dismiss-with-rationale territory per the audit — will note on #327.

Closes #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)