### PR TITLE
fix(runtime): drain admitted work on shutdown

### DIFF
--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -156,7 +156,7 @@ that needs to be written.
 Good examples:
 
 - "Make `SimulationService.run()` preserve one logical `run_id` across the full run and add regression coverage."
-- "Document the world-local shutdown contract for the sugar runtime and add smoke tests."
+- "Document `RuntimeWorld`'s world-local shutdown contract and add smoke tests."
 - "Fix `QueryService` so it either implements real reads or is clearly documented as provisional."
 
 Do not force a contract card onto a spelling fix. Use it when implementation

--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -118,6 +118,7 @@ renaming a task requires updating this table in the same change.
 | `regression` | `query_correctness` | Cold gated reads union component subsets, honor filters/projection, and discover durable signatures |
 | `regression` | `tick_quota_resets` | Per-tick command quotas reset at each tick rather than process-wide |
 | `regression` | `quota_boundaries` | Exact 499/500/501 limits, atomic bulk accounting, actor isolation, and UTC daily rollover |
+| `regression` | `runtime_contracts` | Lazy activation, wait-then-close shutdown, handle invalidation, and sync/async surface parity |
 | `regression` | `episode_value_termination` | Value-based episode termination stops before the defensive cap |
 | `regression` | `poison_in_batch` | A malformed command does not block valid commands in the same drain |
 | `regression` | `missing_payload_keys` | Missing required keys do not corrupt world state |

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -60,13 +60,21 @@ async with ArchetypeRuntime() as runtime: ...
 
 `__aexit__` MUST:
 
-1. Shut down all live world handles (LIFO order).
-2. Call `container.shutdown()`.
-3. Be idempotent. Errors during shutdown are aggregated and re-raised after best-effort completion.
+1. Stop admitting new runtime and handle operations.
+2. Await the operation lock for every live shared world state. A lock-protected
+   call already in progress — including `run()`, `step()`, or `query()` —
+   finishes before that state and all of its aliases close.
+3. Call `container.shutdown()` only after admitted world work has drained.
+4. Be idempotent. Errors during shutdown are aggregated and re-raised after
+   best-effort completion.
 
 ### R6 — Sync parity is part of the contract
 
-`SyncArchetypeRuntime` exposes the same surface as the async runtime, implemented via `asyncio.Runner`. Every method on `RuntimeWorld` has a matching method on `SyncRuntimeWorld`.
+`SyncArchetypeRuntime` exposes the same world-operation surface as the async
+runtime, implemented via `asyncio.Runner`. Every public method on
+`RuntimeWorld` has a matching method on `SyncRuntimeWorld`. Runtime lifecycle
+syntax remains idiomatic to each mode: `async with` / `await shutdown()` for
+async, `with` for sync.
 
 The sync facade owns its own `asyncio.Runner` and does NOT share with any outer event loop.
 

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -636,8 +636,11 @@ Required behavior:
 
 - `fork()` may not race with first activation
 - `shutdown()` may not race with first activation
-- `shutdown()` may not invalidate in-flight `run()`, `step()`, or `query()`
-  calls without a defined error contract
+- Runtime shutdown MUST stop admitting new calls, wait for any call already
+  holding a world's operation lock, and close shared services only after that
+  admitted work completes.
+- Calls queued behind an in-flight operation MAY fail with the runtime's closed
+  error once shutdown has started; they have not yet been admitted.
 
 #### C5. Honest command return values
 
@@ -1008,6 +1011,8 @@ all of the following:
 - live/cold historical-read parity and resumed run continuity
   (`time_travel_and_run_id` capability eval)
 - explicit runtime-vs-world lifetime boundaries
+- lazy single-flight activation, wait-then-close runtime shutdown, handle
+  invalidation, and sync/async handle parity (`runtime_contracts` regression eval)
 - clear distinction between idempotent and non-idempotent operations
 
 ## Runtime Boundary
@@ -1049,7 +1054,7 @@ These contracts should not live only in docs. They need executable tests.
 High-value contract tests include:
 
 - concurrent first-use activation
-- shutdown vs init and fork vs init races
+- shutdown vs admitted work, shutdown vs init, and fork vs init races
 - multi-world lifetime isolation
 - spawn materialization timing
 - async/sync smoke paths

--- a/evals/suites/regression.py
+++ b/evals/suites/regression.py
@@ -15,12 +15,14 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 
 from daft import DataFrame, col
 from uuid_utils import UUID, uuid7
 
 import archetype.app.auth.guard as guard
+from archetype import ArchetypeRuntime, RuntimeWorld, SyncRuntimeWorld
 from archetype.app.auth.errors import GuardrailError
 from archetype.app.auth.guard import (
     estimate_token_cost,
@@ -72,6 +74,21 @@ class CountToGoal(AsyncProcessor):
         return df.with_column("countdown__step", nxt).with_column(
             "countdown__done", (nxt >= col("countdown__goal")) | col("countdown__done")
         )
+
+
+class BlockingHealthIncrement(AsyncProcessor):
+    """Hold one admitted step open so runtime shutdown ordering is observable."""
+
+    components = (Health,)
+
+    def __init__(self, entered: asyncio.Event, release: asyncio.Event) -> None:
+        self.entered = entered
+        self.release = release
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        self.entered.set()
+        await self.release.wait()
+        return df.with_column("health__hp", col("health__hp") + 1)
 
 
 # ---------------------------------------------------------------------------
@@ -668,6 +685,107 @@ async def _task_quota_boundaries() -> list[GraderResult]:
 
 
 # ---------------------------------------------------------------------------
+# Task: runtime activation, shutdown ordering, invalidation, and sync parity
+# ---------------------------------------------------------------------------
+
+
+def task_runtime_contracts() -> list[GraderResult]:
+    """Compose the public runtime's activation and lifecycle boundaries."""
+    reset_tick_counters()
+    reset_daily_tokens()
+    try:
+        activation, shutdown = asyncio.run(_task_runtime_contracts())
+        return [
+            state_check(activation, name="lazy_single_flight_activation"),
+            state_check(shutdown, name="wait_then_close_shutdown"),
+            exact_match(
+                _public_methods(SyncRuntimeWorld),
+                _public_methods(RuntimeWorld),
+                name="sync_async_world_surface",
+            ),
+        ]
+    finally:
+        reset_tick_counters()
+        reset_daily_tokens()
+
+
+def _public_methods(cls: type[object]) -> set[str]:
+    return {name for name in dir(cls) if not name.startswith("_") and callable(getattr(cls, name))}
+
+
+def _raises_runtime_error(operation: Callable[[], object]) -> bool:
+    try:
+        operation()
+    except RuntimeError:
+        return True
+    return False
+
+
+async def _raises_runtime_error_async(
+    operation: Callable[[], Awaitable[object]],
+) -> bool:
+    try:
+        await operation()
+    except RuntimeError:
+        return True
+    return False
+
+
+async def _task_runtime_contracts() -> tuple[dict[str, bool], dict[str, bool]]:
+    with tempfile.TemporaryDirectory() as tmp:
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        runtime = ArchetypeRuntime()
+        world = runtime.world(
+            "runtime-contracts",
+            storage=StorageConfig(uri=f"{tmp}/store", namespace="eval_runtime_contracts"),
+        )
+
+        pre_activation_rejected = _raises_runtime_error(lambda: world.world_id)
+        entity_ids = await asyncio.gather(*(world.spawn(Health(hp=index)) for index in range(12)))
+        info = await world.info()
+        audit_rows = (await world.history(limit=100)).to_pylist()
+        create_events = [row for row in audit_rows if row["command_type"] == "create_world"]
+
+        await world.step()  # persist raw initial conditions
+        await world.add_processor(BlockingHealthIncrement(entered, release))
+        step_task = asyncio.create_task(world.step())
+        await asyncio.wait_for(entered.wait(), timeout=5)
+
+        shutdown_task = asyncio.create_task(runtime.shutdown())
+        await asyncio.sleep(0)  # shutdown stops admission before waiting on op_lock
+        shutdown_started = _raises_runtime_error(lambda: runtime.world("too-late"))
+        shutdown_waited = not shutdown_task.done()
+
+        release.set()
+        await asyncio.wait_for(asyncio.gather(step_task, shutdown_task), timeout=10)
+        handle_invalidated = await _raises_runtime_error_async(world.info)
+        await runtime.shutdown()  # idempotent after the first completion
+
+        activation = {
+            "property_rejects_before_activation": pre_activation_rejected,
+            "one_create_event": len(create_events) == 1,
+            "all_spawns_returned": len(entity_ids) == 12,
+            "entity_ids_are_unique": len(set(entity_ids)) == 12,
+            "handle_and_info_share_world": str(world.world_id) == str(info.world_id),
+        }
+        shutdown = {
+            "new_handles_rejected_during_shutdown": shutdown_started,
+            "shutdown_waited_for_step": shutdown_waited,
+            "in_flight_step_completed": (
+                step_task.done() and not step_task.cancelled() and step_task.exception() is None
+            ),
+            "shutdown_completed": (
+                shutdown_task.done()
+                and not shutdown_task.cancelled()
+                and shutdown_task.exception() is None
+            ),
+            "existing_handle_invalidated": handle_invalidated,
+        }
+        return activation, shutdown
+
+
+# ---------------------------------------------------------------------------
 # Task: value-based "all done" episode termination (bug B2)
 # ---------------------------------------------------------------------------
 
@@ -768,6 +886,12 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_quota_boundaries,
         desc="Exact per-tick and daily quota edges, atomic bulk debit, and actor isolation",
+    )
+    harness.add(
+        "runtime_contracts",
+        suite=SUITE,
+        fn=task_runtime_contracts,
+        desc="Lazy activation, wait-then-close shutdown, handle invalidation, and sync parity",
     )
     harness.add(
         "episode_value_termination",

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -123,8 +123,11 @@ class ArchetypeRuntime:
         await self.shutdown()
 
     async def shutdown(self) -> None:
-        """Close every world handle and release process-level resources.
+        """Drain admitted world operations, then release process resources.
 
+        New operations are rejected as soon as shutdown starts. Each shared
+        world state waits for its current lock-protected operation to finish
+        before closing, so storage stays available to an admitted call.
         Repeated calls have no effect.
         """
         if self._closed:

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -172,20 +172,26 @@ class _RuntimeWorldState:
         return self.world_id
 
     async def shutdown(self, *, from_runtime: bool) -> None:
-        """Shut down this world state. Idempotent."""
-        if self.closed:
-            return
-        self.closed = True
+        """Wait for admitted work, then shut down this world state once."""
+        async with self.op_lock:
+            if self.closed:
+                return
+            self.closed = True
 
-        if not from_runtime and self.owns_world and self.initialized and self.world_id is not None:
-            gate = self.runtime._container.command_service
-            # Use a default admin ctx for shutdown
-            from archetype.runtime._actor import default_actor_ctx
+            if (
+                not from_runtime
+                and self.owns_world
+                and self.initialized
+                and self.world_id is not None
+            ):
+                gate = self.runtime._container.command_service
+                # Use a default admin ctx for shutdown
+                from archetype.runtime._actor import default_actor_ctx
 
-            await gate.destroy_world(default_actor_ctx(), self.world_id)
+                await gate.destroy_world(default_actor_ctx(), self.world_id)
 
-        for alias in list(self.aliases):
-            self.runtime._unregister_handle(alias)
+            for alias in list(self.aliases):
+                self.runtime._unregister_handle(alias)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/app/test_lifecycle_parity.py
+++ b/tests/app/test_lifecycle_parity.py
@@ -3,8 +3,8 @@
 
 """Lifecycle parity tests.
 
-Covers shutdown error aggregation, op_lock serialization, multi-runtime
-isolation, sync/async surface parity, and viewer guardrails.
+Covers shutdown draining and error aggregation, op_lock serialization,
+multi-runtime isolation, sync/async surface parity, and viewer guardrails.
 """
 
 from __future__ import annotations
@@ -12,9 +12,10 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from daft import DataFrame, col
 from uuid_utils import uuid7
 
-from archetype import ArchetypeRuntime, Component
+from archetype import ArchetypeRuntime, AsyncProcessor, Component
 from archetype.app.auth.errors import GuardrailError
 from archetype.app.auth.guard import reset_daily_tokens, reset_tick_counters
 from archetype.app.auth.models import ActorCtx
@@ -26,6 +27,21 @@ from archetype.runtime.world import RuntimeWorld
 class Pos(Component):
     x: float = 0.0
     y: float = 0.0
+
+
+class BlockingIncrement(AsyncProcessor):
+    """Hold one step open so shutdown ordering is observable."""
+
+    components = (Pos,)
+
+    def __init__(self, entered: asyncio.Event, release: asyncio.Event) -> None:
+        self.entered = entered
+        self.release = release
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        self.entered.set()
+        await self.release.wait()
+        return df.with_column("pos__x", col("pos__x") + 1)
 
 
 @pytest.fixture(autouse=True)
@@ -70,6 +86,35 @@ class TestShutdownErrorAggregation:
 
         # world_b should still have been shut down despite world_a's failure
         assert world_b._state.closed
+
+    @pytest.mark.asyncio
+    async def test_shutdown_waits_for_in_flight_step(self, tmp_path):
+        """Runtime services stay open until an admitted world operation exits."""
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        runtime = ArchetypeRuntime()
+        world = runtime.world(
+            "shutdown-race",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns"),
+        )
+
+        await world.spawn(Pos())
+        await world.step()  # persist the raw initial condition
+        await world.add_processor(BlockingIncrement(entered, release))
+
+        step_task = asyncio.create_task(world.step())
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        shutdown_task = asyncio.create_task(runtime.shutdown())
+        await asyncio.sleep(0)  # let shutdown stop admission and reach op_lock
+
+        assert not shutdown_task.done(), "shutdown overtook the in-flight step"
+
+        release.set()
+        await asyncio.wait_for(step_task, timeout=5)
+        await asyncio.wait_for(shutdown_task, timeout=5)
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await world.info()
 
 
 # ── 2. op_lock serialization ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- serialize world-state shutdown through the existing operation lock so storage and shared services remain available to an already-admitted `step()`, `run()`, or `query()` call
- add unit and regression oracles for lazy single-flight activation, exactly one audited world creation, wait-then-close shutdown, handle invalidation, shutdown idempotency, and sync/async world-surface parity
- align the runtime and specification guides with the executable admission boundary, and retire the stale `archetype.sugar` wording

## Root cause

`ArchetypeRuntime.shutdown()` marked world state closed and released container storage without first acquiring the world operation lock. A step already running inside a processor could therefore resume against closed storage and hang or fail. Shutdown now joins the same lock discipline used by public world operations before it closes shared state.

## Impact

Runtime shutdown rejects new work immediately, lets the current admitted world operation finish, then invalidates aliases and releases process resources. Calls still queued behind the operation lock may observe the documented closed error.

## Validation

- `make ci`
- `make docs`
- `uvx ty@0.0.48 check --python .venv`
- focused runtime suites: 20 passed
- `runtime_contracts` regression eval: 3/3 trials, pass@3 and pass^3 100%
- full regression suite: 15/15 tasks across 3 trials, pass@3 and pass^3 100%
- documentation contracts: 8 passed
- Ruff format/check, markdownlint, and `git diff --check`

Refs #142