### PR TITLE
docs(experiment): align Python requirement with package

### DIFF
--- a/experiments/paper.md
+++ b/experiments/paper.md
@@ -66,6 +66,7 @@ lose a fixed metabolic cost ($-2.0$) each tick. Energy is floored at zero.
 ### 2.4 Tick Lifecycle
 
 Each tick proceeds in two phases:
+
 1. **Harvest** (priority 10): All agents simultaneously attempt to harvest their
    desired fraction. If total demand exceeds the available pool, allocations are
    scaled proportionally.
@@ -256,4 +257,4 @@ uv run python experiments/tragedy_of_the_commons.py
 uv run python experiments/generate_figures.py
 ```
 
-Requires: Python 3.11+, Archetype, matplotlib.
+Requires: Python 3.12+, Archetype, matplotlib.

--- a/tests/spec_contracts/test_experiment_documentation_contracts.py
+++ b/tests/spec_contracts/test_experiment_documentation_contracts.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executable contracts for claims made by experiment documentation."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+_EXPERIMENT_ROOT = Path("experiments")
+_PYTHON_LOWER_BOUND = re.compile(r"(?:^|,)\s*>=\s*(\d+\.\d+)")
+_DOCUMENTED_REQUIREMENT = re.compile(
+    r"\bRequires:\s*Python\s+(\d+\.\d+)\+",
+    re.IGNORECASE,
+)
+
+
+def test_experiment_python_requirements_match_package_lower_bound() -> None:
+    """Experiment prerequisites must move with the package's Python floor."""
+    project = tomllib.loads(Path("pyproject.toml").read_text())
+    requires_python = project["project"]["requires-python"]
+    lower_bound = _PYTHON_LOWER_BOUND.search(requires_python)
+    assert lower_bound is not None, (
+        f"cannot derive a Python floor from project.requires-python={requires_python!r}"
+    )
+    expected = lower_bound.group(1)
+
+    documented: list[tuple[Path, int, str]] = []
+    for path in sorted(_EXPERIMENT_ROOT.rglob("*.md")):
+        text = path.read_text()
+        for match in _DOCUMENTED_REQUIREMENT.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            documented.append((path, line, match.group(1)))
+
+    assert documented, "experiment docs no longer state a Python prerequisite"
+    stale = [
+        f"{path}:{line} requires Python {version}+; package floor is {expected}"
+        for path, line, version in documented
+        if version != expected
+    ]
+    assert not stale, "stale experiment Python requirements:\n" + "\n".join(stale)


### PR DESCRIPTION
## Summary

- update the Tragedy of the Commons paper from Python 3.11+ to the package-supported Python 3.12+
- add an experiment-documentation contract that derives the Python floor from `project.requires-python` and checks every explicit experiment prerequisite against it
- fix the touched paper's missing blank before its numbered lifecycle list so the document passes Markdown lint

## Root cause

The paper carried a manually maintained Python prerequisite with no executable connection to package metadata. The project floor moved to Python 3.12, but the experiment text remained at 3.11 and could direct readers into an unsupported environment.

## Impact

The current paper now advertises a supported interpreter, and future Python-floor changes will fail the documentation contract until experiment prerequisites move with the package.

## Validation

- `make ci` — 905 passed, 5 skipped, 85.3% coverage; regression 12/12; idempotency 22/22
- `uv run pytest -q tests/spec_contracts` — 6 passed
- `npx --yes markdownlint-cli2 --config .markdownlint.yaml experiments/paper.md`
- `typos-cli` 1.48.0 on the changed paper and contract test
- `git diff --check`

Closes #361
