### PR TITLE
fix(api): preserve internal catalog version failures

### DIFF
--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -387,7 +387,8 @@ One tick MUST follow this order:
   remain transport-agnostic and do not depend on HTTP.
 - Errors without a public client-recovery contract fail closed as HTTP 500.
   `CatalogSchemaMismatchError` is an integrity failure in this category; its
-  internal detail MUST NOT be exposed to the client.
+  internal detail MUST NOT be exposed to the client. This includes a durable
+  control catalog whose schema version is newer than the running build.
 
 ### StorageService
 

--- a/src/archetype/app/_catalog.py
+++ b/src/archetype/app/_catalog.py
@@ -73,7 +73,7 @@ class CatalogConflictError(ConflictError):
 
 
 class CatalogSchemaMismatchError(RuntimeError):
-    """A stored signature descriptor disagrees with the physical table schema."""
+    """Durable catalog schema is incompatible with this build or physical data."""
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -368,7 +368,8 @@ class SqliteControlCatalog:
             conn.execute("SELECT value FROM catalog_meta WHERE key='schema_version'").fetchone()[0]
         )
         if version > _SCHEMA_VERSION:
-            raise CatalogConflictError(
+            conn.close()
+            raise CatalogSchemaMismatchError(
                 f"catalog {self.path} has schema_version={version}, "
                 f"this build expects {_SCHEMA_VERSION}"
             )

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
+
 import pytest
 from fastapi import HTTPException
 
@@ -14,6 +17,7 @@ from archetype.app._catalog import (
     CatalogSchemaMismatchError,
     ClaimConflictError,
     ClaimPendingError,
+    SqliteControlCatalog,
 )
 from archetype.app.errors import ConflictError
 
@@ -54,6 +58,27 @@ def test_conflict_contract_defaults_to_a_safe_public_detail() -> None:
 def test_catalog_schema_mismatch_remains_an_internal_error() -> None:
     with pytest.raises(HTTPException) as raised:
         raise_api_error(CatalogSchemaMismatchError("private schema detail"))
+
+    assert raised.value.status_code == 500
+    assert raised.value.detail == "Internal server error"
+
+
+@pytest.mark.asyncio
+async def test_newer_catalog_version_remains_a_redacted_internal_error(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "catalog.sqlite"
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE catalog_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        connection.execute("INSERT INTO catalog_meta (key, value) VALUES ('schema_version', '999')")
+
+    catalog = SqliteControlCatalog(path)
+    with pytest.raises(CatalogSchemaMismatchError) as mismatch:
+        await catalog.list_worlds()
+
+    assert "schema_version=999" in str(mismatch.value)
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(mismatch.value)
 
     assert raised.value.status_code == 500
     assert raised.value.detail == "Internal server error"


### PR DESCRIPTION
Closes #413.

## Summary

- classify a durable control catalog created by a newer Archetype build as an
  internal schema-compatibility failure, not a client conflict
- close the SQLite connection before reporting that incompatibility
- exercise the concrete catalog read path and verify the API adapter returns a
  redacted HTTP 500
- record the newer-version case explicitly in the normative specification

## Why this follow-up

#420 established the public conflict taxonomy and merged through the queue. A
late review then identified one existing `CatalogConflictError` call site whose
meaning did not belong in that taxonomy: an on-disk catalog version newer than
the running build cannot be repaired by changing the request. Mapping it to 409
would misclassify an internal compatibility/integrity failure and expose the
wrong recovery contract.

This focused follow-up keeps true request/state conflicts at 409 while routing
the newer-version failure through the existing redacted 500 fallback. The test
constructs an actual SQLite catalog at version 999 and enters through
`SqliteControlCatalog.list_worlds()`, so it guards both the concrete exception
type and the public transport behavior.

## Validation

- `make ci` — 1,051 passed, 2 skipped; 86.07% coverage; regression 12/12;
  idempotency 23/23
- focused API/catalog/import/docs contracts — 29 passed
- `make gate-coverage-audit` — passed
- spec evals — 7/7
- capability evals — 2/2
- `make docs` — passed (existing Griffe annotation warning remains)
- markdownlint — 0 issues across 68 files
- typos and `git diff --check` — passed
