### PR TITLE
fix(api): map service conflicts to HTTP 409

### DIFF
--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -376,6 +376,19 @@ One tick MUST follow this order:
 
 ## Application Layer Contracts
 
+### Service error taxonomy
+
+- Public cross-service error contracts MUST live in `archetype.app.errors`.
+  Private service implementations subclass those contracts; transport adapters
+  MUST NOT import private implementation modules to classify failures.
+- The REST adapter maps `WorldNotFoundError` to HTTP 404 and `ConflictError` to
+  HTTP 409. Conflict responses expose only the contract's client-safe
+  `public_detail`; internal exception text remains server-side. App services
+  remain transport-agnostic and do not depend on HTTP.
+- Errors without a public client-recovery contract fail closed as HTTP 500.
+  `CatalogSchemaMismatchError` is an integrity failure in this category; its
+  internal detail MUST NOT be exposed to the client.
+
 ### StorageService
 
 - `StorageService` is the multiton owner for backend triplets:

--- a/scripts/check_gate_coverage.py
+++ b/scripts/check_gate_coverage.py
@@ -153,15 +153,12 @@ def check_command_dispositions() -> list[str]:
 # a rationale and an issue; a stale entry (class gone or now mapped) fails
 # the audit so the manifest cannot rot.
 INTENTIONAL_UNMAPPED = {
-    "archetype.app._catalog.CatalogConflictError": "conflict mapping tracked in #413",
     "archetype.app._catalog.CatalogSchemaMismatchError": (
-        "integrity violation; 500 may be correct — decision tracked in #413"
+        "integrity violation intentionally surfaces as 500; decision recorded in #413"
     ),
-    "archetype.app._catalog.ClaimConflictError": "conflict mapping tracked in #413",
-    "archetype.app._catalog.ClaimPendingError": "conflict/pending mapping tracked in #413",
     "archetype.app.audit_log.AuditBackpressureError": (
         "observable backpressure per the durability posture; 503-shaped, "
-        "mapping decision tracked in #413"
+        "public mapping tracked in #419"
     ),
 }
 

--- a/src/archetype/api/errors.py
+++ b/src/archetype/api/errors.py
@@ -22,7 +22,7 @@ from typing import NoReturn
 from fastapi import HTTPException
 
 from archetype.app.auth.errors import GuardrailError
-from archetype.app.errors import WorldNotFoundError
+from archetype.app.errors import ConflictError, WorldNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +35,8 @@ def raise_api_error(exc: Exception, *, conflict: bool = False) -> NoReturn:
     # explicit branch it fell through to the 500 fallback (issue #180).
     if isinstance(exc, WorldNotFoundError | KeyError):
         raise HTTPException(status_code=404, detail=str(exc)) from None
+    if isinstance(exc, ConflictError):
+        raise HTTPException(status_code=409, detail=exc.public_detail) from None
     if isinstance(exc, ValueError):
         status_code = 409 if conflict else 400
         raise HTTPException(status_code=status_code, detail=str(exc)) from None

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -55,6 +55,7 @@ from typing import Protocol
 import pyarrow as pa
 
 from archetype._storage_uri import local_storage_path, normalized_storage_uri
+from archetype.app.errors import ConflictError
 from archetype.core.config import StorageConfig
 from archetype.core.interfaces import StaleWriterError
 from archetype.core.paths import require_safe_namespace, resolve_local_root
@@ -65,8 +66,10 @@ _SCHEMA_VERSION = 3
 _DIGEST_DOMAIN = "archetype.catalog.v1"
 
 
-class CatalogConflictError(RuntimeError):
+class CatalogConflictError(ConflictError):
     """Same identity registered with different content — never silently resolved."""
+
+    public_detail = "Catalog entry conflicts with existing state"
 
 
 class CatalogSchemaMismatchError(RuntimeError):
@@ -211,12 +214,16 @@ class ManifestRecord:
     created_at: str
 
 
-class ClaimConflictError(RuntimeError):
+class ClaimConflictError(ConflictError):
     """Same external id claimed/completed with a different payload digest."""
 
+    public_detail = "Claim conflicts with existing state"
 
-class ClaimPendingError(RuntimeError):
+
+class ClaimPendingError(ConflictError):
     """A live lease holds this claim; back off — never blind-retry."""
+
+    public_detail = "Claim is currently pending"
 
 
 @dataclass(frozen=True)

--- a/src/archetype/app/errors.py
+++ b/src/archetype/app/errors.py
@@ -15,9 +15,21 @@
 """Service-layer error types.
 
 Auth-specific errors live in ``archetype.app.auth.errors``. This module holds
-the cross-service exception types that ``CommandService`` (and any future
-gated surface) raise as part of their public contract.
+cross-service exception contracts that gates and transport adapters may depend
+on without importing concrete service implementations.
 """
+
+
+class ConflictError(RuntimeError):
+    """A requested operation conflicts with existing service state.
+
+    Concrete services subclass this public contract so transport adapters can
+    map conflicts without depending on private implementation modules. The
+    internal exception message may contain diagnostic context; adapters expose
+    only ``public_detail``.
+    """
+
+    public_detail = "Request conflicts with existing state"
 
 
 class WorldNotFoundError(LookupError):

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for mapping public app errors at the HTTP adapter boundary."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from archetype.api.errors import raise_api_error
+from archetype.app._catalog import (
+    CatalogConflictError,
+    CatalogSchemaMismatchError,
+    ClaimConflictError,
+    ClaimPendingError,
+)
+from archetype.app.errors import ConflictError
+
+
+@pytest.mark.parametrize(
+    ("error_type", "public_detail"),
+    [
+        (CatalogConflictError, "Catalog entry conflicts with existing state"),
+        (ClaimConflictError, "Claim conflicts with existing state"),
+        (ClaimPendingError, "Claim is currently pending"),
+    ],
+)
+def test_catalog_conflicts_map_through_public_contract(
+    error_type: type[ConflictError],
+    public_detail: str,
+) -> None:
+    private_detail = "catalog /srv/private/archetype/catalog.sqlite already claimed"
+    error = error_type(private_detail)
+
+    assert isinstance(error, RuntimeError)
+    assert str(error) == private_detail
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(error)
+
+    assert raised.value.status_code == 409
+    assert raised.value.detail == public_detail
+    assert "/srv/private" not in raised.value.detail
+
+
+def test_conflict_contract_defaults_to_a_safe_public_detail() -> None:
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(ConflictError("internal path: /srv/private/catalog.sqlite"))
+
+    assert raised.value.status_code == 409
+    assert raised.value.detail == "Request conflicts with existing state"
+
+
+def test_catalog_schema_mismatch_remains_an_internal_error() -> None:
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(CatalogSchemaMismatchError("private schema detail"))
+
+    assert raised.value.status_code == 500
+    assert raised.value.detail == "Internal server error"


### PR DESCRIPTION
Closes #413.

## Summary

- add a public `ConflictError` service-layer contract
- make catalog registration, claim conflict, and live-claim pending errors
  subclass that contract while retaining `RuntimeError` compatibility
- map the public contract to HTTP 409 without importing private catalog code
  into the API adapter
- expose only a stable client-safe `public_detail`, keeping catalog paths and
  other diagnostic exception text out of HTTP responses
- keep catalog schema mismatch as a redacted HTTP 500 integrity failure
- remove the resolved conflict exceptions from the gate-coverage exception
  manifest and move audit backpressure follow-up to #419
- document the dependency direction and transport mapping in the normative
  specification

## Why this shape

HTTP is an adapter concern, but failure semantics belong to the service
contract. A public base in `archetype.app.errors` lets private implementations
declare client-meaningful conflicts without making app services depend on
FastAPI or making the API import `_catalog`. Unexpected implementation and
integrity failures still fail closed through the existing 500 fallback.
Conflict subclasses retain their full internal exception message for service
diagnostics while defining a separate safe detail for transport adapters.

`ClaimPendingError` is mapped to 409 with the other state conflicts: the
request conflicts with a live claim and can be retried after that state
changes. `CatalogSchemaMismatchError` is deliberately not a `ConflictError`;
it indicates an internal storage-integrity disagreement and its detail remains
redacted.

## Validation

- `make ci` — 1,042 passed, 7 skipped; 85.48% coverage; regression 12/12;
  idempotency 23/23
- `make gate-coverage-audit` — passed
- focused error/import/docs contracts — 13 passed
- catalog, remote parity, ingestion, and receipt suites — 39 passed
- API error and route suites — 57 passed
- spec evals — 7/7
- `uv run --extra docs mkdocs build` — passed (existing Griffe annotation
  warning remains)
- `npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"` — 0 issues across 68
  files
- focused Ruff format/lint and `git diff --check` — passed
