### PR TITLE
docs: make example command reference drift-safe

### DIFF
--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -42,23 +42,29 @@ Output:
    player: ADD_PROCESSOR denied (correct)
 ```
 
-**Command types** (15 total, including `run_rollout` and `run_episode` for MCTS):
+**Gated operations in this example (curated, not exhaustive):**
 
-| Command | Payload | Who Can Run It |
-|---------|---------|----------------|
-| `spawn` | `{"components": [...]}` | player, operator, admin |
-| `despawn` | `{"entity_id": int}` | player, operator, admin |
-| `update` | `{"entity_id": int, "components": [...]}` | player, operator, admin |
-| `add_component` | `{"entity_id": int, "components": [...]}` | operator, admin |
-| `remove_component` | `{"entity_id": int, "component_types": [...]}` | operator, admin |
-| `add_processor` | `{"processor": ...}` | operator, admin |
-| `remove_processor` | `{"processor_type": str}` | operator, admin |
-| `create_world` | `{"config": {"name": str}}` | admin |
-| `destroy_world` | `{"world_id": str}` | operator, admin |
-| `fork_world` | `{"source_world_id": str, "name": str}` | operator, admin |
-| `message` | `{"sender_id", "receiver_id", "content"}` | player, operator, admin |
-| `custom` | `{...}` | player, operator, admin |
-| `query_world` | `{}` | viewer, player, operator, admin |
+| Runtime call | Gate command | Allowed roles |
+|---|---|---|
+| `world.step()` | `step` | operator, admin |
+| `world.spawn()` | `spawn` | player, operator, admin |
+| `world.despawn()` | `despawn` | player, operator, admin |
+| `world.update()` | `update` | player, operator, admin |
+| `world.add_components()` | `add_component` | operator, admin |
+| `world.remove_components()` | `remove_component` | operator, admin |
+| `world.add_processor()` | `add_processor` | operator, admin |
+| `world.remove_processor()` | `remove_processor` | operator, admin |
+| `world.fork()` | `fork_world` | operator, admin |
+| `world.info()` | `get_world_info` | viewer, player, operator, admin |
+| `world.query()` | `query_world` | viewer, player, operator, admin |
+| `world.history()` | `get_audit_history` | viewer, player, operator, admin |
+
+The runtime constructs the command payloads for these methods; this is not a
+raw broker-payload schema. The complete command inventory lives in
+`archetype.app.models.CommandType`. See the normative
+[Command Gate](command-gate.md#3-the-permissions-matrix) for the current
+permission matrix, including `run_episode`, `run_rollout`, fact operations,
+hooks, resources, and introspection.
 
 ---
 

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executable contracts for claims made by the hand-authored guides."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from archetype.app.auth.permissions import ROLES_BY_COMMAND
+from archetype.app.models import CommandType
+
+_GUIDE_ROOT = Path("docs/guide")
+_COMMAND_TOTAL_PATTERNS = (
+    re.compile(r"\b(\d+)\s+command\s+types?\b", re.IGNORECASE),
+    re.compile(r"\bcommand\s+types?\*{0,2}\s*\((\d+)\s+total\b", re.IGNORECASE),
+)
+
+
+def test_numeric_command_type_claims_match_the_enum() -> None:
+    """A guide may omit a volatile total, but any total it states must be true."""
+    expected = len(CommandType)
+    stale: list[str] = []
+
+    for guide in sorted(_GUIDE_ROOT.glob("*.md")):
+        text = guide.read_text()
+        for pattern in _COMMAND_TOTAL_PATTERNS:
+            for match in pattern.finditer(text):
+                claimed = int(match.group(1))
+                if claimed != expected:
+                    line = text.count("\n", 0, match.start()) + 1
+                    stale.append(f"{guide}:{line} claims {claimed}; CommandType has {expected}")
+
+    assert not stale, "stale command-type totals:\n" + "\n".join(stale)
+
+
+def test_curated_example_command_roles_follow_permissions() -> None:
+    """The examples table may be selective, but every listed role must be authoritative."""
+    guide = (_GUIDE_ROOT / "examples.md").read_text()
+    heading = "**Gated operations in this example (curated, not exhaustive):**"
+    lines = guide.splitlines()
+    start = lines.index(heading)
+    role_order = ("viewer", "player", "operator", "admin")
+    rows: list[str] = []
+
+    for line in lines[start + 1 :]:
+        if line.startswith("|"):
+            if "---" not in line and "Gate command" not in line:
+                rows.append(line)
+        elif rows:
+            break
+
+    assert rows, "the curated command table is missing"
+    for row in rows:
+        _runtime_call, command_text, roles_text = [
+            cell.strip() for cell in row.strip("|").split("|")
+        ]
+        command = CommandType(command_text.strip("`"))
+        documented = tuple(role.strip() for role in roles_text.split(","))
+        expected = tuple(role for role in role_order if role in ROLES_BY_COMMAND[command])
+        assert documented == expected, (
+            f"{command.value}: documented {documented}, expected {expected}"
+        )


### PR DESCRIPTION
## Summary

- replace the false “15 total” command/payload table with a table explicitly limited to gated runtime operations exercised by `examples/01_world_mutations.py`
- point complete inventory and permission questions to their authorities: `CommandType` and the normative Command Gate
- add documentation contracts that reject stale numeric command totals and verify every curated role list against `ROLES_BY_COMMAND`

## Why

The examples guide conflated a runtime walkthrough with an exhaustive raw-broker reference. It claimed 15 command types while the live enum has 30, listed only 13 rows, and named `run_episode` / `run_rollout` without including either. Manually duplicating the entire enum here would recreate the same drift surface.

## Impact

No runtime behavior changes. Readers get the operations this example actually demonstrates, while volatile inventory and permission facts remain owned by code and the normative gate specification.

## Validation

- red-before: the new total-claim contract reported `examples.md:45 claims 15; CommandType has 30`
- `uv run pytest -q tests/spec_contracts/test_documentation_contracts.py tests/spec_contracts/test_spec_contract_evals.py` — 4 passed
- `uv run --project ... python examples/01_world_mutations.py` — end-to-end smoke passed
- `make check`
- `uv run --extra docs mkdocs build`
- `npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"`
- `git diff --check`

Closes #350