### PR TITLE
fix(build): align local docs lint inputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ docs-serve: docs
 docs-lint:
 	@echo "=== Spelling (typos) ==="
 	@if command -v typos >/dev/null 2>&1; then \
-		typos "docs/**/*.md" "docs/**/*.mdx" "*.md" "*.mdx"; \
+		typos; \
 	else \
 		echo "typos not installed — install via: cargo install typos-cli"; \
 		echo "  or: brew install typos-cli"; \
@@ -308,9 +308,9 @@ docs-lint:
 	@echo ""
 	@echo "=== Markdown lint ==="
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
-		markdownlint-cli2 "docs/**/*.md" "docs/**/*.mdx" "*.md"; \
+		markdownlint-cli2 "docs/**/*.md" "*.md"; \
 	elif npx --yes markdownlint-cli2 --help >/dev/null 2>&1; then \
-		npx --yes markdownlint-cli2 "docs/**/*.md" "docs/**/*.mdx" "*.md"; \
+		npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"; \
 	else \
 		echo "markdownlint-cli2 not available"; \
 		exit 1; \
@@ -318,7 +318,7 @@ docs-lint:
 	@echo ""
 	@echo "=== Link check (lychee) ==="
 	@if command -v lychee >/dev/null 2>&1; then \
-		lychee --config lychee.toml "docs/**/*.md" "docs/**/*.mdx" "*.md"; \
+		lychee --config lychee.toml docs/ README.md CONTRIBUTING.md AGENTS.md; \
 	else \
 		echo "lychee not installed — install via: cargo install lychee"; \
 		echo "  or: brew install lychee"; \

--- a/tests/scripts/test_docs_lint_target.py
+++ b/tests/scripts/test_docs_lint_target.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke contract for the aggregate local documentation gate."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def _write_recorder(bin_dir: Path, name: str) -> None:
+    tool = bin_dir / name
+    tool.write_text(
+        "#!/bin/sh\n"
+        f'for arg in "$@"; do printf "%s\\n" "$arg"; done > "$DOC_LINT_RECORD_DIR/{name}"\n',
+        encoding="utf-8",
+    )
+    tool.chmod(0o755)
+
+
+def test_docs_lint_invokes_tools_with_ci_equivalent_inputs(tmp_path) -> None:
+    bin_dir = tmp_path / "bin"
+    records = tmp_path / "records"
+    bin_dir.mkdir()
+    records.mkdir()
+    for tool in ("typos", "markdownlint-cli2", "lychee"):
+        _write_recorder(bin_dir, tool)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["DOC_LINT_RECORD_DIR"] = str(records)
+
+    result = subprocess.run(
+        ["make", "docs-lint"],
+        cwd=Path.cwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (records / "typos").read_text().splitlines() == []
+    assert (records / "markdownlint-cli2").read_text().splitlines() == [
+        "docs/**/*.md",
+        "*.md",
+    ]
+    assert (records / "lychee").read_text().splitlines() == [
+        "--config",
+        "lychee.toml",
+        "docs/",
+        "README.md",
+        "CONTRIBUTING.md",
+        "AGENTS.md",
+    ]


### PR DESCRIPTION
## What changed

- let `typos` scan the checkout using `_typos.toml`, matching the hosted action
- give Markdownlint the same supported globs as the Docs workflow
- give Lychee the same concrete directories/files as the hosted link check
- add a smoke contract that records every tool invocation without requiring the binaries

## MRE

Issue #392 reproduces on `14d652a` with `typos-cli` 1.48.0: the quoted `docs/**/*.md` argument is treated as a nonexistent literal path and `make docs-lint` exits 64 before scanning anything.

The committed smoke contract also fails before this patch because `typos` receives four literal patterns. It passes on this branch and verifies all three local invocations against their hosted equivalents.

## Validation

- docs-lint invocation smoke contract: passed
- `make ci`: passed
- regression evals: 12/12 passed
- infrastructure idempotency audit: 22/22 passed
- `git diff --check`

Closes #392
