### PR TITLE
refactor(evals): replace taxonomy with live inventory

### DIFF
--- a/docs/guide/dataset-eval-ontology.md
+++ b/docs/guide/dataset-eval-ontology.md
@@ -6,9 +6,10 @@
 fact tables, and every public surface that names benchmarks, suites, tasks,
 trials, or dataset episodes.
 
-This page defines vocabulary and identity. It does not define the trial
+This page defines public vocabulary and identity. It does not define the trial
 execution state machine tracked by issue #322, a particular reader schema, or
-the repository's internal eval harness.
+the `evals/` repository-check runner. That runner reuses ordinary words such as
+task and trial as local implementation labels; it does not extend this model.
 
 ## 1. The contract in one view
 
@@ -203,9 +204,9 @@ The durable evaluation-receipt contract is adjacent but distinct:
   the same dataset episode;
 - receipts carry conclusions and evidence, never promotion authority.
 
-The repository eval harness has its own internal `TrialResult`. That is a
-meta-evaluation attempt used to test Archetype itself; it is not the physical-
-AI dataset `Trial` defined here.
+The repository-check runner's internal `TrialResult` records one repeated
+execution of a framework check. It is not the physical-AI dataset `Trial`
+defined here.
 
 ## 7. Native vocabulary mapping
 

--- a/docs/guide/durable-facts.md
+++ b/docs/guide/durable-facts.md
@@ -134,8 +134,9 @@ finite score — and empty outcome sets fail closed.
 
 **Receipts are evidence, never authority.** A receipt carries no authority
 fields — no accepted, no promote, no approved, no allowed_next_action —
-enforced by the spec-contract eval suite. A PASS means one grader passed
-under one pinned contract; the layer above owns what that means.
+enforced by the `spec.receipt_authority_firewall` repository check. A PASS
+means one grader passed under one pinned contract; the layer above owns what
+that means.
 
 ## 8. Typed Iceberg fact tables
 

--- a/docs/guide/evals.md
+++ b/docs/guide/evals.md
@@ -1,209 +1,105 @@
-# Evaluation Harness
+# Repository Checks
 
-Archetype's evals are independent executable oracles for repository-level
-contracts. They complement unit and integration tests: a task assembles a
-realistic boundary, observes the result, and grades the outcome without
-depending on the feature test that originally motivated the contract.
+The `evals/` package runs end-to-end checks against Archetype. It complements
+pytest by assembling realistic public or service boundaries and grading the
+observable result independently of the focused test that motivated a change.
 
-The harness lives under `evals/` and uses a **task → trial → grader** model.
-It does not ask whether the implementation followed one preferred code path;
-it asks whether the resulting behavior satisfies the contract.
+Its `suite`, `task`, and `trial` labels are runner implementation terms. They
+do not define the public evaluation model, dataset identity, or physical-AI
+trial lifecycle described in the
+[Dataset and Evaluation Ontology](dataset-eval-ontology.md).
 
-These are meta-evaluation terms internal to the repository harness.
-`evals.types.TrialResult` is not the physical-AI trial that produces one
-dataset episode in the
-[Dataset and Evaluation Ontology](dataset-eval-ontology.md), and harness task
-ids are not dataset task natural keys.
-
-## Running the suites
+## Run or inspect checks
 
 ```bash
-make eval          # every suite; writes eval-results.json
-make eval-reg      # regression only
-make eval-idem     # idempotency only
-make eval-cap      # capability only
+make eval          # run every group; optionally write eval-results.json
+make eval-reg      # required behavior checks
+make eval-idem     # retry and replay checks
+make eval-cap      # broader end-to-end scenarios
 
-# Spec-only and repeated-trial runs use the module directly.
 uv run python -m evals.run --suite spec
 uv run python -m evals.run --suite regression --trials 3
 uv run python -m evals.run --out eval-results.json
+uv run python -m evals.run --list
+uv run python -m evals.run --list --suite capability
 ```
 
-`--trials k` must be a positive integer. Each task runs `k` times and reports:
+`--list` reads the live registry built by `evals.run.build_harness()` and does
+not execute tasks. That command is the task inventory; this guide deliberately
+does not duplicate it in a hand-maintained table.
 
-| Metric | Meaning |
+## Execution model
+
+A registered task is a callable that returns one or more `GraderResult`
+objects. The runner executes it once by default or `--trials N` times when a
+scenario needs repeated scheduling evidence. Empty grader output and uncaught
+exceptions are explicit failed trials.
+
+Reports use literal measurements:
+
+| Field | Meaning |
 |---|---|
-| `pass@k` | Fraction of trials that passed |
-| `pass^k` | `1.0` only when every trial passed |
-| `avg_score` | Mean grader score across trials |
-| `all_passed` | Every grader passed in every trial |
+| `trial_count` | Number of executions recorded for the task |
+| `pass_rate` | Fraction of those executions whose graders all passed |
+| `avg_score` | Mean grader score across executions |
+| `all_passed` | Whether every recorded execution passed |
 
-The default is one trial. Repeated trials are useful when a boundary involves
-process scheduling or another source of nondeterminism; they do not turn a
-deterministic failure into an acceptable result.
+These are repository results, not statistical estimates of model capability.
 
-## What passes the gate
+## Execution groups
 
-The four suites have deliberately different meanings:
+The four group names select checks and determine CLI failure behavior. They are
+not a product taxonomy.
 
-| Suite | Contract | CLI exit condition |
+| Group | Contents | Nonzero exit |
 |---|---|---|
-| Regression | Previously working behavior must remain true | Every task passes every trial |
-| Spec | Normative guide claims retain independent executable evidence | Every task passes every trial |
-| Idempotency | Retry, replay, and non-idempotent boundaries match the specification matrix | Every task passes every trial |
-| Capability | Exercise larger end-to-end behavior without turning a score into a release threshold | No trial crashes; grader misses remain visible in the report |
+| `regression` | Established behavior | Any missed grader or task error |
+| `spec` | Structural checks derived from normative guides | Any missed grader or task error |
+| `idempotency` | Repetition, replay, race, and crash-recovery boundaries | Any missed grader or task error |
+| `capability` | Broader end-to-end scenarios | A scenario error; missed graders remain visible but advisory |
 
-An empty requested suite is a failure, never a vacuous success. A full run also
-requires the regression, spec, and idempotency suites to be present.
+An explicitly requested empty group fails instead of succeeding vacuously. A
+full run also requires the regression, spec, and idempotency groups to exist.
 
-`make ci` runs regression and idempotency evals after the static checks and
-pytest suite. The spec suite has its own pytest registration and CLI smoke
-contracts under `tests/spec_contracts/`, so it is exercised by that same gate.
-The GitHub Actions eval job runs regression and capability separately.
+`make ci` runs regression and idempotency checks. Pytest executes the spec
+group and its CLI smoke contract. GitHub's eval job runs regression and
+capability separately. `make idempotency-audit` is the fast static check that
+the normative matrix and its registered scenarios still correspond.
 
-The idempotency suite has an additional fast static oracle:
-`make idempotency-audit` verifies that every normative matrix row in the
-[specification](specification.md) maps to a registered task before the
-behavioral scenarios run.
+## Grader and logging behavior
 
-## Outcomes, not log noise
+Code graders live in `evals/graders.py`. A task may compose exact comparisons,
+state checks, numeric thresholds, expected exceptions, or code-quality
+measurements. Every task must return non-empty evidence; `state_check` likewise
+rejects an empty mapping.
 
-Expected poison commands are part of the regression input. The command drain
-may log while converting one of those failures into a dropped command, but the
-eval CLI filters the known malformed-command, no-op-command, reserved-spawn
-replay, and missing-despawn records from its report. Other `archetype` records
-remain visible. A task failure is still explicit: uncaught exceptions populate
-`TrialResult.error`, failed graders include their details, and either condition
-affects the suite according to the table above.
+Some regression scenarios deliberately submit malformed commands. The CLI
+filters only the known records produced by those inputs so the report stays
+readable. Unexpected Archetype logs remain visible, and the filter does not
+change library logging or `RunConfig(debug=True)`.
 
-This quieting belongs to the eval process boundary. It does not change library
-log levels, production runtime logging, or `RunConfig(debug=True)`. A host that
-has explicitly attached an `archetype` log handler keeps that configuration.
+## Add or change a check
 
-## Graders
+1. Put the scenario in the group whose exit behavior matches its purpose.
+2. Exercise the highest stable boundary that proves the behavior.
+3. Grade externally visible outcomes rather than duplicating implementation
+   logic in the assertion.
+4. Register the task in that module's `register(harness)` function.
+5. Run the focused group and the broader gate appropriate to the changed
+   boundary.
 
-Code-based graders live in `evals/graders.py`:
+Keep task identifiers stable when specifications or issue receipts cite them.
+When semantics change, update the normative source, implementation, and
+executable evidence together.
 
-- `exact_match` checks equality and returns a binary score.
-- `state_check` requires every named boolean check to pass while retaining a
-  fractional score for diagnosis.
-- `threshold` checks an inclusive numeric range.
-- `raises` checks an expected exception type.
-- `crap_score` combines cyclomatic complexity and coverage for code-quality
-  evaluation.
+## Relationship to other evidence
 
-Every trial must produce at least one meaningful `GraderResult`; a task that
-observes nothing is not an oracle. An empty result list fails the trial with a
-`TrialResult.error`, and `state_check` rejects an empty check mapping. A
-required-suite run therefore exits nonzero instead of accepting Python's
-vacuous `all([])` result or a grader that wraps equally vacuous state evidence.
-
-## Registered task manifest
-
-This inventory is checked against `build_harness()` by
-`tests/spec_contracts/test_documentation_contracts.py`. Adding, removing, or
-renaming a task requires updating this table in the same change.
-
-<!-- eval-task-manifest:start -->
-
-### Regression
-
-| Suite | Task | Contract exercised |
-|---|---|---|
-| `regression` | `component_serde` | Component row serialization, prefixes, and schemas |
-| `regression` | `archetype_signatures` | Signature ordering, set operations, naming, and schema composition |
-| `regression` | `rbac_enforcement` | Role permissions, token costs, and the default role |
-| `regression` | `command_ordering` | Deterministic `(tick, priority, seq)` command order |
-| `regression` | `command_pipeline` | Submit → broker → step → history, with RBAC at the service boundary |
-| `regression` | `query_correctness` | Cold gated reads union component subsets, honor filters/projection, and discover durable signatures |
-| `regression` | `tick_quota_resets` | Per-tick command quotas reset at each tick rather than process-wide |
-| `regression` | `quota_boundaries` | Exact 499/500/501 limits, atomic bulk accounting, actor isolation, and UTC daily rollover |
-| `regression` | `runtime_contracts` | Lazy activation, wait-then-close shutdown, handle invalidation, and sync/async surface parity |
-| `regression` | `episode_value_termination` | Value-based episode termination stops before the defensive cap |
-| `regression` | `poison_in_batch` | A malformed command does not block valid commands in the same drain |
-| `regression` | `missing_payload_keys` | Missing required keys do not corrupt world state |
-| `regression` | `unknown_component_type` | An unknown removal type preserves the entity signature |
-| `regression` | `despawn_nonexistent` | Despawning a missing entity is an observable no-op |
-| `regression` | `unhandled_command_noop` | Message, query, and custom commands drain without implicit mutation |
-
-### Spec
-
-| Suite | Task | Contract exercised |
-|---|---|---|
-| `spec` | `spec.manifest_traceability` | Spec cases cite normative sources and registered task IDs |
-| `spec` | `spec.role_permission_matrix` | Code permissions match the command-gate matrix |
-| `spec` | `spec.runtime_gate_only_boundary` | Runtime dependencies remain behind the command gate |
-| `spec` | `spec.command_service_gate_map` | Public command methods retain gate and audit coverage |
-| `spec` | `spec.append_only_protocols` | Storage and audit protocols expose no destructive methods |
-| `spec` | `spec.receipt_authority_firewall` | Receipts and facts remain evidence rather than authority |
-| `spec` | `spec.dataset_eval_ontology` | Dataset natural keys remain separate from optional runtime provenance |
-| `spec` | `spec.info_class_downgrades` | Lifecycle and introspection return frozen information snapshots |
-
-### Idempotency
-
-| Suite | Task | Contract exercised |
-|---|---|---|
-| `idempotency` | `idempotency.manifest_traceability` | The specification matrix and behavioral manifest agree |
-| `idempotency` | `idempotency.storage_pooling_and_shutdown` | Storage pooling and cached-store shutdown converge safely |
-| `idempotency` | `idempotency.world_lifecycle` | Explicit-ID create and missing or repeated destroy behavior |
-| `idempotency` | `idempotency.broker_and_submit_non_idempotent` | Duplicate logical enqueues remain distinct commands |
-| `idempotency` | `idempotency.submit_spawn_distinct_entities` | Repeated submitted spawns reserve distinct entity IDs |
-| `idempotency` | `idempotency.async_world_entity_ids_and_missing_remove` | Entity allocation and missing removal preserve world state |
-| `idempotency` | `idempotency.runtime_aliases_and_history` | Actor aliases and fixed-filter history reads remain stable |
-| `idempotency` | `idempotency.staged_spawn_last_write_wins` | Duplicate raw staged spawn rows resolve last-write-wins at materialization |
-| `idempotency` | `idempotency.same_tick_duplicate_mutations` | Duplicate same-tick entity mutations collapse at materialization |
-| `idempotency` | `idempotency.component_signature_noops` | Signature-preserving component operations stage no rows or hooks |
-| `idempotency` | `idempotency.fixed_reads` | Repeated fixed-state queries, history, and signature reads agree |
-| `idempotency` | `idempotency.query_archetype_repeatable` | Repeated reads are stable while an updater replay remains an append |
-| `idempotency` | `idempotency.step_and_run_non_idempotent` | Repeated execution advances time and appends rows |
-| `idempotency` | `idempotency.atomic_publish_retry` | A failed publication stays invisible and retry publishes once |
-| `idempotency` | `idempotency.durable_discovery` | Cold discovery, reads, and catalog registration converge |
-| `idempotency` | `idempotency.resume_and_writer_fencing` | Resumed writers fence stale attempts from visibility |
-| `idempotency` | `idempotency.durable_fact_replay` | Concurrent fact replay converges; content conflicts fail loudly |
-| `idempotency` | `idempotency.durable_fact_crash_recovery` | Lease takeover completes an appended orphan without duplication |
-| `idempotency` | `idempotency.evaluation_receipt_replay` | Receipt replay returns prior evidence without grading again |
-| `idempotency` | `idempotency.process_crash_cold_resume` | Cold resume retries one tick after a hard process failure |
-| `idempotency` | `idempotency.process_writer_fence_race` | Exactly one of two racing writer processes publishes |
-| `idempotency` | `idempotency.process_fact_replay` | Independent processes converge on one external fact identity |
-| `idempotency` | `idempotency.process_evaluation_replay` | Concurrent grading runs once and changed subjects conflict first |
-
-### Capability
-
-| Suite | Task | Contract exercised |
-|---|---|---|
-| `capability` | `storage_roundtrip` | Mixed component fields survive persistence and retrieval |
-| `capability` | `simulation_correctness` | Multi-step processing preserves entities and updates expected fields |
-| `capability` | `fork_divergence` | Fork-of-fork lineage, first-step continuity, shared resources, and isolated mutations compose through the runtime |
-| `capability` | `time_travel_and_run_id` | Live and cold historical reads preserve one run identity across durable resume |
-| `capability` | `processor_adversarial` | Hook failures stay advisory, processor failure is whole-tick atomic, and matching follows explicit component migrations |
-
-<!-- eval-task-manifest:end -->
-
-## Adding or changing a task
-
-1. Put the scenario in the suite that owns its failure semantics.
-2. Drive the highest stable boundary that proves the contract. Use lower-level
-   seams only when the task is explicitly about that seam or must construct a
-   crash state that public calls cannot produce deterministically.
-3. Grade externally visible outcomes. Do not duplicate the implementation in
-   the assertion.
-4. Register the task in the suite's `register(harness)` function and update the
-   manifest above.
-5. Run the focused suite, its static traceability check when applicable, and
-   `make ci` for cross-layer behavior.
-
-Keep task IDs stable once a contract cites them. When semantics genuinely
-change, update the normative source, implementation, task, and this manifest as
-one reviewable unit.
-
-## Relationship to other checks
-
-- Pytest provides focused unit, integration, race, and contract diagnosis.
-- Evals provide independent repository-level outcomes and traceability.
+- Pytest provides focused diagnosis for units, integrations, races, and local
+  contracts.
+- Repository checks compose those boundaries into independent outcomes.
 - [Mutation testing](mutation-testing.md) probes whether focused assertions
-  detect controlled implementation changes; it is intentionally on demand.
-- Benchmarks measure cost and trend, not semantic correctness.
+  detect controlled implementation changes.
+- [Benchmarks](benchmarking.md) measure cost and trends, not correctness.
 
-No one layer substitutes for the others. A useful change identifies the
-smallest oracle that proves its local contract, then runs the broader gates in
-proportion to the boundary it crosses.
+Use the smallest oracle that proves the local behavior, then run broader gates
+in proportion to the boundary crossed.

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -1015,15 +1015,15 @@ all of the following:
 - stable cross-archetype execution without world bookkeeping corruption
 - advisory hook isolation, whole-tick processor failure atomicity, and
   signature-aware matching across explicit component migrations
-  (`processor_adversarial` capability eval)
+  (`processor_adversarial` repository check)
 - stable reserved-entity spawn semantics through the broker
-- explicit multi-world isolation and fork divergence (`fork_divergence` capability eval)
-- exact actor-local quota boundaries and UTC rollover (`quota_boundaries` regression eval)
+- explicit multi-world isolation and fork divergence (`fork_divergence` repository check)
+- exact actor-local quota boundaries and UTC rollover (`quota_boundaries` repository check)
 - live/cold historical-read parity and resumed run continuity
-  (`time_travel_and_run_id` capability eval)
+  (`time_travel_and_run_id` repository check)
 - explicit runtime-vs-world lifetime boundaries
 - lazy single-flight activation, wait-then-close runtime shutdown, handle
-  invalidation, and sync/async handle parity (`runtime_contracts` regression eval)
+  invalidation, and sync/async handle parity (`runtime_contracts` repository check)
 - clear distinction between idempotent and non-idempotent operations
 
 ## Runtime Boundary

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,18 +1,8 @@
 # Copyright 2025 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Archetype evaluation suite.
+"""Repository-level verification scenarios for Archetype.
 
-Structured after Anthropic's guide to agent evals:
-https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents
-
-Core concepts:
-- **Task**: A single test with defined inputs, success criteria, and graders.
-- **Trial**: One attempt at a task.  Multiple trials handle non-determinism.
-- **Grader**: Logic that scores an aspect of agent performance (code-based,
-  model-based, or human).  A task can have multiple graders.
-- **Eval suite**: A collection of tasks measuring specific capabilities.
-  - *Regression suites* should have ~100% pass rate (protect against backsliding).
-  - *Capability suites* start at a low pass rate (give teams a hill to climb).
-- **pass@k / pass^k**: Metrics for success across multiple trials.
+This package checks the framework itself. Its task, trial, and suite labels are
+runner implementation terms, not the public dataset/evaluation domain model.
 """

--- a/evals/harness.py
+++ b/evals/harness.py
@@ -1,12 +1,11 @@
 # Copyright 2025 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Eval harness: runs tasks, manages trials, grades outcomes, aggregates results.
+"""Run repository checks repeatedly and aggregate their grader evidence.
 
 Each task is a callable that returns a non-empty list of GraderResults (the outcome
 of applying all graders to the task's output).  The harness runs each task
-k times (trials), collects GraderResults per trial, and produces TaskResults
-with pass@k / pass^k metrics.
+one or more times, collects GraderResults per trial, and produces TaskResults.
 
 Usage:
     harness = EvalHarness(trials=3)
@@ -37,6 +36,11 @@ class EvalHarness:
     def add(self, task_id: str, *, suite: str, fn: TaskFn, desc: str = "") -> None:
         """Register a task to be run."""
         self._tasks.append((task_id, suite, fn, desc))
+
+    @property
+    def registered_tasks(self) -> tuple[tuple[str, str, TaskFn, str], ...]:
+        """Immutable live inventory of registered checks."""
+        return tuple(self._tasks)
 
     def run(self, *, suite_filter: str | None = None) -> list[TaskResult]:
         """Run all registered tasks and return aggregated results."""

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,16 +1,15 @@
 # Copyright 2025 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run all evals and report results.
+"""Run repository verification scenarios and report their outcomes.
 
 Usage:
-    python -m evals.run [--out results.json] [--suite regression|spec|idempotency|capability]
-        [--trials 3]
+    python -m evals.run [--out results.json] [--suite SUITE] [--trials 3]
+    python -m evals.run --list [--suite SUITE]
 
-Reports pass@k (fraction of k trials that passed) and pass^k (1.0 only
-when every one of the k trials passed, 0.0 otherwise) per task, grouped
-by suite.  Exit code 0 only when at least one task ran, all regression
-tasks pass, and no capability tasks error out.
+Reports the trial count, pass rate, average grader score, and whether every
+trial passed. Required groups fail on a missed grader; the advisory capability
+group fails only when a scenario crashes.
 """
 
 from __future__ import annotations
@@ -136,8 +135,11 @@ def print_report(results: list[TaskResult]) -> None:
         for t in tasks:
             icon = "PASS" if t.all_passed else "FAIL"
             line = f"    [{icon}] {t.task_id}"
-            if t.k > 1:
-                line += f"  (pass@{t.k}={t.pass_at_k:.0%}, pass^{t.k}={t.pass_pow_k:.0%})"
+            if t.trial_count > 1:
+                line += (
+                    f"  (trials={t.trial_count}, pass_rate={t.pass_rate:.0%}, "
+                    f"all_passed={str(t.all_passed).lower()})"
+                )
             line += f"  score={t.avg_score:.2f}"
 
             # Show failed graders
@@ -159,20 +161,46 @@ def print_report(results: list[TaskResult]) -> None:
     print("=" * 72)
 
 
+def print_task_list(harness: EvalHarness, *, suite_filter: str | None = None) -> int:
+    """Print the live task registry without executing it."""
+    tasks = [
+        registration
+        for registration in harness.registered_tasks
+        if suite_filter is None or registration[1] == suite_filter
+    ]
+    if not tasks:
+        print("No registered tasks match the requested suite.")
+        return 1
+
+    print("suite\ttask\tdescription")
+    for task_id, suite, _fn, desc in tasks:
+        print(f"{suite}\t{task_id}\t{desc}")
+    return 0
+
+
 def main() -> int:
-    _configure_eval_logging()
-    parser = argparse.ArgumentParser(description="Run archetype evals")
+    parser = argparse.ArgumentParser(description="Run Archetype repository checks")
     parser.add_argument("--out", default=None, help="Write JSON results to file")
     parser.add_argument("--suite", choices=KNOWN_SUITES, default=None)
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_tasks",
+        help="List registered tasks without executing them",
+    )
     parser.add_argument(
         "--trials",
         type=_positive_int,
         default=1,
-        help="Trials per task (for pass@k); must be >= 1",
+        help="Repeated executions per task; must be >= 1",
     )
     args = parser.parse_args()
 
     harness = build_harness(trials=args.trials)
+    if args.list_tasks:
+        return print_task_list(harness, suite_filter=args.suite)
+
+    _configure_eval_logging()
     results = harness.run(suite_filter=args.suite)
 
     print_report(results)

--- a/evals/suites/capability.py
+++ b/evals/suites/capability.py
@@ -1,14 +1,10 @@
 # Copyright 2025 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Capability eval suite: tasks that define a hill to climb.
+"""Broader end-to-end repository scenarios with advisory grader outcomes.
 
-These measure what the system can do well and where it struggles.
-Pass rates may start low.  As they improve, tasks can graduate to
-the regression suite.
-
-Graders use outcome verification and partial credit (state_check)
-to capture nuance in multi-component tasks.
+The CLI reports failed checks in this group but reserves a nonzero exit for
+scenario crashes. This is an execution policy, not a product capability model.
 """
 
 from __future__ import annotations

--- a/evals/suites/idempotency.py
+++ b/evals/suites/idempotency.py
@@ -304,7 +304,7 @@ def contract_map() -> list[dict[str, str]]:
 def _registered_tasks() -> list[tuple[str, str, object, str]]:
     harness = EvalHarness()
     register(harness)
-    return list(harness._tasks)
+    return list(harness.registered_tasks)
 
 
 def _registered_task_ids() -> set[str]:

--- a/evals/suites/regression.py
+++ b/evals/suites/regression.py
@@ -1,15 +1,7 @@
 # Copyright 2025 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression eval suite: tasks that must always pass (~100%).
-
-These protect against backsliding.  A decline in score signals something
-is broken.  Tasks here were once capability evals that graduated to
-regression status after reaching consistent pass rates.
-
-Graders are deterministic (code-based) since these test well-understood,
-stable behavior.
-"""
+"""Required repository checks for established behavior."""
 
 from __future__ import annotations
 

--- a/evals/suites/spec_contracts.py
+++ b/evals/suites/spec_contracts.py
@@ -631,7 +631,7 @@ class _UnusedService:
 def _registered_task_ids() -> list[str]:
     harness = EvalHarness()
     register(harness)
-    return [task_id for task_id, _, _, _ in harness._tasks]
+    return [task_id for task_id, _, _, _ in harness.registered_tasks]
 
 
 def task_receipt_authority_firewall() -> list[GraderResult]:

--- a/evals/types.py
+++ b/evals/types.py
@@ -1,14 +1,7 @@
 # Copyright 2025 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Core eval types following Anthropic's agent eval framework.
-
-Vocabulary matches the article:
-- Task: a single test with inputs, expected outcomes, and graders
-- Trial: one attempt at a task (run multiple for non-determinism)
-- Grader: scoring logic applied to the outcome of a trial
-- EvalResult: aggregated result across trials for a task
-"""
+"""Result records for Archetype's repository verification runner."""
 
 from __future__ import annotations
 
@@ -40,39 +33,23 @@ class TrialResult:
 
 @dataclass
 class TaskResult:
-    """Aggregated result of running a task across k trials."""
+    """Aggregated result of running one repository check repeatedly."""
 
     task_id: str
-    suite: str  # "regression" or "capability"
+    suite: str
     trials: list[TrialResult] = field(default_factory=list)
     desc: str = ""
 
     @property
-    def k(self) -> int:
+    def trial_count(self) -> int:
         return len(self.trials)
 
     @property
-    def pass_at_k(self) -> float:
-        """Fraction of the k trials that passed (empirical pass rate).
-
-        For mixed outcomes this is ``passed / k``; for uniformly passing
-        or failing tasks it collapses to 1.0 or 0.0.
-        """
+    def pass_rate(self) -> float:
+        """Fraction of recorded trials that passed."""
         if not self.trials:
             return 0.0
         return sum(1 for t in self.trials if t.passed) / len(self.trials)
-
-    @property
-    def pass_pow_k(self) -> float:
-        """Did ALL k trials succeed?
-
-        Returns 1.0 if every trial passed, 0.0 otherwise.
-        For reliability-critical tasks where anything less than
-        100% consistency is a failure.
-        """
-        if not self.trials:
-            return 0.0
-        return 1.0 if all(t.passed for t in self.trials) else 0.0
 
     @property
     def avg_score(self) -> float:
@@ -90,9 +67,8 @@ class TaskResult:
             "task_id": self.task_id,
             "suite": self.suite,
             "desc": self.desc,
-            "k": self.k,
-            "pass_at_k": round(self.pass_at_k, 4),
-            "pass_pow_k": round(self.pass_pow_k, 4),
+            "trial_count": self.trial_count,
+            "pass_rate": round(self.pass_rate, 4),
             "avg_score": round(self.avg_score, 4),
             "all_passed": self.all_passed,
             "trials": [

--- a/tests/eval_framework/test_harness_trial_validation.py
+++ b/tests/eval_framework/test_harness_trial_validation.py
@@ -14,7 +14,7 @@ import pytest
 
 from evals.graders import state_check
 from evals.harness import EvalHarness
-from evals.run import _configure_eval_logging, _ExpectedEvalNoiseFilter
+from evals.run import _configure_eval_logging, _ExpectedEvalNoiseFilter, build_harness
 from evals.run import main as run_main
 from evals.types import GraderResult, TaskResult, TrialResult
 
@@ -38,41 +38,36 @@ def test_harness_init_accepts_one_trial() -> None:
     assert harness.trials == 1
 
 
-def test_pass_at_k_reports_fraction_for_mixed_trials() -> None:
+def test_pass_rate_reports_fraction_for_mixed_trials() -> None:
     result = TaskResult(task_id="mixed", suite="regression")
     result.trials = [_trial(True, 0), _trial(False, 1), _trial(False, 2)]
-    assert result.pass_at_k == pytest.approx(1 / 3)
-    assert result.pass_pow_k == 0.0
+    assert result.pass_rate == pytest.approx(1 / 3)
     assert result.all_passed is False
 
 
-def test_pass_at_k_is_one_when_every_trial_passes() -> None:
+def test_pass_rate_is_one_when_every_trial_passes() -> None:
     result = TaskResult(task_id="all_pass", suite="regression")
     result.trials = [_trial(True, 0), _trial(True, 1)]
-    assert result.pass_at_k == 1.0
-    assert result.pass_pow_k == 1.0
+    assert result.pass_rate == 1.0
+    assert result.all_passed is True
 
 
-def test_pass_at_k_is_zero_when_no_trials_pass() -> None:
+def test_pass_rate_is_zero_when_no_trials_pass() -> None:
     result = TaskResult(task_id="all_fail", suite="regression")
     result.trials = [_trial(False, 0), _trial(False, 1)]
-    assert result.pass_at_k == 0.0
-    assert result.pass_pow_k == 0.0
+    assert result.pass_rate == 0.0
 
 
-def test_pass_pow_k_is_zero_when_any_trial_fails() -> None:
-    result = TaskResult(task_id="flaky", suite="regression")
-    result.trials = [_trial(True, 0), _trial(True, 1), _trial(False, 2)]
-    assert result.pass_pow_k == 0.0
-
-
-def test_to_dict_round_trips_pass_rate_for_mixed_trials() -> None:
+def test_to_dict_uses_literal_trial_metric_names() -> None:
     result = TaskResult(task_id="mixed_dict", suite="regression")
     result.trials = [_trial(True, 0), _trial(False, 1), _trial(False, 2), _trial(True, 3)]
     payload = result.to_dict()
-    assert payload["pass_at_k"] == pytest.approx(0.5)
-    assert payload["pass_pow_k"] == 0.0
+    assert payload["trial_count"] == 4
+    assert payload["pass_rate"] == pytest.approx(0.5)
     assert payload["all_passed"] is False
+    assert "k" not in payload
+    assert "pass_at_k" not in payload
+    assert "pass_pow_k" not in payload
 
 
 def test_harness_run_records_grader_outcomes_across_trials() -> None:
@@ -86,9 +81,9 @@ def test_harness_run_records_grader_outcomes_across_trials() -> None:
 
     harness.add("flaky_task", suite="regression", fn=task)
     [result] = harness.run()
-    assert result.k == 2
-    assert result.pass_at_k == pytest.approx(0.5)
-    assert result.pass_pow_k == 0.0
+    assert result.trial_count == 2
+    assert result.pass_rate == pytest.approx(0.5)
+    assert result.all_passed is False
 
 
 def test_harness_run_fails_trial_without_grader_evidence() -> None:
@@ -102,8 +97,19 @@ def test_harness_run_fails_trial_without_grader_evidence() -> None:
     assert trial.score == 0.0
     assert trial.grader_results == []
     assert trial.error == "task 'empty_task' produced no grader evidence"
-    assert result.pass_at_k == 0.0
+    assert result.pass_rate == 0.0
     assert result.all_passed is False
+
+
+def test_registered_tasks_expose_an_immutable_inventory() -> None:
+    harness = EvalHarness()
+
+    def task() -> list[GraderResult]:
+        return []
+
+    harness.add("visible", suite="regression", fn=task, desc="listed task")
+
+    assert harness.registered_tasks == (("visible", "regression", task, "listed task"),)
 
 
 def test_harness_run_preserves_multi_grader_aggregation() -> None:
@@ -160,6 +166,21 @@ def test_run_cli_rejects_negative_trials() -> None:
 def test_run_cli_rejects_non_integer_trials() -> None:
     proc = _run_cli("--trials", "abc")
     assert proc.returncode != 0
+
+
+def test_run_cli_lists_the_live_registry_without_executing_tasks() -> None:
+    proc = _run_cli("--list", "--suite", "capability")
+
+    expected = [
+        task_id
+        for task_id, suite, _fn, _desc in build_harness().registered_tasks
+        if suite == "capability"
+    ]
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.stdout.startswith("suite\ttask\tdescription\n")
+    assert "EVAL RESULTS" not in proc.stdout
+    assert expected
+    assert all(f"capability\t{task_id}\t" in proc.stdout for task_id in expected)
 
 
 def test_run_cli_fails_required_task_without_grader_evidence(

--- a/tests/idempotency/test_idempotency_evals.py
+++ b/tests/idempotency/test_idempotency_evals.py
@@ -18,7 +18,9 @@ from evals.suites.idempotency_process import _wait_for_markers
 
 def test_idempotency_eval_suite_is_registered_and_traceable() -> None:
     harness = build_harness(trials=1)
-    registered = {task_id for task_id, suite, _, _ in harness._tasks if suite == idempotency.SUITE}
+    registered = {
+        task_id for task_id, suite, _, _ in harness.registered_tasks if suite == idempotency.SUITE
+    }
     mapped = {case.task_id for case in idempotency.IDEMPOTENCY_CASES}
 
     assert registered == mapped | {"idempotency.manifest_traceability"}

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 from archetype.app.auth.permissions import ROLES_BY_COMMAND
 from archetype.app.models import CommandType
-from evals.run import build_harness
 
 _GUIDE_ROOT = Path("docs/guide")
 _COMMAND_TOTAL_PATTERNS = (
@@ -23,11 +22,6 @@ _DESIGN_ONLY_MESSAGING_TYPES = (
     "DeliveryReceipt",
     "ChatGraphRegistry",
 )
-_EVAL_MANIFEST = re.compile(
-    r"<!-- eval-task-manifest:start -->(.*?)<!-- eval-task-manifest:end -->",
-    re.DOTALL,
-)
-_EVAL_TASK_ROW = re.compile(r"^\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|", re.MULTILINE)
 _BEGINNER_GUIDES = (
     _GUIDE_ROOT / "quickstart.md",
     _GUIDE_ROOT / "building-simulations.md",
@@ -113,22 +107,13 @@ def test_docs_do_not_claim_design_only_messaging_types() -> None:
     assert not stale, "stale messaging infrastructure claims:\n" + "\n".join(stale)
 
 
-def test_eval_guide_manifest_matches_registered_tasks() -> None:
-    """The guide's task inventory is exact, not a hand-maintained sample."""
+def test_eval_guide_uses_live_inventory_instead_of_embedded_taxonomy() -> None:
+    """Task registration stays executable instead of becoming a prose taxonomy."""
     guide = (_GUIDE_ROOT / "evals.md").read_text()
-    manifest = _EVAL_MANIFEST.search(guide)
-    assert manifest is not None, "eval task manifest markers are missing"
 
-    rows = _EVAL_TASK_ROW.findall(manifest.group(1))
-    documented = {(suite, task_id) for suite, task_id in rows}
-    assert len(rows) == len(documented), "eval task manifest contains duplicate rows"
-
-    harness = build_harness(trials=1)
-    registered = {(suite, task_id) for task_id, suite, _, _ in harness._tasks}
-    assert documented == registered, (
-        f"eval guide manifest drifted; missing={registered - documented}, "
-        f"stale={documented - registered}"
-    )
+    assert "python -m evals.run --list" in guide
+    assert "eval-task-manifest" not in guide
+    assert "Registered task manifest" not in guide
 
 
 def test_beginner_surfaces_do_not_route_through_engine_internals() -> None:


### PR DESCRIPTION
## What changed

- replace imported `pass@k` / `pass^k` terminology with literal `trial_count`, `pass_rate`, and `all_passed` fields
- expose an immutable live task registry and add `python -m evals.run --list`
- remove the duplicated 51-row task manifest from the guide
- describe suites as repository-runner execution groups, separate from Archetype's public dataset/evaluation ontology
- tighten adjacent guide references and contracts around the live inventory

## Why

The repository checks had acquired a taxonomy that implied product-level capability semantics and statistical metrics the harness did not implement. The guide then duplicated the executable registry, making drift and verbosity part of the contract.

This keeps the useful execution policies while making the code the inventory and the documentation explain only the durable concepts.

## Impact

Task implementations, registration, suite membership, and gate behavior are unchanged. The internal JSON report schema renames `k` / `pass_at_k` and removes redundant `pass_pow_k`; callers should use `trial_count`, `pass_rate`, and `all_passed`.

Related to #142; does not close it.

## Validation

- `make ci` — 1,171 passed, 8 skipped; regression 15/15; idempotency 23/23
- focused eval/spec/idempotency contracts — 44 passed
- capability suite repeated twice — 5/5 fully passing
- `mkdocs build --strict`
- markdownlint on changed guide files
- `uvx ty@0.0.48 check --python .venv`
- `git diff --check`
