### PR TITLE
fix(core): reserve component discriminator

### DIFF
--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -121,6 +121,8 @@ Each layer may depend downward. No lower layer may depend upward.
   `<component_name_lower>__<field_name>`.
 - `Component.to_payload()` MUST include a `"type"` discriminator so the app
   layer can reconstruct the original concrete component type.
+- `"type"` is reserved payload metadata; component subclasses MUST NOT
+  declare it as a model field.
 - Untyped payload dicts MUST fail loudly rather than silently degrading to the
   base `Component`.
 

--- a/experiments/cooperative_emergence.py
+++ b/experiments/cooperative_emergence.py
@@ -30,7 +30,7 @@ from archetype.core.hooks import PostTick
 
 
 class Strategy(Component):
-    type: str = "cooperative"  # cooperative | greedy | conditional
+    kind: str = "cooperative"  # cooperative | greedy | conditional
     energy: float = 100.0
     lifetime_harvest: float = 0.0
 
@@ -68,11 +68,11 @@ class HarvestProcessor(AsyncProcessor):
         return df.with_columns(
             {
                 "strategy__energy": when(
-                    col("strategy__type") == "greedy",
+                    col("strategy__kind") == "greedy",
                     col("strategy__energy") + 15.0,
                 )
                 .when(
-                    col("strategy__type") == "cooperative",
+                    col("strategy__kind") == "cooperative",
                     col("strategy__energy") - 2.0,
                 )
                 .otherwise(
@@ -80,7 +80,7 @@ class HarvestProcessor(AsyncProcessor):
                     col("strategy__energy") - 2.0,
                 ),
                 "strategy__lifetime_harvest": when(
-                    col("strategy__type") == "greedy",
+                    col("strategy__kind") == "greedy",
                     col("strategy__lifetime_harvest") + 20.0,
                 ).otherwise(
                     col("strategy__lifetime_harvest") + 5.0,
@@ -209,9 +209,9 @@ async def main():
 
         # Seed: 4 cooperative + 3 greedy agents + 1 pool
         for _ in range(4):
-            await world.spawn(Strategy(type="cooperative", energy=100.0))
+            await world.spawn(Strategy(kind="cooperative", energy=100.0))
         for _ in range(3):
-            await world.spawn(Strategy(type="greedy", energy=100.0))
+            await world.spawn(Strategy(kind="greedy", energy=100.0))
         pool_id = await world.spawn(Pool(current=1000.0, capacity=1000.0, regen_rate=0.05))
         # Hooks registered before forking are deep-copied onto every fork,
         # including the per-episode forks created by run_rollout.

--- a/src/archetype/core/component.py
+++ b/src/archetype/core/component.py
@@ -31,6 +31,15 @@ class Component(LanceModel):
     """
 
     @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        if "type" in cls.model_fields:
+            raise TypeError(
+                f"{cls.__name__} declares the reserved Component field 'type'; "
+                "use a domain-specific name such as 'kind' instead"
+            )
+
+    @classmethod
     def get_type_by_name(cls, name: str) -> type["Component"]:
         """Find a Component subclass (at any depth) by its class name.
 
@@ -94,7 +103,7 @@ class Component(LanceModel):
         Unlike `model_dump()`, the result includes the concrete component
         type so `Component.from_dict()` can reconstruct it.
         """
-        return {"type": type(self).__name__, **self.model_dump()}
+        return {**self.model_dump(), "type": type(self).__name__}
 
     @classmethod
     def get_prefix(cls) -> str:

--- a/tests/core/test_component_core.py
+++ b/tests/core/test_component_core.py
@@ -88,6 +88,15 @@ def test_to_payload_round_trips_through_from_dict():
     assert restored.a == 7
 
 
+def test_component_type_field_is_reserved():
+    import pytest
+
+    with pytest.raises(TypeError, match="reserved Component field 'type'"):
+
+        class PayloadDiscriminatorProbe(Component):
+            type: str = "user-value"
+
+
 def test_from_dict_does_not_mutate_input():
     """from_dict does not mutate the caller's dict.
 

--- a/tests/experiments/test_cooperative_emergence.py
+++ b/tests/experiments/test_cooperative_emergence.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the cooperative-emergence experiment schema."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_experiment():
+    path = Path("experiments/cooperative_emergence.py")
+    spec = importlib.util.spec_from_file_location("cooperative_emergence_contract", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_strategy_payload_preserves_domain_kind() -> None:
+    experiment = _load_experiment()
+
+    payload = experiment.Strategy(kind="greedy").to_payload()
+
+    assert payload["type"] == "Strategy"
+    assert payload["kind"] == "greedy"


### PR DESCRIPTION
## Summary

- reserve the flat component payload `type` key for the concrete-class discriminator
- reject colliding component schemas at class definition instead of silently losing domain data
- migrate the tracked cooperative-emergence strategy field from `type` to `kind`
- make the reserved-key boundary normative and cover both the core and experiment contracts

## MREs

Two checkout-relative MREs fail on exact main `a7ba09db` and pass on exact head `ee4c1704`:

1. A component subclass can declare `type`, causing its domain value to replace the routing discriminator. The corrected contract rejects that schema at class definition.
2. `experiments/cooperative_emergence.py` uses the now-reserved name for `Strategy.type`. The migration preserves the strategy choice as `kind` while `type` remains `Strategy`.

The second bug is documented in #422; #355 contains the core discriminator reproduction and corrected fail-loud contract.

## Contract boundary

The existing flat wire format already assigns `type` to routing metadata. Valid component schemas and persisted storage formats are unchanged. Ambiguous schemas now fail at definition time, before data can be serialized or silently discarded.

## Validation

- both MREs fail exact main and pass exact head
- focused core/experiment tests: 11 passed
- `make ci`: 1,057 passed, 4 skipped; 85.96% coverage
- regression eval: 12/12
- idempotency eval: 23/23

Closes #355
Closes #422
