### PR TITLE
ci: auto-revert premature manual arming; document the PR flow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -36,6 +36,7 @@ on:
     types: [completed]
 
 permissions:
+  checks: read # Guard queries review-complete check runs on the armed head.
   contents: write
   pull-requests: write
 
@@ -86,13 +87,18 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          ok=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=review-complete&per_page=20" \
-            --jq '[.check_runs[] | select(.conclusion == "success")] | length')
-          if [ "${ok:-0}" -gt 0 ]; then
-            echo "review-complete already succeeded on ${HEAD_SHA}; arming is legitimate."
+          # LATEST run only: a head's review can be re-triggered without a
+          # new commit (reopen, manual re-run), and a stale success must not
+          # outvote a newer failure. `|| latest=""` keeps an API failure
+          # from tripping -e before the revert loop — failure to positively
+          # confirm the verdict falls through to the revert (fail closed).
+          latest=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=review-complete&per_page=100" \
+            --jq '[.check_runs[]] | sort_by(.started_at) | last | .conclusion // empty') || latest=""
+          if [ "$latest" = "success" ]; then
+            echo "latest review-complete on ${HEAD_SHA} succeeded; arming is legitimate."
             exit 0
           fi
-          echo "No passing review-complete on ${HEAD_SHA}; reverting premature arming."
+          echo "No authoritative passing review-complete on ${HEAD_SHA} (latest: ${latest:-none}); reverting premature arming."
           for attempt in 1 2 3; do
             gh pr merge --disable-auto "$PR_URL" || true
             armed=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest // empty')

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,8 +25,11 @@ name: Auto-merge
 
 on:
   # Every new head invalidates the previous head's review verdict.
+  # auto_merge_enabled feeds the guard job only: a manual `gh pr merge
+  # --auto` ahead of the verdict is reverted, closing the last arming path
+  # this workflow does not control.
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, auto_merge_enabled]
   # The review gate's completion is the arming signal.
   workflow_run:
     workflows: ["Deterministic Review Gate"]
@@ -39,7 +42,9 @@ permissions:
 jobs:
   disarm:
     name: Disarm until the head's review completes
-    if: github.event_name == 'pull_request'
+    # Not on auto_merge_enabled: that event is the guard job's input, and
+    # unconditional disarm there would also revert the arm job's own arming.
+    if: github.event_name == 'pull_request' && github.event.action != 'auto_merge_enabled'
     runs-on: ubuntu-latest
     steps:
       # Verified by postcondition, not exit code: `--disable-auto` exits
@@ -63,6 +68,41 @@ jobs:
             sleep 5
           done
           echo "::error::auto-merge still armed after 3 disarm attempts; a stale arm may carry this unreviewed head into the queue."
+          exit 1
+
+  guard:
+    name: Revert premature arming
+    if: github.event_name == 'pull_request' && github.event.action == 'auto_merge_enabled'
+    runs-on: ubuntu-latest
+    steps:
+      # Arming is the review gate (see header). The arm job below is the
+      # sanctioned arming path and always follows a green review, so this
+      # guard sees its arms as legitimate no-ops. A manual arm ahead of the
+      # verdict is reverted here; when the review later succeeds on this
+      # head, the arm job re-arms — nothing legitimate slows down.
+      - name: Disarm unless the head's review has passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          ok=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=review-complete&per_page=20" \
+            --jq '[.check_runs[] | select(.conclusion == "success")] | length')
+          if [ "${ok:-0}" -gt 0 ]; then
+            echo "review-complete already succeeded on ${HEAD_SHA}; arming is legitimate."
+            exit 0
+          fi
+          echo "No passing review-complete on ${HEAD_SHA}; reverting premature arming."
+          for attempt in 1 2 3; do
+            gh pr merge --disable-auto "$PR_URL" || true
+            armed=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest // empty')
+            if [ -z "$armed" ]; then
+              echo "premature arm reverted (attempt ${attempt})."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::could not revert a premature arm; this head may enter the queue unreviewed."
           exit 1
 
   arm:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,12 @@ make check       # format + lint
 make test-cov    # coverage report
 ```
 
+PR flow: open the PR and stop — never run `gh pr merge --auto`. The
+automerge workflow arms after the review gate passes your current head
+(premature arms are auto-reverted; arming early only skips the review, it
+never merges sooner). Reply to footgun review threads with what you
+changed before resolving them.
+
 ## Command flow
 
 ```text

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,3 +54,12 @@ make ci                         # Gate: lint + lock-check + tests with coverage
 make test                       # Fast tests, no coverage
 make check                      # Auto-format + lint
 ```
+
+## PR flow
+
+Open the PR and stop — never run `gh pr merge --auto`. The automerge
+workflow arms auto-merge only after the deterministic review gate passes
+your current head; arming earlier does not merge sooner, it only lets the
+PR enter the merge queue before its review verdict (premature arms are
+auto-reverted). Reply to footgun review threads with what you changed
+before resolving them.


### PR DESCRIPTION
## Summary
Follow-up to #450, closing its one residual: manual `gh pr merge --auto` re-arms ahead of the verdict and nothing disarmed it until the next push.

- **Guard job** on `pull_request: auto_merge_enabled`: if the current head has no successful `review-complete` check run, the arm is reverted (same postcondition-verified retry pattern as the disarm job — a failed revert goes loud, not silent). The arm job's own arms always follow a green review, so they pass through as no-ops; a reverted PR re-arms automatically when its review succeeds. Zero cost to legitimate flow.
- **Disarm job** scoped to exclude `auto_merge_enabled` (otherwise it would revert the sanctioned arms too).
- **Policy in CLAUDE.md/AGENTS.md**: open the PR and stop — the workflow arms after the review gate passes your head; reply to finding threads with what changed before resolving. Arming early never merges sooner; it only skips the review.

Context: audit of 63 merges since 07-16 (discussion #330 thread) — the gate held 63/63 at the SHA level, but #446/#448/#449 enqueued before their verdicts, which #450 fixed at the arming layer. This closes the last unmanaged arming path.

Per the new flow: this PR is intentionally **not** self-armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)