### PR TITLE
fix(broker): bound per-world command history

### DIFF
--- a/docs/guide/broker.md
+++ b/docs/guide/broker.md
@@ -25,6 +25,9 @@ For RBAC, roles, and audit emission, see [Command Gate](command-gate.md) and [Au
 ## Priority Queue
 
 The broker maintains one priority queue per world, keyed by `str(world_id)`.
+Diagnostic history is also partitioned per world and retained in a bounded
+ring buffer. `max_history` configures the number of recent commands retained
+for each world; it defaults to 50,000.
 
 Commands are ordered by `(tick, priority, seq)`:
 

--- a/src/archetype/app/broker.py
+++ b/src/archetype/app/broker.py
@@ -34,6 +34,7 @@ Features:
 import asyncio
 import heapq
 import logging
+from collections import deque
 
 from uuid_utils import UUID
 
@@ -51,13 +52,25 @@ class CommandBroker:
     The broker mediates all external and agent-initiated commands with RBAC enforcement.
     """
 
-    def __init__(self, max_dequeue: int = 50_000, debug: bool = False):
+    def __init__(
+        self,
+        max_dequeue: int = 50_000,
+        debug: bool = False,
+        max_history: int = 50_000,
+    ):
+        if max_history < 1:
+            raise ValueError(f"max_history must be at least 1, got {max_history}")
         self._queues: dict[str, list[Command]] = {}  # world_id -> priority queue
         self._pending: dict[UUID, Command] = {}
-        self._history: dict[str, list[Command]] = {}
+        self._history: dict[str, deque[Command]] = {}
         self._lock = asyncio.Lock()
         self._max_dequeue = max_dequeue
+        self._max_history = max_history
         self._debug = debug
+
+    def _record_history(self, world_id: str, cmd: Command) -> None:
+        history = self._history.setdefault(world_id, deque(maxlen=self._max_history))
+        history.append(cmd)
 
     async def enqueue(
         self,
@@ -79,7 +92,7 @@ class CommandBroker:
 
             heapq.heappush(self._queues[key], cmd)
             self._pending[cmd.id] = cmd
-            self._history.setdefault(key, []).append(cmd)
+            self._record_history(key, cmd)
 
             if self._debug:
                 logger.debug(
@@ -124,7 +137,7 @@ class CommandBroker:
             for cmd in cmds:
                 heapq.heappush(self._queues[key], cmd)
                 self._pending[cmd.id] = cmd
-                self._history.setdefault(key, []).append(cmd)
+                self._record_history(key, cmd)
 
     async def dequeue(self, world_id: str | UUID, max_items: int | None = None) -> list[Command]:
         """Dequeue commands for a specific world (all pending, regardless of tick)."""
@@ -226,10 +239,10 @@ class CommandBroker:
     async def get_history(self, world_id: str | UUID, limit: int = 100) -> list[Command]:
         """Return recent enqueued commands for a world (most recent last)."""
         async with self._lock:
-            items = self._history.get(str(world_id), [])
+            items = self._history.get(str(world_id))
             if not items:
                 return []
-            return items[-limit:]
+            return list(items)[-limit:]
 
     async def clear(self, world_id: str | UUID | None = None):
         """Clear pending commands."""

--- a/tests/app/test_broker_extended.py
+++ b/tests/app/test_broker_extended.py
@@ -228,6 +228,20 @@ class TestBrokerEdgeCases:
         await broker.remove("w", uuid7())
         assert len(broker._queues["w"]) == 1
 
+    @pytest.mark.asyncio
+    async def test_history_is_bounded_per_world(self):
+        broker = CommandBroker(max_history=2)
+        commands = [Command(type=CommandType.CUSTOM, payload={"i": i}) for i in range(3)]
+
+        for command in commands:
+            await broker.enqueue("world", command)
+
+        assert await broker.get_history("world", limit=100) == commands[-2:]
+
+    def test_history_bound_must_be_positive(self):
+        with pytest.raises(ValueError, match="max_history must be at least 1"):
+            CommandBroker(max_history=0)
+
 
 class TestBrokerConcurrency:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- retain broker diagnostic history in a per-world `deque(maxlen=max_history)`
- expose a concrete `max_history` constructor setting with a 50,000-command default
- preserve `get_history()`'s ordered `list[Command]` return contract and existing positional constructor arguments
- document the retention boundary

## MRE

Issue #369 contains the executable reproduction. Current `main` retains every command ever enqueued for a live world; `get_history(limit=...)` only slices reads and releases nothing.

With `max_history=2`, the MRE now retains and returns only the final two of three commands.

## Validation

- exact MRE + broker/messaging/fork contracts: 71 passed
- `make ci`: 1039 passed, 5 skipped; regression 12/12; idempotency 23/23
- formatting, lint, lazy-audit, API-boundary, idempotency-contract, and gate-coverage checks
- `git diff --check`

Closes #369
