### PR TITLE
fix(experiments): freeze despawned external calls

### DIFF
--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -122,7 +122,7 @@ reason = "Resume-time entity-directory extract (issue #273 A1-resume): the lates
 
 [[entries]]
 path = "src/archetype/experiments/boundary.py"
-line = 119
+line = 122
 method = "to_pylist"
 reason = "series_to_rows helper: converts each Series parameter to a Python list inside a list comprehension. This function is called exclusively from @daft.method.batch UDF bodies (MuJoCo C-library boundary, env RPC boundary, policy inference boundary) where the Daft executor has already materialised the batch. The AST checker auto-exempts to_pylist calls on named parameters of @daft.method.batch functions but cannot trace through this plain helper indirection; the call is semantically equivalent to an auto-sanctioned UDF-boundary access."
 

--- a/src/archetype/experiments/boundary.py
+++ b/src/archetype/experiments/boundary.py
@@ -25,13 +25,17 @@ step, policy inference) shares a structural pattern:
    expressions, unpacks the struct into individual columns, and excludes the
    scratch column.
 
-This module provides two utilities:
+This module provides three utilities:
 
 ``series_to_rows(col_names, *series_args) -> list[dict]``
     Convert ordered Series arguments to a list of row dicts.  Reduces the
     per-column Series-to-list boilerplate in every UDF body.
     For use inside ``@daft.method.batch`` bodies only (per-batch boundary;
     not a DataFrame collect).
+
+``external_call_indices(rows) -> list[int]``
+    Select rows whose external episode may advance. Inactive and completed
+    rows remain pass-through state and never trigger an RPC or inference call.
 
 ``unpack_struct(df, scratch, output_map) -> DataFrame``
     Unpack a struct column produced by a boundary UDF back into individual
@@ -60,12 +64,11 @@ Once-per-worker init invariants:
   Daft worker.  Expensive state (MuJoCo model, Modal stub, network socket)
   is created there, after any unpickling of config scalars.
 
-Done-row freeze and pass-through:
-- Each UDF's batch body receives the previous ``done`` (or equivalent) column
-  as an input Series and is responsible for freezing done rows by copying the
-  previous values into the output dict.  ``series_to_rows`` includes all
-  declared input columns (including done) in each row dict; the UDF's inner
-  loop performs the pass-through check.
+Inactive/done-row freeze and pass-through:
+- Each stateful UDF receives ``is_active`` and ``done`` (or an equivalent
+  terminal column) and freezes rows that fail either lifecycle predicate.
+  ``series_to_rows`` includes the declared inputs in each row dict;
+  ``external_call_indices`` centralizes which rows may cross the boundary.
 """
 
 from __future__ import annotations
@@ -119,6 +122,11 @@ def series_to_rows(col_names: list[str], *series_args: Series) -> list[dict[str,
     lists = [s.to_pylist() for s in series_args]
     n = len(lists[0]) if lists else 0
     return [{col_names[j]: lists[j][i] for j in range(len(col_names))} for i in range(n)]
+
+
+def external_call_indices(rows: list[dict[str, Any]]) -> list[int]:
+    """Return rows whose active, unfinished external episode may advance."""
+    return [i for i, row in enumerate(rows) if row["is_active"] and not row["done"]]
 
 
 def unpack_struct(

--- a/src/archetype/experiments/manipulation.py
+++ b/src/archetype/experiments/manipulation.py
@@ -28,8 +28,8 @@ The episode contract mirrors Stage 1's physics contract:
 - Each tick, ``EnvStepProcessor`` sends the current action to the env and
   records the returned observation: row at tick t+1 is exactly
   ``env.step(action_t)``.
-- ``done`` rows are frozen: the env is not stepped again and the terminal
-  state persists unchanged, so success is latched on the ledger.
+- ``done`` or inactive rows are frozen: the env is not stepped again and the
+  terminal state persists unchanged, so success is latched on the ledger.
 
 One Archetype tick = one control step. Action *chunks* (Stage 3) execute
 inside the env worker between control steps, exactly like Stage 1's
@@ -182,6 +182,11 @@ _FRAMED_STEP_STRUCT = DataType.struct(
 )
 
 
+def _steppable_indices(rows: list[dict[str, Any]]) -> list[int]:
+    """Select rows whose live external episode may advance."""
+    return [i for i, row in enumerate(rows) if row["is_active"] and not row["done"]]
+
+
 @daft.cls()
 class _EnvStepper:
     """The env RPC boundary as a batch UDF: one client call per batch.
@@ -206,6 +211,7 @@ class _EnvStepper:
         done: Series,
         success: Series,
         env_step: Series,
+        is_active: Series,
     ) -> Series:
         rows = series_to_rows(
             [
@@ -219,6 +225,7 @@ class _EnvStepper:
                 "done",
                 "success",
                 "env_step",
+                "is_active",
             ],
             env_key,
             action,
@@ -230,10 +237,10 @@ class _EnvStepper:
             done,
             success,
             env_step,
+            is_active,
         )
 
-        # Done rows are frozen: never step a finished episode.
-        live = [i for i, row in enumerate(rows) if not row["done"]]
+        live = _steppable_indices(rows)
         stepped: dict[int, dict[str, Any]] = {}
         if live:
             results = self._client.step(
@@ -337,6 +344,7 @@ class EnvStepProcessor(AsyncProcessor):
             col("manipstatus__done"),
             col("manipstatus__success"),
             col("manipstatus__env_step"),
+            col("is_active"),
         )
         return unpack_struct(
             df.with_column("_env_next", nxt),
@@ -380,6 +388,7 @@ class _FramedEnvStepper:
         env_step: Series,
         agentview_ref: Series,
         wrist_ref: Series,
+        is_active: Series,
     ) -> Series:
         rows = series_to_rows(
             [
@@ -395,6 +404,7 @@ class _FramedEnvStepper:
                 "env_step",
                 "agentview_ref",
                 "wrist_ref",
+                "is_active",
             ],
             env_key,
             action,
@@ -408,9 +418,10 @@ class _FramedEnvStepper:
             env_step,
             agentview_ref,
             wrist_ref,
+            is_active,
         )
 
-        live = [i for i, row in enumerate(rows) if not row["done"]]
+        live = _steppable_indices(rows)
         stepped: dict[int, dict[str, Any]] = {}
         if live:
             results = self._client.step(
@@ -512,6 +523,7 @@ class FramedEnvStepProcessor(AsyncProcessor):
             col("manipstatus__env_step"),
             col("manipframeref__agentview_ref"),
             col("manipframeref__wrist_ref"),
+            col("is_active"),
         )
         return unpack_struct(
             df.with_column("_env_next", nxt),

--- a/src/archetype/experiments/manipulation.py
+++ b/src/archetype/experiments/manipulation.py
@@ -46,7 +46,11 @@ from daft import DataType, Series, col
 
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
-from archetype.experiments.boundary import series_to_rows, unpack_struct
+from archetype.experiments.boundary import (
+    external_call_indices,
+    series_to_rows,
+    unpack_struct,
+)
 
 ACTION_DIM = 7  # 6-DoF delta pose + gripper, the LIBERO/OSC convention
 
@@ -182,11 +186,6 @@ _FRAMED_STEP_STRUCT = DataType.struct(
 )
 
 
-def _steppable_indices(rows: list[dict[str, Any]]) -> list[int]:
-    """Select rows whose live external episode may advance."""
-    return [i for i, row in enumerate(rows) if row["is_active"] and not row["done"]]
-
-
 @daft.cls()
 class _EnvStepper:
     """The env RPC boundary as a batch UDF: one client call per batch.
@@ -240,7 +239,7 @@ class _EnvStepper:
             is_active,
         )
 
-        live = _steppable_indices(rows)
+        live = external_call_indices(rows)
         stepped: dict[int, dict[str, Any]] = {}
         if live:
             results = self._client.step(
@@ -421,7 +420,7 @@ class _FramedEnvStepper:
             is_active,
         )
 
-        live = _steppable_indices(rows)
+        live = external_call_indices(rows)
         stepped: dict[int, dict[str, Any]] = {}
         if live:
             results = self._client.step(

--- a/src/archetype/experiments/policy.py
+++ b/src/archetype/experiments/policy.py
@@ -66,7 +66,7 @@ from daft import DataType, Series, col
 
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.resources import Resources
-from archetype.experiments.boundary import series_to_rows
+from archetype.experiments.boundary import external_call_indices, series_to_rows
 
 from .manipulation import (
     ACTION_DIM,
@@ -157,6 +157,7 @@ class _PolicyCaller:
         gripper: Series,
         gripper_qpos: Series,
         done: Series,
+        is_active: Series,
         prev_action: Series,
         agentview_ref: Series,
         wrist_ref: Series,
@@ -170,6 +171,7 @@ class _PolicyCaller:
                 "gripper",
                 "gripper_qpos",
                 "done",
+                "is_active",
                 "prev_action",
                 "agentview_ref",
                 "wrist_ref",
@@ -181,14 +183,15 @@ class _PolicyCaller:
             gripper,
             gripper_qpos,
             done,
+            is_active,
             prev_action,
             agentview_ref,
             wrist_ref,
         )
 
-        # Done rows are frozen: keep the terminal action unchanged.
+        # Done or inactive rows are frozen: keep the prior action unchanged.
         actions = [row["prev_action"] for row in rows]
-        live = [i for i, row in enumerate(rows) if not row["done"]]
+        live = external_call_indices(rows)
         if live:
             chosen = self._client.act(
                 [rows[i]["env_key"] for i in live],
@@ -231,22 +234,33 @@ class _PolicyCallerNoRefs:
         eef_quat: Series,
         gripper: Series,
         done: Series,
+        is_active: Series,
         prev_action: Series,
     ) -> Series:
         rows = series_to_rows(
-            ["env_key", "instruction", "eef_pos", "eef_quat", "gripper", "done", "prev_action"],
+            [
+                "env_key",
+                "instruction",
+                "eef_pos",
+                "eef_quat",
+                "gripper",
+                "done",
+                "is_active",
+                "prev_action",
+            ],
             env_key,
             instruction,
             eef_pos,
             eef_quat,
             gripper,
             done,
+            is_active,
             prev_action,
         )
 
-        # Done rows are frozen: keep the terminal action unchanged.
+        # Done or inactive rows are frozen: keep the prior action unchanged.
         actions = [row["prev_action"] for row in rows]
-        live = [i for i, row in enumerate(rows) if not row["done"]]
+        live = external_call_indices(rows)
         if live:
             chosen = self._client.act(
                 [rows[i]["env_key"] for i in live],
@@ -354,6 +368,7 @@ class PolicyActionProcessor(AsyncProcessor):
                     col("manipproprio__gripper"),
                     col("manipproprio__gripper_qpos"),
                     col("manipstatus__done"),
+                    col("is_active"),
                     col("manipaction__values"),
                     col("manipframeref__agentview_ref"),
                     col("manipframeref__wrist_ref"),
@@ -369,6 +384,7 @@ class PolicyActionProcessor(AsyncProcessor):
                     col("manipproprio__eef_quat"),
                     col("manipproprio__gripper"),
                     col("manipstatus__done"),
+                    col("is_active"),
                     col("manipaction__values"),
                 ),
             )

--- a/tests/experiments/test_frame_ref_carriage.py
+++ b/tests/experiments/test_frame_ref_carriage.py
@@ -237,3 +237,28 @@ async def test_done_rows_freeze_refs(tmp_path):
             )
     finally:
         await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_despawned_framed_episode_never_steps_external_env(tmp_path):
+    client = ScriptedFramedReachEnv(targets={0: (1.0, 0.0, 0.5)}, tolerance=0.05)
+    action = [0.3, 0.0, 0.0] + [0.0] * (ACTION_DIM - 3)
+
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="framed_despawn")
+        system = AsyncSystem()
+        await system.add_processor(FramedEnvStepProcessor(client))
+        world = await ws.create_world(
+            WorldConfig(name="framed-despawn"), storage_config=storage, system=system
+        )
+        entity_id = await _spawn_framed_episode(world, client, env_key=0, seed=0, action=action)
+        await world.run(RunConfig(num_steps=1))
+        before = list(client._state[0])
+
+        await world.remove_entity(entity_id)
+        await world.run(RunConfig(num_steps=1))
+
+        assert client._state[0] == before
+    finally:
+        await ws.shutdown()

--- a/tests/experiments/test_manipulation_harness.py
+++ b/tests/experiments/test_manipulation_harness.py
@@ -141,3 +141,28 @@ async def test_success_latches_and_done_rows_freeze(tmp_path):
         assert client._state[0] == [0.05, 0.0, 0.5]
     finally:
         await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_despawned_episode_never_steps_external_env(tmp_path):
+    client = ScriptedReachEnv(targets={0: (1.0, 0.0, 0.5)}, tolerance=0.05)
+    action = [0.3, 0.0, 0.0] + [0.0] * (ACTION_DIM - 3)
+
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="despawn_freeze")
+        system = AsyncSystem()
+        await system.add_processor(EnvStepProcessor(client))
+        world = await ws.create_world(
+            WorldConfig(name="despawn-freeze"), storage_config=storage, system=system
+        )
+        entity_id = await _spawn_episode(world, client, env_key=0, seed=0, action=action)
+        await world.run(RunConfig(num_steps=1))
+        before = list(client._state[0])
+
+        await world.remove_entity(entity_id)
+        await world.run(RunConfig(num_steps=1))
+
+        assert client._state[0] == before
+    finally:
+        await ws.shutdown()

--- a/tests/experiments/test_policy_loop.py
+++ b/tests/experiments/test_policy_loop.py
@@ -18,11 +18,13 @@ who did what to whom on every tick.
 import pytest
 
 from archetype.core.aio import AsyncSystem
+from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 from archetype.experiments.manipulation import (
     ACTION_DIM,
     EnvStepProcessor,
     ManipAction,
+    ManipFrameRef,
     ManipProprio,
     ManipStatus,
     ManipTask,
@@ -36,6 +38,15 @@ SIG = (ManipAction, ManipProprio, ManipStatus, ManipTask)
 TARGETS = {0: (0.15, 0.0, 0.5), 1: (-0.1, 0.05, 0.5)}
 TICKS = 8
 SPAWN_ACTION = [0.0] * ACTION_DIM
+
+
+class RecordingPolicy:
+    def __init__(self) -> None:
+        self.act_calls = 0
+
+    def act(self, env_keys, instructions, observations):
+        self.act_calls += len(env_keys)
+        return [[0.0] * ACTION_DIM for _ in env_keys]
 
 
 @pytest.mark.asyncio
@@ -125,5 +136,45 @@ async def test_ledger_rows_satisfy_action_provenance(tmp_path):
         assert all(final[eid]["manipstatus__success"] for eid in eids.values()), (
             f"both envs should succeed within {TICKS} ticks"
         )
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.parametrize("with_refs", [False, True], ids=["unframed", "framed"])
+@pytest.mark.asyncio
+async def test_despawned_episode_never_calls_external_policy(tmp_path, with_refs):
+    policy = RecordingPolicy()
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(
+            uri=str(tmp_path / "store"), namespace=f"policy_despawn_{with_refs}"
+        )
+        system = AsyncSystem()
+        await system.add_processor(PolicyActionProcessor(policy))
+        world = await ws.create_world(
+            WorldConfig(name=f"policy-despawn-{with_refs}"),
+            storage_config=storage,
+            system=system,
+        )
+        components: list[Component] = [
+            ManipProprio(
+                eef_pos=[0.0, 0.0, 0.5],
+                eef_quat=[0.0, 0.0, 0.0, 1.0],
+                gripper=0.0,
+            ),
+            ManipAction(values=list(SPAWN_ACTION)),
+            ManipStatus(),
+            ManipTask(env_key=7, instruction="reach"),
+        ]
+        if with_refs:
+            components.append(ManipFrameRef(agentview_ref="agent.png", wrist_ref="wrist.png"))
+        entity_id = await world.create_entity(components)
+        await world.run(RunConfig(num_steps=1))
+        calls_before_despawn = policy.act_calls
+
+        await world.remove_entity(entity_id)
+        await world.run(RunConfig(num_steps=1))
+
+        assert policy.act_calls == calls_before_despawn
     finally:
         await ws.shutdown()


### PR DESCRIPTION
Closes #345 and #426.

## What changed

- carry the engine's `is_active` column into environment and policy UDFs
- select every external call through one shared `is_active and not done`
  predicate
- preserve prior observation, status, and frame references for inactive rows
- preserve prior actions for inactive policy rows
- cover framed and unframed environment and policy paths with despawn
  regressions

## Root cause

`AsyncWorld` correctly materializes a pending despawn as `is_active=False`
before processors run, but the manipulation and policy boundaries filtered
only on `ManipStatus.done`. The tombstone row therefore advanced its external
simulator and invoked policy inference once more even though the entity was
already inactive.

The fix keeps the lazy DataFrame contract intact: `is_active` travels as
another Series into the existing batch UDFs. A shared boundary helper selects
only active, unfinished rows from the already-materialized UDF batch. No new
DataFrame collection is introduced. The existing lazy-audit exception moved
by three lines with the boundary module docstring; the audited materialization
site itself is unchanged.

## MRE

The canonical MREs in #345 and #426 both fail on exact current main
`3047b4885c64028cd04e9d6e3b8b56449a96a5c5`: the environment-step and
policy-inference counters each advance from 0 to 1 after despawn. Both
selectors pass on exact candidate head
`d6523906e6368d30a0ace5cf8d20e9aab1f23c0b`.

## Validation

- canonical #345 and #426 MREs: passed on candidate, failed on exact current
  main
- focused external-boundary contracts: 22 passed
- static type check: passed
- full suite: 1051 passed, 6 skipped; 85.8% coverage
- regression evals: 12/12
- idempotency evals: 23/23
- formatting, Ruff, lazy audit, API boundary audit, idempotency audit, gate
  coverage audit, lock check, and `git diff --check`: passed
