### PR TITLE
docs: distinguish messaging queueing from delivery

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -456,50 +456,46 @@ See ``lazy_audit.toml`` for the authoritative policy header and
 
 ---
 
-## Agent Communication: Messaging Pipeline (Mar 2026)
+## Agent Communication: Queueing vs Delivery (updated Jul 2026)
 
-Agent-to-agent messaging is processor-driven, not broker-driven.
+Archetype provides messaging mechanisms, not a framework delivery policy:
 
-**The broker is governance only** — RBAC, quotas, command queuing. It does NOT own message delivery or conversation structure.
+- `CommandType.MESSAGE` is an RBAC-visible command envelope.
+- `CommandBroker` can queue, order, and record recent in-memory enqueue history.
+- `Resources`, processors, and hooks are the primitives applications can
+  compose into routing and realization behavior.
 
-**Components:**
+The framework does not define a message payload schema, recipient validation,
+inbox/outbox components, delivery receipts, channels, or a conversation graph.
+The command-service drain also has no `MESSAGE` application branch, so
+submitting a message command is not equivalent to delivering it to an entity.
+A host that uses brokered message envelopes must supply the consumer and its
+delivery semantics.
 
-```python
-class Outbox(Component):
-    messages: list[str] = []  # JSON-encoded: {"receiver_id": int, "channel": str, "content": str}
-
-class Inbox(Component):
-    messages: list[str] = []  # JSON-encoded: {"sender_id": int, "channel": str, "content": str, "tick": int}
-```
-
-**Delivery pipeline:**
+[`examples/04_messaging.py`](examples/04_messaging.py) demonstrates one such
+policy entirely in application code:
 
 ```text
-Agent processor writes to Outbox (priority 10+)
-        ↓
-MessageDeliveryProcessor (priority -100, runs first next tick)
-  ├── reads Outbox via DataFrame
-  ├── validates: receiver exists? not self-messaging?
-  ├── routes to recipient Inbox via @daft.func
-  ├── updates ChatGraph Resource (if present)
-  └── rejected → sender's DeliveryReceipt
-        ↓
-Downstream processors read Inbox for LLM context
+MessageRealizationProcessor (priority -100)
+  └── drains the example-local Mailbox resource into Inbox components
+GreetingProcessor (priority 10)
+  └── deposits new greetings into Mailbox
+MoodProcessor (priority 20)
+  └── reads the realized Inbox state
 ```
 
-**Key insight:** Messages written to Outbox at tick N are delivered to Inbox at tick N+1. This enforces causal ordering — no agent can read a message from the same tick it was sent.
+Because realization runs before greeting generation, work deposited during
+tick N remains pending until the realization pass in tick N+1. That causal
+delay is a property of this example's priorities and shared `Mailbox`; it is
+not an automatic guarantee of `CommandType.MESSAGE`. The example's `Mailbox`,
+`Inbox`, `Outbox`, and processors are local definitions, not exports from
+`archetype`.
 
-**ChatGraph** is a Resource (not entity data). It tracks conversation structure as a DAG per (world, channel):
-
-```python
-registry = resources.require(ChatGraphRegistry)
-graph = registry.channel(world_id, "strategy")
-context = graph.active_path()  # root → cursor, for LLM context windows
-```
-
-**Channels** are first-class routing keys. Each channel gets its own independent conversation graph. Default is `"general"`.
-
-**`append_history` toggle:** a command with `payload={"append_history": False}` (or equivalent) makes a message ephemeral — delivered but not recorded in broker history or ChatGraph. Use for heartbeats, probes, system messages.
+The mailbox is also mutable world-shared state. The demo keeps all agents in
+one archetype table. A composition that accesses the same mailbox from
+multiple table tasks must add synchronization or use another explicit
+deferred boundary; processor priority orders work within a table, not across
+concurrent table tasks.
 
 ---
 
@@ -534,8 +530,6 @@ Enable with `run_config.debug = True`:
 [archetype] {"event": "tick_start", "world_id": "...", "tick": 0}
 [archetype] processor_start: PhysicsProcessor (priority=10)
 [archetype] processor_end: PhysicsProcessor (rows_out=100)
-[broker] enqueue: world=demo, type=message, pending=6
-[broker] dequeue: world=demo, returned=6, types={'message': 6}
 ```
 
 ---
@@ -643,7 +637,8 @@ for entry in history:
 7. **JSON-encode** complex types (`list[dict]`, nested objects) for Arrow compatibility
 8. **Resources** for type-safe DI in processors
 9. **Hooks** for observability without processor coupling
-10. **Messaging pipeline** — Outbox/Inbox components + MessageDeliveryProcessor (not broker)
+10. **Messaging delivery is application composition** — the broker queues
+    `MESSAGE` envelopes; applications define payloads, routing, and realization
 11. **Tick-gating** for expensive operations (LLM calls, inner worlds)
 12. **Keep columns in DAG** — avoid intermediate `.collect()` breaking lazy evaluation
 

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -150,7 +150,9 @@ apply on the following tick — the table contains `x_0, f(x_0), f^2(x_0), ...`.
 
 ## 4. Agent Messaging
 
-Three agents send greetings to each other via tick-deferred `MESSAGE` commands. Mood and energy update based on messages received.
+Three agents exchange greetings through an example-local shared `Mailbox`.
+Priority-ordered processors realize pending messages on the following tick,
+then update mood and energy from each inbox.
 
 ```bash
 uv run python examples/04_messaging.py
@@ -161,23 +163,31 @@ Source: [`examples/04_messaging.py`](https://github.com/VangelisTech/archetype/b
 **What it demonstrates:**
 
 - **Components**: `AgentState` (name, mood, energy), `Inbox`, `Outbox`
-- **Resources**: `SimConfig` for shared parameters, `CommandBroker` for message routing
-- **Processors**: `GreetingProcessor` (sends messages), `MessageRealizationProcessor` (drains broker into inboxes), `MoodProcessor` (updates mood based on inbox)
+- **Resources**: `SimConfig` for shared parameters, `Mailbox` for pending messages
+- **Processors**: `GreetingProcessor` (deposits messages), `MessageRealizationProcessor` (drains the mailbox into inboxes), `MoodProcessor` (updates mood based on inbox)
 - **Hooks**: `PreTick` and `PostTick` lifecycle callbacks
 
-Output:
+Selected output (earlier history rows omitted):
 
 ```text
-Archetype Messaging Demo: Resources + MESSAGE + Hooks
+Archetype Messaging Demo: Resources + Shared Mailbox + Hooks
 
--> Pre-tick 0: Starting processing...
-<- Post-tick 1: Completed!
-   Messages pending in broker: 6
+-> Pre-tick 1: Starting processing...
+<- Post-tick 2: Completed!
+   Messages delivered so far: 0
+   Messages pending in mailbox: 6
 
-Final State:
-  Alice:   mood=happy, energy=130.0, 2 messages received
-  Bob:     mood=happy, energy=130.0, 2 messages received
-  Charlie: mood=happy, energy=130.0, 2 messages received
+-> Pre-tick 2: Starting processing...
+<- Post-tick 3: Completed!
+   Messages delivered so far: 6
+   Messages pending in mailbox: 6
+
+Message counts:
+  Alice: 2 messages received
+  Bob: 2 messages received
+  Charlie: 2 messages received
+
+Total messages delivered: 6
 ```
 
 ---

--- a/docs/guide/system-execution.md
+++ b/docs/guide/system-execution.md
@@ -28,16 +28,18 @@ When you spawn an entity, its component types determine which **archetype** it b
 `Archetype.sig_from_components()` sorts component types alphabetically by class name to produce a canonical **signature** — a tuple of types:
 
 ```python
-# Entity spawned with [Outbox(), Inbox()]
-sig = Archetype.sig_from_components([Outbox(), Inbox()])
-# => (Inbox, Outbox)  — sorted alphabetically
+# Entity spawned with [Velocity(), Position()]
+sig = Archetype.sig_from_components([Velocity(), Position()])
+# => (Position, Velocity)  — sorted alphabetically
 
-# Entity spawned with [Outbox(), Inbox(), DeliveryReceipt()]
-sig = Archetype.sig_from_components([Outbox(), Inbox(), DeliveryReceipt()])
-# => (DeliveryReceipt, Inbox, Outbox)  — DIFFERENT signature
+# Entity spawned with [Velocity(), Position(), Health()]
+sig = Archetype.sig_from_components([Velocity(), Position(), Health()])
+# => (Health, Position, Velocity)  — DIFFERENT signature
 ```
 
-Sorting ensures that `[Inbox(), Outbox()]` and `[Outbox(), Inbox()]` produce the same signature. Order of construction doesn't matter — only the set of types.
+Sorting ensures that `[Position(), Velocity()]` and `[Velocity(), Position()]`
+produce the same signature. Order of construction doesn't matter — only the
+set of types.
 
 ### Step 2: Schema Construction
 
@@ -49,20 +51,20 @@ BASE_SCHEMA:
   tick (int32), is_active (bool), commit_token (string),
   writer_epoch (int64)
 
-+ Inbox.get_prefixed_schema():
-  inbox__messages (list<string>)
++ Position.get_prefixed_schema():
+  position__x (double), position__y (double)
 
-+ Outbox.get_prefixed_schema():
-  outbox__messages (list<string>)
++ Velocity.get_prefixed_schema():
+  velocity__dx (double), velocity__dy (double)
 
 = Full archetype schema
 ```
 
 Each component class generates its prefix via `Component.get_prefix()`:
 
-- `Inbox` becomes `inbox__`
-- `Outbox` becomes `outbox__`
-- `DeliveryReceipt` becomes `deliveryreceipt__`
+- `Position` becomes `position__`
+- `Velocity` becomes `velocity__`
+- `Health` becomes `health__`
 
 ### Step 3: Archetype Naming
 
@@ -123,10 +125,10 @@ PhysicsProcessor(components=(Position, Velocity))
     runs on (Accel, Position, Velocity)               # superset matches
     skipped for (Position,)                           # missing Velocity
 
-MessageDeliveryProcessor(components=(DeliveryReceipt, Inbox, Outbox))
-    runs on (DeliveryReceipt, Inbox, Outbox)          # exact match
-    runs on (Agent, DeliveryReceipt, Inbox, Outbox)   # superset matches
-    skipped for (Inbox, Outbox)                       # missing DeliveryReceipt
+HealthProcessor(components=(Health,))
+    runs on (Health,)                                 # exact match
+    runs on (Health, Position, Velocity)              # superset matches
+    skipped for (Position, Velocity)                  # missing Health
 
 ObserverProcessor(components=())
     runs on EVERY archetype                           # empty set is subset of all
@@ -175,13 +177,17 @@ Typical priority ranges:
 
 | Range | Use |
 |-------|-----|
-| -100 to -1 | Infrastructure (message delivery, command draining) |
+| -100 to -1 | Application-defined staging or input realization |
 | 1 to 9 | Input gathering, sensor reads |
 | 10 to 49 | Core logic (agent thinking, physics) |
 | 50 to 99 | Output, side effects |
 | 100+ | Cleanup, metrics, bookkeeping |
 
-Example: `MessageDeliveryProcessor` at priority -100 populates inboxes before agent processors at priority 10+ read them. This ensures messages sent in tick N are available in tick N+1.
+For a concrete composition, `examples/04_messaging.py` defines an
+example-local `MessageRealizationProcessor` at priority -100. It drains that
+example's shared `Mailbox` before `GreetingProcessor` at priority 10 deposits
+new work. The resulting one-tick delay belongs to that processor/resource
+composition; `CommandType.MESSAGE` does not install a delivery pipeline.
 
 ## SyncSystem vs AsyncSystem
 
@@ -275,7 +281,11 @@ sharing boundary created by world forks.
 
 **Unnecessary defensive checks.** If your processor runs, the columns exist. Don't add `if "col" in df.columns` guards — they're dead code by construction.
 
-**Not understanding tick boundaries.** Messages written to Outbox at tick N are delivered to Inbox at tick N+1. Spawned entities appear next tick. These are features, not bugs — they ensure causal ordering.
+**Assuming every deferred behavior is built in.** Spawned entities materialize
+at the next tick boundary. Message delivery does not: `CommandType.MESSAGE`
+is a queueable command envelope, not a recipient schema or delivery policy.
+Applications that need inboxes, routing, or a one-tick communication delay
+must compose those semantics explicitly, as `examples/04_messaging.py` does.
 
 **Forgetting that `components=()` matches everything.** An observer processor with an empty components tuple will run on every archetype table. This is useful for metrics but can be surprising if unintentional.
 
@@ -299,3 +309,4 @@ order.
 | `src/archetype/core/aio/async_system.py` | Async subset matching and keyword filtering |
 | `src/archetype/core/aio/async_world.py` | Signature interning and two-phase per-table scheduling |
 | `src/archetype/core/resources.py` | Mutable world-shared resource container |
+| `examples/04_messaging.py` | Application-local mailbox and message-realization composition |

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ uv run python examples/<filename>.py
 | 1 | [`01_world_mutations.py`](01_world_mutations.py) | Every mutation type: spawn, despawn, add_processor, RBAC, fork, audit history | None |
 | 2 | [`02_fork_counterfactual.py`](02_fork_counterfactual.py) | Fork a world three times, run each branch, compare results | None |
 | 3 | [`03_time_travel.py`](03_time_travel.py) | Rewind to any past tick by filtering the `tick` column, then fork a counterfactual branch and diff it against the source | None |
-| 4 | [`04_messaging.py`](04_messaging.py) | Agent-to-agent messaging via tick-deferred `MESSAGE` commands, resources, and lifecycle hooks | None |
+| 4 | [`04_messaging.py`](04_messaging.py) | Agent-to-agent messaging via an application-local mailbox resource, priority-ordered processors, and lifecycle hooks | None |
 | 5 | [`05_llm_agents.py`](05_llm_agents.py) | LLM-powered agents — each entity gets a parallel LLM call every tick via `daft.functions.prompt` | `OPENAI_API_KEY` |
 | 6 | [`06_trajectory_analysis.py`](06_trajectory_analysis.py) | Trajectory analysis — ingest, label, and compare agent trajectories using world forking | Optional: `OPENAI_API_KEY` |
 | 7 | [`07_hooks.py`](07_hooks.py) | Lifecycle hooks for audit logs, tick metrics, and temporary debug traces | None |

--- a/src/archetype/app/models.py
+++ b/src/archetype/app/models.py
@@ -81,7 +81,7 @@ class CommandType(StrEnum):
     ADD_HOOK = "add_hook"
     REMOVE_HOOK = "remove_hook"
 
-    # Agent-to-agent messaging (realized at tick boundary)
+    # Application-defined message envelope (the broker supplies queueing only)
     MESSAGE = "message"
 
     # Extensible

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -16,6 +16,11 @@ _COMMAND_TOTAL_PATTERNS = (
     re.compile(r"\b(\d+)\s+command\s+types?\b", re.IGNORECASE),
     re.compile(r"\bcommand\s+types?\*{0,2}\s*\((\d+)\s+total\b", re.IGNORECASE),
 )
+_DESIGN_ONLY_MESSAGING_TYPES = (
+    "MessageDeliveryProcessor",
+    "DeliveryReceipt",
+    "ChatGraphRegistry",
+)
 
 
 def test_numeric_command_type_claims_match_the_enum() -> None:
@@ -62,3 +67,17 @@ def test_curated_example_command_roles_follow_permissions() -> None:
         assert documented == expected, (
             f"{command.value}: documented {documented}, expected {expected}"
         )
+
+
+def test_docs_do_not_claim_design_only_messaging_types() -> None:
+    """Unimplemented design sketches must not read as framework contracts."""
+    paths = [Path("LEARNINGS.md"), *sorted(_GUIDE_ROOT.glob("*.md"))]
+    stale: list[str] = []
+
+    for path in paths:
+        text = path.read_text()
+        for type_name in _DESIGN_ONLY_MESSAGING_TYPES:
+            if type_name in text:
+                stale.append(f"{path}: presents design-only {type_name}")
+
+    assert not stale, "stale messaging infrastructure claims:\n" + "\n".join(stale)


### PR DESCRIPTION
## Summary

- replace design-only messaging infrastructure in the execution guide and `LEARNINGS.md` with the boundary the repository actually implements
- distinguish the broker's queue/history mechanics from application-defined payload, routing, inbox, and realization policy
- align the messaging example guide and catalog with its real shared-`Mailbox` composition and observed output
- add an executable documentation oracle that rejects the three unimplemented framework types which previously read as current contracts
- correct the `CommandType.MESSAGE` source comment so it no longer promises built-in tick-boundary realization

## Root cause

Historical design notes for a delivery processor, receipts, and a conversation graph were copied into current guidance even though those types were never implemented under `src/archetype`. Meanwhile, `examples/04_messaging.py` moved to an example-local `Mailbox` resource, but its guide and catalog continued to describe brokered `MESSAGE` delivery.

The resulting documentation collapsed three distinct concerns: a queueable command envelope, application delivery policy, and one demo's processor/resource composition.

## Impact

Contributors now get an evidence-backed boundary: `CommandBroker` queues and orders envelopes; applications define delivery semantics. The guide also makes clear that the demo's one-tick delay follows from its processor priorities and is not a universal `CommandType.MESSAGE` guarantee.

## Validation

- `make ci` — 898 passed, 5 skipped, 85.1% coverage; regression 12/12; idempotency 22/22
- `uv run pytest -q tests/spec_contracts/test_documentation_contracts.py tests/integration/test_broker_messaging.py tests/core/test_resources_hooks_messaging.py` — 37 passed
- isolated smoke run of `examples/04_messaging.py`
- `npx --yes markdownlint-cli2 --config .markdownlint.yaml "docs/**/*.md" "*.md"`
- `make docs`
- `typos-cli` 1.48.0 against the checkout
- `lychee` 0.24.2 with the repository config — 215 links checked, 0 errors

Closes #348
