### PR TITLE
docs: make beginner runtime semantics executable

### DIFF
--- a/docs/guide/building-simulations.md
+++ b/docs/guide/building-simulations.md
@@ -76,16 +76,38 @@ async def main():
         await world.spawn(Agent(name="Bob", role="designer", skill=2.0))
         await world.spawn(Agent(name="Charlie", role="manager", skill=1.5))
 
-        await world.run(steps=10)
+        # Persist the initial values, then apply processors ten times.
+        await world.step()
+        result = await world.run(steps=10)
+
+        history = await world.query(Agent)
+        current = history.where(col("tick") == result.final_tick - 1).sort("entity_id")
+        rows = current.select(
+            "agent__name",
+            "agent__skill",
+            "agent__experience",
+            "agent__rating",
+        ).collect().to_pylist()
+        for row in rows:
+            print(
+                f"{row['agent__name']}: skill={row['agent__skill']:.1f}, "
+                f"experience={row['agent__experience']:.0f}, "
+                f"rating={row['agent__rating']:.2f}"
+            )
 ```
 
 Output:
 
 ```text
-Alice:   skill=3.0, experience=60, rating=18.0
-Bob:     skill=2.0, experience=40, rating=8.0
-Charlie: skill=1.5, experience=30, rating=4.5
+Alice:   skill=3.0, experience=60, rating=18.00
+Bob:     skill=2.0, experience=40, rating=8.00
+Charlie: skill=1.5, experience=30, rating=4.50
 ```
+
+The initial `step()` records the spawned values as tick 0. Processors first
+apply on tick 1, so the ten-step run produces ticks 1 through 10. `query()`
+returns the append-only history; filter to `result.final_tick - 1` when you
+want the current persisted state.
 
 ## Key Concepts
 

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -5,6 +5,23 @@ recommended pattern is `ArchetypeRuntime` for scripts. A small number of
 examples intentionally call the service layer when they need lower-level
 storage or queue control.
 
+## 0. Quickstart
+
+The smallest complete simulation defines one component and one processor,
+then runs through the public runtime surface. It stays below 30 non-comment
+source lines and is part of the credential-free example smoke suite.
+
+```bash
+uv run python examples/00_quickstart.py
+```
+
+Source: [`examples/00_quickstart.py`](https://github.com/VangelisTech/archetype/blob/main/examples/00_quickstart.py)
+
+The script prints `3`: the initial state is persisted first, then the
+processor increments the counter on three subsequent ticks.
+
+---
+
 ## 1. World Mutations
 
 Demonstrates every mutation type: spawn entities with components, inject processors at runtime, RBAC permission checks, fork a world, and query the full command audit trail.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -3,6 +3,9 @@
 Use `ArchetypeRuntime` for a Python script. It creates the service container,
 then gives you a lazy handle for each world.
 
+For a copy-and-run version of this page, see
+[`examples/00_quickstart.py`](https://github.com/VangelisTech/archetype/blob/main/examples/00_quickstart.py).
+
 ## Install
 
 ```bash
@@ -49,6 +52,7 @@ async def main() -> None:
         world = runtime.world("demo", processors=[Move()])
 
         entity_id = await world.spawn(Position(), Velocity(dx=2))
+        await world.step()  # Persist the initial component values.
         await world.run(steps=3)
 
         history = await world.query(Position)
@@ -59,9 +63,10 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-`spawn()` reserves a real entity ID immediately. Mutations are materialized by
-the next tick. `query()` returns a lazy Daft DataFrame containing the full
-append-only history for the requested components.
+`spawn()` reserves a real entity ID immediately. The first `step()` persists
+the initial component values; processors apply on the three subsequent ticks.
+`query()` returns a lazy Daft DataFrame containing the full append-only history
+for the requested components.
 
 ## Read the current tick
 
@@ -95,6 +100,7 @@ The sync facade has the same operations without `await`:
 with ArchetypeRuntime.sync() as runtime:
     world = runtime.world("demo", processors=[Move()])
     world.spawn(Position(), Velocity(dx=2))
+    world.step()  # Persist the initial component values.
     world.run(steps=3)
 ```
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -625,7 +625,8 @@ DELETE /worlds/{world_id}
 
 Drop the in-memory world instance. Persisted storage and audit rows are retained.
 
-Requires operator or admin. Destroying an unknown world is a no-op.
+Requires operator or admin. Destroying an unknown world is a no-op; an
+unparsable world id is rejected as a client error.
 
 **Path parameters:**
 

--- a/examples/00_quickstart.py
+++ b/examples/00_quickstart.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The smallest complete Archetype simulation."""
+
+import asyncio
+
+from daft import DataFrame, col
+
+from archetype import ArchetypeRuntime, AsyncProcessor, Component, StorageConfig
+
+
+class Counter(Component):
+    value: int = 0
+
+
+class Increment(AsyncProcessor):
+    components = (Counter,)
+
+    async def process(self, df: DataFrame, **_) -> DataFrame:
+        return df.with_column("counter__value", col("counter__value") + 1)
+
+
+async def main() -> None:
+    storage = StorageConfig(uri="./archetype_data", namespace="quickstart")
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("quickstart", storage=storage, processors=[Increment()])
+        await world.spawn(Counter())
+        await world.step()  # Persist the initial state before processors run.
+        result = await world.run(steps=3)
+        history = await world.query(Counter)
+        current = history.where(col("tick") == result.final_tick - 1)
+        print(current.collect().to_pylist()[0]["counter__value"])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ uv run python examples/<filename>.py
 
 | # | Example | Description | Requires |
 |---|---------|-------------|----------|
+| 0 | [`00_quickstart.py`](00_quickstart.py) | Smallest complete component + processor + runtime simulation | None |
 | 1 | [`01_world_mutations.py`](01_world_mutations.py) | Every mutation type: spawn, despawn, add_processor, RBAC, fork, audit history | None |
 | 2 | [`02_fork_counterfactual.py`](02_fork_counterfactual.py) | Fork a world three times, run each branch, compare results | None |
 | 3 | [`03_time_travel.py`](03_time_travel.py) | Rewind to any past tick by filtering the `tick` column, then fork a counterfactual branch and diff it against the source | None |

--- a/examples/simulation_script.py
+++ b/examples/simulation_script.py
@@ -17,12 +17,9 @@ Usage:
 
 import asyncio
 
-from daft import DataFrame, col, lit
+from daft import DataFrame, col
 
-from archetype import ArchetypeRuntime
-from archetype.core.aio.async_processor import AsyncProcessor
-from archetype.core.component import Component
-from archetype.core.config import StorageConfig
+from archetype import ArchetypeRuntime, AsyncProcessor, Component, StorageConfig
 
 # ── Step 1: Define components ───────────────────────────────────────────────
 
@@ -67,11 +64,6 @@ class RatingProcessor(AsyncProcessor):
 # ── Step 3-5: Create world, spawn entities, run ────────────────────────────
 
 
-async def collect_agent_snapshot(world) -> DataFrame:
-    info = await world.info()
-    return (await world.query(Agent)).with_column("history_tick", lit(info.tick))
-
-
 async def main():
     storage = StorageConfig(uri="./archetype_data", namespace="simulation_script")
 
@@ -88,24 +80,36 @@ async def main():
         await world.spawn(Agent(name="Charlie", role="manager", skill=1.5))
         print("Spawned: Alice (skill=3.0), Bob (skill=2.0), Charlie (skill=1.5)\n")
 
-        history_frames: list[DataFrame] = []
-        for _ in range(10):
-            await world.step()
-            history_frames.append(await collect_agent_snapshot(world))
+        # The first tick persists the raw spawn values. Processors apply on
+        # subsequent ticks, so run ten processor transformations after that.
+        await world.step()
+        result = await world.run(steps=10)
+        history = await world.query(Agent)
+        current = history.where(col("tick") == result.final_tick - 1).sort("entity_id")
 
-        info = await world.info()
-        print(f"Ran {len(history_frames)} ticks (final tick={info.tick})\n")
+        print(f"Ran 10 processor ticks (world tick={result.final_tick})\n")
 
         print("Final state:")
-        (await world.query(Agent)).show()
+        rows = (
+            current.select(
+                "agent__name",
+                "agent__skill",
+                "agent__experience",
+                "agent__rating",
+            )
+            .collect()
+            .to_pylist()
+        )
+        for row in rows:
+            print(
+                f"{row['agent__name']}: skill={row['agent__skill']:.1f}, "
+                f"experience={row['agent__experience']:.0f}, "
+                f"rating={row['agent__rating']:.2f}"
+            )
 
-        history_df = history_frames[0]
-        for frame in history_frames[1:]:
-            history_df = history_df.concat(frame)
-
-        print("\nState history (DataFrame):")
-        history_df.select(
-            "history_tick",
+        print("\nState history sample (DataFrame):")
+        history.select(
+            "tick",
             "entity_id",
             "agent__name",
             "agent__skill",

--- a/tests/scripts/test_generate_api_docs.py
+++ b/tests/scripts/test_generate_api_docs.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the generated REST reference."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.generate_api_docs import OUTPUT, generate
+
+
+@pytest.fixture(scope="module")
+def rest_reference() -> str:
+    return generate()
+
+
+def _operation(reference: str, heading: str) -> str:
+    start = reference.index(f"### {heading}\n")
+    end = reference.index("\n---\n", start)
+    return reference[start:end]
+
+
+def test_committed_rest_reference_matches_openapi(rest_reference: str) -> None:
+    assert OUTPUT.read_text(encoding="utf-8") == rest_reference
+
+
+def test_nullable_query_parameter_keeps_its_integer_type(rest_reference: str) -> None:
+    state = _operation(rest_reference, "Get World State")
+    assert "| `tick` | integer \\| null |" in state
+
+
+def test_optional_step_body_renders_its_fields(rest_reference: str) -> None:
+    step = _operation(rest_reference, "Step World")
+    assert "**Request body:**" in step
+    assert "| `run_config` | RunConfig \\| null |" in step
+    assert "| `num_steps` | integer |" in step
+    assert "| `debug` | boolean |" in step

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -27,6 +28,15 @@ _EVAL_MANIFEST = re.compile(
     re.DOTALL,
 )
 _EVAL_TASK_ROW = re.compile(r"^\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|", re.MULTILINE)
+_BEGINNER_GUIDES = (
+    _GUIDE_ROOT / "quickstart.md",
+    _GUIDE_ROOT / "building-simulations.md",
+    _GUIDE_ROOT / "processors.md",
+)
+_BEGINNER_EXAMPLES = (
+    Path("examples/00_quickstart.py"),
+    Path("examples/simulation_script.py"),
+)
 
 
 def test_numeric_command_type_claims_match_the_enum() -> None:
@@ -105,3 +115,47 @@ def test_eval_guide_manifest_matches_registered_tasks() -> None:
         f"eval guide manifest drifted; missing={registered - documented}, "
         f"stale={documented - registered}"
     )
+
+
+def test_beginner_surfaces_do_not_route_through_engine_internals() -> None:
+    """Beginner paths compose the public runtime instead of wiring core objects."""
+    forbidden_guide_terms = ("archetype.core", "AsyncWorld", "AsyncSystem", "world.system")
+    stale = [
+        f"{path}: contains {term}"
+        for path in _BEGINNER_GUIDES
+        for term in forbidden_guide_terms
+        if term in path.read_text()
+    ]
+
+    for path in _BEGINNER_EXAMPLES:
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
+                "archetype.core"
+            ):
+                stale.append(f"{path}:{node.lineno} imports {node.module}")
+
+    assert not stale, "beginner surfaces expose engine internals:\n" + "\n".join(stale)
+
+
+def test_quickstart_example_stays_under_thirty_source_lines() -> None:
+    """The copy-and-run path remains small enough to understand in one screen."""
+    source_lines = [
+        line
+        for line in _BEGINNER_EXAMPLES[0].read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert len(source_lines) < 30, f"quickstart grew to {len(source_lines)} source lines"
+
+
+def test_quickstart_variants_stage_initial_state_before_running() -> None:
+    """Async and sync snippets must spend the same number of processor ticks."""
+    guide = (_GUIDE_ROOT / "quickstart.md").read_text()
+    async_section, sync_section = guide.split("## Synchronous scripts", maxsplit=1)
+
+    for name, section in (("async", async_section), ("sync", sync_section)):
+        spawn = section.rfind("world.spawn(")
+        step = section.find("world.step()", spawn)
+        run = section.find("world.run(steps=3)", spawn)
+        assert -1 not in (spawn, step, run), f"{name} quickstart lifecycle is incomplete"
+        assert spawn < step < run, f"{name} quickstart must persist spawns before its run"

--- a/tests/test_beginner_examples.py
+++ b/tests/test_beginner_examples.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end contracts for the two beginner-facing Python examples."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_example(name: str, tmp_path: Path) -> str:
+    env = os.environ.copy()
+    env["DO_NOT_TRACK"] = "1"
+    result = subprocess.run(
+        [sys.executable, str(_ROOT / "examples" / name)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result.stdout
+
+
+def test_quickstart_runs_in_one_command(tmp_path: Path) -> None:
+    assert _run_example("00_quickstart.py", tmp_path).strip() == "3"
+
+
+def test_simulation_script_reports_the_current_state(tmp_path: Path) -> None:
+    output = _run_example("simulation_script.py", tmp_path)
+    assert "Alice: skill=3.0, experience=60, rating=18.00" in output
+    assert "Bob: skill=2.0, experience=40, rating=8.00" in output
+    assert "Charlie: skill=1.5, experience=30, rating=4.50" in output


### PR DESCRIPTION
## Summary

- add a 22-source-line, credential-free `ArchetypeRuntime` quickstart that CI executes
- keep beginner guides and linked examples on the public package surface rather than `archetype.core`
- make spawn materialization explicit before processor ticks and filter append-only history to the current persisted tick
- repair the standalone simulation so its reported final values are the values it actually computed
- regenerate the REST reference and make OpenAPI output drift, nullable parameter typing, and optional request-body rendering executable contracts

## Reconciliation

Issue #115 accumulated three independent concerns over time:

- The simulation-building interface is now `ArchetypeRuntime`; this patch gives that interface a sub-30-line copy-and-run oracle and protects the beginner-facing boundary.
- The OpenAPI generator fixes already exist. Current `main` still regenerates a one-line REST-reference diff, so this patch commits that output and adds a schema-to-reference drift check.
- The reported `SyncStore._cache` annotation no longer exists on current `main`; no `core/` change is needed.

## MRE

On exact base `8e1f4d4`:

- `examples/simulation_script.py` queries all history and displays the earliest rows as "Final state"; its snapshot helper also relabels the whole accumulated history on every tick
- running `scripts/generate_api_docs.py` produces an uncommitted REST-reference diff
- the linked standalone example imports three types through `archetype.core`

The candidate examples run in fresh temporary directories and assert the documented output (`3` for the quickstart and `60/40/30` experience for the full simulation).

## Validation

- `make ci` — 1,085 passed, 6 skipped; 85.89% coverage; regression 12/12; idempotency 23/23
- focused documentation and example contracts — 12 passed
- `uvx ty@0.0.48 check --python .venv`
- `uv run --extra docs mkdocs build`
- markdownlint — 0 issues across 69 files
- both beginner examples executed successfully in fresh temporary directories
- exact sync quickstart MRE — `final_tick=4`, current `position__x=6.0`
- `git diff --check`

Closes #115
