### PR TITLE
release: v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-ecs"
-version = "0.4.0"
+version = "0.5.0"
 description = "Dataframe-first, append-only ECS runtime for simulations and AI agents. Built on Daft with LanceDB time-travel storage."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "archetype-ecs"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "daft", extra = ["iceberg", "lance", "openai"] },


### PR DESCRIPTION
Version bump for the v0.5.0 release. Highlights since v0.4.0:

- **Command-gateway integrity**: `run_task_eval` / `run_instruction_sweep` now drive the runtime's gated surface (`world.spawn` / `run_episode` / `query`) instead of raw services; the service path survives one release as a deprecated bridge. Audit-row regression tests included.
- **`@public_api` + `@entrypoint`**: daft-style public-API decorator with an AST-enforced import-boundary gate in CI; `@entrypoint` wraps `ArchetypeRuntime` lifecycle for scripts.
- **Spawn audit metadata preserved** (#449): `spawn_batch`/`spawn_reserved` audit rows were silently dropped 100% of the time; now emitted and regression-tested.
- **Merge-queue enforcement**: arming is the review gate (#450) — auto-merge arms only after the deterministic footgun review passes on the exact head; disarm-on-push with a verified postcondition.
- **Codecov upload made real** (#452): fail-loud upload with org token; the step had been silently no-oping since birth.
- Scope-scaled footgun reviewer budgets, merge-group triggers for required workflows, eval-suite live inventory (#451), bench trend reports (#446) and query-latency suite (#448).

🤖 Generated with [Claude Code](https://claude.com/claude-code)