### PR TITLE
fix(ci): scan lazy calls with AST

### DIFF
--- a/scripts/check_lazy_audit.py
+++ b/scripts/check_lazy_audit.py
@@ -137,10 +137,7 @@ def _collect_batch_udf_param_lines(source: str) -> dict[int, frozenset[str]]:
     body up to and including the last line, so callers can do a simple
     ``line in line_to_params`` check.
     """
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:
-        return {}
+    tree = ast.parse(source)
 
     line_to_params: dict[int, frozenset[str]] = {}
 
@@ -177,10 +174,7 @@ def _scan_file(path: Path, rel: str) -> list[Site]:
     except (OSError, UnicodeDecodeError):
         return []
 
-    try:
-        tree = ast.parse(text)
-    except SyntaxError:
-        return []
+    tree = ast.parse(text)
 
     batch_line_params = _collect_batch_udf_param_lines(text)
     lines = text.splitlines()
@@ -192,23 +186,24 @@ def _scan_file(path: Path, rel: str) -> list[Site]:
         method = node.func.attr
         if method not in _MATERIALIZATION_METHODS:
             continue
-        key = (node.lineno, method)
+        method_line = node.func.end_lineno or node.lineno
+        key = (method_line, method)
         if key in seen:
             continue
         seen.add(key)
         receiver = node.func.value
         sanctioned = (
             method == "to_pylist"
-            and node.lineno in batch_line_params
+            and method_line in batch_line_params
             and isinstance(receiver, ast.Name)
-            and receiver.id in batch_line_params[node.lineno]
+            and receiver.id in batch_line_params[method_line]
         )
         sites.append(
             Site(
                 path=rel,
-                line=node.lineno,
+                line=method_line,
                 method=method,
-                snippet=lines[node.lineno - 1].lstrip(),
+                snippet=lines[method_line - 1].lstrip(),
                 sanctioned=sanctioned,
             )
         )

--- a/scripts/check_lazy_audit.py
+++ b/scripts/check_lazy_audit.py
@@ -59,7 +59,6 @@ from __future__ import annotations
 
 import argparse
 import ast
-import re
 import sys
 import tomllib
 from dataclasses import dataclass
@@ -69,13 +68,7 @@ ROOTS: tuple[str, ...] = ("src",)
 ALLOWLIST_FILENAME = "lazy_audit.toml"
 SELF_RELATIVE = "scripts/check_lazy_audit.py"
 
-# Match attribute-style calls only. Whitespace before the dot avoids hits on
-# e.g. ``module.collect(`` where ``collect`` is a free function in another
-# package — the audit is about chained DataFrame methods, not arbitrary names.
-PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ("collect", re.compile(r"\.collect\s*\(")),
-    ("to_pylist", re.compile(r"\.to_pylist\s*\(")),
-)
+_MATERIALIZATION_METHODS = frozenset({"collect", "to_pylist"})
 
 
 @dataclass(frozen=True)
@@ -158,9 +151,7 @@ def _collect_batch_udf_param_lines(source: str) -> dict[int, frozenset[str]]:
             continue
 
         # Collect parameter names (skip 'self' — it is not a Series param).
-        params: frozenset[str] = frozenset(
-            a.arg for a in node.args.args if a.arg != "self"
-        )
+        params: frozenset[str] = frozenset(a.arg for a in node.args.args if a.arg != "self")
         if not params:
             continue
 
@@ -180,54 +171,48 @@ def _collect_batch_udf_param_lines(source: str) -> dict[int, frozenset[str]]:
     return line_to_params
 
 
-def _call_receiver_name(source_line: str) -> str | None:
-    """Heuristically extract the receiver name from a line like ``foo.to_pylist()``.
-
-    Returns the bare name before the last ``.method(`` or None if ambiguous.
-    This is good enough for the common ``param.to_pylist()`` pattern.
-    """
-    # Strip leading whitespace and find last occurrence of ``<name>.to_pylist``
-    # or ``<name>.collect``.
-    m = re.search(r"\b(\w+)\.(to_pylist|collect)\s*\(", source_line)
-    if m:
-        return m.group(1)
-    return None
-
-
 def _scan_file(path: Path, rel: str) -> list[Site]:
-    sites: list[Site] = []
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
-        return sites
+        return []
 
-    # Build batch-UDF param map once per file (AST parse).
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+
     batch_line_params = _collect_batch_udf_param_lines(text)
-
     lines = text.splitlines()
-    for n, raw in enumerate(lines, start=1):
-        stripped = raw.lstrip()
-        if stripped.startswith("#"):
+    sites: list[Site] = []
+    seen: set[tuple[int, str]] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
             continue
-        for method, pat in PATTERNS:
-            if not pat.search(raw):
-                continue
-            # Determine if this is a sanctioned UDF-boundary access.
-            sanctioned = False
-            if method == "to_pylist" and n in batch_line_params:
-                receiver = _call_receiver_name(raw)
-                if receiver and receiver in batch_line_params[n]:
-                    sanctioned = True
-            sites.append(
-                Site(
-                    path=rel,
-                    line=n,
-                    method=method,
-                    snippet=stripped,
-                    sanctioned=sanctioned,
-                )
+        method = node.func.attr
+        if method not in _MATERIALIZATION_METHODS:
+            continue
+        key = (node.lineno, method)
+        if key in seen:
+            continue
+        seen.add(key)
+        receiver = node.func.value
+        sanctioned = (
+            method == "to_pylist"
+            and node.lineno in batch_line_params
+            and isinstance(receiver, ast.Name)
+            and receiver.id in batch_line_params[node.lineno]
+        )
+        sites.append(
+            Site(
+                path=rel,
+                line=node.lineno,
+                method=method,
+                snippet=lines[node.lineno - 1].lstrip(),
+                sanctioned=sanctioned,
             )
-    return sites
+        )
+    return sorted(sites, key=lambda site: (site.line, site.method))
 
 
 def scan(root: Path) -> list[Site]:
@@ -393,9 +378,7 @@ def main() -> int:
         )
 
     if not (new_sites or stale_entries or weak_reasons):
-        print(
-            f"lazy audit: {len(audited_sites)} audited site(s), all accounted for."
-        )
+        print(f"lazy audit: {len(audited_sites)} audited site(s), all accounted for.")
         return 0
 
     print(STERN_HEADER, file=sys.stderr)

--- a/tests/scripts/test_check_lazy_audit.py
+++ b/tests/scripts/test_check_lazy_audit.py
@@ -189,6 +189,19 @@ def test_collect_is_never_sanctioned(tmp_path):
         assert not s.sanctioned, ".collect() must never be sanctioned"
 
 
+def test_non_call_text_is_ignored(tmp_path):
+    py = _write_py(
+        tmp_path,
+        "non_calls.py",
+        """\
+        message = "documentation mentions frame.collect()"
+        value = 1  # no call here: frame.to_pylist()
+        """,
+    )
+
+    assert _scan_file(py, "non_calls.py") == []
+
+
 # ---------------------------------------------------------------------------
 # End-to-end: full scan + allowlist gating
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_check_lazy_audit.py
+++ b/tests/scripts/test_check_lazy_audit.py
@@ -20,6 +20,8 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 # Make scripts/ importable without installing it as a package.
 _SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
@@ -200,6 +202,30 @@ def test_non_call_text_is_ignored(tmp_path):
     )
 
     assert _scan_file(py, "non_calls.py") == []
+
+
+def test_multiline_call_reports_the_method_line(tmp_path):
+    py = _write_py(
+        tmp_path,
+        "multiline.py",
+        """\
+        result = (
+            frame
+            .collect()
+        )
+        """,
+    )
+
+    sites = _scan_file(py, "multiline.py")
+
+    assert [(site.line, site.snippet) for site in sites] == [(3, ".collect()")]
+
+
+def test_syntax_error_fails_the_scan(tmp_path):
+    py = _write_py(tmp_path, "broken.py", "result = (frame.collect()")
+
+    with pytest.raises(SyntaxError):
+        _scan_file(py, "broken.py")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- discover executable `collect()` and `to_pylist()` calls from Python's AST
- ignore matching text in string literals and inline comments
- anchor multiline findings to the materialization method's source line
- fail the gate when a Python file cannot be parsed instead of treating it as clean
- preserve the existing batch-UDF exemption and line/method allowlist contract

## MRE matrix

All three claims have checkout-relative deterministic MREs:

- #339 fails exact main `c6881f32`: materialization text in a string or comment is reported as code
- #398 fails exact main and the initial AST head `c3ad152e`: unparseable Python does not fail the audit
- #399 fails the initial AST head: a multiline `.collect()` is keyed to the receiver line
- all three pass exact candidate `c3c4cf7c`

## Validation

- `make ci` — passed; 85.7% coverage; regression eval 12/12; idempotency eval 23/23
- lazy-audit unit suite: 12 passed
- exact MRE suite: 3 passed
- `make lazy-audit` — all 19 production sites accounted for

Closes #339
Closes #398
Closes #399
