### PR TITLE
fix(ci): make the Codecov upload real (v5, fail loud, scoped skips)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -45,14 +45,23 @@ jobs:
       - name: Run CI gate (lint + lock-check + tests with coverage)
         run: make ci
 
+      # fail_ci_if_error must stay true: with it false, this step spent its
+      # whole life green while uploading nothing (no CODECOV_TOKEN secret
+      # existed). Skips: merge groups (synthetic commits carry no coverage
+      # signal, and a Codecov hiccup must not block the queue) and fork PRs
+      # (GitHub withholds secrets there, so the upload can only fail).
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4
+        if: >-
+          matrix.python-version == '3.12' &&
+          github.event_name != 'merge_group' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
           flags: unittests
           name: archetype-coverage
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   evals:


### PR DESCRIPTION
The Codecov upload step has been a silent no-op for its entire life: `fail_ci_if_error: false` plus a `CODECOV_TOKEN` secret that never existed meant every run green-checked while uploading nothing.

With Codecov now installed on the VangelisTech org and the token going in as a secret, this makes the step real:

- `fail_ci_if_error: true` — a failed upload is a red check, not a shrug
- `codecov/codecov-action` v4 → v5
- skip on `merge_group` — synthetic queue commits carry no coverage signal, and a Codecov hiccup must not block the queue
- skip on fork PRs — GitHub withholds secrets there, so the upload can only fail

`coverage.xml` generation was already correct (`make ci` → `test-cov` → `--cov-report=xml`, path pinned in `[tool.coverage.xml]`).

**Draft until two preconditions land:** the `CODECOV_TOKEN` secret exists (Everett), and #450 merges so arming happens post-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)