### PR TITLE
feat: add typed mission transition authority

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -82,11 +82,15 @@ multi-task attempt selects the next task in the same committed row.
 3. validates non-empty prompt and validator objects;
 4. requires coherent attempt counters below `max_attempts`;
 5. derives the next positive attempt index; and
-6. hashes world, run, entity, source state, task, and attempt identity into one
-   deterministic idempotency key.
+6. hashes the canonical full plan into a stable plan identity; and
+7. hashes world, run, entity, source state, plan, task, and attempt identity
+   into one deterministic idempotency key.
 
-The request carries its source state and step index. `apply_attempt` rejects a
-stale request if either changed before settlement.
+The request carries its source state, step index, and full-plan identity.
+`apply_attempt` rejects a stale request if any of them changed before
+settlement. This prevents an in-flight result from becoming final or advancing
+against a plan that was edited after execution began, even when its current
+step text stayed unchanged.
 
 An attempt advances only when all of the following hold:
 

--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -1,0 +1,150 @@
+# Agent mission transitions
+
+**Document type:** Normative.
+
+**Scope:** Provider-neutral mission, task, and completed-attempt state under
+`src/archetype/app/missions/`.
+
+This specification owns when a coding task may advance. Sandbox execution,
+provider credentials, artifact publication, and repository automation are
+separate capabilities and cannot bypass this authority.
+
+## 1. Ownership and persistence boundary
+
+The `missions` family owns:
+
+- immutable task-plan parsing;
+- deterministic task and attempt identity;
+- retry and exhaustion policy;
+- validator, commit, checkpoint, and finalization gates;
+- the typed transition graph; and
+- terminal mission state.
+
+It does not own a provider client, live sandbox handle, credential, world
+lifecycle, or authorization decision. `MissionService` is a pure transformer
+over one persisted ECS row. A world processor may call it, but the world tick
+remains the commit boundary for the returned row.
+
+The component columns are strings because LanceDB's Pydantic-to-Arrow bridge
+does not support Python enum fields. That storage constraint does not make
+states free-form: `MissionStatus`, `TaskStatus`, `AttemptStatus`,
+`CheckpointStatus`, `FinalizationPhase`, and `MissionTransitionEvent` are the
+only accepted values. Component validators reject invalid construction, and
+`MissionTransitionGraph` parses every persisted value again before use.
+
+## 2. Typed mission/task/attempt transition graph
+
+One immutable graph owns the state of all three scopes. Its source is the
+persisted `(mission status, current-task status)` pair. Its edge records one
+attempt result and its event. Its target is the next persisted mission/task
+pair.
+
+Legal source pairs are:
+
+| Mission | Current task | Meaning |
+|---|---|---|
+| `ready` | `ready` | No attempt has completed. |
+| `running` | `ready` | A prior task advanced and the next task is ready. |
+| `running` | `retryable` | The current task retained control after an unsuccessful attempt. |
+
+Each active source admits the same eight explicit edges:
+
+| Event | Attempt | Target mission | Target task |
+|---|---|---|---|
+| `rejected_retry` | `rejected` | `running` | `retryable` |
+| `incomplete_retry` | `incomplete` | `running` | `retryable` |
+| `failed_retry` | `failed` | `running` | `retryable` |
+| `rejected_exhausted` | `rejected` | `failed` | `exhausted` |
+| `incomplete_exhausted` | `incomplete` | `failed` | `exhausted` |
+| `failed_exhausted` | `failed` | `failed` | `exhausted` |
+| `task_advanced` | `accepted` | `running` | `ready` |
+| `mission_succeeded` | `accepted` | `succeeded` | `passed` |
+
+Terminal states have no outgoing edge. A row outside this graph fails closed;
+the service does not repair it by guessing.
+
+Every completed attempt persists its graph edge in `Attempt`:
+
+- `mission_status_before` and `task_status_before`;
+- `transition_event` and authoritative terminal `status`;
+- `mission_status_after` and `task_status_after`; and
+- the provider's raw terminal status separately as `provider_status`.
+
+Append-only world history therefore retains the edge even when a successful
+multi-task attempt selects the next task in the same committed row.
+
+## 3. Attempt and evidence gate
+
+`prepare_attempt`:
+
+1. parses and validates the persisted source state;
+2. selects the immutable plan entry at `step_index`;
+3. validates non-empty prompt and validator objects;
+4. requires coherent attempt counters below `max_attempts`;
+5. derives the next positive attempt index; and
+6. hashes world, run, entity, source state, task, and attempt identity into one
+   deterministic idempotency key.
+
+The request carries its source state and step index. `apply_attempt` rejects a
+stale request if either changed before settlement.
+
+An attempt advances only when all of the following hold:
+
+- the receipt identity matches the request;
+- validator details are non-empty JSON objects;
+- the provider reports an accepted result;
+- a checkpoint has `created` status, a non-empty state reference, and is
+  restorable;
+- finalization meets the task's typed minimum phase; and
+- a non-empty commit SHA exists.
+
+Provider acceptance without complete recovery/finalization evidence becomes
+the authoritative attempt state `incomplete`. It is not silently treated as
+success. Rejection, incomplete evidence, and provider failure remain committed
+attempts and retain the current task until the retry budget is exhausted.
+
+## 4. Tick and task advancement semantics
+
+A world tick is a commit opportunity, not a synonym for model execution. A
+processor may execute no attempt, one attempt, or only recovery work. An
+unsuccessful attempt does not abort the tick: the rejected or incomplete graph
+edge is valuable state and must remain queryable.
+
+For a successful non-final task, the same output row records the accepted
+attempt edge and selects the next task with status `ready` and attempt count
+zero. For the final task, the graph enters `succeeded/passed`. Exhaustion enters
+`failed/exhausted`. Booleans such as `finished`, `succeeded`, and `passed` are
+compatibility projections and must agree with their typed status.
+
+Only the world's ordinary two-phase tick commit makes a returned transition
+durable and visible. `MissionService` never writes around that boundary.
+
+## 5. Current execution guarantee and next authority
+
+This contract proves persisted completed-attempt edges. It does **not** yet
+claim exactly-once model submission.
+
+Before provider execution is production-ready, the control authority must add
+a durable pre-execution claim and an explicit `possibly_submitted` recovery
+state. The required crash distinction is:
+
+- a claimed attempt that never crossed the submission boundary may execute;
+- a possibly submitted attempt must reconcile provider/session evidence and
+  may not be blindly submitted again; and
+- terminal settlement replay must converge on the same graph edge.
+
+That control-plane claim is intentionally separate from this completed-row
+graph. It will be exercised by reliability evals for claim replay, crash after
+submission, duplicate tick delivery, settlement replay, and checkpoint
+reattachment.
+
+## 6. Executable enforcement
+
+- `tests/app/test_mission_transition_authority.py` exhausts every graph edge,
+  terminal rejection, stale request, evidence gate, retry, and multi-task
+  advancement.
+- `evals/suites/capability/agent_missions.py` grades a credential-free rejected,
+  incomplete, then accepted sequence without importing the feature tests.
+- `quality/contracts.toml` registers
+  `missions.transition.evidence_gated` as a blocking PR contract.
+- `quality/architecture.toml` confines the family to its own models and graph.

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -93,6 +93,7 @@ src/archetype/app/
   gateway/           authorization policy boundary
   audit/             journals, outboxes, projections
   research/          autoresearch and multi-run research workflows
+  missions/          typed mission/task/attempt transition authority
   errors.py          cross-family application error contracts
   container.py       sole concrete cross-family wiring root
 ```
@@ -143,6 +144,7 @@ gateway, runtime, API, or CLI boundary.
 | Commands | Durable admission, order, leasing, dispatch, retry, settlement and dead letters | Control catalog plus world and mutation ports |
 | Audit | Transactional journal/outbox and analytical projection | Storage or control-authority ports |
 | Research | Multi-run research workflows | World and simulation ports plus explicit evaluator callbacks |
+| Missions | Deterministic attempt identity, typed task transitions, retry/exhaustion and evidence gates | None |
 | RuntimeApplication | Canonical actor-free application facade and per-world operation serialization | Approved family workflow ports only |
 | CommandGateway | Authorization, safe downgrade, access-audit notification, delegation | RuntimeApplication port, authorizer, audit-journal port |
 | ServiceContainer | Concrete construction, ownership, and callback wiring | Every concrete implementation it constructs |
@@ -285,6 +287,9 @@ services and the container are not top-level exports.
 `quality/architecture.toml` contains the complete allowed family DAG and zero
 migration exceptions. `scripts/check_architecture.py` enforces package
 direction, protocol imports, concrete construction, and concrete inheritance.
+
+The mission family is pure transition authority over persisted row values. It
+does not own provider clients or write around the world tick commit boundary.
 
 Two deliberately retained implementation seams are documented rather than
 hidden: `QueryService` uses `iAuditLog` for compatibility history reads, and

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -53,6 +53,7 @@ iCommandScheduler  -> iWorldService + iMutationService
 iResearchService   -> iWorldService + iSimulationService
 iAuditLog          -> iStorageService
 iArtifactBundleService -> iStorageService + iWorldService
+iMissionService    -> typed mission rows (no service dependency)
 ```
 
 `ServiceContainer` alone selects concrete implementations.
@@ -75,6 +76,7 @@ iArtifactBundleService -> iStorageService + iWorldService
 | `iCommandScheduler` | `CommandScheduler` | application | Durable admission, leasing, dispatch, retry, settlement and outbox inspection |
 | `iAuditLog` | `AuditLog` | application, gateway, query | Append-only access rows and command-outbox projection |
 | `iResearchService` | `AutoResearchService` | application | Multi-run autoresearch workflow and research ledger |
+| `iMissionService` | `MissionService` | coding-agent orchestration | Deterministic attempt identity, typed transition graph, retry/exhaustion, and evidence gates |
 
 ## 4. Boundary rules
 
@@ -108,6 +110,13 @@ workflows. `iArtifactBundleService` owns full attempt-bundle publication and
 reconciliation while provider checkpoints remain recovery objects.
 `iAuditLog` is a projection/read port, not the authority for command outcome.
 
+### Mission transition port
+
+`iMissionService` is the sole mission/task/attempt transition authority. It is
+a pure row transformer: it owns no provider, live handle, world, storage
+client, or authorization context. Consumers persist its result through the
+ordinary world tick. See [Agent mission transitions](agent-missions.md).
+
 ## 5. Models crossing families
 
 Cross-family models are immutable or frozen where identity matters. The root
@@ -117,6 +126,7 @@ owners:
 
 - artifact descriptors and receipts: `app/artifacts/models.py`;
 - artifact bundle requests and publication receipts: `app/artifacts/bundle_models.py`;
+- mission facts, attempt requests, and typed states: `app/missions/`;
 - evaluation contracts, outcomes, and receipts: `app/evaluation/models.py`;
 - research contracts and ledger components: `app/research/`;
 - audit access events: `app/audit/models.py`;
@@ -158,3 +168,4 @@ closes container-owned world/storage resources.
 - [Audit Log](audit-log.md)
 - [Execution Hierarchy](execution-hierarchy.md)
 - [Artifact Finalization](artifact-finalization.md)
+- [Agent Mission Transitions](agent-missions.md)

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -24,6 +24,7 @@ The current contract set is split across design docs and executable tests.
 | [Durable Discovery](durable-discovery.md) | Control catalog and cold reads | Catalog authority, `discover_worlds`/`open_world_readonly`, fail-closed cold queries. |
 | [Atomic Visibility](atomic-visibility.md) | Tick commit identity | Manifest-published ticks, commit tokens, writer fencing, epoch-0 legacy reads. |
 | [Artifacts](artifacts.md) | External-artifact ingestion | Typed Iceberg tables, Daft file processors, content identity, and claim-backed receipt compatibility. |
+| [Agent Mission Transitions](agent-missions.md) | Mission/task/attempt authority | Typed completed-attempt graph, evidence gate, retry, exhaustion, and task advancement. |
 | [Dataset and Evaluation Ontology](dataset-eval-ontology.md) | Dataset/eval identity and vocabulary | Dataset-vs-runtime coordinates, trial/episode cardinality, typed-artifact ownership, and grader composition. |
 | [Audit Log](audit-log.md) | Audit rows | Append-only audit history and query contract. |
 | [Repository Harness](repository-harness.md) | Executable evidence | Focused tests, contract matrices, repository scenarios, benchmarks, static audits, and mutation probes. |
@@ -84,6 +85,7 @@ This specification covers:
 - multi-world orchestration and world forking
 - idempotency expectations and non-idempotent boundaries
 - typed external artifacts and dataset/evaluation identity
+- typed coding-agent mission transitions and completed-attempt evidence gates
 
 This specification does not authorize direct edits to `src/archetype/core/`.
 It defines the behavior that higher layers must preserve and that future

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -30,6 +30,7 @@ machine authority; this page is its review surface.
 | `release.package.installable` | `release` | high | [docs/guide/api-stability.md](../guide/api-stability.md) — What counts as public | pytest: 2; static: 1 | `release` |
 | `storage.remote.control_parity` | `storage` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 10. Supported durability profile | pytest: 2; static: 1 | `main`, `release` |
 | `artifacts.bundle.publication_replay` | `artifacts` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — 4. Publication state machine | pytest: 4 | `pr`, `main`, `release` |
+| `missions.transition.evidence_gated` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 2. Typed mission/task/attempt transition graph | pytest: 1; static: 1; eval: 1 | `pr`, `main`, `release` |
 
 Profile membership states where a contract must be enforced. Eval suite
 blocking/advisory policy is defined separately in `quality/eval_profiles.toml`;

--- a/evals/suites/capability/__init__.py
+++ b/evals/suites/capability/__init__.py
@@ -1,8 +1,18 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Advisory capability-evaluation package."""
+"""Blocking architectural capability-evaluation package."""
 
-from evals.suites.capability.tasks import register
+from __future__ import annotations
 
-__all__ = ["register"]
+from evals.harness import EvalHarness
+from evals.suites.capability import agent_missions, tasks
+
+
+def register(harness: EvalHarness) -> None:
+    """Register the stable capability suite in diagnostic order."""
+    tasks.register(harness)
+    agent_missions.register(harness)
+
+
+__all__ = ["agent_missions", "register", "tasks"]

--- a/evals/suites/capability/agent_missions.py
+++ b/evals/suites/capability/agent_missions.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graded, credential-free mission-transition capability checks.
+
+This suite proves typed transition authority over rows that the world persists:
+validator rejection and an incomplete checkpoint produce explicit graph edges
+without advancing the task, while complete evidence does. It does not claim a
+durable pre-execution claim, crash recovery, resumption, or exactly-once model
+submission; those require a control-authority claim before provider execution.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from archetype.app.missions import MissionService
+from evals.graders import state_check
+from evals.harness import EvalHarness
+from evals.types import GraderResult
+
+SUITE = "capability"
+
+
+def _row() -> dict[str, Any]:
+    return {
+        "world_id": "world-eval",
+        "run_id": "run-eval",
+        "entity_id": 7,
+        "mission__status": "ready",
+        "mission__finished": False,
+        "mission__succeeded": False,
+        "mission__failure_reason": "",
+        "mission__pr_ready": False,
+        "mission__pr_url": "",
+        "mission__plan_json": json.dumps(
+            [
+                {
+                    "name": "fix-bug",
+                    "prompt": "Fix the issue.",
+                    "validators": [{"name": "regression", "command": ["pytest"]}],
+                }
+            ]
+        ),
+        "taskgate__step_index": 0,
+        "taskgate__attempts": 0,
+        "taskgate__max_attempts": 5,
+        "taskgate__status": "ready",
+        "taskgate__required_finalization_phase": "checkpointed",
+        "attempt__agent_session_id": "",
+        "attempt__validator_details_json": "[]",
+        "frictionlog__entries_json": "[]",
+    }
+
+
+def _outcome(
+    request: Any,
+    *,
+    accepted: bool,
+    checkpoint_restorable: bool,
+) -> dict[str, Any]:
+    status = "accepted" if accepted else "rejected"
+    return {
+        "attempt_id": f"attempt-{request.attempt_index}",
+        "attempt_index": request.attempt_index,
+        "idempotency_key": request.idempotency_key,
+        "status": status,
+        "accepted": accepted,
+        "harness": "fake",
+        "agent_session_id": "session-eval",
+        "validator_details": [{"name": "regression", "passed": accepted}],
+        "checkpoint_provider": "fake",
+        "checkpoint_status": "created" if checkpoint_restorable else "failed",
+        "checkpoint_restorable": checkpoint_restorable,
+        "checkpoint_created_at_ms": 1,
+        "checkpoint_expires_at_ms": 2,
+        "sandbox_state_ref": "fake://checkpoint" if checkpoint_restorable else "",
+        "finalization_phase": "checkpointed",
+        "finalization_manifest_ref": "fake://manifest",
+        "finalization_error": "" if checkpoint_restorable else "checkpoint unavailable",
+        "results": {"regression": accepted},
+        "trace_ref": "fake://trace",
+        "traces_ref": "fake://traces",
+        "filesystem_start_ref": "fake://fs-start",
+        "filesystem_end_ref": "fake://fs-end",
+        "filesystem_diff_ref": "fake://fs-diff",
+        "git_status_ref": "fake://status",
+        "git_patch_ref": "fake://patch",
+        "git_bundle_ref": "fake://bundle",
+        "context_ref": "fake://context",
+        "friction": [],
+        "sha": "abc123" if accepted else "",
+        "message": "fix: resolve bug" if accepted else "",
+        "pushed": False,
+    }
+
+
+def task_agent_mission_transition_authority() -> list[GraderResult]:
+    """Reject twice for different reasons, then advance on complete evidence."""
+    service = MissionService()
+    initial = _row()
+
+    first_request = service.prepare_attempt(initial, tick=1)
+    assert first_request is not None
+    rejected = service.apply_attempt(
+        initial,
+        first_request,
+        _outcome(first_request, accepted=False, checkpoint_restorable=True),
+    )
+
+    second_request = service.prepare_attempt(rejected, tick=2)
+    assert second_request is not None
+    uncheckpointed = service.apply_attempt(
+        rejected,
+        second_request,
+        _outcome(second_request, accepted=True, checkpoint_restorable=False),
+    )
+
+    third_request = service.prepare_attempt(uncheckpointed, tick=3)
+    assert third_request is not None
+    completed = service.apply_attempt(
+        uncheckpointed,
+        third_request,
+        _outcome(third_request, accepted=True, checkpoint_restorable=True),
+    )
+
+    return [
+        state_check(
+            {
+                "rejection_is_durable": rejected["attempt__status"] == "rejected",
+                "rejection_edge_is_typed": (
+                    rejected["attempt__transition_event"] == "rejected_retry"
+                    and rejected["mission__status"] == "running"
+                    and rejected["taskgate__status"] == "retryable"
+                ),
+                "rejection_does_not_advance": rejected["taskgate__step_index"] == 0,
+                "accepted_without_checkpoint_does_not_advance": (
+                    uncheckpointed["taskgate__step_index"] == 0
+                    and not uncheckpointed["mission__finished"]
+                ),
+                "attempt_identity_changes": len(
+                    {
+                        first_request.idempotency_key,
+                        second_request.idempotency_key,
+                        third_request.idempotency_key,
+                    }
+                )
+                == 3,
+            },
+            name="mission_gate_holds",
+        ),
+        state_check(
+            {
+                "complete_evidence_finishes": completed["mission__finished"],
+                "complete_evidence_succeeds": completed["mission__succeeded"],
+                "complete_evidence_is_pr_ready": completed["mission__pr_ready"],
+                "commit_is_recorded": completed["commit__sha"] == "abc123",
+                "success_edge_is_typed": (
+                    completed["attempt__transition_event"] == "mission_succeeded"
+                    and completed["mission__status"] == "succeeded"
+                    and completed["taskgate__status"] == "passed"
+                ),
+                "attempt_count_is_three": completed["taskgate__attempts"] == 3,
+            },
+            name="mission_gate_advances",
+        ),
+    ]
+
+
+def register(harness: EvalHarness) -> None:
+    harness.add(
+        "agent_mission_transition_authority",
+        suite=SUITE,
+        fn=task_agent_mission_transition_authority,
+        desc="Mission progress requires validator, commit, checkpoint, and finalization evidence",
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - Atomic Visibility: guide/atomic-visibility.md
       - Artifacts: guide/artifacts.md
       - Artifact Finalization: guide/artifact-finalization.md
+      - Agent Mission Transitions: guide/agent-missions.md
       - Dataset and Evaluation Ontology: guide/dataset-eval-ontology.md
       - Audit Log: guide/audit-log.md
       - Repository Harness: guide/repository-harness.md

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -12,6 +12,7 @@ types = [
   "CommandScheduler",
   "EvaluationService",
   "MutationService",
+  "MissionService",
   "QueryService",
   "RuntimeApplication",
   "ServiceContainer",
@@ -103,6 +104,13 @@ allowed_app = [
   "archetype.app.query.interfaces",
   "archetype.app.artifacts.interfaces",
   "archetype.app.models",
+]
+
+[[family_rule]]
+name = "mission-family"
+consumer = "archetype.app.missions"
+allowed_app = [
+  "archetype.app.missions",
 ]
 
 [[family_rule]]
@@ -243,6 +251,14 @@ allowed_interfaces = [
 allowed_app = [
   "archetype.app.evaluation.models",
   "archetype.app.models",
+]
+
+[[module_rule]]
+module = "archetype.app.missions.service"
+allowed_interfaces = []
+allowed_app = [
+  "archetype.app.missions.models",
+  "archetype.app.missions.transitions",
 ]
 
 [[module_rule]]

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -329,3 +329,15 @@ static = []
 evals = []
 benchmarks = []
 profiles = ["pr", "main", "release"]
+
+[[contract]]
+id = "missions.transition.evidence_gated"
+source = "docs/guide/agent-missions.md"
+section = "2. Typed mission/task/attempt transition graph"
+owner = "missions"
+risk = "high"
+pytest = ["tests/app/test_mission_transition_authority.py"]
+static = ["scripts/check_architecture.py"]
+evals = ["agent_mission_transition_authority"]
+benchmarks = []
+profiles = ["pr", "main", "release"]

--- a/src/archetype/app/missions/__init__.py
+++ b/src/archetype/app/missions/__init__.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mission lifecycle and validator-gated state transitions."""
+
+from archetype.app.missions.interfaces import iMissionService
+from archetype.app.missions.models import (
+    MISSION_COMPONENTS,
+    Attempt,
+    Checkpoint,
+    Commit,
+    Evidence,
+    Finalization,
+    FrictionLog,
+    Mission,
+    MissionAttemptRequest,
+    TaskGate,
+)
+from archetype.app.missions.service import MissionService
+from archetype.app.missions.transitions import (
+    MISSION_TRANSITION_GRAPH,
+    AttemptStatus,
+    CheckpointStatus,
+    FinalizationPhase,
+    MissionStatus,
+    MissionTaskState,
+    MissionTransition,
+    MissionTransitionEvent,
+    MissionTransitionGraph,
+    TaskStatus,
+)
+
+__all__ = [
+    "MISSION_COMPONENTS",
+    "Attempt",
+    "AttemptStatus",
+    "Checkpoint",
+    "CheckpointStatus",
+    "Commit",
+    "Evidence",
+    "Finalization",
+    "FinalizationPhase",
+    "FrictionLog",
+    "Mission",
+    "MissionStatus",
+    "MissionAttemptRequest",
+    "MissionService",
+    "MissionTaskState",
+    "MissionTransition",
+    "MissionTransitionEvent",
+    "MissionTransitionGraph",
+    "MISSION_TRANSITION_GRAPH",
+    "TaskGate",
+    "TaskStatus",
+    "iMissionService",
+]

--- a/src/archetype/app/missions/interfaces.py
+++ b/src/archetype/app/missions/interfaces.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ports owned by the mission family."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
+
+from archetype.app.missions.models import MissionAttemptRequest
+
+
+@runtime_checkable
+class iMissionService(Protocol):
+    """Prepare attempts and authorize task-state transitions."""
+
+    def prepare_attempt(
+        self, row: Mapping[str, Any], *, tick: int
+    ) -> MissionAttemptRequest | None: ...
+
+    def apply_attempt(
+        self,
+        row: Mapping[str, Any],
+        request: MissionAttemptRequest,
+        outcome: Mapping[str, Any],
+    ) -> dict[str, Any]: ...

--- a/src/archetype/app/missions/models.py
+++ b/src/archetype/app/missions/models.py
@@ -200,6 +200,7 @@ class MissionAttemptRequest:
     step_name: str
     step_index: int
     attempt_index: int
+    plan_digest: str
     idempotency_key: str
     previous_session_id: str
     previous_validator_details: tuple[dict[str, Any], ...]

--- a/src/archetype/app/missions/models.py
+++ b/src/archetype/app/missions/models.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persisted mission state and provider-neutral attempt requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import field_validator, model_validator
+
+from archetype.app.missions.transitions import (
+    AttemptStatus,
+    CheckpointStatus,
+    FinalizationPhase,
+    MissionStatus,
+    MissionTaskState,
+    MissionTransitionEvent,
+    TaskStatus,
+)
+from archetype.core.component import Component
+
+
+class Mission(Component):
+    """Episode-level mission; ``finished`` is its terminal latch."""
+
+    name: str = ""
+    repo: str = ""
+    branch: str = "agent/mission"
+    plan_json: str = "[]"
+    status: str = MissionStatus.READY.value
+    finished: bool = False
+    succeeded: bool = False
+    failure_reason: str = ""
+    pr_ready: bool = False
+    pr_url: str = ""
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status(cls, value: str) -> str:
+        return MissionStatus(value).value
+
+    @model_validator(mode="after")
+    def _consistent_terminal_flags(self) -> Mission:
+        status = MissionStatus(self.status)
+        expected = {
+            MissionStatus.READY: (False, False),
+            MissionStatus.RUNNING: (False, False),
+            MissionStatus.SUCCEEDED: (True, True),
+            MissionStatus.FAILED: (True, False),
+        }[status]
+        if (self.finished, self.succeeded) != expected:
+            raise ValueError(
+                f"mission status {status.value!r} requires "
+                f"finished={expected[0]} and succeeded={expected[1]}"
+            )
+        return self
+
+
+class TaskGate(Component):
+    """Current task and the durable evidence threshold required to advance."""
+
+    step_index: int = 0
+    step_name: str = ""
+    prompt: str = ""
+    validators_json: str = "[]"
+    attempts: int = 0
+    max_attempts: int = 5
+    status: str = TaskStatus.READY.value
+    required_finalization_phase: str = FinalizationPhase.CHECKPOINTED.value
+    passed: bool = False
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status(cls, value: str) -> str:
+        return TaskStatus(value).value
+
+    @field_validator("required_finalization_phase")
+    @classmethod
+    def _valid_phase(cls, value: str) -> str:
+        return FinalizationPhase(value).value
+
+    @model_validator(mode="after")
+    def _valid_counters_and_flags(self) -> TaskGate:
+        if self.step_index < 0 or self.attempts < 0 or self.max_attempts < 1:
+            raise ValueError("task indexes are non-negative and max_attempts is positive")
+        if self.attempts > self.max_attempts:
+            raise ValueError("task attempts cannot exceed max_attempts")
+        if self.passed != (TaskStatus(self.status) is TaskStatus.PASSED):
+            raise ValueError("task passed flag must agree with task status")
+        return self
+
+
+class Attempt(Component):
+    """Exactly one submission, persisted whether accepted or rejected."""
+
+    attempt_id: str = ""
+    attempt_index: int = 0
+    status: str = AttemptStatus.PENDING.value
+    provider_status: str = ""
+    harness: str = ""
+    agent_session_id: str = ""
+    validator_details_json: str = "[]"
+    transition_event: str = ""
+    mission_status_before: str = ""
+    task_status_before: str = ""
+    mission_status_after: str = ""
+    task_status_after: str = ""
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status(cls, value: str) -> str:
+        return AttemptStatus(value).value
+
+    @field_validator("transition_event")
+    @classmethod
+    def _valid_event(cls, value: str) -> str:
+        return MissionTransitionEvent(value).value if value else ""
+
+    @field_validator("mission_status_before", "mission_status_after")
+    @classmethod
+    def _valid_mission_edge(cls, value: str) -> str:
+        return MissionStatus(value).value if value else ""
+
+    @field_validator("task_status_before", "task_status_after")
+    @classmethod
+    def _valid_task_edge(cls, value: str) -> str:
+        return TaskStatus(value).value if value else ""
+
+
+class Checkpoint(Component):
+    """Provider-native recovery point captured after an attempt."""
+
+    provider: str = ""
+    status: str = CheckpointStatus.PENDING.value
+    state_ref: str = ""
+    restorable: bool = False
+    created_at_ms: int = 0
+    expires_at_ms: int = 0
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status(cls, value: str) -> str:
+        return CheckpointStatus(value).value
+
+
+class Finalization(Component):
+    """Progress from evidence capture through durable publication."""
+
+    phase: str = FinalizationPhase.PENDING.value
+    idempotency_key: str = ""
+    manifest_ref: str = ""
+    error: str = ""
+
+    @field_validator("phase")
+    @classmethod
+    def _valid_phase(cls, value: str) -> str:
+        return FinalizationPhase(value).value
+
+
+class Commit(Component):
+    """Verified Git identity produced by the task gate."""
+
+    sha: str = ""
+    message: str = ""
+    pushed: bool = False
+
+
+class Evidence(Component):
+    """Queryable references to portable and provider-native attempt evidence."""
+
+    results_json: str = "{}"
+    trace_ref: str = ""
+    traces_ref: str = ""
+    live_status_ref: str = ""
+    live_events_ref: str = ""
+    sandbox_state_ref: str = ""
+    filesystem_start_ref: str = ""
+    filesystem_end_ref: str = ""
+    filesystem_diff_ref: str = ""
+    git_status_ref: str = ""
+    git_patch_ref: str = ""
+    git_bundle_ref: str = ""
+    context_ref: str = ""
+
+
+class FrictionLog(Component):
+    """Agent-reported operational friction retained as episode evidence."""
+
+    entries_json: str = "[]"
+
+
+@dataclass(frozen=True)
+class MissionAttemptRequest:
+    """One deterministic submission requested by the mission state machine."""
+
+    prompt: str
+    validators: tuple[dict[str, Any], ...]
+    step_name: str
+    step_index: int
+    attempt_index: int
+    idempotency_key: str
+    previous_session_id: str
+    previous_validator_details: tuple[dict[str, Any], ...]
+    correlation: dict[str, Any]
+    source: MissionTaskState
+
+
+MISSION_COMPONENTS = (
+    Mission,
+    TaskGate,
+    Attempt,
+    Checkpoint,
+    Finalization,
+    Commit,
+    Evidence,
+    FrictionLog,
+)

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic, provider-neutral mission transition authority."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from archetype.app.missions.models import MissionAttemptRequest
+from archetype.app.missions.transitions import (
+    AttemptStatus,
+    CheckpointStatus,
+    FinalizationPhase,
+    MissionStatus,
+    MissionTaskState,
+    MissionTransitionEvent,
+    MissionTransitionGraph,
+    TaskStatus,
+    retry_event,
+)
+
+
+class MissionService:
+    """Gate mission progress on validators and durable evidence.
+
+    A tick records at most one completed attempt. Rejection and incomplete
+    finalization are ordinary committed states; only this service traverses
+    the typed mission/task/attempt graph.
+    """
+
+    def __init__(self, graph: MissionTransitionGraph | None = None) -> None:
+        self._graph = graph or MissionTransitionGraph()
+
+    def prepare_attempt(self, row: Mapping[str, Any], *, tick: int) -> MissionAttemptRequest | None:
+        source = self._state(row)
+        finished = bool(row.get("mission__finished"))
+        terminal = source.mission in {MissionStatus.SUCCEEDED, MissionStatus.FAILED}
+        if finished != terminal:
+            raise ValueError("mission finished flag does not agree with its typed status")
+        if terminal:
+            return None
+        self._graph.require_active(source)
+
+        plan = self._plan(row)
+        step_index = int(row["taskgate__step_index"])
+        if step_index < 0:
+            raise ValueError("mission step_index must be non-negative")
+        if step_index >= len(plan):
+            raise ValueError("active mission step_index is outside its plan")
+
+        step = plan[step_index]
+        name = str(step.get("name", "")).strip()
+        prompt = str(step.get("prompt", "")).strip()
+        validators = tuple(step.get("validators") or ())
+        if not name or not prompt:
+            raise ValueError("mission tasks require non-empty name and prompt")
+        if not validators:
+            raise ValueError(f"mission task {name!r} requires at least one validator")
+        if any(not isinstance(value, dict) for value in validators):
+            raise TypeError("mission validators must be JSON objects")
+
+        attempts = int(row["taskgate__attempts"])
+        max_attempts = int(row["taskgate__max_attempts"])
+        if attempts < 0 or max_attempts < 1 or attempts >= max_attempts:
+            raise ValueError("active task attempt counters are inconsistent")
+        attempt_index = attempts + 1
+        gate_material = json.dumps(
+            {
+                "world_id": str(row["world_id"]),
+                "run_id": str(row["run_id"]),
+                "entity_id": str(row["entity_id"]),
+                "mission_status": source.mission.value,
+                "task_status": source.task.value,
+                "step_index": step_index,
+                "attempt_index": attempt_index,
+                "step": step,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        prior = (
+            json.loads(str(row.get("attempt__validator_details_json") or "[]"))
+            if attempt_index > 1
+            else []
+        )
+        if not isinstance(prior, list) or any(not isinstance(value, dict) for value in prior):
+            raise ValueError("persisted validator details must be a JSON list of objects")
+        return MissionAttemptRequest(
+            prompt=prompt,
+            validators=validators,
+            step_name=name,
+            step_index=step_index,
+            attempt_index=attempt_index,
+            idempotency_key=hashlib.sha256(gate_material.encode()).hexdigest(),
+            previous_session_id=str(row.get("attempt__agent_session_id") or ""),
+            previous_validator_details=tuple(prior),
+            correlation={
+                "world_id": str(row["world_id"]),
+                "run_id": str(row["run_id"]),
+                "entity_id": str(row["entity_id"]),
+                "tick": tick,
+                "step_index": step_index,
+            },
+            source=source,
+        )
+
+    def apply_attempt(
+        self,
+        row: Mapping[str, Any],
+        request: MissionAttemptRequest,
+        outcome: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        source = self._state(row)
+        if bool(row.get("mission__finished")):
+            raise ValueError("a terminal mission cannot accept another attempt")
+        self._graph.require_active(source)
+        if source != request.source:
+            raise ValueError("mission state changed after this attempt was prepared")
+        if int(row["taskgate__step_index"]) != request.step_index:
+            raise ValueError("mission step changed after this attempt was prepared")
+        if int(row["taskgate__attempts"]) + 1 != request.attempt_index:
+            raise ValueError("mission attempt counter changed after this attempt was prepared")
+        if int(outcome["attempt_index"]) != request.attempt_index:
+            raise ValueError("sandbox outcome attempt_index does not match the request")
+        if str(outcome["idempotency_key"]) != request.idempotency_key:
+            raise ValueError("sandbox outcome idempotency_key does not match the request")
+
+        plan = self._plan(row)
+        details = list(outcome["validator_details"])
+        if not details or any(not isinstance(value, dict) for value in details):
+            raise ValueError("sandbox outcomes require non-empty validator details")
+        friction = list(outcome.get("friction") or ())
+        if any(not isinstance(value, dict) for value in friction):
+            raise ValueError("sandbox friction entries must be JSON objects")
+        prior_friction = json.loads(str(row.get("frictionlog__entries_json") or "[]"))
+        if not isinstance(prior_friction, list) or any(
+            not isinstance(value, dict) for value in prior_friction
+        ):
+            raise ValueError("persisted friction log must be a JSON list of objects")
+        prior_friction.extend(friction)
+
+        provider_status = self._provider_status(outcome)
+        checkpoint_status = self._checkpoint_status(outcome)
+        required_phase = self._phase(row["taskgate__required_finalization_phase"], "required")
+        actual_phase = self._phase(outcome["finalization_phase"], "outcome")
+        gate_passed = (
+            bool(outcome["accepted"])
+            and bool(outcome["checkpoint_restorable"])
+            and actual_phase.rank >= required_phase.rank
+        )
+        attempt_status = self._attempt_status(provider_status, gate_passed=gate_passed)
+        exhausted = request.attempt_index >= int(row["taskgate__max_attempts"])
+
+        if gate_passed:
+            event = (
+                MissionTransitionEvent.MISSION_SUCCEEDED
+                if request.step_index + 1 >= len(plan)
+                else MissionTransitionEvent.TASK_ADVANCED
+            )
+        else:
+            event = retry_event(attempt_status, exhausted=exhausted)
+        transition = self._graph.transition(source, event)
+
+        updated = dict(row)
+        updated.update(
+            {
+                "mission__status": transition.target.mission.value,
+                "taskgate__step_name": request.step_name,
+                "taskgate__prompt": request.prompt,
+                "taskgate__validators_json": self._json(list(request.validators)),
+                "taskgate__attempts": request.attempt_index,
+                "taskgate__status": transition.target.task.value,
+                "taskgate__passed": transition.target.task is TaskStatus.PASSED,
+                "attempt__attempt_id": str(outcome["attempt_id"]),
+                "attempt__attempt_index": request.attempt_index,
+                "attempt__status": transition.attempt.value,
+                "attempt__provider_status": provider_status.value,
+                "attempt__harness": str(outcome["harness"]),
+                "attempt__agent_session_id": str(outcome["agent_session_id"]),
+                "attempt__validator_details_json": self._json(details),
+                "attempt__transition_event": transition.event.value,
+                "attempt__mission_status_before": transition.source.mission.value,
+                "attempt__task_status_before": transition.source.task.value,
+                "attempt__mission_status_after": transition.target.mission.value,
+                "attempt__task_status_after": transition.target.task.value,
+                "checkpoint__provider": str(outcome["checkpoint_provider"]),
+                "checkpoint__status": checkpoint_status.value,
+                "checkpoint__state_ref": str(outcome["sandbox_state_ref"]),
+                "checkpoint__restorable": bool(outcome["checkpoint_restorable"]),
+                "checkpoint__created_at_ms": int(outcome["checkpoint_created_at_ms"]),
+                "checkpoint__expires_at_ms": int(outcome["checkpoint_expires_at_ms"]),
+                "finalization__phase": actual_phase.value,
+                "finalization__idempotency_key": request.idempotency_key,
+                "finalization__manifest_ref": str(outcome["finalization_manifest_ref"]),
+                "finalization__error": str(outcome["finalization_error"]),
+                "evidence__results_json": self._json(outcome["results"]),
+                "evidence__trace_ref": str(outcome["trace_ref"]),
+                "evidence__traces_ref": str(outcome["traces_ref"]),
+                "evidence__live_status_ref": str(outcome.get("live_status_ref", "")),
+                "evidence__live_events_ref": str(outcome.get("live_events_ref", "")),
+                "evidence__sandbox_state_ref": str(outcome["sandbox_state_ref"]),
+                "evidence__filesystem_start_ref": str(outcome["filesystem_start_ref"]),
+                "evidence__filesystem_end_ref": str(outcome["filesystem_end_ref"]),
+                "evidence__filesystem_diff_ref": str(outcome["filesystem_diff_ref"]),
+                "evidence__git_status_ref": str(outcome["git_status_ref"]),
+                "evidence__git_patch_ref": str(outcome["git_patch_ref"]),
+                "evidence__git_bundle_ref": str(outcome["git_bundle_ref"]),
+                "evidence__context_ref": str(outcome["context_ref"]),
+                "frictionlog__entries_json": self._json(prior_friction),
+            }
+        )
+
+        if gate_passed:
+            sha = str(outcome["sha"])
+            if not sha:
+                raise ValueError("an accepted, finalized attempt requires a commit SHA")
+            updated["commit__sha"] = sha
+            updated["commit__message"] = str(outcome["message"])
+            updated["commit__pushed"] = bool(outcome["pushed"])
+            if transition.advances_task:
+                next_index = request.step_index + 1
+                nxt = plan[next_index]
+                updated.update(
+                    {
+                        "taskgate__step_index": next_index,
+                        "taskgate__step_name": str(nxt["name"]),
+                        "taskgate__prompt": str(nxt["prompt"]),
+                        "taskgate__validators_json": self._json(nxt["validators"]),
+                        "taskgate__attempts": 0,
+                    }
+                )
+            else:
+                updated.update(
+                    {
+                        "mission__finished": True,
+                        "mission__succeeded": True,
+                        "mission__pr_ready": True,
+                        "mission__pr_url": str(
+                            outcome.get("pr_url") or row.get("mission__pr_url", "")
+                        ),
+                    }
+                )
+        elif transition.terminal:
+            updated.update(
+                {
+                    "mission__finished": True,
+                    "mission__succeeded": False,
+                    "mission__failure_reason": (
+                        f"task {request.step_name!r} exhausted {request.attempt_index} attempts; "
+                        f"latest status={attempt_status.value} phase={actual_phase.value}"
+                    ),
+                }
+            )
+        return updated
+
+    def _state(self, row: Mapping[str, Any]) -> MissionTaskState:
+        return self._graph.state(row.get("mission__status"), row.get("taskgate__status"))
+
+    @staticmethod
+    def _provider_status(outcome: Mapping[str, Any]) -> AttemptStatus:
+        try:
+            status = AttemptStatus(str(outcome["status"]))
+        except ValueError as exc:
+            raise ValueError(f"unknown sandbox outcome status: {outcome['status']!r}") from exc
+        accepted = bool(outcome["accepted"])
+        if accepted and status is not AttemptStatus.ACCEPTED:
+            raise ValueError("accepted sandbox outcome must have accepted status")
+        if not accepted and status not in {AttemptStatus.REJECTED, AttemptStatus.FAILED}:
+            raise ValueError("unaccepted sandbox outcome must be rejected or failed")
+        return status
+
+    @staticmethod
+    def _checkpoint_status(outcome: Mapping[str, Any]) -> CheckpointStatus:
+        try:
+            status = CheckpointStatus(str(outcome["checkpoint_status"]))
+        except ValueError as exc:
+            raise ValueError(
+                f"unknown checkpoint status: {outcome['checkpoint_status']!r}"
+            ) from exc
+        restorable = bool(outcome["checkpoint_restorable"])
+        state_ref = str(outcome["sandbox_state_ref"])
+        if restorable and (status is not CheckpointStatus.CREATED or not state_ref):
+            raise ValueError("restorable checkpoint requires created status and state reference")
+        if not restorable and status is CheckpointStatus.CREATED:
+            raise ValueError("created checkpoint must be restorable")
+        return status
+
+    @staticmethod
+    def _attempt_status(provider: AttemptStatus, *, gate_passed: bool) -> AttemptStatus:
+        if gate_passed:
+            return AttemptStatus.ACCEPTED
+        if provider is AttemptStatus.ACCEPTED:
+            return AttemptStatus.INCOMPLETE
+        return provider
+
+    @staticmethod
+    def _phase(value: object, label: str) -> FinalizationPhase:
+        try:
+            return FinalizationPhase(str(value))
+        except ValueError as exc:
+            raise ValueError(f"unknown {label} finalization phase: {value!r}") from exc
+
+    @staticmethod
+    def _json(value: Any) -> str:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+
+    @staticmethod
+    def _plan(row: Mapping[str, Any]) -> list[dict[str, Any]]:
+        plan = json.loads(str(row.get("mission__plan_json") or "[]"))
+        if not isinstance(plan, list) or any(not isinstance(step, dict) for step in plan):
+            raise ValueError("mission plan must be a JSON list of task objects")
+        if not plan:
+            raise ValueError("mission plan must contain at least one task")
+        return plan

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -68,6 +68,7 @@ class MissionService:
         if attempts < 0 or max_attempts < 1 or attempts >= max_attempts:
             raise ValueError("active task attempt counters are inconsistent")
         attempt_index = attempts + 1
+        plan_digest = self._plan_digest(plan)
         gate_material = json.dumps(
             {
                 "world_id": str(row["world_id"]),
@@ -77,6 +78,7 @@ class MissionService:
                 "task_status": source.task.value,
                 "step_index": step_index,
                 "attempt_index": attempt_index,
+                "plan_digest": plan_digest,
                 "step": step,
             },
             sort_keys=True,
@@ -95,6 +97,7 @@ class MissionService:
             step_name=name,
             step_index=step_index,
             attempt_index=attempt_index,
+            plan_digest=plan_digest,
             idempotency_key=hashlib.sha256(gate_material.encode()).hexdigest(),
             previous_session_id=str(row.get("attempt__agent_session_id") or ""),
             previous_validator_details=tuple(prior),
@@ -124,12 +127,14 @@ class MissionService:
             raise ValueError("mission step changed after this attempt was prepared")
         if int(row["taskgate__attempts"]) + 1 != request.attempt_index:
             raise ValueError("mission attempt counter changed after this attempt was prepared")
+        plan = self._plan(row)
+        if self._plan_digest(plan) != request.plan_digest:
+            raise ValueError("mission plan changed after this attempt was prepared")
         if int(outcome["attempt_index"]) != request.attempt_index:
             raise ValueError("sandbox outcome attempt_index does not match the request")
         if str(outcome["idempotency_key"]) != request.idempotency_key:
             raise ValueError("sandbox outcome idempotency_key does not match the request")
 
-        plan = self._plan(row)
         details = list(outcome["validator_details"])
         if not details or any(not isinstance(value, dict) for value in details):
             raise ValueError("sandbox outcomes require non-empty validator details")
@@ -313,6 +318,10 @@ class MissionService:
             ensure_ascii=True,
             allow_nan=False,
         )
+
+    @classmethod
+    def _plan_digest(cls, plan: list[dict[str, Any]]) -> str:
+        return hashlib.sha256(cls._json(plan).encode()).hexdigest()
 
     @staticmethod
     def _plan(row: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/src/archetype/app/missions/transitions.py
+++ b/src/archetype/app/missions/transitions.py
@@ -1,0 +1,212 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed mission, task, and attempt transition authority.
+
+Arrow persists component states as strings. This module is the single parser
+and graph for those strings; services never compare or invent state literals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+
+
+class MissionStatus(StrEnum):
+    """Episode-level mission states."""
+
+    READY = "ready"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class TaskStatus(StrEnum):
+    """State of the task currently selected by ``step_index``."""
+
+    READY = "ready"
+    RETRYABLE = "retryable"
+    PASSED = "passed"
+    EXHAUSTED = "exhausted"
+
+
+class AttemptStatus(StrEnum):
+    """Authoritative result of one completed submission attempt."""
+
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    INCOMPLETE = "incomplete"
+    FAILED = "failed"
+
+
+class CheckpointStatus(StrEnum):
+    """Provider-checkpoint outcomes recorded with an attempt."""
+
+    PENDING = "pending"
+    CREATED = "created"
+    FAILED = "failed"
+
+
+class FinalizationPhase(StrEnum):
+    """Ordered evidence-finalization phases."""
+
+    PENDING = "pending"
+    CAPTURED = "captured"
+    CHECKPOINTED = "checkpointed"
+    INDEXED = "indexed"
+    PUBLISHED = "published"
+
+    @property
+    def rank(self) -> int:
+        return _FINALIZATION_RANK[self]
+
+
+class MissionTransitionEvent(StrEnum):
+    """Every legal graph edge produced by one attempt."""
+
+    REJECTED_RETRY = "rejected_retry"
+    INCOMPLETE_RETRY = "incomplete_retry"
+    FAILED_RETRY = "failed_retry"
+    REJECTED_EXHAUSTED = "rejected_exhausted"
+    INCOMPLETE_EXHAUSTED = "incomplete_exhausted"
+    FAILED_EXHAUSTED = "failed_exhausted"
+    TASK_ADVANCED = "task_advanced"
+    MISSION_SUCCEEDED = "mission_succeeded"
+
+
+@dataclass(frozen=True)
+class MissionTaskState:
+    """Typed aggregate state persisted across mission and task components."""
+
+    mission: MissionStatus
+    task: TaskStatus
+
+
+@dataclass(frozen=True)
+class MissionTransition:
+    """One validated edge that will be persisted with the attempt."""
+
+    source: MissionTaskState
+    event: MissionTransitionEvent
+    attempt: AttemptStatus
+    target: MissionTaskState
+
+    @property
+    def advances_task(self) -> bool:
+        return self.event is MissionTransitionEvent.TASK_ADVANCED
+
+    @property
+    def terminal(self) -> bool:
+        return self.target.mission in {MissionStatus.SUCCEEDED, MissionStatus.FAILED}
+
+
+_FINALIZATION_RANK = MappingProxyType(
+    {
+        FinalizationPhase.PENDING: 0,
+        FinalizationPhase.CAPTURED: 1,
+        FinalizationPhase.CHECKPOINTED: 2,
+        FinalizationPhase.INDEXED: 3,
+        FinalizationPhase.PUBLISHED: 4,
+    }
+)
+
+_EVENT_TARGETS = MappingProxyType(
+    {
+        MissionTransitionEvent.REJECTED_RETRY: (
+            AttemptStatus.REJECTED,
+            MissionTaskState(MissionStatus.RUNNING, TaskStatus.RETRYABLE),
+        ),
+        MissionTransitionEvent.INCOMPLETE_RETRY: (
+            AttemptStatus.INCOMPLETE,
+            MissionTaskState(MissionStatus.RUNNING, TaskStatus.RETRYABLE),
+        ),
+        MissionTransitionEvent.FAILED_RETRY: (
+            AttemptStatus.FAILED,
+            MissionTaskState(MissionStatus.RUNNING, TaskStatus.RETRYABLE),
+        ),
+        MissionTransitionEvent.REJECTED_EXHAUSTED: (
+            AttemptStatus.REJECTED,
+            MissionTaskState(MissionStatus.FAILED, TaskStatus.EXHAUSTED),
+        ),
+        MissionTransitionEvent.INCOMPLETE_EXHAUSTED: (
+            AttemptStatus.INCOMPLETE,
+            MissionTaskState(MissionStatus.FAILED, TaskStatus.EXHAUSTED),
+        ),
+        MissionTransitionEvent.FAILED_EXHAUSTED: (
+            AttemptStatus.FAILED,
+            MissionTaskState(MissionStatus.FAILED, TaskStatus.EXHAUSTED),
+        ),
+        MissionTransitionEvent.TASK_ADVANCED: (
+            AttemptStatus.ACCEPTED,
+            MissionTaskState(MissionStatus.RUNNING, TaskStatus.READY),
+        ),
+        MissionTransitionEvent.MISSION_SUCCEEDED: (
+            AttemptStatus.ACCEPTED,
+            MissionTaskState(MissionStatus.SUCCEEDED, TaskStatus.PASSED),
+        ),
+    }
+)
+
+_ACTIVE_SOURCES = (
+    MissionTaskState(MissionStatus.READY, TaskStatus.READY),
+    MissionTaskState(MissionStatus.RUNNING, TaskStatus.READY),
+    MissionTaskState(MissionStatus.RUNNING, TaskStatus.RETRYABLE),
+)
+
+# One immutable graph owns mission, task, and terminal attempt state together.
+# Keeping the complete edge map public makes exhaustive contract tests possible.
+MISSION_TRANSITION_GRAPH = MappingProxyType(
+    {
+        (source, event): MissionTransition(source, event, attempt, target)
+        for source in _ACTIVE_SOURCES
+        for event, (attempt, target) in _EVENT_TARGETS.items()
+    }
+)
+
+
+class MissionTransitionGraph:
+    """Parse durable states and reject every edge absent from the graph."""
+
+    @staticmethod
+    def state(mission: object, task: object) -> MissionTaskState:
+        try:
+            return MissionTaskState(MissionStatus(str(mission)), TaskStatus(str(task)))
+        except ValueError as exc:
+            raise ValueError(f"invalid persisted mission/task state: {mission!r}/{task!r}") from exc
+
+    @staticmethod
+    def transition(
+        source: MissionTaskState,
+        event: MissionTransitionEvent | str,
+    ) -> MissionTransition:
+        try:
+            parsed_event = MissionTransitionEvent(event)
+        except ValueError as exc:
+            raise ValueError(f"unknown mission transition event: {event!r}") from exc
+        try:
+            return MISSION_TRANSITION_GRAPH[(source, parsed_event)]
+        except KeyError as exc:
+            raise ValueError(
+                "illegal mission transition: "
+                f"{source.mission.value}/{source.task.value} via {parsed_event.value}"
+            ) from exc
+
+    @staticmethod
+    def require_active(source: MissionTaskState) -> None:
+        if source not in _ACTIVE_SOURCES:
+            raise ValueError(
+                f"mission is not attemptable from state {source.mission.value}/{source.task.value}"
+            )
+
+
+def retry_event(attempt: AttemptStatus, *, exhausted: bool) -> MissionTransitionEvent:
+    """Select the sole retry/exhaustion edge for a terminal attempt result."""
+
+    suffix = "exhausted" if exhausted else "retry"
+    try:
+        return MissionTransitionEvent(f"{attempt.value}_{suffix}")
+    except ValueError as exc:
+        raise ValueError(f"attempt state {attempt.value!r} cannot retry or exhaust") from exc

--- a/tests/app/test_mission_transition_authority.py
+++ b/tests/app/test_mission_transition_authority.py
@@ -1,0 +1,338 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from archetype.app.missions import (
+    MISSION_TRANSITION_GRAPH,
+    Attempt,
+    AttemptStatus,
+    Checkpoint,
+    Finalization,
+    Mission,
+    MissionService,
+    MissionStatus,
+    MissionTaskState,
+    MissionTransitionEvent,
+    MissionTransitionGraph,
+    TaskGate,
+    TaskStatus,
+)
+
+
+def _row(*, max_attempts: int = 3, plan: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    plan = plan or [
+        {
+            "name": "fix",
+            "prompt": "Fix the bug",
+            "validators": [{"name": "tests", "command": ["pytest"]}],
+        }
+    ]
+    return {
+        "world_id": "world-test",
+        "run_id": "run-test",
+        "entity_id": 7,
+        "mission__name": "mission",
+        "mission__plan_json": json.dumps(plan),
+        "mission__status": MissionStatus.READY.value,
+        "mission__finished": False,
+        "mission__succeeded": False,
+        "mission__failure_reason": "",
+        "mission__pr_ready": False,
+        "mission__pr_url": "",
+        "taskgate__step_index": 0,
+        "taskgate__step_name": plan[0]["name"],
+        "taskgate__prompt": plan[0]["prompt"],
+        "taskgate__validators_json": json.dumps(plan[0]["validators"]),
+        "taskgate__attempts": 0,
+        "taskgate__max_attempts": max_attempts,
+        "taskgate__status": TaskStatus.READY.value,
+        "taskgate__required_finalization_phase": "checkpointed",
+        "taskgate__passed": False,
+        "attempt__agent_session_id": "",
+        "attempt__validator_details_json": "[]",
+        "frictionlog__entries_json": "[]",
+    }
+
+
+def _outcome(
+    request: Any,
+    *,
+    accepted: bool,
+    checkpoint: bool = True,
+    status: str | None = None,
+    phase: str = "checkpointed",
+) -> dict[str, Any]:
+    provider_status = status or ("accepted" if accepted else "rejected")
+    return {
+        "attempt_id": f"attempt-{request.attempt_index}",
+        "attempt_index": request.attempt_index,
+        "idempotency_key": request.idempotency_key,
+        "status": provider_status,
+        "accepted": accepted,
+        "harness": "fake",
+        "agent_session_id": "session-test",
+        "validator_details": [{"name": "tests", "passed": accepted}],
+        "checkpoint_provider": "fake",
+        "checkpoint_status": "created" if checkpoint else "failed",
+        "checkpoint_restorable": checkpoint,
+        "checkpoint_created_at_ms": 1,
+        "checkpoint_expires_at_ms": 2,
+        "sandbox_state_ref": "fake://checkpoint" if checkpoint else "",
+        "finalization_phase": phase,
+        "finalization_manifest_ref": "fake://manifest",
+        "finalization_error": "" if checkpoint else "checkpoint unavailable",
+        "results": {"tests": accepted},
+        "trace_ref": "fake://trace",
+        "traces_ref": "fake://traces",
+        "filesystem_start_ref": "fake://fs-start",
+        "filesystem_end_ref": "fake://fs-end",
+        "filesystem_diff_ref": "fake://fs-diff",
+        "git_status_ref": "fake://status",
+        "git_patch_ref": "fake://patch",
+        "git_bundle_ref": "fake://bundle",
+        "context_ref": "fake://context",
+        "friction": [{"kind": "note", "message": "fixture"}],
+        "sha": "abc123" if accepted else "",
+        "message": "fix: resolve bug" if accepted else "",
+        "pushed": False,
+    }
+
+
+def test_transition_graph_is_complete_for_every_active_source_and_event() -> None:
+    active = {
+        MissionTaskState(MissionStatus.READY, TaskStatus.READY),
+        MissionTaskState(MissionStatus.RUNNING, TaskStatus.READY),
+        MissionTaskState(MissionStatus.RUNNING, TaskStatus.RETRYABLE),
+    }
+    assert len(MISSION_TRANSITION_GRAPH) == len(active) * len(MissionTransitionEvent)
+    for source in active:
+        for event in MissionTransitionEvent:
+            edge = MissionTransitionGraph.transition(source, event)
+            assert edge.source == source
+            assert edge.event is event
+            assert edge.attempt is not AttemptStatus.PENDING
+
+    terminal = MissionTaskState(MissionStatus.SUCCEEDED, TaskStatus.PASSED)
+    with pytest.raises(ValueError, match="illegal mission transition"):
+        MissionTransitionGraph.transition(terminal, MissionTransitionEvent.MISSION_SUCCEEDED)
+    with pytest.raises(ValueError, match="invalid persisted mission/task state"):
+        MissionTransitionGraph.state("invented", "ready")
+    with pytest.raises(ValueError, match="unknown mission transition event"):
+        MissionTransitionGraph.transition(next(iter(active)), "invented")
+
+
+def test_component_state_strings_are_enum_validated_without_breaking_arrow() -> None:
+    assert Mission.to_pyarrow_schema().field("status").type == "string"
+    assert TaskGate.to_pyarrow_schema().field("status").type == "string"
+    assert Attempt.to_pyarrow_schema().field("status").type == "string"
+
+    with pytest.raises(ValidationError, match="mission status"):
+        Mission(status="succeeded")
+    with pytest.raises(ValidationError):
+        Mission(status="invented")
+    with pytest.raises(ValidationError, match="passed flag"):
+        TaskGate(status="passed", passed=False)
+    with pytest.raises(ValidationError):
+        Attempt(status="invented")
+    with pytest.raises(ValidationError):
+        Checkpoint(status="invented")
+    with pytest.raises(ValidationError):
+        Finalization(phase="invented")
+
+
+def test_rejection_and_incomplete_evidence_commit_edges_before_success() -> None:
+    service = MissionService()
+    initial = _row()
+
+    first = service.prepare_attempt(initial, tick=1)
+    assert first is not None
+    rejected = service.apply_attempt(initial, first, _outcome(first, accepted=False))
+    assert rejected["mission__status"] == "running"
+    assert rejected["taskgate__status"] == "retryable"
+    assert rejected["attempt__status"] == "rejected"
+    assert rejected["attempt__transition_event"] == "rejected_retry"
+    assert rejected["attempt__mission_status_before"] == "ready"
+    assert rejected["attempt__mission_status_after"] == "running"
+    assert rejected["taskgate__step_index"] == 0
+
+    second = service.prepare_attempt(rejected, tick=2)
+    assert second is not None
+    incomplete = service.apply_attempt(
+        rejected,
+        second,
+        _outcome(second, accepted=True, checkpoint=False),
+    )
+    assert incomplete["attempt__provider_status"] == "accepted"
+    assert incomplete["attempt__status"] == "incomplete"
+    assert incomplete["attempt__transition_event"] == "incomplete_retry"
+    assert incomplete["mission__finished"] is False
+
+    third = service.prepare_attempt(incomplete, tick=3)
+    assert third is not None
+    completed = service.apply_attempt(incomplete, third, _outcome(third, accepted=True))
+    assert completed["mission__status"] == "succeeded"
+    assert completed["mission__finished"] is True
+    assert completed["mission__succeeded"] is True
+    assert completed["taskgate__status"] == "passed"
+    assert completed["taskgate__passed"] is True
+    assert completed["attempt__status"] == "accepted"
+    assert completed["attempt__transition_event"] == "mission_succeeded"
+    assert completed["commit__sha"] == "abc123"
+    assert service.prepare_attempt(completed, tick=4) is None
+
+
+@pytest.mark.parametrize(
+    ("accepted", "status", "checkpoint", "attempt_status", "event"),
+    [
+        (False, "rejected", True, "rejected", "rejected_exhausted"),
+        (False, "failed", False, "failed", "failed_exhausted"),
+        (True, "accepted", False, "incomplete", "incomplete_exhausted"),
+    ],
+)
+def test_each_failed_attempt_kind_exhausts_through_the_typed_graph(
+    accepted: bool,
+    status: str,
+    checkpoint: bool,
+    attempt_status: str,
+    event: str,
+) -> None:
+    service = MissionService()
+    row = _row(max_attempts=1)
+    request = service.prepare_attempt(row, tick=0)
+    assert request is not None
+    result = service.apply_attempt(
+        row,
+        request,
+        _outcome(request, accepted=accepted, checkpoint=checkpoint, status=status),
+    )
+    assert result["mission__status"] == "failed"
+    assert result["mission__finished"] is True
+    assert result["mission__succeeded"] is False
+    assert result["taskgate__status"] == "exhausted"
+    assert result["attempt__status"] == attempt_status
+    assert result["attempt__transition_event"] == event
+
+
+def test_multistep_acceptance_advances_to_a_typed_ready_state() -> None:
+    service = MissionService()
+    row = _row(
+        plan=[
+            {
+                "name": "fix",
+                "prompt": "Fix the bug",
+                "validators": [{"name": "tests", "command": ["pytest"]}],
+            },
+            {
+                "name": "review",
+                "prompt": "Review the fix",
+                "validators": [{"name": "lint", "command": ["ruff"]}],
+            },
+        ]
+    )
+    request = service.prepare_attempt(row, tick=0)
+    assert request is not None
+    advanced = service.apply_attempt(row, request, _outcome(request, accepted=True))
+    assert advanced["mission__status"] == "running"
+    assert advanced["taskgate__status"] == "ready"
+    assert advanced["taskgate__step_index"] == 1
+    assert advanced["taskgate__step_name"] == "review"
+    assert advanced["taskgate__attempts"] == 0
+    assert advanced["attempt__transition_event"] == "task_advanced"
+
+    next_request = service.prepare_attempt(advanced, tick=1)
+    assert next_request is not None
+    assert next_request.step_index == 1
+    assert next_request.source == MissionTaskState(MissionStatus.RUNNING, TaskStatus.READY)
+
+
+def test_prepare_attempt_fails_closed_on_corrupt_or_inactive_state() -> None:
+    service = MissionService()
+    cases = []
+
+    invalid_state = _row()
+    invalid_state["taskgate__status"] = "invented"
+    cases.append((invalid_state, "invalid persisted"))
+
+    inconsistent_terminal = _row()
+    inconsistent_terminal["mission__status"] = "succeeded"
+    cases.append((inconsistent_terminal, "finished flag"))
+
+    exhausted_counter = _row(max_attempts=1)
+    exhausted_counter["taskgate__attempts"] = 1
+    cases.append((exhausted_counter, "attempt counters"))
+
+    outside_plan = _row()
+    outside_plan["taskgate__step_index"] = 2
+    cases.append((outside_plan, "outside its plan"))
+
+    invalid_previous = _row()
+    invalid_previous["taskgate__attempts"] = 1
+    invalid_previous["mission__status"] = "running"
+    invalid_previous["taskgate__status"] = "retryable"
+    invalid_previous["attempt__validator_details_json"] = "{}"
+    cases.append((invalid_previous, "validator details"))
+
+    for row, message in cases:
+        with pytest.raises(ValueError, match=message):
+            service.prepare_attempt(row, tick=0)
+
+
+def test_apply_attempt_rejects_stale_identity_and_vacuous_evidence() -> None:
+    service = MissionService()
+    row = _row()
+    request = service.prepare_attempt(row, tick=0)
+    assert request is not None
+
+    stale = dict(row, mission__status="running")
+    with pytest.raises(ValueError, match="state changed"):
+        service.apply_attempt(stale, request, _outcome(request, accepted=False))
+
+    mismatch = _outcome(request, accepted=False)
+    mismatch["attempt_index"] = 99
+    with pytest.raises(ValueError, match="attempt_index"):
+        service.apply_attempt(row, request, mismatch)
+
+    mismatch = _outcome(request, accepted=False)
+    mismatch["idempotency_key"] = "wrong"
+    with pytest.raises(ValueError, match="idempotency_key"):
+        service.apply_attempt(row, request, mismatch)
+
+    vacuous = _outcome(request, accepted=False)
+    vacuous["validator_details"] = []
+    with pytest.raises(ValueError, match="validator details"):
+        service.apply_attempt(row, request, vacuous)
+
+    wrong_status = _outcome(request, accepted=True, status="rejected")
+    with pytest.raises(ValueError, match="accepted status"):
+        service.apply_attempt(row, request, wrong_status)
+
+    bad_checkpoint = _outcome(request, accepted=True)
+    bad_checkpoint["checkpoint_status"] = "failed"
+    with pytest.raises(ValueError, match="restorable checkpoint"):
+        service.apply_attempt(row, request, bad_checkpoint)
+
+    no_commit = _outcome(request, accepted=True)
+    no_commit["sha"] = ""
+    with pytest.raises(ValueError, match="commit SHA"):
+        service.apply_attempt(row, request, no_commit)
+
+
+def test_attempt_identity_binds_typed_source_state() -> None:
+    service = MissionService()
+    ready = _row()
+    first = service.prepare_attempt(ready, tick=0)
+    assert first is not None
+
+    running = dict(ready, mission__status="running")
+    second = service.prepare_attempt(running, tick=0)
+    assert second is not None
+    assert first.idempotency_key != second.idempotency_key
+    assert first.source.mission is MissionStatus.READY
+    assert second.source.mission is MissionStatus.RUNNING

--- a/tests/app/test_mission_transition_authority.py
+++ b/tests/app/test_mission_transition_authority.py
@@ -294,6 +294,18 @@ def test_apply_attempt_rejects_stale_identity_and_vacuous_evidence() -> None:
     with pytest.raises(ValueError, match="state changed"):
         service.apply_attempt(stale, request, _outcome(request, accepted=False))
 
+    changed_plan = json.loads(row["mission__plan_json"])
+    changed_plan.append(
+        {
+            "name": "review",
+            "prompt": "Review the fix",
+            "validators": [{"name": "lint", "command": ["ruff"]}],
+        }
+    )
+    stale = dict(row, mission__plan_json=json.dumps(changed_plan))
+    with pytest.raises(ValueError, match="plan changed"):
+        service.apply_attempt(stale, request, _outcome(request, accepted=True))
+
     mismatch = _outcome(request, accepted=False)
     mismatch["attempt_index"] = 99
     with pytest.raises(ValueError, match="attempt_index"):
@@ -334,5 +346,36 @@ def test_attempt_identity_binds_typed_source_state() -> None:
     second = service.prepare_attempt(running, tick=0)
     assert second is not None
     assert first.idempotency_key != second.idempotency_key
+    assert first.plan_digest == second.plan_digest
     assert first.source.mission is MissionStatus.READY
     assert second.source.mission is MissionStatus.RUNNING
+
+
+def test_attempt_identity_binds_the_canonical_full_plan() -> None:
+    service = MissionService()
+    initial = _row()
+    first = service.prepare_attempt(initial, tick=0)
+    assert first is not None
+
+    equivalent = dict(
+        initial, mission__plan_json=json.dumps(json.loads(initial["mission__plan_json"]), indent=2)
+    )
+    same = service.prepare_attempt(equivalent, tick=0)
+    assert same is not None
+    assert same.plan_digest == first.plan_digest
+    assert same.idempotency_key == first.idempotency_key
+
+    extended_plan = json.loads(initial["mission__plan_json"])
+    extended_plan.append(
+        {
+            "name": "review",
+            "prompt": "Review the fix",
+            "validators": [{"name": "lint", "command": ["ruff"]}],
+        }
+    )
+    extended = service.prepare_attempt(
+        dict(initial, mission__plan_json=json.dumps(extended_plan)), tick=0
+    )
+    assert extended is not None
+    assert extended.plan_digest != first.plan_digest
+    assert extended.idempotency_key != first.idempotency_key


### PR DESCRIPTION
## Summary

This is slice 2 of the mechanical review stack extracted from #487. It keeps the mission state contract, implementation, executable oracle, capability eval, and normative documentation together while leaving sandbox/provider orchestration for later slices.

- add one provider-neutral app/missions family with an actor-free iMissionService
- define the authoritative typed mission/task/attempt transition graph as immutable data
- validate every persisted state string at the component boundary while retaining Arrow-compatible string columns
- persist each completed attempt source state, event, authoritative outcome, and destination state
- bind attempt identity to the complete source state and canonical full-plan identity so stale or replayed requests fail closed
- reject settlement when the plan changes in flight, even if the current step text is unchanged
- require checkpoint/finalization/commit evidence before a provider-accepted result can advance a task
- distinguish raw provider status from the authoritative attempt status
- add normative docs, architecture/contract registry entries, exhaustive graph tests, and a capability eval

## Transition authority

The graph has 24 explicit edges: eight events from each valid source pair (ready/ready, running/ready, and running/retryable). Terminal mission states expose no outgoing edges. Accepted provider output without complete evidence becomes incomplete, never success.

Boolean fields remain compatibility projections only and are checked against typed state during model construction.

A prepared request carries a digest of the canonical full plan. apply_attempt recomputes it from the current durable row before it considers the sandbox receipt, preventing an old result from being settled against changed task topology.

## Deliberate boundary

This slice is a pure row transition authority. It does not claim durable pre-execution ownership or exactly-once model submission. The subsequent control-authority slice will add the durable claim and explicit possibly_submitted recovery state before any provider execution is wired through this graph.

## Validation

- rebased onto merged artifact foundation at main 6db40f63
- focused transition suite: 11 passed, including exhaustive coverage of all 24 graph edges and stale-plan settlement rejection
- make static: passed
- make ci on current head 1e230f5b:
  - 1,281 tests passed, 10 skipped
  - coverage 86.75%
  - regression eval 15/15
  - specification eval 8/8
  - capability eval 6/6, including agent_mission_transition_authority
  - package smoke, all credential-free examples, and docs build passed

## Stack

- #494 — durable artifact bundle publication (merged)
- this PR — typed mission/task/attempt transition authority
- #496 — provider-neutral sandbox kernel
- #497 — bounded artifact extraction and resolver compatibility follow-up
- following slices — durable claim/recovery integration, provider adapters, coding-agent orchestration, retained live evidence/benchmarks

No auto-merge is armed. Supersedes the corresponding transition-authority portion of #487.
