### PR TITLE
ci: arm auto-merge only after the review gate passes the current head

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -52,17 +52,21 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
+      # Look the PR up by listing open PRs and filtering on headRefOid
+      # client-side — NOT via `--search "sha:..."`. SHA search rides the
+      # search index through an undocumented qualifier: it can lag a fresh
+      # push or stop matching entirely, and either way this job would take
+      # the empty-result exit and silently never arm anything again.
       - name: Arm the reviewed head
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || github.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open \
-            --search "sha:${HEAD_SHA}" \
+          pr=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --limit 100 \
             --json number,author,isDraft,headRefOid \
             --jq ".[] | select(.headRefOid == \"${HEAD_SHA}\" and .author.login == \"everettVT\" and (.isDraft | not)) | .number" | head -1)
           if [ -z "$pr" ]; then
-            echo "No armable open PR at reviewed head ${HEAD_SHA}; nothing to do."
+            echo "No open non-draft everettVT PR currently at ${HEAD_SHA} (superseded, closed, or draft); nothing to arm."
             exit 0
           fi
           echo "Review gate succeeded on ${HEAD_SHA}; arming #${pr}."

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -42,11 +42,28 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      # Verified by postcondition, not exit code: `--disable-auto` exits
+      # nonzero on the benign "wasn't armed" no-op, but swallowing every
+      # failure (`|| true`) would also swallow a transient API failure and
+      # leave a prior head's arm in force across the new, unreviewed push —
+      # and merge-group runs skip the review checks, so nothing downstream
+      # would catch it. Retry, then require the PR to actually be unarmed.
       - name: Disable auto-merge pending review
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --disable-auto "$PR_URL" || true
+        run: |
+          for attempt in 1 2 3; do
+            gh pr merge --disable-auto "$PR_URL" || true
+            armed=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest // empty')
+            if [ -z "$armed" ]; then
+              echo "auto-merge disarmed (attempt ${attempt})."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::auto-merge still armed after 3 disarm attempts; a stale arm may carry this unreviewed head into the queue."
+          exit 1
 
   arm:
     name: Arm auto-merge for maintainer PRs

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,11 +11,15 @@
 # push, arm on review success. A PR whose review never completes, or whose
 # findings are unfixed, simply never enters the queue.
 #
-# Token note: if AUTOMERGE_PAT (a fine-grained PAT with contents:write +
-# pull-requests:write) is present, it is preferred. With the default
-# GITHUB_TOKEN the merge is attributed to github-actions, and pushes made
-# by GITHUB_TOKEN do not trigger `on: push` workflows — the docs deploy to
-# Cloudflare Pages on main would be skipped for auto-merged PRs.
+# Token note: the arm job prefers AUTOMERGE_PAT (a fine-grained PAT with
+# contents:write + pull-requests:write) because the eventual merge commit
+# must trigger `on: push` workflows — pushes made by the default
+# GITHUB_TOKEN do not, so the docs deploy to Cloudflare Pages on main
+# would be skipped for auto-merged PRs. The disarm job deliberately uses
+# only github.token: disarming needs no downstream triggers, and a job
+# whose YAML executes from the PR ref (plain `pull_request`) should not
+# reference secrets it doesn't need — least privilege, even though GitHub
+# already withholds repo secrets from fork-triggered pull_request runs.
 
 name: Auto-merge
 
@@ -40,7 +44,7 @@ jobs:
     steps:
       - name: Disable auto-merge pending review
         env:
-          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || github.token }}
+          GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --disable-auto "$PR_URL" || true
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,7 +1,15 @@
-# Arm auto-merge (squash) on maintainer PRs the moment they open or leave
-# draft. The merge itself still waits on every required check and on
-# review-conversation resolution — this only removes the manual
-# `gh pr merge --auto --squash` step.
+# Arm auto-merge (squash) on maintainer PRs ONLY after the deterministic
+# review gate succeeds on the current head — and disarm on every new push
+# until it succeeds again.
+#
+# Why arming is the review gate now: with the merge queue, required review
+# checks deliberately SKIP on merge groups (the substantive review binds to
+# the PR head). That removed the old accidental back-pressure where a
+# failing/incomplete `review-complete` on the head blocked the merge — PRs
+# #446/#448/#449 merged carrying "Footgun review — incomplete" comments.
+# Queue entry must therefore imply a completed, clean review: disarm on
+# push, arm on review success. A PR whose review never completes, or whose
+# findings are unfixed, simply never enters the queue.
 #
 # Token note: if AUTOMERGE_PAT (a fine-grained PAT with contents:write +
 # pull-requests:write) is present, it is preferred. With the default
@@ -12,24 +20,50 @@
 name: Auto-merge
 
 on:
+  # Every new head invalidates the previous head's review verdict.
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
+  # The review gate's completion is the arming signal.
+  workflow_run:
+    workflows: ["Deterministic Review Gate"]
+    types: [completed]
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  arm:
-    name: Arm auto-merge for maintainer PRs
-    if: >-
-      github.event.pull_request.user.login == 'everettVT' &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+  disarm:
+    name: Disarm until the head's review completes
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge (squash)
+      - name: Disable auto-merge pending review
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --disable-auto "$PR_URL" || true
+
+  arm:
+    name: Arm auto-merge for maintainer PRs
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Arm the reviewed head
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open \
+            --search "sha:${HEAD_SHA}" \
+            --json number,author,isDraft,headRefOid \
+            --jq ".[] | select(.headRefOid == \"${HEAD_SHA}\" and .author.login == \"everettVT\" and (.isDraft | not)) | .number" | head -1)
+          if [ -z "$pr" ]; then
+            echo "No armable open PR at reviewed head ${HEAD_SHA}; nothing to do."
+            exit 0
+          fi
+          echo "Review gate succeeded on ${HEAD_SHA}; arming #${pr}."
+          gh pr merge --auto --squash --repo "${GITHUB_REPOSITORY}" "$pr"


### PR DESCRIPTION
Closes the review-enforcement hole Everett caught: with the queue live, review checks skip on merge groups (by design — review binds to the PR head), but arming happened at PR-open, so PRs could enqueue before their review finished. #446/#448/#449 merged carrying "Footgun review — incomplete" comments; late-posted findings would sail through identically.

**Arming becomes the review gate**:
- `pull_request` (opened/synchronize/reopened/ready): **disarm** — a new head invalidates the previous verdict.
- `workflow_run` (Deterministic Review Gate, success, same-repo): **arm** the reviewed head (maintainer, non-draft PRs).

Queue entry now implies a completed, clean review; incomplete reviews and unfixed findings mean the PR simply never enqueues. Merge-group skip semantics unchanged.

Interim protection applied manually: currently-armed PRs without a passing review on head are being disarmed while this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)