### PR TITLE
fix(app): preserve spawn audit metadata

### DIFF
--- a/docs/guide/audit-log.md
+++ b/docs/guide/audit-log.md
@@ -73,6 +73,13 @@ Multi-step gate methods still emit exactly one audit row:
 
 The row payload captures sub-operation outcomes when one gated method performs multiple internal actions.
 
+Spawn metadata is structured rather than encoded in the command name:
+
+- `create_entities` records one `spawn_batch` row with
+  `payload_json = {"count": N}`, not one row per entity.
+- `spawn_with_reserved_id` records one `spawn_reserved` row with
+  `payload_json = {"entity_id": N}`.
+
 ## 5. Row Schema
 
 `AuditRow` is defined in `app/models.py`.

--- a/src/archetype/app/command_service.py
+++ b/src/archetype/app/command_service.py
@@ -181,14 +181,30 @@ class CommandService:
         if not self._worlds.has_world(world_id):
             raise WorldNotFoundError(world_id)
 
-    async def _emit(self, ctx: ActorCtx, command_type: str, world_id=None, **kw) -> None:
+    async def _emit(
+        self,
+        ctx: ActorCtx,
+        command_type: str,
+        world_id: str | UUID | None = None,
+        *,
+        command_id: UUID | None = None,
+        status: str = "applied",
+        payload_json: str = "{}",
+    ) -> None:
         """Emit one audit row. Best-effort — never raises."""
         if self._audit is None:
             return
         try:
             from archetype.app.audit_log import make_audit_row
 
-            row = make_audit_row(ctx, command_type, world_id, **kw)
+            row = make_audit_row(
+                ctx,
+                command_type,
+                world_id,
+                command_id=command_id,
+                status=status,
+                payload_json=payload_json,
+            )
             await self._audit.record(row)
         except Exception:
             logger.warning("audit emission failed", exc_info=True)
@@ -217,7 +233,12 @@ class CommandService:
         """Batch-spawn entities. Applies one RBAC gate check for the batch."""
         self._gate(Command(type=CommandType.SPAWN), ctx)
         result = await self._mutations.create_entities(world_id, entities)
-        await self._emit(ctx, "spawn_batch", world_id, count=len(entities))
+        await self._emit(
+            ctx,
+            "spawn_batch",
+            world_id,
+            payload_json=json.dumps({"count": len(entities)}),
+        )
         return result
 
     @instrument("gate.reserve_entity_ids")
@@ -242,7 +263,12 @@ class CommandService:
         """Materialise a previously reserved entity ID."""
         self._gate(Command(type=CommandType.SPAWN), ctx)
         await self._mutations.spawn_with_reserved_id(world_id, entity_id, components)
-        await self._emit(ctx, "spawn_reserved", world_id, entity_id=entity_id)
+        await self._emit(
+            ctx,
+            "spawn_reserved",
+            world_id,
+            payload_json=json.dumps({"entity_id": entity_id}),
+        )
 
     @instrument("gate.remove_entity")
     async def remove_entity(

--- a/tests/app/test_spawn_audit_metadata.py
+++ b/tests/app/test_spawn_audit_metadata.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Audit metadata contracts for direct spawn operations."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from uuid_utils import uuid7
+
+from archetype.app.auth.models import ActorCtx
+from archetype.app.container import ServiceContainer
+from archetype.core.component import Component
+from archetype.core.config import StorageBackend, StorageConfig, WorldConfig
+
+
+class AuditPosition(Component):
+    x: float = 0.0
+
+
+def _audit_storage(tmp_path: Path) -> StorageConfig:
+    return StorageConfig(
+        uri=str(tmp_path / "audit-store"),
+        namespace="spawn_audit",
+        backend=StorageBackend.ICEBERG,
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_operations_emit_one_row_with_structured_metadata(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    container = ServiceContainer(audit_storage_config=_audit_storage(tmp_path))
+    actor = ActorCtx(id=uuid7(), roles={"admin"})
+    try:
+        world = await container.world_service.create_world(
+            WorldConfig(name="spawn-audit-contract"),
+            StorageConfig(uri=str(tmp_path / "world-store")),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="archetype.app.command_service"):
+            batch_ids = await container.command_service.create_entities(
+                actor,
+                world.world_id,
+                [[AuditPosition(x=1.0)], [AuditPosition(x=2.0)]],
+            )
+            reserved_id = container.command_service.reserve_entity_ids(
+                actor,
+                world.world_id,
+                1,
+            )[0]
+            await container.command_service.spawn_with_reserved_id(
+                actor,
+                world.world_id,
+                reserved_id,
+                [AuditPosition(x=3.0)],
+            )
+
+        rows = (await container.audit_log.query(world_id=world.world_id)).to_pylist()
+
+        assert len(batch_ids) == 2
+        assert len(rows) == 2
+        assert {row["command_type"]: json.loads(row["payload_json"]) for row in rows} == {
+            "spawn_batch": {"count": 2},
+            "spawn_reserved": {"entity_id": reserved_id},
+        }
+        assert "audit emission failed" not in caplog.text
+    finally:
+        await container.shutdown()


### PR DESCRIPTION
## Summary

- preserve the audit row for gated batch spawns by encoding the batch size in `payload_json`
- fix the adjacent reserved-ID spawn path, which dropped its audit row through the same invalid-keyword failure
- replace `CommandService._emit(**kw)` with an explicit metadata signature matching `make_audit_row`, so unsupported fields become type errors instead of swallowed runtime warnings
- add a real `ServiceContainer` contract that proves both mutations apply, exactly two corresponding audit rows persist, their metadata round-trips structurally, and no audit warning is emitted
- synchronize the normative audit guide with the executable payload contract

## Root cause

`create_entities()` forwarded `count=` and `spawn_with_reserved_id()` forwarded `entity_id=` into `_emit(**kw)`. `_emit` passed those arbitrary keywords to `make_audit_row()`, whose supported fields are only `command_id`, `status`, and `payload_json`. The resulting `TypeError` was correctly suppressed by best-effort audit policy after each mutation had applied, but that left both successful operations absent from durable history.

The fix keeps best-effort failure semantics unchanged. It narrows the private composition seam and moves operation-specific data into the existing structured payload field.

## Validation

- red-before/green-after real-service oracle: two applied mutations previously produced two warnings and zero rows; now they produce two rows and no warning
- `make ci` — 1,171 passed, 7 skipped; 86.18% coverage; regression 15/15; idempotency 23/23
- focused audit/runtime contracts — 24 passed
- `ty` 0.0.48, gate-coverage audit, API-boundary audit, Ruff lint/format
- MkDocs build, Markdown lint, and spelling check

No `core/` or `AuditLog` behavior changes.

Closes #447.