### PR TITLE
ci: report required contexts on merge groups — merge-queue prerequisite

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -9,6 +9,12 @@ on:
   # count as satisfied, which would fail open.)
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+  # Merge queue: the required review contexts must exist on merge groups.
+  # Both jobs SKIP on merge_group (skipped required checks count as
+  # satisfied) — deliberately fail-open here and only here: the substantive
+  # review binds to the PR head and is enforced before queue entry; the
+  # queue's merge groups revalidate build/test, not review.
+  merge_group:
 
 permissions: {}
 
@@ -19,6 +25,7 @@ concurrency:
 jobs:
   footgun-review:
     name: footgun-review
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -221,7 +228,9 @@ jobs:
   review-complete:
     name: review-complete
     needs: footgun-review
-    if: always()
+    # always() so a footgun crash cannot skip-satisfy the gate on PRs;
+    # merge groups skip both jobs (see the trigger comment).
+    if: always() && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -19,7 +19,11 @@ on:
 permissions: {}
 
 concurrency:
-  group: deterministic-review-${{ github.event.pull_request.number }}
+  # pull_request.number is empty on merge_group events; without the fallback
+  # every queue entry would share one key and cancel-in-progress would let
+  # merge groups cancel each other's check runs, stalling the queue. On
+  # merge_group, github.ref is the unique merge-group ref.
+  group: deterministic-review-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,9 @@ on:
       # The generated Python, CLI, and REST references derive from source.
       - "src/archetype/**"
       - ".github/workflows/docs.yml"
+  # Merge queue: required contexts must report on the queue's merge groups
+  # (path filters are not supported on merge_group; the jobs are fast).
+  merge_group:
   # No path filter on pull_request: Spelling, Markdown lint, and Build docs
   # are required status checks on main, and a required check that never runs
   # blocks the merge forever. The jobs cost ~30s combined per PR.

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Merge queue: required contexts must report on the queue's merge groups.
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
Prerequisite for enabling the merge queue on main (agreed with Everett to drain the 20-PR backlog).

- `python-tests.yml` + `docs.yml`: `merge_group` trigger so the ten build/test/docs required contexts report on merge groups.
- `deterministic-review.yml`: triggers on `merge_group` but **skips both jobs there** — deliberate, documented fail-open in exactly this one place: skipped required checks count as satisfied, and the substantive review binds to the PR head *before* queue entry; merge groups revalidate build/test, not review. PR-level fail-closed semantics unchanged.
- `automerge.yml` needs no change: `gh pr merge --auto --squash` enqueues once a queue is required.

Next (post-merge): a dedicated "Main — Merge Queue" ruleset (squash, ALLGREEN batching), then the backlog drains through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)