### PR TITLE
fix(commands): enforce reserved spawn replay guard

### DIFF
--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -346,8 +346,11 @@ One tick MUST follow this order:
 - Duplicate despawns for the same entity in one tick MUST collapse.
 - Duplicate spawns for the same entity in one tick MUST resolve
   deterministically.
-- The current deterministic contract is last-write-wins by entity ID within the
-  tick.
+- Spawn rows legitimately staged under the same signature resolve
+  last-write-wins by entity ID within the tick.
+- A tick-deferred spawn carrying an explicit reserved entity ID MUST use the
+  guarded `spawn_with_reserved_id` mutation path. Once that ID is registered,
+  a replay is rejected and cannot replace the first staged spawn.
 - Despawn-only signatures MUST still be processed during the next tick, even if
   no active entities remain in that archetype after bookkeeping updates.
 
@@ -867,7 +870,8 @@ the constraints that any acceptable design must satisfy.
 | `AsyncWorld.remove_entity(missing)` | Safe no-op with observability |
 | `RuntimeWorld.as_actor(ctx)` | Idempotent as handle binding only; creates another alias, not another world |
 | Duplicate despawn in one tick | Idempotent collapse by entity ID |
-| Duplicate spawn for same entity in one tick | Deterministic last-write-wins |
+| Duplicate staged spawn rows for the same entity in one tick | Deterministic last-write-wins at materialization |
+| Replay of an already-registered reserved spawn through `CommandService` | First spawn applies; replay is rejected |
 | `RuntimeWorld.history()` | Idempotent for fixed audit history |
 | `add_components()` with no signature change | Idempotent no-op |
 | `remove_components()` with no signature change | Idempotent no-op |

--- a/evals/suites/idempotency.py
+++ b/evals/suites/idempotency.py
@@ -138,8 +138,13 @@ IDEMPOTENCY_CASES: tuple[IdempotencyCase, ...] = (
         task_id="idempotency.same_tick_duplicate_mutations",
     ),
     IdempotencyCase(
-        operation="Duplicate spawn for same entity in one tick",
-        expected_contract="Deterministic last-write-wins",
+        operation="Duplicate staged spawn rows for the same entity in one tick",
+        expected_contract="Deterministic last-write-wins at materialization",
+        task_id="idempotency.same_tick_duplicate_mutations",
+    ),
+    IdempotencyCase(
+        operation="Replay of an already-registered reserved spawn through `CommandService`",
+        expected_contract="First spawn applies; replay is rejected",
         task_id="idempotency.same_tick_duplicate_mutations",
     ),
     IdempotencyCase(
@@ -703,7 +708,7 @@ async def _task_runtime_aliases_and_history() -> list[GraderResult]:
 
 
 def task_duplicate_same_tick_mutations_collapse() -> list[GraderResult]:
-    """Same-entity duplicate spawn/despawn commands collapse at materialization."""
+    """Reserved-spawn replays reject; duplicate despawns collapse."""
     return asyncio.run(_task_duplicate_same_tick_mutations_collapse())
 
 
@@ -770,9 +775,9 @@ async def _task_duplicate_same_tick_mutations_collapse() -> list[GraderResult]:
             return [
                 state_check(
                     {
-                        "both_duplicate_spawns_applied": spawn_applied == 2,
-                        "duplicate_spawn_materialized_once": len(spawn_rows) == 1,
-                        "duplicate_spawn_last_write_wins": spawn_value == 9,
+                        "replayed_reserved_spawn_rejected": spawn_applied == 1,
+                        "reserved_spawn_materialized_once": len(spawn_rows) == 1,
+                        "first_reserved_spawn_preserved": spawn_value == 1,
                         "spawn_row_starts_active": spawn_active is True,
                         "both_duplicate_despawns_applied": despawn_applied == 2,
                         "duplicate_despawn_materialized_once": len(despawn_rows) == 1,

--- a/evals/suites/idempotency.py
+++ b/evals/suites/idempotency.py
@@ -140,7 +140,7 @@ IDEMPOTENCY_CASES: tuple[IdempotencyCase, ...] = (
     IdempotencyCase(
         operation="Duplicate staged spawn rows for the same entity in one tick",
         expected_contract="Deterministic last-write-wins at materialization",
-        task_id="idempotency.same_tick_duplicate_mutations",
+        task_id="idempotency.staged_spawn_last_write_wins",
     ),
     IdempotencyCase(
         operation="Replay of an already-registered reserved spawn through `CommandService`",
@@ -707,6 +707,51 @@ async def _task_runtime_aliases_and_history() -> list[GraderResult]:
         reset_daily_tokens()
 
 
+def task_staged_spawn_last_write_wins() -> list[GraderResult]:
+    """Duplicate raw staged rows retain the last value at materialization."""
+    return asyncio.run(_task_staged_spawn_last_write_wins())
+
+
+async def _task_staged_spawn_last_write_wins() -> list[GraderResult]:
+    reset_tick_counters()
+    reset_daily_tokens()
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="idem_staged_spawns")
+            world = await container.world_service.create_world(
+                WorldConfig(name="staged-spawn-last-write-wins"),
+                storage,
+            )
+
+            entity_id = await world.create_entity([IdemCounter(value=1)])
+            sig = world.entity2sig[entity_id]
+            duplicate_row = {
+                **world.spawn_cache[sig][-1],
+                "idemcounter__value": 9,
+            }
+            world.spawn_cache[sig].append(duplicate_row)
+            staged_count = len(world.spawn_cache[sig])
+            await container.simulation_service.step(world.world_id, RunConfig())
+            rows = (await world.query_archetype(sig=(IdemCounter,), ticks=[0])).to_pylist()
+
+            return [
+                state_check(
+                    {
+                        "two_raw_rows_staged_for_same_entity": staged_count == 2,
+                        "duplicate_staged_spawn_materialized_once": len(rows) == 1,
+                        "duplicate_staged_spawn_last_write_wins": bool(rows)
+                        and rows[0]["idemcounter__value"] == 9,
+                    },
+                    name="staged_spawn_last_write_wins",
+                )
+            ]
+        finally:
+            await container.shutdown()
+            reset_tick_counters()
+            reset_daily_tokens()
+
+
 def task_duplicate_same_tick_mutations_collapse() -> list[GraderResult]:
     """Reserved-spawn replays reject; duplicate despawns collapse."""
     return asyncio.run(_task_duplicate_same_tick_mutations_collapse())
@@ -1092,10 +1137,16 @@ def register(harness: EvalHarness) -> None:
         desc="RuntimeWorld.as_actor aliases handles and fixed-filter history remains stable.",
     )
     harness.add(
+        "idempotency.staged_spawn_last_write_wins",
+        suite=SUITE,
+        fn=task_staged_spawn_last_write_wins,
+        desc="Duplicate raw staged spawn rows resolve last-write-wins at materialization.",
+    )
+    harness.add(
         "idempotency.same_tick_duplicate_mutations",
         suite=SUITE,
         fn=task_duplicate_same_tick_mutations_collapse,
-        desc="Duplicate same-entity spawn/despawn commands collapse at materialization.",
+        desc="Reserved-spawn replays reject and duplicate despawns collapse.",
     )
     harness.add(
         "idempotency.component_signature_noops",

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -1116,13 +1116,11 @@ class CommandService:
                 components = self._hydrate_components(payload.get("components", []))
                 entity_id = payload.get("entity_id")
                 if entity_id is not None:
-                    # Deferred spawn with reserved id — register directly
-                    # on the world so the pre-reserved ID is honored.
-                    from archetype.core.aio import AsyncWorld
-
-                    world = self._worlds.get_world(UUID(str(world_id)))
-                    if isinstance(world, AsyncWorld):
-                        await world._register_entity(int(entity_id), components)
+                    await self._mutations.spawn_with_reserved_id(
+                        world_id,
+                        int(entity_id),
+                        components,
+                    )
                 else:
                     await self._mutations.create_entity(world_id, components)
 

--- a/tests/idempotency/test_idempotency_evals.py
+++ b/tests/idempotency/test_idempotency_evals.py
@@ -10,6 +10,7 @@ import sys
 
 import pytest
 
+from archetype.core.aio.async_world import AsyncWorld
 from evals.run import build_harness
 from evals.suites import idempotency
 from evals.suites.idempotency_process import _wait_for_markers
@@ -49,6 +50,26 @@ def test_idempotency_contract_audit_detects_unmapped_spec_row(tmp_path, monkeypa
     checks = idempotency.traceability_checks()
 
     assert not checks["matrix_rows_match_eval_manifest"]
+
+
+def test_staged_spawn_eval_detects_first_write_wins_regression(monkeypatch) -> None:
+    original_spawn_frame = AsyncWorld._spawn_frame
+
+    def first_write_wins(self, sig):
+        rows = self.spawn_cache.get(sig)
+        if rows:
+            self.spawn_cache[sig] = list(reversed(rows))
+        try:
+            return original_spawn_frame(self, sig)
+        finally:
+            if rows is not None:
+                self.spawn_cache[sig] = rows
+
+    monkeypatch.setattr(AsyncWorld, "_spawn_frame", first_write_wins)
+
+    results = idempotency.task_staged_spawn_last_write_wins()
+
+    assert any(not result.passed for result in results)
 
 
 def test_process_readiness_failure_reports_child_stderr(tmp_path) -> None:

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -14,6 +14,7 @@ from uuid_utils import uuid7
 from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
 from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
+from archetype.app.models import Command, CommandType
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 
@@ -50,6 +51,38 @@ async def test_submit_spawn_reserved_id_survives_drain(tmp_path):
         assert reserved_id in world.entity2sig
         # Step to materialize
         await c.simulation_service.step(world.world_id, RunConfig())
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_replayed_reserved_spawn_is_not_applied_twice(tmp_path):
+    """The drain path enforces the same double-spawn guard as direct mutation calls."""
+    c = ServiceContainer()
+    ctx = ActorCtx(id=uuid7(), roles={"admin"})
+    try:
+        world = await c.world_service.create_world(
+            WorldConfig(name="spawn-replay"),
+            StorageConfig(uri=str(tmp_path / "store")),
+        )
+        (entity_id,) = world.reserve_entity_ids(1)
+        first = Command(
+            type=CommandType.SPAWN,
+            payload={"entity_id": entity_id, "components": [Marker(tag="first")]},
+        )
+        replay = Command(
+            type=CommandType.SPAWN,
+            payload={"entity_id": entity_id, "components": [Marker(tag="replay")]},
+        )
+        await c.command_service.submit_batch(ctx, world.world_id, [first, replay])
+
+        applied = await c.command_service.drain_and_apply(world.world_id, tick=0)
+
+        assert [command.id for command in applied] == [first.id]
+        sig = world.entity2sig[entity_id]
+        staged = [row for row in world.spawn_cache[sig] if row["entity_id"] == entity_id]
+        assert len(staged) == 1
+        assert staged[0]["marker__tag"] == "first"
     finally:
         await c.shutdown()
 


### PR DESCRIPTION
## Summary

- route tick-deferred reserved spawns through `MutationService.spawn_with_reserved_id()`
- remove the app-layer call to private `AsyncWorld._register_entity()`
- define replay semantics explicitly: the first reserved spawn applies; a replay is rejected and cannot replace it
- distinguish protected reserved-ID replay from legitimate same-signature staged-row last-write-wins
- update the idempotency manifest and behavioral eval with the normative contract
- give raw staged-row last-write-wins its own mutation-sensitive eval instead of conflating it with reserved-ID replay

## MRE

Issue #370 contains the executable reproduction. On exact `main` head `00f9e9c`, two spawn commands carrying the same reserved ID are both reported applied and both stage rows; last-write-wins only masks the duplicate lifecycle work later.

The exact MRE now reports only the first command applied and preserves its payload.

Issue #414 contains a separate mutation MRE for the review-discovered oracle gap: changing `_spawn_frame()` to first-write-wins incorrectly left the matrix-linked eval green. The new dedicated task fails under that mutation while the reserved-spawn task remains focused on replay rejection.

## Validation

- exact MRE + command-flow/eval/path-safety contracts: 46 passed
- full pytest coverage run: 989 passed, 6 skipped on the current `main` merge
- regression eval: 12/12
- corrected idempotency eval: 23/23
- `make check`
- `git diff --check`

Closes #370
Closes #414
