### PR TITLE
feat(datasets): codify dataset eval ontology

### DIFF
--- a/docs/guide/dataset-eval-ontology.md
+++ b/docs/guide/dataset-eval-ontology.md
@@ -1,0 +1,246 @@
+# Dataset and Evaluation Ontology
+
+**Document type:** Normative.
+
+**Scope:** Dataset readers and exporters, physical-AI evaluation, typed dataset
+fact tables, and every public surface that names benchmarks, suites, tasks,
+trials, or dataset episodes.
+
+This page defines vocabulary and identity. It does not define the trial
+execution state machine tracked by issue #322, a particular reader schema, or
+the repository's internal eval harness.
+
+## 1. The contract in one view
+
+```text
+Dataset      1—N  Suite
+Suite        1—N  Task
+Task         1—N  Dataset Episode
+Trial        1—1  Dataset Episode      one seeded execution produces evidence
+Dataset Episode = 1 Trajectory + 0..N FrameStreams
+
+Benchmark    = Dataset + task-bound evaluation
+Eval         = 1 Task + 1 Rubric
+Rubric       = 1..N Graders
+Grader       ∈ {check, test, judge}
+EvalSuite    = the eval for each task in a Suite; it is derived, not primitive
+```
+
+The shortest useful laws are:
+
+- **a dataset records; a benchmark judges**;
+- **datasets are frozen trials**;
+- dataset identity and runtime provenance travel together when both exist,
+  but one never substitutes for the other;
+- graders consume persisted evidence, not privileged live process state.
+
+## 2. Definitions
+
+### Dataset and benchmark
+
+A **Dataset** records what happened. It contains task-bound episodes and their
+signals, organized into suites. It does not contain an acceptance decision.
+
+A **Benchmark** is the dataset plus grading: rubrics bound to tasks and the
+resulting evaluation evidence. Dataset and benchmark commonly share a name
+such as `libero`, but the words describe different responsibilities.
+
+### Suite and task
+
+A **Suite** is a named set of tasks inside a benchmark. It is only a task
+collection; a collection of graders is a rubric, not a suite. A benchmark MAY
+have one suite.
+
+A **Task** is the stable label and instruction for what is attempted. Its
+natural key is `(benchmark, suite, task_key)`. Dataset-native identifiers such
+as a LIBERO integer task id MUST be normalized to the string `task_key` at the
+adapter boundary.
+
+### Dataset episode, trajectory, and frame stream
+
+A **Dataset Episode** is the frozen evidence from one trial. Its natural key is
+`(benchmark, episode_id)`, where `episode_id` is a zero-based integer allocated
+by the dataset curator or exporter. A bare integer is not globally unique.
+
+An episode contains exactly one **Trajectory**: the time-indexed state and
+action signals for the subject. It may also contain zero or more
+**FrameStreams**, one per camera or other framed sensor. Trajectory and frame
+stream records MUST carry explicit sampling rates; path names and row counts
+do not define timing.
+
+Episode is not a synonym for trajectory. One episode can be represented across
+several strict typed fact tables as long as each row carries the same dataset
+coordinates and the streams retain their own timing.
+
+### Trial
+
+A **Trial** is one seeded execution of one task. A trial produces exactly one dataset episode.
+The trial is the act; the episode is its frozen evidence.
+
+`archetype.datasets.Trial` is an immutable evidence-side record. It is not a
+pending/running orchestration object. Submission, polling, retry, and terminal
+execution state belong to the lifecycle tracked by issue #322.
+
+### Evaluation vocabulary
+
+An **Eval** binds exactly one task to exactly one non-empty **Rubric**. A rubric
+composes named **Graders**:
+
+- **check** — a mechanical predicate over stored state;
+- **test** — a deterministic behavioral assertion over episode dynamics;
+- **judge** — qualitative, model-graded scoring.
+
+An **EvalSuite** is derived by binding an eval to every task in a suite. It is
+not another primitive container.
+
+Evaluation receipts remain evidence, never authority. A pass under one grader
+contract does not itself mean accepted, promoted, or safe to deploy; the layer
+above evaluation owns those decisions.
+
+## 3. Dataset coordinates and runtime provenance
+
+There are two coordinate systems, and conforming adapters preserve the
+difference.
+
+| System | Coordinates | Meaning |
+|---|---|---|
+| Dataset | `benchmark`, `suite`, `task_key`, `episode_id: int` | What curated episode this is |
+| Runtime | `world_id`, `run_id`, `entity_id`, `start_tick`, `final_tick` | Where a live trial's ledger evidence can be queried |
+
+**Dataset coordinates are natural keys.** They are allocated by the dataset
+curator or exporter and remain stable when data moves between storage systems.
+
+**Runtime coordinates are provenance.** They are surrogate locations minted by
+Archetype. They explain where live evidence came from; they are not dataset
+episode identity.
+
+Consequences:
+
+- An imported DROID, EgoDex, LeRobot, or similar episode can have dataset
+  coordinates with no Archetype runtime provenance.
+- A live trial has both once exported: dataset coordinates identify the frozen
+  episode, while `RuntimeSlice` locates the source entity and ticks.
+- `entity_id` is required in runtime provenance because one world/run may host
+  several trial entities.
+- An adapter MUST NOT place a UUID runtime episode id in the integer dataset
+  `episode_id` field, or use dataset coordinates as world identifiers.
+- The task and episode bound by one trial MUST name the same benchmark.
+
+The complete dataset coordinate tuple for a trial is
+`(benchmark, suite, task_key, episode_id)`. Episode identity remains the
+shorter `(benchmark, episode_id)` key; suite and task describe its binding.
+
+## 4. Runtime Episode is a different noun
+
+`EpisodeConfig` and `EpisodeResult` in the
+[Execution Hierarchy](execution-hierarchy.md) describe a control-flow call:
+step one world until termination or a bound. Their `episode_id` is a UUID and
+their scope is a runtime world.
+
+A runtime episode MAY batch many trials. The current colocated manipulation
+eval does exactly this: one `(world_id, run_id)` contains several trial
+entities, and each entity's `ManipTask` and ledger rows identify its slice.
+Therefore these relationships are invalid:
+
+```text
+trial == EpisodeResult                 # invalid
+dataset episode_id == runtime UUID     # invalid
+trial provenance == (world_id, run_id) # incomplete without entity/ticks
+```
+
+The valid bridge is:
+
+```text
+runtime EpisodeResult
+    ├─ trial entity A + tick slice ──freeze──> dataset episode 17
+    ├─ trial entity B + tick slice ──freeze──> dataset episode 18
+    └─ trial entity C + tick slice ──freeze──> dataset episode 19
+```
+
+This is what “datasets are frozen trials” means. It does not require one
+runtime world, run, or `EpisodeResult` per trial.
+
+## 5. Persistence in typed fact tables
+
+Dataset readers and exporters write domain rows through the typed Iceberg
+fact-table path in [Durable Facts](durable-facts.md). The division of
+responsibility is strict:
+
+| Owner | Columns / concern |
+|---|---|
+| `FactService` | `fact_id`, owning `world_id` / `run_id`, `source_uri`, `content_hash`, strict append and dedup behavior |
+| Dataset adapter | `benchmark`, `suite`, `task_key`, `episode_id`, stream/timing fields, domain payload |
+| Live-trial exporter | Optional source `RuntimeSlice` provenance in addition to dataset coordinates |
+
+**The FactService envelope is storage ownership and write identity.** Its
+`world_id` and `run_id` scope the fact view; `source_uri` and `content_hash`
+form part of the logical write key. That envelope **does not replace dataset
+coordinates** and does not prove where an imported episode originally ran.
+
+For example, importing an external dataset creates an Archetype world/run for
+the ingestion operation. Those envelope values name the owner of the typed
+table rows, not a fictional original simulation. Conversely, exporting a live
+trial MAY persist its source `RuntimeSlice` as typed payload provenance.
+
+Typed tables fail on schema drift. Adapters MUST normalize native vocabulary
+before the `FactService` boundary and MUST NOT depend on silent widening.
+Large media remains content-addressed data referenced from typed rows rather
+than an opaque path masquerading as identity.
+
+## 6. Grading symmetry and receipts
+
+Graders SHOULD be query-backed over persisted rows. Given the same normalized
+episode schema, a grader must not branch merely because evidence came from an
+external reader or a live rollout. Runtime provenance may support diagnosis,
+but its absence is not a grading result.
+
+The durable evaluation-receipt contract is adjacent but distinct:
+
+- a receipt pins one grader contract and one immutable subject snapshot;
+- receipt `evaluation_id` identifies a grader execution and is not a dataset
+  `episode_id`;
+- repeated nondeterministic grader trials can produce distinct receipts over
+  the same dataset episode;
+- receipts carry conclusions and evidence, never promotion authority.
+
+The repository eval harness has its own internal `TrialResult`. That is a
+meta-evaluation attempt used to test Archetype itself; it is not the physical-
+AI dataset `Trial` defined here.
+
+## 7. Native vocabulary mapping
+
+Dataset-native nouns stop at their adapter.
+
+| Native term | Source | Archetype term |
+|---|---|---|
+| `episode_index` | LeRobot | dataset `episode_id` |
+| language instruction / annotation | DROID, LeRobot | task instruction |
+| wrist / exterior camera | DROID, EgoDex, LIBERO | frame stream |
+| joint / effector / action series | physical-AI datasets | trajectory |
+| `libero_spatial`, `libero_object`, … | LIBERO | suite |
+| BDDL task id and language | LIBERO | `task_key` and instruction |
+| one seeded environment entity | colocated eval | trial |
+
+## 8. Executable mirror and current gaps
+
+The immutable identity vocabulary lives in
+`archetype.datasets.definitions`. Readers, exporters, and evaluation code MUST
+import these definitions rather than create competing meanings for the same
+nouns. The spec eval checks the cardinality, key types, coordinate separation,
+and exact grader kinds.
+
+Current implementation truth:
+
+- typed fact tables and query-backed colocated evaluation exist;
+- the colocated evaluator keeps N trial entities in one ledger and derives its
+  report from persisted rows;
+- the canonical dataset episode row schemas, exporters, reader adapters, and
+  shared reader conformance suite do not exist yet;
+- the durable submit/poll trial lifecycle remains issue #322;
+- allocation of zero-based dataset episode ids belongs to the future
+  reader/exporter boundary, not `SimulationService`.
+
+These are **CURRENT GAP** items, not behavior the documentation pretends is
+already implemented. A first reader or exporter must add one shared
+conformance suite covering natural keys, trajectory/frame separation, sampling
+rates, and optional runtime provenance.

--- a/docs/guide/durable-facts.md
+++ b/docs/guide/durable-facts.md
@@ -166,6 +166,13 @@ view and may ingest the same source under its new identity. Inheriting ancestor
 facts without a fact-time boundary would incorrectly expose facts added to the
 ancestor after the fork.
 
+For dataset tables, this envelope describes storage ownership and write
+identity; it is not dataset episode identity or original execution provenance.
+Dataset payloads retain their natural keys and optional source-runtime slice as
+defined by the [Dataset and Evaluation Ontology](dataset-eval-ontology.md).
+An ingestion world's `world_id` / `run_id` MUST NOT be presented as the runtime
+that originally produced an imported episode.
+
 Each logical name maps to `facts__<table_name>` in the same catalog and
 namespace as the world. The remaining columns are the domain schema. Schema
 drift fails before append; fact tables do not silently widen or coerce.

--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -9,6 +9,12 @@ The harness lives under `evals/` and uses a **task → trial → grader** model.
 It does not ask whether the implementation followed one preferred code path;
 it asks whether the resulting behavior satisfies the contract.
 
+These are meta-evaluation terms internal to the repository harness.
+`evals.types.TrialResult` is not the physical-AI trial that produces one
+dataset episode in the
+[Dataset and Evaluation Ontology](dataset-eval-ontology.md), and harness task
+ids are not dataset task natural keys.
+
 ## Running the suites
 
 ```bash
@@ -127,6 +133,7 @@ renaming a task requires updating this table in the same change.
 | `spec` | `spec.command_service_gate_map` | Public command methods retain gate and audit coverage |
 | `spec` | `spec.append_only_protocols` | Storage and audit protocols expose no destructive methods |
 | `spec` | `spec.receipt_authority_firewall` | Receipts and facts remain evidence rather than authority |
+| `spec` | `spec.dataset_eval_ontology` | Dataset natural keys remain separate from optional runtime provenance |
 | `spec` | `spec.info_class_downgrades` | Lifecycle and introspection return frozen information snapshots |
 
 ### Idempotency

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -23,6 +23,7 @@ The current contract set is split across design docs and executable tests.
 | [Durable Discovery](durable-discovery.md) | Control catalog and cold reads | Catalog authority, `discover_worlds`/`open_world_readonly`, fail-closed cold queries. |
 | [Atomic Visibility](atomic-visibility.md) | Tick commit identity | Manifest-published ticks, commit tokens, writer fencing, epoch-0 legacy reads. |
 | [Durable Facts](durable-facts.md) | External-fact ingestion | Typed Iceberg tables, Daft file processors, content identity, and claim-backed receipt compatibility. |
+| [Dataset and Evaluation Ontology](dataset-eval-ontology.md) | Dataset/eval identity and vocabulary | Dataset-vs-runtime coordinates, trial/episode cardinality, typed-fact ownership, and grader composition. |
 | [Audit Log](audit-log.md) | Audit rows | Append-only audit history and query contract. |
 | [`tests/app/test_runtime_contracts.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_contracts.py) | Executable runtime contracts | Enforces activation single-flight, runtime-vs-world lifetime, fork isolation, spawn visibility, governance, and smoke paths. |
 | [`tests/app/test_runtime_fork_storage.py`](https://github.com/VangelisTech/archetype/blob/main/tests/app/test_runtime_fork_storage.py) | Runtime fork storage contracts | Enforces fork storage inheritance through the runtime layer, lineage reads on fork handles, fork run_id minting, and gate-side storage resolution. |
@@ -80,6 +81,7 @@ This specification covers:
 - top-level runtime API constraints
 - multi-world orchestration and world forking
 - idempotency expectations and non-idempotent boundaries
+- typed external facts and dataset/evaluation identity
 
 This specification does not authorize direct edits to `src/archetype/core/`.
 It defines the behavior that higher layers must preserve and that future

--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -98,6 +98,27 @@ SPEC_CASES: tuple[SpecCase, ...] = (
         anchors=("Append-only invariant", "no `drop_*` or `delete_*` methods"),
         task_id="spec.append_only_protocols",
     ),
+    SpecCase(
+        spec_id="dataset-eval-ontology.1",
+        source="dataset-eval-ontology.md",
+        anchors=("Dataset coordinates are natural keys", "Runtime coordinates are provenance"),
+        task_id="spec.dataset_eval_ontology",
+    ),
+    SpecCase(
+        spec_id="dataset-eval-ontology.2",
+        source="dataset-eval-ontology.md",
+        anchors=(
+            "A trial produces exactly one dataset episode",
+            "A runtime episode MAY batch many trials",
+        ),
+        task_id="spec.dataset_eval_ontology",
+    ),
+    SpecCase(
+        spec_id="dataset-eval-ontology.3",
+        source="dataset-eval-ontology.md",
+        anchors=("FactService envelope is storage ownership", "does not replace dataset"),
+        task_id="spec.dataset_eval_ontology",
+    ),
 )
 
 _EXPECTED_TASK_IDS = frozenset(case.task_id for case in SPEC_CASES)
@@ -621,6 +642,61 @@ def task_receipt_authority_firewall() -> list[GraderResult]:
     return [state_check(checks, name="receipt_authority_firewall")]
 
 
+def task_dataset_eval_ontology() -> list[GraderResult]:
+    """Typed vocabulary preserves dataset identity and runtime provenance."""
+    from dataclasses import fields, is_dataclass
+    from typing import get_type_hints
+
+    from archetype.datasets import definitions as defs
+
+    task = defs.TaskRef(benchmark="libero", suite="libero_spatial", task_key="3")
+    episode = defs.EpisodeRef(benchmark="libero", episode_id=17)
+    runtime = defs.RuntimeSlice(
+        world_id="world-7",
+        run_id="run-9",
+        entity_id=12,
+        start_tick=0,
+        final_tick=41,
+    )
+    trial = defs.Trial(task=task, seed=5, episode=episode, runtime=runtime)
+    rubric = defs.Rubric(graders=(defs.Grader(name="success", kind=defs.GraderKind.CHECK),))
+    evaluation = defs.Eval(task=task, rubric=rubric)
+    vocabulary = (
+        defs.TaskRef,
+        defs.EpisodeRef,
+        defs.RuntimeSlice,
+        defs.Grader,
+        defs.Rubric,
+        defs.Eval,
+        defs.Trial,
+    )
+    episode_hints = get_type_hints(defs.EpisodeRef)
+
+    checks = {
+        "task_natural_key_fields": [field.name for field in fields(defs.TaskRef)]
+        == ["benchmark", "suite", "task_key"],
+        "episode_natural_key_fields": [field.name for field in fields(defs.EpisodeRef)]
+        == ["benchmark", "episode_id"],
+        "episode_id_is_integer": episode_hints["episode_id"] is int,
+        "runtime_slice_fields": [field.name for field in fields(defs.RuntimeSlice)]
+        == ["world_id", "run_id", "entity_id", "start_tick", "final_tick"],
+        "dataset_coordinates_are_independent": trial.dataset_coordinates
+        == ("libero", "libero_spatial", "3", 17),
+        "runtime_provenance_is_preserved": trial.runtime == runtime,
+        "trial_produces_one_episode": trial.episode is episode,
+        "reader_runtime_is_optional": defs.Trial(task=task, seed=5, episode=episode).runtime
+        is None,
+        "eval_binds_one_task": evaluation.task is task,
+        "rubric_is_non_empty": evaluation.rubric.graders == rubric.graders,
+        "grader_kinds_are_exact": {kind.value for kind in defs.GraderKind}
+        == {"check", "test", "judge"},
+        "vocabulary_is_frozen": all(
+            is_dataclass(item) and item.__dataclass_params__.frozen for item in vocabulary
+        ),
+    }
+    return [state_check(checks, name="dataset_eval_ontology")]
+
+
 def register(harness: EvalHarness) -> None:
     harness.add(
         "spec.manifest_traceability",
@@ -657,6 +733,12 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_receipt_authority_firewall,
         desc="Receipt/fact components carry no authority fields (evidence only).",
+    )
+    harness.add(
+        "spec.dataset_eval_ontology",
+        suite=SUITE,
+        fn=task_dataset_eval_ontology,
+        desc="Dataset identity remains separate from optional runtime provenance.",
     )
     harness.add(
         "spec.info_class_downgrades",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Durable Discovery: guide/durable-discovery.md
       - Atomic Visibility: guide/atomic-visibility.md
       - Durable Facts: guide/durable-facts.md
+      - Dataset and Evaluation Ontology: guide/dataset-eval-ontology.md
       - Audit Log: guide/audit-log.md
       - Evaluation Harness: guide/evals.md
       - CORE INTERNALS:

--- a/src/archetype/datasets/__init__.py
+++ b/src/archetype/datasets/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dataset and evaluation identity vocabulary.
+
+The normative contract lives in :doc:`docs/guide/dataset-eval-ontology.md`.
+This package defines immutable references and compositions; dataset readers,
+exporters, and trial execution remain separate adapters and services.
+"""
+
+from archetype.datasets.definitions import (
+    EpisodeRef,
+    Eval,
+    Grader,
+    GraderKind,
+    Rubric,
+    RuntimeSlice,
+    TaskRef,
+    Trial,
+)
+
+__all__ = [
+    "EpisodeRef",
+    "Eval",
+    "Grader",
+    "GraderKind",
+    "Rubric",
+    "RuntimeSlice",
+    "TaskRef",
+    "Trial",
+]

--- a/src/archetype/datasets/definitions.py
+++ b/src/archetype/datasets/definitions.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable vocabulary for dataset identity and evaluation composition.
+
+These types describe identity and cardinality. They are not ECS components,
+typed-fact row schemas, or the trial execution lifecycle tracked by issue
+#322. Adapters keep dataset coordinates and runtime provenance side by side
+instead of substituting one for the other.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+def _require_text(value: str, field_name: str) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{field_name} must be non-empty")
+
+
+def _require_non_negative_int(value: int, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{field_name} must be non-negative")
+
+
+class GraderKind(StrEnum):
+    """Supported grader semantics, ordered from mechanical to qualitative."""
+
+    CHECK = "check"
+    TEST = "test"
+    JUDGE = "judge"
+
+
+@dataclass(frozen=True, slots=True)
+class TaskRef:
+    """Natural identity of one task inside a benchmark suite."""
+
+    benchmark: str
+    suite: str
+    task_key: str
+
+    def __post_init__(self) -> None:
+        _require_text(self.benchmark, "benchmark")
+        _require_text(self.suite, "suite")
+        _require_text(self.task_key, "task_key")
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        """Return the canonical task natural key."""
+        return self.benchmark, self.suite, self.task_key
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeRef:
+    """Natural identity of one frozen dataset episode.
+
+    ``episode_id`` is a zero-based integer allocated by the dataset curator or
+    exporter. It is not ``EpisodeResult.episode_id``, which is a runtime UUID.
+    """
+
+    benchmark: str
+    episode_id: int
+
+    def __post_init__(self) -> None:
+        _require_text(self.benchmark, "benchmark")
+        _require_non_negative_int(self.episode_id, "episode_id")
+
+    @property
+    def key(self) -> tuple[str, int]:
+        """Return the canonical episode natural key."""
+        return self.benchmark, self.episode_id
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSlice:
+    """Optional provenance locating one trial in an Archetype ledger.
+
+    A runtime episode can batch several trial entities. The entity and tick
+    bounds therefore belong in the provenance; ``world_id`` and ``run_id``
+    alone do not identify one trial.
+    """
+
+    world_id: str
+    run_id: str
+    entity_id: int
+    start_tick: int
+    final_tick: int
+
+    def __post_init__(self) -> None:
+        _require_text(self.world_id, "world_id")
+        _require_text(self.run_id, "run_id")
+        _require_non_negative_int(self.entity_id, "entity_id")
+        _require_non_negative_int(self.start_tick, "start_tick")
+        _require_non_negative_int(self.final_tick, "final_tick")
+        if self.final_tick < self.start_tick:
+            raise ValueError("final_tick must be greater than or equal to start_tick")
+
+
+@dataclass(frozen=True, slots=True)
+class Grader:
+    """One named scorer used by a rubric."""
+
+    name: str
+    kind: GraderKind
+
+    def __post_init__(self) -> None:
+        _require_text(self.name, "grader name")
+        if not isinstance(self.kind, GraderKind):
+            raise TypeError("grader kind must be a GraderKind")
+
+
+@dataclass(frozen=True, slots=True)
+class Rubric:
+    """A non-empty, named-by-member composition of graders."""
+
+    graders: tuple[Grader, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.graders, tuple):
+            raise TypeError("rubric graders must be a tuple")
+        if not self.graders:
+            raise ValueError("a rubric must contain at least one grader")
+        if not all(isinstance(grader, Grader) for grader in self.graders):
+            raise TypeError("rubric graders must all be Grader instances")
+        names = [grader.name for grader in self.graders]
+        if len(names) != len(set(names)):
+            raise ValueError("grader names must be unique within a rubric")
+
+
+@dataclass(frozen=True, slots=True)
+class Eval:
+    """The rubric bound to exactly one task."""
+
+    task: TaskRef
+    rubric: Rubric
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.task, TaskRef):
+            raise TypeError("eval task must be a TaskRef")
+        if not isinstance(self.rubric, Rubric):
+            raise TypeError("eval rubric must be a Rubric")
+
+
+@dataclass(frozen=True, slots=True)
+class Trial:
+    """A recorded seeded execution that produced one dataset episode.
+
+    This is the immutable evidence-side record. Pending/submitted/running
+    lifecycle state belongs to the orchestration layer tracked by issue #322.
+    """
+
+    task: TaskRef
+    seed: int
+    episode: EpisodeRef
+    runtime: RuntimeSlice | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.task, TaskRef):
+            raise TypeError("trial task must be a TaskRef")
+        _require_non_negative_int(self.seed, "seed")
+        if not isinstance(self.episode, EpisodeRef):
+            raise TypeError("trial episode must be an EpisodeRef")
+        if self.runtime is not None and not isinstance(self.runtime, RuntimeSlice):
+            raise TypeError("trial runtime must be a RuntimeSlice or None")
+        if self.task.benchmark != self.episode.benchmark:
+            raise ValueError("trial task and episode must belong to the same benchmark")
+
+    @property
+    def dataset_coordinates(self) -> tuple[str, str, str, int]:
+        """Return the complete dataset coordinate tuple for this trial."""
+        return (*self.task.key, self.episode.episode_id)

--- a/tests/test_dataset_definitions.py
+++ b/tests/test_dataset_definitions.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executable contracts for the dataset/eval ontology vocabulary."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from archetype.datasets import (
+    EpisodeRef,
+    Eval,
+    Grader,
+    GraderKind,
+    Rubric,
+    RuntimeSlice,
+    TaskRef,
+    Trial,
+)
+
+
+def _task() -> TaskRef:
+    return TaskRef(benchmark="libero", suite="libero_spatial", task_key="3")
+
+
+def _rubric() -> Rubric:
+    return Rubric(
+        graders=(
+            Grader(name="success_flag", kind=GraderKind.CHECK),
+            Grader(name="goal_within_horizon", kind=GraderKind.TEST),
+        )
+    )
+
+
+def test_eval_binds_one_task_to_a_non_empty_rubric():
+    evaluation = Eval(task=_task(), rubric=_rubric())
+
+    assert evaluation.task.key == ("libero", "libero_spatial", "3")
+    assert [grader.kind for grader in evaluation.rubric.graders] == [
+        GraderKind.CHECK,
+        GraderKind.TEST,
+    ]
+
+
+def test_trial_keeps_dataset_identity_and_runtime_provenance_separate():
+    runtime = RuntimeSlice(
+        world_id="world-7",
+        run_id="run-9",
+        entity_id=12,
+        start_tick=0,
+        final_tick=41,
+    )
+    trial = Trial(
+        task=_task(),
+        seed=5,
+        episode=EpisodeRef(benchmark="libero", episode_id=17),
+        runtime=runtime,
+    )
+
+    assert trial.dataset_coordinates == ("libero", "libero_spatial", "3", 17)
+    assert trial.runtime == runtime
+    assert trial.episode.key == ("libero", 17)
+
+
+def test_reader_trial_may_have_no_runtime_provenance():
+    trial = Trial(
+        task=_task(),
+        seed=0,
+        episode=EpisodeRef(benchmark="libero", episode_id=0),
+    )
+
+    assert trial.runtime is None
+
+
+@pytest.mark.parametrize("episode_id", [-1, True, 1.5, "1"])
+def test_episode_id_is_a_non_negative_integer(episode_id):
+    error = ValueError if episode_id == -1 else TypeError
+    with pytest.raises(error):
+        EpisodeRef(benchmark="libero", episode_id=episode_id)
+
+
+def test_trial_rejects_cross_benchmark_episode():
+    with pytest.raises(ValueError, match="same benchmark"):
+        Trial(
+            task=_task(),
+            seed=0,
+            episode=EpisodeRef(benchmark="droid", episode_id=0),
+        )
+
+
+def test_runtime_slice_rejects_reversed_tick_bounds():
+    with pytest.raises(ValueError, match="final_tick"):
+        RuntimeSlice(
+            world_id="world-7",
+            run_id="run-9",
+            entity_id=12,
+            start_tick=5,
+            final_tick=4,
+        )
+
+
+def test_rubric_requires_unique_graders():
+    grader = Grader(name="success", kind=GraderKind.CHECK)
+
+    with pytest.raises(ValueError, match="unique"):
+        Rubric(graders=(grader, grader))
+
+
+def test_vocabulary_is_immutable():
+    task = _task()
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        task.suite = "changed"  # type: ignore[misc]


### PR DESCRIPTION
Closes #325.

## Summary

- add a normative dataset/evaluation ontology grounded in the current typed-fact and colocated-eval architecture
- add immutable `archetype.datasets` identity/composition types for tasks, dataset episodes, runtime slices, trials, rubrics, graders, and evals
- bind the prose to a new independent spec-eval task and focused validation contracts
- link the ontology from the specification inventory, Durable Facts, the eval-harness guide, and MkDocs navigation

## Contract decisions

This rewrites rather than rebases the stale #259 draft:

- a trial produces exactly one **dataset** episode, but one runtime `EpisodeResult` may batch many trial entities
- dataset natural keys `(benchmark, suite, task_key, episode_id)` remain distinct from runtime provenance `(world_id, run_id, entity_id, start_tick, final_tick)`
- the FactService envelope is storage ownership and write identity; it never replaces dataset identity or invents source-runtime provenance for imported data
- zero-based dataset episode allocation belongs to a reader/exporter boundary, not `SimulationService`
- unimplemented reader/exporter schemas and the submit/poll lifecycle remain explicit `CURRENT GAP`s rather than documented as shipped behavior

## Validation

Exact head `eb168913cbb0e910605d61de4a52a3b5ae644cbf` on `bc6cab63eddaa6ba582fa85aaad7e4ebdec31465`:

- `make ci` — 1,072 passed, 7 skipped; 85.51% coverage; regression 12/12; idempotency 23/23
- `uv run python -m evals.run --suite spec` — 8/8
- `uvx ty@0.0.48 check --python .venv` — clean
- `uv run --extra docs mkdocs build` — clean apart from the existing Griffe warning for `AsyncSystem.execute(**input_kwargs)`
- `markdownlint-cli2` — 0 issues across 69 files
- `git diff --check origin/main...HEAD` — clean

The first full parallel run also caught a test-package name collision with Hugging Face `datasets`; the test was moved to a non-shadowing top-level module before the successful exact-head run.
