### PR TITLE
fix(evals): document harness and quiet expected failures

### DIFF
--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -1,0 +1,195 @@
+# Evaluation Harness
+
+Archetype's evals are independent executable oracles for repository-level
+contracts. They complement unit and integration tests: a task assembles a
+realistic boundary, observes the result, and grades the outcome without
+depending on the feature test that originally motivated the contract.
+
+The harness lives under `evals/` and uses a **task → trial → grader** model.
+It does not ask whether the implementation followed one preferred code path;
+it asks whether the resulting behavior satisfies the contract.
+
+## Running the suites
+
+```bash
+make eval          # every suite; writes eval-results.json
+make eval-reg      # regression only
+make eval-idem     # idempotency only
+make eval-cap      # capability only
+
+# Spec-only and repeated-trial runs use the module directly.
+uv run python -m evals.run --suite spec
+uv run python -m evals.run --suite regression --trials 3
+uv run python -m evals.run --out eval-results.json
+```
+
+`--trials k` must be a positive integer. Each task runs `k` times and reports:
+
+| Metric | Meaning |
+|---|---|
+| `pass@k` | Fraction of trials that passed |
+| `pass^k` | `1.0` only when every trial passed |
+| `avg_score` | Mean grader score across trials |
+| `all_passed` | Every grader passed in every trial |
+
+The default is one trial. Repeated trials are useful when a boundary involves
+process scheduling or another source of nondeterminism; they do not turn a
+deterministic failure into an acceptable result.
+
+## What passes the gate
+
+The four suites have deliberately different meanings:
+
+| Suite | Contract | CLI exit condition |
+|---|---|---|
+| Regression | Previously working behavior must remain true | Every task passes every trial |
+| Spec | Normative guide claims retain independent executable evidence | Every task passes every trial |
+| Idempotency | Retry, replay, and non-idempotent boundaries match the specification matrix | Every task passes every trial |
+| Capability | Exercise larger end-to-end behavior without turning a score into a release threshold | No trial crashes; grader misses remain visible in the report |
+
+An empty requested suite is a failure, never a vacuous success. A full run also
+requires the regression, spec, and idempotency suites to be present.
+
+`make ci` runs regression and idempotency evals after the static checks and
+pytest suite. The spec suite has its own pytest registration and CLI smoke
+contracts under `tests/spec_contracts/`, so it is exercised by that same gate.
+The GitHub Actions eval job runs regression and capability separately.
+
+The idempotency suite has an additional fast static oracle:
+`make idempotency-audit` verifies that every normative matrix row in the
+[specification](specification.md) maps to a registered task before the
+behavioral scenarios run.
+
+## Outcomes, not log noise
+
+Expected poison commands are part of the regression input. The command drain
+may log while converting one of those failures into a dropped command, but the
+eval CLI filters the known malformed-command, no-op-command, reserved-spawn
+replay, and missing-despawn records from its report. Other `archetype` records
+remain visible. A task failure is still explicit: uncaught exceptions populate
+`TrialResult.error`, failed graders include their details, and either condition
+affects the suite according to the table above.
+
+This quieting belongs to the eval process boundary. It does not change library
+log levels, production runtime logging, or `RunConfig(debug=True)`. A host that
+has explicitly attached an `archetype` log handler keeps that configuration.
+
+## Graders
+
+Code-based graders live in `evals/graders.py`:
+
+- `exact_match` checks equality and returns a binary score.
+- `state_check` requires every named boolean check to pass while retaining a
+  fractional score for diagnosis.
+- `threshold` checks an inclusive numeric range.
+- `raises` checks an expected exception type.
+- `crap_score` combines cyclomatic complexity and coverage for code-quality
+  evaluation.
+
+**Current gap (#410):** an empty grader list receives a zero score but can
+still pass through Python's vacuous `all([])` behavior. Until the harness fails
+closed, every task must return at least one meaningful `GraderResult`; a task
+that observes nothing is not an oracle.
+
+## Registered task manifest
+
+This inventory is checked against `build_harness()` by
+`tests/spec_contracts/test_documentation_contracts.py`. Adding, removing, or
+renaming a task requires updating this table in the same change.
+
+<!-- eval-task-manifest:start -->
+
+### Regression
+
+| Suite | Task | Contract exercised |
+|---|---|---|
+| `regression` | `component_serde` | Component row serialization, prefixes, and schemas |
+| `regression` | `archetype_signatures` | Signature ordering, set operations, naming, and schema composition |
+| `regression` | `rbac_enforcement` | Role permissions, token costs, and the default role |
+| `regression` | `command_ordering` | Deterministic `(tick, priority, seq)` command order |
+| `regression` | `command_pipeline` | Submit → broker → step → history, with RBAC at the service boundary |
+| `regression` | `tick_quota_resets` | Per-tick command quotas reset at each tick rather than process-wide |
+| `regression` | `episode_value_termination` | Value-based episode termination stops before the defensive cap |
+| `regression` | `poison_in_batch` | A malformed command does not block valid commands in the same drain |
+| `regression` | `missing_payload_keys` | Missing required keys do not corrupt world state |
+| `regression` | `unknown_component_type` | An unknown removal type preserves the entity signature |
+| `regression` | `despawn_nonexistent` | Despawning a missing entity is an observable no-op |
+| `regression` | `unhandled_command_noop` | Message, query, and custom commands drain without implicit mutation |
+
+### Spec
+
+| Suite | Task | Contract exercised |
+|---|---|---|
+| `spec` | `spec.manifest_traceability` | Spec cases cite normative sources and registered task IDs |
+| `spec` | `spec.role_permission_matrix` | Code permissions match the command-gate matrix |
+| `spec` | `spec.runtime_gate_only_boundary` | Runtime dependencies remain behind the command gate |
+| `spec` | `spec.command_service_gate_map` | Public command methods retain gate and audit coverage |
+| `spec` | `spec.append_only_protocols` | Storage and audit protocols expose no destructive methods |
+| `spec` | `spec.receipt_authority_firewall` | Receipts and facts remain evidence rather than authority |
+| `spec` | `spec.info_class_downgrades` | Lifecycle and introspection return frozen information snapshots |
+
+### Idempotency
+
+| Suite | Task | Contract exercised |
+|---|---|---|
+| `idempotency` | `idempotency.manifest_traceability` | The specification matrix and behavioral manifest agree |
+| `idempotency` | `idempotency.storage_pooling_and_shutdown` | Storage pooling and cached-store shutdown converge safely |
+| `idempotency` | `idempotency.world_lifecycle` | Explicit-ID create and missing or repeated destroy behavior |
+| `idempotency` | `idempotency.broker_and_submit_non_idempotent` | Duplicate logical enqueues remain distinct commands |
+| `idempotency` | `idempotency.submit_spawn_distinct_entities` | Repeated submitted spawns reserve distinct entity IDs |
+| `idempotency` | `idempotency.async_world_entity_ids_and_missing_remove` | Entity allocation and missing removal preserve world state |
+| `idempotency` | `idempotency.runtime_aliases_and_history` | Actor aliases and fixed-filter history reads remain stable |
+| `idempotency` | `idempotency.staged_spawn_last_write_wins` | Duplicate raw staged spawn rows resolve last-write-wins at materialization |
+| `idempotency` | `idempotency.same_tick_duplicate_mutations` | Duplicate same-tick entity mutations collapse at materialization |
+| `idempotency` | `idempotency.component_signature_noops` | Signature-preserving component operations stage no rows or hooks |
+| `idempotency` | `idempotency.fixed_reads` | Repeated fixed-state queries, history, and signature reads agree |
+| `idempotency` | `idempotency.query_archetype_repeatable` | Repeated reads are stable while an updater replay remains an append |
+| `idempotency` | `idempotency.step_and_run_non_idempotent` | Repeated execution advances time and appends rows |
+| `idempotency` | `idempotency.atomic_publish_retry` | A failed publication stays invisible and retry publishes once |
+| `idempotency` | `idempotency.durable_discovery` | Cold discovery, reads, and catalog registration converge |
+| `idempotency` | `idempotency.resume_and_writer_fencing` | Resumed writers fence stale attempts from visibility |
+| `idempotency` | `idempotency.durable_fact_replay` | Concurrent fact replay converges; content conflicts fail loudly |
+| `idempotency` | `idempotency.durable_fact_crash_recovery` | Lease takeover completes an appended orphan without duplication |
+| `idempotency` | `idempotency.evaluation_receipt_replay` | Receipt replay returns prior evidence without grading again |
+| `idempotency` | `idempotency.process_crash_cold_resume` | Cold resume retries one tick after a hard process failure |
+| `idempotency` | `idempotency.process_writer_fence_race` | Exactly one of two racing writer processes publishes |
+| `idempotency` | `idempotency.process_fact_replay` | Independent processes converge on one external fact identity |
+| `idempotency` | `idempotency.process_evaluation_replay` | Concurrent grading runs once and changed subjects conflict first |
+
+### Capability
+
+| Suite | Task | Contract exercised |
+|---|---|---|
+| `capability` | `storage_roundtrip` | Mixed component fields survive persistence and retrieval |
+| `capability` | `simulation_correctness` | Multi-step processing preserves entities and updates expected fields |
+
+<!-- eval-task-manifest:end -->
+
+## Adding or changing a task
+
+1. Put the scenario in the suite that owns its failure semantics.
+2. Drive the highest stable boundary that proves the contract. Use lower-level
+   seams only when the task is explicitly about that seam or must construct a
+   crash state that public calls cannot produce deterministically.
+3. Grade externally visible outcomes. Do not duplicate the implementation in
+   the assertion.
+4. Register the task in the suite's `register(harness)` function and update the
+   manifest above.
+5. Run the focused suite, its static traceability check when applicable, and
+   `make ci` for cross-layer behavior.
+
+Keep task IDs stable once a contract cites them. When semantics genuinely
+change, update the normative source, implementation, task, and this manifest as
+one reviewable unit.
+
+## Relationship to other checks
+
+- Pytest provides focused unit, integration, race, and contract diagnosis.
+- Evals provide independent repository-level outcomes and traceability.
+- [Mutation testing](mutation-testing.md) probes whether focused assertions
+  detect controlled implementation changes; it is intentionally on demand.
+- Benchmarks measure cost and trend, not semantic correctness.
+
+No one layer substitutes for the others. A useful change identifies the
+smallest oracle that proves its local contract, then runs the broader gates in
+proportion to the boundary it crosses.

--- a/evals/run.py
+++ b/evals/run.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 
 from evals.harness import EvalHarness
 from evals.suites import capability, idempotency, poison_command, regression, spec_contracts
@@ -24,6 +25,70 @@ from evals.types import TaskResult
 
 REQUIRED_SUITES = frozenset({"regression", "spec", "idempotency"})
 KNOWN_SUITES = ("regression", "spec", "idempotency", "capability")
+
+
+class _ExpectedEvalNoiseFilter:
+    """Drop only records produced by intentional adversarial eval inputs."""
+
+    _NOOP_COMMAND_TYPES = frozenset({"message", "query_world", "custom"})
+    _RESERVED_SPAWN_PREFIX = "Entity "
+    _RESERVED_SPAWN_SUFFIX = (
+        " is already registered. Use update_entity to change component values on a live entity."
+    )
+
+    @classmethod
+    def _is_expected_apply_failure(cls, record: logging.LogRecord) -> bool:
+        if not record.exc_info:
+            return False
+        error = record.exc_info[1]
+        if isinstance(error, KeyError):
+            return error.args == ("entity_id",)
+        if not isinstance(error, ValueError):
+            return False
+        detail = str(error)
+        if (
+            "requires a 'type' key" in detail
+            or detail == "Component type 'TotallyFakeComponent' not found."
+        ):
+            return True
+        if not (
+            detail.startswith(cls._RESERVED_SPAWN_PREFIX)
+            and detail.endswith(cls._RESERVED_SPAWN_SUFFIX)
+        ):
+            return False
+        entity_id = detail[len(cls._RESERVED_SPAWN_PREFIX) : -len(cls._RESERVED_SPAWN_SUFFIX)]
+        return entity_id.isdigit()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        if record.name == "archetype.app.command_service":
+            if message.startswith("Failed to apply command "):
+                return not self._is_expected_apply_failure(record)
+            prefix = "Unhandled command type in drain: "
+            if message.startswith(prefix):
+                return message.removeprefix(prefix) not in self._NOOP_COMMAND_TYPES
+        if record.name == "archetype.core.aio.async_world":
+            return "Entity Removal Failed: No entity:" not in message
+        return True
+
+
+def _configure_eval_logging() -> None:
+    """Filter expected adversarial noise unless a host configured logging.
+
+    Poison-command tasks deliberately exercise failures that the command
+    drain converts into graded outcomes.  Without an application-owned
+    handler, Python's ``lastResort`` handler prints those expected records as
+    tracebacks.  The eval CLI is the application boundary, so it owns a
+    filtered package sink while leaving handlers configured on the package or
+    an ancestor alone. Unexpected records still reach the host's sink.
+    """
+    package_logger = logging.getLogger("archetype")
+    if package_logger.hasHandlers():
+        return
+    handler = logging.StreamHandler()
+    handler.addFilter(_ExpectedEvalNoiseFilter())
+    package_logger.addHandler(handler)
+    package_logger.propagate = False
 
 
 def _positive_int(value: str) -> int:
@@ -95,6 +160,7 @@ def print_report(results: list[TaskResult]) -> None:
 
 
 def main() -> int:
+    _configure_eval_logging()
     parser = argparse.ArgumentParser(description="Run archetype evals")
     parser.add_argument("--out", default=None, help="Write JSON results to file")
     parser.add_argument("--suite", choices=KNOWN_SUITES, default=None)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
       - Atomic Visibility: guide/atomic-visibility.md
       - Durable Facts: guide/durable-facts.md
       - Audit Log: guide/audit-log.md
+      - Evaluation Harness: guide/evals.md
       - CORE INTERNALS:
           - Archetypes: guide/archetype.md
           - Systems: guide/system-execution.md

--- a/tests/eval_framework/test_harness_trial_validation.py
+++ b/tests/eval_framework/test_harness_trial_validation.py
@@ -6,12 +6,14 @@ and pass-rate reporting semantics (issue #144)."""
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import sys
 
 import pytest
 
 from evals.harness import EvalHarness
+from evals.run import _configure_eval_logging, _ExpectedEvalNoiseFilter
 from evals.types import GraderResult, TaskResult, TrialResult
 
 
@@ -111,3 +113,56 @@ def test_run_cli_rejects_negative_trials() -> None:
 def test_run_cli_rejects_non_integer_trials() -> None:
     proc = _run_cli("--trials", "abc")
     assert proc.returncode != 0
+
+
+def test_regression_cli_reports_poison_outcomes_without_library_tracebacks() -> None:
+    proc = _run_cli("--suite", "regression")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.stderr == ""
+    assert "Traceback" not in proc.stdout
+    assert "[PASS] poison_in_batch" in proc.stdout
+    assert "[PASS] despawn_nonexistent" in proc.stdout
+
+
+def _apply_failure_record(error: Exception) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="archetype.app.command_service",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="Failed to apply command command-id (spawn)",
+        args=(),
+        exc_info=(type(error), error, None),
+    )
+
+
+def test_eval_log_filter_quiets_reserved_spawn_replay() -> None:
+    error = ValueError(
+        "Entity 77 is already registered. "
+        "Use update_entity to change component values on a live entity."
+    )
+
+    assert not _ExpectedEvalNoiseFilter().filter(_apply_failure_record(error))
+
+
+def test_eval_log_filter_keeps_unexpected_apply_failures_visible() -> None:
+    error = RuntimeError("unexpected storage failure")
+
+    assert _ExpectedEvalNoiseFilter().filter(_apply_failure_record(error))
+
+
+def test_eval_logging_honors_handler_inherited_from_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_logger = logging.getLogger("archetype")
+    root_logger = logging.getLogger()
+    root_handler = logging.NullHandler()
+    monkeypatch.setattr(package_logger, "handlers", [])
+    monkeypatch.setattr(package_logger, "propagate", True)
+    monkeypatch.setattr(root_logger, "handlers", [root_handler])
+
+    _configure_eval_logging()
+
+    assert package_logger.handlers == []
+    assert package_logger.propagate is True

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from archetype.app.auth.permissions import ROLES_BY_COMMAND
 from archetype.app.models import CommandType
+from evals.run import build_harness
 
 _GUIDE_ROOT = Path("docs/guide")
 _COMMAND_TOTAL_PATTERNS = (
@@ -21,6 +22,11 @@ _DESIGN_ONLY_MESSAGING_TYPES = (
     "DeliveryReceipt",
     "ChatGraphRegistry",
 )
+_EVAL_MANIFEST = re.compile(
+    r"<!-- eval-task-manifest:start -->(.*?)<!-- eval-task-manifest:end -->",
+    re.DOTALL,
+)
+_EVAL_TASK_ROW = re.compile(r"^\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|", re.MULTILINE)
 
 
 def test_numeric_command_type_claims_match_the_enum() -> None:
@@ -81,3 +87,21 @@ def test_docs_do_not_claim_design_only_messaging_types() -> None:
                 stale.append(f"{path}: presents design-only {type_name}")
 
     assert not stale, "stale messaging infrastructure claims:\n" + "\n".join(stale)
+
+
+def test_eval_guide_manifest_matches_registered_tasks() -> None:
+    """The guide's task inventory is exact, not a hand-maintained sample."""
+    guide = (_GUIDE_ROOT / "evals.md").read_text()
+    manifest = _EVAL_MANIFEST.search(guide)
+    assert manifest is not None, "eval task manifest markers are missing"
+
+    rows = _EVAL_TASK_ROW.findall(manifest.group(1))
+    documented = {(suite, task_id) for suite, task_id in rows}
+    assert len(rows) == len(documented), "eval task manifest contains duplicate rows"
+
+    harness = build_harness(trials=1)
+    registered = {(suite, task_id) for task_id, suite, _, _ in harness._tasks}
+    assert documented == registered, (
+        f"eval guide manifest drifted; missing={registered - documented}, "
+        f"stale={documented - registered}"
+    )


### PR DESCRIPTION
Closes #324.

## Summary

- add a current guide to the task → trial → grader model, suite exit semantics, CI placement, and all registered eval tasks
- machine-check the guide manifest against `build_harness()` so task additions, removals, and renames cannot silently drift
- keep expected poison-command tracebacks out of eval CLI reports with a filtered `archetype` sink only when the host has not configured one
- filter only the known malformed-command, deliberate no-op, reserved-spawn replay, and missing-despawn records; unexpected Archetype records remain visible
- preserve failures as grader details or `TrialResult.error`; production logging and `RunConfig.debug` are unchanged

## Why this shape

The stale #248 patch changed command-service and core logging globally. The current contract only needs quiet eval output, and those seams are concurrently owned. Treating `evals.run` as the application boundary fixes the observed noise without changing library severity or touching `core/`.

The documentation audit also found a separate vacuous-success edge: tasks returning no graders currently pass through `all([])`. That behavior is documented as a current gap and tracked independently in #410 rather than expanding this PR.

## Validation

- `make ci` — 993 passed, 7 skipped; 85.34% coverage; regression 12/12; idempotency 23/23
- `uv run pytest -q tests/eval_framework/test_harness_trial_validation.py tests/spec_contracts/test_documentation_contracts.py` — 20 passed, including inherited root-handler ownership and reserved-spawn replay filtering
- `make eval-cap` — 2/2 passed
- `uv run python -m evals.run --suite spec` — 7/7 passed
- `make idempotency-audit` — passed
- `uv run --extra docs mkdocs build` — passed (existing Griffe annotation warning remains)
- `npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"` — 0 issues
- focused Ruff format/lint and `git diff --check` — passed

A strict MkDocs build still fails on the pre-existing `async_system.py` Griffe warning; this PR adds no strict-build warning.
