### PR TITLE
fix(example): treat closed pull requests as done

### DIFF
--- a/examples/pr_triage.py
+++ b/examples/pr_triage.py
@@ -133,7 +133,7 @@ class TriageProcessor(AsyncProcessor):
     async def process(self, df: DataFrame, **kwargs) -> DataFrame:
         @daft.func
         def decide(state: str, staleness: float, risk: str) -> str:
-            if state == "MERGED":
+            if state in ("CLOSED", "MERGED"):
                 return "done"
             if staleness > 0.7:
                 return "close"

--- a/tests/integration/test_pr_triage_example.py
+++ b/tests/integration/test_pr_triage_example.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral contracts for the PR-triage example."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import daft
+import pytest
+
+
+def _load_example():
+    path = Path("examples/pr_triage.py")
+    spec = importlib.util.spec_from_file_location("pr_triage_contract", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_closed_pull_requests_are_terminal() -> None:
+    triage = _load_example()
+    frame = daft.from_pylist(
+        [
+            {
+                "pullrequest__state": state,
+                "triage__staleness": 0.1,
+                "triage__risk": "low",
+            }
+            for state in ("CLOSED", "MERGED", "OPEN")
+        ]
+    )
+
+    result = await triage.TriageProcessor().process(frame)
+
+    assert [row["triage__action"] for row in result.collect().to_pylist()] == [
+        "done",
+        "done",
+        "merge",
+    ]


### PR DESCRIPTION
## What changed

- classify both GitHub terminal PR states (`CLOSED` and `MERGED`) as `done`
- preserve the existing recommendation behavior for open PRs
- add a three-state executable example contract

## MRE

Issue #354 reproduces on exact current main `be3028f`: a closed, low-risk,
recent PR is labeled `merge`. The checkout-relative MRE passes on this branch,
and the committed regression verifies `CLOSED → done`, `MERGED → done`, and
`OPEN → merge` for the same inputs.

This changes one example processor and its contract test only. It does not
touch core, app services, storage, credentials, audit, or runtime contracts.

## Validation

- exact issue #354 MRE: passed
- committed terminal-state contract: passed
- `make ci`: 1104 passed, 6 skipped; 85.53% coverage
- regression evals: 12/12 passed
- infrastructure idempotency audit: 23/23 passed
- changed files pass Ruff lint and format checks; `git diff --check`

Closes #354
