### PR TITLE
fix: remove vulnerable thrift dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
 dependencies = [
  "bytes",
  "half",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -161,18 +161,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -237,12 +237,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -485,12 +479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,19 +600,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "parquet"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+checksum = "5302d4da74d6596a1f11f9928767995b53bca657cbeea1e4e8c5074f8a1157dd"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -648,7 +627,6 @@ dependencies = [
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "twox-hash",
  "zstd",
 ]
@@ -839,17 +817,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,15 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 anyhow = "1.0.100"
-arrow-array = { version = "58.3.0", features = ["ffi"] }
-arrow-buffer = "58.3.0"
-arrow-data = { version = "58.3.0", features = ["ffi"] }
-arrow-schema = { version = "58.3.0", features = ["ffi"] }
-arrow-select = "58.3.0"
+# Security floor: Parquet 59 removes thrift <0.23 (CVE-2026-43868).
+# Keep the Arrow family aligned so one schema/array ABI reaches every crate.
+arrow-array = { version = "59.1.0", features = ["ffi"] }
+arrow-buffer = "59.1.0"
+arrow-data = { version = "59.1.0", features = ["ffi"] }
+arrow-schema = { version = "59.1.0", features = ["ffi"] }
+arrow-select = "59.1.0"
 async-trait = "0.1.89"
-parquet = { version = "58.3.0", features = ["arrow"] }
+parquet = { version = "59.1.0", features = ["arrow"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }

--- a/tests/spec_contracts/test_dependency_contracts.py
+++ b/tests/spec_contracts/test_dependency_contracts.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executable contracts for security-sensitive dependency floors."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_PATCHED_THRIFT_RELEASE = (0, 23, 0)
+
+
+def _is_affected_thrift(version: str) -> bool:
+    release = version.split("+", 1)[0]
+    core, prerelease_separator, _prerelease = release.partition("-")
+    parts = tuple(int(part) for part in core.split("."))
+    return parts < _PATCHED_THRIFT_RELEASE or (
+        parts == _PATCHED_THRIFT_RELEASE and bool(prerelease_separator)
+    )
+
+
+def test_thrift_advisory_boundary_matches_semver_ordering() -> None:
+    expected = {
+        "0.17.0": True,
+        "0.22.0": True,
+        "0.23.0-rc.1": True,
+        "0.23.0": False,
+        "0.24.0": False,
+    }
+
+    assert {version: _is_affected_thrift(version) for version in expected} == expected
+
+
+def test_cargo_lock_excludes_thrift_affected_by_cve_2026_43868() -> None:
+    lock = tomllib.loads(Path("Cargo.lock").read_text())
+    affected = [
+        package["version"]
+        for package in lock["package"]
+        if package["name"] == "thrift" and _is_affected_thrift(package["version"])
+    ]
+
+    assert not affected, (
+        f"Cargo.lock reintroduced thrift before 0.23.0 (CVE-2026-43868): {', '.join(affected)}"
+    )


### PR DESCRIPTION
Closes #329.

## Contract

- The Rust workspace must not resolve an Apache Thrift release before `0.23.0`,
  the affected range for CVE-2026-43868.
- Arrow crates stay on one release family so `RecordBatch`, schema, FFI, and
  Parquet types cross crate boundaries without duplicate-version type splits.

## Change

- Upgrade the coordinated Arrow/Parquet family from `58.3.0` to `59.1.0`.
- Remove `thrift 0.17.0` and its now-unused transitive dependencies from
  `Cargo.lock`; Parquet 59 uses its own compact-protocol implementation.
- Add an executable lockfile contract for the advisory boundary, including the
  `0.23.0-rc` prerelease edge.
- Record the security and lockstep rationale beside the workspace dependencies.

Upstream explicitly removed the dependency for this advisory in
<https://github.com/apache/arrow-rs/pull/9962>; the removal shipped in
<https://github.com/apache/arrow-rs/releases/tag/59.0.0>.

## Validation

- `make ci` — 1,145 passed, 7 skipped, 86.24% coverage; regression 15/15;
  idempotency 23/23
- `cargo fmt --all --check`
- `cargo test --workspace --all-targets --locked` — 40 passed, 1 ignored
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `pytest tests/spec_contracts/test_dependency_contracts.py -q` — 2 passed
- `ruff check` and `ruff format --check` for the new contract
- dependency graph contains one Arrow 59.1 family and no `thrift` package
