### PR TITLE
feat(harness): gate-coverage audit + footgun sibling-sweep rule

### DIFF
--- a/.claude/skills/footgun-detector/SKILL.md
+++ b/.claude/skills/footgun-detector/SKILL.md
@@ -39,6 +39,16 @@ You do NOT need to read these if you already have them in context from this sess
 
 Check every changed file in the diff against the categories below. For each file, read enough surrounding context (the full file or relevant functions) to understand intent — don't just pattern-match on the diff lines.
 
+**Sibling sweep.** When the diff fixes or establishes an invariant — a guard,
+an unwind, a containment check, an ordering — enumerate the codebase's mirror
+implementations and verify each sibling upholds the same invariant in this
+same review: sync (`core/sync/`) vs async (`core/aio/`) worlds, LanceDB vs
+Iceberg storage paths, `create_world` vs `fork_world` vs `open_world_mutable`
+lifecycle. A sibling that violates the invariant is a finding even though its
+code is unchanged; anchor it to the changed line that establishes the
+invariant it breaks. This exists because serial rounds on one PR repeatedly
+found the fixed hunk's unfixed twin one round later.
+
 In deterministic CI, the working tree is the protected base. Use it for
 surrounding context and `.footgun-review.diff` for the exact candidate changes;
 a newly added file is represented in full by its diff.

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ format:
 		evals/infra/idempotency_worker.py scripts/check_idempotency_contracts.py
 
 .PHONY: lint
-lint: lazy-audit api-boundary-audit idempotency-audit
+lint: lazy-audit api-boundary-audit idempotency-audit gate-coverage-audit
 	@uv run ruff check src tests evals/suites/idempotency.py \
 		evals/suites/idempotency_durable.py evals/suites/idempotency_process.py \
 		evals/infra/idempotency_worker.py scripts/check_idempotency_contracts.py
@@ -116,6 +116,12 @@ api-boundary-audit:
 .PHONY: idempotency-audit
 idempotency-audit:
 	@PYTHONPATH=$(PYTHONPATH):. uv run python scripts/check_idempotency_contracts.py
+
+# Command-disposition manifest + API error taxonomy. Static guard for the
+# accepted-then-dropped class (#178/#368) and unmapped-500 class (#180).
+.PHONY: gate-coverage-audit
+gate-coverage-audit:
+	@PYTHONPATH=$(PYTHONPATH) uv run python scripts/check_gate_coverage.py
 
 # Cyclomatic complexity + maintainability report.
 # Uses uvx so radon stays out of the project lock file.

--- a/scripts/check_gate_coverage.py
+++ b/scripts/check_gate_coverage.py
@@ -197,15 +197,19 @@ def _app_exception_classes() -> dict[str, type[Exception]]:
 
     import archetype.app as app_pkg
 
+    # walk_packages yields children only, never the anchor package itself —
+    # include archetype/app/__init__.py explicitly so an exception defined
+    # there cannot escape the scan.
+    module_names = ["archetype.app"]
+    module_names += [
+        module_info.name
+        for module_info in pkgutil.walk_packages(app_pkg.__path__, "archetype.app.")
+    ]
     classes: dict[str, type[Exception]] = {}
-    for module_info in pkgutil.walk_packages(app_pkg.__path__, "archetype.app."):
-        module = importlib.import_module(module_info.name)
+    for name in module_names:
+        module = importlib.import_module(name)
         for obj in vars(module).values():
-            if (
-                isinstance(obj, type)
-                and issubclass(obj, Exception)
-                and obj.__module__ == module_info.name
-            ):
+            if isinstance(obj, type) and issubclass(obj, Exception) and obj.__module__ == name:
                 classes[f"{obj.__module__}.{obj.__name__}"] = obj
     return classes
 

--- a/scripts/check_gate_coverage.py
+++ b/scripts/check_gate_coverage.py
@@ -145,8 +145,25 @@ def check_command_dispositions() -> list[str]:
 
 
 # ── Check 2: error taxonomy ──────────────────────────────────────────────────
+# The whole archetype.app package is walked for Exception subclasses — a
+# hardcoded module list would fail open the moment errors are defined
+# elsewhere (footgun review on PR #407: app/_catalog.py's four exceptions).
 
-APP_ERROR_MODULES = ("archetype.app.errors", "archetype.app.auth.errors")
+# Exceptions that deliberately surface as HTTP 500 for now. Every entry needs
+# a rationale and an issue; a stale entry (class gone or now mapped) fails
+# the audit so the manifest cannot rot.
+INTENTIONAL_UNMAPPED = {
+    "archetype.app._catalog.CatalogConflictError": "conflict mapping tracked in #413",
+    "archetype.app._catalog.CatalogSchemaMismatchError": (
+        "integrity violation; 500 may be correct — decision tracked in #413"
+    ),
+    "archetype.app._catalog.ClaimConflictError": "conflict mapping tracked in #413",
+    "archetype.app._catalog.ClaimPendingError": "conflict/pending mapping tracked in #413",
+    "archetype.app.audit_log.AuditBackpressureError": (
+        "observable backpressure per the durability posture; 503-shaped, "
+        "mapping decision tracked in #413"
+    ),
+}
 
 
 def _mapped_exception_bases() -> tuple[type[BaseException], ...]:
@@ -174,26 +191,51 @@ def _mapped_exception_bases() -> tuple[type[BaseException], ...]:
     return tuple(bases)
 
 
+def _app_exception_classes() -> dict[str, type[Exception]]:
+    """Every Exception subclass defined anywhere in the archetype.app package."""
+    import pkgutil
+
+    import archetype.app as app_pkg
+
+    classes: dict[str, type[Exception]] = {}
+    for module_info in pkgutil.walk_packages(app_pkg.__path__, "archetype.app."):
+        module = importlib.import_module(module_info.name)
+        for obj in vars(module).values():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, Exception)
+                and obj.__module__ == module_info.name
+            ):
+                classes[f"{obj.__module__}.{obj.__name__}"] = obj
+    return classes
+
+
 def check_error_taxonomy() -> list[str]:
     problems: list[str] = []
     bases = _mapped_exception_bases()
     if not bases:
         return ["could not derive any mapped exception bases from raise_api_error"]
 
-    for module_name in APP_ERROR_MODULES:
-        module = importlib.import_module(module_name)
-        for obj in vars(module).values():
-            if (
-                isinstance(obj, type)
-                and issubclass(obj, Exception)
-                and obj.__module__ == module_name
-                and not issubclass(obj, tuple(bases))
-            ):
-                problems.append(
-                    f"{module_name}.{obj.__name__} is not a subclass of any base "
-                    "raise_api_error maps — it will surface as HTTP 500. Map it "
-                    "in src/archetype/api/errors.py or subclass a mapped base."
-                )
+    app_exceptions = _app_exception_classes()
+    for qualname, cls in sorted(app_exceptions.items()):
+        mapped = issubclass(cls, bases)
+        declared = qualname in INTENTIONAL_UNMAPPED
+        if not mapped and not declared:
+            problems.append(
+                f"{qualname} is not a subclass of any base raise_api_error maps — "
+                "it will surface as HTTP 500. Map it in src/archetype/api/errors.py, "
+                "subclass a mapped base, or declare it in INTENTIONAL_UNMAPPED "
+                "with a rationale and issue."
+            )
+        elif mapped and declared:
+            problems.append(
+                f"{qualname} is declared INTENTIONAL_UNMAPPED but is now mapped — "
+                "remove the stale manifest entry."
+            )
+
+    for qualname in INTENTIONAL_UNMAPPED:
+        if qualname not in app_exceptions:
+            problems.append(f"INTENTIONAL_UNMAPPED names a class that no longer exists: {qualname}")
     return problems
 
 

--- a/scripts/check_gate_coverage.py
+++ b/scripts/check_gate_coverage.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Gate-surface coverage audit (deterministic).
+
+Two checks that keep the command gate's claim-vs-effect surface honest:
+
+1. **Command disposition manifest** — every ``CommandType`` member is
+   classified below, and ``CommandService._apply``'s match arms equal the
+   applied-in-drain set exactly. A new enum member without a classification,
+   or a drain arm drifting from the manifest, fails this audit. This is the
+   static guard for the accepted-then-dropped class (issues #178/#368): a
+   command the gate accepts must either have a drain arm, be a direct-gated
+   operation, or be documented broker-queued data.
+
+2. **API error taxonomy** — every exception class defined in the app layer's
+   error modules must be mapped by ``api.errors.raise_api_error`` to a
+   non-500 branch (issue #180: ``WorldNotFoundError`` extended
+   ``LookupError``, missed the ``KeyError`` branch, and fell through to the
+   500 fallback while tests stayed green).
+
+Run via ``make lint`` (PYTHONPATH=src). Exits non-zero with a specific
+message on any drift.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMAND_SERVICE = ROOT / "src/archetype/app/command_service.py"
+API_ERRORS = ROOT / "src/archetype/api/errors.py"
+
+# ── Check 1 manifest ─────────────────────────────────────────────────────────
+# Every CommandType member must appear in exactly one bucket. Reclassifying a
+# type is a contract decision: update the manifest in the same PR as the code.
+
+# Tick-deferred mutations: submit() enqueues them and _apply MUST have an arm.
+APPLIED_IN_DRAIN = {
+    "SPAWN",
+    "DESPAWN",
+    "UPDATE",
+    "ADD_COMPONENT",
+    "REMOVE_COMPONENT",
+    "ADD_PROCESSOR",
+    "REMOVE_PROCESSOR",
+}
+
+# Direct-gated operations (CommandService exposes an explicit method; the
+# broker is not their application path). KNOWN GAP (issue #368): submit()
+# currently accepts these and drain drops them with a warning — when #368
+# lands, this audit should additionally assert submit-time rejection.
+DIRECT_ONLY = {
+    "INGEST_FACT",
+    "EVALUATE",
+    "CREATE_WORLD",
+    "DESTROY_WORLD",
+    "FORK_WORLD",
+    "STEP",
+    "RUN",
+    "RUN_ROLLOUT",
+    "RUN_EPISODE",
+    "AUTORESEARCH",
+    "QUERY_WORLD",
+    "GET_WORLD_INFO",
+    "GET_AUDIT_HISTORY",
+    "LIST_SIGNATURES",
+    "LIST_WORLDS",
+    "LIST_PROCESSORS",
+    "LIST_HOOKS",
+    "LIST_RESOURCES",
+    "ADD_RESOURCE",
+    "ADD_HOOK",
+    "REMOVE_HOOK",
+}
+
+# Application-defined envelopes: the broker supplies queueing only; consumers
+# (message-delivery processors, custom handlers) dequeue and interpret them.
+BROKER_DATA = {"MESSAGE", "CUSTOM"}
+
+
+def _drain_case_arms(path: Path) -> set[str]:
+    """CommandType names matched by ``case`` arms inside ``_apply``."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    arms: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_apply":
+            for inner in ast.walk(node):
+                if not isinstance(inner, ast.Match):
+                    continue
+                for case in inner.cases:
+                    pattern = case.pattern
+                    if isinstance(pattern, ast.MatchValue) and isinstance(
+                        pattern.value, ast.Attribute
+                    ):
+                        value = pattern.value
+                        if isinstance(value.value, ast.Name) and value.value.id == "CommandType":
+                            arms.add(value.attr)
+    return arms
+
+
+def check_command_dispositions() -> list[str]:
+    from archetype.app.models import CommandType
+
+    problems: list[str] = []
+    members = set(CommandType.__members__)
+    classified = APPLIED_IN_DRAIN | DIRECT_ONLY | BROKER_DATA
+
+    overlap = (
+        (APPLIED_IN_DRAIN & DIRECT_ONLY)
+        | (APPLIED_IN_DRAIN & BROKER_DATA)
+        | (DIRECT_ONLY & BROKER_DATA)
+    )
+    if overlap:
+        problems.append(f"manifest buckets overlap: {sorted(overlap)}")
+
+    unclassified = members - classified
+    if unclassified:
+        problems.append(
+            "CommandType members with no disposition (classify them in "
+            f"scripts/check_gate_coverage.py): {sorted(unclassified)}"
+        )
+    phantom = classified - members
+    if phantom:
+        problems.append(f"manifest names non-existent CommandType members: {sorted(phantom)}")
+
+    arms = _drain_case_arms(COMMAND_SERVICE)
+    missing_arms = APPLIED_IN_DRAIN - arms
+    if missing_arms:
+        problems.append(
+            "applied-in-drain commands with NO _apply arm (accepted-then-"
+            f"dropped at drain): {sorted(missing_arms)}"
+        )
+    surprise_arms = arms - APPLIED_IN_DRAIN
+    if surprise_arms:
+        problems.append(
+            "_apply handles commands the manifest does not classify as "
+            f"applied-in-drain (update the manifest): {sorted(surprise_arms)}"
+        )
+    return problems
+
+
+# ── Check 2: error taxonomy ──────────────────────────────────────────────────
+
+APP_ERROR_MODULES = ("archetype.app.errors", "archetype.app.auth.errors")
+
+
+def _mapped_exception_bases() -> tuple[type[BaseException], ...]:
+    """Exception bases raise_api_error maps to non-500 statuses (AST-derived)."""
+    tree = ast.parse(API_ERRORS.read_text(), filename=str(API_ERRORS))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "raise_api_error":
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Name)
+                    and inner.func.id == "isinstance"
+                    and len(inner.args) == 2
+                ):
+                    for leaf in ast.walk(inner.args[1]):
+                        if isinstance(leaf, ast.Name):
+                            names.add(leaf.id)
+    api_errors = importlib.import_module("archetype.api.errors")
+    bases: list[type[BaseException]] = []
+    for name in names:
+        obj = getattr(api_errors, name, None) or getattr(builtins, name, None)
+        if isinstance(obj, type) and issubclass(obj, BaseException):
+            bases.append(obj)
+    return tuple(bases)
+
+
+def check_error_taxonomy() -> list[str]:
+    problems: list[str] = []
+    bases = _mapped_exception_bases()
+    if not bases:
+        return ["could not derive any mapped exception bases from raise_api_error"]
+
+    for module_name in APP_ERROR_MODULES:
+        module = importlib.import_module(module_name)
+        for obj in vars(module).values():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, Exception)
+                and obj.__module__ == module_name
+                and not issubclass(obj, tuple(bases))
+            ):
+                problems.append(
+                    f"{module_name}.{obj.__name__} is not a subclass of any base "
+                    "raise_api_error maps — it will surface as HTTP 500. Map it "
+                    "in src/archetype/api/errors.py or subclass a mapped base."
+                )
+    return problems
+
+
+def main() -> int:
+    sys.path.insert(0, str(ROOT / "src"))
+    problems = check_command_dispositions() + check_error_taxonomy()
+    if problems:
+        print("Gate coverage audit FAILED:")
+        for problem in problems:
+            print(f"  - {problem}")
+        print(
+            "\nEvery CommandType needs a disposition (drain arm, direct-gated, "
+            "or broker data), and every app-layer error needs a non-500 HTTP "
+            "mapping. See the manifest in this script."
+        )
+        return 1
+    print("Gate coverage audit passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why
The footgun gate caught three real findings on #379 — but serially, one per CI round, and two were *mechanizable classes* it shouldn't have to spend model turns on. This PR moves the deterministic part into `make lint` and teaches the detector to sweep siblings in one round.

## What
**`scripts/check_gate_coverage.py`** (new, in `make lint` as `gate-coverage-audit`):
1. **Command disposition manifest** — every `CommandType` member classified as applied-in-drain / direct-only / broker-data; `_apply`'s match arms must equal the applied-in-drain set exactly. Statically catches the accepted-then-dropped class (#178, #368, the pre-#332 UPDATE drop). Negative-tested: removing an arm fires the audit.
2. **API error taxonomy** — every exception class in `app/errors.py` + `app/auth/errors.py` must subclass a base `raise_api_error` maps to a non-500 (AST-derives the mapped bases, currently `GuardrailError | PermissionError | WorldNotFoundError | KeyError | ValueError`). Statically catches the #180 class.

**`.claude/skills/footgun-detector/SKILL.md`** — sibling-sweep rule: when a diff fixes an invariant, verify the sync/async, LanceDB/Iceberg, and create/fork/resume mirrors in the *same* review, anchored to the changed line establishing the invariant. This is the round-collapser: on #379, rounds 2 and 3 were both the fixed hunk's unfixed twin.

## Not in this PR (candidate follow-ups)
- Lifecycle unwind sweep (fault-inject every boundary call in create/fork/resume, assert no registry/fence residue) — blocked on #379 landing.
- Parametrized sync/async shared contract suite (makes "fixed async, forgot sync" structurally impossible).
- Detector fan-out matrix per perspective (pairs with #394's turn-budget scaling).

## Tests
`make lint` green (audit passes on main's current surface), full suite 934 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)