### PR TITLE
fix(api): map audit backpressure to unavailable

### DIFF
--- a/docs/guide/audit-log.md
+++ b/docs/guide/audit-log.md
@@ -41,6 +41,12 @@ unavailable, the incoming row is rejected with `AuditBackpressureError`, the
 full batch remains intact, and `rejected_rows` increments. The log never grows
 an unbounded process-memory queue to conceal a storage outage.
 
+`AuditBackpressureError` implements the public `AvailabilityError` contract so
+a host that directly exposes audit operations can classify it without importing
+the concrete audit module. The built-in `CommandService` does not propagate
+audit backpressure to REST callers: the gated operation has already applied by
+the time audit emission runs, so returning 503 would invite an unsafe retry.
+
 Concurrent processes append to the same table using Iceberg's optimistic
 commit protocol. A conflicting append refreshes table metadata and retries
 with bounded backoff; it does not create a process-local audit fork.

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -381,10 +381,11 @@ One tick MUST follow this order:
 - Public cross-service error contracts MUST live in `archetype.app.errors`.
   Private service implementations subclass those contracts; transport adapters
   MUST NOT import private implementation modules to classify failures.
-- The REST adapter maps `WorldNotFoundError` to HTTP 404 and `ConflictError` to
-  HTTP 409. Conflict responses expose only the contract's client-safe
-  `public_detail`; internal exception text remains server-side. App services
-  remain transport-agnostic and do not depend on HTTP.
+- The REST adapter maps `WorldNotFoundError` to HTTP 404, `ConflictError` to
+  HTTP 409, and `AvailabilityError` to HTTP 503. Conflict and availability
+  responses expose only the contract's client-safe `public_detail`; internal
+  exception text remains server-side. App services remain transport-agnostic
+  and do not depend on HTTP.
 - Errors without a public client-recovery contract fail closed as HTTP 500.
   `CatalogSchemaMismatchError` is an integrity failure in this category; its
   internal detail MUST NOT be exposed to the client. This includes a durable

--- a/scripts/check_gate_coverage.py
+++ b/scripts/check_gate_coverage.py
@@ -156,10 +156,6 @@ INTENTIONAL_UNMAPPED = {
     "archetype.app._catalog.CatalogSchemaMismatchError": (
         "integrity violation intentionally surfaces as 500; decision recorded in #413"
     ),
-    "archetype.app.audit_log.AuditBackpressureError": (
-        "observable backpressure per the durability posture; 503-shaped, "
-        "public mapping tracked in #419"
-    ),
 }
 
 

--- a/src/archetype/api/errors.py
+++ b/src/archetype/api/errors.py
@@ -22,7 +22,7 @@ from typing import NoReturn
 from fastapi import HTTPException
 
 from archetype.app.auth.errors import GuardrailError
-from archetype.app.errors import ConflictError, WorldNotFoundError
+from archetype.app.errors import AvailabilityError, ConflictError, WorldNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,8 @@ def raise_api_error(exc: Exception, *, conflict: bool = False) -> NoReturn:
         raise HTTPException(status_code=404, detail=str(exc)) from None
     if isinstance(exc, ConflictError):
         raise HTTPException(status_code=409, detail=exc.public_detail) from None
+    if isinstance(exc, AvailabilityError):
+        raise HTTPException(status_code=503, detail=exc.public_detail) from None
     if isinstance(exc, ValueError):
         status_code = 409 if conflict else 400
         raise HTTPException(status_code=status_code, detail=str(exc)) from None

--- a/src/archetype/app/audit_log.py
+++ b/src/archetype/app/audit_log.py
@@ -26,6 +26,7 @@ from daft import Expression, Schema
 from daft.catalog import Table
 from uuid_utils import UUID
 
+from archetype.app.errors import AvailabilityError
 from archetype.app.iceberg import IcebergCatalogContext
 from archetype.app.models import AuditRow
 from archetype.app.storage_service import StorageService
@@ -35,8 +36,10 @@ _AUDIT_TABLE = "audit_rows"
 DEFAULT_AUDIT_FLUSH_ROWS = 128
 
 
-class AuditBackpressureError(RuntimeError):
+class AuditBackpressureError(AvailabilityError):
     """The bounded audit buffer rejected a row while storage was unavailable."""
+
+    public_detail = "Audit log is temporarily unavailable"
 
 
 def default_audit_storage() -> StorageConfig:

--- a/src/archetype/app/errors.py
+++ b/src/archetype/app/errors.py
@@ -32,6 +32,18 @@ class ConflictError(RuntimeError):
     public_detail = "Request conflicts with existing state"
 
 
+class AvailabilityError(RuntimeError):
+    """A service dependency is temporarily unable to accept work.
+
+    Concrete services subclass this public contract so transport adapters can
+    expose a retryable availability signal without importing implementation
+    modules. The internal exception message may contain diagnostic context;
+    adapters expose only ``public_detail``.
+    """
+
+    public_detail = "Service is temporarily unavailable"
+
+
 class WorldNotFoundError(LookupError):
     """Raised when a gated operation targets a ``world_id`` not in the registry.
 

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -19,7 +19,8 @@ from archetype.app._catalog import (
     ClaimPendingError,
     SqliteControlCatalog,
 )
-from archetype.app.errors import ConflictError
+from archetype.app.audit_log import AuditBackpressureError
+from archetype.app.errors import AvailabilityError, ConflictError
 
 
 @pytest.mark.parametrize(
@@ -53,6 +54,29 @@ def test_conflict_contract_defaults_to_a_safe_public_detail() -> None:
 
     assert raised.value.status_code == 409
     assert raised.value.detail == "Request conflicts with existing state"
+
+
+def test_audit_backpressure_maps_through_public_availability_contract() -> None:
+    private_detail = "audit flush failed for /srv/private/audit"
+    error = AuditBackpressureError(private_detail)
+
+    assert isinstance(error, AvailabilityError)
+    assert isinstance(error, RuntimeError)
+    assert str(error) == private_detail
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(error)
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == "Audit log is temporarily unavailable"
+    assert "/srv/private" not in raised.value.detail
+
+
+def test_availability_contract_defaults_to_a_safe_public_detail() -> None:
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(AvailabilityError("private dependency failure"))
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == "Service is temporarily unavailable"
 
 
 def test_catalog_schema_mismatch_remains_an_internal_error() -> None:

--- a/tests/app/test_audit_contracts.py
+++ b/tests/app/test_audit_contracts.py
@@ -3,6 +3,8 @@
 
 """Contracts for the bounded, append-only Iceberg audit table."""
 
+import logging
+
 import pytest
 from uuid_utils import uuid7
 
@@ -35,6 +37,33 @@ def test_audit_configuration_fails_closed(tmp_path):
         AuditLog(storage_config=_storage(tmp_path), flush_rows=0)
     with pytest.raises(ValueError, match="backend=iceberg"):
         AuditLog(storage_config=StorageConfig(uri=str(tmp_path / "lance")))
+
+
+@pytest.mark.asyncio
+async def test_command_gate_keeps_audit_backpressure_advisory(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    container = ServiceContainer(audit_storage_config=_storage(tmp_path, "advisory"))
+    ctx = ActorCtx(id=uuid7(), roles={"admin"})
+
+    async def reject_record(_row):
+        raise AuditBackpressureError("bounded audit batch is full")
+
+    monkeypatch.setattr(container.audit_log, "record", reject_record)
+    try:
+        with caplog.at_level(logging.WARNING, logger="archetype.app.command_service"):
+            world = await container.command_service.create_world(
+                ctx,
+                WorldConfig(name="applied-despite-audit-backpressure"),
+                StorageConfig(uri=str(tmp_path / "world")),
+            )
+
+        assert world.name == "applied-despite-audit-backpressure"
+        assert "audit emission failed" in caplog.text
+    finally:
+        await container.shutdown()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #419.

## Summary

- add a public `AvailabilityError` service-layer contract with a client-safe
  default detail
- make `AuditBackpressureError` subclass that contract while preserving its
  existing `RuntimeError` compatibility and diagnostic exception message
- map the public contract once in the REST adapter to HTTP 503 without
  importing the concrete audit implementation
- remove the now-stale intentional-500 gate manifest entry
- document both the cross-layer mapping and the concrete audit response
- cover the generic contract, concrete audit subtype, safe detail, and the
  command gate's intentional advisory suppression

## Why this shape

Temporary availability is a service failure semantic, while HTTP 503 is an
adapter decision. A public base in `archetype.app.errors` lets concrete
services declare retryable unavailability without making the API depend on
their implementation modules or making app code depend on FastAPI.

Like the conflict contract, availability exposes a separate `public_detail`:
the internal exception message remains available for server diagnostics but
cannot leak filesystem paths or dependency detail to clients. The command
gate's existing best-effort audit behavior is unchanged; it still logs and
suppresses audit emission failures after an operation has applied. This PR
only defines the transport result when an availability error is surfaced.

## Validation

- `make ci` — 1,054 passed, 6 skipped; 85.90% coverage; regression 12/12;
  idempotency 23/23
- focused API, audit, and import-boundary contracts — 21 passed
- `make gate-coverage-audit` and `make api-boundary-audit` — passed
- spec evals — 7/7
- capability evals — 2/2
- documentation contracts — 4 passed
- MkDocs build — passed (existing Griffe annotation warning remains)
- markdownlint — 0 issues across 68 files
- type checking, typos, focused Ruff, and `git diff --check` — passed
