### PR TITLE
fix: review pull requests beyond GitHub diff limits

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -51,7 +51,10 @@ jobs:
       - name: Checkout trusted base
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          fetch-depth: 1
+          # Full trusted-base history lets git find the PR merge base after
+          # fetching the candidate head as inert objects. The candidate is
+          # never checked out or executed.
+          fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}
 
@@ -66,12 +69,22 @@ jobs:
         run: |
           gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
             > "${RUNNER_TEMP}/pr-before.json"
+
+          git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"
+          FETCHED_HEAD="$(git rev-parse FETCH_HEAD)"
+          if [[ "${FETCHED_HEAD}" != "${HEAD_SHA}" ]]; then
+            echo "Fetched PR head does not match the event head."
+            exit 1
+          fi
+          python3 scripts/footgun_review_gate.py scope \
+            --base "${BASE_SHA}" \
+            --head "${HEAD_SHA}" \
+            --scope "${RUNNER_TEMP}/git-scope.json" \
+            --diff "${DIFF_FILE}"
+
           gh api --paginate --slurp \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
             > "${RUNNER_TEMP}/pr-files.json"
-          gh api -H "Accept: application/vnd.github.diff" \
-            "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
-            > "${DIFF_FILE}"
           gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
             > "${RUNNER_TEMP}/pr-after.json"
 
@@ -85,6 +98,10 @@ jobs:
             --files "${RUNNER_TEMP}/pr-files.json" \
             --diff "${DIFF_FILE}" \
             --scope "${SCOPE_FILE}"
+          if ! cmp --silent "${RUNNER_TEMP}/git-scope.json" "${SCOPE_FILE}"; then
+            echo "Git and GitHub API review scopes do not match."
+            exit 1
+          fi
           echo "schema=$(python3 scripts/footgun_review_gate.py schema)" >> "${GITHUB_OUTPUT}"
 
       - name: Compute turn budget from scope
@@ -256,7 +273,8 @@ jobs:
       - name: Checkout trusted base
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          fetch-depth: 1
+          # Rebuild the same inert diff independently before publication.
+          fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}
 
@@ -270,12 +288,22 @@ jobs:
         run: |
           gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
             > "${RUNNER_TEMP}/pr-before.json"
+
+          git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"
+          FETCHED_HEAD="$(git rev-parse FETCH_HEAD)"
+          if [[ "${FETCHED_HEAD}" != "${HEAD_SHA}" ]]; then
+            echo "Fetched PR head does not match the event head."
+            exit 1
+          fi
+          python3 scripts/footgun_review_gate.py scope \
+            --base "${BASE_SHA}" \
+            --head "${HEAD_SHA}" \
+            --scope "${RUNNER_TEMP}/git-scope.json" \
+            --diff "${DIFF_FILE}"
+
           gh api --paginate --slurp \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
             > "${RUNNER_TEMP}/pr-files.json"
-          gh api -H "Accept: application/vnd.github.diff" \
-            "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
-            > "${DIFF_FILE}"
           gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
             > "${RUNNER_TEMP}/pr-after.json"
 
@@ -289,6 +317,10 @@ jobs:
             --files "${RUNNER_TEMP}/pr-files.json" \
             --diff "${DIFF_FILE}" \
             --scope "${SCOPE_FILE}"
+          if ! cmp --silent "${RUNNER_TEMP}/git-scope.json" "${SCOPE_FILE}"; then
+            echo "Git and GitHub API review scopes do not match."
+            exit 1
+          fi
 
       - name: Download detector result
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -474,6 +474,19 @@ def test_workflow_has_one_bounded_validator_feedback_retry():
     assert "Require detector completion" not in workflow
 
 
+def test_workflow_materializes_large_diffs_from_inert_git_objects():
+    workflow = (
+        Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deterministic-review.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "application/vnd.github.diff" not in workflow
+    assert workflow.count("fetch-depth: 0") == 2
+    assert workflow.count('git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"') == 2
+    assert workflow.count('if [[ "${FETCHED_HEAD}" != "${HEAD_SHA}" ]]') == 2
+    assert workflow.count("python3 scripts/footgun_review_gate.py scope") == 2
+    assert workflow.count('cmp --silent "${RUNNER_TEMP}/git-scope.json" "${SCOPE_FILE}"') == 2
+
+
 def test_review_payload_batches_each_finding_as_an_inline_thread():
     normalized = validate_result(_result(findings=[_finding()]), _scope(), DIFF)
     digest = artifact_digest(normalized)


### PR DESCRIPTION
## Summary

- materialize deterministic review diffs from locally fetched, inert PR-head Git objects
- bind the fetched object to the exact event SHA and retain the API before/after race check
- require the local rename-aware file manifest to equal GitHub's paginated file manifest
- rebuild the same scope independently in the publication job
- add a workflow contract test that prevents a return to GitHub's 20,000-line diff endpoint

Candidate code remains data-only under `pull_request_target`: the protected base is checked out, and the PR head is never checked out or executed.

## Reproduction and validation

- reproduced the prior HTTP 406 against #475
- generated and cross-validated #475's 261-file, 28,195-line, 1,203,760-byte diff locally
- `uv run pytest -q tests/scripts/test_footgun_review_gate.py` — 32 passed
- `uv run ruff check tests/scripts/test_footgun_review_gate.py scripts/footgun_review_gate.py`
- `git diff --check`

Fixes #485.

After this lands on `main`, #475's `pull_request_target` review can be rerun with the corrected trusted workflow.
