### PR TITLE
ci(footgun): scale detector turn budget with scope size

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -20,7 +20,7 @@ jobs:
   footgun-review:
     name: footgun-review
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 35
     permissions:
       contents: read
       pull-requests: read # Supply PR metadata to the read-only detector.
@@ -75,6 +75,21 @@ jobs:
             --scope "${SCOPE_FILE}"
           echo "schema=$(python3 scripts/footgun_review_gate.py schema)" >> "${GITHUB_OUTPUT}"
 
+      - name: Compute turn budget from scope
+        id: budget
+        run: |
+          python3 - <<'EOF' >> "${GITHUB_OUTPUT}"
+          import json, os
+          scope = json.load(open(os.environ["SCOPE_FILE"]))
+          n = len(scope["files"])
+          # A flat 40 turns starved dense diffs (the detector died at ~8 min
+          # on PR #375/#303-class heads with no structured output, while
+          # deletion-heavy #333 finished in 2m36s). Read/Grep/Glob coverage of
+          # every scoped file across all detector categories costs turns
+          # roughly linear in file count; scale with scope and cap the spend.
+          print(f"turns={min(120, max(40, 24 + 6 * n))}")
+          EOF
+
       - name: Run read-only footgun detector
         id: detector
         continue-on-error: true
@@ -84,7 +99,7 @@ jobs:
           github_token: ${{ github.token }}
           claude_args: |
             --allowedTools "Read,Grep,Glob"
-            --max-turns 40
+            --max-turns ${{ steps.budget.outputs.turns }}
             --json-schema '${{ steps.scope.outputs.schema }}'
           prompt: |
             Review PR #${{ github.event.pull_request.number }} at exact head


### PR DESCRIPTION
Fixes the footgun reviewer's capacity flakiness properly instead of bypassing it.

**Diagnosis**: flat `--max-turns 40` vs. a gate contract requiring every scoped file covered across all 22 detector categories with Read/Grep/Glob only. Deletion-heavy #333 fit (2m36s ✅); dense diffs starve — the action dies ~8 min in with no structured output (#303 heads ×2, #375 ×2), and `review-complete` correctly refuses. The merge then blocks on reviewer *capacity*, not review substance — the "gate blocks ~3/8 PRs" harness-audit residual.

**Fix**: turns scale deterministically from the scope artifact the gate already validates: `min(120, max(40, 24 + 6·n_files))`. Small PRs unchanged (40-turn floor), worst case bounded (120 turns / 35-min job timeout, up from 15). Example: #375's ~12-file scope → 96 turns.

Once on main, #375's footgun rerun picks this up via the merge ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)