### PR TITLE
fix(commands): harden deferred command gating

### DIFF
--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -451,6 +451,10 @@ Idempotency:
 - Direct methods authorize, delegate, audit, and return a result immediately.
 - `submit()` and `submit_batch()` are tick-deferred APIs. They return command IDs
   and enqueue work for later application.
+- Generic deferred submission MUST accept only commands with a tick-boundary
+  dispatcher, plus the intentional `MESSAGE`, `CUSTOM`, and `QUERY_WORLD`
+  application envelopes. All other command types MUST be rejected before quota
+  debit, audit emission, or broker enqueue.
 - `submit_spawn()` is the special case that reserves a world-local entity ID
   before enqueue so `spawn()` can honestly return `entity_id`.
 - Reservation MUST be serialized per world.
@@ -933,7 +937,7 @@ behavior and an executable oracle.
 | Item | Status | Contract or remaining work | Oracle or tracking |
 |---|---|---|---|
 | 1 | Resolved | Async and sync updater/store failures raise instead of returning a stamped-but-uncommitted frame. | `tests/core/test_async_store_updater_failures.py`; `tests/sync/test_sync_stack_contracts.py` |
-| 2 | Closed | Tick-deferred submission rejects world-lifecycle command types before authorization, audit, or enqueue; callers use the direct gated lifecycle methods. | Issue #368 |
+| 2 | Resolved | Tick-deferred submission is allowlisted to dispatched commands and intentional application envelopes; all direct operations fail before quota, audit, or enqueue. | `tests/integration/test_command_flow.py::test_direct_only_commands_cannot_enter_tick_deferred_broker`; Issues #368, #415, #418 |
 | 3 | Resolved | `CommandService.submit*` reject an unknown world with `WorldNotFoundError` before quota, enqueue, or audit side effects. | `tests/integration/test_command_flow.py::test_submit_to_unknown_world_rejected` |
 | 4 | Resolved | Duplicate-name and catalog-registration failures leave no hidden live world. | `tests/core/test_orchestrator_errors_and_instrumentation.py`; `tests/app/test_durable_discovery.py::test_failed_catalog_registration_leaves_no_live_world` |
 | 5 | Resolved | Spawn, despawn, and component migration hooks fire from their public mutation paths with the documented queue-time semantics. | `tests/core/test_resources_hooks_messaging.py`; `tests/core/test_batch_spawn_contract.py`; `tests/sync/test_sync_world.py` |

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -929,7 +929,7 @@ behavior and an executable oracle.
 | Item | Status | Contract or remaining work | Oracle or tracking |
 |---|---|---|---|
 | 1 | Resolved | Async and sync updater/store failures raise instead of returning a stamped-but-uncommitted frame. | `tests/core/test_async_store_updater_failures.py`; `tests/sync/test_sync_stack_contracts.py` |
-| 2 | Open | Define truthful ack semantics for world-lifecycle command types submitted through the tick-deferred broker. | Issue #368 |
+| 2 | Closed | Tick-deferred submission rejects world-lifecycle command types before authorization, audit, or enqueue; callers use the direct gated lifecycle methods. | Issue #368 |
 | 3 | Resolved | `CommandService.submit*` reject an unknown world with `WorldNotFoundError` before quota, enqueue, or audit side effects. | `tests/integration/test_command_flow.py::test_submit_to_unknown_world_rejected` |
 | 4 | Resolved | Duplicate-name and catalog-registration failures leave no hidden live world. | `tests/core/test_orchestrator_errors_and_instrumentation.py`; `tests/app/test_durable_discovery.py::test_failed_catalog_registration_leaves_no_live_world` |
 | 5 | Resolved | Spawn, despawn, and component migration hooks fire from their public mutation paths with the documented queue-time semantics. | `tests/core/test_resources_hooks_messaging.py`; `tests/core/test_batch_spawn_contract.py`; `tests/sync/test_sync_world.py` |

--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -217,7 +217,10 @@ _COMMAND_GATE_MAP: dict[str, CommandType] = {
     "submit_spawn": CommandType.SPAWN,
 }
 
-_DYNAMIC_GATE_METHODS = frozenset({"submit", "submit_batch"})
+_DYNAMIC_GATE_METHODS = {
+    "submit": "_gate",
+    "submit_batch": "_gate_batch",
+}
 
 
 def _python_files(path: Path) -> list[Path]:
@@ -417,14 +420,14 @@ def task_command_service_gate_map() -> list[GraderResult]:
                 c.lineno for c in emit_calls
             )
 
-    for method in _DYNAMIC_GATE_METHODS:
+    for method, gate_method in _DYNAMIC_GATE_METHODS.items():
         node = functions.get(method)
         checks[f"{method}:exists"] = node is not None
         if node is None:
             continue
         calls = [call for call in ast.walk(node) if isinstance(call, ast.Call)]
         checks[f"{method}:has_dynamic_gate"] = any(
-            _called_attr_name(call) == "_gate" for call in calls
+            _called_attr_name(call) == gate_method for call in calls
         )
         checks[f"{method}:emits_audit"] = any(_called_attr_name(call) == "_emit" for call in calls)
 

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -83,13 +83,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_DIRECT_ONLY_COMMANDS = frozenset(
+_DEFERRED_COMMAND_TYPES = frozenset(
     {
-        CommandType.INGEST_FACT,
-        CommandType.EVALUATE,
-        CommandType.CREATE_WORLD,
-        CommandType.FORK_WORLD,
-        CommandType.DESTROY_WORLD,
+        CommandType.SPAWN,
+        CommandType.UPDATE,
+        CommandType.DESPAWN,
+        CommandType.ADD_COMPONENT,
+        CommandType.REMOVE_COMPONENT,
+        CommandType.ADD_PROCESSOR,
+        CommandType.REMOVE_PROCESSOR,
+        CommandType.MESSAGE,
+        CommandType.CUSTOM,
+        CommandType.QUERY_WORLD,
     }
 )
 
@@ -157,10 +162,10 @@ class CommandService:
 
     @staticmethod
     def _validate_deferred_command(cmd: Command) -> None:
-        if cmd.type in _DIRECT_ONLY_COMMANDS:
+        if cmd.type not in _DEFERRED_COMMAND_TYPES:
             raise ValueError(
-                f"{cmd.type.value} is a direct gated operation; "
-                "it cannot be submitted through the tick-deferred broker"
+                f"{cmd.type.value} is a direct gated operation with no tick-deferred dispatcher; "
+                "it cannot enter the tick-deferred broker"
             )
 
     def _require_world(self, world_id: str | UUID) -> None:

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -83,8 +83,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_DIRECT_LIFECYCLE_COMMANDS = frozenset(
+_DIRECT_ONLY_COMMANDS = frozenset(
     {
+        CommandType.INGEST_FACT,
+        CommandType.EVALUATE,
         CommandType.CREATE_WORLD,
         CommandType.FORK_WORLD,
         CommandType.DESTROY_WORLD,
@@ -142,9 +144,9 @@ class CommandService:
 
     @staticmethod
     def _validate_deferred_command(cmd: Command) -> None:
-        if cmd.type in _DIRECT_LIFECYCLE_COMMANDS:
+        if cmd.type in _DIRECT_ONLY_COMMANDS:
             raise ValueError(
-                f"{cmd.type.value} is a direct gated lifecycle operation; "
+                f"{cmd.type.value} is a direct gated operation; "
                 "it cannot be submitted through the tick-deferred broker"
             )
 

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -83,6 +83,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DIRECT_LIFECYCLE_COMMANDS = frozenset(
+    {
+        CommandType.CREATE_WORLD,
+        CommandType.FORK_WORLD,
+        CommandType.DESTROY_WORLD,
+    }
+)
+
 
 class CommandService:
     """Policy enforcement point.
@@ -118,6 +126,14 @@ class CommandService:
     def _gate(self, cmd: Command, ctx: ActorCtx) -> None:
         """RBAC + quota check. Raises GuardrailError if denied."""
         guardrail_allow(cmd, ctx)
+
+    @staticmethod
+    def _validate_deferred_command(cmd: Command) -> None:
+        if cmd.type in _DIRECT_LIFECYCLE_COMMANDS:
+            raise ValueError(
+                f"{cmd.type.value} is a direct gated lifecycle operation; "
+                "it cannot be submitted through the tick-deferred broker"
+            )
 
     def _require_world(self, world_id: str | UUID) -> None:
         """Reject submissions to worlds not in the registry.
@@ -1001,6 +1017,7 @@ class CommandService:
         """Gate, then enqueue for application at cmd.tick."""
         ctx, world_id, cmd = self._normalize_submit_args(ctx, world_id, cmd)
         self._require_world(world_id)
+        self._validate_deferred_command(cmd)
         self._gate(cmd, ctx)
         await self._broker.enqueue(world_id, cmd)
         await self._emit(ctx, cmd.type.value, world_id, command_id=cmd.id, status="queued")
@@ -1015,6 +1032,8 @@ class CommandService:
         """Gate all-or-nothing, then enqueue atomically."""
         ctx, world_id, cmds = self._normalize_submit_args(ctx, world_id, cmds)
         self._require_world(world_id)
+        for cmd in cmds:
+            self._validate_deferred_command(cmd)
         for cmd in cmds:
             self._gate(cmd, ctx)
         await self._broker.enqueue_bulk(world_id, cmds)

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Any
 from uuid_utils import UUID
 
 from archetype._obs import instrument
-from archetype.app.auth.guard import guardrail_allow
+from archetype.app.auth.guard import guardrail_allow, guardrail_check, guardrail_commit
 from archetype.app.models import (
     Command,
     CommandType,
@@ -141,6 +141,19 @@ class CommandService:
     def _gate(self, cmd: Command, ctx: ActorCtx) -> None:
         """RBAC + quota check. Raises GuardrailError if denied."""
         guardrail_allow(cmd, ctx)
+
+    @staticmethod
+    def _gate_batch(cmds: list[Command], ctx: ActorCtx) -> None:
+        """Validate a batch completely, then debit its quota once."""
+        projected_tokens = 0
+        for index, cmd in enumerate(cmds):
+            projected_tokens += guardrail_check(
+                cmd,
+                ctx,
+                projected_count=index,
+                projected_tokens=projected_tokens,
+            )
+        guardrail_commit(ctx, count=len(cmds), tokens=projected_tokens)
 
     @staticmethod
     def _validate_deferred_command(cmd: Command) -> None:
@@ -1049,8 +1062,7 @@ class CommandService:
         self._require_world(world_id)
         for cmd in cmds:
             self._validate_deferred_command(cmd)
-        for cmd in cmds:
-            self._gate(cmd, ctx)
+        self._gate_batch(cmds, ctx)
         await self._broker.enqueue_bulk(world_id, cmds)
         for cmd in cmds:
             await self._emit(ctx, cmd.type.value, world_id, command_id=cmd.id, status="queued")

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -11,6 +11,8 @@ Flow: submit_spawn -> broker queue -> drain_and_apply -> entity materialized wit
 import pytest
 from uuid_utils import uuid7
 
+from archetype.app.auth import guard as guard_state
+from archetype.app.auth.errors import GuardrailError
 from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
 from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
@@ -212,6 +214,32 @@ async def test_lifecycle_command_rejects_entire_submit_batch(tmp_path):
         with pytest.raises(ValueError, match="direct gated operation"):
             await c.command_service.submit_batch(ctx, world.world_id, commands)
 
+        assert await c.broker.get_pending_count(world.world_id) == 0
+        assert await c.broker.get_history(world.world_id) == []
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_rejected_submit_batch_does_not_debit_quota(tmp_path):
+    """All batch members pass authorization before any quota is committed."""
+    c = ServiceContainer()
+    ctx = ActorCtx(id=uuid7(), roles={"player"})
+    try:
+        world = await c.world_service.create_world(
+            WorldConfig(name="batch-quota"),
+            StorageConfig(uri=str(tmp_path / "store")),
+        )
+        commands = [
+            Command(type=CommandType.CUSTOM),
+            Command(type=CommandType.ADD_PROCESSOR),
+        ]
+
+        with pytest.raises(GuardrailError):
+            await c.command_service.submit_batch(ctx, world.world_id, commands)
+
+        assert guard_state._tick_counters.get(ctx.id, 0) == 0
+        assert guard_state._daily_tokens.get(ctx.id, 0) == 0
         assert await c.broker.get_pending_count(world.world_id) == 0
         assert await c.broker.get_history(world.world_id) == []
     finally:

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -167,10 +167,16 @@ async def test_submit_to_unknown_world_rejected():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "command_type",
-    [CommandType.CREATE_WORLD, CommandType.FORK_WORLD, CommandType.DESTROY_WORLD],
+    [
+        CommandType.INGEST_FACT,
+        CommandType.EVALUATE,
+        CommandType.CREATE_WORLD,
+        CommandType.FORK_WORLD,
+        CommandType.DESTROY_WORLD,
+    ],
 )
-async def test_lifecycle_commands_cannot_enter_tick_deferred_broker(tmp_path, command_type):
-    """Lifecycle operations use their direct gated methods and cannot be acked as queue work."""
+async def test_direct_only_commands_cannot_enter_tick_deferred_broker(tmp_path, command_type):
+    """Direct operations cannot be acknowledged as tick-deferred queue work."""
     c = ServiceContainer()
     ctx = ActorCtx(id=uuid7(), roles={"admin"})
     try:
@@ -179,7 +185,7 @@ async def test_lifecycle_commands_cannot_enter_tick_deferred_broker(tmp_path, co
             StorageConfig(uri=str(tmp_path / "store")),
         )
 
-        with pytest.raises(ValueError, match="direct gated lifecycle operation"):
+        with pytest.raises(ValueError, match="direct gated operation"):
             await c.command_service.submit(ctx, world.world_id, Command(type=command_type))
 
         assert await c.broker.get_pending_count(world.world_id) == 0
@@ -203,7 +209,7 @@ async def test_lifecycle_command_rejects_entire_submit_batch(tmp_path):
             Command(type=CommandType.FORK_WORLD),
         ]
 
-        with pytest.raises(ValueError, match="direct gated lifecycle operation"):
+        with pytest.raises(ValueError, match="direct gated operation"):
             await c.command_service.submit_batch(ctx, world.world_id, commands)
 
         assert await c.broker.get_pending_count(world.world_id) == 0

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -20,6 +20,24 @@ from archetype.app.models import Command, CommandType
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 
+_DEFERRED_COMMAND_TYPES = frozenset(
+    {
+        CommandType.SPAWN,
+        CommandType.UPDATE,
+        CommandType.DESPAWN,
+        CommandType.ADD_COMPONENT,
+        CommandType.REMOVE_COMPONENT,
+        CommandType.ADD_PROCESSOR,
+        CommandType.REMOVE_PROCESSOR,
+        CommandType.MESSAGE,
+        CommandType.CUSTOM,
+        CommandType.QUERY_WORLD,
+    }
+)
+_DIRECT_COMMAND_TYPES = tuple(
+    sorted(set(CommandType) - _DEFERRED_COMMAND_TYPES, key=lambda command_type: command_type.value)
+)
+
 
 class CommandFlowMarker(Component):
     tag: str = ""
@@ -169,13 +187,7 @@ async def test_submit_to_unknown_world_rejected():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "command_type",
-    [
-        CommandType.INGEST_FACT,
-        CommandType.EVALUATE,
-        CommandType.CREATE_WORLD,
-        CommandType.FORK_WORLD,
-        CommandType.DESTROY_WORLD,
-    ],
+    _DIRECT_COMMAND_TYPES,
 )
 async def test_direct_only_commands_cannot_enter_tick_deferred_broker(tmp_path, command_type):
     """Direct operations cannot be acknowledged as tick-deferred queue work."""
@@ -187,7 +199,7 @@ async def test_direct_only_commands_cannot_enter_tick_deferred_broker(tmp_path, 
             StorageConfig(uri=str(tmp_path / "store")),
         )
 
-        with pytest.raises(ValueError, match="direct gated operation"):
+        with pytest.raises(ValueError, match="no tick-deferred dispatcher"):
             await c.command_service.submit(ctx, world.world_id, Command(type=command_type))
 
         assert await c.broker.get_pending_count(world.world_id) == 0
@@ -211,7 +223,7 @@ async def test_lifecycle_command_rejects_entire_submit_batch(tmp_path):
             Command(type=CommandType.FORK_WORLD),
         ]
 
-        with pytest.raises(ValueError, match="direct gated operation"):
+        with pytest.raises(ValueError, match="no tick-deferred dispatcher"):
             await c.command_service.submit_batch(ctx, world.world_id, commands)
 
         assert await c.broker.get_pending_count(world.world_id) == 0

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -14,6 +14,7 @@ from uuid_utils import uuid7
 from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
 from archetype.app.auth.models import ActorCtx
 from archetype.app.container import ServiceContainer
+from archetype.app.models import Command, CommandType
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 
@@ -90,6 +91,54 @@ async def test_submit_to_unknown_world_rejected():
 
         # Broker holds no orphan queue for the phantom world.
         assert await c.broker.get_pending_count(phantom) == 0
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_type",
+    [CommandType.CREATE_WORLD, CommandType.FORK_WORLD, CommandType.DESTROY_WORLD],
+)
+async def test_lifecycle_commands_cannot_enter_tick_deferred_broker(tmp_path, command_type):
+    """Lifecycle operations use their direct gated methods and cannot be acked as queue work."""
+    c = ServiceContainer()
+    ctx = ActorCtx(id=uuid7(), roles={"admin"})
+    try:
+        world = await c.world_service.create_world(
+            WorldConfig(name="lifecycle-submit"),
+            StorageConfig(uri=str(tmp_path / "store")),
+        )
+
+        with pytest.raises(ValueError, match="direct gated lifecycle operation"):
+            await c.command_service.submit(ctx, world.world_id, Command(type=command_type))
+
+        assert await c.broker.get_pending_count(world.world_id) == 0
+        assert await c.broker.get_history(world.world_id) == []
+    finally:
+        await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_command_rejects_entire_submit_batch(tmp_path):
+    """Batch validation happens before any command is gated, audited, or enqueued."""
+    c = ServiceContainer()
+    ctx = ActorCtx(id=uuid7(), roles={"admin"})
+    try:
+        world = await c.world_service.create_world(
+            WorldConfig(name="lifecycle-batch"),
+            StorageConfig(uri=str(tmp_path / "store")),
+        )
+        commands = [
+            Command(type=CommandType.CUSTOM),
+            Command(type=CommandType.FORK_WORLD),
+        ]
+
+        with pytest.raises(ValueError, match="direct gated lifecycle operation"):
+            await c.command_service.submit_batch(ctx, world.world_id, commands)
+
+        assert await c.broker.get_pending_count(world.world_id) == 0
+        assert await c.broker.get_history(world.world_id) == []
     finally:
         await c.shutdown()
 


### PR DESCRIPTION
## Summary

- fail closed on deferred submission with an explicit dispatcher/application-envelope allowlist
- validate every batch member before committing quota, audit emission, or broker enqueue
- require the spec evaluator to recognize the dedicated atomic batch gate
- record the deferred-dispatch boundary in the normative specification

## MRE

Issue #368 contains the executable reproduction. On exact `main` head `00f9e9c`, a `FORK_WORLD` command submitted to an existing world is accepted into the broker instead of raising; drain then logs it as unhandled and reports it applied.

Issue #415 reproduces the same invalid queue acknowledgement for `INGEST_FACT` and `EVALUATE`, which only have direct receipt-returning service methods. Issue #416 reproduces a rejected `[CUSTOM, ADD_PROCESSOR]` player batch consuming quota even though nothing is enqueued or audited.

Issue #418 exhaustively partitions every `CommandType`. The candidate blocklist still acknowledged 15 direct simulation, read, resource, and hook operations that had no deferred dispatcher. The corrected allowlist preserves the documented `MESSAGE`, `CUSTOM`, and `QUERY_WORLD` no-op/application envelopes.

All four MREs pass on this branch and verify that rejection leaves quota, pending queues, and broker history unchanged.

## Validation

- exact MREs + command/auth/broker/spec contracts: 87 passed
- `make ci`: 1031 passed, 6 skipped; regression 12/12; idempotency 23/23
- formatting, lint, lazy-audit, API-boundary, idempotency-contract, and gate-coverage checks
- `git diff --check`

Closes #368
Closes #415
Closes #416
Closes #418
