### PR TITLE
feat(eval): grade time-travel continuity

### DIFF
--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -173,6 +173,7 @@ renaming a task requires updating this table in the same change.
 | `capability` | `storage_roundtrip` | Mixed component fields survive persistence and retrieval |
 | `capability` | `simulation_correctness` | Multi-step processing preserves entities and updates expected fields |
 | `capability` | `fork_divergence` | Fork-of-fork lineage, first-step continuity, shared resources, and isolated mutations compose through the runtime |
+| `capability` | `time_travel_and_run_id` | Live and cold historical reads preserve one run identity across durable resume |
 
 <!-- eval-task-manifest:end -->
 

--- a/docs/guide/history-and-forks.md
+++ b/docs/guide/history-and-forks.md
@@ -29,6 +29,41 @@ Rows include `world_id`, `run_id`, `entity_id`, `tick`, and `is_active`, plus
 the prefixed fields for every requested component. A component named
 `Position` with field `x` becomes `position__x`.
 
+## Read after restart
+
+A fresh runtime can attach a non-owning, read-only handle to the same durable
+world. Pass the storage identity used by the writer:
+
+```python
+from archetype import ArchetypeRuntime, StorageConfig
+
+storage = StorageConfig(uri="./data", namespace="experiment")
+
+async with ArchetypeRuntime() as runtime:
+    cold = runtime.attach(world_id, storage=storage)
+    cold_history = await cold.query(Position)
+```
+
+`RuntimeWorld.query()` always uses the durable query path, whether the world is
+live in the current process or only recorded in storage. It resolves the
+world's recorded active `run_id`; there is no live-versus-durable preference
+flag on this API.
+
+A cold `info().tick` is the catalog's last published tick head, not a mutable
+next-step cursor. To continue writing, resume explicitly; the runtime rebuilds
+the next tick from committed history. Processors, resources, and hooks are
+code, not durable state, so reinstall them before stepping:
+
+```python
+async with ArchetypeRuntime() as runtime:
+    resumed = await runtime.resume(world_id, storage=storage)
+    await resumed.add_processor(MoveProcessor())
+    await resumed.run(steps=10)
+```
+
+Resume preserves the world's active `run_id`, so earlier rows, new rows, and
+`RunResult.run_id` address one continuous timeline.
+
 ## Branch a run
 
 `fork()` creates another world from the source's current state. The branch

--- a/docs/guide/run-config.md
+++ b/docs/guide/run-config.md
@@ -4,10 +4,11 @@ Archetype uses Pydantic models for all configuration. There are four config type
 
 ## RunConfig
 
-`RunConfig` describes one bounded sequence of ticks. Its generated `run_id`
-seeds a world's active run identity on first execution; after that identity is
-pinned, later steps and runs keep the world's existing `run_id` so state stays
-continuous.
+`RunConfig` describes one bounded sequence of ticks. A normal world already
+owns an active `run_id` when it is constructed; execution keeps that identity
+across ticks and repeated calls so its append-only history stays continuous.
+The config's generated `run_id` is a call-level candidate retained for
+lower-level compatibility, not a request to rename an active world.
 
 ```python
 from archetype.core.config import RunConfig
@@ -18,13 +19,14 @@ await world.run(config=config)
 
 ### Contract
 
-- A `RunConfig` carries one candidate `run_id` shared by every tick in that
-  bounded call. It initializes a new world's active run identity but does not
-  replace an identity already pinned to that world.
+- A new world mints its active `run_id`; mutable resume restores it, and a fork
+  mints a fresh identity for its new lineage.
+- A `RunConfig` carries one candidate `run_id`, but execution does not replace
+  an active world's identity with it. `RunResult.run_id` reports the identity
+  actually stamped on durable rows.
 - `SimulationService.step()` and the lower-level `AsyncWorld.step()` require an
-  explicit `RunConfig`; callers driving multiple individual steps reuse one
-  config. `RuntimeWorld.step()` creates the ordinary one-step config when the
-  public caller omits it.
+  explicit `RunConfig`. `RuntimeWorld.step()` creates the ordinary one-step
+  config when the public caller omits it.
 - `SimulationService.run()` and the world implementations thread the caller's
   `RunConfig` into every internal `step()` call.
 - `EpisodeConfig` wraps `RunConfig` with termination semantics.
@@ -34,7 +36,7 @@ await world.run(config=config)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `run_id` | `str \| UUID` | auto (uuid7) | Candidate identifier used when the world has no active run |
+| `run_id` | `str \| UUID` | auto (uuid7) | Call-level candidate; the world's active identity remains authoritative |
 | `num_steps` | `int` | `1` | Number of ticks to execute |
 | `debug` | `bool` | `False` | Emit per-tick diagnostic panels |
 | `show_rows` | `int` | `8` | Maximum rows in each debug snapshot; `0` disables snapshots |

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -312,9 +312,14 @@ One tick MUST follow this order:
 
 ### Run contract
 
-- A `RunConfig` describes a sequence of steps that share one `run_id`.
-- `world.run(run_config)` MUST preserve that same `run_id` across every tick in
-  the run.
+- A world owns one active `run_id`. A new world mints it at construction,
+  mutable resume restores it, and a fork mints a fresh identity for its new
+  lineage.
+- `RunConfig.run_id` is a call-level candidate retained for lower-level
+  compatibility. Execution MUST NOT replace an active world's `run_id` with
+  it.
+- `world.run(run_config)` MUST stamp the world's active `run_id` across every
+  tick in the call and across repeated calls on that world.
 - Query defaults that rely on the current run SHOULD use the world's active
   `run_id`.
 
@@ -494,10 +499,10 @@ CURRENT GAPS:
 - `step()` is the authoritative world execution boundary.
 - `step()` MUST apply due commands before world execution.
 - `step()` MUST receive an explicit `RunConfig` from the caller; the service
-  MUST NOT mint a fresh `RunConfig` per call. Callers drive a multi-tick run
-  by reusing the same `RunConfig` across every step so the `run_id` is stable.
-- `run()` MUST preserve one logical `run_id` across all steps in the run by
-  threading the caller's `RunConfig` into every `step()` call.
+  MUST NOT mint a fresh `RunConfig` per call. The world's active `run_id`, not
+  reuse of a particular config object, provides continuity across calls.
+- `run()` MUST thread the caller's `RunConfig` into every `step()` call while
+  preserving and reporting the world's active `run_id`.
 - Episodes and rollouts follow [Execution Hierarchy](execution-hierarchy.md).
 
 ### QueryService
@@ -1000,6 +1005,8 @@ all of the following:
 - stable reserved-entity spawn semantics through the broker
 - explicit multi-world isolation and fork divergence (`fork_divergence` capability eval)
 - exact actor-local quota boundaries and UTC rollover (`quota_boundaries` regression eval)
+- live/cold historical-read parity and resumed run continuity
+  (`time_travel_and_run_id` capability eval)
 - explicit runtime-vs-world lifetime boundaries
 - clear distinction between idempotent and non-idempotent operations
 

--- a/docs/guide/worlds.md
+++ b/docs/guide/worlds.md
@@ -75,7 +75,7 @@ world = AsyncWorld(
 | `name` | `str` | Human-readable name |
 | `tick` | `int` | Current simulation tick (starts at 0) |
 | `resources` | `Resources` | Type-safe dependency injection container |
-| `run_id` | `str` | Current run identifier (set by `run()`) |
+| `run_id` | `str` | Active durable timeline identifier, retained across repeated runs |
 
 ## Entity Management
 
@@ -139,7 +139,10 @@ from archetype.core.config import RunConfig
 await world.run(RunConfig(num_steps=10))
 ```
 
-This calls `step()` in a loop. Each run gets a unique `run_id` for storage isolation.
+This calls `step()` in a loop. The world keeps one active `run_id` across
+repeated steps and `run()` calls so every row belongs to one continuous
+timeline. A fork, by contrast, mints its own `run_id` and carries explicit
+lineage back to its source.
 
 ## The _live Cache
 
@@ -147,9 +150,13 @@ This calls `step()` in a loop. Each run gets a unique `run_id` for storage isola
 
 ### Why It Exists
 
-The store is the durability layer, but reading from it between consecutive ticks is fragile. Each `SimulationService.step()` emits a fresh `run_id`, so store reads filtered by the current `run_id` miss rows written by earlier ticks. World forks exhibit the same issue: the cloned snapshot is persisted under a placeholder run_id and the next step queries under a different one.
+The store is an append-only historical ledger, while the next engine tick
+needs exactly the latest active frame. Reconstructing that frame from durable
+history on every step would add query work to the hot execution path.
 
-`_live` fixes this (archetype#72). After all archetypes finish processing, `step()` updates `_live` with the output DataFrames filtered to active rows:
+`_live` retains the already-computed frame. After all archetypes finish
+processing, `step()` updates it with the output DataFrames filtered to active
+rows:
 
 ```python
 self._live = {
@@ -166,7 +173,10 @@ else:
     df = await self.query_archetype(sig, ...)
 ```
 
-The store read is only used for tick 0 (when there is no prior output) or for archetypes not yet in `_live`.
+The store read is only used for tick 0 (when there is no prior output) or for
+archetypes not yet in `_live`. This cache is an engine implementation detail,
+not a user-facing read preference: `RuntimeWorld.query()` goes through the
+durable query path for both live and cold worlds.
 
 ## Mutation Internals
 

--- a/evals/suites/capability.py
+++ b/evals/suites/capability.py
@@ -65,6 +65,10 @@ class ForkValue(Component):
     amount: int = 0
 
 
+class TimelineValue(Component):
+    amount: int = 0
+
+
 @dataclass
 class ForkStepSize:
     delta: int = 1
@@ -92,6 +96,16 @@ class AdvanceForkValue(AsyncProcessor):
         step_size = resources.get(ForkStepSize) if resources else None
         delta = step_size.delta if step_size else 0
         return df.with_column("forkvalue__amount", col("forkvalue__amount") + delta)
+
+
+class AdvanceTimelineValue(AsyncProcessor):
+    """Advance a durable value once per tick after its initial condition."""
+
+    components = (TimelineValue,)
+    priority = 1
+
+    async def process(self, df, **kwargs):
+        return df.with_column("timelinevalue__amount", col("timelinevalue__amount") + 1)
 
 
 # ---------------------------------------------------------------------------
@@ -402,6 +416,107 @@ async def _task_fork_divergence() -> list[GraderResult]:
 
 
 # ---------------------------------------------------------------------------
+# Task: Time-travel reads and run identity across fresh runtimes
+# ---------------------------------------------------------------------------
+
+
+def task_time_travel_and_run_id() -> list[GraderResult]:
+    """Read one durable timeline live, cold, and after mutable resume."""
+    return asyncio.run(_task_time_travel_and_run_id())
+
+
+def _timeline_history(rows: list[dict]) -> list[tuple[str, str, int, int, int]]:
+    """Normalize durable rows into an order-independent contract surface."""
+    return sorted(
+        (
+            str(row["world_id"]),
+            str(row["run_id"]),
+            int(row["entity_id"]),
+            int(row["tick"]),
+            int(row["timelinevalue__amount"]),
+        )
+        for row in rows
+    )
+
+
+async def _task_time_travel_and_run_id() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        storage_cfg = StorageConfig(uri=f"{tmp}/store", namespace="eval_time_travel")
+
+        async with ArchetypeRuntime() as writer:
+            world = writer.world(
+                "timeline",
+                storage=storage_cfg,
+                processors=[AdvanceTimelineValue()],
+            )
+            entity_id = await world.spawn(TimelineValue(amount=0))
+            first_result = await world.run(steps=4)
+            live_info = await world.info()
+            live_rows = (await world.query(TimelineValue, entity_ids=[entity_id])).to_pylist()
+
+        world_id = str(live_info.world_id)
+        run_id = str(live_info.run_id)
+        expected_initial = [
+            (world_id, run_id, entity_id, tick, amount) for tick, amount in enumerate(range(4))
+        ]
+
+        async with ArchetypeRuntime() as reader:
+            cold = reader.attach(world_id, storage=storage_cfg)
+            cold_info = await cold.info()
+            cold_rows = (await cold.query(TimelineValue, entity_ids=[entity_id])).to_pylist()
+
+        async with ArchetypeRuntime() as resumer:
+            resumed = await resumer.resume(world_id, storage=storage_cfg)
+            resumed_before = await resumed.info()
+            await resumed.add_processor(AdvanceTimelineValue())
+            second_result = await resumed.run(steps=2)
+            resumed_after = await resumed.info()
+            resumed_rows = (await resumed.query(TimelineValue, entity_ids=[entity_id])).to_pylist()
+
+        live_history = _timeline_history(live_rows)
+        cold_history = _timeline_history(cold_rows)
+        resumed_history = _timeline_history(resumed_rows)
+        expected_resumed = [
+            (world_id, run_id, entity_id, tick, amount) for tick, amount in enumerate(range(6))
+        ]
+
+        return [
+            exact_match(live_history, expected_initial, name="live_historical_read"),
+            exact_match(cold_history, live_history, name="cold_read_parity"),
+            exact_match(resumed_history, expected_resumed, name="resumed_history_continuity"),
+            state_check(
+                {
+                    "first_result_world": str(first_result.world_id) == world_id,
+                    "first_result_run": str(first_result.run_id) == run_id,
+                    "first_result_ticks": first_result.ticks_completed == 4,
+                    "first_result_final_tick": first_result.final_tick == 4,
+                    "run_id_is_present": live_info.run_id is not None
+                    and run_id not in {"", "None"},
+                    "live_info_run": str(live_info.run_id) == run_id,
+                    "live_info_next_tick": live_info.tick == 4,
+                    "cold_info_world": str(cold_info.world_id) == world_id,
+                    "cold_info_run": str(cold_info.run_id) == run_id,
+                },
+                name="durable_read_identity",
+            ),
+            state_check(
+                {
+                    "resume_restores_next_tick": resumed_before.tick == 4,
+                    "resume_preserves_run": str(resumed_before.run_id) == run_id,
+                    "second_result_world": str(second_result.world_id) == world_id,
+                    "second_result_run": str(second_result.run_id) == run_id,
+                    "second_result_ticks": second_result.ticks_completed == 2,
+                    "second_result_final_tick": second_result.final_tick == 6,
+                    "resumed_info_next_tick": resumed_after.tick == 6,
+                    "resumed_info_run": str(resumed_after.run_id) == run_id,
+                    "one_row_per_tick": len(resumed_rows) == 6,
+                },
+                name="resume_run_continuity",
+            ),
+        ]
+
+
+# ---------------------------------------------------------------------------
 # Register all capability tasks
 # ---------------------------------------------------------------------------
 
@@ -425,4 +540,10 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_fork_divergence,
         desc="Fork-of-fork lineage continuity, shared resources, and isolated branch mutations",
+    )
+    harness.add(
+        "time_travel_and_run_id",
+        suite=SUITE,
+        fn=task_time_travel_and_run_id,
+        desc="Live and cold historical reads preserve run identity across durable resume",
     )


### PR DESCRIPTION
## Summary

- add a `time_travel_and_run_id` capability task at the public `ArchetypeRuntime` boundary
- grade exact historical rows through a live writer, a fresh cold attachment, and a fresh mutable resume
- require `WorldInfo`, both `RunResult`s, and every durable row to preserve one active run identity while resume restores the next tick
- replace stale guide claims that each step/run mints a new `run_id`; document durable runtime queries, cold attachment, explicit resume, and the `_live` cache's actual role

## Contract exercised

The scenario writes ticks 0–3, closes the writer runtime, reads the same rows through a new read-only attachment, resumes through a third runtime, reinstalls processor code, and appends ticks 4–5. It grades exact values and identities at each boundary.

This intentionally supersedes the issue's obsolete `prefer_live_reads=True/False` wording: `RuntimeWorld.query()` is the durable historical read path for both live and cold handles. The engine's `_live` frame is not a public read preference.

Refs #142.

## Validation

- `make ci` — 1,142 passed, 7 skipped; 86.05% coverage; regression 14/14; idempotency 23/23
- `python -m evals.run --suite capability --trials 3` — 4/4, pass@3 and pass^3 both 100%
- documentation contracts — 8 passed
- `uvx ty@0.0.48 check --python .venv`
- Markdown lint on all touched guides
- `make docs`
- Radon: new async task rank A (3); suite average A
