### PR TITLE
fix(eval): inspect plain app imports

### DIFF
--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -368,6 +368,9 @@ def task_runtime_gate_only_boundary() -> list[GraderResult]:
 
             if isinstance(node, ast.Import):
                 for alias in node.names:
+                    if alias.name.startswith("archetype.app"):
+                        key = f"{rel}:{node.lineno}:allowed_app_import:{alias.name}"
+                        import_checks[key] = alias.name in _RUNTIME_ALLOWED_APP_IMPORTS
                     if alias.name in {"iWorld", "AsyncWorld"}:
                         key = f"{rel}:{node.lineno}:world_import:{alias.name}"
                         world_ref_checks[key] = _in_ranges(node.lineno, tc_ranges)

--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -123,16 +123,18 @@ SPEC_CASES: tuple[SpecCase, ...] = (
 
 _EXPECTED_TASK_IDS = frozenset(case.task_id for case in SPEC_CASES)
 
-_RUNTIME_ALLOWED_APP_IMPORTS = frozenset(
+_RUNTIME_TYPE_ONLY_APP_IMPORTS = frozenset(
+    {
+        "archetype.app.autoresearch_service",
+        "archetype.app.eval_service",
+    }
+)
+_RUNTIME_ALLOWED_APP_IMPORTS = _RUNTIME_TYPE_ONLY_APP_IMPORTS | frozenset(
     {
         "archetype.app.command_service",
         "archetype.app.container",
         "archetype.app.models",
         "archetype.app.auth.models",
-        # Type-only signature references; the operations themselves route
-        # through the gate (CommandType.AUTORESEARCH, QUERY_WORLD).
-        "archetype.app.autoresearch_service",
-        "archetype.app.eval_service",
     }
 )
 
@@ -275,6 +277,18 @@ def _in_ranges(lineno: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= lineno <= end for start, end in ranges)
 
 
+def _is_app_module(module: str) -> bool:
+    return module == "archetype.app" or module.startswith("archetype.app.")
+
+
+def _runtime_app_import_is_allowed(
+    module: str, lineno: int, type_checking_ranges: list[tuple[int, int]]
+) -> bool:
+    return module in _RUNTIME_ALLOWED_APP_IMPORTS and (
+        module not in _RUNTIME_TYPE_ONLY_APP_IMPORTS or _in_ranges(lineno, type_checking_ranges)
+    )
+
+
 def _called_attr_name(call: ast.Call) -> str | None:
     if isinstance(call.func, ast.Attribute):
         return call.func.attr
@@ -382,9 +396,11 @@ def task_runtime_gate_only_boundary() -> list[GraderResult]:
         rel = py.relative_to(ROOT)
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module:
-                if node.module.startswith("archetype.app"):
+                if _is_app_module(node.module):
                     key = f"{rel}:{node.lineno}:allowed_app_import:{node.module}"
-                    import_checks[key] = node.module in _RUNTIME_ALLOWED_APP_IMPORTS
+                    import_checks[key] = _runtime_app_import_is_allowed(
+                        node.module, node.lineno, tc_ranges
+                    )
                 for alias in node.names:
                     if alias.name in {"iWorld", "AsyncWorld"}:
                         key = f"{rel}:{node.lineno}:world_import:{alias.name}"
@@ -392,9 +408,11 @@ def task_runtime_gate_only_boundary() -> list[GraderResult]:
 
             if isinstance(node, ast.Import):
                 for alias in node.names:
-                    if alias.name.startswith("archetype.app"):
+                    if _is_app_module(alias.name):
                         key = f"{rel}:{node.lineno}:allowed_app_import:{alias.name}"
-                        import_checks[key] = alias.name in _RUNTIME_ALLOWED_APP_IMPORTS
+                        import_checks[key] = _runtime_app_import_is_allowed(
+                            alias.name, node.lineno, tc_ranges
+                        )
                     if alias.name in {"iWorld", "AsyncWorld"}:
                         key = f"{rel}:{node.lineno}:world_import:{alias.name}"
                         world_ref_checks[key] = _in_ranges(node.lineno, tc_ranges)

--- a/scripts/check_api_import_boundaries.py
+++ b/scripts/check_api_import_boundaries.py
@@ -113,12 +113,16 @@ def _imported_modules(node: ast.AST) -> list[str]:
     return []
 
 
+def _is_app_module(module: str) -> bool:
+    return module == "archetype.app" or module.startswith("archetype.app.")
+
+
 def _import_violations(path: Path, allowed: set[str], forbidden: set[str], scope: str) -> list[str]:
     tree = ast.parse(path.read_text(), filename=str(path))
     violations: list[str] = []
     for node in ast.walk(tree):
         for module in _imported_modules(node):
-            if not module.startswith("archetype.app"):
+            if not _is_app_module(module):
                 continue
             if module in forbidden:
                 violations.append(

--- a/tests/app/test_import_boundaries.py
+++ b/tests/app/test_import_boundaries.py
@@ -14,23 +14,28 @@ import ast
 import typing
 from pathlib import Path
 
+import pytest
+
 _ROOT = Path(__file__).resolve().parents[2] / "src" / "archetype"
 _RUNTIME_DIR = _ROOT / "runtime"
 _API_DIR = _ROOT / "api"
 
 # ─── Allowed app imports ─────────────────────────────────────────────────────
 
+_RUNTIME_TYPE_ONLY_APP = frozenset(
+    {
+        "archetype.app.autoresearch_service",
+        "archetype.app.eval_service",
+    }
+)
+
 # Modules inside archetype.app that runtime/ may import from.
-_RUNTIME_ALLOWED_APP = frozenset(
+_RUNTIME_ALLOWED_APP = _RUNTIME_TYPE_ONLY_APP | frozenset(
     {
         "archetype.app.command_service",
         "archetype.app.container",
         "archetype.app.models",
         "archetype.app.auth.models",
-        # Type-only signature references for world.autoresearch / world.grade;
-        # the operations themselves route through the gate.
-        "archetype.app.autoresearch_service",
-        "archetype.app.eval_service",
     }
 )
 
@@ -53,45 +58,66 @@ def _python_files(directory: Path) -> list[Path]:
     return sorted(directory.rglob("*.py"))
 
 
+def _type_checking_ranges(tree: ast.AST) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        is_type_checking = (
+            isinstance(test, ast.Name)
+            and test.id == "TYPE_CHECKING"
+            or isinstance(test, ast.Attribute)
+            and test.attr == "TYPE_CHECKING"
+        )
+        if not is_type_checking or not node.body:
+            continue
+        start = min(getattr(child, "lineno", node.lineno) for child in node.body)
+        end = max(
+            getattr(child, "end_lineno", getattr(child, "lineno", node.lineno))
+            for child in node.body
+        )
+        ranges.append((start, end))
+    return ranges
+
+
+def _in_ranges(lineno: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= lineno <= end for start, end in ranges)
+
+
+def _is_app_module(module: str) -> bool:
+    return module == "archetype.app" or module.startswith("archetype.app.")
+
+
+def _runtime_app_import_is_allowed(module: str, in_type_checking: bool) -> bool:
+    return module in _RUNTIME_ALLOWED_APP and (
+        module not in _RUNTIME_TYPE_ONLY_APP or in_type_checking
+    )
+
+
 def _extract_app_imports(filepath: Path) -> list[tuple[str, int, bool]]:
     """Parse *filepath* and return (module, lineno, in_type_checking) for every
-    ``from archetype.app...`` import.
+    ``archetype.app`` import.
 
     *in_type_checking* is True when the import lives inside an
     ``if TYPE_CHECKING:`` block.
     """
     source = filepath.read_text()
     tree = ast.parse(source, filename=str(filepath))
-
-    # Detect TYPE_CHECKING block ranges
-    tc_ranges: list[tuple[int, int]] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.If):
-            test = node.test
-            # Match: TYPE_CHECKING  or  typing.TYPE_CHECKING
-            is_tc = False
-            if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
-                is_tc = True
-            elif isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
-                is_tc = True
-            if is_tc:
-                start = node.body[0].lineno if node.body else node.lineno
-                end = max(
-                    getattr(n, "end_lineno", n.lineno) for n in node.body if hasattr(n, "lineno")
-                )
-                tc_ranges.append((start, end))
-
-    def _in_tc(lineno: int) -> bool:
-        return any(s <= lineno <= e for s, e in tc_ranges)
+    type_checking_ranges = _type_checking_ranges(tree)
 
     results: list[tuple[str, int, bool]] = []
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.ImportFrom)
-            and node.module
-            and node.module.startswith("archetype.app")
-        ):
-            results.append((node.module, node.lineno, _in_tc(node.lineno)))
+        if isinstance(node, ast.ImportFrom) and node.module and _is_app_module(node.module):
+            results.append(
+                (node.module, node.lineno, _in_ranges(node.lineno, type_checking_ranges))
+            )
+        elif isinstance(node, ast.Import):
+            results.extend(
+                (alias.name, node.lineno, _in_ranges(node.lineno, type_checking_ranges))
+                for alias in node.names
+                if _is_app_module(alias.name)
+            )
     return results
 
 
@@ -99,26 +125,7 @@ def _extract_name_imports(filepath: Path, names: frozenset[str]) -> list[tuple[s
     """Return (name, lineno, in_type_checking) for imports of any *names*."""
     source = filepath.read_text()
     tree = ast.parse(source, filename=str(filepath))
-
-    # Detect TYPE_CHECKING block ranges (same logic)
-    tc_ranges: list[tuple[int, int]] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.If):
-            test = node.test
-            is_tc = False
-            if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
-                is_tc = True
-            elif isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
-                is_tc = True
-            if is_tc:
-                start = node.body[0].lineno if node.body else node.lineno
-                end = max(
-                    getattr(n, "end_lineno", n.lineno) for n in node.body if hasattr(n, "lineno")
-                )
-                tc_ranges.append((start, end))
-
-    def _in_tc(lineno: int) -> bool:
-        return any(s <= lineno <= e for s, e in tc_ranges)
+    type_checking_ranges = _type_checking_ranges(tree)
 
     results: list[tuple[str, int, bool]] = []
     for node in ast.walk(tree):
@@ -130,7 +137,9 @@ def _extract_name_imports(filepath: Path, names: frozenset[str]) -> list[tuple[s
                 imported = [alias.name for alias in node.names]
             for name in imported:
                 if name in names:
-                    results.append((name, node.lineno, _in_tc(node.lineno)))
+                    results.append(
+                        (name, node.lineno, _in_ranges(node.lineno, type_checking_ranges))
+                    )
     return results
 
 
@@ -143,14 +152,52 @@ class TestRuntimeAppBoundary:
     def test_runtime_imports_only_allowed_app_modules(self):
         violations: list[str] = []
         for py in _python_files(_RUNTIME_DIR):
-            for module, lineno, _in_tc in _extract_app_imports(py):
-                if module not in _RUNTIME_ALLOWED_APP:
+            for module, lineno, in_type_checking in _extract_app_imports(py):
+                if not _runtime_app_import_is_allowed(module, in_type_checking):
                     rel = py.relative_to(_ROOT)
                     violations.append(f"{rel}:{lineno}  imports {module}")
 
         assert not violations, "runtime/ imports disallowed app modules:\n  " + "\n  ".join(
             violations
         )
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    [
+        (
+            "import archetype.app.world_service\n",
+            [("archetype.app.world_service", False)],
+        ),
+        (
+            "from archetype.app.eval_service import EvaluationResult\n",
+            [("archetype.app.eval_service", False)],
+        ),
+        ("from archetype.application import Service\n", []),
+        (
+            "from typing import TYPE_CHECKING\n"
+            "if TYPE_CHECKING:\n"
+            "    import archetype.app.eval_service\n",
+            [("archetype.app.eval_service", True)],
+        ),
+        (
+            "from typing import TYPE_CHECKING\n"
+            "if TYPE_CHECKING:\n"
+            "    from archetype.app.eval_service import EvaluationResult\n",
+            [("archetype.app.eval_service", True)],
+        ),
+    ],
+)
+def test_runtime_app_import_oracle_contract(tmp_path, source_text, expected) -> None:
+    probe = tmp_path / "probe.py"
+    probe.write_text(source_text, encoding="utf-8")
+
+    actual = [
+        (module, _runtime_app_import_is_allowed(module, in_type_checking))
+        for module, _, in_type_checking in _extract_app_imports(probe)
+    ]
+
+    assert actual == expected
 
 
 class TestApiAppBoundary:

--- a/tests/app/test_import_boundaries.py
+++ b/tests/app/test_import_boundaries.py
@@ -40,8 +40,12 @@ _RUNTIME_ALLOWED_APP = _RUNTIME_TYPE_ONLY_APP | frozenset(
 )
 
 # Modules inside archetype.app that api/ may import from.
-_API_ALLOWED_APP = _RUNTIME_ALLOWED_APP | frozenset(
+_API_ALLOWED_APP = frozenset(
     {
+        "archetype.app.command_service",
+        "archetype.app.container",
+        "archetype.app.models",
+        "archetype.app.auth.models",
         "archetype.app.auth.errors",
         # The gate's typed error contract; mapping it to HTTP status codes
         # is the adapter's job (issue #180: WorldNotFoundError -> 404).
@@ -93,6 +97,10 @@ def _runtime_app_import_is_allowed(module: str, in_type_checking: bool) -> bool:
     return module in _RUNTIME_ALLOWED_APP and (
         module not in _RUNTIME_TYPE_ONLY_APP or in_type_checking
     )
+
+
+def _api_app_import_is_allowed(module: str) -> bool:
+    return module in _API_ALLOWED_APP
 
 
 def _extract_app_imports(filepath: Path) -> list[tuple[str, int, bool]]:
@@ -207,11 +215,24 @@ class TestApiAppBoundary:
         violations: list[str] = []
         for py in _python_files(_API_DIR):
             for module, lineno, _in_tc in _extract_app_imports(py):
-                if module not in _API_ALLOWED_APP:
+                if not _api_app_import_is_allowed(module):
                     rel = py.relative_to(_ROOT)
                     violations.append(f"{rel}:{lineno}  imports {module}")
 
         assert not violations, "api/ imports disallowed app modules:\n  " + "\n  ".join(violations)
+
+
+@pytest.mark.parametrize(
+    ("module", "expected"),
+    [
+        ("archetype.app.command_service", True),
+        ("archetype.app.errors", True),
+        ("archetype.app.eval_service", False),
+        ("archetype.app.autoresearch_service", False),
+    ],
+)
+def test_api_app_import_oracle_contract(module: str, expected: bool) -> None:
+    assert _api_app_import_is_allowed(module) is expected
 
 
 class TestNoWorldLeakInRuntime:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -355,6 +355,15 @@ class TestCLIIntegration:
             assert empty in result.output
 
 
+def _is_app_module(module: str) -> bool:
+    return module == "archetype.app" or module.startswith("archetype.app.")
+
+
+def test_cli_app_import_boundary_uses_dotted_segments():
+    assert _is_app_module("archetype.app.models")
+    assert not _is_app_module("archetype.application")
+
+
 def test_cli_does_not_import_forbidden_app_modules():
     source = cli_mod.__file__
     tree = ast.parse(open(source).read())
@@ -366,9 +375,9 @@ def test_cli_does_not_import_forbidden_app_modules():
             module = node.module
         elif isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name.startswith("archetype.app") and alias.name not in allowed:
+                if _is_app_module(alias.name) and alias.name not in allowed:
                     forbidden.append(alias.name)
-        if module and module.startswith("archetype.app") and module not in allowed:
+        if module and _is_app_module(module) and module not in allowed:
             forbidden.append(module)
     assert forbidden == []
 

--- a/tests/spec_contracts/test_spec_contract_evals.py
+++ b/tests/spec_contracts/test_spec_contract_evals.py
@@ -8,8 +8,24 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import pytest
+
 from evals.run import build_harness
 from evals.suites import spec_contracts
+
+
+def _runtime_import_result(tmp_path, monkeypatch, source_text):
+    runtime_dir = tmp_path / "src" / "archetype" / "runtime"
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "probe.py").write_text(source_text, encoding="utf-8")
+    monkeypatch.setattr(spec_contracts, "ROOT", tmp_path)
+    monkeypatch.setattr(spec_contracts, "SRC", tmp_path / "src" / "archetype")
+
+    return next(
+        result
+        for result in spec_contracts.task_runtime_gate_only_boundary()
+        if result.grader_name == "runtime_app_imports"
+    )
 
 
 def test_spec_contract_eval_suite_passes() -> None:
@@ -43,16 +59,59 @@ def test_spec_contract_cli_suite_is_runnable() -> None:
 
 
 def test_runtime_gate_rejects_disallowed_plain_import(tmp_path, monkeypatch) -> None:
-    runtime_dir = tmp_path / "src" / "archetype" / "runtime"
-    runtime_dir.mkdir(parents=True)
-    (runtime_dir / "bad.py").write_text("import archetype.app.world_service\n", encoding="utf-8")
-    monkeypatch.setattr(spec_contracts, "ROOT", tmp_path)
-    monkeypatch.setattr(spec_contracts, "SRC", tmp_path / "src" / "archetype")
-
-    results = spec_contracts.task_runtime_gate_only_boundary()
-
-    runtime_imports = next(
-        result for result in results if result.grader_name == "runtime_app_imports"
+    result = _runtime_import_result(
+        tmp_path,
+        monkeypatch,
+        "import archetype.app.world_service\n",
     )
-    assert runtime_imports.passed is False
-    assert "archetype.app.world_service" in runtime_imports.details
+
+    assert result.passed is False
+    assert "archetype.app.world_service" in result.details
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        "import archetype.application\n",
+        "from archetype.application import Service\n",
+    ],
+)
+def test_runtime_gate_uses_a_dotted_app_boundary(tmp_path, monkeypatch, source_text) -> None:
+    result = _runtime_import_result(tmp_path, monkeypatch, source_text)
+
+    assert result.passed is True
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        "import archetype.app.eval_service\n",
+        "from archetype.app.eval_service import EvaluationResult\n",
+    ],
+)
+def test_runtime_gate_rejects_operational_type_only_imports(
+    tmp_path, monkeypatch, source_text
+) -> None:
+    result = _runtime_import_result(tmp_path, monkeypatch, source_text)
+
+    assert result.passed is False
+    assert "archetype.app.eval_service" in result.details
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    import archetype.app.eval_service\n",
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    from archetype.app.eval_service import EvaluationResult\n",
+    ],
+)
+def test_runtime_gate_allows_type_only_imports_under_type_checking(
+    tmp_path, monkeypatch, source_text
+) -> None:
+    result = _runtime_import_result(tmp_path, monkeypatch, source_text)
+
+    assert result.passed is True

--- a/tests/spec_contracts/test_spec_contract_evals.py
+++ b/tests/spec_contracts/test_spec_contract_evals.py
@@ -40,3 +40,19 @@ def test_spec_contract_cli_suite_is_runnable() -> None:
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "[SPEC]" in proc.stdout
+
+
+def test_runtime_gate_rejects_disallowed_plain_import(tmp_path, monkeypatch) -> None:
+    runtime_dir = tmp_path / "src" / "archetype" / "runtime"
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "bad.py").write_text("import archetype.app.world_service\n", encoding="utf-8")
+    monkeypatch.setattr(spec_contracts, "ROOT", tmp_path)
+    monkeypatch.setattr(spec_contracts, "SRC", tmp_path / "src" / "archetype")
+
+    results = spec_contracts.task_runtime_gate_only_boundary()
+
+    runtime_imports = next(
+        result for result in results if result.grader_name == "runtime_app_imports"
+    )
+    assert runtime_imports.passed is False
+    assert "archetype.app.world_service" in runtime_imports.details

--- a/tests/test_boundary_checker.py
+++ b/tests/test_boundary_checker.py
@@ -87,6 +87,17 @@ def test_experiments_scope_allows_models(tmp_path, monkeypatch):
     )
 
 
+def test_import_scope_ignores_dotted_sibling_packages(tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+    path = _write(tmp_path, "import archetype.application\n")
+    assert (
+        checker._import_violations(
+            path, checker.ALLOWED_APP_IMPORTS_EXPERIMENTS, set(), "experiments"
+        )
+        == []
+    )
+
+
 def test_experiments_scope_scans_nested_subdirectories(tmp_path, monkeypatch):
     """Nested experiment modules must not escape the import scan (the reviewer
     caught the original non-recursive glob)."""


### PR DESCRIPTION
## Summary

- apply the runtime app-import allowlist to plain `import archetype.app...` statements
- share one dotted package-boundary predicate across `Import` and `ImportFrom`
- require `autoresearch_service` and `eval_service` imports to remain under `TYPE_CHECKING`
- align the independent fast pytest oracle while keeping its implementation separate
- keep the API oracle's allowlist explicit instead of inheriting runtime-only exceptions
- apply the same dotted package boundary to the API checker and CLI oracle
- cover forbidden, sibling-prefix, operational, and type-only forms in contract tests

## MRE

On exact `main` (`3aa9757`), a runtime module containing
`import archetype.app.world_service` passes the R1 boundary grader. The same
checkout-relative MRE passes on this branch because the grader rejects that
forbidden dependency.

The exact review MREs also establish that pre-fix head `4d0cd6c` rejects the
unrelated sibling `archetype.application` (#430) and allows an operational
`archetype.app.eval_service` import outside `TYPE_CHECKING` (#431). Both pass on
this head, including positive controls for both import syntaxes under
`TYPE_CHECKING`.

The second exact review exposed the older fast oracle's three-way disagreement
with the R1 eval (#432). Its checkout-relative MRE fails all three cases on
`main` and pre-fix head `96e5f14`; all three pass on this head.

The third exact review found two more independent-oracle defects. The API
pytest oracle permits operational `eval_service` imports that the API checker
forbids (#433), while the API checker and CLI oracle both misclassify
`archetype.application` as an app import (#434). Their three checkout-relative
MRE cases fail on current `main` and pass on this branch.

## Validation

- exact #343, #430, #431, #432, #433, and #434 MREs — 10 passed on this branch
- focused boundary-contract tests — 54 passed
- `make ci` — 1102 passed, 7 skipped; 85.66% coverage
- regression evals — 12/12 passed
- infrastructure idempotency audit — 23/23 passed
- `git diff --check`; changed files pass Ruff lint and format checks

Closes #343
Closes #430
Closes #431
Closes #432
Closes #433
Closes #434
