### PR TITLE
fix(core): preserve empty-signature entities

### DIFF
--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -590,7 +590,7 @@ class AsyncWorld(iAsyncWorld):
         """Attach additional components to an existing entity. Fires
         ``OnComponentAdded`` iff the signature actually changes."""
         old_sig = self.entity2sig.get(entity_id)
-        if not old_sig:
+        if old_sig is None:
             logger.warning("add_components: entity %s not found", entity_id)
             return
 

--- a/src/archetype/core/sync/world.py
+++ b/src/archetype/core/sync/world.py
@@ -415,7 +415,7 @@ class SyncWorld(iWorld):
         """Attach additional components to an existing entity. Fires
         ``OnComponentAdded`` iff the signature actually changes."""
         old_sig = self.entity2sig.get(entity_id)
-        if not old_sig:
+        if old_sig is None:
             logger.warning(f"add_components: entity {entity_id} not found")
             return
 

--- a/tests/aio/test_async_world_edges.py
+++ b/tests/aio/test_async_world_edges.py
@@ -57,6 +57,19 @@ async def test_add_components_before_first_step_handles_empty_live(world):
 
 
 @pytest.mark.asyncio
+async def test_empty_signature_entity_can_receive_first_component(world):
+    ent = await world.create_entity([])
+    await world.step(RunConfig())
+
+    await world.add_components(ent, [Position(x=2, y=3)])
+    await world.step(RunConfig())
+
+    df = await world.get_components([Position], entity_ids=[ent])
+    assert df is not None
+    assert df.collect().to_pylist()[0]["position__x"] == 2
+
+
+@pytest.mark.asyncio
 async def test_remove_nonexistent_entity_is_noop(world):
     # Removing an unknown entity should not crash
     await world.remove_entity(999999)

--- a/tests/core/test_same_tick_mutation_composition.py
+++ b/tests/core/test_same_tick_mutation_composition.py
@@ -113,6 +113,26 @@ async def test_spawn_then_add_component_before_first_step(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_empty_spawn_then_add_component_before_first_step(tmp_path):
+    ws = make_world_service()
+    try:
+        world = await _make_world(ws, tmp_path)
+        eid = await world.create_entity([])
+
+        await world.add_components(eid, [ComposeVel(vx=4.0)])
+
+        assert () not in world.spawn_cache
+        await world.step(RunConfig())
+
+        rows = (await world.query_archetype(sig=(ComposeVel,), ticks=[0])).to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["entity_id"] == eid
+        assert rows[0]["composevel__vx"] == 4.0
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_add_components_without_prior_row_is_noop(tmp_path):
     """Issue #367: no staged row + no persisted row -> logged no-op."""
     ws = make_world_service()

--- a/tests/sync/test_sync_stack_contracts.py
+++ b/tests/sync/test_sync_stack_contracts.py
@@ -555,6 +555,20 @@ def test_sync_world_add_components_before_first_step_uses_pending_spawn_row(tmp_
     assert rows[0]["velocity__vx"] == 5
 
 
+def test_sync_empty_signature_entity_can_receive_first_component(tmp_path):
+    _store, _querier, _updater, _system, world = _make_sync_stack(tmp_path, "world_empty_signature")
+    entity_id = world.create_entity([])
+    world.step(RunConfig(num_steps=1))
+
+    world.add_components(entity_id, [Position(x=2, y=3)])
+    world.step(RunConfig(num_steps=1))
+
+    sig = Archetype.sig_from_components([Position(x=0, y=0)])
+    rows = _committed_rows(world, sig)
+    assert rows[0]["entity_id"] == entity_id
+    assert rows[0]["position__x"] == 2
+
+
 def test_sync_world_execute_passes_resources_and_kwargs(tmp_path):
     class ApplyBonus(SyncProcessor):
         components = (Position,)

--- a/tests/sync/test_sync_stack_contracts.py
+++ b/tests/sync/test_sync_stack_contracts.py
@@ -564,6 +564,24 @@ def test_sync_world_add_components_before_first_step_uses_pending_spawn_row(tmp_
     )
 
 
+def test_sync_empty_spawn_then_add_component_before_first_step(tmp_path):
+    _store, _querier, _updater, _system, world = _make_sync_stack(
+        tmp_path, "world_pre_step_empty_move"
+    )
+    entity_id = world.create_entity([])
+
+    world.add_components(entity_id, [Position(x=7, y=0)])
+
+    assert () not in world.spawn_cache
+    world.step(RunConfig(num_steps=1))
+
+    sig = Archetype.sig_from_components([Position()])
+    rows = _committed_rows(world, sig)
+    assert len(rows) == 1
+    assert rows[0]["entity_id"] == entity_id
+    assert rows[0]["position__x"] == 7
+
+
 def test_sync_world_add_components_without_prior_row_is_noop(tmp_path):
     """Issues #367: no staged row + no persisted row -> logged no-op."""
     _store, _querier, _updater, _system, world = _make_sync_stack(tmp_path, "world_noop_move")


### PR DESCRIPTION
## Summary

- distinguish the valid empty archetype signature `()` from the missing-entity sentinel `None`
- apply the same existence contract to async and sync component attachment
- cover both post-materialization and same-tick staged-spawn widening

## MREs

The combined async/sync MRE fails exact main `6716e313` and passes exact head `0f06eda3`:

- async: same-tick attachment is dropped, so the widened signature is unknown
- sync: same-tick attachment is dropped, so no widened row is written
- corrected candidate: each staged empty spawn is consumed once and materializes only under the widened signature

#358 covers first-component attachment after the empty entity has materialized. #424 and #425 document the async and sync same-tick failures discovered while validating the review comments.

## Contract boundary

`()` remains a valid archetype signature. `None` alone means the entity lookup failed. The change is two sentinel checks; signature representation, storage formats, and lifecycle wiring are unchanged.

## Validation

- combined async/sync MRE fails exact main and passes exact head
- focused async/core/sync tests: 44 passed
- `make ci`: 1,062 passed, 6 skipped; 85.91% coverage
- regression eval: 12/12
- idempotency eval: 23/23

Closes #358
Closes #424
Closes #425
