### PR TITLE
fix(examples): cap eligible distinct trajectories

### DIFF
--- a/examples/06_trajectory_analysis.py
+++ b/examples/06_trajectory_analysis.py
@@ -241,20 +241,19 @@ class SamplingProcessor(AsyncProcessor):
                     col("sessiontrajectory__tags_json"), daft.lit(tag)
                 )
 
-        df = df.with_columns({"label__sampled": sampled})
+        if config.max_trajectories <= 0:
+            return df.with_column("label__sampled", sampled)
 
-        if config.max_trajectories > 0:
-            trajectory_rank = dense_rank().over(
-                daft.Window().order_by("sessiontrajectory__trajectory_id")
-            )
-            df = df.with_columns(
-                {
-                    "label__sampled": col("label__sampled")
-                    & (trajectory_rank <= config.max_trajectories),
-                }
-            )
-
-        return df
+        df = df.with_column("_sampling_eligible", sampled)
+        trajectory_rank = dense_rank().over(
+            daft.Window()
+            .partition_by("_sampling_eligible")
+            .order_by("sessiontrajectory__trajectory_id")
+        )
+        return df.with_column(
+            "label__sampled",
+            col("_sampling_eligible") & (trajectory_rank <= config.max_trajectories),
+        ).exclude("_sampling_eligible")
 
 
 class LabelingProcessor(AsyncProcessor):

--- a/examples/06_trajectory_analysis.py
+++ b/examples/06_trajectory_analysis.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import daft
 from daft import DataFrame, col
+from daft.functions import dense_rank
 
 from archetype import ArchetypeRuntime
 from archetype.core.aio.async_processor import AsyncProcessor
@@ -243,13 +244,15 @@ class SamplingProcessor(AsyncProcessor):
         df = df.with_columns({"label__sampled": sampled})
 
         if config.max_trajectories > 0:
-            df = df._add_monotonically_increasing_id("_sample_idx")
+            trajectory_rank = dense_rank().over(
+                daft.Window().order_by("sessiontrajectory__trajectory_id")
+            )
             df = df.with_columns(
                 {
                     "label__sampled": col("label__sampled")
-                    & (col("_sample_idx") < config.max_trajectories),
+                    & (trajectory_rank <= config.max_trajectories),
                 }
-            ).exclude("_sample_idx")
+            )
 
         return df
 

--- a/tests/integration/test_trajectory_analysis.py
+++ b/tests/integration/test_trajectory_analysis.py
@@ -10,6 +10,7 @@ import json
 import sys
 from pathlib import Path
 
+import daft
 import pytest
 from uuid_utils import uuid7
 
@@ -96,6 +97,27 @@ class TestTrajectoryComponent:
 
 
 # ── SamplingProcessor ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sampling_processor_caps_distinct_trajectories():
+    """Every label row for a selected trajectory remains sampled."""
+    resources = Resources()
+    resources.insert(SamplingConfig(max_trajectories=1))
+    df = daft.from_pydict(
+        {
+            "sessiontrajectory__trajectory_id": ["trajectory-a", "trajectory-a", "trajectory-b"],
+            "sessiontrajectory__total_turns": [2, 2, 2],
+            "sessiontrajectory__outcome": ["ok", "ok", "ok"],
+            "sessiontrajectory__tags_json": ["[]", "[]", "[]"],
+            "label__technique": ["correctness", "style", "correctness"],
+            "label__sampled": [True, True, True],
+        }
+    )
+
+    rows = (await SamplingProcessor().process(df, resources=resources)).collect().to_pylist()
+
+    assert [row["label__sampled"] for row in rows] == [True, True, False]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_trajectory_analysis.py
+++ b/tests/integration/test_trajectory_analysis.py
@@ -121,6 +121,27 @@ async def test_sampling_processor_caps_distinct_trajectories():
 
 
 @pytest.mark.asyncio
+async def test_sampling_cap_counts_only_filter_eligible_trajectories():
+    resources = Resources()
+    resources.insert(SamplingConfig(min_turns=3, max_trajectories=1))
+    df = daft.from_pydict(
+        {
+            "sessiontrajectory__trajectory_id": ["trajectory-a", "trajectory-b"],
+            "sessiontrajectory__total_turns": [1, 5],
+            "sessiontrajectory__outcome": ["ok", "ok"],
+            "sessiontrajectory__tags_json": ["[]", "[]"],
+            "label__technique": ["correctness", "correctness"],
+            "label__sampled": [True, True],
+        }
+    )
+
+    rows = (await SamplingProcessor().process(df, resources=resources)).collect().to_pylist()
+    sampled_by_id = {row["sessiontrajectory__trajectory_id"]: row["label__sampled"] for row in rows}
+
+    assert sampled_by_id == {"trajectory-a": False, "trajectory-b": True}
+
+
+@pytest.mark.asyncio
 async def test_sampling_processor_filters_by_min_turns(tmp_path):
     """SamplingProcessor marks entities with fewer turns than min_turns as not sampled."""
     container = ServiceContainer()


### PR DESCRIPTION
Closes #362 and #421.

## What changed

- apply the ordinary sampling predicates before enforcing
  `max_trajectories`
- dense-rank eligible rows by `sessiontrajectory__trajectory_id`
- retain every label row belonging to a selected trajectory
- add regressions for duplicate label rows and ineligible trajectories ahead
  of eligible ones

## Root cause

The old cap used a monotonically increasing row index. That counted label
entities rather than distinct trajectories, so a second labeling technique
could consume another slot. It also counted rows that had already failed
`min_turns`, outcome, or tag filters, allowing an ineligible trajectory to
exhaust the cap.

The fix remains a lazy Daft pipeline: it materializes the filter expression as
a temporary eligibility column, computes a dense rank within the eligibility
partition, masks the sampled flag, and removes the temporary column. There is
no collect or Python row loop.

## MREs

On exact current main `28a43ef6a8bfa6333c00f606f7382c279ffaf317`:

- #362 fails because two labels on one trajectory become `[true, false]`
  under a one-trajectory cap
- #421 fails because an ineligible earlier trajectory consumes the only slot,
  leaving the eligible trajectory unsampled

Both canonical selectors pass on exact candidate head
`df0aca3b11fbd2305b60e76cfdf9302abc864f1a`.

## Validation

- canonical #362 and #421 MREs: passed on candidate, failed on exact current
  main
- trajectory-analysis integration contracts: 9 passed
- static type check: passed
- full suite: 1051 passed, 8 skipped; 85.4% coverage
- regression evals: 12/12
- idempotency evals: 23/23
- formatting, Ruff, lazy audit, API boundary audit, idempotency audit, gate
  coverage audit, lock check, and `git diff --check`: passed
