### PR TITLE
feat(eval): grade processor failure boundaries

### DIFF
--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -175,6 +175,7 @@ renaming a task requires updating this table in the same change.
 | `capability` | `simulation_correctness` | Multi-step processing preserves entities and updates expected fields |
 | `capability` | `fork_divergence` | Fork-of-fork lineage, first-step continuity, shared resources, and isolated mutations compose through the runtime |
 | `capability` | `time_travel_and_run_id` | Live and cold historical reads preserve one run identity across durable resume |
+| `capability` | `processor_adversarial` | Hook failures stay advisory, processor failure is whole-tick atomic, and matching follows explicit component migrations |
 
 <!-- eval-task-manifest:end -->
 

--- a/docs/guide/processors.md
+++ b/docs/guide/processors.md
@@ -46,6 +46,33 @@ class ResolveCollisions(AsyncProcessor):
 Keep one processor responsible for one transformation. It makes order and
 tests straightforward.
 
+## Failure and archetype boundaries
+
+A processor error fails the whole world tick, not only the table whose
+processor raised. Archetype computes every table before it appends any of
+them. On failure, `step()` raises, the tick does not advance, no table appends,
+and staged mutations remain available for retry.
+
+A processor's `components` tuple is a matching predicate, not a request to
+change an entity's component set. Return a DataFrame compatible with the
+current archetype. Widen or narrow an entity explicitly between steps:
+
+```python
+await world.add_components(entity_id, Targetable())
+await world.step()  # carries the row into the wider signature
+await world.step()  # processors newly matched by Targetable now transform it
+
+await world.remove_components(entity_id, Targetable)
+```
+
+The migration step persists the carried row under its target signature after
+that tick's processor pass. Processors newly matched by the target signature
+first see the row on the following step.
+
+Hooks have a deliberately different failure policy. They are advisory
+callbacks: exceptions are logged and suppressed so later hooks and the tick
+can continue. See [Lifecycle Hooks](hooks.md).
+
 ## Add processors to a world
 
 Pass processors when you create the handle for the usual script path:

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -229,6 +229,11 @@ Failure observability:
 - A processor MUST declare the component set it depends on.
 - A processor matches a signature when its required component set is a subset
   of the archetype signature.
+- A processor's component declaration is a match predicate, not a component
+  mutation. Widening and narrowing flow through the world mutation API. The
+  carried row materializes under its target signature on the migration tick;
+  processors newly matched by that signature first transform it on the next
+  tick.
 - Within one archetype, processors MUST execute in ascending `priority`.
 - Across different archetypes, execution MAY proceed concurrently.
 - Processor registration is instance-based; removal is type-based.
@@ -253,6 +258,9 @@ Failure policy:
   (`test_async_world_processor_error_fails_the_step`,
   `test_failed_tick_commits_nothing_and_is_retryable`,
   `test_one_failing_archetype_blocks_all_appends`).
+- Composed public-boundary evidence: the `processor_adversarial` capability
+  eval combines advisory hook failures, one-table processor failure, atomic
+  retry, and signature-aware matching across component migrations.
 
 Idempotency:
 
@@ -1005,6 +1013,9 @@ all of the following:
 - append-only persistence scoped by world and run
 - stable processor ordering within an archetype
 - stable cross-archetype execution without world bookkeeping corruption
+- advisory hook isolation, whole-tick processor failure atomicity, and
+  signature-aware matching across explicit component migrations
+  (`processor_adversarial` capability eval)
 - stable reserved-entity spawn semantics through the broker
 - explicit multi-world isolation and fork divergence (`fork_divergence` capability eval)
 - exact actor-local quota boundaries and UTC rollover (`quota_boundaries` regression eval)

--- a/docs/guide/system-execution.md
+++ b/docs/guide/system-execution.md
@@ -299,6 +299,13 @@ but resources, processor instances, and external side effects are shared.
 Synchronize mutable shared objects and do not depend on cross-archetype task
 order.
 
+**Trying to migrate an entity from `process()`.** A processor's component
+declaration only decides which existing signatures it matches. Use
+`world.add_components()` or `world.remove_components()` between steps to move
+the entity. The carried row materializes under its target signature on the
+migration step; processors newly matched by that signature act on it on the
+following step.
+
 ## Key Source Files
 
 | File | What to Look For |

--- a/docs/guide/worlds.md
+++ b/docs/guide/worlds.md
@@ -115,6 +115,10 @@ await world.remove_components(entity_id, [Health])
 
 Component mutations trigger **archetype migration**: the entity's row is marked inactive in the old archetype table and a new row (with carried-over field values) is spawned in the target archetype table.
 
+The target row is a carried initial condition. It materializes on the next
+successful step after that step's processor pass; processors newly matched by
+the target signature first transform it on the following step.
+
 ## Tick Lifecycle
 
 Each call to `step()` executes one simulation tick:
@@ -123,13 +127,17 @@ Each call to `step()` executes one simulation tick:
 1. `PreTick` hooks fire
 2. For each archetype (in parallel):
    a. Query previous state (from _live cache or store)
-   b. Materialize deferred mutations (spawns/despawns)
-   c. Execute matching processors in priority order
-   d. Persist updated DataFrame to store
-3. Update _live snapshots
-4. Increment tick counter
-5. `PostTick` hooks fire
+   b. Apply pending despawns and prepare raw spawn/migration rows
+   c. Execute matching processors over the existing population in priority order
+   d. Append the raw spawn/migration rows to the computed frame
+3. If every archetype computed successfully, persist all frames
+4. Update _live snapshots
+5. Increment tick counter
+6. `PostTick` hooks fire
 ```
+
+The compute barrier in step 3 is the failure boundary: one processor failure
+prevents every archetype from appending and leaves the tick retryable.
 
 ### Running Multiple Ticks
 

--- a/evals/suites/capability.py
+++ b/evals/suites/capability.py
@@ -25,6 +25,7 @@ from archetype.app.world_service import WorldService
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.hooks import PostTick, PreTick
 from evals.graders import exact_match, state_check
 from evals.harness import EvalHarness
 from evals.types import GraderResult
@@ -69,6 +70,14 @@ class TimelineValue(Component):
     amount: int = 0
 
 
+class AdversarialValue(Component):
+    amount: int = 0
+
+
+class AdversarialMarker(Component):
+    label: str = "marked"
+
+
 @dataclass
 class ForkStepSize:
     delta: int = 1
@@ -106,6 +115,42 @@ class AdvanceTimelineValue(AsyncProcessor):
 
     async def process(self, df, **kwargs):
         return df.with_column("timelinevalue__amount", col("timelinevalue__amount") + 1)
+
+
+class IncrementAdversarialValue(AsyncProcessor):
+    """Advance every adversarial value by one."""
+
+    components = (AdversarialValue,)
+    priority = 10
+
+    async def process(self, df, **kwargs):
+        return df.with_column(
+            "adversarialvalue__amount",
+            col("adversarialvalue__amount") + 1,
+        )
+
+
+class BoostMarkedAdversarialValue(AsyncProcessor):
+    """Apply an additional increment only while an entity is marked."""
+
+    components = (AdversarialValue, AdversarialMarker)
+    priority = 20
+
+    async def process(self, df, **kwargs):
+        return df.with_column(
+            "adversarialvalue__amount",
+            col("adversarialvalue__amount") + 10,
+        )
+
+
+class FailMarkedArchetype(AsyncProcessor):
+    """Fail one matching table so the world's compute barrier is observable."""
+
+    components = (AdversarialMarker,)
+    priority = 15
+
+    async def process(self, df, **kwargs):
+        raise RuntimeError("intentional marked-archetype failure")
 
 
 # ---------------------------------------------------------------------------
@@ -517,6 +562,204 @@ async def _task_time_travel_and_run_id() -> list[GraderResult]:
 
 
 # ---------------------------------------------------------------------------
+# Task: Processor and hook failure boundaries across archetype migration
+# ---------------------------------------------------------------------------
+
+
+def task_processor_adversarial() -> list[GraderResult]:
+    """Compose advisory hooks, atomic processor failure, and signature matching."""
+    return asyncio.run(_task_processor_adversarial())
+
+
+def _adversarial_history(rows: list[dict]) -> list[tuple[str, str, int, int, bool, int]]:
+    """Normalize durable value rows so a failed-step comparison is order independent."""
+    return sorted(
+        (
+            str(row["world_id"]),
+            str(row["run_id"]),
+            int(row["entity_id"]),
+            int(row["tick"]),
+            bool(row["is_active"]),
+            int(row["adversarialvalue__amount"]),
+        )
+        for row in rows
+    )
+
+
+def _active_value_timeline(rows: list[dict], entity_id: int) -> dict[int, int]:
+    return {
+        int(row["tick"]): int(row["adversarialvalue__amount"])
+        for row in rows
+        if int(row["entity_id"]) == entity_id and bool(row["is_active"])
+    }
+
+
+def _active_marker_ticks(rows: list[dict], entity_id: int) -> list[int]:
+    return sorted(
+        int(row["tick"])
+        for row in rows
+        if int(row["entity_id"]) == entity_id and bool(row["is_active"])
+    )
+
+
+async def _task_processor_adversarial() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp:
+        storage_cfg = StorageConfig(uri=f"{tmp}/store", namespace="eval_processor_adversarial")
+        hook_counts = {"bad_pre": 0, "good_pre": 0, "bad_post": 0, "good_post": 0}
+
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("processor-adversarial", storage=storage_cfg)
+            plain_id = await world.spawn(AdversarialValue(amount=0))
+            marked_id = await world.spawn(
+                AdversarialValue(amount=100),
+                AdversarialMarker(),
+            )
+            await world.step()  # persist raw initial conditions
+
+            async def failing_pre(_event: PreTick) -> None:
+                hook_counts["bad_pre"] += 1
+                raise RuntimeError("intentional pre-tick hook failure")
+
+            async def healthy_pre(_event: PreTick) -> None:
+                hook_counts["good_pre"] += 1
+
+            async def failing_post(_event: PostTick) -> None:
+                hook_counts["bad_post"] += 1
+                raise RuntimeError("intentional post-tick hook failure")
+
+            async def healthy_post(_event: PostTick) -> None:
+                hook_counts["good_post"] += 1
+
+            # Register failures first: the healthy handlers prove suppression
+            # is per hook rather than an early exit from the event bucket.
+            hook_handles = [
+                await world.add_hook(PreTick, failing_pre),
+                await world.add_hook(PreTick, healthy_pre),
+                await world.add_hook(PostTick, failing_post),
+                await world.add_hook(PostTick, healthy_post),
+            ]
+            await world.add_processor(IncrementAdversarialValue())
+            await world.add_processor(BoostMarkedAdversarialValue())
+
+            await world.step()  # tick 1: plain=1, marked=111
+            before_failure_info = await world.info()
+            before_failure_history = _adversarial_history(
+                (await world.query(AdversarialValue)).to_pylist()
+            )
+
+            await world.add_processor(FailMarkedArchetype())
+            processor_error: RuntimeError | None = None
+            try:
+                await world.step()
+            except RuntimeError as exc:
+                processor_error = exc
+
+            after_failure_info = await world.info()
+            after_failure_history = _adversarial_history(
+                (await world.query(AdversarialValue)).to_pylist()
+            )
+            hook_counts_after_failure = dict(hook_counts)
+
+            await world.remove_processor(FailMarkedArchetype)
+            await world.step()  # retry tick 2 exactly once
+            retry_info = await world.info()
+            retry_rows = (await world.query(AdversarialValue)).to_pylist()
+            for handle in hook_handles:
+                await world.remove_hook(handle)
+
+            # Component-set changes are explicit world mutations. The carried
+            # row materializes under its new signature; newly matching
+            # processors first transform it on the following tick.
+            await world.add_components(plain_id, AdversarialMarker(label="moved"))
+            await world.step()  # tick 3: carried value remains 2
+            await world.step()  # tick 4: increment + marked boost => 13
+            await world.remove_components(plain_id, AdversarialMarker)
+            await world.step()  # tick 5: carried value remains 13
+            await world.step()  # tick 6: unmarked increment only => 14
+
+            final_info = await world.info()
+            value_rows = (await world.query(AdversarialValue)).to_pylist()
+            marker_rows = (await world.query(AdversarialMarker)).to_pylist()
+
+        active_keys = [
+            (int(row["entity_id"]), int(row["tick"]))
+            for row in value_rows
+            if bool(row["is_active"])
+        ]
+        plain_timeline = _active_value_timeline(value_rows, plain_id)
+        marked_timeline = _active_value_timeline(value_rows, marked_id)
+
+        return [
+            state_check(
+                {
+                    "failed_pre_hook_reached": hook_counts_after_failure["bad_pre"] == 2,
+                    "later_pre_hook_still_ran": hook_counts_after_failure["good_pre"] == 2,
+                    "failed_step_skipped_post_hooks": (
+                        hook_counts_after_failure["bad_post"] == 1
+                        and hook_counts_after_failure["good_post"] == 1
+                    ),
+                    "failed_post_hook_did_not_stop_later_hook": (
+                        hook_counts["bad_post"] == hook_counts["good_post"] == 2
+                    ),
+                    "all_pre_hooks_observed_every_installed_attempt": (
+                        hook_counts["bad_pre"] == hook_counts["good_pre"] == 3
+                    ),
+                },
+                name="hook_failure_isolation",
+            ),
+            state_check(
+                {
+                    "processor_error_surfaced": (
+                        processor_error is not None
+                        and "marked-archetype failure" in str(processor_error)
+                    ),
+                    "failed_tick_did_not_advance": (
+                        before_failure_info.tick == after_failure_info.tick == 2
+                    ),
+                    "retry_advanced_same_tick_once": retry_info.tick == 3,
+                    "plain_retry_applied_once": (
+                        _active_value_timeline(retry_rows, plain_id).get(2) == 2
+                    ),
+                    "marked_retry_applied_once": (
+                        _active_value_timeline(retry_rows, marked_id).get(2) == 122
+                    ),
+                },
+                name="whole_tick_failure_and_retry",
+            ),
+            exact_match(
+                after_failure_history,
+                before_failure_history,
+                name="failed_tick_committed_nothing",
+            ),
+            exact_match(
+                plain_timeline,
+                {0: 0, 1: 1, 2: 2, 3: 2, 4: 13, 5: 13, 6: 14},
+                name="widened_then_narrowed_timeline",
+            ),
+            exact_match(
+                marked_timeline,
+                {0: 100, 1: 111, 2: 122, 3: 133, 4: 144, 5: 155, 6: 166},
+                name="stable_marked_timeline",
+            ),
+            state_check(
+                {
+                    "marker_matches_only_while_plain_is_wide": (
+                        _active_marker_ticks(marker_rows, plain_id) == [3, 4]
+                    ),
+                    "original_marker_remains_matched": (
+                        _active_marker_ticks(marker_rows, marked_id) == list(range(7))
+                    ),
+                    "one_active_row_per_entity_tick": (
+                        len(active_keys) == len(set(active_keys)) == 14
+                    ),
+                    "world_completed_six_successful_adversarial_steps": final_info.tick == 7,
+                },
+                name="signature_migration_matching",
+            ),
+        ]
+
+
+# ---------------------------------------------------------------------------
 # Register all capability tasks
 # ---------------------------------------------------------------------------
 
@@ -546,4 +789,10 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_time_travel_and_run_id,
         desc="Live and cold historical reads preserve run identity across durable resume",
+    )
+    harness.add(
+        "processor_adversarial",
+        suite=SUITE,
+        fn=task_processor_adversarial,
+        desc="Hook isolation, atomic processor failure, retry, and migration-aware matching",
     )


### PR DESCRIPTION
## Summary

- add the `processor_adversarial` capability task at the public `ArchetypeRuntime` boundary
- compose advisory PreTick/PostTick hook failures, a processor failure isolated to one archetype, the whole-tick compute barrier, healing and retry, and processor matching after explicit widen/narrow migrations
- align the processor, system-execution, world, eval, and normative specification guides with the executable boundary

## Why

The focused unit contracts already proved hook suppression, processor fail-fast behavior, and component migration independently, but the capability matrix had no public-boundary oracle showing that they compose. The issue wording also implied that processors widen or narrow archetypes; in the current architecture, a processor declaration is only a signature-matching predicate and migrations flow through explicit world mutations.

## Impact

A failed processor on one table is now continuously graded to prove that no healthy table appends, the tick does not advance, and retry applies each transformation once. The same scenario proves that a marker-only processor begins matching after a widen and stops matching after a narrow, while throwing hooks remain advisory and do not prevent later handlers.

No production or core code changed.

## Validation

- `make ci`: 1,144 passed, 6 skipped, 86.05% coverage; regression 15/15 and idempotency 23/23
- capability suite: 5/5 tasks across 3 trials; pass@3 and pass^3 100%
- focused processor/hook/migration contracts: 58 passed
- documentation contracts: 8 passed
- `make docs`
- Ruff format/check, `ty`, markdownlint, and `git diff --check`
- complexity: new task B(7), suite average A

Refs #142