### PR TITLE
feat(eval): grade quota boundaries

### DIFF
--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -117,6 +117,7 @@ renaming a task requires updating this table in the same change.
 | `regression` | `command_pipeline` | Submit → broker → step → history, with RBAC at the service boundary |
 | `regression` | `query_correctness` | Cold gated reads union component subsets, honor filters/projection, and discover durable signatures |
 | `regression` | `tick_quota_resets` | Per-tick command quotas reset at each tick rather than process-wide |
+| `regression` | `quota_boundaries` | Exact 499/500/501 limits, atomic bulk accounting, actor isolation, and UTC daily rollover |
 | `regression` | `episode_value_termination` | Value-based episode termination stops before the defensive cap |
 | `regression` | `poison_in_batch` | A malformed command does not block valid commands in the same drain |
 | `regression` | `missing_payload_keys` | Missing required keys do not corrupt world state |

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -999,6 +999,7 @@ all of the following:
 - stable cross-archetype execution without world bookkeeping corruption
 - stable reserved-entity spawn semantics through the broker
 - explicit multi-world isolation and fork divergence (`fork_divergence` capability eval)
+- exact actor-local quota boundaries and UTC rollover (`quota_boundaries` regression eval)
 - explicit runtime-vs-world lifetime boundaries
 - clear distinction between idempotent and non-idempotent operations
 

--- a/docs/guide/token-quotas.md
+++ b/docs/guide/token-quotas.md
@@ -3,36 +3,48 @@ title: Token Costs and Quotas
 description: Gate-level quota system, token costs per command, and rate limits
 ---
 
-Every gated command has a token cost. `guardrail_allow()` enforces role permissions, per-tick command limits, and daily token budgets before the operation is accepted.
+Every gated command has a token-cost estimate. `guardrail_allow()` enforces role
+permissions, per-tick command limits, and daily token budgets before the
+operation is accepted.
 
 The command gate is `iCommandService`; the broker is only used for tick-deferred queueing.
 
 ## Token Costs
 
-Each command type has a fixed token cost:
+Most command types have a fixed cost. `autoresearch` scales with its requested
+iteration count because its internal rollouts are not gated separately:
 
 | Command Type | Token Cost | Description |
 |---|---:|---|
+| `get_world_info` | 2 | Read world identity/tick info |
+| `list_signatures` | 2 | List known archetype signatures |
+| `list_worlds` | 2 | List live world identities |
+| `list_processors` | 2 | List world processors |
+| `list_hooks` | 2 | List world hooks |
+| `list_resources` | 2 | List world resources |
 | `message` | 3 | Agent-to-agent messaging |
 | `despawn` | 5 | Remove an entity |
 | `remove_component` | 5 | Remove a component type from an entity |
 | `remove_processor` | 5 | Remove a processor |
 | `query_world` | 5 | Read world state |
-| `get_world_info` | 5 | Read world identity/tick info |
 | `get_audit_history` | 5 | Read audit history |
+| `remove_hook` | 5 | Remove a hook |
 | `update` | 8 | Overlay existing component values |
 | `add_component` | 8 | Extend an entity archetype |
+| `ingest_fact` | 10 | Append a durable external fact |
+| `evaluate` | 10 | Claim and grade one evaluation |
 | `spawn` | 10 | Create a new entity |
-| `custom` | 10 | User-defined command |
+| `custom` | 10 | Submit an application-defined command |
 | `destroy_world` | 10 | Destroy live world state; persisted rows remain |
+| `step` | 10 | Execute one tick |
+| `add_hook` | 10 | Register a hook |
+| `add_resource` | 10 | Attach a resource |
 | `add_processor` | 15 | Register a processor |
-| `add_hook` | 15 | Register a hook |
-| `add_resource` | 15 | Attach a resource |
-| `step` | 25 | Execute one tick |
 | `run` | 50 | Execute N steps |
 | `create_world` | 50 | Create a world identity |
 | `fork_world` | 100 | Fork world state |
 | `run_rollout` | 200 | Run N forked episodes |
+| `autoresearch` | 200 per iteration | Run the optimization loop over rollouts |
 | `run_episode` | 500 | Run until termination or cap on one world |
 
 Unknown command types default to a cost of 10.
@@ -44,9 +56,13 @@ Two quotas are enforced per actor:
 | Quota | Limit | Scope |
 |---|---:|---|
 | Per-tick | 500 commands | Reset at tick boundary |
-| Daily | 200,000 tokens | Reset at day boundary |
+| Daily | 200,000 tokens | Reset at midnight UTC |
 
 Both direct gated calls and tick-deferred `submit` calls consume quota.
+`submit_batch` counts and charges every command, and rejects the whole batch
+without a partial debit when its projected total would cross either limit.
+Counters are process-local and keyed by actor identity; see the durability
+posture in the [Specification](specification.md#durability-posture-v03-issue-276).
 
 ## Enforcement Flow
 

--- a/evals/suites/regression.py
+++ b/evals/suites/regression.py
@@ -15,11 +15,13 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+from datetime import UTC, datetime
 
 from daft import DataFrame, col
-from uuid_utils import uuid7
+from uuid_utils import UUID, uuid7
 
 import archetype.app.auth.guard as guard
+from archetype.app.auth.errors import GuardrailError
 from archetype.app.auth.guard import (
     estimate_token_cost,
     guardrail_allow,
@@ -27,6 +29,7 @@ from archetype.app.auth.guard import (
     reset_tick_counters,
 )
 from archetype.app.auth.models import ActorCtx
+from archetype.app.command_service import CommandService
 from archetype.app.container import ServiceContainer
 from archetype.app.models import Command, CommandType, EpisodeConfig
 from archetype.core.aio.async_processor import AsyncProcessor
@@ -510,6 +513,161 @@ async def _task_tick_quota_resets() -> list[GraderResult]:
 
 
 # ---------------------------------------------------------------------------
+# Task: exact quota boundaries, atomic bulk accounting, and UTC rollover
+# ---------------------------------------------------------------------------
+
+
+def task_quota_boundaries() -> list[GraderResult]:
+    """Quota accounting is exact, actor-local, atomic, and UTC-day scoped."""
+    return asyncio.run(_task_quota_boundaries())
+
+
+def _custom_commands(count: int) -> list[Command]:
+    return [Command(type=CommandType.CUSTOM) for _ in range(count)]
+
+
+async def _submit_allowed(
+    service: CommandService,
+    world_id: str | UUID,
+    ctx: ActorCtx,
+    count: int,
+) -> bool:
+    try:
+        if count == 1:
+            await service.submit(ctx, world_id, _custom_commands(1)[0])
+        else:
+            await service.submit_batch(ctx, world_id, _custom_commands(count))
+    except GuardrailError:
+        return False
+    return True
+
+
+def _guard_allowed(ctx: ActorCtx, now: datetime) -> bool:
+    try:
+        guardrail_allow(Command(type=CommandType.CUSTOM), ctx, now=now)
+    except GuardrailError:
+        return False
+    return True
+
+
+async def _task_quota_boundaries() -> list[GraderResult]:
+    reset_tick_counters()
+    reset_daily_tokens()
+    saved_daily_limit = guard.MAX_TOKENS_PER_DAY
+
+    with tempfile.TemporaryDirectory() as tmp:
+        container = ServiceContainer()
+        try:
+            storage = StorageConfig(uri=f"{tmp}/store", namespace="eval_quota_boundaries")
+            world = await container.world_service.create_world(
+                WorldConfig(name="quota-boundaries"),
+                storage,
+            )
+            actors = (
+                ActorCtx(id=uuid7(), roles={"admin"}),
+                ActorCtx(id=uuid7(), roles={"admin"}),
+            )
+
+            accepted_at_499 = await asyncio.gather(
+                *(
+                    _submit_allowed(container.command_service, world.world_id, actor, 499)
+                    for actor in actors
+                )
+            )
+            pending_at_499 = await container.broker.get_pending_count(world.world_id)
+
+            bulk_overflow_allowed = await asyncio.gather(
+                *(
+                    _submit_allowed(container.command_service, world.world_id, actor, 2)
+                    for actor in actors
+                )
+            )
+            pending_after_bulk_rejection = await container.broker.get_pending_count(world.world_id)
+
+            accepted_at_500 = await asyncio.gather(
+                *(
+                    _submit_allowed(container.command_service, world.world_id, actor, 1)
+                    for actor in actors
+                )
+            )
+            pending_at_500 = await container.broker.get_pending_count(world.world_id)
+
+            command_501_allowed = await asyncio.gather(
+                *(
+                    _submit_allowed(container.command_service, world.world_id, actor, 1)
+                    for actor in actors
+                )
+            )
+            pending_after_501 = await container.broker.get_pending_count(world.world_id)
+
+            reset_tick_counters()
+            reset_daily_tokens()
+            guard.MAX_TOKENS_PER_DAY = 20
+            before_midnight = datetime(2030, 1, 1, 23, 59, 59, tzinfo=UTC)
+            at_midnight = datetime(2030, 1, 2, tzinfo=UTC)
+            guard._last_reset_date = before_midnight.date()
+            daily_actor = ActorCtx(id=uuid7(), roles={"admin"})
+            daily_peer = ActorCtx(id=uuid7(), roles={"admin"})
+
+            daily_exact_limit = all(_guard_allowed(daily_actor, before_midnight) for _ in range(2))
+            daily_over_limit_allowed = _guard_allowed(daily_actor, before_midnight)
+            peer_allowed_same_day = _guard_allowed(daily_peer, before_midnight)
+
+            actor_allowed_at_midnight = _guard_allowed(daily_actor, at_midnight)
+            peer_exact_limit_after_rollover = all(
+                _guard_allowed(daily_peer, at_midnight) for _ in range(2)
+            )
+            peer_over_limit_after_rollover = _guard_allowed(daily_peer, at_midnight)
+
+            return [
+                state_check(
+                    {
+                        "both_actors_accepted": all(accepted_at_499),
+                        "499_each_queued": pending_at_499 == 998,
+                    },
+                    name="concurrent_actor_499_boundary",
+                ),
+                state_check(
+                    {
+                        "both_bulk_overflows_rejected": not any(bulk_overflow_allowed),
+                        "queue_unchanged": pending_after_bulk_rejection == pending_at_499,
+                        "quota_unchanged": all(accepted_at_500),
+                    },
+                    name="bulk_overflow_atomic",
+                ),
+                state_check(
+                    {
+                        "500_each_queued": pending_at_500 == 1000,
+                        "both_501_commands_rejected": not any(command_501_allowed),
+                        "rejection_did_not_enqueue": pending_after_501 == pending_at_500,
+                    },
+                    name="exact_500_501_boundary",
+                ),
+                state_check(
+                    {
+                        "exact_daily_budget_allowed": daily_exact_limit,
+                        "next_token_cost_rejected": not daily_over_limit_allowed,
+                        "peer_budget_is_independent": peer_allowed_same_day,
+                    },
+                    name="daily_budget_actor_isolation",
+                ),
+                state_check(
+                    {
+                        "blocked_actor_recovers_at_midnight": actor_allowed_at_midnight,
+                        "peer_receives_full_new_budget": peer_exact_limit_after_rollover,
+                        "new_day_budget_still_enforced": not peer_over_limit_after_rollover,
+                    },
+                    name="utc_midnight_rollover",
+                ),
+            ]
+        finally:
+            guard.MAX_TOKENS_PER_DAY = saved_daily_limit
+            await container.shutdown()
+            reset_tick_counters()
+            reset_daily_tokens()
+
+
+# ---------------------------------------------------------------------------
 # Task: value-based "all done" episode termination (bug B2)
 # ---------------------------------------------------------------------------
 
@@ -604,6 +762,12 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_tick_quota_resets,
         desc="Per-tick RBAC command quota resets each tick, not process-wide (B1)",
+    )
+    harness.add(
+        "quota_boundaries",
+        suite=SUITE,
+        fn=task_quota_boundaries,
+        desc="Exact per-tick and daily quota edges, atomic bulk debit, and actor isolation",
     )
     harness.add(
         "episode_value_termination",


### PR DESCRIPTION
## What changed

- add the `quota_boundaries` regression task from #142 at the `CommandService` gate
- run two actors against the shared process-local counters and require independent acceptance at 499 and 500 plus rejection at 501
- attempt a two-command bulk at 499 and require atomic rejection with no queue growth or quota debit
- exercise the exact daily token limit through the deterministic guard clock, then require a global reset at midnight UTC while actor budgets remain independent
- synchronize the eval manifest and specification acceptance criterion
- correct the token-cost guide to match the implemented command estimates and process-local durability posture

This is an executable-evidence and guide-alignment slice only: no auth, broker, service, runtime, API, CLI, or core production code changes.

## Validation

- `make ci`: 1,143 passed, 6 skipped; 86.40% coverage; regression 14/14; idempotency 23/23
- regression suite with `--trials 3`: pass@3 and pass^3 are 100% for all 14 tasks
- documentation manifest contracts: 8 passed
- `ruff format --check` and `ruff check`: passed
- `ty`: passed
- markdownlint: 0 issues
- MkDocs build: passed with the pre-existing Griffe annotation warning
- new task cyclomatic complexity: B(7); suite average: A
- `git diff --check`

Implements the `quota_boundaries` slice of #142; the umbrella remains open for time-travel/run semantics, runtime contracts, and processor/LLM adversarial coverage.