### PR TITLE
feat(eval): grade LLM failure policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,10 +91,13 @@ asyncio.run(main())
 
 ## LLM-powered processors
 
-`daft.functions.prompt` inside `AsyncProcessor.process()` gives every entity an LLM call per tick, executed in parallel by Daft.
+`daft.functions.prompt` inside `AsyncProcessor.process()` gives every entity an
+LLM call per tick, executed in parallel by Daft. Inject a provider with explicit
+timeout and retry bounds; do not inherit ambient transport defaults.
 
 ```python
 from daft import DataFrame, col
+from daft.ai.openai.provider import OpenAIProvider
 from daft.functions import prompt
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
@@ -108,6 +111,9 @@ class ThinkProcessor(AsyncProcessor):
     components = (Agent,)
     priority = 10
 
+    def __init__(self, provider: OpenAIProvider) -> None:
+        self.provider = provider
+
     async def process(self, df: DataFrame, tick: int = 0, **kwargs) -> DataFrame:
         return df.with_column(
             "agent__last_thought",
@@ -115,9 +121,13 @@ class ThinkProcessor(AsyncProcessor):
                 "You are " + col("agent__name")
                 + ". Tick: " + str(tick)
                 + ". What is your next action? Be brief.",
+                provider=self.provider,
                 model="gpt-5-mini",
             ),
         )
+
+provider = OpenAIProvider(timeout=30.0, max_retries=2)
+think = ThinkProcessor(provider)
 ```
 
 See `LEARNINGS.md` for the data-centric principle and the UDF decision tree. Both are mandatory reading before writing a processor.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -559,7 +559,10 @@ result = df.collect()  # Single materialization
 `prompt()` builds a lazy expression. Provider calls happen when the world
 materializes the processor plan, after `process()` has returned. A terminal
 timeout or rate-limit error therefore follows the ordinary processor failure
-contract: the whole tick fails and no world rows append.
+contract: the whole tick fails and no world rows append. `AsyncWorld.step()`
+aggregates per-table compute failures into a `RuntimeError`; the provider's
+exception type does not cross that public boundary, although its detail is
+included in the aggregate message.
 
 The provider side is not rolled back. Some row calls may already have
 completed or incurred cost before another row fails, and retrying the tick may

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -562,7 +562,13 @@ timeout or rate-limit error therefore follows the ordinary processor failure
 contract: the whole tick fails and no world rows append. `AsyncWorld.step()`
 aggregates per-table compute failures into a `RuntimeError`; the provider's
 exception type does not cross that public boundary, although its detail is
-included in the aggregate message.
+included in the aggregate message. That message may also contain unrelated
+processor failures, so it is evidence for diagnosis, not a safe fallback
+classifier. Never authorize fallback by substring-matching it. Until the
+structured public failure contract tracked in
+[Archetype #444](https://github.com/VangelisTech/archetype/issues/444) lands,
+fallback requires an independent boundary that establishes the provider was
+the only failure.
 
 The provider side is not rolled back. Some row calls may already have
 completed or incurred cost before another row fails, and retrying the tick may

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -554,6 +554,34 @@ result = df.collect()  # Single materialization
 
 ---
 
+## LLM Failures: State Atomicity Is Not External Exactly-Once (Jul 2026)
+
+`prompt()` builds a lazy expression. Provider calls happen when the world
+materializes the processor plan, after `process()` has returned. A terminal
+timeout or rate-limit error therefore follows the ordinary processor failure
+contract: the whole tick fails and no world rows append.
+
+The provider side is not rolled back. Some row calls may already have
+completed or incurred cost before another row fails, and retrying the tick may
+repeat them. Configure bounded provider timeouts/retries, keep calls safe to
+repeat, and make continuation policy explicit. A deterministic whole-tick
+fallback removes the failing processor, installs a pure fallback processor,
+and retries the unchanged tick.
+
+Archetype's command-gate token costs are command admission estimates. They do
+not observe prompt tokens, provider quotas, or spend.
+
+The admitted Daft 0.7.19 OpenAI adapter also has an option-routing footgun:
+passing prompt UDF `on_error` forwards it to the OpenAI request. Upstream
+[Daft #7277](https://github.com/Eventual-Inc/Daft/pull/7277) fixes the
+separation, but it landed after the admitted release. Until a containing
+release clears the dependency gate, keep built-in OpenAI prompts fail-closed
+and use explicit whole-tick fallback rather than a local monkeypatch.
+[Archetype #442](https://github.com/VangelisTech/archetype/issues/442) owns the
+coordinated dependency, oracle, and documentation update.
+
+---
+
 ## Row-wise `@daft.func` vs `@daft.func.batch` (Jan 2026)
 
 For simple row transforms, prefer `@daft.func` over `@daft.func.batch`:

--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -176,6 +176,7 @@ renaming a task requires updating this table in the same change.
 | `capability` | `fork_divergence` | Fork-of-fork lineage, first-step continuity, shared resources, and isolated mutations compose through the runtime |
 | `capability` | `time_travel_and_run_id` | Live and cold historical reads preserve one run identity across durable resume |
 | `capability` | `processor_adversarial` | Hook failures stay advisory, processor failure is whole-tick atomic, and matching follows explicit component migrations |
+| `capability` | `llm_facing` | Real prompt execution handles bounded timeout and quota failures with atomic ticks and explicit deterministic fallback |
 
 <!-- eval-task-manifest:end -->
 

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -224,6 +224,7 @@ Source: [`examples/05_llm_agents.py`](https://github.com/VangelisTech/archetype/
 
 - **Component**: `Agent` with name, role, and a JSON journal of thoughts
 - **Processor**: `ThinkProcessor` uses `daft.functions.prompt` to call an LLM for every agent entity in a single DataFrame operation
+- **Provider policy**: the injected OpenAI provider has explicit timeout and retry bounds
 - **Pattern**: `ArchetypeRuntime` keeps the script surface to `world.spawn(...)`, `world.run(...)`, and `world.query(...)`
 
 Requires an OpenAI API key (or any provider via `daft.set_provider()`).

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -227,7 +227,8 @@ Source: [`examples/05_llm_agents.py`](https://github.com/VangelisTech/archetype/
 - **Provider policy**: the injected OpenAI provider has explicit timeout and retry bounds
 - **Pattern**: `ArchetypeRuntime` keeps the script surface to `world.spawn(...)`, `world.run(...)`, and `world.query(...)`
 
-Requires an OpenAI API key (or any provider via `daft.set_provider()`).
+Requires an OpenAI API key. Provider settings are injected into
+`ThinkProcessor` explicitly instead of being read from ambient configuration.
 
 ---
 
@@ -246,6 +247,7 @@ Source: [`examples/06_trajectory_analysis.py`](https://github.com/VangelisTech/a
 - **Components**: `Trajectory` (JSON-encoded turns), `Label` (evaluation result)
 - **Processors**: `SamplingProcessor` (filter), `LabelingProcessor` (LLM eval), `ScoringProcessor` (normalize)
 - **Resources**: `SamplingConfig`, `LabelingConfig` staged on `runtime.world(..., resources=[...])`
+- **Provider policy**: LLM labeling injects an OpenAI provider with explicit timeout and retry bounds; without credentials, that processor is omitted
 - **Fork-based comparison**: Clone a world with `world.fork(...)` and run an independent branch
 
 ---

--- a/docs/guide/processors.md
+++ b/docs/guide/processors.md
@@ -173,7 +173,6 @@ retry the unchanged tick explicitly:
 
 ```python
 from daft import lit
-from openai import APITimeoutError, RateLimitError
 
 
 class FallbackThought(AsyncProcessor):
@@ -183,13 +182,27 @@ class FallbackThought(AsyncProcessor):
         return df.with_column("agent__last_thought", lit("provider_unavailable"))
 
 
+def is_recoverable_provider_failure(error: RuntimeError) -> bool:
+    detail = str(error).lower()
+    return "timed out" in detail or "error code: 429" in detail
+
+
 try:
     await world.step()
-except (APITimeoutError, RateLimitError):
+except RuntimeError as error:
+    # The public step boundary aggregates per-table compute failures.
+    # Re-raise processor bugs instead of silently converting them to fallback.
+    if not is_recoverable_provider_failure(error):
+        raise
     await world.remove_processor(Think)
     await world.add_processor(FallbackThought())
     await world.step()  # retries the same tick without another model request
 ```
+
+The public step boundary currently aggregates table failures into a
+`RuntimeError` whose detail includes the provider error; provider exception
+classes do not reach this caller directly. Classify only the failures your
+application has chosen to recover from and re-raise everything else.
 
 Persist a source/status field when downstream logic must distinguish model
 output from fallback state. Keep the fallback deterministic: do not introduce

--- a/docs/guide/processors.md
+++ b/docs/guide/processors.md
@@ -122,27 +122,94 @@ See [Resources](resources.md) for lifecycle and fork behavior.
 
 Use Daft's `prompt()` function when a processor needs an LLM call. Daft runs
 the row work in parallel and returns a column you can persist like any other
-state.
+state. Set transport bounds explicitly rather than inheriting a provider's
+long defaults.
 
 ```python
+from daft.ai.openai.provider import OpenAIProvider
 from daft.functions import prompt
 
 
 class Think(AsyncProcessor):
     components = (Agent,)
 
+    def __init__(self, provider: OpenAIProvider) -> None:
+        self.provider = provider
+
     async def process(self, df: DataFrame, **_) -> DataFrame:
         return df.with_column(
             "agent__last_thought",
             prompt(
                 "You are " + col("agent__name") + ". What should you do next?",
+                provider=self.provider,
                 model="gpt-5-mini",
             ),
         )
+
+
+provider = OpenAIProvider(timeout=15.0, max_retries=2)
+world = runtime.world("demo", processors=[Think(provider)])
 ```
 
 The component field is part of your history, so keep prompts and outputs small
 enough for the storage and cost profile you want.
+
+### Choose the failure policy
+
+`prompt()` is lazy. A processor builds the expression, but the provider call
+happens later when Archetype materializes the tick. The default policy is
+fail-closed: once the provider's bounded retries are exhausted, a timeout,
+HTTP 429, or other terminal error fails the whole tick. No archetype appends
+and the tick remains available for retry.
+
+That atomicity covers Archetype state, not the provider. Requests already sent,
+tokens already billed, and any other external effects cannot be rolled back.
+Retrying a failed tick can repeat them. Keep model calls side-effect-free from
+the simulation's perspective, use provider idempotency controls when available,
+and never treat a tick retry as exactly-once delivery to an external service.
+
+For a deterministic whole-tick fallback, replace the failing processor and
+retry the unchanged tick explicitly:
+
+```python
+from daft import lit
+from openai import APITimeoutError, RateLimitError
+
+
+class FallbackThought(AsyncProcessor):
+    components = (Agent,)
+
+    async def process(self, df: DataFrame, **_) -> DataFrame:
+        return df.with_column("agent__last_thought", lit("provider_unavailable"))
+
+
+try:
+    await world.step()
+except (APITimeoutError, RateLimitError):
+    await world.remove_processor(Think)
+    await world.add_processor(FallbackThought())
+    await world.step()  # retries the same tick without another model request
+```
+
+Persist a source/status field when downstream logic must distinguish model
+output from fallback state. Keep the fallback deterministic: do not introduce
+a second unbounded network path while handling the first one.
+
+The repository currently admits Daft 0.7.19. With that version, keep the
+built-in OpenAI `prompt()` path fail-closed and do not pass its UDF
+`on_error` option: the adapter incorrectly forwards that option to the OpenAI
+request. The upstream separation fix landed in
+[Daft #7277](https://github.com/Eventual-Inc/Daft/pull/7277) after the admitted
+release. Per-row null/fallback policy should be adopted only after a release
+containing that fix passes this repository's dependency gate; the coordinated
+upgrade is tracked in [Archetype #442](https://github.com/VangelisTech/archetype/issues/442).
+
+Finally, Archetype's command-gate "token" budget is an admission estimate for
+commands such as `step` and `run`; it does not meter prompt tokens or provider
+spend. Enforce real model budgets at the provider or deployment boundary. The
+credential-free `llm_facing` capability eval exercises success, transport
+timeout, HTTP 429, atomic failure, and explicit fallback against a loopback
+OpenAI-compatible fixture.
 
 ## Test a processor
 

--- a/docs/guide/processors.md
+++ b/docs/guide/processors.md
@@ -169,7 +169,8 @@ the simulation's perspective, use provider idempotency controls when available,
 and never treat a tick retry as exactly-once delivery to an external service.
 
 For a deterministic whole-tick fallback, replace the failing processor and
-retry the unchanged tick explicitly:
+retry the unchanged tick explicitly. Keep that policy separate from error
+classification:
 
 ```python
 from daft import lit
@@ -182,18 +183,9 @@ class FallbackThought(AsyncProcessor):
         return df.with_column("agent__last_thought", lit("provider_unavailable"))
 
 
-def is_recoverable_provider_failure(error: RuntimeError) -> bool:
-    detail = str(error).lower()
-    return "timed out" in detail or "error code: 429" in detail
-
-
-try:
-    await world.step()
-except RuntimeError as error:
-    # The public step boundary aggregates per-table compute failures.
-    # Re-raise processor bugs instead of silently converting them to fallback.
-    if not is_recoverable_provider_failure(error):
-        raise
+async def retry_with_confirmed_fallback() -> None:
+    # Invoke only after an independent decision establishes that the failed
+    # tick contained no failure other than the provider outage.
     await world.remove_processor(Think)
     await world.add_processor(FallbackThought())
     await world.step()  # retries the same tick without another model request
@@ -201,8 +193,15 @@ except RuntimeError as error:
 
 The public step boundary currently aggregates table failures into a
 `RuntimeError` whose detail includes the provider error; provider exception
-classes do not reach this caller directly. Classify only the failures your
-application has chosen to recover from and re-raise everything else.
+classes do not reach this caller directly. One aggregate can contain both a
+provider timeout and an unrelated processor bug. Do not parse or substring
+match `str(error)` to authorize fallback: doing so can hide the other failure.
+Let the step error propagate unless an independent boundary can establish that
+the provider was the only failure—for example, an isolated provider-only
+operation reviewed by an operator or guarded by application-specific evidence.
+Structured public processor failures are tracked in
+[Archetype #444](https://github.com/VangelisTech/archetype/issues/444); once
+they exist, callers can classify every member without relying on message text.
 
 Persist a source/status field when downstream logic must distinguish model
 output from fallback state. Keep the fallback deterministic: do not introduce

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -254,6 +254,17 @@ Failure policy:
 - A store failure during the commit phase preserves the failed archetype's
   staged mutations; archetypes whose appends committed consume their caches
   with the append.
+- Tick atomicity governs Archetype state only. Processor calls to LLMs or other
+  external services MAY have completed, incurred cost, or produced side
+  effects before a compute failure. The engine cannot roll those effects back,
+  and retrying the tick MAY repeat them.
+- LLM transport retries MUST be bounded by the provider/client policy. After
+  exhaustion, the built-in prompt path is fail-closed: the terminal error
+  follows the processor failure contract above. Continuing with fallback state
+  requires an explicit deterministic processor or world operation and a retry
+  of the unchanged tick.
+- Command-gate token costs are admission estimates and MUST NOT be represented
+  as measured LLM token usage or provider spend.
 - Contract tests: `tests/core/test_async_world_error_propagation.py`
   (`test_async_world_processor_error_fails_the_step`,
   `test_failed_tick_commits_nothing_and_is_retryable`,
@@ -261,6 +272,10 @@ Failure policy:
 - Composed public-boundary evidence: the `processor_adversarial` capability
   eval combines advisory hook failures, one-table processor failure, atomic
   retry, and signature-aware matching across component migrations.
+- LLM-boundary evidence: the credential-free `llm_facing` capability eval runs
+  the real Daft prompt/OpenAI transport against a loopback fixture and grades
+  success, timeout, HTTP 429, no state commit, bounded attempts, and explicit
+  deterministic fallback on the same tick.
 
 Idempotency:
 
@@ -1000,6 +1015,7 @@ undocumented gap.
 | Mutation idempotency | **Simulation mutations stay non-idempotent by design** — `create_entity` twice is two entities, because spawns are simulation events, not external ones. Typed fact writes deduplicate logical keys within their serialized writer; legacy `ingest_fact` supplies claim-backed cross-process deduplication. Deterministic replays use reserved entity ids. |
 | API auth | **Development-grade by contract**: the default admin `ActorCtx` is for the reference deployment. A production front must inject authenticated `ActorCtx` (roles resolved by the deployment's identity layer) and never expose the default. |
 | RBAC quota state | **Process-local and advisory** in v0.3 (daily token budgets reset on restart). Durable quota accounting is a control-catalog follow-up; deployments needing hard budgets enforce them at the identity layer above. |
+| Processor LLM calls | **External and provider-owned**: tick publication is atomic, but requests and spend are not rolled back. Command token estimates do not meter model usage. Deployments own provider budgets and idempotency; bounded terminal failures either fail the tick or enter an explicit deterministic fallback path. |
 
 Receipts and facts carry no authority (enforced by `spec.receipt_authority_firewall`); the audit log records who asked, the ledger records what happened, and every durable guarantee in this table traces to the visibility contract in [Atomic Visibility](atomic-visibility.md).
 
@@ -1016,6 +1032,9 @@ all of the following:
 - advisory hook isolation, whole-tick processor failure atomicity, and
   signature-aware matching across explicit component migrations
   (`processor_adversarial` capability eval)
+- bounded LLM transport failure, no failed-tick state publication, and explicit
+  deterministic fallback without another provider attempt (`llm_facing`
+  capability eval)
 - stable reserved-entity spawn semantics through the broker
 - explicit multi-world isolation and fork divergence (`fork_divergence` capability eval)
 - exact actor-local quota boundaries and UTC rollover (`quota_boundaries` regression eval)

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -263,6 +263,11 @@ Failure policy:
   follows the processor failure contract above. Continuing with fallback state
   requires an explicit deterministic processor or world operation and a retry
   of the unchanged tick.
+- A caller MUST NOT authorize LLM fallback by substring-matching the aggregate
+  public `RuntimeError`: one tick may contain a provider failure and unrelated
+  processor failures. Until public failures preserve structured members, an
+  automated fallback requires an independent boundary that establishes the
+  provider was the only failure.
 - Command-gate token costs are admission estimates and MUST NOT be represented
   as measured LLM token usage or provider spend.
 - Contract tests: `tests/core/test_async_world_error_propagation.py`

--- a/docs/guide/system-execution.md
+++ b/docs/guide/system-execution.md
@@ -311,6 +311,11 @@ commits no world rows, but a provider may already have served or billed some
 requests. Bound retries and make repeated calls safe; use an explicit
 deterministic fallback when the simulation must continue without the provider.
 
+**Parsing the aggregate step error to trigger fallback.** One public
+`RuntimeError` can join a provider timeout with an unrelated processor bug.
+Substring matching that message can hide the bug. Preserve the failure unless
+an independent boundary establishes that the provider was the only cause.
+
 **Trying to migrate an entity from `process()`.** A processor's component
 declaration only decides which existing signatures it matches. Use
 `world.add_components()` or `world.remove_components()` between steps to move

--- a/docs/guide/system-execution.md
+++ b/docs/guide/system-execution.md
@@ -272,6 +272,13 @@ synchronization (for example, an `asyncio.Lock`) or expose concurrency-safe
 operations. Keep deterministic entity state in DataFrame columns and use an
 explicit deferred mechanism when communication belongs at a tick boundary.
 
+The same boundary applies to LLMs and other external calls. The two-phase tick
+prevents a failed processor from appending partial world state, but it cannot
+undo requests, spend, or side effects that happened while computing a frame.
+A retry may repeat those calls. Transport retries must be bounded, and a
+fallback that changes simulation state must be an explicit processor or world
+operation rather than an assumption that external work is transactional.
+
 See [Resources](resources.md) for the resource lifecycle and the additional
 sharing boundary created by world forks.
 
@@ -298,6 +305,11 @@ field when the distinction must be represented in storage.
 but resources, processor instances, and external side effects are shared.
 Synchronize mutable shared objects and do not depend on cross-archetype task
 order.
+
+**Treating tick atomicity as external exactly-once.** A failed LLM-backed tick
+commits no world rows, but a provider may already have served or billed some
+requests. Bound retries and make repeated calls safe; use an explicit
+deterministic fallback when the simulation must continue without the provider.
 
 **Trying to migrate an entity from `process()`.** A processor's component
 declaration only decides which existing signatures it matches. Use

--- a/docs/guide/token-quotas.md
+++ b/docs/guide/token-quotas.md
@@ -7,6 +7,11 @@ Every gated command has a token-cost estimate. `guardrail_allow()` enforces role
 permissions, per-tick command limits, and daily token budgets before the
 operation is accepted.
 
+"Token" here is a control-plane cost unit, not observed model usage. A `step`
+costs 10 whether it runs no processor or thousands of LLM prompts. Provider
+rate limits, billed tokens, and spend ceilings are separate data-plane concerns
+and must be enforced by the provider client or the deployment around it.
+
 The command gate is `iCommandService`; the broker is only used for tick-deferred queueing.
 
 ## Token Costs
@@ -105,6 +110,10 @@ See [Command Gate](command-gate.md) for the authoritative matrix.
 | Heavy day: 1000 spawns, 5000 messages, 10 forks | 6,010 commands | 26,000 |
 
 At these rates, the daily budget supports substantial workloads. The per-tick limit is the more common burst constraint.
+
+These examples budget command admission only. Do not use them to estimate or
+cap LLM cost inside processors; see the failure and provider boundary in
+[Processors](processors.md#choose-the-failure-policy).
 
 ## Source Reference
 

--- a/docs/guide/trajectories.md
+++ b/docs/guide/trajectories.md
@@ -124,14 +124,18 @@ Clamps `label__score` to [0, 1].
 Recommended runtime setup:
 
 ```python
+from daft.ai.openai.provider import OpenAIProvider
+
 from archetype import ArchetypeRuntime
 from archetype.core.config import RunConfig, StorageConfig
+
+provider = OpenAIProvider(timeout=30.0, max_retries=2)
 
 async with ArchetypeRuntime() as runtime:
     world = runtime.world(
         "trajectory-eval",
         storage=StorageConfig(uri="./trajectory_data", namespace="trajectories"),
-        processors=[SamplingProcessor(), LabelingProcessor(), ScoringProcessor()],
+        processors=[SamplingProcessor(), LabelingProcessor(provider), ScoringProcessor()],
         resources=[
             SamplingConfig(min_turns=3),
             LabelingConfig(model="gpt-5-mini"),

--- a/evals/infra/llm_fixture.py
+++ b/evals/infra/llm_fixture.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Credential-free OpenAI-compatible transport fixture for LLM capability evals."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections import Counter
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+_KNOWN_CASES = ("healthy", "timeout", "quota")
+
+
+class _FixtureState:
+    def __init__(self) -> None:
+        self._counts: Counter[str] = Counter()
+        self._lock = threading.Lock()
+
+    def record(self, case: str) -> None:
+        with self._lock:
+            self._counts[case] += 1
+
+    def snapshot(self) -> dict[str, int]:
+        with self._lock:
+            return {case: self._counts[case] for case in _KNOWN_CASES}
+
+
+class _FixtureHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        address: tuple[str, int],
+        state: _FixtureState,
+        timeout_delay_seconds: float,
+    ) -> None:
+        self.fixture_state = state
+        self.timeout_delay_seconds = timeout_delay_seconds
+        super().__init__(address, _OpenAIHandler)
+
+
+class _OpenAIHandler(BaseHTTPRequestHandler):
+    server: _FixtureHTTPServer
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler protocol
+        if self.path != "/v1/chat/completions":
+            self._write_json(404, {"error": {"message": "unknown fixture route"}})
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length))
+        case = self._case_from(body)
+        self.server.fixture_state.record(case)
+
+        if case == "timeout":
+            time.sleep(self.server.timeout_delay_seconds)
+        if case == "quota":
+            self._write_json(
+                429,
+                {
+                    "error": {
+                        "message": "fixture provider quota exhausted",
+                        "type": "rate_limit_error",
+                        "code": "rate_limit_exceeded",
+                    }
+                },
+                headers={"Retry-After": "0"},
+            )
+            return
+
+        self._write_json(
+            200,
+            {
+                "id": f"chatcmpl-{case}",
+                "object": "chat.completion",
+                "created": 0,
+                "model": body.get("model", "fixture-model"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": f"provider:{case}"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
+        )
+
+    @staticmethod
+    def _case_from(body: dict[str, Any]) -> str:
+        messages = body.get("messages", [])
+        content = messages[-1].get("content", []) if messages else []
+        if isinstance(content, list):
+            text = " ".join(str(part.get("text", "")) for part in content if isinstance(part, dict))
+        else:
+            text = str(content)
+        for case in _KNOWN_CASES:
+            if case in text:
+                return case
+        raise ValueError(f"fixture request did not name one of {_KNOWN_CASES!r}: {text!r}")
+
+    def _write_json(
+        self,
+        status: int,
+        payload: dict[str, Any],
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        encoded = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
+        self.end_headers()
+        try:
+            self.wfile.write(encoded)
+        except (BrokenPipeError, ConnectionResetError):
+            # The timeout case deliberately responds after the client has left.
+            pass
+
+    def log_message(self, _format: str, *args: Any) -> None:
+        """Keep expected local fixture traffic out of eval output."""
+
+
+class LocalOpenAIServer:
+    """Serve deterministic success, timeout, and quota responses on loopback."""
+
+    def __init__(self, *, timeout_delay_seconds: float = 0.25) -> None:
+        self._state = _FixtureState()
+        self._timeout_delay_seconds = timeout_delay_seconds
+        self._server: _FixtureHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> LocalOpenAIServer:
+        self._server = _FixtureHTTPServer(
+            ("127.0.0.1", 0),
+            self._state,
+            self._timeout_delay_seconds,
+        )
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="archetype-llm-eval-fixture",
+            daemon=True,
+        )
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join()
+        self._server = None
+        self._thread = None
+
+    @property
+    def base_url(self) -> str:
+        if self._server is None:
+            raise RuntimeError("LocalOpenAIServer is not running")
+        return f"http://127.0.0.1:{self._server.server_port}/v1"
+
+    @property
+    def request_counts(self) -> dict[str, int]:
+        return self._state.snapshot()

--- a/evals/suites/capability.py
+++ b/evals/suites/capability.py
@@ -936,15 +936,15 @@ async def _task_llm_facing() -> list[GraderResult]:
             {
                 "healthy_call_succeeded": healthy.error_type is None,
                 "timeout_error_surfaced": (
-                    timeout.error_type is not None and "timed out" in timeout_detail
+                    timeout.error_type == "RuntimeError" and "timed out" in timeout_detail
                 ),
                 "quota_error_surfaced": (
-                    quota.error_type is not None
+                    quota.error_type == "RuntimeError"
                     and "429" in quota_detail
                     and "quota exhausted" in quota_detail
                 ),
             },
-            name="provider_outcomes_surface",
+            name="provider_outcomes_surface_through_step",
         ),
         state_check(
             {

--- a/evals/suites/capability.py
+++ b/evals/suites/capability.py
@@ -17,7 +17,9 @@ import asyncio
 import tempfile
 from dataclasses import dataclass
 
-from daft import col
+from daft import col, lit
+from daft.ai.openai.provider import OpenAIProvider
+from daft.functions import prompt
 
 from archetype import ArchetypeRuntime
 from archetype.app.storage_service import StorageService
@@ -28,6 +30,7 @@ from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 from archetype.core.hooks import PostTick, PreTick
 from evals.graders import exact_match, state_check
 from evals.harness import EvalHarness
+from evals.infra.llm_fixture import LocalOpenAIServer
 from evals.types import GraderResult
 
 SUITE = "capability"
@@ -76,6 +79,12 @@ class AdversarialValue(Component):
 
 class AdversarialMarker(Component):
     label: str = "marked"
+
+
+class LLMExchange(Component):
+    request: str
+    response: str = ""
+    source: str = "pending"
 
 
 @dataclass
@@ -151,6 +160,54 @@ class FailMarkedArchetype(AsyncProcessor):
 
     async def process(self, df, **kwargs):
         raise RuntimeError("intentional marked-archetype failure")
+
+
+class FixturePromptProcessor(AsyncProcessor):
+    """Run the real Daft prompt expression against a local OpenAI transport."""
+
+    components = (LLMExchange,)
+    priority = 10
+
+    def __init__(self, base_url: str, *, timeout_seconds: float = 0.05) -> None:
+        self._provider = OpenAIProvider(
+            name="archetype-eval",
+            api_key="credential-free-fixture",
+            base_url=base_url,
+            timeout=timeout_seconds,
+            max_retries=0,
+        )
+
+    async def process(self, df, **kwargs):
+        return df.with_columns(
+            {
+                "llmexchange__response": prompt(
+                    col("llmexchange__request"),
+                    provider=self._provider,
+                    model="fixture-model",
+                    use_chat_completions=True,
+                    temperature=0,
+                ),
+                "llmexchange__source": lit("provider"),
+            }
+        )
+
+
+class DeterministicLLMFallback(AsyncProcessor):
+    """Replace an exhausted provider attempt with explicit deterministic state."""
+
+    components = (LLMExchange,)
+    priority = 10
+
+    def __init__(self, reason: str) -> None:
+        self._reason = reason
+
+    async def process(self, df, **kwargs):
+        return df.with_columns(
+            {
+                "llmexchange__response": lit(f"fallback:{self._reason}"),
+                "llmexchange__source": lit("fallback"),
+            }
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -760,6 +817,162 @@ async def _task_processor_adversarial() -> list[GraderResult]:
 
 
 # ---------------------------------------------------------------------------
+# Task: LLM transport failures and deterministic whole-tick fallback
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _LLMCaseObservation:
+    case: str
+    error_type: str | None
+    error_message: str
+    tick_before_attempt: int
+    tick_after_attempt: int
+    final_tick: int
+    history_before_attempt: list[tuple[int, str, str]]
+    history_after_attempt: list[tuple[int, str, str]]
+    final_history: list[tuple[int, str, str]]
+
+
+def task_llm_facing() -> list[GraderResult]:
+    """Grade prompt success, timeout/429 atomicity, and explicit fallback."""
+    return asyncio.run(_task_llm_facing())
+
+
+def _llm_history(rows: list[dict], entity_id: int) -> list[tuple[int, str, str]]:
+    return sorted(
+        (
+            int(row["tick"]),
+            str(row["llmexchange__response"]),
+            str(row["llmexchange__source"]),
+        )
+        for row in rows
+        if int(row["entity_id"]) == entity_id and bool(row["is_active"])
+    )
+
+
+async def _exercise_llm_case(
+    runtime: ArchetypeRuntime,
+    storage_cfg: StorageConfig,
+    fixture: LocalOpenAIServer,
+    case: str,
+) -> _LLMCaseObservation:
+    world = runtime.world(f"llm-{case}", storage=storage_cfg)
+    entity_id = await world.spawn(LLMExchange(request=case))
+    await world.step()  # persist the raw request before the prompt processor sees it
+
+    before_info = await world.info()
+    before_history = _llm_history((await world.query(LLMExchange)).to_pylist(), entity_id)
+    timeout_seconds = 0.05 if case == "timeout" else 2.0
+    await world.add_processor(
+        FixturePromptProcessor(fixture.base_url, timeout_seconds=timeout_seconds)
+    )
+
+    attempt_error: Exception | None = None
+    try:
+        await world.step()
+    except Exception as exc:
+        # Daft deliberately surfaces provider-specific terminal exceptions.
+        # The eval observes their public effect rather than depending on one
+        # provider exception class as the repository-level contract.
+        attempt_error = exc
+
+    after_info = await world.info()
+    after_history = _llm_history((await world.query(LLMExchange)).to_pylist(), entity_id)
+
+    if attempt_error is not None:
+        await world.remove_processor(FixturePromptProcessor)
+        await world.add_processor(DeterministicLLMFallback(case))
+        await world.step()  # retry the unchanged tick without another provider call
+
+    final_info = await world.info()
+    final_history = _llm_history((await world.query(LLMExchange)).to_pylist(), entity_id)
+    return _LLMCaseObservation(
+        case=case,
+        error_type=type(attempt_error).__name__ if attempt_error is not None else None,
+        error_message=str(attempt_error) if attempt_error is not None else "",
+        tick_before_attempt=before_info.tick,
+        tick_after_attempt=after_info.tick,
+        final_tick=final_info.tick,
+        history_before_attempt=before_history,
+        history_after_attempt=after_history,
+        final_history=final_history,
+    )
+
+
+async def _task_llm_facing() -> list[GraderResult]:
+    with tempfile.TemporaryDirectory() as tmp, LocalOpenAIServer() as fixture:
+        storage_cfg = StorageConfig(uri=f"{tmp}/store", namespace="eval_llm_facing")
+        async with ArchetypeRuntime() as runtime:
+            observations = {
+                case: await _exercise_llm_case(runtime, storage_cfg, fixture, case)
+                for case in ("healthy", "timeout", "quota")
+            }
+        request_counts = fixture.request_counts
+
+    healthy = observations["healthy"]
+    timeout = observations["timeout"]
+    quota = observations["quota"]
+    timeout_detail = f"{timeout.error_type} {timeout.error_message}".lower()
+    quota_detail = f"{quota.error_type} {quota.error_message}".lower()
+
+    return [
+        exact_match(
+            healthy.final_history,
+            [(0, "", "pending"), (1, "provider:healthy", "provider")],
+            name="healthy_prompt_persists",
+        ),
+        exact_match(
+            timeout.final_history,
+            [(0, "", "pending"), (1, "fallback:timeout", "fallback")],
+            name="timeout_fallback_is_deterministic",
+        ),
+        exact_match(
+            quota.final_history,
+            [(0, "", "pending"), (1, "fallback:quota", "fallback")],
+            name="quota_fallback_is_deterministic",
+        ),
+        state_check(
+            {
+                "healthy_call_succeeded": healthy.error_type is None,
+                "timeout_error_surfaced": (
+                    timeout.error_type is not None and "timed out" in timeout_detail
+                ),
+                "quota_error_surfaced": (
+                    quota.error_type is not None
+                    and "429" in quota_detail
+                    and "quota exhausted" in quota_detail
+                ),
+            },
+            name="provider_outcomes_surface",
+        ),
+        state_check(
+            {
+                "timeout_tick_did_not_advance": (
+                    timeout.tick_before_attempt == timeout.tick_after_attempt == 1
+                ),
+                "timeout_committed_nothing": (
+                    timeout.history_after_attempt == timeout.history_before_attempt
+                ),
+                "quota_tick_did_not_advance": (
+                    quota.tick_before_attempt == quota.tick_after_attempt == 1
+                ),
+                "quota_committed_nothing": (
+                    quota.history_after_attempt == quota.history_before_attempt
+                ),
+                "fallback_retried_the_same_tick": (timeout.final_tick == quota.final_tick == 2),
+            },
+            name="llm_failure_is_whole_tick_atomic",
+        ),
+        exact_match(
+            request_counts,
+            {"healthy": 1, "timeout": 1, "quota": 1},
+            name="provider_attempts_are_bounded",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Register all capability tasks
 # ---------------------------------------------------------------------------
 
@@ -795,4 +1008,10 @@ def register(harness: EvalHarness) -> None:
         suite=SUITE,
         fn=task_processor_adversarial,
         desc="Hook isolation, atomic processor failure, retry, and migration-aware matching",
+    )
+    harness.add(
+        "llm_facing",
+        suite=SUITE,
+        fn=task_llm_facing,
+        desc="Prompt success, bounded timeout/429 failure, atomicity, and deterministic fallback",
     )

--- a/examples/05_llm_agents.py
+++ b/examples/05_llm_agents.py
@@ -27,6 +27,7 @@ import os
 import sys
 
 from daft import DataFrame, col
+from daft.ai.openai.provider import OpenAIProvider
 from daft.functions import prompt
 
 from archetype import ArchetypeRuntime
@@ -57,6 +58,9 @@ class ThinkProcessor(AsyncProcessor):
     components = (Agent,)
     priority = 10
 
+    def __init__(self, provider: OpenAIProvider) -> None:
+        self._provider = provider
+
     async def process(self, df: DataFrame, tick: int = 0, **kwargs) -> DataFrame:
         # Build a prompt from each agent's name, role, and journal
         input_col = (
@@ -78,6 +82,7 @@ class ThinkProcessor(AsyncProcessor):
                 "Respond with a single short thought or action. "
                 "Be creative and stay in character."
             ),
+            provider=self._provider,
             model="gpt-5-mini",
             max_output_tokens=60,
         )
@@ -110,9 +115,14 @@ async def main():
         ("Iris", "You are a thoughtful philosopher who questions everything."),
     ]
     storage = StorageConfig(uri="./archetype_data", namespace="llm_agents")
+    provider = OpenAIProvider(timeout=30.0, max_retries=2)
 
     async with ArchetypeRuntime() as runtime:
-        world = runtime.world("llm-agents", storage=storage, processors=[ThinkProcessor()])
+        world = runtime.world(
+            "llm-agents",
+            storage=storage,
+            processors=[ThinkProcessor(provider)],
+        )
 
         for name, role in agents:
             await world.spawn(Agent(name=name, role=role))

--- a/examples/05_llm_agents.py
+++ b/examples/05_llm_agents.py
@@ -15,7 +15,7 @@ of their thoughts over time.
 
 Requirements:
     export OPENAI_API_KEY=sk-...
-    # or configure any provider via daft.set_provider()
+    # Provider timeout/retry policy is constructed explicitly in main().
 
 Usage:
     uv run python examples/05_llm_agents.py

--- a/examples/06_trajectory_analysis.py
+++ b/examples/06_trajectory_analysis.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import daft
 from daft import DataFrame, col
+from daft.ai.openai.provider import OpenAIProvider
 from daft.functions import dense_rank
 
 from archetype import ArchetypeRuntime
@@ -262,6 +263,9 @@ class LabelingProcessor(AsyncProcessor):
     components = (SessionTrajectory, Label)
     priority = 20
 
+    def __init__(self, provider: OpenAIProvider) -> None:
+        self._provider = provider
+
     async def process(
         self, df: DataFrame, resources: Resources | None = None, **kwargs: Any
     ) -> DataFrame:
@@ -300,6 +304,7 @@ class LabelingProcessor(AsyncProcessor):
 
         llm_col = prompt(
             eval_prompt,
+            provider=self._provider,
             model=config.model,
             max_output_tokens=config.max_output_tokens,
         )
@@ -531,6 +536,9 @@ def make_trajectories() -> list[SessionTrajectory]:
 
 async def main():
     has_openai_key = bool(os.getenv("OPENAI_API_KEY"))
+    labeling_processor = (
+        LabelingProcessor(OpenAIProvider(timeout=30.0, max_retries=2)) if has_openai_key else None
+    )
 
     trajectories = make_trajectories()
     print(f"Created {len(trajectories)} synthetic trajectories\n")
@@ -543,7 +551,7 @@ async def main():
             storage=storage,
             processors=[
                 SamplingProcessor(),
-                *([LabelingProcessor()] if has_openai_key else []),
+                *([labeling_processor] if labeling_processor is not None else []),
                 ScoringProcessor(),
             ],
             resources=[SamplingConfig(min_turns=3), LabelingConfig(model="gpt-5-mini")],

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -41,6 +41,16 @@ _LLM_EXAMPLES = (
     Path("examples/05_llm_agents.py"),
     Path("examples/06_trajectory_analysis.py"),
 )
+_LLM_REFERENCE_SURFACES = (
+    Path("AGENTS.md"),
+    _GUIDE_ROOT / "trajectories.md",
+    Path("examples/05_llm_agents.py"),
+)
+_STALE_LLM_POLICY = (
+    "LabelingProcessor()",
+    "or configure any provider via daft.set_provider()",
+)
+_REQUIRED_LLM_POLICY = ("OpenAIProvider(", "timeout=", "max_retries=")
 
 
 def _direct_call_name(node: ast.Call) -> str | None:
@@ -207,3 +217,22 @@ def test_llm_examples_use_explicit_bounded_providers() -> None:
     violations = [violation for path in _LLM_EXAMPLES for violation in _llm_policy_violations(path)]
 
     assert not violations, "unbounded LLM examples:\n" + "\n".join(violations)
+
+
+def test_llm_reference_surfaces_reject_stale_provider_policy() -> None:
+    """Copyable guidance follows required explicit-provider constructors."""
+    text_by_path = {path: path.read_text() for path in _LLM_REFERENCE_SURFACES}
+    violations = [
+        f"{path}: contains {snippet}"
+        for path, text in text_by_path.items()
+        for snippet in _STALE_LLM_POLICY
+        if snippet in text
+    ]
+    violations.extend(
+        f"{path}: omits {snippet}"
+        for path, text in text_by_path.items()
+        for snippet in _REQUIRED_LLM_POLICY
+        if snippet not in text
+    )
+
+    assert not violations, "stale LLM provider guidance:\n" + "\n".join(violations)

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -37,6 +37,33 @@ _BEGINNER_EXAMPLES = (
     Path("examples/00_quickstart.py"),
     Path("examples/simulation_script.py"),
 )
+_LLM_EXAMPLES = (
+    Path("examples/05_llm_agents.py"),
+    Path("examples/06_trajectory_analysis.py"),
+)
+
+
+def _direct_call_name(node: ast.Call) -> str | None:
+    return node.func.id if isinstance(node.func, ast.Name) else None
+
+
+def _llm_policy_violations(path: Path) -> list[str]:
+    violations: list[str] = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        call_name = _direct_call_name(node)
+        keywords = {keyword.arg for keyword in node.keywords}
+        if call_name == "prompt" and "provider" not in keywords:
+            violations.append(f"{path}:{node.lineno} prompt() has no explicit provider")
+        elif call_name == "OpenAIProvider" and not {"timeout", "max_retries"} <= keywords:
+            violations.append(
+                f"{path}:{node.lineno} OpenAIProvider() has no bounded attempt policy"
+            )
+
+    return violations
 
 
 def test_numeric_command_type_claims_match_the_enum() -> None:
@@ -173,3 +200,10 @@ def test_quickstart_variants_stage_initial_state_before_running() -> None:
         run = section.find("world.run(steps=3)", spawn)
         assert -1 not in (spawn, step, run), f"{name} quickstart lifecycle is incomplete"
         assert spawn < step < run, f"{name} quickstart must persist spawns before its run"
+
+
+def test_llm_examples_use_explicit_bounded_providers() -> None:
+    """Reference prompts never inherit a provider's ambient retry policy."""
+    violations = [violation for path in _LLM_EXAMPLES for violation in _llm_policy_violations(path)]
+
+    assert not violations, "unbounded LLM examples:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary

- add a credential-free loopback OpenAI-compatible fixture that drives the real pinned `daft.functions.prompt` transport through success, timeout, and HTTP 429 outcomes
- add the public-runtime `llm_facing` capability task, grading failed-tick atomicity, bounded attempts, and explicit deterministic fallback on the unchanged tick
- align the processor, execution, quota, specification, eval, and contributor guidance around the actual boundary: world state is atomic; provider requests and spend are not transactional
- inject explicit timeout/retry policy into the LLM example while preserving its credential-free degraded smoke path
- record #442 for the first admitted Daft release containing upstream option-routing fix Eventual-Inc/Daft#7277; this change deliberately adds no vendored patch or runtime monkeypatch

## Contract

The built-in prompt path stays fail-closed after bounded provider retries. A terminal timeout or quota response raises through `step()`, advances no tick, and appends no world rows. A caller that chooses continuation installs a deterministic fallback processor and retries that same tick without another provider call.

This is state atomicity, not external exactly-once: calls already served or billed cannot be rolled back and may repeat on retry. Command-gate token costs remain admission estimates rather than measured model usage.

No `core/`, `app/`, or runtime production behavior changes.

## Validation

- `make ci`: 1,144 passed, 6 skipped; 86.28% coverage; regression 15/15; idempotency 23/23
- `uv run python -m evals.run --suite capability --trials 3`: 6/6 tasks; `llm_facing` pass@3 and pass^3 100%
- direct `llm_facing`: 6/6 graders
- documentation contracts: 8 passed
- `make docs`: passed
- Markdown lint: 69 files, 0 issues
- `uvx ty@0.0.48 check --python .venv`: passed
- Ruff lint and format: passed
- `OPENAI_API_KEY= uv run python examples/05_llm_agents.py`: graceful credential-free exit
- Radon: A average; new task A (5), case exercise B (6), fixture maximum B (7)

Closes #142.
Related to #442.
