### PR TITLE
fix(query): discover durable signatures cold

### DIFF
--- a/docs/guide/durable-discovery.md
+++ b/docs/guide/durable-discovery.md
@@ -117,7 +117,9 @@ Missing, drifted, or identity-mismatched historical records are skipped with a
 warning so one unrelated old world cannot block storage-wide discovery. Mutable
 world resume remains strict because it resolves only the target world's live
 entity signatures. When both sources know a table, the exact process-local
-class identity takes precedence over an ambiguous catalog reconstruction.
+class identity takes precedence over an ambiguous catalog reconstruction. If
+the catalog itself is unavailable, discovery returns the process-local subset
+and logs the degradation; commit-visibility checks remain fail-closed.
 
 ## 5. Fail-closed schema check
 

--- a/docs/guide/durable-discovery.md
+++ b/docs/guide/durable-discovery.md
@@ -112,8 +112,11 @@ df = await container.command_service.query_components(
 process-local cache with every durable catalog record. Listing a complete
 Python signature requires the corresponding component classes to be imported;
 records are matched to those classes by full schema fingerprint, never by name
-alone. A missing or drifted definition fails loudly instead of silently
-omitting the persisted archetype.
+alone, and the recomputed table identity must equal the durable `table_id`.
+Missing, drifted, or identity-mismatched historical records are skipped with a
+warning so one unrelated old world cannot block storage-wide discovery. Mutable
+world resume remains strict because it resolves only the target world's live
+entity signatures.
 
 ## 5. Fail-closed schema check
 

--- a/docs/guide/durable-discovery.md
+++ b/docs/guide/durable-discovery.md
@@ -116,7 +116,8 @@ alone, and the recomputed table identity must equal the durable `table_id`.
 Missing, drifted, or identity-mismatched historical records are skipped with a
 warning so one unrelated old world cannot block storage-wide discovery. Mutable
 world resume remains strict because it resolves only the target world's live
-entity signatures.
+entity signatures. When both sources know a table, the exact process-local
+class identity takes precedence over an ambiguous catalog reconstruction.
 
 ## 5. Fail-closed schema check
 

--- a/docs/guide/durable-discovery.md
+++ b/docs/guide/durable-discovery.md
@@ -82,7 +82,7 @@ async def open_world_readonly(
 Both operations respect the info-class downgrade: callers get `WorldInfo`,
 never a world handle.
 
-## 4. Cold subset queries
+## 4. Cold queries and signature discovery
 
 `query_components` unions two sources:
 
@@ -107,6 +107,13 @@ df = await container.command_service.query_components(
     storage_config=storage_config,
 )
 ```
+
+`list_signatures` uses the same authority split: it unions the store's
+process-local cache with every durable catalog record. Listing a complete
+Python signature requires the corresponding component classes to be imported;
+records are matched to those classes by full schema fingerprint, never by name
+alone. A missing or drifted definition fails loudly instead of silently
+omitting the persisted archetype.
 
 ## 5. Fail-closed schema check
 

--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -115,6 +115,7 @@ renaming a task requires updating this table in the same change.
 | `regression` | `rbac_enforcement` | Role permissions, token costs, and the default role |
 | `regression` | `command_ordering` | Deterministic `(tick, priority, seq)` command order |
 | `regression` | `command_pipeline` | Submit → broker → step → history, with RBAC at the service boundary |
+| `regression` | `query_correctness` | Cold gated reads union component subsets, honor filters/projection, and discover durable signatures |
 | `regression` | `tick_quota_resets` | Per-tick command quotas reset at each tick rather than process-wide |
 | `regression` | `episode_value_termination` | Value-based episode termination stops before the defensive cap |
 | `regression` | `poison_in_batch` | A malformed command does not block valid commands in the same drain |

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -257,6 +257,8 @@ async def run_rollout(ctx, world_id, config, **kw) -> RolloutResult
 ```python
 async def query_archetype(ctx, sig, world_id, run_id, storage_config=None,
                            *, ticks=None, entity_ids=None, components=None) -> DataFrame
+async def query_components(ctx, components, world_id, run_id, storage_config=None,
+                           *, ticks=None, entity_ids=None) -> DataFrame
 async def list_signatures(ctx, storage_config=None) -> list[ArchetypeSignature]
 async def query_facts(ctx, world_id, table_name,
                       storage_config=None) -> DataFrame

--- a/docs/guide/services.md
+++ b/docs/guide/services.md
@@ -109,6 +109,7 @@ See [Execution Hierarchy](execution-hierarchy.md).
 External reads go through `iCommandService`:
 
 - `query_archetype`
+- `query_components`
 - `list_signatures`
 - `get_world_info`
 - `get_audit_history`

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -510,8 +510,10 @@ CURRENT GAPS:
 - Coordinated reads MUST restrict results to catalog-published commit tokens.
 - Fork-aware reads MUST compose persisted lineage segments with the fork's own
   rows without requiring a live source world.
-- `get_lineage()` reads persisted ancestry, and `list_signatures()` reads the
-  selected store's registered archetypes.
+- `get_lineage()` reads persisted ancestry. `list_signatures()` combines the
+  selected store's process-local registry with its durable control-catalog
+  records, resolving imported component classes by schema fingerprint so a
+  cold process does not silently omit persisted archetypes.
 - Audit history is served by `iAuditLog` through `iCommandService`.
   `QueryService.get_command_history()` remains a compatibility read over queued
   audit rows, not an in-memory broker-history contract.

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -512,8 +512,10 @@ CURRENT GAPS:
   rows without requiring a live source world.
 - `get_lineage()` reads persisted ancestry. `list_signatures()` combines the
   selected store's process-local registry with its durable control-catalog
-  records, resolving imported component classes by schema fingerprint so a
-  cold process does not silently omit persisted archetypes.
+  records, resolving imported component classes by schema fingerprint and
+  exact durable table identity. Unresolvable historical records emit a warning
+  and are skipped so unrelated schema drift cannot disable storage-wide
+  discovery; mutable resume remains strict for the target world's live rows.
 - Audit history is served by `iAuditLog` through `iCommandService`.
   `QueryService.get_command_history()` remains a compatibility read over queued
   audit rows, not an in-memory broker-history contract.

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -515,7 +515,8 @@ CURRENT GAPS:
   records, resolving imported component classes by schema fingerprint and
   exact durable table identity. Unresolvable historical records emit a warning
   and are skipped so unrelated schema drift cannot disable storage-wide
-  discovery; mutable resume remains strict for the target world's live rows.
+  discovery. Exact process-local class identities take precedence over catalog
+  reconstruction; mutable resume remains strict for the target world's live rows.
 - Audit history is served by `iAuditLog` through `iCommandService`.
   `QueryService.get_command_history()` remains a compatibility read over queued
   audit rows, not an in-memory broker-history contract.

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -516,7 +516,8 @@ CURRENT GAPS:
   exact durable table identity. Unresolvable historical records emit a warning
   and are skipped so unrelated schema drift cannot disable storage-wide
   discovery. Exact process-local class identities take precedence over catalog
-  reconstruction; mutable resume remains strict for the target world's live rows.
+  reconstruction. Catalog outages degrade discovery to the process-local
+  subset; mutable resume and commit-visibility checks remain strict.
 - Audit history is served by `iAuditLog` through `iCommandService`.
   `QueryService.get_command_history()` remains a compatibility read over queued
   audit rows, not an in-memory broker-history contract.

--- a/evals/suites/regression.py
+++ b/evals/suites/regression.py
@@ -321,6 +321,151 @@ async def _task_command_pipeline() -> list[GraderResult]:
 
 
 # ---------------------------------------------------------------------------
+# Task: cold service-layer query correctness
+# ---------------------------------------------------------------------------
+
+
+def task_query_correctness() -> list[GraderResult]:
+    """Gated durable reads remain correct without a live AsyncWorld."""
+    return asyncio.run(_task_query_correctness())
+
+
+async def _task_query_correctness() -> list[GraderResult]:
+    reset_tick_counters()
+    reset_daily_tokens()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = StorageConfig(uri=f"{tmp}/store", namespace="eval_query")
+        admin = ActorCtx(id=uuid7(), roles={"admin"})
+        writer = ServiceContainer()
+        try:
+            info = await writer.command_service.create_world(
+                admin,
+                WorldConfig(name="query-correctness"),
+                storage,
+            )
+            health_only = await writer.command_service.create_entity(
+                admin,
+                info.world_id,
+                [Health(hp=10)],
+            )
+            tagged = await writer.command_service.create_entity(
+                admin,
+                info.world_id,
+                [Health(hp=20), Tag(label="target")],
+            )
+            first_run = await writer.command_service.run(
+                admin,
+                info.world_id,
+                RunConfig(num_steps=1),
+            )
+            await writer.command_service.update_entity(
+                admin,
+                info.world_id,
+                health_only,
+                [Health(hp=11)],
+            )
+            await writer.command_service.run(
+                admin,
+                info.world_id,
+                RunConfig(num_steps=1),
+            )
+            world_id = str(info.world_id)
+            run_id = str(first_run.run_id)
+        finally:
+            try:
+                await writer.shutdown()
+            finally:
+                reset_tick_counters()
+                reset_daily_tokens()
+
+        # A new composition root has no live world object. Reads must cross
+        # the public gate and resolve the durable QueryService path instead.
+        reader = ServiceContainer()
+        viewer = ActorCtx(id=uuid7(), roles={"viewer"})
+        try:
+            cold_reader = not reader.world_service.has_world(world_id)
+            signatures = await reader.command_service.list_signatures(viewer, storage)
+            tick_zero = (
+                await reader.command_service.query_components(
+                    viewer,
+                    [Health],
+                    world_id,
+                    run_id,
+                    storage,
+                    ticks=[0],
+                )
+            ).to_pylist()
+            selected = (
+                await reader.command_service.query_components(
+                    viewer,
+                    [Health],
+                    world_id,
+                    run_id,
+                    storage,
+                    ticks=[1],
+                    entity_ids=[health_only],
+                )
+            ).to_pylist()
+            projected = (
+                await reader.command_service.query_archetype(
+                    viewer,
+                    (Health, Tag),
+                    world_id,
+                    run_id,
+                    storage,
+                    ticks=[0],
+                    components=[Health],
+                )
+            ).to_pylist()
+
+            signature_names = {
+                tuple(component.__name__ for component in signature) for signature in signatures
+            }
+            tick_zero_values = sorted((row["entity_id"], row["health__hp"]) for row in tick_zero)
+            selected_values = [
+                (row["entity_id"], row["tick"], row["health__hp"]) for row in selected
+            ]
+            projection = projected[0] if len(projected) == 1 else {}
+
+            return [
+                exact_match(cold_reader, True, name="no_live_world_shortcut"),
+                exact_match(
+                    tick_zero_values,
+                    [(health_only, 10), (tagged, 20)],
+                    name="subset_union_across_signatures",
+                ),
+                exact_match(
+                    selected_values,
+                    [(health_only, 1, 11)],
+                    name="tick_and_entity_filters",
+                ),
+                state_check(
+                    {
+                        "one_exact_row": len(projected) == 1,
+                        "exact_entity": projection.get("entity_id") == tagged,
+                        "health_projected": projection.get("health__hp") == 20,
+                        "tag_not_projected": "tag__label" not in projection,
+                    },
+                    name="exact_signature_projection",
+                ),
+                state_check(
+                    {
+                        "health_signature": ("Health",) in signature_names,
+                        "health_tag_signature": ("Health", "Tag") in signature_names,
+                    },
+                    name="cold_signature_discovery",
+                ),
+            ]
+        finally:
+            try:
+                await reader.shutdown()
+            finally:
+                reset_tick_counters()
+                reset_daily_tokens()
+
+
+# ---------------------------------------------------------------------------
 # Task: per-tick RBAC quota resets across ticks (bug B1)
 # ---------------------------------------------------------------------------
 
@@ -447,6 +592,12 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_command_pipeline,
         desc="Submit → broker → step → history + RBAC at service boundary",
+    )
+    harness.add(
+        "query_correctness",
+        suite=SUITE,
+        fn=task_query_correctness,
+        desc="Cold gated component/archetype reads, filters, projection, and discovery",
     )
     harness.add(
         "tick_quota_resets",

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -92,7 +92,7 @@ reason = "Episode-termination boundary: the value-based 'all entities done' chec
 
 [[entries]]
 path = "src/archetype/app/query_service.py"
-line = 335
+line = 349
 method = "to_pylist"
 reason = "Bounded compatibility boundary: queued audit rows are already filtered and limited lazily, then materialized into the legacy list[Command] return contract used by pre-gate callers."
 
@@ -116,7 +116,7 @@ reason = "Processor candidate boundary: materializes the distinct, existing-key-
 
 [[entries]]
 path = "src/archetype/app/world_service.py"
-line = 724
+line = 703
 method = "to_pylist"
 reason = "Resume-time entity-directory extract (issue #273 A1-resume): the latest visible row per entity — already reduced in Daft to one (entity_id, tick, is_active) row per entity via groupby-max + join — must enter Python control flow to become the entity2sig registry and next_entity_id counter that route all subsequent mutations; imperative world reconstruction at the cold-resume boundary, bounded by live entity count, not a downstream dataframe computation."
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -92,7 +92,7 @@ reason = "Episode-termination boundary: the value-based 'all entities done' chec
 
 [[entries]]
 path = "src/archetype/app/query_service.py"
-line = 361
+line = 365
 method = "to_pylist"
 reason = "Bounded compatibility boundary: queued audit rows are already filtered and limited lazily, then materialized into the legacy list[Command] return contract used by pre-gate callers."
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -92,7 +92,7 @@ reason = "Episode-termination boundary: the value-based 'all entities done' chec
 
 [[entries]]
 path = "src/archetype/app/query_service.py"
-line = 349
+line = 361
 method = "to_pylist"
 reason = "Bounded compatibility boundary: queued audit rows are already filtered and limited lazily, then materialized into the legacy list[Command] return contract used by pre-gate callers."
 

--- a/src/archetype/app/_signature_resolution.py
+++ b/src/archetype/app/_signature_resolution.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve durable signature records to imported component classes.
+
+The control catalog stores component names and a schema fingerprint, not
+Python import paths.  A process may also have several same-named component
+classes loaded (tests, plugins, or an evolved definition), so names alone are
+not identity.  This module is the single app-layer boundary that joins a
+durable record back to an interchangeable, schema-identical class tuple.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from itertools import product
+
+from archetype.app._catalog import SignatureRecord, schema_fingerprint
+from archetype.core.archetype import Archetype
+from archetype.core.component import Component
+from archetype.core.interfaces import ArchetypeSignature
+
+
+def _component_classes_by_name() -> dict[str, list[type[Component]]]:
+    """Return every imported Component subclass, grouped by class name."""
+    classes: dict[str, list[type[Component]]] = {}
+    stack: list[type[Component]] = list(Component.__subclasses__())
+    seen: set[type[Component]] = set()
+    while stack:
+        cls = stack.pop()
+        if cls in seen:
+            continue
+        seen.add(cls)
+        stack.extend(cls.__subclasses__())
+        classes.setdefault(cls.__name__, []).append(cls)
+    return classes
+
+
+def resolve_signature_records(
+    records: Iterable[SignatureRecord],
+    *,
+    operation: str,
+) -> dict[str, ArchetypeSignature]:
+    """Resolve catalog records by full schema identity or fail loudly.
+
+    Multiple imported classes with the same name are harmless when their
+    complete archetype schema has the recorded fingerprint: they are
+    interchangeable for reads.  A missing or drifted definition is not
+    guessed because doing so would make code, rather than the stored schema,
+    silently reinterpret durable rows.
+    """
+    available = _component_classes_by_name()
+    resolved: dict[str, ArchetypeSignature] = {}
+    problems: dict[str, str] = {}
+
+    for record in records:
+        if record.table_id in resolved or record.table_id in problems:
+            continue
+
+        missing = sorted(name for name in record.component_names if not available.get(name))
+        if missing:
+            problems[record.table_id] = f"component class(es) {', '.join(missing)} are not imported"
+            continue
+
+        matches: list[ArchetypeSignature] = []
+        candidates = (
+            sorted(available[name], key=lambda cls: (cls.__module__, cls.__qualname__))
+            for name in record.component_names
+        )
+        for combination in product(*candidates):
+            signature = tuple(sorted(set(combination), key=lambda cls: cls.__name__))
+            try:
+                fingerprint = schema_fingerprint(Archetype.get_archetype_schema(signature))
+            except Exception:
+                continue
+            if fingerprint == record.fingerprint and signature not in matches:
+                matches.append(signature)
+
+        if matches:
+            # Candidate ordering makes the representative deterministic.
+            # Every match is interchangeable by the complete fingerprint.
+            resolved[record.table_id] = matches[0]
+        else:
+            problems[record.table_id] = (
+                "no imported class combination matches the stored schema "
+                "(the definitions may have drifted since the rows were written)"
+            )
+
+    if problems:
+        detail = "; ".join(
+            f"table {table_id}: {message}" for table_id, message in sorted(problems.items())
+        )
+        raise RuntimeError(
+            f"cannot {operation}: {detail} (code is not rows — import the exact component "
+            "definitions before reading durable signatures)"
+        )
+
+    return resolved

--- a/src/archetype/app/_signature_resolution.py
+++ b/src/archetype/app/_signature_resolution.py
@@ -36,18 +36,18 @@ def _component_classes_by_name() -> dict[str, list[type[Component]]]:
     return classes
 
 
-def resolve_signature_records(
+def match_signature_records(
     records: Iterable[SignatureRecord],
-    *,
-    operation: str,
-) -> dict[str, ArchetypeSignature]:
-    """Resolve catalog records by full schema identity or fail loudly.
+) -> tuple[dict[str, ArchetypeSignature], dict[str, str]]:
+    """Partition catalog records into exact matches and diagnosed problems.
 
     Multiple imported classes with the same name are harmless when their
-    complete archetype schema has the recorded fingerprint: they are
-    interchangeable for reads.  A missing or drifted definition is not
-    guessed because doing so would make code, rather than the stored schema,
-    silently reinterpret durable rows.
+    complete archetype schema and table identity match the durable record.
+    A missing or drifted definition is not guessed because doing so would
+    make code, rather than the stored schema, silently reinterpret rows.
+
+    The non-raising partition lets discovery skip unrelated historical drift
+    while strict lifecycle callers use :func:`resolve_signature_records`.
     """
     available = _component_classes_by_name()
     resolved: dict[str, ArchetypeSignature] = {}
@@ -63,6 +63,7 @@ def resolve_signature_records(
             continue
 
         matches: list[ArchetypeSignature] = []
+        mismatched_table_ids: set[str] = set()
         candidates = (
             sorted(available[name], key=lambda cls: (cls.__module__, cls.__qualname__))
             for name in record.component_names
@@ -70,21 +71,45 @@ def resolve_signature_records(
         for combination in product(*candidates):
             signature = tuple(sorted(set(combination), key=lambda cls: cls.__name__))
             try:
-                fingerprint = schema_fingerprint(Archetype.get_archetype_schema(signature))
+                schema = Archetype.get_archetype_schema(signature)
+                fingerprint = schema_fingerprint(schema)
+                table_id = Archetype.get_name(signature)
             except Exception:
                 continue
-            if fingerprint == record.fingerprint and signature not in matches:
+            if fingerprint != record.fingerprint:
+                continue
+            if table_id != record.table_id:
+                mismatched_table_ids.add(table_id)
+                continue
+            if signature not in matches:
                 matches.append(signature)
 
         if matches:
             # Candidate ordering makes the representative deterministic.
             # Every match is interchangeable by the complete fingerprint.
             resolved[record.table_id] = matches[0]
+        elif mismatched_table_ids:
+            rendered = ", ".join(sorted(mismatched_table_ids))
+            problems[record.table_id] = (
+                "schema-compatible imported class combination resolves to different "
+                f"table identity: {rendered}"
+            )
         else:
             problems[record.table_id] = (
                 "no imported class combination matches the stored schema "
                 "(the definitions may have drifted since the rows were written)"
             )
+
+    return resolved, problems
+
+
+def resolve_signature_records(
+    records: Iterable[SignatureRecord],
+    *,
+    operation: str,
+) -> dict[str, ArchetypeSignature]:
+    """Resolve every record exactly or fail the bounded lifecycle operation."""
+    resolved, problems = match_signature_records(records)
 
     if problems:
         detail = "; ".join(

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -323,10 +323,10 @@ class QueryService:
 
         A store's Python signature registry is only a cache. A fresh process
         therefore matches control-catalog records against imported Component
-        classes by both schema fingerprint and durable table identity, then
-        unions compatible local entries (including legacy/read-created
-        signatures). Unrelated historical records that can no longer be
-        resolved are skipped with an observable warning.
+        classes by both schema fingerprint and durable table identity. Durable
+        matches fill gaps without replacing exact process-local class objects.
+        Unrelated historical records that can no longer be resolved are
+        skipped with an observable warning.
         """
         effective_config, _store, querier = await self._querier_for(storage_config)
         signatures = {
@@ -345,7 +345,7 @@ class QueryService:
                 len(problems),
                 detail,
             )
-        signatures.update(discovered)
+        signatures = discovered | signatures
         return [signature for _table_id, signature in sorted(signatures.items())]
 
     async def get_command_history(

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -26,7 +26,7 @@ import logging
 from daft import DataFrame, col, lit
 from uuid_utils import UUID
 
-from archetype.app._signature_resolution import resolve_signature_records
+from archetype.app._signature_resolution import match_signature_records
 from archetype.app.models import Command, CommandType
 from archetype.app.storage_service import StorageService
 from archetype.core.aio import AsyncQueryManager
@@ -321,10 +321,12 @@ class QueryService:
     ) -> list[ArchetypeSignature]:
         """List process-local and durably cataloged archetype signatures.
 
-        A store's Python signature registry is only a cache.  A fresh process
-        therefore resolves the control catalog's schema-identified records
-        against imported Component classes, then unions any compatible local
-        entries (including legacy/read-created signatures).
+        A store's Python signature registry is only a cache. A fresh process
+        therefore matches control-catalog records against imported Component
+        classes by both schema fingerprint and durable table identity, then
+        unions compatible local entries (including legacy/read-created
+        signatures). Unrelated historical records that can no longer be
+        resolved are skipped with an observable warning.
         """
         effective_config, _store, querier = await self._querier_for(storage_config)
         signatures = {
@@ -333,7 +335,17 @@ class QueryService:
         }
         catalog = self._storage_service.get_control_catalog(effective_config)
         records = await catalog.list_signatures()
-        signatures.update(resolve_signature_records(records, operation="list signatures"))
+        discovered, problems = match_signature_records(records)
+        if problems:
+            detail = "; ".join(
+                f"{table_id}: {message}" for table_id, message in sorted(problems.items())
+            )
+            logger.warning(
+                "list_signatures skipped %d unresolved durable record(s): %s",
+                len(problems),
+                detail,
+            )
+        signatures.update(discovered)
         return [signature for _table_id, signature in sorted(signatures.items())]
 
     async def get_command_history(

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -26,6 +26,7 @@ import logging
 from daft import DataFrame, col, lit
 from uuid_utils import UUID
 
+from archetype.app._signature_resolution import resolve_signature_records
 from archetype.app.models import Command, CommandType
 from archetype.app.storage_service import StorageService
 from archetype.core.aio import AsyncQueryManager
@@ -318,9 +319,22 @@ class QueryService:
         self,
         storage_config: StorageConfig | None = None,
     ) -> list[ArchetypeSignature]:
-        """List all archetype signatures in a store."""
-        _config, _store, querier = await self._querier_for(storage_config)
-        return await querier.list_signatures()
+        """List process-local and durably cataloged archetype signatures.
+
+        A store's Python signature registry is only a cache.  A fresh process
+        therefore resolves the control catalog's schema-identified records
+        against imported Component classes, then unions any compatible local
+        entries (including legacy/read-created signatures).
+        """
+        effective_config, _store, querier = await self._querier_for(storage_config)
+        signatures = {
+            Archetype.get_name(signature): signature
+            for signature in await querier.list_signatures()
+        }
+        catalog = self._storage_service.get_control_catalog(effective_config)
+        records = await catalog.list_signatures()
+        signatures.update(resolve_signature_records(records, operation="list signatures"))
+        return [signature for _table_id, signature in sorted(signatures.items())]
 
     async def get_command_history(
         self,

--- a/src/archetype/app/query_service.py
+++ b/src/archetype/app/query_service.py
@@ -26,6 +26,7 @@ import logging
 from daft import DataFrame, col, lit
 from uuid_utils import UUID
 
+from archetype.app._catalog import SignatureRecord
 from archetype.app._signature_resolution import match_signature_records
 from archetype.app.models import Command, CommandType
 from archetype.app.storage_service import StorageService
@@ -153,6 +154,15 @@ class QueryService:
         result = await _read(world_id, run_id, ticks)
         return await self._union_lineage(result, lineage, ticks, _read)
 
+    async def _signature_records(self, storage_config: StorageConfig) -> list[SignatureRecord]:
+        """Return durable discovery records, degrading safely when unavailable."""
+        try:
+            catalog = self._storage_service.get_control_catalog(storage_config)
+            return await catalog.list_signatures()
+        except Exception:
+            logger.exception("control catalog unavailable for durable signature discovery")
+            return []
+
     async def _catalog_candidates(
         self, storage_config: StorageConfig, components: list[type[Component]]
     ):
@@ -163,12 +173,7 @@ class QueryService:
         every table ever committed against this storage identity.
         """
         requested = {c.__name__ for c in components}
-        try:
-            catalog = self._storage_service.get_control_catalog(storage_config)
-            records = await catalog.list_signatures()
-        except Exception:
-            logger.exception("control catalog unavailable for %s", storage_config.uri)
-            return []
+        records = await self._signature_records(storage_config)
         return [r for r in records if requested.issubset(set(r.component_names))]
 
     async def _visible_tokens(
@@ -333,8 +338,7 @@ class QueryService:
             Archetype.get_name(signature): signature
             for signature in await querier.list_signatures()
         }
-        catalog = self._storage_service.get_control_catalog(effective_config)
-        records = await catalog.list_signatures()
+        records = await self._signature_records(effective_config)
         discovered, problems = match_signature_records(records)
         if problems:
             detail = "; ".join(

--- a/src/archetype/app/world_service.py
+++ b/src/archetype/app/world_service.py
@@ -32,8 +32,9 @@ from typing import TYPE_CHECKING
 
 from uuid_utils import UUID, uuid7
 
-from archetype.app._catalog import SignatureRecord, WorldRecord, schema_fingerprint
+from archetype.app._catalog import SignatureRecord, WorldRecord
 from archetype.app._commit import CatalogCommitCoordinator
+from archetype.app._signature_resolution import resolve_signature_records
 from archetype.app.models import WorldInfo
 from archetype.app.storage_service import StorageService
 from archetype.core.aio import (
@@ -42,8 +43,6 @@ from archetype.core.aio import (
     AsyncUpdateManager,
     AsyncWorld,
 )
-from archetype.core.archetype import Archetype
-from archetype.core.component import Component
 from archetype.core.config import CacheConfig, StorageConfig, WorldConfig
 from archetype.core.hooks import HookRegistry
 from archetype.core.interfaces import iAsyncStore, iAsyncSystem
@@ -54,26 +53,6 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
-
-
-def _component_classes_by_name() -> dict[str, list[type[Component]]]:
-    """All importable Component subclasses, keyed by class name.
-
-    Distinct classes may share a name across modules (test doubles, forks of
-    an old component). Resume disambiguates by schema fingerprint — identity
-    is the schema, never the name alone.
-    """
-    classes: dict[str, list[type[Component]]] = {}
-    stack: list[type[Component]] = list(Component.__subclasses__())
-    seen: set[type[Component]] = set()
-    while stack:
-        cls = stack.pop()
-        if cls in seen:
-            continue
-        seen.add(cls)
-        stack.extend(cls.__subclasses__())
-        classes.setdefault(cls.__name__, []).append(cls)
-    return classes
 
 
 @dataclass(frozen=True)
@@ -759,50 +738,7 @@ class WorldService:
         the rows were written is refused rather than silently misread.
         Fails loudly, naming every table it cannot faithfully resolve.
         """
-        from itertools import product
-
-        available = _component_classes_by_name()
-        resolved: dict[str, tuple] = {}
-        problems: dict[str, str] = {}
-        for rec in directory.values():
-            if rec.table_id in resolved or rec.table_id in problems:
-                continue
-            missing = sorted(n for n in rec.component_names if not available.get(n))
-            if missing:
-                problems[rec.table_id] = (
-                    f"component class(es) {', '.join(missing)} are not imported"
-                )
-                continue
-            matches: list[tuple] = []
-            candidates = (
-                sorted(available[n], key=lambda t: (t.__module__, t.__qualname__))
-                for n in rec.component_names
-            )
-            for combo in product(*candidates):
-                sig = tuple(sorted(set(combo), key=lambda t: t.__name__))
-                try:
-                    fingerprint = schema_fingerprint(Archetype.get_archetype_schema(sig))
-                except Exception:
-                    continue
-                if fingerprint == rec.fingerprint and sig not in matches:
-                    matches.append(sig)
-            if matches:
-                # Multiple matches are interchangeable BY CONSTRUCTION: the
-                # fingerprint covers every column name and type, so any
-                # matching combination reads and writes this table
-                # faithfully. Candidate order makes the pick deterministic.
-                resolved[rec.table_id] = matches[0]
-            else:
-                problems[rec.table_id] = (
-                    "no imported class combination matches the stored schema "
-                    "(the definitions may have drifted since the rows were written)"
-                )
-        if problems:
-            detail = "; ".join(f"table {tid}: {msg}" for tid, msg in sorted(problems.items()))
-            raise RuntimeError(
-                f"cannot resume: {detail} (code is not rows — import the exact component "
-                "definitions before resuming)"
-            )
+        resolved = resolve_signature_records(directory.values(), operation="resume")
         entity2sig = {eid: resolved[rec.table_id] for eid, rec in directory.items()}
         return entity2sig, set(resolved)
 

--- a/tests/app/test_durable_discovery.py
+++ b/tests/app/test_durable_discovery.py
@@ -25,11 +25,14 @@ from archetype.app._catalog import (
     SignatureRecord,
     SqliteControlCatalog,
     WorldRecord,
+    arrow_schema_descriptor,
     catalog_path_for,
     schema_fingerprint,
     storage_fingerprint,
 )
+from archetype.app._signature_resolution import match_signature_records
 from archetype.app.container import ServiceContainer
+from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 
@@ -337,6 +340,50 @@ async def test_p0_cold_subset_query_across_process_boundary(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_cold_signature_listing_skips_unresolvable_history(tmp_path, caplog):
+    """One unrelated stale record cannot poison storage-wide discovery."""
+    storage = _storage(tmp_path)
+    writer = ServiceContainer()
+    try:
+        world = await writer.world_service.create_world(WorldConfig(name="current"), storage)
+        await writer.mutation_service.create_entity(world.world_id, [Score(points=1.0)])
+        await writer.simulation_service.step(world.world_id, RunConfig())
+
+        schema = Archetype.get_archetype_schema((Score,))
+        catalog = writer.storage_service.get_control_catalog(storage)
+        await catalog.register_signature(
+            SignatureRecord(
+                table_id="a_removed_history",
+                component_names=("RemovedQueryHistoryComponent",),
+                schema_json="{}",
+                fingerprint="removed",
+            )
+        )
+        await catalog.register_signature(
+            SignatureRecord(
+                table_id="a_schema_match_wrong_identity",
+                component_names=("Score",),
+                schema_json=json.dumps(arrow_schema_descriptor(schema)),
+                fingerprint=schema_fingerprint(schema),
+            )
+        )
+    finally:
+        await writer.shutdown()
+
+    reader = ServiceContainer()
+    try:
+        with caplog.at_level(logging.WARNING, logger="archetype.app.query_service"):
+            signatures = await reader.query_service.list_signatures(storage)
+
+        names = {tuple(component.__name__ for component in sig) for sig in signatures}
+        assert ("Score",) in names
+        assert "a_removed_history" in caplog.text
+        assert "a_schema_match_wrong_identity" in caplog.text
+    finally:
+        await reader.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_p0_stale_descriptor_fails_closed(tmp_path):
     """A catalog descriptor whose fingerprint disagrees with the physical
     table must refuse to read — never an empty frame, never a created table."""
@@ -440,6 +487,22 @@ async def test_signature_record_roundtrip(tmp_path):
             )
         )
     await catalog.close()
+
+
+def test_signature_resolution_requires_durable_table_identity():
+    """A normalized schema match cannot redirect a read to a new table id."""
+    schema = Archetype.get_archetype_schema((Score,))
+    record = SignatureRecord(
+        table_id="a_schema_match_wrong_identity",
+        component_names=("Score",),
+        schema_json=json.dumps(arrow_schema_descriptor(schema)),
+        fingerprint=schema_fingerprint(schema),
+    )
+
+    resolved, problems = match_signature_records([record])
+
+    assert resolved == {}
+    assert "different table identity" in problems[record.table_id]
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_durable_discovery.py
+++ b/tests/app/test_durable_discovery.py
@@ -9,6 +9,7 @@ committed there. P0 tests use true subprocess restarts — same-process
 container recycling would not prove cold discovery.
 """
 
+import gc
 import json
 import logging
 import multiprocessing
@@ -381,6 +382,40 @@ async def test_cold_signature_listing_skips_unresolvable_history(tmp_path, caplo
         assert "a_schema_match_wrong_identity" in caplog.text
     finally:
         await reader.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_warm_signature_listing_preserves_local_class_identity(tmp_path):
+    """Catalog ambiguity fills cold gaps but cannot replace an exact local class."""
+    storage = _storage(tmp_path)
+    container = ServiceContainer()
+    shadow_score_type: type[Component] | None = None
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="warm"), storage)
+        await container.mutation_service.create_entity(world.world_id, [Score(points=1.0)])
+        await container.simulation_service.step(world.world_id, RunConfig())
+
+        shadow_score_type = type(
+            "Score",
+            (Component,),
+            {
+                "__module__": "aaa_catalog_shadow",
+                "__annotations__": {"points": float},
+                "points": 0.0,
+            },
+        )
+        assert Archetype.get_name((shadow_score_type,)) == Archetype.get_name((Score,))
+
+        signatures = await container.query_service.list_signatures(storage)
+        score_table_id = Archetype.get_name((Score,))
+        by_table_id = {Archetype.get_name(signature): signature for signature in signatures}
+
+        assert by_table_id[score_table_id] == (Score,)
+        assert by_table_id[score_table_id] != (shadow_score_type,)
+    finally:
+        shadow_score_type = None
+        gc.collect()
+        await container.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_durable_discovery.py
+++ b/tests/app/test_durable_discovery.py
@@ -419,6 +419,29 @@ async def test_warm_signature_listing_preserves_local_class_identity(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_warm_signature_listing_survives_catalog_failure(tmp_path, monkeypatch, caplog):
+    """Best-effort discovery retains the complete pre-catalog local answer."""
+    storage = _storage(tmp_path)
+    container = ServiceContainer()
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="warm"), storage)
+        await container.mutation_service.create_entity(world.world_id, [Score(points=1.0)])
+        await container.simulation_service.step(world.world_id, RunConfig())
+
+        def _unavailable(_storage_config):
+            raise RuntimeError("injected catalog outage")
+
+        monkeypatch.setattr(container.storage_service, "get_control_catalog", _unavailable)
+        with caplog.at_level(logging.ERROR, logger="archetype.app.query_service"):
+            signatures = await container.query_service.list_signatures(storage)
+
+        assert (Score,) in signatures
+        assert "control catalog unavailable for durable signature discovery" in caplog.text
+    finally:
+        await container.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_p0_stale_descriptor_fails_closed(tmp_path):
     """A catalog descriptor whose fingerprint disagrees with the physical
     table must refuse to read — never an empty frame, never a created table."""

--- a/tests/app/test_durable_discovery.py
+++ b/tests/app/test_durable_discovery.py
@@ -320,6 +320,15 @@ async def test_p0_cold_subset_query_across_process_boundary(tmp_path):
         assert [str(i.world_id) for i in infos] == [world_id]
         info = await c.world_service.open_world_readonly(storage, world_id)
 
+        signatures = await c.query_service.list_signatures(storage)
+        signature_names = {
+            tuple(component.__name__ for component in signature) for signature in signatures
+        }
+        assert {("Score",), ("Flag", "Score")} <= signature_names, (
+            "cold signature discovery must use the durable catalog, not the "
+            "fresh store's empty process-local registry"
+        )
+
         df = await c.query_service.query_components([Score], world_id, str(info.run_id), storage)
         points = sorted(row["score__points"] for row in df.to_pylist())
         assert points == [2.5, 7.5], "subset query must union both archetypes, cold"


### PR DESCRIPTION
## What changed

- add the `query_correctness` regression eval from #142: write through the command gate, discard the live composition root, then grade cold component/archetype reads through a fresh gate
- make `QueryService.list_signatures()` compose its process-local cache with durable control-catalog records
- extract the existing schema-fingerprint resolver from `WorldService` so resume and query discovery share one identity rule
- require exact durable table identity, warn and skip unrelated stale catalog history, preserve authoritative process-local class identity, and degrade catalog outages to the local subset
- synchronize the eval manifest, service protocols/overview, durable-discovery guide, and normative QueryService contract

## Reproduction

Before this change, a fresh container could read rows from both persisted archetypes through `query_components()`, while `list_signatures()` silently omitted any signature that had not first been touched in that process. The new subprocess regression writes `(Score,)` and `(Flag, Score)` in another process and requires both to be discoverable cold.

Reviewer-driven regressions cover four catalog hazards: a schema-compatible record whose recomputed table ID differs from its durable identity, unrelated missing/drifted historical records that must not poison every discovery caller, an ambiguous same-named class that must not replace the exact class already registered by a warm store, and a catalog outage that must preserve the complete process-local answer.

## Validation

- `make ci`: 1,142 passed, 7 skipped; 85.88% coverage
- regression evals: 13/13 passed, including `query_correctness`
- idempotency evals: 23/23 passed
- `ty`: passed
- focused cold/warm discovery, outage, resolution, and resume tests: 15 passed
- markdownlint: 0 issues across edited guides
- MkDocs build: passed (one pre-existing Griffe annotation warning)
- `git diff --check`

Implements the `query_correctness` slice of #142; the umbrella remains open for its fork, quota, runtime, and adversarial suites.