### PR TITLE
feat(cli): restore lazy component query terminals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ See `LEARNINGS.md` for the data-centric principle and the UDF decision tree. Bot
 archetype serve                    # Start API server
 archetype world create my-sim      # Create world
 archetype run <world-id> --steps 10
-archetype query <world-id>
+archetype query <world-id> [ComponentTypes] [--where EXPR] [--show N | --count]
 archetype history <world-id>
 ```
 

--- a/docs/guide/api-layer.md
+++ b/docs/guide/api-layer.md
@@ -103,9 +103,10 @@ See [Execution Hierarchy](execution-hierarchy.md).
 Reads are authorized at `iCommandService`; `iQueryService` remains the internal read implementation.
 The component route accepts one inert comparison through `where`, then applies either the
 `show` row limit or the `count` terminal. Filtering happens before either terminal and before
-row serialization. `show` and `count` are mutually exclusive. The filter grammar is deliberately
-small: one component column, one of `>`, `>=`, `<`, `<=`, `==`, or `!=`, and one scalar value.
-Calls, attribute access, arithmetic, and Boolean composition are rejected rather than evaluated.
+row serialization. All three options require at least one component type; `show` and `count` are
+mutually exclusive. The filter grammar is deliberately small: one component column, one of `>`,
+`>=`, `<`, `<=`, `==`, or `!=`, and one scalar value. Calls, attribute access, arithmetic, and
+Boolean composition are rejected rather than evaluated.
 
 See the [REST API Reference](../reference/rest-api.md) for generated schemas.
 

--- a/docs/guide/api-layer.md
+++ b/docs/guide/api-layer.md
@@ -97,10 +97,15 @@ See [Execution Hierarchy](execution-hierarchy.md).
 |---|---|---|
 | `/worlds/{id}/state` | GET | Query world state through the gate |
 | `/worlds/{id}/entities/{eid}` | GET | Query one entity projection |
-| `/worlds/{id}/components` | GET | Query component projections |
+| `/worlds/{id}/components` | GET | Lazily filter, limit, or count component projections |
 | `/worlds/{id}/history` | GET | Audit history through `get_audit_history` |
 
 Reads are authorized at `iCommandService`; `iQueryService` remains the internal read implementation.
+The component route accepts one inert comparison through `where`, then applies either the
+`show` row limit or the `count` terminal. Filtering happens before either terminal and before
+row serialization. `show` and `count` are mutually exclusive. The filter grammar is deliberately
+small: one component column, one of `>`, `>=`, `<`, `<=`, `==`, or `!=`, and one scalar value.
+Calls, attribute access, arithmetic, and Boolean composition are rejected rather than evaluated.
 
 See the [REST API Reference](../reference/rest-api.md) for generated schemas.
 
@@ -145,7 +150,7 @@ archetype step               POST /worlds/{id}/step
 archetype run                POST /worlds/{id}/run
 archetype episode            POST /worlds/{id}/episode
 archetype rollout            POST /worlds/{id}/rollout
-archetype query              GET /worlds/{id}/state
+archetype query              GET /worlds/{id}/state or /worlds/{id}/components
 archetype history            GET /worlds/{id}/history
 archetype processors list    GET /worlds/{id}/processors
 archetype hooks list         GET /worlds/{id}/hooks
@@ -155,6 +160,16 @@ archetype resources list     GET /worlds/{id}/resources
 The server URL defaults to `http://localhost:8000` and can be overridden with
 `ARCHETYPE_URL` or per command with `--url`. HTTP commands accept the developer
 auth shortcut `--role` / `-r` and the bearer-token option `--token`.
+
+Without component types, `query` returns the world-state projection. Pass comma-separated
+component types positionally to use the lazy component-query path:
+
+```bash
+archetype query <world-id> Agent,Score --where "score__value > 0.5" --show 5
+archetype query <world-id> Agent,Score --where "score__value > 0.5" --count
+```
+
+`--types` remains available as a compatibility spelling for the positional component list.
 
 ## Source Reference
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -67,10 +67,10 @@ archetype history <WORLD_ID> [OPTIONS]
 
 ### `archetype query`
 
-Query world state.
+Query world state or lazily filter matching component rows.
 
 ```bash
-archetype query <WORLD_ID> [OPTIONS]
+archetype query <WORLD_ID> [COMPONENT_TYPES] [OPTIONS]
 ```
 
 **Arguments:**
@@ -78,6 +78,7 @@ archetype query <WORLD_ID> [OPTIONS]
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `WORLD_ID` | text | Yes | World ID |
+| `COMPONENT_TYPES` | text | No | Comma-separated component types, for example Agent,Score |
 
 **Options:**
 
@@ -87,6 +88,9 @@ archetype query <WORLD_ID> [OPTIONS]
 | `--tick` / `-t` | integer | — | Tick to query |
 | `--ticks` | text | — | Comma-separated ticks; first is used |
 | `--entity-ids` | text | — | Comma-separated entity IDs |
+| `--show` / `-s` | integer range | — | Limit to N rows |
+| `--count` / `-c` | boolean | `False` | Return the row count only |
+| `--where` / `-w` | text | — | Filter with one comparison, for example "score__value > 0.5" |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
 | `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
 | `--token` | text | — | Bearer token to send verbatim |

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -282,9 +282,9 @@ Read entities containing component types. Requires viewer, player, operator, or 
 | `types` | string | `""` | Comma-separated component type names |
 | `tick` | integer \| null | — |  |
 | `entity_ids` | string \| null | — |  |
-| `show` | integer \| null | — | Maximum matching rows to return |
-| `count` | boolean | `false` | Return the matching row count instead of rows |
-| `where` | string \| null | — | One column comparison, for example score__value > 0.5 |
+| `show` | integer \| null | — | Maximum matching rows to return; requires types |
+| `count` | boolean | `false` | Return the matching row count instead of rows; requires types |
+| `where` | string \| null | — | One column comparison, for example score__value > 0.5; requires types |
 
 **Error codes:** `422`
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -282,6 +282,9 @@ Read entities containing component types. Requires viewer, player, operator, or 
 | `types` | string | `""` | Comma-separated component type names |
 | `tick` | integer \| null | — |  |
 | `entity_ids` | string \| null | — |  |
+| `show` | integer \| null | — | Maximum matching rows to return |
+| `count` | boolean | `false` | Return the matching row count instead of rows |
+| `where` | string \| null | — | One column comparison, for example score__value > 0.5 |
 
 **Error codes:** `422`
 

--- a/src/archetype/api/models.py
+++ b/src/archetype/api/models.py
@@ -86,6 +86,10 @@ class EntityResponse(BaseModel):
     entity_id: int
 
 
+class QueryCountResponse(BaseModel):
+    count: int
+
+
 class SubmitCommandRequest(BaseModel):
     type: str = "custom"
     tick: int = 0
@@ -172,6 +176,7 @@ __all__ = [
     "EntityResponse",
     "EpisodeConfig",
     "ForkWorldRequest",
+    "QueryCountResponse",
     "RolloutConfig",
     "RunConfig",
     "RunRequest",

--- a/src/archetype/api/query_filter.py
+++ b/src/archetype/api/query_filter.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Safe parsing for the CLI/REST component-query filter grammar."""
+
+from __future__ import annotations
+
+import ast
+import math
+from dataclasses import dataclass
+from typing import cast
+
+from daft import Expression, col
+
+_EXPECTED = "expected one comparison such as score__value > 0.5"
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedWhere:
+    """One validated column comparison and its Daft expression."""
+
+    column: str
+    expression: Expression
+
+
+def _invalid(source: str) -> ValueError:
+    return ValueError(f"Invalid where expression {source!r}; {_EXPECTED}")
+
+
+def _literal(node: ast.expr, source: str) -> str | int | float | bool:
+    if isinstance(node, ast.Constant):
+        value = node.value
+        if isinstance(value, str | int | float | bool) and value is not None:
+            if isinstance(value, float) and not math.isfinite(value):
+                raise _invalid(source)
+            return value
+
+    if isinstance(node, ast.Name):
+        # Preserve the original CLI's ergonomic bare-string form while calls,
+        # attributes, containers, and all other executable syntax stay invalid.
+        return node.id
+
+    if (
+        isinstance(node, ast.UnaryOp)
+        and isinstance(node.op, ast.UAdd | ast.USub)
+        and isinstance(node.operand, ast.Constant)
+        and isinstance(node.operand.value, int | float)
+        and not isinstance(node.operand.value, bool)
+    ):
+        value = node.operand.value if isinstance(node.op, ast.UAdd) else -node.operand.value
+        if isinstance(value, float) and not math.isfinite(value):
+            raise _invalid(source)
+        return value
+
+    raise _invalid(source)
+
+
+def parse_where(source: str) -> ParsedWhere:
+    """Parse one inert ``column operator literal`` comparison.
+
+    The grammar intentionally excludes calls, attribute access, Boolean
+    composition, arithmetic, containers, and chained comparisons. The parsed
+    tree is translated to a Daft expression; user input is never evaluated.
+    """
+    try:
+        body = ast.parse(source, mode="eval").body
+    except (SyntaxError, ValueError):
+        raise _invalid(source) from None
+
+    if (
+        not isinstance(body, ast.Compare)
+        or not isinstance(body.left, ast.Name)
+        or len(body.ops) != 1
+        or len(body.comparators) != 1
+    ):
+        raise _invalid(source)
+
+    value = _literal(body.comparators[0], source)
+    column = body.left.id
+    left = col(column)
+    operator = body.ops[0]
+
+    # Daft's type stubs describe comparison dunders as bool even though the
+    # runtime returns Expression objects.
+    if isinstance(operator, ast.Gt):
+        expression = left > value  # ty: ignore[unsupported-operator]
+    elif isinstance(operator, ast.GtE):
+        expression = left >= value  # ty: ignore[unsupported-operator]
+    elif isinstance(operator, ast.Lt):
+        expression = left < value  # ty: ignore[unsupported-operator]
+    elif isinstance(operator, ast.LtE):
+        expression = left <= value  # ty: ignore[unsupported-operator]
+    elif isinstance(operator, ast.Eq):
+        expression = cast("Expression", left == value)
+    elif isinstance(operator, ast.NotEq):
+        expression = cast("Expression", left != value)
+    else:
+        raise _invalid(source)
+
+    return ParsedWhere(column=column, expression=expression)
+
+
+__all__ = ["ParsedWhere", "parse_where"]

--- a/src/archetype/api/routes/query.py
+++ b/src/archetype/api/routes/query.py
@@ -16,11 +16,13 @@
 
 from typing import Any
 
+from daft import DataFrame
 from fastapi import APIRouter, Depends, Query
 
 from archetype.api.deps import get_actor_ctx, get_command_service
 from archetype.api.errors import raise_api_error
-from archetype.api.models import dataframe_to_rows, hydrate_component_types
+from archetype.api.models import QueryCountResponse, dataframe_to_rows, hydrate_component_types
+from archetype.api.query_filter import parse_where
 from archetype.app.auth.models import ActorCtx
 from archetype.app.command_service import CommandService
 from archetype.app.models import HookInfo, ProcessorInfo, ResourceInfo
@@ -85,6 +87,29 @@ async def _query_ids(cs: CommandService, ctx: ActorCtx, world_id: str) -> tuple[
     return str(info.world_id), str(info.run_id or "")
 
 
+async def _query_components_frame(
+    cs: CommandService,
+    ctx: ActorCtx,
+    world_id: str,
+    *,
+    component_names: list[str],
+    tick: int | None = None,
+    entity_ids: list[int] | None = None,
+) -> DataFrame | None:
+    if not component_names:
+        return None
+    query_world_id, run_id = await _query_ids(cs, ctx, world_id)
+    component_types = hydrate_component_types(component_names)
+    return await cs.query_components(
+        ctx,
+        component_types,
+        query_world_id,
+        run_id,
+        ticks=[tick] if tick is not None else None,
+        entity_ids=entity_ids,
+    )
+
+
 async def _query_components(
     cs: CommandService,
     ctx: ActorCtx,
@@ -93,20 +118,16 @@ async def _query_components(
     component_names: list[str],
     tick: int | None = None,
     entity_ids: list[int] | None = None,
-):
-    if not component_names:
-        return []
-    query_world_id, run_id = await _query_ids(cs, ctx, world_id)
-    component_types = hydrate_component_types(component_names)
-    df = await cs.query_components(
+) -> list[dict[str, Any]]:
+    frame = await _query_components_frame(
+        cs,
         ctx,
-        component_types,
-        query_world_id,
-        run_id,
-        ticks=[tick] if tick is not None else None,
+        world_id,
+        component_names=component_names,
+        tick=tick,
         entity_ids=entity_ids,
     )
-    return dataframe_to_rows(df)
+    return [] if frame is None else dataframe_to_rows(frame)
 
 
 @router.get("/worlds/{world_id}/state", response_model=list[dict[str, Any]])
@@ -164,25 +185,57 @@ async def get_entity(
         raise_api_error(exc)
 
 
-@router.get("/worlds/{world_id}/components", response_model=list[dict[str, Any]])
+@router.get(
+    "/worlds/{world_id}/components",
+    response_model=list[dict[str, Any]] | QueryCountResponse,
+)
 async def get_components(
     world_id: str,
     types: str = Query("", description="Comma-separated component type names"),
     tick: int | None = None,
     entity_ids: str | None = None,
+    show: int | None = Query(None, ge=1, description="Maximum matching rows to return"),
+    count: bool = Query(False, description="Return the matching row count instead of rows"),
+    where: str | None = Query(
+        None,
+        description="One column comparison, for example score__value > 0.5",
+    ),
     cs: CommandService = Depends(get_command_service),
     ctx: ActorCtx = Depends(get_actor_ctx),
 ):
     """Read entities containing component types. Requires viewer, player, operator, or admin."""
     try:
-        return await _query_components(
+        if count and show is not None:
+            raise ValueError("count and show are mutually exclusive terminal operations")
+
+        component_names = _split_csv(types)
+        frame = await _query_components_frame(
             cs,
             ctx,
             world_id,
-            component_names=_split_csv(types),
+            component_names=component_names,
             tick=tick,
             entity_ids=_entity_ids(entity_ids),
         )
+        if frame is None:
+            if where:
+                raise ValueError("where requires at least one component type")
+            return QueryCountResponse(count=0) if count else []
+
+        if where:
+            parsed = parse_where(where)
+            if parsed.column not in frame.column_names:
+                raise ValueError(
+                    f"Unknown query column {parsed.column!r}; available columns: "
+                    + ", ".join(frame.column_names)
+                )
+            frame = frame.where(parsed.expression)
+
+        if count:
+            return QueryCountResponse(count=frame.count_rows())
+        if show is not None:
+            frame = frame.limit(show)
+        return dataframe_to_rows(frame)
     except Exception as exc:
         raise_api_error(exc)
 

--- a/src/archetype/api/routes/query.py
+++ b/src/archetype/api/routes/query.py
@@ -194,11 +194,18 @@ async def get_components(
     types: str = Query("", description="Comma-separated component type names"),
     tick: int | None = None,
     entity_ids: str | None = None,
-    show: int | None = Query(None, ge=1, description="Maximum matching rows to return"),
-    count: bool = Query(False, description="Return the matching row count instead of rows"),
+    show: int | None = Query(
+        None,
+        ge=1,
+        description="Maximum matching rows to return; requires types",
+    ),
+    count: bool = Query(
+        False,
+        description="Return the matching row count instead of rows; requires types",
+    ),
     where: str | None = Query(
         None,
-        description="One column comparison, for example score__value > 0.5",
+        description="One column comparison, for example score__value > 0.5; requires types",
     ),
     cs: CommandService = Depends(get_command_service),
     ctx: ActorCtx = Depends(get_actor_ctx),
@@ -209,6 +216,9 @@ async def get_components(
             raise ValueError("count and show are mutually exclusive terminal operations")
 
         component_names = _split_csv(types)
+        if not component_names and (show is not None or count or where):
+            raise ValueError("show, count, and where require at least one component type")
+
         frame = await _query_components_frame(
             cs,
             ctx,
@@ -218,9 +228,7 @@ async def get_components(
             entity_ids=_entity_ids(entity_ids),
         )
         if frame is None:
-            if where:
-                raise ValueError("where requires at least one component type")
-            return QueryCountResponse(count=0) if count else []
+            return []
 
         if where:
             parsed = parse_where(where)

--- a/src/archetype/cli/main.py
+++ b/src/archetype/cli/main.py
@@ -593,31 +593,77 @@ def rollout(
 @app.command()
 def query(
     world_id: str = typer.Argument(..., help="World ID"),
+    component_types: str | None = typer.Argument(
+        None,
+        help="Comma-separated component types, for example Agent,Score",
+    ),
     types: str | None = typer.Option(None, "--types", help="Comma-separated component types"),
     tick: int | None = typer.Option(None, "--tick", "-t", help="Tick to query"),
     ticks: str | None = typer.Option(None, "--ticks", help="Comma-separated ticks; first is used"),
     entity_ids: str | None = typer.Option(None, "--entity-ids", help="Comma-separated entity IDs"),
+    show: int | None = typer.Option(None, "--show", "-s", min=1, help="Limit to N rows"),
+    count: bool = typer.Option(False, "--count", "-c", help="Return the row count only"),
+    where: str | None = typer.Option(
+        None,
+        "--where",
+        "-w",
+        help='Filter with one comparison, for example "score__value > 0.5"',
+    ),
     url: str | None = typer.Option(None, "--url", help="Override ARCHETYPE_URL for this command"),
     role: Role | None = ROLE_OPTION,
     token: str | None = typer.Option(None, "--token", help="Bearer token to send verbatim"),
     json_output: bool = typer.Option(False, "--json", help="Emit raw JSON"),
 ):
-    """Query world state."""
+    """Query world state or lazily filter matching component rows."""
+    if component_types and types:
+        typer.echo(
+            "validation error: pass component types positionally or with --types, not both",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    selected_types = component_types or types
+    if count and show is not None:
+        typer.echo("validation error: --count and --show are mutually exclusive", err=True)
+        raise typer.Exit(code=1)
+    if (show is not None or count or where) and not selected_types:
+        typer.echo(
+            "validation error: --show, --count, and --where require component types",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
     params: dict[str, Any] = {}
-    if types:
-        params["components"] = types
     if entity_ids:
         params["entity_ids"] = entity_ids
     if tick is not None:
         params["tick"] = tick
     elif ticks:
         params["tick"] = _csv(ticks)[0]
-    data = _request_list(
-        "get",
-        f"/worlds/{world_id}/state",
-        params=params,
+
+    path = f"/worlds/{world_id}/state"
+    if selected_types:
+        path = f"/worlds/{world_id}/components"
+        params["types"] = selected_types
+        if show is not None:
+            params["show"] = show
+        if count:
+            params["count"] = True
+        if where:
+            params["where"] = where
+
+    request_kwargs = {
+        "params": params,
         **_common_request_kwargs(url, role, token),
-    )
+    }
+    if count:
+        result = _request_obj("get", path, **request_kwargs)
+        if json_output:
+            _print_json(result)
+        else:
+            typer.echo(f"Count: {result['count']}")
+        return
+
+    data = _request_list("get", path, **request_kwargs)
     if json_output:
         _print_json(data)
         return

--- a/tests/api/test_query_filter.py
+++ b/tests/api/test_query_filter.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import daft
+import pytest
+
+from archetype.api.query_filter import parse_where
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    (
+        ("score__value > 0.5", [0.75, 1.0]),
+        ("score__value >= 0.75", [0.75, 1.0]),
+        ("score__value < 0.75", [0.25]),
+        ("score__value <= 0.75", [0.25, 0.75]),
+        ("score__value == 0.75", [0.75]),
+        ("score__value != 0.75", [0.25, 1.0]),
+    ),
+)
+def test_parse_where_builds_a_daft_comparison(source: str, expected: list[float]) -> None:
+    parsed = parse_where(source)
+    frame = daft.from_pydict({"score__value": [0.25, 0.75, 1.0]})
+    rows = frame.where(parsed.expression).collect().to_pylist()
+    assert parsed.column == "score__value"
+    assert [row["score__value"] for row in rows] == expected
+
+
+def test_parse_where_supports_quoted_and_bare_strings() -> None:
+    frame = daft.from_pydict({"agent__status": ["ready", "waiting"]})
+    for source in ('agent__status == "ready"', "agent__status == ready"):
+        parsed = parse_where(source)
+        assert frame.where(parsed.expression).collect().to_pylist() == [{"agent__status": "ready"}]
+
+
+def test_parse_where_supports_negative_numeric_literals() -> None:
+    parsed = parse_where("metric__value >= -1.5")
+    frame = daft.from_pydict({"metric__value": [-2.0, -1.5, 0.0]})
+    assert frame.where(parsed.expression).collect().to_pylist() == [
+        {"metric__value": -1.5},
+        {"metric__value": 0.0},
+    ]
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "",
+        "score__value",
+        "score__value > 0 and score__value < 1",
+        "0 < score__value < 1",
+        "score__value + 1 > 2",
+        "score__value in [1, 2]",
+        "score__value > dangerous()",
+        "record.score > 1",
+        "score__value > 1e309",
+    ),
+)
+def test_parse_where_rejects_executable_or_ambiguous_syntax(source: str) -> None:
+    with pytest.raises(ValueError, match="Invalid where expression"):
+        parse_where(source)

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -460,6 +460,18 @@ class TestQueryRoutes:
                 {"types": "QueryRouteMetric104", "count": True, "show": 2},
                 "mutually exclusive",
             ),
+            (
+                {"count": True},
+                "require at least one component type",
+            ),
+            (
+                {"show": 2},
+                "require at least one component type",
+            ),
+            (
+                {"where": "entity_id > 0"},
+                "require at least one component type",
+            ),
         ),
     )
     def test_component_query_rejects_invalid_options(self, client, tmp_path, params, detail):

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -17,7 +17,13 @@ pytest.importorskip("httpx", reason="httpx required for API tests")
 
 from fastapi.testclient import TestClient
 
+from archetype import Component
+
 ROLES = ("admin", "operator", "player", "viewer")
+
+
+class QueryRouteMetric104(Component):
+    value: float = 0.0
 
 
 @pytest.fixture(autouse=True)
@@ -360,6 +366,109 @@ class TestSimulationRoutes:
 
 
 class TestQueryRoutes:
+    @staticmethod
+    def _create_metric_world(client, tmp_path) -> str:
+        create_resp = client.post(
+            "/worlds",
+            json={"name": "query-options", "storage_uri": str(tmp_path / "store")},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        world_id = create_resp.json()["world_id"]
+
+        for value in range(5):
+            spawn = client.post(
+                f"/worlds/{world_id}/entities",
+                json={"components": [QueryRouteMetric104(value=value).to_payload()]},
+            )
+            assert spawn.status_code == 201, spawn.text
+
+        step = client.post(f"/worlds/{world_id}/step", json={})
+        assert step.status_code == 200, step.text
+        return world_id
+
+    def test_component_query_filters_before_show(self, client, tmp_path):
+        world_id = self._create_metric_world(client, tmp_path)
+        response = client.get(
+            f"/worlds/{world_id}/components",
+            params={
+                "types": "QueryRouteMetric104",
+                "where": "queryroutemetric104__value >= 2",
+                "show": 2,
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        rows = response.json()
+        assert len(rows) == 2
+        assert all(row["queryroutemetric104__value"] >= 2 for row in rows)
+
+    def test_component_query_count_is_a_distinct_terminal(self, client, tmp_path, monkeypatch):
+        world_id = self._create_metric_world(client, tmp_path)
+
+        def forbid_row_materialization(_frame):
+            pytest.fail("count queries must not serialize rows")
+
+        monkeypatch.setattr(
+            "archetype.api.routes.query.dataframe_to_rows",
+            forbid_row_materialization,
+        )
+        response = client.get(
+            f"/worlds/{world_id}/components",
+            params={
+                "types": "QueryRouteMetric104",
+                "where": "queryroutemetric104__value > 1",
+                "count": True,
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {"count": 3}
+
+    def test_component_query_tick_selects_a_historical_snapshot(self, client, tmp_path):
+        world_id = self._create_metric_world(client, tmp_path)
+        spawn = client.post(
+            f"/worlds/{world_id}/entities",
+            json={"components": [QueryRouteMetric104(value=5).to_payload()]},
+        )
+        assert spawn.status_code == 201, spawn.text
+        step = client.post(f"/worlds/{world_id}/step", json={})
+        assert step.status_code == 200, step.text
+
+        counts = []
+        for tick in (0, 1):
+            response = client.get(
+                f"/worlds/{world_id}/components",
+                params={"types": "QueryRouteMetric104", "tick": tick, "count": True},
+            )
+            assert response.status_code == 200, response.text
+            counts.append(response.json()["count"])
+
+        assert counts == [5, 6]
+
+    @pytest.mark.parametrize(
+        ("params", "detail"),
+        (
+            (
+                {"types": "QueryRouteMetric104", "where": "value > 1 and value < 4"},
+                "Invalid where expression",
+            ),
+            (
+                {"types": "QueryRouteMetric104", "where": "missing__value > 1"},
+                "Unknown query column",
+            ),
+            (
+                {"types": "QueryRouteMetric104", "count": True, "show": 2},
+                "mutually exclusive",
+            ),
+        ),
+    )
+    def test_component_query_rejects_invalid_options(self, client, tmp_path, params, detail):
+        world_id = self._create_metric_world(client, tmp_path)
+        response = client.get(f"/worlds/{world_id}/components", params=params)
+
+        assert response.status_code == 400, response.text
+        assert detail in response.json()["detail"]
+
     def test_history_accepts_tick_range(self, client, tmp_path):
         create_resp = client.post(
             "/worlds",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+from click import unstyle
 from click.exceptions import Exit as ClickExit
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
@@ -95,12 +96,13 @@ class TestCLI:
         assert result.exit_code == 0
 
     def test_query_help_exposes_lazy_terminals(self):
-        result = runner.invoke(app, ["query", "--help"])
+        result = runner.invoke(app, ["query", "--help"], color=True)
         assert result.exit_code == 0, result.output
-        assert "COMPONENT_TYPES" in result.output
-        assert "--show" in result.output
-        assert "--count" in result.output
-        assert "--where" in result.output
+        output = unstyle(result.output)
+        assert "COMPONENT_TYPES" in output
+        assert "--show" in output
+        assert "--count" in output
+        assert "--where" in output
 
     def test_query_forwards_positional_components_and_options(self, monkeypatch):
         captured = {}

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -94,6 +94,79 @@ class TestCLI:
         result = runner.invoke(app, ["world", "create", "--help"])
         assert result.exit_code == 0
 
+    def test_query_help_exposes_lazy_terminals(self):
+        result = runner.invoke(app, ["query", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "COMPONENT_TYPES" in result.output
+        assert "--show" in result.output
+        assert "--count" in result.output
+        assert "--where" in result.output
+
+    def test_query_forwards_positional_components_and_options(self, monkeypatch):
+        captured = {}
+
+        def fake_request(method, path, **kwargs):
+            captured.update(method=method, path=path, kwargs=kwargs)
+            return [{"score__value": 0.75}]
+
+        monkeypatch.setattr(cli_mod, "_request", fake_request)
+        result = runner.invoke(
+            app,
+            [
+                "query",
+                "world-1",
+                "Agent,Score",
+                "--tick",
+                "3",
+                "--entity-ids",
+                "7,8",
+                "--where",
+                "score__value > 0.5",
+                "--show",
+                "5",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["method"] == "get"
+        assert captured["path"] == "/worlds/world-1/components"
+        assert captured["kwargs"]["params"] == {
+            "entity_ids": "7,8",
+            "tick": 3,
+            "types": "Agent,Score",
+            "show": 5,
+            "where": "score__value > 0.5",
+        }
+
+    def test_query_count_uses_object_terminal(self, monkeypatch):
+        captured = {}
+
+        def fake_request(method, path, **kwargs):
+            captured.update(method=method, path=path, kwargs=kwargs)
+            return {"count": 3}
+
+        monkeypatch.setattr(cli_mod, "_request", fake_request)
+        result = runner.invoke(app, ["query", "world-1", "Score", "--count"])
+
+        assert result.exit_code == 0, result.output
+        assert "Count: 3" in result.output
+        assert captured["path"] == "/worlds/world-1/components"
+        assert captured["kwargs"]["params"] == {"types": "Score", "count": True}
+
+    @pytest.mark.parametrize(
+        "arguments",
+        (
+            ["world-1", "Score", "--types", "Score"],
+            ["world-1", "Score", "--count", "--show", "2"],
+            ["world-1", "--where", "score__value > 0.5"],
+        ),
+    )
+    def test_query_rejects_ambiguous_option_combinations(self, arguments):
+        result = runner.invoke(app, ["query", *arguments])
+        assert result.exit_code == 1
+        assert "validation error" in result.output
+
     def test_base_url_uses_env_and_strips_trailing_slash(self, monkeypatch):
         monkeypatch.setenv(ENV_BASE_URL, "http://example.com/api/")
         assert _base_url() == "http://example.com/api"

--- a/tests/scripts/test_generate_cli_docs.py
+++ b/tests/scripts/test_generate_cli_docs.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the generated CLI reference."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.generate_cli_docs import OUTPUT, generate
+
+
+@pytest.fixture(scope="module")
+def cli_reference() -> str:
+    return generate()
+
+
+def _command(reference: str, heading: str) -> str:
+    start = reference.index(f"### `{heading}`\n")
+    end = reference.index("\n---\n", start)
+    return reference[start:end]
+
+
+def test_committed_cli_reference_matches_click_app(cli_reference: str) -> None:
+    assert OUTPUT.read_text(encoding="utf-8") == cli_reference
+
+
+def test_query_reference_exposes_component_terminals(cli_reference: str) -> None:
+    query = _command(cli_reference, "archetype query")
+    assert "[COMPONENT_TYPES]" in query
+    assert "`--show`" in query
+    assert "`--count`" in query
+    assert "`--where`" in query


### PR DESCRIPTION
## Summary

- restore positional component queries and the `--show`, `--count`, and `--where` CLI terminals lost after #111
- compose a validated Daft filter and terminal on the server after the `CommandService` authorization gate
- keep world-state queries and the existing `--types` spelling backward compatible
- reject advanced REST terminals without component types instead of returning a misleading zero
- document the query contract and pin both generated CLI and REST references against their executable sources

## Contract

`--where` accepts one inert `column operator scalar` comparison. Calls, attributes, arithmetic, containers, Boolean composition, and chained comparisons are rejected; user input is never evaluated. Filtering precedes `limit` or `count`, count queries do not serialize rows, and all advanced terminals require component types.

Coverage exercises real persisted component rows, historical tick selection, filter-before-limit ordering, the distinct count terminal, CLI-to-HTTP forwarding, invalid combinations, and generated-reference parity.

## Validation

- `make ci` — 1,135 passed, 8 skipped; 85.68% coverage; 12/12 regression evaluations
- `uvx ty@0.0.48 check --python .venv`
- `uv run --extra docs mkdocs build`
- spelling, Markdown, and link gates — 224 links checked, zero errors

Closes #104
