### PR TITLE
fix(bench): isolate default benchmark storage

### DIFF
--- a/bench/core/ecs/run.py
+++ b/bench/core/ecs/run.py
@@ -9,13 +9,13 @@ from dataclasses import asdict
 from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
 
 from . import add_remove, entity_cycle, fragmented_iteration, packed_iteration, simple_iteration
+from .common import _default_storage
 
 
-def _storage_for_bench(storage: StorageConfig | None, bench_name: str) -> StorageConfig | None:
+def _storage_for_bench(storage: StorageConfig | None, bench_name: str) -> StorageConfig:
     """Give each bench its own namespace so sibling benches cannot see one
     another's tables when they happen to share component class names."""
-    if storage is None:
-        return None
+    storage = storage or _default_storage()
     suffix = bench_name.replace("-", "_")
     namespace = f"{storage.namespace}__{suffix}" if storage.namespace else suffix
     return storage.model_copy(update={"namespace": namespace})

--- a/tests/bench/test_ecs_run_isolation.py
+++ b/tests/bench/test_ecs_run_isolation.py
@@ -8,8 +8,16 @@ from archetype.core.config import StorageBackend, StorageConfig
 from bench.core.ecs.run import _storage_for_bench, run_all
 
 
-def test_storage_for_bench_returns_none_when_storage_is_none():
-    assert _storage_for_bench(None, "packed_iteration") is None
+def test_storage_for_bench_suffixes_default_storage(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARCHETYPE_DATA_URI", str(tmp_path))
+    monkeypatch.setenv("ARCHETYPE_BENCH_NS", "default")
+
+    packed = _storage_for_bench(None, "packed_iteration")
+    simple = _storage_for_bench(None, "simple_iteration")
+
+    assert packed.uri == str(tmp_path)
+    assert packed.namespace == "default__packed_iteration"
+    assert simple.namespace == "default__simple_iteration"
 
 
 def test_storage_for_bench_appends_bench_suffix_to_namespace():

--- a/tests/bench/test_ecs_run_isolation.py
+++ b/tests/bench/test_ecs_run_isolation.py
@@ -1,4 +1,4 @@
-"""Regression tests for bench/core/ecs/run.py dataset isolation (issue #146)."""
+"""Regression tests for bench/core/ecs/run.py dataset isolation (issue #338)."""
 
 from __future__ import annotations
 
@@ -23,7 +23,6 @@ def test_storage_for_bench_suffixes_default_storage(tmp_path, monkeypatch):
 def test_storage_for_bench_appends_bench_suffix_to_namespace():
     storage = StorageConfig(uri="/tmp/x", namespace="benchmarks")
     out = _storage_for_bench(storage, "packed_iteration")
-    assert out is not None
     assert out.uri == "/tmp/x"
     assert out.namespace == "benchmarks__packed_iteration"
 


### PR DESCRIPTION
## What changed

- resolve `storage=None` through the existing environment-aware benchmark default
- append the benchmark name before each benchmark creates its world
- cover both explicit and default storage namespace isolation

## MRE

Issue #338 reproduces on exact current main `646f07d`: sibling benchmarks both
resolve to the `ARCHETYPE_BENCH_NS` namespace. The same checkout-relative MRE
passes on this branch with `mre__packed_iteration` and
`mre__simple_iteration`.

This changes only benchmark orchestration. It does not alter `StorageConfig`,
the storage factory, credential handling, or core persistence contracts.

## Validation

- exact issue #338 MRE: passed
- benchmark isolation suite: 6 passed
- `make ci`: 1102 passed, 7 skipped, 85.41% coverage
- regression evals: 12/12 passed
- infrastructure idempotency audit: 23/23 passed
- changed files pass Ruff lint and format checks; `git diff --check`

Closes #338
