### PR TITLE
fix(evals): reject empty grader evidence

### DIFF
--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -86,10 +86,11 @@ Code-based graders live in `evals/graders.py`:
 - `crap_score` combines cyclomatic complexity and coverage for code-quality
   evaluation.
 
-**Current gap (#410):** an empty grader list receives a zero score but can
-still pass through Python's vacuous `all([])` behavior. Until the harness fails
-closed, every task must return at least one meaningful `GraderResult`; a task
-that observes nothing is not an oracle.
+Every trial must produce at least one meaningful `GraderResult`; a task that
+observes nothing is not an oracle. An empty result list fails the trial with a
+`TrialResult.error`, and `state_check` rejects an empty check mapping. A
+required-suite run therefore exits nonzero instead of accepting Python's
+vacuous `all([])` result or a grader that wraps equally vacuous state evidence.
 
 ## Registered task manifest
 

--- a/evals/graders.py
+++ b/evals/graders.py
@@ -31,11 +31,13 @@ def exact_match(actual: Any, expected: Any, *, name: str = "exact_match") -> Gra
 def state_check(checks: dict[str, bool], *, name: str = "state_check") -> GraderResult:
     """Outcome verification: passes if ALL state checks are True.
 
-    Supports partial credit (score = fraction of checks passing).
+    Rejects an empty check set. Otherwise, supports partial credit
+    (score = fraction of checks passing).
     """
+    if not checks:
+        raise ValueError("state_check requires at least one check")
+
     total = len(checks)
-    if total == 0:
-        return GraderResult(grader_name=name, passed=True, score=1.0)
     passed_count = sum(1 for v in checks.values() if v)
     score = passed_count / total
     failed = {k for k, v in checks.items() if not v}

--- a/evals/harness.py
+++ b/evals/harness.py
@@ -3,7 +3,7 @@
 
 """Eval harness: runs tasks, manages trials, grades outcomes, aggregates results.
 
-Each task is a callable that returns a list of GraderResults (the outcome
+Each task is a callable that returns a non-empty list of GraderResults (the outcome
 of applying all graders to the task's output).  The harness runs each task
 k times (trials), collects GraderResults per trial, and produces TaskResults
 with pass@k / pass^k metrics.
@@ -21,7 +21,7 @@ from collections.abc import Callable
 
 from evals.types import GraderResult, TaskResult, TrialResult
 
-# A task function returns the grader results for one trial.
+# A task function returns one or more grader results for one trial.
 TaskFn = Callable[[], list[GraderResult]]
 
 
@@ -53,13 +53,11 @@ class EvalHarness:
                 try:
                     grader_results = fn()
                     elapsed = time.perf_counter() - t0
+                    if not grader_results:
+                        raise ValueError(f"task {task_id!r} produced no grader evidence")
 
                     all_passed = all(g.passed for g in grader_results)
-                    avg_score = (
-                        sum(g.score for g in grader_results) / len(grader_results)
-                        if grader_results
-                        else 0.0
-                    )
+                    avg_score = sum(g.score for g in grader_results) / len(grader_results)
 
                     task_result.trials.append(
                         TrialResult(

--- a/tests/eval_framework/test_harness_trial_validation.py
+++ b/tests/eval_framework/test_harness_trial_validation.py
@@ -12,8 +12,10 @@ import sys
 
 import pytest
 
+from evals.graders import state_check
 from evals.harness import EvalHarness
 from evals.run import _configure_eval_logging, _ExpectedEvalNoiseFilter
+from evals.run import main as run_main
 from evals.types import GraderResult, TaskResult, TrialResult
 
 
@@ -89,6 +91,51 @@ def test_harness_run_records_grader_outcomes_across_trials() -> None:
     assert result.pass_pow_k == 0.0
 
 
+def test_harness_run_fails_trial_without_grader_evidence() -> None:
+    harness = EvalHarness()
+    harness.add("empty_task", suite="regression", fn=lambda: [])
+
+    [result] = harness.run()
+    [trial] = result.trials
+
+    assert trial.passed is False
+    assert trial.score == 0.0
+    assert trial.grader_results == []
+    assert trial.error == "task 'empty_task' produced no grader evidence"
+    assert result.pass_at_k == 0.0
+    assert result.all_passed is False
+
+
+def test_harness_run_preserves_multi_grader_aggregation() -> None:
+    grader_results = [
+        GraderResult(grader_name="passing", passed=True, score=0.25),
+        GraderResult(grader_name="failing", passed=False, score=0.75),
+    ]
+    harness = EvalHarness()
+    harness.add("multi_grader", suite="regression", fn=lambda: grader_results)
+
+    [result] = harness.run()
+    [trial] = result.trials
+
+    assert trial.passed is False
+    assert trial.score == pytest.approx(0.5)
+    assert trial.grader_results == grader_results
+    assert trial.error is None
+
+
+def test_state_check_rejects_empty_evidence() -> None:
+    with pytest.raises(ValueError, match="requires at least one check"):
+        state_check({})
+
+
+def test_state_check_preserves_partial_credit_for_nonempty_checks() -> None:
+    result = state_check({"materialized": True, "persisted": False})
+
+    assert result.passed is False
+    assert result.score == pytest.approx(0.5)
+    assert result.details == "failed: {'persisted'}"
+
+
 def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "evals.run", *args],
@@ -113,6 +160,21 @@ def test_run_cli_rejects_negative_trials() -> None:
 def test_run_cli_rejects_non_integer_trials() -> None:
     proc = _run_cli("--trials", "abc")
     assert proc.returncode != 0
+
+
+def test_run_cli_fails_required_task_without_grader_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    harness = EvalHarness()
+    harness.add("empty_task", suite="regression", fn=lambda: [])
+    monkeypatch.setattr("evals.run.build_harness", lambda trials=1: harness)
+    monkeypatch.setattr(sys, "argv", ["evals.run", "--suite", "regression"])
+
+    assert run_main() == 1
+    report = capsys.readouterr().out
+    assert "[FAIL] empty_task" in report
+    assert "error: task 'empty_task' produced no grader evidence" in report
 
 
 def test_regression_cli_reports_poison_outcomes_without_library_tracebacks() -> None:


### PR DESCRIPTION
Closes #410.

## Summary

- fail a trial when its task returns no grader results instead of accepting Python's vacuous `all([])`
- reject an empty `state_check` mapping instead of manufacturing a passing grader result
- report the task ID and missing-evidence reason through the existing `TrialResult.error` channel
- preserve normal multi-grader pass and average-score aggregation
- preserve `state_check` partial credit for non-empty checks
- prove a required-suite CLI run reports the failure and returns a nonzero status
- replace the guide's tracked gap with the fail-closed contract

## Why this shape

`EvalService.run_graders()` already rejects missing graders and empty grader outputs because an evaluation without evidence is undefined. The standalone repository harness now applies the same policy at its task-to-trial aggregation boundary, while `state_check` enforces it at the individual-grader boundary. Reusing the existing exception-to-`TrialResult.error` path keeps reporting and suite exit semantics centralized; it does not invent a synthetic grader or alter capability scoring thresholds.

## Validation

- `make ci` — 1,015 passed, 5 skipped; 85.92% coverage; regression 12/12; idempotency 23/23
- `make gate-coverage-audit` — passed
- `uv run pytest -q tests/eval_framework/test_harness_trial_validation.py tests/spec_contracts/test_documentation_contracts.py` — 25 passed
- minimal reproduction now reports `all_passed=False`, `pass_at_k=0.0`, `trial_passed=False`, and `task 'empty' produced no grader evidence`
- regression 12/12, spec 7/7, idempotency 23/23, capability 2/2
- `uv run --extra docs mkdocs build` — passed (existing Griffe annotation warning remains)
- `npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"` — 0 issues across 68 files
- focused Ruff format/lint and `git diff --check` — passed
