### PR TITLE
docs: point LIBERO guidance to robot-evals

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -456,11 +456,17 @@ See ``lazy_audit.toml`` for the authoritative policy header and
 
 ---
 
-## Agent Communication: Messaging Pipeline (Mar 2026)
+## Agent Communication: Processor-Driven Messaging Sketch (Mar 2026)
 
-Agent-to-agent messaging is processor-driven, not broker-driven.
+This is an application-level design sketch, not implemented framework
+infrastructure. Archetype exposes brokered `MESSAGE` commands, but it does not
+export `Outbox`, `Inbox`, `DeliveryReceipt`, `MessageDeliveryProcessor`, or
+`ChatGraphRegistry`. Applications can define those types when they want
+mailboxes and conversation graphs represented in ECS state.
 
-**The broker is governance only** — RBAC, quotas, command queuing. It does NOT own message delivery or conversation structure.
+In this sketch, **the broker is governance only** — RBAC, quotas, and command
+queuing. The application-level processor owns message delivery and
+conversation structure.
 
 **Components:**
 
@@ -643,7 +649,8 @@ for entry in history:
 7. **JSON-encode** complex types (`list[dict]`, nested objects) for Arrow compatibility
 8. **Resources** for type-safe DI in processors
 9. **Hooks** for observability without processor coupling
-10. **Messaging pipeline** — Outbox/Inbox components + MessageDeliveryProcessor (not broker)
+10. **Messaging design sketch** — applications may define Outbox/Inbox
+    components and a delivery processor
 11. **Tick-gating** for expensive operations (LLM calls, inner worlds)
 12. **Keep columns in DAG** — avoid intermediate `.collect()` breaking lazy evaluation
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -719,11 +719,12 @@ recipe before touching torch pins or arguing about a Modal split. Highlights
 (still true, recorded here because the lessons are archetype-shaped):
 
 - **LIBERO and the VLA-JEPA policy run in-process**, one Python 3.12
-  interpreter shared with Archetype. `bench/libero/image.py` builds both images
-  and owns the **RUN LEDGER** (what has actually executed, with dates — check
-  it before citing any number from this surface); `in_process.py` drives
-  `OffScreenRenderEnv` directly; `in_process_policy.py` runs the VLA in the
-  same container. **No Modal interpreter split** —
+  interpreter shared with Archetype. In robot-evals,
+  `src/robot_evals/image.py` builds both images and owns the **RUN LEDGER**
+  (what has actually executed, with dates — check it before citing any number
+  from this surface); `src/robot_evals/in_process.py` drives
+  `OffScreenRenderEnv` directly; `src/robot_evals/in_process_policy.py` runs
+  the VLA in the same container. **No Modal interpreter split** —
   `modal_worker.py`/`vla_jepa_worker.py` were deleted 2026-07-15 (git history).
 - **Two commands** (in robot-evals): `modal run src/robot_evals/image.py`
   (env-only smoke) and `...::colocated_eval_task` (policy-driven eval).
@@ -756,8 +757,8 @@ mean 65/255 — the step-7 PNG was EGL noise.
 
 **Rule: any renderer (MuJoCo/EGL, OpenGL, most GPU sims) driven from archetype
 processors must marshal ALL calls — creation, reset, step — onto one
-persistent thread.** Reference implementation:
-`bench/libero/in_process.py::_EnvThread` (a daemon worker thread;
+persistent thread.** Reference implementation (in `everettVT/robot-evals`):
+`src/robot_evals/in_process.py::_EnvThread` (a daemon worker thread;
 `ThreadPoolExecutor` holds container shutdown hostage). Verification: dump an
 actual mid-episode frame and look at it — file-write success and correct
 proprio prove nothing about pixels.

--- a/docs/guide/autoresearch.md
+++ b/docs/guide/autoresearch.md
@@ -182,8 +182,9 @@ packaged experiment services:
   top, and `src/robot_evals/in_process_policy.py` colocates a VLA policy with
   the env.
 
-`docs/guide/libero-recipe.md` is the full recipe. The large benchmark sweeps are
-**user-triggered actions** (GPU cost); never run them in CI.
+`docs/guide/libero-recipe.md` records the extraction boundary and retained
+Archetype interfaces. The large benchmark sweeps are **user-triggered actions**
+(GPU cost); never run them in CI.
 
 ## References
 

--- a/docs/guide/autoresearch.md
+++ b/docs/guide/autoresearch.md
@@ -162,8 +162,9 @@ Experiment state gets the same operational properties as any other simulation in
 
 ## LIBERO on the ledger
 
-The same lab-world pattern extends to robotics benchmarks. `bench/libero/eval_run.py`
-runs batched LIBERO evals the Archetype-native way:
+The same lab-world pattern extends to robotics benchmarks. The external
+`everettVT/robot-evals` harness runs batched LIBERO evals against Archetype's
+packaged experiment services:
 
 - **One control-plane world per task, N trial entities** keyed by `env_key`. The env
   client batches by `env_key`, so one tick steps every live trial at once; finished
@@ -176,9 +177,10 @@ runs batched LIBERO evals the Archetype-native way:
   service**, not computed in the driver, so there is no summary component to drift
   from the ledger. (The old `eval_driver.py` / `EvalTrialResult` stack had exactly
   that drift problem and was removed.)
-- `bench/libero/in_process.py` runs LIBERO envs in-process (no Modal required);
-  `bench/libero/instruction_sweep.py` layers instruction optimization on top, and
-  `bench/libero/in_process_policy.py` colocates a VLA policy with the env.
+- In robot-evals, `src/robot_evals/in_process.py` runs LIBERO envs in-process;
+  `src/robot_evals/instruction_sweep.py` layers instruction optimization on
+  top, and `src/robot_evals/in_process_policy.py` colocates a VLA policy with
+  the env.
 
 `docs/guide/libero-recipe.md` is the full recipe. The large benchmark sweeps are
 **user-triggered actions** (GPU cost); never run them in CI.
@@ -188,5 +190,6 @@ runs batched LIBERO evals the Archetype-native way:
 - Andrej Karpathy's framing of autonomous software optimization and branch-frontier agent workflows
 - `src/archetype/experiments/` — the current component implementations
 - `archetype-runner` — the agent-in-VM runner whose registry feeds this schema
-- `bench/libero/eval_run.py` — batched control-plane LIBERO eval
-- `docs/guide/libero-recipe.md` — the end-to-end LIBERO recipe
+- `src/archetype/experiments/eval_rollouts.py` — packaged batched rollout orchestration
+- `everettVT/robot-evals` — external LIBERO harness, GPU entrypoints, and run ledgers
+- `docs/guide/libero-recipe.md` — extraction pointer and retained Archetype boundary

--- a/docs/guide/system-execution.md
+++ b/docs/guide/system-execution.md
@@ -6,6 +6,11 @@ processor's declared components are a subset of that archetype's signature.
 The subset check eliminates per-entity component lookups and guarantees that
 the declared component columns exist in the DataFrame.
 
+> The messaging names used below are application-defined examples. Archetype
+> does not export `Inbox`, `Outbox`, `DeliveryReceipt`, or
+> `MessageDeliveryProcessor`; applications may implement that processor-driven
+> mailbox design on top of the execution model described here.
+
 `AsyncWorld.step()` supplies the per-archetype concurrency: it schedules one
 compute task for each active physical table, then commits the successful
 results as a separate phase. `AsyncSystem` itself processes the one DataFrame
@@ -181,7 +186,9 @@ Typical priority ranges:
 | 50 to 99 | Output, side effects |
 | 100+ | Cleanup, metrics, bookkeeping |
 
-Example: `MessageDeliveryProcessor` at priority -100 populates inboxes before agent processors at priority 10+ read them. This ensures messages sent in tick N are available in tick N+1.
+Application-level example: a `MessageDeliveryProcessor` at priority -100 can
+populate inboxes before agent processors at priority 10+ read them. In that
+design, messages sent in tick N become available in tick N+1.
 
 ## SyncSystem vs AsyncSystem
 
@@ -275,7 +282,9 @@ sharing boundary created by world forks.
 
 **Unnecessary defensive checks.** If your processor runs, the columns exist. Don't add `if "col" in df.columns` guards — they're dead code by construction.
 
-**Not understanding tick boundaries.** Messages written to Outbox at tick N are delivered to Inbox at tick N+1. Spawned entities appear next tick. These are features, not bugs — they ensure causal ordering.
+**Not understanding tick boundaries.** In the illustrative mailbox design,
+messages written to Outbox at tick N are delivered to Inbox at tick N+1.
+Spawned entities appear next tick. Both patterns preserve causal ordering.
 
 **Forgetting that `components=()` matches everything.** An observer processor with an empty components tuple will run on every archetype table. This is useful for metrics but can be surprising if unintentional.
 

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -62,3 +62,12 @@ def test_curated_example_command_roles_follow_permissions() -> None:
         assert documented == expected, (
             f"{command.value}: documented {documented}, expected {expected}"
         )
+
+
+def test_current_robotics_guides_do_not_reference_extracted_libero_paths() -> None:
+    """Current guidance must point into robot-evals, not the removed bench tree."""
+    guides = (Path("LEARNINGS.md"), _GUIDE_ROOT / "autoresearch.md")
+
+    stale = [str(path) for path in guides if "bench/libero/" in path.read_text()]
+
+    assert not stale, f"current guides reference the extracted bench/libero tree: {stale}"

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -69,13 +69,18 @@ def test_curated_example_command_roles_follow_permissions() -> None:
         )
 
 
-def test_current_robotics_guides_do_not_reference_extracted_libero_paths() -> None:
+def test_current_robotics_guides_point_to_extracted_libero_harness() -> None:
     """Current guidance must point into robot-evals, not the removed bench tree."""
     guides = (Path("LEARNINGS.md"), _GUIDE_ROOT / "autoresearch.md")
 
-    stale = [str(path) for path in guides if "bench/libero/" in path.read_text()]
+    text_by_path = {path: path.read_text() for path in guides}
+    stale = [str(path) for path, text in text_by_path.items() if "bench/libero/" in text]
+    missing_successor = [
+        str(path) for path, text in text_by_path.items() if "robot-evals" not in text
+    ]
 
     assert not stale, f"current guides reference the extracted bench/libero tree: {stale}"
+    assert not missing_successor, f"current guides omit robot-evals: {missing_successor}"
 
 
 def test_docs_do_not_claim_design_only_messaging_types() -> None:

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -71,3 +71,19 @@ def test_current_robotics_guides_do_not_reference_extracted_libero_paths() -> No
     stale = [str(path) for path in guides if "bench/libero/" in path.read_text()]
 
     assert not stale, f"current guides reference the extracted bench/libero tree: {stale}"
+
+
+def test_messaging_examples_are_labeled_as_application_defined() -> None:
+    """Design-sketch names must not read like exported framework contracts."""
+    guides = (Path("LEARNINGS.md"), _GUIDE_ROOT / "system-execution.md")
+    example_names = ("DeliveryReceipt", "MessageDeliveryProcessor", "ChatGraphRegistry")
+
+    for path in guides:
+        text = path.read_text()
+        boundary_match = re.search(r"does not\s+export", text)
+        assert boundary_match is not None, f"{path} is missing the export boundary"
+        boundary = boundary_match.start()
+        first_example = min(text.find(name) for name in example_names if name in text)
+        assert boundary < first_example, (
+            f"{path} must label messaging examples before presenting their type names"
+        )


### PR DESCRIPTION
## What changed

- replace current-facing `bench/libero/*` references with the external `robot-evals` paths
- point readers at the packaged `archetype.experiments.eval_rollouts` service
- describe `docs/guide/libero-recipe.md` accurately as an extraction pointer
- add an executable contract requiring both the extraction boundary and its successor

## MRE interpretation

Issue #346's checkout-relative MRE fails both current guides on exact current
main `6a72435`: each retains a `bench/libero/` pointer. Both cases pass on this
branch because the guides name `everettVT/robot-evals` and its current paths.
Restoring deleted benchmark files would violate the completed extraction and
is not an accepted fix.

PR #393 independently resolved #348 while this branch was in review. This branch now includes that merged `main` change and has no additional messaging-contract diff.

## Validation

- exact issue #346 MRE: 2 passed
- documentation contract suite: 8 passed
- `make ci`: 1138 passed, 7 skipped; 85.83% coverage
- regression evals: 12/12 passed
- infrastructure idempotency audit: 23/23 passed
- markdownlint: 0 issues across edited guides
- MkDocs build: passed (one pre-existing Griffe annotation warning)
- `git diff --check`; changed Python test passes Ruff lint and format checks

This is documentation plus its executable documentation contract only. It does
not change core, app services, storage, credentials, audit, or runtime
contracts.

Closes #346
