### PR TITLE
docs: define system execution sharing boundaries

### DIFF
--- a/docs/guide/archetype.md
+++ b/docs/guide/archetype.md
@@ -96,6 +96,14 @@ v0.3 produced new table ids instead of mutating v0.2 tables in place. Stores
 may read a legacy table through its old schema-derived name, but new writes use
 the current name.
 
+The name identifies a physical table, not a unique Python signature. Distinct
+signatures with the same component count and identical storage schemas map to
+the same name. Empty tag components contribute no fields, so two one-tag
+signatures are the common edge case. `AsyncWorld` interns one canonical
+signature per table name to prevent processing that shared table twice. See
+[System Execution](system-execution.md#step-3-archetype-naming) for the
+executable example and processor-matching consequences.
+
 ```python
 name = Archetype.get_name(sig)  # "a_2c_s9f3a1b2c4d5e6f7"
 ```

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -20,6 +20,13 @@ The container is a `dict[type, object]` -- each resource is keyed by its concret
 
 Every `AsyncWorld` owns a `.resources` instance. During tick execution, `AsyncSystem.execute()` passes it into each processor's `process()` method as a keyword argument.
 
+Every per-table compute task in that world receives the same container and the
+same stored objects. A resource mutation can therefore be visible to another
+archetype during the same tick. Per-table DataFrames are separate; resources
+are not isolated. Stateful resources must expose concurrency-safe operations
+or protect compound mutations with synchronization such as an `asyncio.Lock`.
+Do not rely on task scheduling to order cross-archetype resource access.
+
 Runtime users usually stage resources when creating a handle:
 
 ```python

--- a/docs/guide/system-execution.md
+++ b/docs/guide/system-execution.md
@@ -1,38 +1,20 @@
 # System Execution Model
 
-`System.execute()` iterates processors in priority order and runs each one on every archetype whose signature is a superset of the processor's declared components. This subset check eliminates per-entity component lookups and guarantees that every column a processor references exists in the DataFrame.
+`AsyncSystem.execute()` and `SyncSystem.execute()` each process one archetype
+DataFrame. They run registered processors in priority order when the
+processor's declared components are a subset of that archetype's signature.
+The subset check eliminates per-entity component lookups and guarantees that
+the declared component columns exist in the DataFrame.
+
+`AsyncWorld.step()` supplies the per-archetype concurrency: it schedules one
+compute task for each active physical table, then commits the successful
+results as a separate phase. `AsyncSystem` itself processes the one DataFrame
+passed to each `execute()` call.
 
 ```python
-class AsyncSystem(iAsyncSystem):
-    def __init__(self):
-        self.processors: list[AsyncProcessor] = []
-
-    async def add_processor(self, proc: "AsyncProcessor"):
-        self.processors.append(proc)
-
-    async def remove_processor(self, proc_type: type["AsyncProcessor"]):
-        self.processors = [p for p in self.processors if not isinstance(p, proc_type)]
-
-    async def execute(
-        self,
-        df: DataFrame,
-        sig: ArchetypeSignature,
-        resources: Resources | None = None,
-        debug: bool = False,
-        **input_kwargs,
-    ) -> DataFrame:
-        if resources is not None:
-            input_kwargs["resources"] = resources
-
-        for proc_instance in sorted(self.processors, key=lambda x: x.priority):
-            if set(proc_instance.components).issubset(set(sig)):
-                sig_params = inspect.signature(proc_instance.process).parameters
-                filtered_input_kwargs = {
-                    k: v for k, v in input_kwargs.items() if k in sig_params
-                }
-                df = await proc_instance.process(df, **filtered_input_kwargs)
-
-        return df
+for processor in sorted(self.processors, key=lambda item: item.priority):
+    if set(processor.components).issubset(set(sig)):
+        df = await processor.process(df, **accepted_kwargs)
 ```
 
 The sections below detail each stage of the execution pipeline.
@@ -64,7 +46,8 @@ Sorting ensures that `[Inbox(), Outbox()]` and `[Outbox(), Inbox()]` produce the
 ```text
 BASE_SCHEMA:
   world_id (string), run_id (string), entity_id (int32),
-  tick (int32), is_active (bool)
+  tick (int32), is_active (bool), commit_token (string),
+  writer_epoch (int64)
 
 + Inbox.get_prefixed_schema():
   inbox__messages (list<string>)
@@ -83,11 +66,42 @@ Each component class generates its prefix via `Component.get_prefix()`:
 
 ### Step 3: Archetype Naming
 
-The signature maps to a table name like `a_2c_s<hash>` — `2c` for two components, followed by a SHA-256 hash of the schema. Different signatures always produce different tables.
+The component count and full storage schema map to a table name such as
+`a_2c_s<hash>`: `2c` records two component types and `<hash>` is the first 16
+hexadecimal characters of the schema's SHA-256 digest. The schema includes the
+base storage metadata, so a schema-generation change also produces new table
+IDs.
+
+This mapping is not a one-to-one encoding of Python component types. Distinct
+signatures with the same component count and identical storage schemas share a
+physical table ID. Empty tag components contribute no fields, for example:
+
+```python
+class FirstTag(Component):
+    pass
+
+
+class SecondTag(Component):
+    pass
+
+
+first = Archetype.sig_from_components([FirstTag()])
+second = Archetype.sig_from_components([SecondTag()])
+
+assert first != second
+assert Archetype.get_name(first) == Archetype.get_name(second)
+```
+
+`AsyncWorld` interns one canonical signature per table ID so a schema-identical
+table is processed only once. Treat empty tags as schema-neutral; do not assume
+that a different tag class creates a distinct storage partition.
 
 ### The Result
 
-Entities with identical component sets share a table. Entities with different component sets live in separate tables. This structural partitioning is what makes everything else work.
+Entities with identical field-bearing component sets share a table. Different
+component sets usually produce different tables because their prefixed fields
+change the schema, but the schema-identical exception above is part of the
+table-identity contract.
 
 ## The Subset Rule
 
@@ -122,11 +136,17 @@ ObserverProcessor(components=())
 
 The subset rule provides three structural guarantees:
 
-**No per-entity component lookups.** Entities are partitioned by component set at storage time. If the subset check passes, every row in the DataFrame contains the required columns — no runtime `has_component()` test is needed.
+**No per-entity component lookups.** The world tracks one canonical signature
+for each physical table. If the subset check passes, every row in the
+DataFrame contains the processor's required component fields — no runtime
+`has_component()` test is needed.
 
 **Schema correctness.** If a processor executes, the columns it references are present. The archetype schema is constructed from the same component types the processor declares, so `if "col" in df.columns` guards are dead code.
 
-**Per-archetype parallelism.** Archetype tables are disjoint partitions. A processor operating on one archetype's DataFrame cannot observe or mutate another's. `AsyncWorld.step()` runs all archetypes concurrently via `asyncio.gather`.
+**Per-table DataFrame scheduling.** Each matching call transforms the DataFrame
+for one physical table. `AsyncWorld.step()` can schedule those transformations
+concurrently. This separates the DataFrame inputs; it does not isolate shared
+Python objects, services, or side effects.
 
 ### The `components=()` Pattern
 
@@ -148,7 +168,8 @@ class MetricsProcessor(AsyncProcessor):
 sorted(self.processors, key=lambda x: x.priority)
 ```
 
-Lower priority number means the processor runs first. This ordering is deterministic and consistent across ticks.
+Lower priority number means the processor runs first. Within one table's
+processor chain, this ordering is deterministic and consistent across ticks.
 
 Typical priority ranges:
 
@@ -164,9 +185,12 @@ Example: `MessageDeliveryProcessor` at priority -100 populates inboxes before ag
 
 ## SyncSystem vs AsyncSystem
 
-Both systems share the identical core subset check. The differences are in ergonomics:
+Both systems share priority ordering, the subset check, resource injection, and
+fail-fast processor errors. When a caller supplies `resources`, both pass that
+same container to every matching processor. The differences are in keyword
+forwarding and in how their worlds schedule table execution.
 
-### SyncSystem (`core/sync/system.py`)
+### SyncSystem (`src/archetype/core/sync/system.py`)
 
 Straightforward loop:
 
@@ -176,44 +200,74 @@ for proc_instance in sorted(self.processors, key=lambda x: x.priority):
         df = proc_instance.process(df, **input_kwargs)
 ```
 
-Passes all kwargs directly. Error recovery logs and skips the failing processor.
+Passes all input kwargs directly, including `resources` when supplied. A
+processor exception is logged and re-raised, so the execution fails rather
+than continuing with a partial processor chain.
 
-### AsyncSystem (`core/aio/async_system.py`)
+### AsyncSystem (`src/archetype/core/aio/async_system.py`)
 
 Same subset check, plus:
 
-- **Resources injection** — the `Resources` container is added to kwargs so processors can access shared state via type-safe DI.
-- **Signature filtering** — `inspect.signature()` introspects each processor's `process()` method. Only kwargs that the processor's signature declares are forwarded. Processors opt into `resources`, `tick`, etc. via their function signature — no need for `**kwargs` to accept everything.
-- **Error recovery** — on exception, the original DataFrame is preserved (DataFrames are immutable, so the pre-error state is safe) and execution continues with the next processor.
+- **Signature-aware forwarding** — `inspect.signature()` introspects each processor's `process()` method. A processor with `**kwargs` receives every input; otherwise only explicitly declared keywords are forwarded. Processors can opt into `resources`, `tick`, or `debug` without accepting unrelated inputs.
+- **Fail-fast errors** — a processor exception is logged and re-raised. The world aggregates compute failures and does not enter the commit phase for that tick.
 
 ```python
 # Processor only accepts what it needs:
-async def process(self, df, tick: int = 0, resources: Resources = None):
+async def process(
+    self,
+    df: DataFrame,
+    tick: int = 0,
+    resources: Resources | None = None,
+) -> DataFrame:
     ...
 
-# AsyncSystem filters kwargs to match:
-sig_params = inspect.signature(proc_instance.process).parameters
-filtered_kwargs = {k: v for k, v in kwargs.items() if k in sig_params}
-df = await proc_instance.process(df, **filtered_kwargs)
+# AsyncSystem filters only when the processor does not accept **kwargs:
+parameters = inspect.signature(processor.process).parameters
+accepts_all = any(
+    parameter.kind is inspect.Parameter.VAR_KEYWORD
+    for parameter in parameters.values()
+)
+accepted_kwargs = (
+    dict(input_kwargs)
+    if accepts_all
+    else {key: value for key, value in input_kwargs.items() if key in parameters}
+)
+df = await processor.process(df, **accepted_kwargs)
 ```
 
 ## Per-Archetype Parallelism
 
-In `AsyncWorld.step()`, each archetype's full processor chain runs as an independent `asyncio.gather` task:
+In `AsyncWorld.step()`, each active physical table's compute path runs as an
+independent `asyncio.gather` task:
 
 ```python
-futures = [self._run_archetype(sig, run_config, **kwargs) for sig in sigs]
+futures = [self._compute_archetype(sig, run_config, **kwargs) for sig in sigs]
 results = await asyncio.gather(*futures, return_exceptions=True)
 ```
 
-The subset rule makes this safe. Archetypes are disjoint partitions — a processor operating on one archetype's DataFrame cannot observe or mutate another's. Each archetype goes through the same sequence independently:
+The DataFrame input and output of each compute task belong to that physical
+table. The tick uses two phases:
 
 1. Query previous state
 2. Materialize mutations (spawns/despawns)
 3. Execute matching processors in priority order
-4. Persist to storage
+4. If every compute succeeds, commit all resulting frames
 
-Cross-archetype communication happens through deferred mechanisms (spawn/despawn caches, the message delivery pipeline) that take effect on the next tick.
+That is DataFrame partitioning, not general task isolation. The tasks share:
+
+- the world's mutable `Resources` container and every object stored in it;
+- the registered processor instances; and
+- any external services or process-level side effects those objects reach.
+
+A processor can therefore mutate a resource that another archetype observes
+during the same tick. Scheduling across archetypes is not a deterministic
+ordering mechanism. Stateful resources and processors must provide their own
+synchronization (for example, an `asyncio.Lock`) or expose concurrency-safe
+operations. Keep deterministic entity state in DataFrame columns and use an
+explicit deferred mechanism when communication belongs at a tick boundary.
+
+See [Resources](resources.md) for the resource lifecycle and the additional
+sharing boundary created by world forks.
 
 ## Common Pitfalls
 
@@ -225,14 +279,23 @@ Cross-archetype communication happens through deferred mechanisms (spawn/despawn
 
 **Forgetting that `components=()` matches everything.** An observer processor with an empty components tuple will run on every archetype table. This is useful for metrics but can be surprising if unintentional.
 
+**Using empty tags as table discriminators.** Empty components add no storage
+fields. Two same-arity signatures made only from different empty tags can map
+to the same table ID and are interned to one canonical signature. Add a real
+field when the distinction must be represented in storage.
+
+**Treating concurrent tasks as isolated.** Per-table DataFrames are separate,
+but resources, processor instances, and external side effects are shared.
+Synchronize mutable shared objects and do not depend on cross-archetype task
+order.
+
 ## Key Source Files
 
 | File | What to Look For |
 |------|-----------------|
-| `core/archetype.py:45-52` | `sig_from_components()` — signature construction |
-| `core/archetype.py:91-101` | `get_archetype_schema()` — schema construction |
-| `core/component.py:45-47` | `get_prefix()` — column prefix generation |
-| `core/sync/system.py:60-62` | `SyncSystem.execute()` — the subset check |
-| `core/aio/async_system.py:78-79` | `AsyncSystem.execute()` — same check, async |
-| `core/aio/async_system.py:93-96` | `inspect.signature` filtering |
-| `core/aio/async_world.py:160-161` | `asyncio.gather` — per-archetype parallelism |
+| `src/archetype/core/archetype.py` | Signature construction, storage schema, and table naming |
+| `src/archetype/core/component.py` | Component prefixes and Arrow schemas |
+| `src/archetype/core/sync/system.py` | Synchronous subset matching and failure behavior |
+| `src/archetype/core/aio/async_system.py` | Async subset matching and keyword filtering |
+| `src/archetype/core/aio/async_world.py` | Signature interning and two-phase per-table scheduling |
+| `src/archetype/core/resources.py` | Mutable world-shared resource container |

--- a/tests/aio/test_async_world_execution.py
+++ b/tests/aio/test_async_world_execution.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 import pytest_asyncio
-from daft import col, lit
+from daft import col, from_pylist, lit
 
 from archetype.core.aio.async_cached_store import AsyncCachedStore
 from archetype.core.aio.async_processor import AsyncProcessor
@@ -24,6 +24,26 @@ from archetype.runtime.session import configure_session
 class Position(Component):
     x: int
     y: int
+
+
+class ResourceProbeMarker(Component):
+    value: int
+
+
+class SharedCounter:
+    def __init__(self) -> None:
+        self.value = 0
+
+
+class ObserveSharedCounter(AsyncProcessor):
+    components = ()
+    priority = 1
+
+    async def process(self, df, resources: Resources):
+        counter = resources.require(SharedCounter)
+        prior = counter.value
+        counter.value += 1
+        return df.with_column("observed_prior", lit(prior))
 
 
 class P1ScaleX(AsyncProcessor):
@@ -180,6 +200,30 @@ async def test_archetypes_process_in_parallel(world, store_backend):
     await step_task
     # With two archetypes, processors should overlap at least once
     assert shared["peak"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_archetype_executions_share_resources():
+    """Per-archetype DataFrames are separate; world resources are not."""
+    system = AsyncSystem()
+    await system.add_processor(ObserveSharedCounter())
+    resources = Resources()
+    counter = SharedCounter()
+    resources.insert(counter)
+
+    position_df = from_pylist([{"position__x": 0, "position__y": 0}])
+    marker_df = from_pylist([{"resourceprobemarker__value": 0}])
+    position_out, marker_out = await asyncio.gather(
+        system.execute(position_df, (Position,), resources=resources),
+        system.execute(marker_df, (ResourceProbeMarker,), resources=resources),
+    )
+
+    observed = [
+        position_out.collect().to_pylist()[0]["observed_prior"],
+        marker_out.collect().to_pylist()[0]["observed_prior"],
+    ]
+    assert sorted(observed) == [0, 1]
+    assert counter.value == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_archetype_core_signatures.py
+++ b/tests/core/test_archetype_core_signatures.py
@@ -20,6 +20,14 @@ class prefixcollisiona(Component):  # noqa: N801 — intentional name collision
     value: int = 0
 
 
+class FirstTag(Component):
+    pass
+
+
+class SecondTag(Component):
+    pass
+
+
 def test_sig_from_components_is_sorted_by_type_name():
     """Signature creation should be order-invariant and sorted by component type names."""
     sig1 = Archetype.sig_from_components([B(y=1), A(x=1)])
@@ -82,6 +90,21 @@ def test_get_name_is_order_invariant_and_hash_suffixed():
     n2 = Archetype.get_name(sig2)
     assert n1 == n2
     assert n1.startswith("a_2c_s")
+
+
+def test_schema_identical_tag_signatures_share_a_table_name():
+    """Physical table identity is schema-and-arity based, not class based.
+
+    Empty tag components contribute no fields. Two one-component signatures
+    made from different empty tags are therefore distinct logical signatures
+    with the same storage schema and physical table name.
+    """
+    first = Archetype.sig_from_components([FirstTag()])
+    second = Archetype.sig_from_components([SecondTag()])
+
+    assert first != second
+    assert Archetype.get_archetype_schema(first) == Archetype.get_archetype_schema(second)
+    assert Archetype.get_name(first) == Archetype.get_name(second)
 
 
 def test_get_archetype_schema_raises_on_prefix_collision():


### PR DESCRIPTION
## Summary

- define physical table identity as component count plus full storage-schema hash, including the schema-identical empty-tag case and `AsyncWorld` signature interning
- scope per-archetype parallelism to table-local DataFrames while documenting the shared `Resources`, processor-instance, and side-effect boundary
- reconcile adjacent system guide drift: current commit metadata columns, fail-fast processor errors, two-phase compute/commit scheduling, and stable source references
- add focused engine oracles for schema-identical tag signatures and shared resources across concurrent archetype executions

## Why

The guide treated Python signatures as one-to-one table identities and treated concurrent archetype tasks as isolated. The engine intentionally does neither: table names derive from schema and arity, and each task receives the same world resources and registered processor objects. Those stronger prose claims could lead contributors to depend on nonexistent isolation or to use empty tags as physical table discriminators.

## Contract decision

No core behavior changes. The guide now names the narrower guarantees the engine actually provides, and the tests preserve those boundaries as executable oracles.

## Validation

- `make ci` — 895 passed, 7 skipped; 84.8% coverage; regression evals 12/12; idempotency evals 22/22
- `uv run pytest -q tests/core/test_archetype_core_signatures.py tests/aio/test_async_world_execution.py tests/spec_contracts/test_documentation_contracts.py` — 26 passed
- `uv run --extra docs mkdocs build`
- `npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"`
- `git diff --check`

Closes #349
Closes #360