### PR TITLE
fix: make docs-lint executable locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ docs-serve: docs
 docs-lint:
 	@echo "=== Spelling (typos) ==="
 	@if command -v typos >/dev/null 2>&1; then \
-		typos "docs/**/*.md" "docs/**/*.mdx" "*.md" "*.mdx"; \
+		typos --config ./_typos.toml .; \
 	else \
 		echo "typos not installed — install via: cargo install typos-cli"; \
 		echo "  or: brew install typos-cli"; \
@@ -308,9 +308,9 @@ docs-lint:
 	@echo ""
 	@echo "=== Markdown lint ==="
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
-		markdownlint-cli2 "docs/**/*.md" "docs/**/*.mdx" "*.md"; \
-	elif npx --yes markdownlint-cli2 --help >/dev/null 2>&1; then \
-		npx --yes markdownlint-cli2 "docs/**/*.md" "docs/**/*.mdx" "*.md"; \
+		markdownlint-cli2 --config .markdownlint.yaml "docs/**/*.md" "*.md"; \
+	elif command -v npx >/dev/null 2>&1; then \
+		npx --yes markdownlint-cli2 --config .markdownlint.yaml "docs/**/*.md" "*.md"; \
 	else \
 		echo "markdownlint-cli2 not available"; \
 		exit 1; \
@@ -318,7 +318,7 @@ docs-lint:
 	@echo ""
 	@echo "=== Link check (lychee) ==="
 	@if command -v lychee >/dev/null 2>&1; then \
-		lychee --config lychee.toml "docs/**/*.md" "docs/**/*.mdx" "*.md"; \
+		lychee --config lychee.toml "docs/" "README.md" "CONTRIBUTING.md" "AGENTS.md"; \
 	else \
 		echo "lychee not installed — install via: cargo install lychee"; \
 		echo "  or: brew install lychee"; \

--- a/tests/scripts/test_docs_lint_target.py
+++ b/tests/scripts/test_docs_lint_target.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the local documentation quality gate."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _install_capture_stub(bin_dir: Path, command: str) -> None:
+    stub = bin_dir / command
+    stub.write_text(f'#!/bin/sh\nprintf "%s\\n" "$@" > "$DOCS_LINT_CAPTURE_DIR/{command}.args"\n')
+    stub.chmod(0o755)
+
+
+def _run_docs_lint_with_stubs(tmp_path: Path, commands: tuple[str, ...]) -> Path:
+    bin_dir = tmp_path / "bin"
+    capture_dir = tmp_path / "captures"
+    bin_dir.mkdir()
+    capture_dir.mkdir()
+
+    for command in commands:
+        _install_capture_stub(bin_dir, command)
+
+    env = os.environ.copy()
+    env["PATH"] = str(bin_dir)
+    env["DOCS_LINT_CAPTURE_DIR"] = str(capture_dir)
+    make = shutil.which("make")
+    assert make is not None, "make is required to exercise the target"
+    result = subprocess.run(
+        [make, "docs-lint"],
+        cwd=_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    return capture_dir
+
+
+def _captured_args(capture_dir: Path, command: str) -> list[str]:
+    return (capture_dir / f"{command}.args").read_text().splitlines()
+
+
+def test_docs_lint_invokes_ci_equivalent_document_scopes(tmp_path: Path) -> None:
+    """The Make target must pass paths each tool accepts and CI actually checks."""
+    capture_dir = _run_docs_lint_with_stubs(
+        tmp_path,
+        ("typos", "markdownlint-cli2", "lychee"),
+    )
+    expected = {
+        "typos": ["--config", "./_typos.toml", "."],
+        "markdownlint-cli2": [
+            "--config",
+            ".markdownlint.yaml",
+            "docs/**/*.md",
+            "*.md",
+        ],
+        "lychee": [
+            "--config",
+            "lychee.toml",
+            "docs/",
+            "README.md",
+            "CONTRIBUTING.md",
+            "AGENTS.md",
+        ],
+    }
+    for command, arguments in expected.items():
+        captured = _captured_args(capture_dir, command)
+        assert captured == arguments, f"{command}: {captured} != {arguments}"
+
+
+def test_docs_lint_npx_fallback_does_not_probe_nonzero_help(tmp_path: Path) -> None:
+    """A usable npx fallback must run even though markdownlint --help exits 2."""
+    capture_dir = _run_docs_lint_with_stubs(
+        tmp_path,
+        ("typos", "npx", "lychee"),
+    )
+    captured = _captured_args(capture_dir, "npx")
+    assert captured == [
+        "--yes",
+        "markdownlint-cli2",
+        "--config",
+        ".markdownlint.yaml",
+        "docs/**/*.md",
+        "*.md",
+    ]


### PR DESCRIPTION
## Summary

- make `typos` scan the checkout with the repository config instead of receiving quoted, nonexistent glob paths
- align local Markdown and link inputs with the corresponding hosted docs jobs
- replace the failing `markdownlint-cli2 --help` availability probe with an `npx` presence check
- add a dependency-free Make-target contract that captures and verifies arguments for both the installed CLI and `npx` fallback paths

## Root cause

The local target assumed every checker interpreted quoted globs the same way. `typos` instead treats them as literal paths and failed before scanning any documents. Its Markdown fallback had a second semantic mismatch: current `markdownlint-cli2 --help` prints help but exits with status 2, so the target rejected a usable `npx` installation.

## Impact

Contributors can run the advertised aggregate docs gate locally, and its spelling, Markdown, and link scopes now match the hosted workflows rather than maintaining a separate document set.

## Validation

- `PATH="$PWD/.context/doc-tools/bin:$PATH" make docs-lint` — spelling, 67-file Markdown lint, and 215-link check passed
- `uv run pytest -q tests/scripts/test_docs_lint_target.py` — 2 passed
- `make ci` — 906 passed, 6 skipped, 85.0% coverage; regression 12/12; idempotency 22/22
- `git diff --check`

Closes #392
