### PR TITLE
fix: bound checkpoint artifact extraction

### DIFF
--- a/docs/guide/artifact-finalization.md
+++ b/docs/guide/artifact-finalization.md
@@ -128,14 +128,19 @@ Provider-qualified source references are data, not live handles. The built-in
 resolver supports direct files and
 `apple-container-rootfs://<archive>#<path>`. The Modal provider supplies a
 resolver that reads a live sandbox or restores a `modal-image://` checkpoint.
-Other providers implement `ArtifactSourceResolver`.
+Other providers implement the stable
+`ArtifactSourceResolver.materialize(candidates, destination)` contract.
 
-The service passes the configured per-artifact and aggregate bundle byte
-limits into every resolver. Archive resolvers must reject a member from its
-declared size before copying its bytes and must account for repeated and
-recursive selections cumulatively. The service validates the materialized
-files again before Daft reads them; the archive preflight is the resource
-control, while the second check defends against stale or dishonest metadata.
+Resolvers that can preflight provider objects implement the optional
+`BoundedArtifactSourceResolver.materialize_bounded` capability. The service
+passes the configured per-artifact and aggregate bundle byte limits through
+that capability. Archive resolvers must reject a member from its declared
+size before copying its bytes and must account for repeated and recursive
+selections cumulatively. Legacy two-argument resolvers remain supported and
+are checked after materialization, but they cannot provide resource control
+during the copy itself. The service always validates materialized files again
+before Daft reads them; bounded preflight is the resource control, while the
+second check defends against legacy resolvers and stale or dishonest metadata.
 
 Every `ArtifactIndexRecord` is scalar and Parquet-friendly:
 

--- a/docs/guide/artifact-finalization.md
+++ b/docs/guide/artifact-finalization.md
@@ -130,6 +130,13 @@ resolver supports direct files and
 resolver that reads a live sandbox or restores a `modal-image://` checkpoint.
 Other providers implement `ArtifactSourceResolver`.
 
+The service passes the configured per-artifact and aggregate bundle byte
+limits into every resolver. Archive resolvers must reject a member from its
+declared size before copying its bytes and must account for repeated and
+recursive selections cumulatively. The service validates the materialized
+files again before Daft reads them; the archive preflight is the resource
+control, while the second check defends against stale or dishonest metadata.
+
 Every `ArtifactIndexRecord` is scalar and Parquet-friendly:
 
 | Group | Fields |

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -142,7 +142,8 @@ identity, complete publication claims, or expose generic domain "artifacts."
 The artifact-bundle DTOs exported from the top-level `archetype` package are
 supported runtime contracts: `ArtifactBundleRequest`, `ArtifactCandidate`,
 `ArtifactIndexRecord`, `ArtifactPublishReceipt`, `ArtifactReconcileResult`,
-`ArtifactSourceResolver`, `ArtifactStoreConfig`, and `MaterializedArtifact`.
+`ArtifactSourceResolver`, `BoundedArtifactSourceResolver`,
+`ArtifactStoreConfig`, and `MaterializedArtifact`.
 Their physical `app.artifacts.bundle_models` module is internal; application
 code imports the top-level names. The runtime's narrow import allowance for
 that module exists only to type its actor-free application-port methods and

--- a/docs/reference/python/artifact-bundles.md
+++ b/docs/reference/python/artifact-bundles.md
@@ -102,6 +102,8 @@
 
 ::: archetype.app.artifacts.bundle_models.ArtifactSourceResolver
 
+::: archetype.app.artifacts.bundle_models.BoundedArtifactSourceResolver
+
 ::: archetype.app.artifacts.bundle_models.ArtifactStoreConfig
     options:
       members:

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -140,30 +140,30 @@ reason = "same grading-boundary site as the collect above: per-entity terminal r
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 937
+line = 957
 method = "to_pylist"
 reason = "Artifact-manifest boundary: the caller-declared, size-bounded file set has already been hashed and MIME-classified by native Daft expressions; scalar metadata must enter Python to construct validated immutable index records and the canonical bundle manifest."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 989
+line = 1009
 method = "to_pylist"
 reason = "Object-store completion boundary: each caller-declared, size-bounded upload has executed through Daft and its returned object URI must enter Python to construct the portable manifest and deterministic artifact-index rows."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1002
+line = 1022
 method = "to_pylist"
 reason = "Single-object upload boundary: one generated bundle-manifest byte value is uploaded through Daft and its sole destination URI must enter the durable publication receipt and control-catalog record."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1017
+line = 1037
 method = "to_pylist"
 reason = "Content-addressed retry boundary: only object paths inside one deterministic artifact folder are materialized so imperative reconciliation can choose a stable existing upload rather than issue duplicate external I/O."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1033
+line = 1053
 method = "to_pylist"
 reason = "Bundle-index idempotency boundary: the Iceberg query is filtered to one deterministic bundle and its bounded artifact rows must enter Python for exact conflict detection and missing-row selection before an append."

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -140,30 +140,30 @@ reason = "same grading-boundary site as the collect above: per-entity terminal r
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 865
+line = 937
 method = "to_pylist"
 reason = "Artifact-manifest boundary: the caller-declared, size-bounded file set has already been hashed and MIME-classified by native Daft expressions; scalar metadata must enter Python to construct validated immutable index records and the canonical bundle manifest."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 917
+line = 989
 method = "to_pylist"
 reason = "Object-store completion boundary: each caller-declared, size-bounded upload has executed through Daft and its returned object URI must enter Python to construct the portable manifest and deterministic artifact-index rows."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 930
+line = 1002
 method = "to_pylist"
 reason = "Single-object upload boundary: one generated bundle-manifest byte value is uploaded through Daft and its sole destination URI must enter the durable publication receipt and control-catalog record."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 945
+line = 1017
 method = "to_pylist"
 reason = "Content-addressed retry boundary: only object paths inside one deterministic artifact folder are materialized so imperative reconciliation can choose a stable existing upload rather than issue duplicate external I/O."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 961
+line = 1033
 method = "to_pylist"
 reason = "Bundle-index idempotency boundary: the Iceberg query is filtered to one deterministic bundle and its bounded artifact rows must enter Python for exact conflict detection and missing-row selection before an append."

--- a/scripts/generate_python_api_docs.py
+++ b/scripts/generate_python_api_docs.py
@@ -78,6 +78,7 @@ PAGES: tuple[ReferencePage, ...] = (
             "ArtifactPublishReceipt",
             "ArtifactReconcileResult",
             "ArtifactSourceResolver",
+            "BoundedArtifactSourceResolver",
             "ArtifactStoreConfig",
             "MaterializedArtifact",
         ),

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -102,6 +102,7 @@ __all__ = [
     "ArtifactPublishReceipt",
     "ArtifactReconcileResult",
     "ArtifactSourceResolver",
+    "BoundedArtifactSourceResolver",
     "ArtifactStoreConfig",
     "MaterializedArtifact",
     # Models
@@ -190,6 +191,10 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "ArtifactSourceResolver": (
         "archetype.app.artifacts.bundle_models",
         "ArtifactSourceResolver",
+    ),
+    "BoundedArtifactSourceResolver": (
+        "archetype.app.artifacts.bundle_models",
+        "BoundedArtifactSourceResolver",
     ),
     "ArtifactStoreConfig": ("archetype.app.artifacts.bundle_models", "ArtifactStoreConfig"),
     "MaterializedArtifact": (

--- a/src/archetype/app/artifacts/bundle_models.py
+++ b/src/archetype/app/artifacts/bundle_models.py
@@ -46,6 +46,9 @@ class ArtifactSourceResolver(Protocol):
         self,
         candidates: tuple[ArtifactCandidate, ...],
         destination: Path,
+        *,
+        max_artifact_bytes: int,
+        max_bundle_bytes: int,
     ) -> list[MaterializedArtifact]: ...
 
 

--- a/src/archetype/app/artifacts/bundle_models.py
+++ b/src/archetype/app/artifacts/bundle_models.py
@@ -14,7 +14,7 @@ import hashlib
 import json
 import re
 from pathlib import Path, PurePosixPath
-from typing import Literal, Protocol
+from typing import Literal, Protocol, runtime_checkable
 
 from daft.io import IOConfig
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -40,9 +40,25 @@ class MaterializedArtifact(BaseModel):
 
 
 class ArtifactSourceResolver(Protocol):
-    """Materialize immutable source references into ordinary local files."""
+    """Materialize immutable source references into ordinary local files.
+
+    This two-argument method is the stable provider contract. Resolvers that
+    can reject oversized provider objects before copying them may additionally
+    implement :class:`BoundedArtifactSourceResolver`.
+    """
 
     async def materialize(
+        self,
+        candidates: tuple[ArtifactCandidate, ...],
+        destination: Path,
+    ) -> list[MaterializedArtifact]: ...
+
+
+@runtime_checkable
+class BoundedArtifactSourceResolver(ArtifactSourceResolver, Protocol):
+    """Optional provider capability for resource-bounded materialization."""
+
+    async def materialize_bounded(
         self,
         candidates: tuple[ArtifactCandidate, ...],
         destination: Path,

--- a/src/archetype/app/artifacts/bundle_service.py
+++ b/src/archetype/app/artifacts/bundle_service.py
@@ -39,6 +39,7 @@ from archetype.app.artifacts.bundle_models import (
     ArtifactReconcileResult,
     ArtifactSourceResolver,
     ArtifactStoreConfig,
+    BoundedArtifactSourceResolver,
     MaterializedArtifact,
     _canonical_json,
 )
@@ -103,9 +104,21 @@ class CheckpointArtifactSourceResolver:
         self,
         candidates: tuple[ArtifactCandidate, ...],
         destination: Path,
+    ) -> list[MaterializedArtifact]:
+        return await self.materialize_bounded(
+            candidates,
+            destination,
+            max_artifact_bytes=_DEFAULT_MAX_ARTIFACT_BYTES,
+            max_bundle_bytes=_DEFAULT_MAX_BUNDLE_BYTES,
+        )
+
+    async def materialize_bounded(
+        self,
+        candidates: tuple[ArtifactCandidate, ...],
+        destination: Path,
         *,
-        max_artifact_bytes: int = _DEFAULT_MAX_ARTIFACT_BYTES,
-        max_bundle_bytes: int = _DEFAULT_MAX_BUNDLE_BYTES,
+        max_artifact_bytes: int,
+        max_bundle_bytes: int,
     ) -> list[MaterializedArtifact]:
         if max_artifact_bytes < 1:
             raise ValueError("max_artifact_bytes must be positive")
@@ -732,12 +745,19 @@ class ArtifactBundleService:
             expires_at_ms = created_at_ms + retention_seconds * 1000 if retention_seconds else 0
 
         with tempfile.TemporaryDirectory(prefix="archetype-artifacts-") as temp_dir:
-            materialized = await self._source_resolver.materialize(
-                request.artifacts,
-                Path(temp_dir),
-                max_artifact_bytes=config.max_artifact_bytes,
-                max_bundle_bytes=config.max_bundle_bytes,
-            )
+            destination = Path(temp_dir)
+            if isinstance(self._source_resolver, BoundedArtifactSourceResolver):
+                materialized = await self._source_resolver.materialize_bounded(
+                    request.artifacts,
+                    destination,
+                    max_artifact_bytes=config.max_artifact_bytes,
+                    max_bundle_bytes=config.max_bundle_bytes,
+                )
+            else:
+                materialized = await self._source_resolver.materialize(
+                    request.artifacts,
+                    destination,
+                )
             self._assert_materialized_metadata_safe(materialized)
             self._validate_materialized(materialized)
             sanitized, redaction_receipts = await asyncio.to_thread(

--- a/src/archetype/app/artifacts/bundle_service.py
+++ b/src/archetype/app/artifacts/bundle_service.py
@@ -58,6 +58,8 @@ if TYPE_CHECKING:
 _ARTIFACT_INDEX_TABLE = "artifact_index_v1"
 _ROOTFS_SCHEME = "apple-container-rootfs://"
 _MAX_FAILURE_DETAIL_CHARS = 4096
+_DEFAULT_MAX_ARTIFACT_BYTES = 1 << 30
+_DEFAULT_MAX_BUNDLE_BYTES = 4 << 30
 logger = logging.getLogger(__name__)
 
 
@@ -101,13 +103,28 @@ class CheckpointArtifactSourceResolver:
         self,
         candidates: tuple[ArtifactCandidate, ...],
         destination: Path,
+        *,
+        max_artifact_bytes: int = _DEFAULT_MAX_ARTIFACT_BYTES,
+        max_bundle_bytes: int = _DEFAULT_MAX_BUNDLE_BYTES,
     ) -> list[MaterializedArtifact]:
-        return await asyncio.to_thread(self._materialize_sync, candidates, destination)
+        if max_artifact_bytes < 1:
+            raise ValueError("max_artifact_bytes must be positive")
+        if max_bundle_bytes < max_artifact_bytes:
+            raise ValueError("max_bundle_bytes must be >= max_artifact_bytes")
+        return await asyncio.to_thread(
+            self._materialize_sync,
+            candidates,
+            destination,
+            max_artifact_bytes,
+            max_bundle_bytes,
+        )
 
     def _materialize_sync(
         self,
         candidates: tuple[ArtifactCandidate, ...],
         destination: Path,
+        max_artifact_bytes: int,
+        max_bundle_bytes: int,
     ) -> list[MaterializedArtifact]:
         destination.mkdir(parents=True, exist_ok=True)
         direct: list[ArtifactCandidate] = []
@@ -125,10 +142,45 @@ class CheckpointArtifactSourceResolver:
                 direct.append(candidate)
 
         resolved = self._materialize_direct(direct)
+        materialized_bytes = self._bounded_existing_size(
+            resolved,
+            max_artifact_bytes=max_artifact_bytes,
+            max_bundle_bytes=max_bundle_bytes,
+        )
         for archive, requested in archives.items():
-            resolved.extend(self._materialize_archive(archive, requested, destination))
+            extracted, materialized_bytes = self._materialize_archive(
+                archive,
+                requested,
+                destination,
+                materialized_bytes=materialized_bytes,
+                max_artifact_bytes=max_artifact_bytes,
+                max_bundle_bytes=max_bundle_bytes,
+            )
+            resolved.extend(extracted)
         self._reject_logical_collisions(resolved)
         return sorted(resolved, key=lambda value: value.logical_path)
+
+    @staticmethod
+    def _bounded_existing_size(
+        values: list[MaterializedArtifact],
+        *,
+        max_artifact_bytes: int,
+        max_bundle_bytes: int,
+    ) -> int:
+        total = 0
+        for value in values:
+            size = value.path.stat().st_size
+            if size > max_artifact_bytes:
+                raise ValueError(
+                    f"artifact {value.logical_path!r} is {size} bytes; "
+                    f"limit is {max_artifact_bytes}"
+                )
+            total += size
+            if total > max_bundle_bytes:
+                raise ValueError(
+                    f"artifact bundle is at least {total} bytes; limit is {max_bundle_bytes}"
+                )
+        return total
 
     @staticmethod
     def _split_rootfs_ref(source_ref: str) -> tuple[Path, str]:
@@ -208,7 +260,11 @@ class CheckpointArtifactSourceResolver:
         archive: Path,
         requested: list[tuple[ArtifactCandidate, str]],
         destination: Path,
-    ) -> list[MaterializedArtifact]:
+        *,
+        materialized_bytes: int,
+        max_artifact_bytes: int,
+        max_bundle_bytes: int,
+    ) -> tuple[list[MaterializedArtifact], int]:
         matches = [0] * len(requested)
         resolved: list[MaterializedArtifact] = []
         archive_destination = destination / hashlib.sha256(str(archive).encode()).hexdigest()[:16]
@@ -234,9 +290,22 @@ class CheckpointArtifactSourceResolver:
                         if relative
                         else candidate.logical_path
                     )
+                    size = int(member.size)
+                    if size > max_artifact_bytes:
+                        raise ValueError(
+                            f"artifact {logical_path!r} is {size} bytes; "
+                            f"limit is {max_artifact_bytes}"
+                        )
+                    next_total = materialized_bytes + size
+                    if next_total > max_bundle_bytes:
+                        raise ValueError(
+                            f"artifact bundle would be at least {next_total} bytes; "
+                            f"limit is {max_bundle_bytes}"
+                        )
                     output = archive_destination / f"{len(resolved):08d}-{Path(member_name).name}"
                     with output.open("wb") as target:
                         shutil.copyfileobj(stream, target, length=1 << 20)
+                    materialized_bytes = next_total
                     matches[index] += 1
                     source_ref = f"{_ROOTFS_SCHEME}{archive}#/{member_name}"
                     resolved.append(
@@ -253,7 +322,7 @@ class CheckpointArtifactSourceResolver:
                 raise FileNotFoundError(
                     f"required artifact {member!r} is absent from checkpoint {archive}"
                 )
-        return resolved
+        return resolved, materialized_bytes
 
     @staticmethod
     def _reject_logical_collisions(values: list[MaterializedArtifact]) -> None:
@@ -664,7 +733,10 @@ class ArtifactBundleService:
 
         with tempfile.TemporaryDirectory(prefix="archetype-artifacts-") as temp_dir:
             materialized = await self._source_resolver.materialize(
-                request.artifacts, Path(temp_dir)
+                request.artifacts,
+                Path(temp_dir),
+                max_artifact_bytes=config.max_artifact_bytes,
+                max_bundle_bytes=config.max_bundle_bytes,
             )
             self._assert_materialized_metadata_safe(materialized)
             self._validate_materialized(materialized)

--- a/tests/app/test_artifact_bundle_service.py
+++ b/tests/app/test_artifact_bundle_service.py
@@ -20,6 +20,7 @@ from archetype.app.artifacts.bundle_models import (
     ArtifactBundleRequest,
     ArtifactCandidate,
     ArtifactStoreConfig,
+    MaterializedArtifact,
 )
 from archetype.app.artifacts.bundle_service import (
     _ARTIFACT_INDEX_TABLE,
@@ -45,6 +46,54 @@ pytestmark = [
 
 class _ArtifactProbe(Component):
     value: int = 0
+
+
+class _LegacyProviderResolver:
+    """The supported provider contract from before bounded preflight existed."""
+
+    def __init__(self, source: Path) -> None:
+        self.source = source
+        self.calls = 0
+
+    async def materialize(
+        self,
+        candidates: tuple[ArtifactCandidate, ...],
+        _destination: Path,
+    ) -> list[MaterializedArtifact]:
+        self.calls += 1
+        return [
+            MaterializedArtifact(
+                path=self.source,
+                source_ref=candidate.source_ref,
+                logical_path=candidate.logical_path,
+                kind=candidate.kind,
+            )
+            for candidate in candidates
+        ]
+
+
+class _BoundedProviderResolver(_LegacyProviderResolver):
+    def __init__(self, source: Path) -> None:
+        super().__init__(source)
+        self.limits: tuple[int, int] | None = None
+
+    async def materialize(
+        self,
+        candidates: tuple[ArtifactCandidate, ...],
+        destination: Path,
+    ) -> list[MaterializedArtifact]:
+        raise AssertionError("bounded providers must use materialize_bounded")
+
+    async def materialize_bounded(
+        self,
+        candidates: tuple[ArtifactCandidate, ...],
+        destination: Path,
+        *,
+        max_artifact_bytes: int,
+        max_bundle_bytes: int,
+    ) -> list[MaterializedArtifact]:
+        self.limits = (max_artifact_bytes, max_bundle_bytes)
+        return await super().materialize(candidates, destination)
 
 
 def _request(
@@ -348,6 +397,74 @@ async def test_bundle_publication_fails_closed_when_not_configured(tmp_path):
         await container.shutdown()
 
 
+async def test_legacy_provider_resolver_contract_remains_supported(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "provider-result.txt"
+    source.write_text("legacy provider evidence")
+    resolver = _LegacyProviderResolver(source)
+    container = ServiceContainer(
+        artifact_store_config=artifact_config,
+        artifact_source_resolver=resolver,
+    )
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        receipt = await container.artifact_bundle_service.publish(
+            _request(world, source), storage_config=storage
+        )
+        assert receipt.status == "indexed"
+        assert resolver.calls == 1
+    finally:
+        await container.shutdown()
+
+
+async def test_legacy_provider_resolver_still_obeys_post_materialization_limits(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts").model_copy(
+        update={"max_artifact_bytes": 3, "max_bundle_bytes": 4}
+    )
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "provider-result.bin"
+    source.write_bytes(b"1234")
+    resolver = _LegacyProviderResolver(source)
+    container = ServiceContainer(
+        artifact_store_config=artifact_config,
+        artifact_source_resolver=resolver,
+    )
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        with pytest.raises(ValueError, match="result.json.*4 bytes; limit is 3"):
+            await container.artifact_bundle_service.publish(
+                _request(world, source), storage_config=storage
+            )
+        assert resolver.calls == 1
+    finally:
+        await container.shutdown()
+
+
+async def test_bounded_provider_receives_configured_materialization_limits(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts").model_copy(
+        update={"max_artifact_bytes": 4, "max_bundle_bytes": 8}
+    )
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "provider-result.bin"
+    source.write_bytes(b"1234")
+    resolver = _BoundedProviderResolver(source)
+    container = ServiceContainer(
+        artifact_store_config=artifact_config,
+        artifact_source_resolver=resolver,
+    )
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        receipt = await container.artifact_bundle_service.publish(
+            _request(world, source), storage_config=storage
+        )
+        assert receipt.status == "indexed"
+        assert resolver.calls == 1
+        assert resolver.limits == (4, 8)
+    finally:
+        await container.shutdown()
+
+
 async def test_apple_rootfs_resolver_extracts_file_and_directory(tmp_path):
     tree = tmp_path / "tree"
     (tree / "workspace/repo/.context").mkdir(parents=True)
@@ -405,7 +522,7 @@ async def test_apple_rootfs_resolver_rejects_member_before_copying(tmp_path, mon
         logical_path="oversized.bin",
     )
     with pytest.raises(ValueError, match="oversized.bin.*5 bytes; limit is 4"):
-        await CheckpointArtifactSourceResolver().materialize(
+        await CheckpointArtifactSourceResolver().materialize_bounded(
             (candidate,),
             tmp_path / "extracted",
             max_artifact_bytes=4,
@@ -438,7 +555,7 @@ async def test_apple_rootfs_resolver_bounds_recursive_cumulative_copy(tmp_path, 
         recursive=True,
     )
     with pytest.raises(ValueError, match="bundle would be at least 6 bytes; limit is 5"):
-        await CheckpointArtifactSourceResolver().materialize(
+        await CheckpointArtifactSourceResolver().materialize_bounded(
             (candidate,),
             tmp_path / "extracted",
             max_artifact_bytes=3,
@@ -458,7 +575,7 @@ async def test_artifact_resolver_rejects_invalid_materialization_limits(
     tmp_path, max_artifact_bytes, max_bundle_bytes, message
 ):
     with pytest.raises(ValueError, match=message):
-        await CheckpointArtifactSourceResolver().materialize(
+        await CheckpointArtifactSourceResolver().materialize_bounded(
             (),
             tmp_path / "extracted",
             max_artifact_bytes=max_artifact_bytes,
@@ -475,7 +592,7 @@ async def test_direct_artifact_limits_are_checked_before_archive_extraction(tmp_
     )
     resolver = CheckpointArtifactSourceResolver()
     with pytest.raises(ValueError, match="oversized.bin.*4 bytes; limit is 3"):
-        await resolver.materialize(
+        await resolver.materialize_bounded(
             (oversized_candidate,),
             tmp_path / "oversized-output",
             max_artifact_bytes=3,
@@ -487,7 +604,7 @@ async def test_direct_artifact_limits_are_checked_before_archive_extraction(tmp_
     first.write_bytes(b"123")
     second.write_bytes(b"456")
     with pytest.raises(ValueError, match="bundle is at least 6 bytes; limit is 5"):
-        await resolver.materialize(
+        await resolver.materialize_bounded(
             (
                 ArtifactCandidate(source_ref=str(first), logical_path="first.bin"),
                 ArtifactCandidate(source_ref=str(second), logical_path="second.bin"),

--- a/tests/app/test_artifact_bundle_service.py
+++ b/tests/app/test_artifact_bundle_service.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import json
+import shutil
 import tarfile
 import time
 from dataclasses import replace
@@ -379,6 +380,122 @@ async def test_apple_rootfs_resolver_extracts_file_and_directory(tmp_path):
         "context/findings.md",
     }
     assert {value.path.read_text() for value in values} == {'{"ok":true}', "finding"}
+
+
+async def test_apple_rootfs_resolver_rejects_member_before_copying(tmp_path, monkeypatch):
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    (tree / "oversized.bin").write_bytes(b"12345")
+    archive = tmp_path / "rootfs.tar"
+    with tarfile.open(archive, "w") as output:
+        output.add(tree / "oversized.bin", arcname="workspace/oversized.bin")
+
+    copied = False
+
+    def unexpected_copy(*args, **kwargs):
+        nonlocal copied
+        copied = True
+        raise AssertionError("oversized checkpoint member must not be copied")
+
+    monkeypatch.setattr(
+        "archetype.app.artifacts.bundle_service.shutil.copyfileobj", unexpected_copy
+    )
+    candidate = ArtifactCandidate(
+        source_ref=f"apple-container-rootfs://{archive}#/workspace/oversized.bin",
+        logical_path="oversized.bin",
+    )
+    with pytest.raises(ValueError, match="oversized.bin.*5 bytes; limit is 4"):
+        await CheckpointArtifactSourceResolver().materialize(
+            (candidate,),
+            tmp_path / "extracted",
+            max_artifact_bytes=4,
+            max_bundle_bytes=8,
+        )
+    assert not copied
+
+
+async def test_apple_rootfs_resolver_bounds_recursive_cumulative_copy(tmp_path, monkeypatch):
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    (tree / "first.bin").write_bytes(b"123")
+    (tree / "second.bin").write_bytes(b"456")
+    archive = tmp_path / "rootfs.tar"
+    with tarfile.open(archive, "w") as output:
+        output.add(tree, arcname="workspace")
+
+    real_copy = shutil.copyfileobj
+    copies = 0
+
+    def counted_copy(*args, **kwargs):
+        nonlocal copies
+        copies += 1
+        return real_copy(*args, **kwargs)
+
+    monkeypatch.setattr("archetype.app.artifacts.bundle_service.shutil.copyfileobj", counted_copy)
+    candidate = ArtifactCandidate(
+        source_ref=f"apple-container-rootfs://{archive}#/workspace",
+        logical_path="workspace",
+        recursive=True,
+    )
+    with pytest.raises(ValueError, match="bundle would be at least 6 bytes; limit is 5"):
+        await CheckpointArtifactSourceResolver().materialize(
+            (candidate,),
+            tmp_path / "extracted",
+            max_artifact_bytes=3,
+            max_bundle_bytes=5,
+        )
+    assert copies == 1
+
+
+@pytest.mark.parametrize(
+    ("max_artifact_bytes", "max_bundle_bytes", "message"),
+    [
+        (0, 1, "max_artifact_bytes must be positive"),
+        (2, 1, "max_bundle_bytes must be >= max_artifact_bytes"),
+    ],
+)
+async def test_artifact_resolver_rejects_invalid_materialization_limits(
+    tmp_path, max_artifact_bytes, max_bundle_bytes, message
+):
+    with pytest.raises(ValueError, match=message):
+        await CheckpointArtifactSourceResolver().materialize(
+            (),
+            tmp_path / "extracted",
+            max_artifact_bytes=max_artifact_bytes,
+            max_bundle_bytes=max_bundle_bytes,
+        )
+
+
+async def test_direct_artifact_limits_are_checked_before_archive_extraction(tmp_path):
+    oversized = tmp_path / "oversized.bin"
+    oversized.write_bytes(b"1234")
+    oversized_candidate = ArtifactCandidate(
+        source_ref=str(oversized),
+        logical_path="oversized.bin",
+    )
+    resolver = CheckpointArtifactSourceResolver()
+    with pytest.raises(ValueError, match="oversized.bin.*4 bytes; limit is 3"):
+        await resolver.materialize(
+            (oversized_candidate,),
+            tmp_path / "oversized-output",
+            max_artifact_bytes=3,
+            max_bundle_bytes=5,
+        )
+
+    first = tmp_path / "first.bin"
+    second = tmp_path / "second.bin"
+    first.write_bytes(b"123")
+    second.write_bytes(b"456")
+    with pytest.raises(ValueError, match="bundle is at least 6 bytes; limit is 5"):
+        await resolver.materialize(
+            (
+                ArtifactCandidate(source_ref=str(first), logical_path="first.bin"),
+                ArtifactCandidate(source_ref=str(second), logical_path="second.bin"),
+            ),
+            tmp_path / "bundle-output",
+            max_artifact_bytes=3,
+            max_bundle_bytes=5,
+        )
 
 
 async def test_runtime_world_exposes_publish_query_and_reconcile(tmp_path):


### PR DESCRIPTION
## Summary

- pass configured per-artifact and aggregate byte limits into bounded checkpoint source resolvers
- reject oversized archive members and cumulative expansion before copying bytes
- preflight direct files and retain post-materialization validation as defense in depth
- preserve the stable two-argument ArtifactSourceResolver contract for existing provider integrations
- expose an optional BoundedArtifactSourceResolver capability for providers that can enforce limits before copying
- document both resolver paths and add deterministic regressions

This is the focused follow-up to the late archive-extraction review finding on #494, which has already merged.

## Review follow-up

The compatibility review on the first head was correct: passing new keyword arguments directly to every provider resolver broke existing implementations. The service now capability-detects bounded resolvers, calls legacy resolvers through their original signature, and always applies post-materialization validation. Archive-aware providers can opt into pre-copy resource control through the new bounded method.

## Validation

- focused artifact contracts: 48 passed
- make static: passed
- make ci:
  - 1,281 passed, 7 skipped
  - 87.01% coverage
  - regression 15/15
  - specification 8/8
  - capability 5/5
  - package smoke, examples, and docs passed
