### PR TITLE
feat(bench): add comparable trend reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,9 @@ help:
 	@echo "  make mutmut-clean   Remove mutmut cache and generated mutants"
 	@echo ""
 	@echo "Benchmarks & Evals:"
-	@echo "  make bench          Run ECS microbenchmarks (1 step)"
-	@echo "  make bench-full     Run ECS microbenchmarks (3 steps)"
+	@echo "  make bench          Run and archive ECS microbenchmarks (1 step)"
+	@echo "  make bench-full     Run and archive ECS microbenchmarks (3 steps)"
+	@echo "  make bench-compare  Compare the latest run with compatible history"
 	@echo "  make eval           Run all eval suites"
 	@echo "  make eval-reg       Run regression suite only"
 	@echo "  make eval-idem      Run idempotency suite only"
@@ -200,15 +201,21 @@ mutmut-clean:
 # Benchmarks & Evals
 # ------------------------------------------------------------------------------
 
+BENCH_HISTORY ?= .bench_out/history
+
 .PHONY: bench
 bench:
-	@PYTHONPATH=$(PYTHONPATH) uv run python -m bench.core.ecs.run --steps 1 --out bench-results.json
+	@PYTHONPATH=$(PYTHONPATH) uv run python -m bench.core.ecs.run --steps 1 --out bench-results.json --history-dir "$(BENCH_HISTORY)"
 	@echo "Benchmark results written to bench-results.json"
 
 .PHONY: bench-full
 bench-full:
-	@PYTHONPATH=$(PYTHONPATH) uv run python -m bench.core.ecs.run --steps 3 --out bench-results.json
+	@PYTHONPATH=$(PYTHONPATH) uv run python -m bench.core.ecs.run --steps 3 --out bench-results.json --history-dir "$(BENCH_HISTORY)"
 	@echo "Benchmark results written to bench-results.json"
+
+.PHONY: bench-compare
+bench-compare:
+	@PYTHONPATH=$(PYTHONPATH) uv run python -m bench.core.compare --current bench-results.json --history-dir "$(BENCH_HISTORY)"
 
 .PHONY: eval
 eval:

--- a/bench/core/compare.py
+++ b/bench/core/compare.py
@@ -1,0 +1,329 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare one benchmark report with compatible historical runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from bench.core.report import (
+    ReportFormatError,
+    benchmark_identity,
+    compatibility_identity,
+    load_report,
+    report_timestamp,
+    validate_report,
+)
+
+Direction = Literal["lower", "higher"]
+
+
+@dataclass(frozen=True)
+class MetricRule:
+    """Describe which direction represents improvement for one metric."""
+
+    name: str
+    direction: Direction
+
+
+@dataclass(frozen=True)
+class BaselineSelection:
+    """Compatible prior reports selected for one chronological window."""
+
+    reports: tuple[dict[str, Any], ...]
+    compatible_available: int
+    incompatible_report_ids: tuple[str, ...]
+    non_prior_report_ids: tuple[str, ...]
+
+
+DEFAULT_RULES = (
+    MetricRule("elapsed_s", "lower"),
+    MetricRule("steps_per_sec", "higher"),
+    MetricRule("entities_per_sec", "higher"),
+)
+
+
+def compare_report(
+    current: Mapping[str, Any],
+    baselines: Sequence[Mapping[str, Any]],
+    *,
+    rules: Sequence[MetricRule] = DEFAULT_RULES,
+    min_samples: int = 3,
+    sigma_multiplier: float = 2.0,
+    history_window: int = 20,
+) -> dict[str, Any]:
+    """Compare current metrics against matching historical distributions.
+
+    Reports must have the same suite, benchmark configuration, runner, OS,
+    Python, and dependency versions. Each metric is aligned by benchmark name
+    and dimensions. A regression lies strictly beyond the rolling median by
+    ``sigma_multiplier`` population standard deviations in the worse direction.
+    """
+    _validate_options(
+        min_samples=min_samples,
+        sigma_multiplier=sigma_multiplier,
+        history_window=history_window,
+    )
+    current_report = validate_report(dict(current))
+    selection = _select_baselines(current_report, baselines, history_window=history_window)
+    baseline_by_benchmark = _index_benchmarks(selection.reports)
+    comparisons = _comparison_rows(
+        current_report,
+        baseline_by_benchmark,
+        rules=rules,
+        min_samples=min_samples,
+        sigma_multiplier=sigma_multiplier,
+    )
+    regression_count = _status_count(comparisons, "regression")
+    insufficient_count = _status_count(comparisons, "insufficient")
+    return {
+        "current_report_id": current_report["report_id"],
+        "compatible_reports_available": selection.compatible_available,
+        "compatible_reports": len(selection.reports),
+        "baseline_report_ids": [report["report_id"] for report in selection.reports],
+        "incompatible_report_ids": list(selection.incompatible_report_ids),
+        "non_prior_report_ids": list(selection.non_prior_report_ids),
+        "history_window": history_window,
+        "min_samples": min_samples,
+        "sigma_multiplier": sigma_multiplier,
+        "status": _summary_status(comparisons),
+        "regression_count": regression_count,
+        "insufficient_count": insufficient_count,
+        "comparisons": comparisons,
+    }
+
+
+def _validate_options(*, min_samples: int, sigma_multiplier: float, history_window: int) -> None:
+    if min_samples < 2:
+        raise ValueError("min_samples must be at least 2")
+    if not math.isfinite(sigma_multiplier) or sigma_multiplier <= 0:
+        raise ValueError("sigma_multiplier must be finite and positive")
+    if history_window < min_samples:
+        raise ValueError("history_window must be at least min_samples")
+
+
+def _select_baselines(
+    current: Mapping[str, Any],
+    candidates: Sequence[Mapping[str, Any]],
+    *,
+    history_window: int,
+) -> BaselineSelection:
+    current_id = current["report_id"]
+    compatibility = compatibility_identity(current)
+    timestamp = report_timestamp(current)
+    compatible: dict[str, dict[str, Any]] = {}
+    incompatible_ids: set[str] = set()
+    non_prior_ids: set[str] = set()
+
+    for candidate in candidates:
+        report = validate_report(dict(candidate))
+        report_id = report["report_id"]
+        if report_id == current_id or report_id in compatible:
+            continue
+        if compatibility_identity(report) != compatibility:
+            incompatible_ids.add(report_id)
+        elif report_timestamp(report) >= timestamp:
+            non_prior_ids.add(report_id)
+        else:
+            compatible[report_id] = report
+
+    selected = sorted(
+        compatible.values(), key=lambda report: (report_timestamp(report), report["report_id"])
+    )[-history_window:]
+    return BaselineSelection(
+        reports=tuple(selected),
+        compatible_available=len(compatible),
+        incompatible_report_ids=tuple(sorted(incompatible_ids)),
+        non_prior_report_ids=tuple(sorted(non_prior_ids)),
+    )
+
+
+def _index_benchmarks(
+    reports: Sequence[Mapping[str, Any]],
+) -> dict[str, list[Mapping[str, Any]]]:
+    indexed: dict[str, list[Mapping[str, Any]]] = {}
+    for report in reports:
+        for benchmark in report["benchmarks"]:
+            indexed.setdefault(benchmark_identity(benchmark), []).append(benchmark)
+    return indexed
+
+
+def _comparison_rows(
+    current: Mapping[str, Any],
+    baselines: Mapping[str, Sequence[Mapping[str, Any]]],
+    *,
+    rules: Sequence[MetricRule],
+    min_samples: int,
+    sigma_multiplier: float,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    rule_by_name = {rule.name: rule for rule in rules}
+    for benchmark in current["benchmarks"]:
+        historical = baselines.get(benchmark_identity(benchmark), ())
+        for metric_name, current_value in sorted(benchmark["metrics"].items()):
+            rule = rule_by_name.get(metric_name)
+            if rule is not None:
+                rows.append(
+                    _compare_metric(
+                        benchmark=benchmark,
+                        metric=rule,
+                        current_value=current_value,
+                        samples=_metric_samples(historical, metric_name),
+                        min_samples=min_samples,
+                        sigma_multiplier=sigma_multiplier,
+                    )
+                )
+    return rows
+
+
+def _metric_samples(benchmarks: Sequence[Mapping[str, Any]], metric_name: str) -> list[float]:
+    return [
+        benchmark["metrics"][metric_name]
+        for benchmark in benchmarks
+        if metric_name in benchmark["metrics"]
+    ]
+
+
+def _status_count(comparisons: Sequence[Mapping[str, Any]], status: str) -> int:
+    return sum(row["status"] == status for row in comparisons)
+
+
+def _summary_status(comparisons: Sequence[Mapping[str, Any]]) -> str:
+    statuses = {row["status"] for row in comparisons}
+    if "regression" in statuses:
+        return "regression"
+    if "insufficient" in statuses or not statuses:
+        return "insufficient"
+    return "ok"
+
+
+def _compare_metric(
+    *,
+    benchmark: Mapping[str, Any],
+    metric: MetricRule,
+    current_value: float,
+    samples: Sequence[float],
+    min_samples: int,
+    sigma_multiplier: float,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "benchmark": benchmark["name"],
+        "dimensions": benchmark["dimensions"],
+        "metric": metric.name,
+        "direction": metric.direction,
+        "current": current_value,
+        "baseline_samples": len(samples),
+        "median": None,
+        "population_sigma": None,
+        "regression_threshold": None,
+        "worse_by_sigma": None,
+        "delta_percent": None,
+        "status": "insufficient",
+    }
+    if len(samples) < min_samples:
+        return row
+
+    median = statistics.median(samples)
+    population_sigma = statistics.pstdev(samples)
+    regression_threshold = (
+        median + sigma_multiplier * population_sigma
+        if metric.direction == "lower"
+        else median - sigma_multiplier * population_sigma
+    )
+    regressed = (
+        current_value > regression_threshold
+        if metric.direction == "lower"
+        else current_value < regression_threshold
+    )
+    worse_delta = current_value - median if metric.direction == "lower" else median - current_value
+
+    row.update(
+        {
+            "median": median,
+            "population_sigma": population_sigma,
+            "regression_threshold": regression_threshold,
+            "worse_by_sigma": worse_delta / population_sigma if population_sigma else None,
+            "delta_percent": ((current_value - median) / median * 100) if median else None,
+            "status": "regression" if regressed else "ok",
+        }
+    )
+    return row
+
+
+def _load_history(directory: Path, *, current_path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    baselines: list[dict[str, Any]] = []
+    invalid: list[str] = []
+    current_resolved = current_path.resolve()
+    if not directory.exists():
+        return baselines, invalid
+
+    for path in sorted(directory.glob("*.json")):
+        if path.resolve() == current_resolved:
+            continue
+        try:
+            baselines.append(load_report(path))
+        except ReportFormatError as exc:
+            invalid.append(str(exc))
+    return baselines, invalid
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare compatible Archetype benchmark runs")
+    parser.add_argument("--current", type=Path, required=True, help="Current schema-v1 report")
+    parser.add_argument(
+        "--history-dir",
+        type=Path,
+        required=True,
+        help="Directory containing historical schema-v1 reports",
+    )
+    parser.add_argument("--min-samples", type=int, default=3)
+    parser.add_argument("--sigma", type=float, default=2.0, dest="sigma_multiplier")
+    parser.add_argument("--window", type=int, default=20, dest="history_window")
+    parser.add_argument("--out", type=Path, default=None, help="Optional JSON summary path")
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Exit 1 when a comparable metric crosses its regression threshold",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        current = load_report(args.current)
+        baselines, invalid = _load_history(args.history_dir, current_path=args.current)
+        if invalid:
+            raise ReportFormatError("; ".join(invalid))
+        summary = compare_report(
+            current,
+            baselines,
+            min_samples=args.min_samples,
+            sigma_multiplier=args.sigma_multiplier,
+            history_window=args.history_window,
+        )
+    except (OSError, ReportFormatError, ValueError) as exc:
+        print(f"benchmark comparison failed: {exc}", file=sys.stderr)
+        return 2
+
+    rendered = json.dumps(summary, allow_nan=False, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered)
+    print(rendered, end="")
+    if args.fail_on_regression and summary["status"] == "regression":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/core/ecs/add_remove.py
+++ b/bench/core/ecs/add_remove.py
@@ -57,13 +57,11 @@ async def run(
     orchestrator: WorldService | None = None,
     storage: StorageConfig | None = None,
     cache_config: CacheConfig | None = None,
-    instrumented: bool | None = None,
 ) -> tuple[BenchResult, tuple]:
     world, orch = await make_world(
         "add-remove",
         storage=storage,
         cache_config=cache_config,
-        instrumented=instrumented,
         orchestrator=orchestrator,
     )
     try:

--- a/bench/core/ecs/common.py
+++ b/bench/core/ecs/common.py
@@ -52,7 +52,6 @@ async def make_world(
     system: AsyncSystem | None = None,
     storage: StorageConfig | None = None,
     cache_config: CacheConfig | None = None,
-    instrumented: bool | None = None,
     orchestrator: WorldService | None = None,
 ) -> tuple[object, WorldService]:
     """

--- a/bench/core/ecs/entity_cycle.py
+++ b/bench/core/ecs/entity_cycle.py
@@ -56,13 +56,11 @@ async def run(
     orchestrator: WorldService | None = None,
     storage: StorageConfig | None = None,
     cache_config: CacheConfig | None = None,
-    instrumented: bool | None = None,
 ) -> tuple[BenchResult, tuple]:
     world, orch = await make_world(
         "entity-cycle",
         storage=storage,
         cache_config=cache_config,
-        instrumented=instrumented,
         orchestrator=orchestrator,
     )
     try:

--- a/bench/core/ecs/fragmented_iteration.py
+++ b/bench/core/ecs/fragmented_iteration.py
@@ -51,13 +51,11 @@ async def run(
     orchestrator: WorldService | None = None,
     storage: StorageConfig | None = None,
     cache_config: CacheConfig | None = None,
-    instrumented: bool | None = None,
 ) -> tuple[BenchResult, tuple]:
     world, orch = await make_world(
         "fragmented-iteration",
         storage=storage,
         cache_config=cache_config,
-        instrumented=instrumented,
         orchestrator=orchestrator,
     )
     try:

--- a/bench/core/ecs/packed_iteration.py
+++ b/bench/core/ecs/packed_iteration.py
@@ -77,13 +77,11 @@ async def run(
     orchestrator: WorldService | None = None,
     storage: StorageConfig | None = None,
     cache_config: CacheConfig | None = None,
-    instrumented: bool | None = None,
 ) -> tuple[BenchResult, tuple]:
     world, orch = await make_world(
         "packed-iteration",
         storage=storage,
         cache_config=cache_config,
-        instrumented=instrumented,
         orchestrator=orchestrator,
     )
     try:

--- a/bench/core/ecs/run.py
+++ b/bench/core/ecs/run.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from dataclasses import asdict
 
 from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
+from bench.core.report import build_report, capture_environment, write_report
 
 from . import add_remove, entity_cycle, fragmented_iteration, packed_iteration, simple_iteration
 from .common import _default_storage
@@ -21,12 +22,24 @@ def _storage_for_bench(storage: StorageConfig | None, bench_name: str) -> Storag
     return storage.model_copy(update={"namespace": namespace})
 
 
+def _storage_from_args(args: argparse.Namespace) -> StorageConfig:
+    """Resolve CLI overrides against the same defaults used by ``run_all``."""
+    storage = _default_storage()
+    updates = {}
+    if args.uri is not None:
+        updates["uri"] = args.uri
+    if args.namespace is not None:
+        updates["namespace"] = args.namespace
+    if args.backend is not None:
+        updates["backend"] = StorageBackend(args.backend)
+    return storage.model_copy(update=updates)
+
+
 async def run_all(
     *,
     steps: int = 1,
     storage: StorageConfig | None = None,
     cache: CacheConfig | None = None,
-    instrumented: bool | None = None,
 ) -> list[dict]:
     results = []
     benches: Sequence[tuple[str, callable]] = [
@@ -43,7 +56,6 @@ async def run_all(
             orchestrator=None,
             storage=_storage_for_bench(storage, name),
             cache_config=cache,
-            instrumented=instrumented,
         )
         rec = asdict(res)
         rec.update({"world_id": str(ids[0]), "run_id": str(ids[1]), "bench_name": name})
@@ -56,33 +68,47 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Run ECS microbenchmarks")
     p.add_argument("--steps", type=int, default=1)
     p.add_argument("--use-cache", action="store_true")
-    p.add_argument("--backend", choices=["iceberg", "lancedb"], default="iceberg")
+    p.add_argument(
+        "--backend",
+        choices=["iceberg", "lancedb"],
+        default=None,
+        help="Override StorageConfig's backend",
+    )
     p.add_argument("--uri", default=None, help="Override storage uri (absolute path recommended)")
-    p.add_argument("--namespace", default="benchmarks")
-    p.add_argument("--instrumented", action="store_true")
-    p.add_argument("--out", default=None, help="Write JSON results to this file")
+    p.add_argument("--namespace", default=None, help="Override ARCHETYPE_BENCH_NS")
+    p.add_argument("--out", default=None, help="Write the current schema-v1 report here")
+    p.add_argument(
+        "--history-dir",
+        default=None,
+        help="Also archive the report in this history directory",
+    )
+    p.add_argument(
+        "--runner-id",
+        default=None,
+        help="Stable machine identity; defaults to ARCHETYPE_BENCH_RUNNER or hostname",
+    )
     return p.parse_args()
 
 
 def main():
     args = parse_args()
-    storage = None
-    if args.uri:
-        backend = StorageBackend.ICEBERG if args.backend == "iceberg" else StorageBackend.LANCEDB
-        storage = StorageConfig(uri=args.uri, namespace=args.namespace, backend=backend)
+    storage = _storage_from_args(args)
     cache = CacheConfig() if args.use_cache else None
-    out = asyncio.run(
-        run_all(steps=args.steps, storage=storage, cache=cache, instrumented=args.instrumented)
+    results = asyncio.run(run_all(steps=args.steps, storage=storage, cache=cache))
+    report = build_report(
+        results,
+        suite="ecs",
+        config={
+            "steps": args.steps,
+            "storage_backend": storage.backend.value,
+            "cache": args.use_cache,
+        },
+        environment=capture_environment(runner_id=args.runner_id),
     )
-    if args.out:
-        import os
-
-        os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
-        with open(args.out, "w") as f:
-            json.dump(out, f, indent=2)
-    else:
-        for r in out:
-            print(r)
+    if args.out is not None or args.history_dir is not None:
+        write_report(report, current_path=args.out, history_dir=args.history_dir)
+    if args.out is None:
+        print(json.dumps(report, allow_nan=False, indent=2, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/bench/core/ecs/simple_iteration.py
+++ b/bench/core/ecs/simple_iteration.py
@@ -77,13 +77,11 @@ async def run(
     orchestrator: WorldService | None = None,
     storage: StorageConfig | None = None,
     cache_config: CacheConfig | None = None,
-    instrumented: bool | None = None,
 ) -> tuple[BenchResult, tuple]:
     world, orch = await make_world(
         "simple-iteration",
         storage=storage,
         cache_config=cache_config,
-        instrumented=instrumented,
         orchestrator=orchestrator,
     )
     try:

--- a/bench/core/report.py
+++ b/bench/core/report.py
@@ -1,0 +1,390 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned benchmark reports with explicit comparability provenance."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import platform
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+_PACKAGES = ("archetype-ecs", "daft", "lancedb", "pyiceberg")
+
+
+class ReportFormatError(ValueError):
+    """A benchmark report does not satisfy the versioned wire contract."""
+
+
+def capture_environment(*, runner_id: str | None = None) -> dict[str, Any]:
+    """Capture fields that determine whether two timing runs are comparable."""
+    packages: dict[str, str] = {}
+    for package in _PACKAGES:
+        try:
+            packages[package] = metadata.version(package)
+        except metadata.PackageNotFoundError:
+            packages[package] = "not-installed"
+
+    return {
+        "runner_id": (
+            runner_id or os.environ.get("ARCHETYPE_BENCH_RUNNER") or platform.node() or "unknown"
+        ),
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "python_implementation": platform.python_implementation(),
+        "python_version": platform.python_version(),
+        "packages": packages,
+    }
+
+
+def capture_revision() -> dict[str, Any]:
+    """Capture the measured Git revision without making Git a hard dependency."""
+    commit = os.environ.get("GITHUB_SHA")
+    if not commit:
+        commit = _git_output("rev-parse", "HEAD") or "unknown"
+
+    dirty_output = _git_output("status", "--short")
+    return {
+        "commit": commit,
+        "dirty": None if dirty_output is None else bool(dirty_output),
+    }
+
+
+def build_report(
+    results: Sequence[Mapping[str, Any]],
+    *,
+    suite: str,
+    config: Mapping[str, Any],
+    environment: Mapping[str, Any] | None = None,
+    revision: Mapping[str, Any] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Normalize raw benchmark rows into the stable report schema."""
+    report: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "suite": suite,
+        "created_at": created_at or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "revision": dict(revision or capture_revision()),
+        "environment": dict(environment or capture_environment()),
+        "config": dict(config),
+        "benchmarks": [_normalize_result(result) for result in results],
+    }
+    _assert_json_value(report, "report")
+    report["report_id"] = _report_id(report)
+    validate_report(report)
+    return report
+
+
+def validate_report(report: Any) -> dict[str, Any]:
+    """Validate and return one schema-v1 report.
+
+    Historical files are inputs to regression decisions, so malformed or
+    hand-edited data fails closed instead of being silently ignored.
+    """
+    if not isinstance(report, dict):
+        raise ReportFormatError("report must be a JSON object")
+    _validate_report_header(report)
+    _validate_benchmarks(report.get("benchmarks"))
+
+    expected_id = _report_id({key: value for key, value in report.items() if key != "report_id"})
+    if report["report_id"] != expected_id:
+        raise ReportFormatError("report_id does not match report contents")
+    _assert_json_value(report, "report")
+    return report
+
+
+def _validate_report_header(report: Mapping[str, Any]) -> None:
+    if report.get("schema_version") != SCHEMA_VERSION:
+        raise ReportFormatError(
+            f"unsupported benchmark report schema: {report.get('schema_version')!r}"
+        )
+
+    for field in ("suite", "created_at", "report_id"):
+        if not isinstance(report.get(field), str) or not report[field]:
+            raise ReportFormatError(f"{field} must be a non-empty string")
+    _parse_created_at(report["created_at"])
+    for field in ("revision", "environment", "config"):
+        if not isinstance(report.get(field), dict):
+            raise ReportFormatError(f"{field} must be an object")
+    _validate_revision(report["revision"])
+    _validate_environment(report["environment"])
+
+
+def _validate_benchmarks(benchmarks: Any) -> None:
+    if not isinstance(benchmarks, list) or not benchmarks:
+        raise ReportFormatError("benchmarks must be a non-empty array")
+    identities: set[str] = set()
+    for index, benchmark in enumerate(benchmarks):
+        _validate_benchmark(benchmark, index)
+        identity = benchmark_identity(benchmark)
+        if identity in identities:
+            raise ReportFormatError(f"duplicate benchmark identity at benchmarks[{index}]")
+        identities.add(identity)
+
+
+def load_report(path: str | Path) -> dict[str, Any]:
+    """Load one report from disk and validate its content hash and schema."""
+    report_path = Path(path)
+    try:
+        payload = json.loads(report_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportFormatError(f"cannot read {report_path}: {exc}") from exc
+    try:
+        return validate_report(payload)
+    except ReportFormatError as exc:
+        raise ReportFormatError(f"invalid report {report_path}: {exc}") from exc
+
+
+def write_report(
+    report: Mapping[str, Any],
+    *,
+    current_path: str | Path | None = None,
+    history_dir: str | Path | None = None,
+) -> Path | None:
+    """Atomically write the current report and an optional immutable history copy."""
+    validated = validate_report(dict(report))
+    if current_path is None and history_dir is None:
+        raise ValueError("current_path or history_dir is required")
+
+    if current_path is not None:
+        _atomic_json_write(Path(current_path), validated)
+
+    if history_dir is None:
+        return None
+
+    history_path = Path(history_dir) / f"{validated['report_id']}.json"
+    if history_path.exists():
+        existing = load_report(history_path)
+        if existing != validated:
+            raise ReportFormatError(f"history collision at {history_path}")
+        return history_path
+    _atomic_json_write(history_path, validated)
+    return history_path
+
+
+def benchmark_identity(benchmark: Mapping[str, Any]) -> str:
+    """Return the stable identity used to align one benchmark across runs."""
+    payload = {
+        "name": benchmark["name"],
+        "dimensions": benchmark["dimensions"],
+    }
+    return _canonical_json(payload)
+
+
+def compatibility_identity(report: Mapping[str, Any]) -> str:
+    """Return the fields that must match before timing values are compared."""
+    payload = {
+        "suite": report["suite"],
+        "environment": report["environment"],
+        "config": report["config"],
+    }
+    return _canonical_json(payload)
+
+
+def report_timestamp(report: Mapping[str, Any]) -> datetime:
+    """Return a validated report timestamp for chronological windowing."""
+    value = report.get("created_at")
+    if not isinstance(value, str):
+        raise ReportFormatError("created_at must be a string")
+    return _parse_created_at(value)
+
+
+def _normalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    name = _required_string(result, "name")
+    bench_name = result.get("bench_name")
+    if bench_name is not None and bench_name != name:
+        raise ReportFormatError(f"bench_name {bench_name!r} does not match name {name!r}")
+
+    entities = _required_number(result, "entities", integer=True)
+    steps = _required_number(result, "steps", integer=True)
+    elapsed = _required_number(result, "elapsed_s")
+    if entities < 0 or steps <= 0 or elapsed <= 0:
+        raise ReportFormatError(
+            "entities must be non-negative; steps and elapsed_s must be positive"
+        )
+
+    extras = result.get("extras", {})
+    if not isinstance(extras, dict):
+        raise ReportFormatError(f"{name}: extras must be an object")
+
+    normalized: dict[str, Any] = {
+        "name": name,
+        "dimensions": {
+            "entities": entities,
+            "steps": steps,
+            "extras": extras,
+        },
+        "metrics": {
+            "elapsed_s": elapsed,
+            "steps_per_sec": steps / elapsed,
+            "entities_per_sec": (entities * steps) / elapsed,
+        },
+    }
+
+    provenance = {
+        field: str(result[field])
+        for field in ("world_id", "run_id")
+        if result.get(field) is not None
+    }
+    if provenance:
+        normalized["provenance"] = provenance
+    return normalized
+
+
+def _validate_benchmark(benchmark: Any, index: int) -> None:
+    prefix = f"benchmarks[{index}]"
+    if not isinstance(benchmark, dict):
+        raise ReportFormatError(f"{prefix} must be an object")
+    if not isinstance(benchmark.get("name"), str) or not benchmark["name"]:
+        raise ReportFormatError(f"{prefix}.name must be a non-empty string")
+    if not isinstance(benchmark.get("dimensions"), dict):
+        raise ReportFormatError(f"{prefix}.dimensions must be an object")
+    _assert_json_value(benchmark["dimensions"], f"{prefix}.dimensions")
+    _validate_metrics(benchmark.get("metrics"), prefix)
+    _validate_provenance(benchmark.get("provenance"), prefix)
+
+
+def _validate_metrics(metrics: Any, prefix: str) -> None:
+    if not isinstance(metrics, dict) or not metrics:
+        raise ReportFormatError(f"{prefix}.metrics must be a non-empty object")
+    for name, value in metrics.items():
+        if not isinstance(name, str) or not _is_finite_number(value) or value < 0:
+            raise ReportFormatError(f"{prefix}.metrics contains an invalid value")
+
+
+def _validate_provenance(provenance: Any, prefix: str) -> None:
+    if provenance is not None and (
+        not isinstance(provenance, dict)
+        or any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in provenance.items()
+        )
+    ):
+        raise ReportFormatError(f"{prefix}.provenance must map strings to strings")
+
+
+def _parse_created_at(value: str) -> datetime:
+    if not value.endswith("Z"):
+        raise ReportFormatError("created_at must be an RFC 3339 UTC timestamp ending in Z")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise ReportFormatError("created_at must be an RFC 3339 UTC timestamp") from exc
+    if parsed.utcoffset() != UTC.utcoffset(parsed):
+        raise ReportFormatError("created_at must use UTC")
+    return parsed
+
+
+def _validate_revision(revision: Mapping[str, Any]) -> None:
+    if not isinstance(revision.get("commit"), str) or not revision["commit"]:
+        raise ReportFormatError("revision.commit must be a non-empty string")
+    if revision.get("dirty") is not None and not isinstance(revision["dirty"], bool):
+        raise ReportFormatError("revision.dirty must be a boolean or null")
+
+
+def _validate_environment(environment: Mapping[str, Any]) -> None:
+    fields = (
+        "runner_id",
+        "system",
+        "release",
+        "machine",
+        "processor",
+        "python_implementation",
+        "python_version",
+    )
+    for field in fields:
+        if not isinstance(environment.get(field), str):
+            raise ReportFormatError(f"environment.{field} must be a string")
+    if not environment["runner_id"]:
+        raise ReportFormatError("environment.runner_id must not be empty")
+    packages = environment.get("packages")
+    if not isinstance(packages, dict) or not packages:
+        raise ReportFormatError("environment.packages must be a non-empty object")
+    if any(
+        not isinstance(name, str) or not isinstance(version, str)
+        for name, version in packages.items()
+    ):
+        raise ReportFormatError("environment.packages must map strings to strings")
+
+
+def _required_string(result: Mapping[str, Any], field: str) -> str:
+    value = result.get(field)
+    if not isinstance(value, str) or not value:
+        raise ReportFormatError(f"raw benchmark {field} must be a non-empty string")
+    return value
+
+
+def _required_number(
+    result: Mapping[str, Any], field: str, *, integer: bool = False
+) -> int | float:
+    value = result.get(field)
+    if not _is_finite_number(value) or (integer and not isinstance(value, int)):
+        expected = "integer" if integer else "finite number"
+        raise ReportFormatError(f"raw benchmark {field} must be a {expected}")
+    return value
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def _assert_json_value(value: Any, path: str) -> None:
+    try:
+        json.dumps(value, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ReportFormatError(f"{path} is not finite JSON data: {exc}") from exc
+
+
+def _report_id(report: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(report).encode()).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        return json.dumps(value, allow_nan=False, separators=(",", ":"), sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ReportFormatError(f"value is not canonical JSON data: {exc}") from exc
+
+
+def _git_output(*args: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def _atomic_json_write(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w") as stream:
+            json.dump(payload, stream, allow_nan=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise

--- a/docs/guide/benchmarking.md
+++ b/docs/guide/benchmarking.md
@@ -1,0 +1,92 @@
+# Performance Benchmarking
+
+Archetype's benchmark harness records enough provenance to decide whether two
+runs are comparable before it compares their timings. It does not gate normal
+CI: shared GitHub-hosted runners are too noisy to establish performance
+regressions.
+
+## Run and retain a measurement
+
+Give a stable machine a durable identity, then run the suite:
+
+```bash
+export ARCHETYPE_BENCH_RUNNER=mac-mini-m2-pro
+make bench
+```
+
+`make bench` writes the latest report to `bench-results.json` and archives the
+same content-addressed report under `.bench_out/history/`. Both locations are
+gitignored. Copy the history directory to durable artifact storage when the
+machine is ephemeral; the repository does not pretend that a local ignored
+directory is durable storage.
+
+Use `make bench-full` for the three-step profile. A different step count is a
+different benchmark configuration and is not mixed into the same comparison.
+
+## Compare compatible history
+
+After at least three earlier runs on the same machine and configuration:
+
+```bash
+make bench-compare
+```
+
+The comparator aligns rows by benchmark name and dimensions. A historical
+report is admitted only when all of these match the current report:
+
+- suite and benchmark configuration;
+- runner identity, operating system release, machine, and processor;
+- Python implementation and version;
+- Archetype, Daft, LanceDB, and PyIceberg versions.
+
+Incompatible runs are reported but never folded into the distribution. Duplicate
+report IDs are counted once, and the current report's archived copy is excluded.
+Malformed or hand-edited history fails closed because every report ID is a hash
+of its contents.
+
+## Regression rule
+
+For each metric, the comparator uses the 20 most recent compatible reports that
+predate the current report, then computes their median and population standard
+deviation. A result is a regression only when it lies strictly more than two
+standard deviations beyond the median in the worse direction:
+
+- `elapsed_s`: higher is worse;
+- `steps_per_sec`: lower is worse;
+- `entities_per_sec`: lower is worse.
+
+Fewer than three compatible samples produces `insufficient`, not a pass or a
+regression. When historical variance is zero, any strictly worse value crosses
+the zero-width threshold. This is intentionally literal evidence rather than an
+invented tolerance.
+
+Comparison is advisory by default. A stable dedicated runner may opt into a
+failing exit code after its history is established:
+
+```bash
+uv run python -m bench.core.compare \
+  --current bench-results.json \
+  --history-dir .bench_out/history \
+  --fail-on-regression
+```
+
+Do not add that flag to shared-runner CI. A performance gate becomes meaningful
+only after the runner, retention location, cadence, and response policy have
+named owners.
+
+## Report contract
+
+Schema version 1 separates three kinds of data:
+
+- `environment` and `config` decide comparability;
+- benchmark `name` and `dimensions` decide row identity;
+- `metrics` carry measured values.
+
+World and run IDs remain available under `provenance`, but they do not change a
+benchmark's identity. `revision` records the measured commit and whether tracked
+files were dirty. This keeps execution receipts useful without treating a new
+world UUID as a new benchmark.
+
+The current ECS suite is still a microbenchmark. End-to-end step scaling, query,
+fork, contention, memory, recovery, and backend-parity coverage remain tracked
+in [issue #141](https://github.com/VangelisTech/archetype/issues/141).

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -179,6 +179,8 @@ make test        # fast test suite
 make test-cov    # test suite with coverage report
 make check       # format + lint
 make ci          # main gate: lint + lock-check + tests with coverage
+make bench       # record one local ECS microbenchmark report
+make bench-compare  # compare it with compatible local history
 uv run mkdocs build
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - Dataset and Evaluation Ontology: guide/dataset-eval-ontology.md
       - Audit Log: guide/audit-log.md
       - Evaluation Harness: guide/evals.md
+      - Performance Benchmarking: guide/benchmarking.md
       - CORE INTERNALS:
           - Archetypes: guide/archetype.md
           - Systems: guide/system-execution.md

--- a/tests/bench/test_benchmark_reports.py
+++ b/tests/bench/test_benchmark_reports.py
@@ -1,0 +1,290 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executable contracts for benchmark history and trend decisions."""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+
+import pytest
+
+from bench.core.compare import compare_report
+from bench.core.compare import main as compare_main
+from bench.core.report import (
+    ReportFormatError,
+    benchmark_identity,
+    build_report,
+    load_report,
+    write_report,
+)
+
+_ENVIRONMENT = {
+    "runner_id": "stable-runner",
+    "system": "TestOS",
+    "release": "1",
+    "machine": "test64",
+    "processor": "test-cpu",
+    "python_implementation": "CPython",
+    "python_version": "3.12.10",
+    "packages": {
+        "archetype-ecs": "0.4.0",
+        "daft": "0.7.19",
+        "lancedb": "0.22.0",
+        "pyiceberg": "0.10.0",
+    },
+}
+_CONFIG = {
+    "steps": 1,
+    "storage_backend": "lancedb",
+    "cache": False,
+}
+
+
+def _raw(elapsed_s: float, *, world_id: str = "world", run_id: str = "run") -> dict:
+    return {
+        "name": "packed_iteration",
+        "bench_name": "packed_iteration",
+        "entities": 100,
+        "steps": 1,
+        "elapsed_s": elapsed_s,
+        "extras": {"width": 5},
+        "world_id": world_id,
+        "run_id": run_id,
+    }
+
+
+def _report(
+    elapsed_s: float,
+    index: int,
+    *,
+    environment: dict | None = None,
+    config: dict | None = None,
+    world_id: str = "world",
+    created_at: str | None = None,
+) -> dict:
+    return build_report(
+        [_raw(elapsed_s, world_id=world_id, run_id=f"run-{index}")],
+        suite="ecs",
+        config=config or _CONFIG,
+        environment=environment or _ENVIRONMENT,
+        revision={"commit": f"{index:040x}", "dirty": False},
+        created_at=created_at or f"2026-07-17T12:00:{index:02d}Z",
+    )
+
+
+def _comparison(summary: dict, metric: str) -> dict:
+    return next(row for row in summary["comparisons"] if row["metric"] == metric)
+
+
+def test_build_report_normalizes_metrics_and_separates_provenance() -> None:
+    report = _report(2.0, 1)
+    benchmark = report["benchmarks"][0]
+
+    assert report["schema_version"] == 1
+    assert len(report["report_id"]) == 64
+    assert benchmark == {
+        "name": "packed_iteration",
+        "dimensions": {
+            "entities": 100,
+            "steps": 1,
+            "extras": {"width": 5},
+        },
+        "metrics": {
+            "elapsed_s": 2.0,
+            "steps_per_sec": 0.5,
+            "entities_per_sec": 50.0,
+        },
+        "provenance": {"world_id": "world", "run_id": "run-1"},
+    }
+
+
+def test_benchmark_identity_ignores_run_provenance() -> None:
+    first = _report(2.0, 1, world_id="first")["benchmarks"][0]
+    second = _report(3.0, 2, world_id="second")["benchmarks"][0]
+
+    assert benchmark_identity(first) == benchmark_identity(second)
+
+
+def test_write_report_atomically_keeps_current_and_history(tmp_path: Path) -> None:
+    report = _report(2.0, 1)
+    current = tmp_path / "current.json"
+    history = tmp_path / "history"
+
+    history_path = write_report(report, current_path=current, history_dir=history)
+
+    assert history_path is not None
+    assert load_report(current) == report
+    assert load_report(history_path) == report
+    assert list(history.glob("*.json")) == [history_path]
+    assert not list(tmp_path.rglob(".*.json.*")), "atomic temporary files must not leak"
+
+
+def test_report_content_hash_rejects_hand_edited_history(tmp_path: Path) -> None:
+    report = _report(2.0, 1)
+    report["benchmarks"][0]["metrics"]["elapsed_s"] = 200.0
+    path = tmp_path / "tampered.json"
+    path.write_text(json.dumps(report))
+
+    with pytest.raises(ReportFormatError, match="report_id does not match"):
+        load_report(path)
+
+
+def test_report_rejects_non_utc_timestamp_and_duplicate_identity() -> None:
+    with pytest.raises(ReportFormatError, match="ending in Z"):
+        _report(2.0, 1, created_at="2026-07-17T12:00:01+01:00")
+
+    with pytest.raises(ReportFormatError, match="duplicate benchmark identity"):
+        build_report(
+            [_raw(1.0), _raw(2.0)],
+            suite="ecs",
+            config=_CONFIG,
+            environment=_ENVIRONMENT,
+            revision={"commit": "1" * 40, "dirty": False},
+            created_at="2026-07-17T12:00:01Z",
+        )
+
+
+def test_elapsed_regression_is_strictly_beyond_two_population_sigma() -> None:
+    elapsed = [8.0, 10.0, 12.0]
+    baselines = [_report(value, index) for index, value in enumerate(elapsed, start=1)]
+    threshold = statistics.median(elapsed) + 2 * statistics.pstdev(elapsed)
+
+    exact = compare_report(_report(threshold, 10), baselines)
+    beyond = compare_report(_report(threshold + 1e-9, 11), baselines)
+
+    assert _comparison(exact, "elapsed_s")["status"] == "ok"
+    assert _comparison(beyond, "elapsed_s")["status"] == "regression"
+    assert exact["status"] == "ok"
+    assert beyond["status"] == "regression"
+
+
+def test_throughput_regression_is_strictly_below_two_population_sigma() -> None:
+    throughputs = [8.0, 10.0, 12.0]
+    baselines = [
+        _report(1.0 / throughput, index) for index, throughput in enumerate(throughputs, start=1)
+    ]
+    threshold = statistics.median(throughputs) - 2 * statistics.pstdev(throughputs)
+
+    exact = compare_report(_report(1.0 / threshold, 10), baselines)
+    beyond = compare_report(_report(1.0 / (threshold - 1e-9), 11), baselines)
+
+    assert _comparison(exact, "steps_per_sec")["status"] == "ok"
+    assert _comparison(beyond, "steps_per_sec")["status"] == "regression"
+
+
+def test_zero_variance_history_flags_any_worse_value() -> None:
+    baselines = [_report(10.0, index) for index in range(1, 4)]
+
+    unchanged = compare_report(_report(10.0, 10), baselines)
+    slower = compare_report(_report(10.0001, 11), baselines)
+
+    assert _comparison(unchanged, "elapsed_s")["status"] == "ok"
+    row = _comparison(slower, "elapsed_s")
+    assert row["status"] == "regression"
+    assert row["population_sigma"] == 0
+    assert row["worse_by_sigma"] is None
+
+
+def test_comparison_requires_enough_compatible_history() -> None:
+    other_environment = {**_ENVIRONMENT, "runner_id": "shared-runner"}
+    other_config = {**_CONFIG, "steps": 3}
+    baselines = [
+        _report(9.0, 1),
+        _report(10.0, 2),
+        _report(11.0, 3, environment=other_environment),
+        _report(12.0, 4, config=other_config),
+    ]
+
+    summary = compare_report(_report(20.0, 10), baselines)
+
+    assert summary["compatible_reports"] == 2
+    assert len(summary["incompatible_report_ids"]) == 2
+    assert summary["regression_count"] == 0
+    assert summary["insufficient_count"] == 3
+    assert summary["status"] == "insufficient"
+    assert {row["status"] for row in summary["comparisons"]} == {"insufficient"}
+
+
+def test_comparison_rejects_non_finite_sigma() -> None:
+    with pytest.raises(ValueError, match="finite and positive"):
+        compare_report(_report(10.0, 10), [], sigma_multiplier=float("nan"))
+
+
+def test_duplicate_history_report_is_not_weighted_twice() -> None:
+    baselines = [_report(value, index) for index, value in enumerate((8.0, 10.0, 12.0), 1)]
+
+    summary = compare_report(_report(10.0, 10), [*baselines, baselines[0]])
+
+    assert summary["compatible_reports"] == 3
+    assert _comparison(summary, "elapsed_s")["baseline_samples"] == 3
+
+
+def test_comparison_uses_only_the_most_recent_prior_window() -> None:
+    baselines = [_report(value, index) for index, value in enumerate((100.0, 8.0, 10.0, 12.0), 1)]
+
+    summary = compare_report(_report(10.0, 10), baselines, history_window=3)
+
+    assert summary["compatible_reports_available"] == 4
+    assert summary["compatible_reports"] == 3
+    assert summary["history_window"] == 3
+    assert summary["baseline_report_ids"] == [report["report_id"] for report in baselines[1:]]
+    assert _comparison(summary, "elapsed_s")["median"] == 10.0
+
+
+def test_history_window_orders_fractional_utc_timestamps_chronologically() -> None:
+    baselines = [
+        _report(100.0, 1, created_at="2026-07-17T12:00:00Z"),
+        _report(8.0, 2, created_at="2026-07-17T12:00:00.100000Z"),
+        _report(10.0, 3, created_at="2026-07-17T12:00:00.200000Z"),
+        _report(12.0, 4, created_at="2026-07-17T12:00:00.300000Z"),
+    ]
+    current = _report(10.0, 10, created_at="2026-07-17T12:00:00.400000Z")
+
+    summary = compare_report(current, baselines, history_window=3)
+
+    assert _comparison(summary, "elapsed_s")["median"] == 10.0
+
+
+def test_comparison_excludes_same_time_and_future_reports() -> None:
+    current = _report(10.0, 10)
+    same_time = _report(11.0, 10)
+    future = _report(12.0, 11)
+    prior = [_report(value, index) for index, value in enumerate((8.0, 9.0, 10.0), 1)]
+
+    summary = compare_report(current, [*prior, same_time, future])
+
+    assert summary["compatible_reports"] == 3
+    assert set(summary["non_prior_report_ids"]) == {
+        same_time["report_id"],
+        future["report_id"],
+    }
+
+
+def test_cli_is_advisory_unless_regression_failure_is_requested(tmp_path: Path, capsys) -> None:
+    history = tmp_path / "history"
+    for index, elapsed in enumerate((8.0, 10.0, 12.0), 1):
+        write_report(_report(elapsed, index), history_dir=history)
+    current = tmp_path / "current.json"
+    write_report(_report(100.0, 10), current_path=current)
+    args = ["--current", str(current), "--history-dir", str(history)]
+
+    assert compare_main(args) == 0
+    advisory = json.loads(capsys.readouterr().out)
+    assert advisory["status"] == "regression"
+    assert compare_main([*args, "--fail-on-regression"]) == 1
+
+
+def test_cli_fails_closed_on_invalid_history(tmp_path: Path, capsys) -> None:
+    history = tmp_path / "history"
+    history.mkdir()
+    (history / "broken.json").write_text("{not-json")
+    current = tmp_path / "current.json"
+    write_report(_report(10.0, 10), current_path=current)
+
+    code = compare_main(["--current", str(current), "--history-dir", str(history)])
+
+    assert code == 2
+    assert "cannot read" in capsys.readouterr().err

--- a/tests/bench/test_ecs_run_isolation.py
+++ b/tests/bench/test_ecs_run_isolation.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from argparse import Namespace
+
 import pytest
 
 from archetype.core.config import StorageBackend, StorageConfig
-from bench.core.ecs.run import _storage_for_bench, run_all
+from bench.core.ecs.run import _storage_for_bench, _storage_from_args, run_all
 
 
 def test_storage_for_bench_suffixes_default_storage(tmp_path, monkeypatch):
@@ -55,6 +57,18 @@ def test_storage_for_bench_gives_each_bench_a_unique_namespace():
     ]
     namespaces = {_storage_for_bench(storage, n).namespace for n in names}
     assert len(namespaces) == len(names)
+
+
+def test_storage_cli_backend_override_does_not_require_a_uri(tmp_path, monkeypatch):
+    """The old CLI advertised --backend but ignored it unless --uri was also set."""
+    monkeypatch.setenv("ARCHETYPE_DATA_URI", str(tmp_path))
+    monkeypatch.setenv("ARCHETYPE_BENCH_NS", "environment-default")
+
+    storage = _storage_from_args(Namespace(uri=None, namespace="explicit", backend="iceberg"))
+
+    assert storage.uri == str(tmp_path)
+    assert storage.namespace == "explicit"
+    assert storage.backend is StorageBackend.ICEBERG
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a versioned, content-addressed benchmark report contract with explicit environment, configuration, revision, metric, dimension, and run provenance
- archive reports atomically and compare the latest 20 compatible prior runs using the rolling median and population sigma
- keep comparison advisory by default, with an explicit opt-in regression exit for stable dedicated runners
- document runner identity, history retention, comparability, and the exact greater-than-two-sigma rule
- fix the backend override so it works without a URI override, and remove the obsolete no-op instrumented option so reported configuration matches execution

## Contract boundary

This is a bounded infrastructure slice related to #141. It does not establish a dedicated runner or durable artifact owner, and it does not add the remaining step, query, fork, contention, memory, recovery, or backend-parity benchmark families. Issue #141 should remain open for those phases.

## Validation

- `make ci`: 1,164 passed, 5 skipped; regression 15/15; idempotency 23/23
- `uv run pytest tests/bench -q`: 23 passed
- real five-benchmark CLI/archive/compare smoke: schema v1, five rows, full SHA-256 ID, one archived object, fresh history reported as insufficient
- `make docs`: passed with existing warnings only
- changed Markdown: 0 markdownlint findings
- Radon: average A (4.02), no function above B/10

Related to #141