### PR TITLE
fix(ci): guard docs deployment status

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -310,14 +310,16 @@ jobs:
             });
 
       - name: Update deployment status (failure)
-        if: failure()
+        if: failure() && steps.gh-deploy.outputs.deployment-id != ''
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          DEPLOYMENT_ID: ${{ steps.gh-deploy.outputs.deployment-id }}
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              deployment_id: ${{ steps.gh-deploy.outputs.deployment-id }},
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
               state: 'failure',
               log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               description: 'Cloudflare Pages deploy failed',

--- a/tests/scripts/test_docs_workflow.py
+++ b/tests/scripts/test_docs_workflow.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_failure_status_requires_a_created_deployment():
+    workflow = (ROOT / ".github" / "workflows" / "docs.yml").read_text(encoding="utf-8")
+    failure_step = workflow[workflow.index("- name: Update deployment status (failure)") :]
+
+    assert "if: failure() && steps.gh-deploy.outputs.deployment-id != ''" in failure_step
+    assert "DEPLOYMENT_ID: ${{ steps.gh-deploy.outputs.deployment-id }}" in failure_step
+    assert "deployment_id: Number(process.env.DEPLOYMENT_ID)," in failure_step
+    assert "deployment_id: ${{" not in failure_step


### PR DESCRIPTION
## Summary

- skip the failure-status call when GitHub never created a deployment
- pass the deployment ID through the step environment instead of interpolating it into JavaScript
- add a workflow regression for the empty-output failure path

## MRE

The checkout-relative MRE fails exact main `bc6cab63` by rendering `deployment_id: ,` when the creation step has no output. It passes exact head `82a7d083`, where the failure handler requires a non-empty deployment ID and JavaScript reads it from `process.env`.

## Boundary

This changes only the docs deployment failure-reporting path. If deployment creation itself failed, there is no GitHub deployment to mark failed; the original error remains visible. Runtime, storage, and core contracts are untouched.

## Validation

- exact MRE fails main and passes the candidate
- committed workflow regression: 1 passed
- Ruff lint and format checks pass
- `make ci` passes; 85.8% coverage
- regression eval: 12/12
- idempotency eval: 23/23

Closes #351
