### PR TITLE
feat: add pre-durability secret redaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ format:
 	@uv run ruff format $(RUFF_PATHS)
 
 .PHONY: lint
-lint: lazy-audit architecture-audit api-boundary-audit idempotency-audit gate-coverage-audit
+lint: lazy-audit architecture-audit api-boundary-audit idempotency-audit gate-coverage-audit redaction-audit
 	@uv run ruff check $(RUFF_PATHS)
 
 .PHONY: lint-fix
@@ -154,6 +154,10 @@ idempotency-audit:
 .PHONY: gate-coverage-audit
 gate-coverage-audit:
 	@PYTHONPATH=$(PYTHONPATH) uv run python scripts/check_gate_coverage.py
+
+.PHONY: redaction-audit
+redaction-audit:
+	@uv run python scripts/check_pre_durability_redaction.py
 
 # Cyclomatic complexity + maintainability report.
 # Uses uvx so radon stays out of the project lock file.

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -88,6 +88,7 @@ src/archetype/app/
   storage/           stores, catalog/control authority, backend construction
   query/             persisted ECS read paths
   artifacts/         ingestion, publication claims, content and indexes
+  redaction/         pre-durability secret scanning, receipts and quarantine
   evaluation/        graders, snapshot pinning, receipts
   commands/          durable ledger, scheduling, dispatch, settlement
   gateway/           authorization policy boundary
@@ -139,7 +140,8 @@ gateway, runtime, API, or CLI boundary.
 | Mutation | Mutate a resolved live world | World port |
 | Simulation | Step, run, episode, and rollout | World port plus named command-drain and quota-reset callables |
 | Query | Persisted ECS reads, durable discovery, and compatibility history reads | Storage and audit ports |
-| Artifacts | Durable ingestion, immutable content, contextual links, publication claims and indexes | Storage and world-coordinate ports |
+| Redaction | Provider-neutral secret scanning, deterministic text redaction, safe receipts and quarantine | None |
+| Artifacts | Durable ingestion, immutable content, contextual links, publication claims and indexes | Redaction, storage and world-coordinate ports |
 | Evaluation | Snapshot pinning, grader contracts, grading, evidence and durable receipts | Query and artifact ports |
 | Commands | Durable admission, order, leasing, dispatch, retry, settlement and dead letters | Control catalog plus world and mutation ports |
 | Audit | Transactional journal/outbox and analytical projection | Storage or control-authority ports |

--- a/docs/guide/artifact-finalization.md
+++ b/docs/guide/artifact-finalization.md
@@ -77,8 +77,12 @@ One publication request is identified by:
 bundle_id = SHA256(domain, world_id, run_id, idempotency_key)
 ```
 
-Reusing that key with the same canonical request returns the original receipt.
-Reusing it with a different request digest is a conflict and fails closed.
+Reusing that key with the same producer request returns the original receipt.
+Reusing it with a different producer request digest is a conflict and fails
+closed. The digest excludes the service-bound `redaction_policy_id`: upgrading
+the scanner must not turn replay of an already indexed bundle into an identity
+conflict. The persisted canonical request still records the exact policy that
+processed the payload.
 The control row's immutable claim time supplies `created_at_ms` and any derived
 retention deadline, so replaying a `PENDING` upload produces the same manifest
 and index rows rather than resetting their lifecycle clock.
@@ -148,7 +152,93 @@ back to the logical filename's registered MIME type. Upload uses
 `IOConfig`. Credentials remain in that process-local configuration and are
 never serialized into requests, control rows, manifests, or the index.
 
-## 4. Publication state machine
+## 4. Pre-durability secret redaction
+
+`RedactionService` is the single provider-neutral authority for data that may
+cross from an agent or sandbox into a durable control row, object, index,
+trace, or external event stream. Artifact publication consumes only its
+`iRedactionService` port. Provider adapters, collectors, and proxies must use
+the same port rather than implementing separate regular-expression filters.
+
+The artifact handoff applies the following dispositions:
+
+| Input | Pre-durability disposition |
+|---|---|
+| Request identity, source/checkpoint references, logical paths, object-store roots, returned object URIs, index strings | Scan before the catalog claim or next durable write; quarantine on any finding because rewriting identity would break recovery |
+| UTF-8 text, JSON/JSONL, logs, patches, and declared text artifacts | Copy into a controlled local snapshot, redact deterministically, then hash and upload the sanitized bytes |
+| Opaque binary | Scan the complete byte stream for the shared high-confidence corpus; quarantine on a finding because byte replacement may corrupt the artifact |
+| Tar or ZIP archive | Traverse regular members without extraction, validate every member name, enforce declared and observed member/count/expanded-byte bounds, and quarantine on a finding, link or special member, encrypted member, unsafe member path, nested/disguised container, or incomplete inspection |
+| Known credential path such as `.codex/auth.json`, `.claude/.credentials.json`, `.config/opencode/auth.json`, `.aws/credentials`, `.git-credentials`, `.netrc`, or a private SSH key | Quarantine by path even when content patterns do not recognize the credential |
+
+The scanner covers Codex/OpenAI, Claude/Anthropic, GitHub, Modal, OpenRouter,
+AWS and common cloud formats, OAuth access/refresh tokens, signed URLs,
+private-key blocks, Authorization/Bearer headers, and generic sensitive
+assignments. This is defense in depth, not a claim that arbitrary encrypted or
+proprietary binary encodings can be semantically decoded. Uninspectable
+containers fail closed; other opaque binaries receive complete byte-pattern
+scanning. Credential files must still be excluded from mission checkpoints and
+artifact declarations by construction.
+
+The order is authoritative:
+
+1. Bind the active scanner `policy_id` into a copy of the immutable request.
+2. Scan all request and destination metadata before the control-catalog claim.
+3. Persist the credential-free claim before provider or object-store I/O.
+4. Materialize sources, copy each file into a controlled snapshot, and scan or
+   redact that copy.
+5. Compute MIME type, size, and content hash from exactly the approved copy;
+   upload those same bytes.
+6. Generate and scan the manifest, validate every index string, then record
+   upload metadata and append the index.
+
+Every retry diagnostic is also redacted and bounded before the control catalog
+records it. Quarantine exceptions retain only rule identifiers—not the matched
+value or caller-provided scope—and the HTTP adapter maps them to a fixed 422
+detail. Reconciler logs emit error types rather than raw provider diagnostics,
+so an untrusted exception cannot turn the retry ledger or reconciliation log
+into a credential side channel.
+
+The caller's source and the provider checkpoint are never mutated. This both
+preserves resumability and prevents a source-file change between scan and
+upload from bypassing the gate. Snapshot copying opens a verified regular-file
+handle without following symlinks and rejects an inode swap between inspection
+and open; hashes and uploads then consume only that controlled copy.
+
+`ArtifactBundleRequest.redaction_policy_id` is empty at ingress and bound by
+the service. Its canonical durable form always contains the active policy ID.
+A caller-supplied mismatch fails before the claim. A reconciler may resume a
+`PENDING` publication only when that exact policy implementation remains
+available; policy deployments must therefore retain old implementations or
+drain their pending claims. Reapplying a compatible policy is deterministic,
+and content-addressed placement reuses prior sanitized uploads. `UPLOADED`
+recovery and `INDEXED` replay no longer need the retired implementation because
+their approved bytes and safe records are already durable; the current policy
+still scans their metadata before index or receipt visibility.
+
+Deployments upgrading an existing catalog must treat rows without a bound
+policy explicitly. Legacy `INDEXED` rows remain queryable historical evidence,
+but their payload bytes are not retroactively certified by this gate and must
+not be labeled redaction-approved. Legacy `PENDING` rows fail closed rather
+than reopening a checkpoint under an unknown policy; an operator must expire
+and republish them through the current scanner. Legacy `UPLOADED` rows may be
+indexed only after their durable metadata passes the current scanner, while
+retaining the same historical limitation for already-uploaded payload bytes.
+
+Successful manifests contain only safe evidence: policy ID, clean/redacted
+status, file and byte counts, redaction count, rule IDs, and per-file receipts.
+Receipts and quarantine errors never retain or echo matched text. A text
+finding is redacted; a metadata, credential-file, archive, or opaque-binary
+finding raises `SecretQuarantineError`. Metadata quarantine creates no claim.
+Payload quarantine leaves a retryable `PENDING` claim with a safe diagnostic,
+no object/index visibility, and the original provider checkpoint available for
+operator recovery.
+
+Sandbox live events, sandbox-side spans, OTel export, and policy-controlled L7
+traffic capture are required to consume this same authority before their
+respective durable/external writes. Those integrations extend this contract;
+they do not weaken the artifact gate while their transports are developed.
+
+## 5. Publication state machine
 
 The control catalog records the canonical request **before external I/O**.
 
@@ -196,7 +286,7 @@ rare physical duplicates without changing the index contract.
 | After Iceberg commit | Query rows visible, control row `UPLOADED` | Verify rows, mark `INDEXED` |
 | After completion | `INDEXED` | Return duplicate receipt |
 
-## 5. Reconciler contract
+## 6. Reconciler contract
 
 `ArtifactBundleService.reconcile(world_id, limit=N)` is one bounded,
 idempotent pass.
@@ -222,7 +312,7 @@ Long operations renew the lease. Reconciler attempts are expected to be
 at-least-once; object placement and index verification make their effects
 idempotent.
 
-## 6. Lifecycle policy for review
+## 7. Lifecycle policy for review
 
 There are two independent clocks:
 
@@ -250,7 +340,7 @@ primary policy, because lifecycle rules cannot evaluate index columns. Provider
 checkpoints must not be deleted until the bundle is `INDEXED` and no task or
 branch resume policy still references them.
 
-## 7. Query, authorization, and telemetry
+## 8. Query, authorization, and telemetry
 
 - `RuntimeApplication` owns actor-free publish, reconcile, and query semantics;
   an untrusted API adapter must apply gateway authorization before invoking it.
@@ -263,6 +353,10 @@ branch resume policy still references them.
 - Agent CLI JSONL and sandbox-side OTel output are portable artifacts. Shipping
   live sandbox spans to an OTel collector is complementary and must use the
   same correlation attributes. It is not required for publication correctness.
+- Every portable payload and generated manifest passes the pre-durability gate
+  in section 4. Live telemetry exporters must apply the same policy before
+  enqueueing or sending a span; an observability outage or quarantine never
+  changes mission state authority.
 - Provider and model secrets are process capabilities. They must not appear in
   sandbox manifests, artifact requests, control rows, object paths, traces, or
   index rows.
@@ -275,7 +369,7 @@ branch resume policy still references them.
   the sandbox-provider credential. It must not require or inject the model or
   GitHub secret; the Modal resolver enforces this separation.
 
-## 8. Relationship to tick progression
+## 9. Relationship to tick progression
 
 An Archetype tick records an attempt whether it is accepted or rejected. A
 validator failure does not abort persistence of that tick. What is gated is the

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -43,6 +43,8 @@ iRuntimeApplication
   -> iResearchService
 
 iEvaluationService -> iQueryService + iArtifactService
+iArtifactBundleService -> iRedactionService + iStorageService + iWorldService
+iRedactionService -> no lower application family
 iArtifactService   -> iStorageService + iWorldService
 iArtifactTableService -> iStorageService + iWorldService
 iQueryService      -> iStorageService + iAuditLog
@@ -52,7 +54,6 @@ iSimulationService -> iWorldService + injected callbacks
 iCommandScheduler  -> iWorldService + iMutationService
 iResearchService   -> iWorldService + iSimulationService
 iAuditLog          -> iStorageService
-iArtifactBundleService -> iStorageService + iWorldService
 iMissionService    -> typed mission rows (no service dependency)
 ```
 
@@ -72,6 +73,7 @@ iMissionService    -> typed mission rows (no service dependency)
 | `iArtifactService` | `ArtifactService` | application, evaluation | Claim-backed component publication and immutable snapshot pinning |
 | `iArtifactTableService` | `ArtifactTableService` | application | Typed file/row ingestion and contextual reads |
 | `iArtifactBundleService` | `ArtifactBundleService` | application | Portable evidence publication, indexing, and reconciliation |
+| `iRedactionService` | `RedactionService` | artifact bundles; future sandbox/telemetry/proxy adapters | Provider-neutral pre-durability scanning, deterministic text redaction, safe receipts, and quarantine |
 | `iEvaluationService` | `EvaluationService` | application | Query, grade, validate and publish evaluation evidence |
 | `iCommandScheduler` | `CommandScheduler` | application | Durable admission, leasing, dispatch, retry, settlement and outbox inspection |
 | `iAuditLog` | `AuditLog` | application, gateway, query | Append-only access rows and command-outbox projection |
@@ -107,7 +109,10 @@ its drain and quota-reset callables.
 the control catalog. Tick publication performs terminal applied settlement.
 `iArtifactService` and `iEvaluationService` expose separate claim-backed
 workflows. `iArtifactBundleService` owns full attempt-bundle publication and
-reconciliation while provider checkpoints remain recovery objects.
+reconciliation while provider checkpoints remain recovery objects. It consumes
+`iRedactionService` before its control, object, manifest, and index durability
+boundaries. Future live-event, OTel, and proxy exporters consume that same port;
+they do not fork scanner policy.
 `iAuditLog` is a projection/read port, not the authority for command outcome.
 
 ### Mission transition port
@@ -127,6 +132,7 @@ owners:
 - artifact descriptors and receipts: `app/artifacts/models.py`;
 - artifact bundle requests and publication receipts: `app/artifacts/bundle_models.py`;
 - mission facts, attempt requests, and typed states: `app/missions/`;
+- redaction policy configuration, safe receipts, and quarantine errors: `app/redaction/models.py`;
 - evaluation contracts, outcomes, and receipts: `app/evaluation/models.py`;
 - research contracts and ledger components: `app/research/`;
 - audit access events: `app/audit/models.py`;

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -24,6 +24,7 @@ The current contract set is split across design docs and executable tests.
 | [Durable Discovery](durable-discovery.md) | Control catalog and cold reads | Catalog authority, `discover_worlds`/`open_world_readonly`, fail-closed cold queries. |
 | [Atomic Visibility](atomic-visibility.md) | Tick commit identity | Manifest-published ticks, commit tokens, writer fencing, epoch-0 legacy reads. |
 | [Artifacts](artifacts.md) | External-artifact ingestion | Typed Iceberg tables, Daft file processors, content identity, and claim-backed receipt compatibility. |
+| [Artifact Finalization](artifact-finalization.md) | Sandbox evidence durability | Provider checkpoints, portable bundle publication/replay, pre-durability redaction, indexing, and retention. |
 | [Agent Mission Transitions](agent-missions.md) | Mission/task/attempt authority | Typed completed-attempt graph, evidence gate, retry, exhaustion, and task advancement. |
 | [Dataset and Evaluation Ontology](dataset-eval-ontology.md) | Dataset/eval identity and vocabulary | Dataset-vs-runtime coordinates, trial/episode cardinality, typed-artifact ownership, and grader composition. |
 | [Audit Log](audit-log.md) | Audit rows | Append-only audit history and query contract. |

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -29,8 +29,9 @@ machine authority; this page is its review surface.
 | `core.ecs.data_model` | `core` | high | [docs/guide/specification.md](../guide/specification.md) — Data Model Contracts | pytest: 2; eval: 2; benchmark: 1 | `pr`, `main`, `release` |
 | `release.package.installable` | `release` | high | [docs/guide/api-stability.md](../guide/api-stability.md) — What counts as public | pytest: 2; static: 1 | `release` |
 | `storage.remote.control_parity` | `storage` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 10. Supported durability profile | pytest: 2; static: 1 | `main`, `release` |
-| `artifacts.bundle.publication_replay` | `artifacts` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — 4. Publication state machine | pytest: 4 | `pr`, `main`, `release` |
+| `artifacts.bundle.publication_replay` | `artifacts` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — 5. Publication state machine | pytest: 4 | `pr`, `main`, `release` |
 | `missions.transition.evidence_gated` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 2. Typed mission/task/attempt transition graph | pytest: 1; static: 1; eval: 1 | `pr`, `main`, `release` |
+| `security.redaction.pre_durability` | `redaction` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — 4. Pre-durability secret redaction | pytest: 3; static: 2; eval: 1 | `pr`, `main`, `release` |
 
 Profile membership states where a contract must be enforced. Eval suite
 blocking/advisory policy is defined separately in `quality/eval_profiles.toml`;

--- a/docs/reference/python/artifact-bundles.md
+++ b/docs/reference/python/artifact-bundles.md
@@ -18,6 +18,7 @@
 | `tick` | `int` | `required` |
 | `attempt_id` | `str` | `required` |
 | `idempotency_key` | `str` | `required` |
+| `redaction_policy_id` | `str` | `''` |
 | `checkpoint_ref` | `str` | `required` |
 | `checkpoint_provider` | `str` | `required` |
 | `checkpoint_restorable` | `bool` | `True` |

--- a/evals/suites/capability/__init__.py
+++ b/evals/suites/capability/__init__.py
@@ -6,13 +6,14 @@
 from __future__ import annotations
 
 from evals.harness import EvalHarness
-from evals.suites.capability import agent_missions, tasks
+from evals.suites.capability import agent_missions, redaction, tasks
 
 
 def register(harness: EvalHarness) -> None:
     """Register the stable capability suite in diagnostic order."""
     tasks.register(harness)
     agent_missions.register(harness)
+    redaction.register(harness)
 
 
-__all__ = ["agent_missions", "register", "tasks"]
+__all__ = ["agent_missions", "redaction", "register", "tasks"]

--- a/evals/suites/capability/redaction.py
+++ b/evals/suites/capability/redaction.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Credential-free capability proof for pre-durability redaction."""
+
+from __future__ import annotations
+
+from archetype.app.redaction import RedactionService, SecretQuarantineError
+from evals.graders import state_check
+from evals.harness import EvalHarness
+from evals.types import GraderResult
+from quality.secret_corpus import SAFE_REDACTION_CORPUS, SECRET_LEAK_CORPUS
+
+SUITE = "capability"
+
+
+def task_pre_durability_redaction() -> list[GraderResult]:
+    service = RedactionService()
+    leak_results = [
+        (case, service.redact_text(case.payload, scope=f"eval:{case.name}"))
+        for case in SECRET_LEAK_CORPUS
+    ]
+    safe_results = [
+        service.redact_text(value, scope="eval:safe") for value in SAFE_REDACTION_CORPUS
+    ]
+
+    errors_are_safe = True
+    metadata_fails_closed = True
+    for case in SECRET_LEAK_CORPUS:
+        try:
+            service.assert_safe_metadata(case.payload, field=f"eval:{case.name}")
+        except SecretQuarantineError as exc:
+            errors_are_safe = errors_are_safe and case.payload not in str(exc)
+        else:
+            metadata_fails_closed = False
+
+    return [
+        state_check(
+            {
+                "every_provider_format_redacted": all(
+                    result.receipt.status == "redacted" and case.rule_id in result.receipt.rule_ids
+                    for case, result in leak_results
+                ),
+                "no_synthetic_secret_survives": all(
+                    case.payload not in result.text for case, result in leak_results
+                ),
+                "safe_placeholders_are_stable": all(
+                    result.receipt.status == "clean" and result.text == original
+                    for original, result in zip(SAFE_REDACTION_CORPUS, safe_results, strict=True)
+                ),
+                "metadata_fails_closed": metadata_fails_closed,
+                "quarantine_errors_do_not_echo": errors_are_safe,
+                "policy_identity_is_versioned": service.policy_id.startswith(
+                    "archetype-secret-redaction-v1:"
+                ),
+            },
+            name="pre_durability_secret_redaction",
+        )
+    ]
+
+
+def register(harness: EvalHarness) -> None:
+    harness.add(
+        "security.pre_durability_redaction",
+        suite=SUITE,
+        fn=task_pre_durability_redaction,
+        desc=(
+            "Shared scanner redacts provider/cloud credentials, preserves safe placeholders, "
+            "and fails metadata closed without echoing secrets"
+        ),
+    )

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -140,30 +140,30 @@ reason = "same grading-boundary site as the collect above: per-entity terminal r
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 716
+line = 865
 method = "to_pylist"
 reason = "Artifact-manifest boundary: the caller-declared, size-bounded file set has already been hashed and MIME-classified by native Daft expressions; scalar metadata must enter Python to construct validated immutable index records and the canonical bundle manifest."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 768
+line = 917
 method = "to_pylist"
 reason = "Object-store completion boundary: each caller-declared, size-bounded upload has executed through Daft and its returned object URI must enter Python to construct the portable manifest and deterministic artifact-index rows."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 781
+line = 930
 method = "to_pylist"
 reason = "Single-object upload boundary: one generated bundle-manifest byte value is uploaded through Daft and its sole destination URI must enter the durable publication receipt and control-catalog record."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 796
+line = 945
 method = "to_pylist"
 reason = "Content-addressed retry boundary: only object paths inside one deterministic artifact folder are materialized so imperative reconciliation can choose a stable existing upload rather than issue duplicate external I/O."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 812
+line = 961
 method = "to_pylist"
 reason = "Bundle-index idempotency boundary: the Iceberg query is filtered to one deterministic bundle and its bounded artifact rows must enter Python for exact conflict detection and missing-row selection before an append."

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -14,6 +14,7 @@ types = [
   "MutationService",
   "MissionService",
   "QueryService",
+  "RedactionService",
   "RuntimeApplication",
   "ServiceContainer",
   "SimulationService",
@@ -92,8 +93,18 @@ name = "artifact-family"
 consumer = "archetype.app.artifacts"
 allowed_app = [
   "archetype.app.artifacts",
+  "archetype.app.redaction.interfaces",
+  "archetype.app.redaction.models",
   "archetype.app.storage",
   "archetype.app.world.interfaces",
+]
+
+[[family_rule]]
+name = "redaction-family"
+consumer = "archetype.app.redaction"
+allowed_app = [
+  "archetype.app.redaction",
+  "archetype.app.errors",
 ]
 
 [[family_rule]]
@@ -232,12 +243,21 @@ allowed_app = [
 [[module_rule]]
 module = "archetype.app.artifacts.bundle_service"
 allowed_interfaces = [
+  "archetype.app.redaction.interfaces.iRedactionService",
   "archetype.app.storage.interfaces.iStorageService",
   "archetype.app.world.interfaces.iWorldService",
 ]
 allowed_app = [
   "archetype.app.artifacts.bundle_models",
+  "archetype.app.redaction.models",
   "archetype.app.storage.catalog",
+]
+
+[[module_rule]]
+module = "archetype.app.redaction.service"
+allowed_interfaces = []
+allowed_app = [
+  "archetype.app.redaction.models",
 ]
 
 [[module_rule]]

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -316,7 +316,7 @@ profiles = ["main", "release"]
 [[contract]]
 id = "artifacts.bundle.publication_replay"
 source = "docs/guide/artifact-finalization.md"
-section = "4. Publication state machine"
+section = "5. Publication state machine"
 owner = "artifacts"
 risk = "high"
 pytest = [
@@ -339,5 +339,24 @@ risk = "high"
 pytest = ["tests/app/test_mission_transition_authority.py"]
 static = ["scripts/check_architecture.py"]
 evals = ["agent_mission_transition_authority"]
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
+id = "security.redaction.pre_durability"
+source = "docs/guide/artifact-finalization.md"
+section = "4. Pre-durability secret redaction"
+owner = "redaction"
+risk = "high"
+pytest = [
+  "tests/app/test_redaction_service.py",
+  "tests/app/test_artifact_bundle_service.py",
+  "tests/scripts/test_check_pre_durability_redaction.py",
+]
+static = [
+  "scripts/check_pre_durability_redaction.py",
+  "scripts/check_architecture.py",
+]
+evals = ["security.pre_durability_redaction"]
 benchmarks = []
 profiles = ["pr", "main", "release"]

--- a/quality/secret_corpus.py
+++ b/quality/secret_corpus.py
@@ -1,0 +1,108 @@
+"""Synthetic credential corpus shared by redaction tests and capability evals.
+
+Values are assembled at runtime so repository secret scanners do not mistake
+the corpus for live credentials. None of these values grants access anywhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SecretLeakCase:
+    name: str
+    payload: str
+    rule_id: str
+
+
+SECRET_LEAK_CORPUS = (
+    SecretLeakCase(
+        "codex-openai-api-key",
+        "OPENAI_API_KEY=" + "sk-proj-" + "A" * 32,
+        "sensitive-assignment",
+    ),
+    SecretLeakCase(
+        "claude-anthropic-api-key",
+        "ANTHROPIC_API_KEY=" + "sk-ant-api03-" + "B" * 32,
+        "sensitive-assignment",
+    ),
+    SecretLeakCase(
+        "github-token",
+        "clone credential " + "ghp_" + "C" * 36,
+        "github-token",
+    ),
+    SecretLeakCase(
+        "modal-token-secret",
+        "MODAL_ENDPOINT_TOKEN_SECRET=" + "as-" + "D" * 32,
+        "sensitive-assignment",
+    ),
+    SecretLeakCase(
+        "modal-token-id",
+        "request token " + "ak-" + "E" * 32,
+        "modal-token",
+    ),
+    SecretLeakCase(
+        "openrouter-api-key",
+        "router=" + "sk-or-v1-" + "F" * 32,
+        "openrouter-api-key",
+    ),
+    SecretLeakCase(
+        "aws-access-key",
+        "AWS_ACCESS_KEY_ID=" + "AKIA" + "G" * 16,
+        "aws-access-key-id",
+    ),
+    SecretLeakCase(
+        "google-api-key",
+        "google=" + "AIza" + "H" * 35,
+        "google-api-key",
+    ),
+    SecretLeakCase(
+        "codex-oauth-refresh-token",
+        '{"refresh_' + 'token":"codex-refresh-' + "I" * 32 + '"}',
+        "sensitive-assignment",
+    ),
+    SecretLeakCase(
+        "claude-oauth-access-token",
+        '{"access_' + 'token":"claude-access-' + "J" * 32 + '"}',
+        "sensitive-assignment",
+    ),
+    SecretLeakCase(
+        "generic-bearer",
+        "Authorization: Bearer " + "K" * 40,
+        "authorization-header",
+    ),
+    SecretLeakCase(
+        "signed-url",
+        "https://objects.invalid/file?X-Amz-Signature=" + "L" * 64,
+        "signed-url-query",
+    ),
+    SecretLeakCase(
+        "azure-account-key",
+        "AccountKey=" + "M" * 48,
+        "sensitive-assignment",
+    ),
+    SecretLeakCase(
+        "generic-cli-key",
+        "agent --api-key " + "N" * 40,
+        "cli-secret-argument",
+    ),
+    SecretLeakCase(
+        "private-key",
+        "-----BEGIN "
+        + "PRIVATE KEY-----\n"
+        + "TUlJRXZBSUJBREFOQmdrcWhraUc5dzBCQVFFRkFBU0M="
+        + "\n-----END PRIVATE KEY-----",
+        "private-key",
+    ),
+)
+
+
+SAFE_REDACTION_CORPUS = (
+    "OPENAI_API_KEY=sk-...",
+    '"Modal-Secret":"{env:MODAL_ENDPOINT_TOKEN_SECRET}"',
+    '"authorization":"<redacted:authorization-header>"',
+    "idempotency_key=attempt-0001",
+    "content_hash=" + "a" * 64,
+    "No credentials are present in this session log.",
+)

--- a/scripts/check_pre_durability_redaction.py
+++ b/scripts/check_pre_durability_redaction.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Fail when artifact durability bypasses the shared redaction authority."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TARGET = ROOT / "src" / "archetype" / "app" / "artifacts" / "bundle_service.py"
+
+
+def _service_methods(tree: ast.Module) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "ArtifactBundleService":
+            return {
+                child.name: child
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+    return {}
+
+
+def _call_lines(node: ast.AST, name: str) -> list[int]:
+    # ``asyncio.to_thread(self._sanitize_materialized, ...)`` passes a bound
+    # method rather than calling it syntactically. Attribute-use ordering is
+    # therefore the correct audit surface for both direct and to-thread calls.
+    return sorted(
+        child.lineno
+        for child in ast.walk(node)
+        if isinstance(child, ast.Attribute) and child.attr == name
+    )
+
+
+def _require_order(
+    errors: list[str],
+    method: ast.AST,
+    method_name: str,
+    first: str,
+    second: str,
+) -> None:
+    first_lines = _call_lines(method, first)
+    second_lines = _call_lines(method, second)
+    if not first_lines:
+        errors.append(f"{method_name} must call {first}()")
+    if not second_lines:
+        errors.append(f"{method_name} must call {second}()")
+    if first_lines and second_lines and first_lines[0] >= second_lines[0]:
+        errors.append(f"{method_name} must call {first}() before {second}()")
+
+
+def audit_path(path: Path = DEFAULT_TARGET) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    methods = _service_methods(tree)
+    errors: list[str] = []
+    required = {"publish", "reconcile", "_upload_bundle"}
+    missing = sorted(required - methods.keys())
+    errors.extend(f"ArtifactBundleService is missing {name}()" for name in missing)
+    if missing:
+        return errors
+
+    publish = methods["publish"]
+    reconcile = methods["reconcile"]
+    upload_bundle = methods["_upload_bundle"]
+    _require_order(
+        errors,
+        publish,
+        "publish",
+        "_bind_redaction_policy",
+        "_control_catalog",
+    )
+    _require_order(
+        errors,
+        publish,
+        "publish",
+        "_safe_failure_detail",
+        "fail_artifact_publication",
+    )
+    _require_order(
+        errors,
+        reconcile,
+        "reconcile",
+        "_safe_failure_detail",
+        "fail_artifact_publication",
+    )
+    _require_order(
+        errors,
+        upload_bundle,
+        "_upload_bundle",
+        "_assert_materialized_metadata_safe",
+        "_upload_files",
+    )
+    _require_order(
+        errors,
+        upload_bundle,
+        "_upload_bundle",
+        "_sanitize_materialized",
+        "_file_metadata",
+    )
+    _require_order(
+        errors,
+        upload_bundle,
+        "_upload_bundle",
+        "_file_metadata",
+        "_upload_files",
+    )
+    _require_order(
+        errors,
+        upload_bundle,
+        "_upload_bundle",
+        "_redaction_manifest",
+        "_upload_bytes",
+    )
+    _require_order(
+        errors,
+        upload_bundle,
+        "_upload_bundle",
+        "_upload_bytes",
+        "_assert_records_safe",
+    )
+    return errors
+
+
+def main() -> int:
+    errors = audit_path()
+    if errors:
+        print("Pre-durability redaction audit failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+    print("Pre-durability redaction audit passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/archetype/api/errors.py
+++ b/src/archetype/api/errors.py
@@ -21,7 +21,12 @@ from typing import NoReturn
 
 from fastapi import HTTPException
 
-from archetype.app.errors import AvailabilityError, ConflictError, WorldNotFoundError
+from archetype.app.errors import (
+    AvailabilityError,
+    ConflictError,
+    PayloadRejectedError,
+    WorldNotFoundError,
+)
 from archetype.app.gateway.auth.errors import GuardrailError
 
 logger = logging.getLogger(__name__)
@@ -39,6 +44,8 @@ def raise_api_error(exc: Exception, *, conflict: bool = False) -> NoReturn:
         raise HTTPException(status_code=409, detail=exc.public_detail) from None
     if isinstance(exc, AvailabilityError):
         raise HTTPException(status_code=503, detail=exc.public_detail) from None
+    if isinstance(exc, PayloadRejectedError):
+        raise HTTPException(status_code=422, detail=exc.public_detail) from None
     if isinstance(exc, ValueError):
         status_code = 409 if conflict else 400
         raise HTTPException(status_code=status_code, detail=str(exc)) from None

--- a/src/archetype/app/artifacts/bundle_models.py
+++ b/src/archetype/app/artifacts/bundle_models.py
@@ -105,6 +105,7 @@ class ArtifactBundleRequest(BaseModel):
     tick: int = Field(ge=0)
     attempt_id: str
     idempotency_key: str
+    redaction_policy_id: str = ""
     checkpoint_ref: str
     checkpoint_provider: str
     checkpoint_restorable: bool = True
@@ -129,6 +130,11 @@ class ArtifactBundleRequest(BaseModel):
         if not value:
             raise ValueError("must not be empty")
         return value
+
+    @field_validator("redaction_policy_id")
+    @classmethod
+    def _optional_policy_identity(cls, value: str) -> str:
+        return value.strip()
 
     @model_validator(mode="after")
     def _unique_logical_paths(self) -> ArtifactBundleRequest:
@@ -161,7 +167,13 @@ class ArtifactBundleRequest(BaseModel):
         return _canonical_json(payload)
 
     def digest(self) -> str:
-        return hashlib.sha256(self.canonical_json().encode()).hexdigest()
+        # ``redaction_policy_id`` is bound by the service, not supplied by the
+        # producer. Excluding it preserves producer idempotency across scanner
+        # upgrades while the persisted canonical request still pins the exact
+        # policy required to resume a PENDING publication.
+        payload = json.loads(self.canonical_json())
+        payload.pop("redaction_policy_id", None)
+        return hashlib.sha256(_canonical_json(payload).encode()).hexdigest()
 
 
 class ArtifactIndexRecord(BaseModel):

--- a/src/archetype/app/artifacts/bundle_service.py
+++ b/src/archetype/app/artifacts/bundle_service.py
@@ -42,6 +42,8 @@ from archetype.app.artifacts.bundle_models import (
     MaterializedArtifact,
     _canonical_json,
 )
+from archetype.app.redaction.interfaces import iRedactionService
+from archetype.app.redaction.models import RedactionReceipt
 from archetype.app.storage.catalog import (
     ArtifactPublicationExpiredError,
     ArtifactPublicationRecord,
@@ -55,6 +57,7 @@ if TYPE_CHECKING:
 
 _ARTIFACT_INDEX_TABLE = "artifact_index_v1"
 _ROOTFS_SCHEME = "apple-container-rootfs://"
+_MAX_FAILURE_DETAIL_CHARS = 4096
 logger = logging.getLogger(__name__)
 
 
@@ -275,15 +278,89 @@ class ArtifactBundleService:
         world_service: iWorldService,
         config: ArtifactStoreConfig | None = None,
         source_resolver: ArtifactSourceResolver | None = None,
+        *,
+        redaction_service: iRedactionService,
     ) -> None:
         self._storage_service = storage_service
         self._world_service = world_service
         self._config = config
         self._source_resolver = source_resolver or CheckpointArtifactSourceResolver()
+        self._redaction_service = redaction_service
 
     @property
     def enabled(self) -> bool:
         return self._config is not None
+
+    def _bind_redaction_policy(self, request: ArtifactBundleRequest) -> ArtifactBundleRequest:
+        policy_id = self._redaction_service.policy_id
+        if request.redaction_policy_id and request.redaction_policy_id != policy_id:
+            raise ValueError(
+                "artifact request redaction_policy_id does not match the active policy"
+            )
+        bound = (
+            request
+            if request.redaction_policy_id
+            else request.model_copy(update={"redaction_policy_id": policy_id})
+        )
+        self._assert_request_metadata_safe(bound)
+        self._redaction_service.assert_safe_metadata(
+            self._normalized_object_uri(),
+            field="artifact_store.object_uri",
+        )
+        return bound
+
+    def _assert_request_metadata_safe(self, request: ArtifactBundleRequest) -> None:
+        values = {
+            "world_id": request.world_id,
+            "run_id": request.run_id,
+            "attempt_id": request.attempt_id,
+            "idempotency_key": request.idempotency_key,
+            "redaction_policy_id": request.redaction_policy_id,
+            "checkpoint_ref": request.checkpoint_ref,
+            "checkpoint_provider": request.checkpoint_provider,
+        }
+        for field, value in values.items():
+            self._redaction_service.assert_safe_metadata(
+                value,
+                field=f"artifact_request.{field}",
+            )
+        for index, candidate in enumerate(request.artifacts):
+            for field in ("source_ref", "logical_path", "kind"):
+                self._redaction_service.assert_safe_metadata(
+                    str(getattr(candidate, field)),
+                    field=f"artifact_request.artifacts[{index}].{field}",
+                )
+
+    def _assert_records_safe(self, records: tuple[ArtifactIndexRecord, ...]) -> None:
+        for index, record in enumerate(records):
+            for field, value in record.model_dump(mode="python").items():
+                if isinstance(value, str):
+                    self._redaction_service.assert_safe_metadata(
+                        value,
+                        field=f"artifact_index[{index}].{field}",
+                    )
+
+    def _assert_materialized_metadata_safe(
+        self,
+        values: list[MaterializedArtifact],
+    ) -> None:
+        for index, value in enumerate(values):
+            for field in ("source_ref", "logical_path", "kind"):
+                self._redaction_service.assert_safe_metadata(
+                    str(getattr(value, field)),
+                    field=f"materialized_artifact[{index}].{field}",
+                )
+
+    def _safe_failure_detail(self, exc: BaseException) -> str:
+        """Return a bounded diagnostic approved for the durable retry catalog."""
+        try:
+            result = self._redaction_service.redact_text(
+                f"{type(exc).__name__}: {exc}",
+                scope="artifact.failure_detail",
+            )
+        except BaseException:
+            return f"{type(exc).__name__}: failure detail unavailable"
+        return result.text[:_MAX_FAILURE_DETAIL_CHARS]
 
     async def publish(
         self,
@@ -293,6 +370,7 @@ class ArtifactBundleService:
     ) -> ArtifactPublishReceipt:
         """Upload and index one bundle, or return its original receipt."""
         config = self._require_config()
+        request = self._bind_redaction_policy(request)
         catalog = await self._control_catalog(request, storage_config)
         claimant = f"artifact-{uuid7()}"
         now_ms = int(time.time() * 1000)
@@ -320,22 +398,26 @@ class ArtifactBundleService:
                     publication.last_error
                     or f"artifact publication {publication.publication_key} expired"
                 )
-
             try:
+                if outcome == "recovered":
+                    request = self._request_from_publication(
+                        publication,
+                        require_policy=publication.status == "PENDING",
+                    )
                 return await self._resume(request, publication, claimant, catalog)
             except Exception as exc:
+                failure_detail = self._safe_failure_detail(exc)
                 try:
                     await catalog.fail_artifact_publication(
                         request.world_id,
                         publication.publication_key,
                         claimant,
-                        f"{type(exc).__name__}: {exc}",
+                        failure_detail,
                         retry_at=time.time() + config.retry_delay_seconds,
                     )
                 except Exception as record_error:
                     exc.add_note(
-                        "failed to record artifact retry state: "
-                        f"{type(record_error).__name__}: {record_error}"
+                        f"failed to record artifact retry state: {type(record_error).__name__}"
                     )
                 raise
 
@@ -406,46 +488,52 @@ class ArtifactBundleService:
                     expired += 1
                     continue
                 owned = True
-                request = self._request_from_publication(publication)
                 if publication.status == "PENDING" and (
                     int(time.time() * 1000) > publication.retry_until_ms
                 ):
                     await catalog.expire_artifact_publication(
-                        request.world_id,
+                        publication.world_id,
                         publication.publication_key,
                         claimant,
                         "artifact publication retry window elapsed before upload",
                     )
                     expired += 1
                     continue
+                request = self._request_from_publication(
+                    publication,
+                    require_policy=publication.status == "PENDING",
+                )
                 await self._resume(request, publication, claimant, catalog)
                 indexed += 1
             except Exception as exc:
                 failed += 1
                 if not owned:
-                    logger.exception(
-                        "artifact reconciliation failed before lease acquisition for %s",
+                    logger.error(
+                        "artifact reconciliation failed before lease acquisition for %s (%s)",
                         stale.publication_key,
+                        type(exc).__name__,
                     )
                     continue
+                failure_detail = self._safe_failure_detail(exc)
                 try:
                     await catalog.fail_artifact_publication(
                         publication.world_id,
                         publication.publication_key,
                         claimant,
-                        f"{type(exc).__name__}: {exc}",
+                        failure_detail,
                         retry_at=time.time() + config.retry_delay_seconds,
                     )
                 except Exception as record_error:
                     exc.add_note(
                         "failed to record artifact reconciliation retry state: "
-                        f"{type(record_error).__name__}: {record_error}"
+                        f"{type(record_error).__name__}"
                     )
-                    logger.exception(
-                        "artifact reconciler failed to record retry state for %s after %s: %s",
+                    logger.error(
+                        "artifact reconciler failed to record retry state for %s after %s; "
+                        "retry-state recording also failed (%s)",
                         publication.publication_key,
                         type(exc).__name__,
-                        exc,
+                        type(record_error).__name__,
                     )
         return ArtifactReconcileResult(
             examined=len(due),
@@ -455,9 +543,11 @@ class ArtifactBundleService:
             bundle_ids=tuple(bundle_ids),
         )
 
-    @staticmethod
     def _request_from_publication(
+        self,
         publication: ArtifactPublicationRecord,
+        *,
+        require_policy: bool = True,
     ) -> ArtifactBundleRequest:
         """Decode and authenticate a durable request after owning its lease."""
         request = ArtifactBundleRequest.model_validate_json(publication.request_json)
@@ -477,6 +567,9 @@ class ArtifactBundleService:
             raise ValueError("durable artifact request identity does not match its publication row")
         if request.digest() != publication.request_digest:
             raise ValueError("durable artifact request digest does not match its publication row")
+        if require_policy and request.redaction_policy_id != self._redaction_service.policy_id:
+            raise ValueError("durable artifact request requires an unavailable redaction policy")
+        self._assert_request_metadata_safe(request)
         return request
 
     async def _resume(
@@ -526,6 +619,7 @@ class ArtifactBundleService:
                 ArtifactIndexRecord.model_validate(value)
                 for value in json.loads(publication.records_json)
             )
+            self._assert_records_safe(records)
 
         await catalog.renew_artifact_publication(
             request.world_id,
@@ -572,8 +666,15 @@ class ArtifactBundleService:
             materialized = await self._source_resolver.materialize(
                 request.artifacts, Path(temp_dir)
             )
+            self._assert_materialized_metadata_safe(materialized)
             self._validate_materialized(materialized)
-            metadata = self._file_metadata(materialized)
+            sanitized, redaction_receipts = await asyncio.to_thread(
+                self._sanitize_materialized,
+                materialized,
+                Path(temp_dir) / "redacted",
+            )
+            self._validate_materialized(sanitized)
+            metadata = self._file_metadata(sanitized)
             total = sum(int(row["size_bytes"]) for row in metadata)
             if total > config.max_bundle_bytes:
                 raise ValueError(
@@ -635,18 +736,28 @@ class ArtifactBundleService:
                 "tick": request.tick,
                 "attempt_id": request.attempt_id,
                 "idempotency_key": request.idempotency_key,
+                "redaction": self._redaction_manifest(redaction_receipts),
                 "checkpoint": checkpoint.model_dump(mode="json"),
                 "artifacts": [
                     record.model_dump(mode="json")
                     for record in sorted(portable, key=lambda value: value.logical_path)
                 ],
             }
-            manifest_bytes = _canonical_json(manifest_payload).encode()
+            manifest_json = _canonical_json(manifest_payload)
+            self._redaction_service.assert_safe_metadata(
+                manifest_json,
+                field="artifact.bundle_manifest",
+            )
+            manifest_bytes = manifest_json.encode()
             manifest_hash = hashlib.sha256(manifest_bytes).hexdigest()
             manifest_id = self._artifact_id(bundle_id, "artifact-manifest.json", manifest_hash)
             manifest_folder = self._object_folder(request, bundle_id, manifest_id)
             manifest_uri = self._existing_object(manifest_folder) or self._upload_bytes(
                 manifest_bytes, manifest_folder
+            )
+            self._redaction_service.assert_safe_metadata(
+                manifest_uri,
+                field="artifact.manifest_uri",
             )
             manifest_record = ArtifactIndexRecord(
                 schema_version=1,
@@ -679,7 +790,45 @@ class ArtifactBundleService:
                     [*portable, checkpoint, manifest_record], key=lambda value: value.artifact_id
                 )
             )
+            self._assert_records_safe(records)
             return records, manifest_uri
+
+    def _sanitize_materialized(
+        self,
+        values: list[MaterializedArtifact],
+        destination: Path,
+    ) -> tuple[list[MaterializedArtifact], list[RedactionReceipt]]:
+        destination.mkdir(parents=True, exist_ok=True)
+        sanitized: list[MaterializedArtifact] = []
+        receipts: list[RedactionReceipt] = []
+        for index, value in enumerate(values):
+            result = self._redaction_service.sanitize_file(
+                value.path,
+                destination / f"{index:08d}",
+                logical_path=value.logical_path,
+            )
+            sanitized.append(
+                MaterializedArtifact(
+                    path=result.path,
+                    source_ref=value.source_ref,
+                    logical_path=value.logical_path,
+                    kind=value.kind,
+                )
+            )
+            receipts.append(result.receipt)
+        return sanitized, receipts
+
+    def _redaction_manifest(self, receipts: list[RedactionReceipt]) -> dict[str, object]:
+        redacted = [receipt for receipt in receipts if receipt.status == "redacted"]
+        return {
+            "policy_id": self._redaction_service.policy_id,
+            "status": "redacted" if redacted else "clean",
+            "files_scanned": len(receipts),
+            "bytes_scanned": sum(receipt.scanned_bytes for receipt in receipts),
+            "redaction_count": sum(receipt.redaction_count for receipt in receipts),
+            "rule_ids": sorted({rule for receipt in receipts for rule in receipt.rule_ids}),
+            "files": [receipt.model_dump(mode="json") for receipt in receipts],
+        }
 
     def _file_metadata(self, values: list[MaterializedArtifact]) -> list[_FileMetadata]:
         if not values:
@@ -1022,17 +1171,22 @@ class ArtifactBundleService:
                     raise
                 body_error.add_note(
                     "artifact publication lease renewal also failed: "
-                    f"{type(heartbeat_error).__name__}: {heartbeat_error}"
+                    f"{type(heartbeat_error).__name__}"
                 )
 
-    @staticmethod
     def _receipt(
-        publication: ArtifactPublicationRecord, *, duplicate: bool
+        self, publication: ArtifactPublicationRecord, *, duplicate: bool
     ) -> ArtifactPublishReceipt:
         records = tuple(
             ArtifactIndexRecord.model_validate(value)
             for value in json.loads(publication.records_json)
         )
+        self._assert_records_safe(records)
+        if publication.manifest_uri:
+            self._redaction_service.assert_safe_metadata(
+                publication.manifest_uri,
+                field="artifact.manifest_uri",
+            )
         return ArtifactPublishReceipt(
             bundle_id=publication.publication_key,
             world_id=publication.world_id,

--- a/src/archetype/app/container.py
+++ b/src/archetype/app/container.py
@@ -27,6 +27,8 @@ from archetype.app.evaluation.service import EvaluationService
 from archetype.app.gateway.auth import reset_tick_counters
 from archetype.app.gateway.service import CommandGateway
 from archetype.app.query.service import QueryService
+from archetype.app.redaction.interfaces import iRedactionService
+from archetype.app.redaction.service import RedactionService
 from archetype.app.research.service import AutoResearchService
 from archetype.app.storage.service import StorageService
 from archetype.app.world.mutation import MutationService
@@ -50,6 +52,7 @@ class ServiceContainer:
         audit_storage_config: StorageConfig | None = None,
         artifact_store_config: ArtifactStoreConfig | None = None,
         artifact_source_resolver: ArtifactSourceResolver | None = None,
+        redaction_service: iRedactionService | None = None,
     ):
         if storage_service is not None and storage_service.has_injected_session:
             if audit_storage_config is None:
@@ -62,6 +65,9 @@ class ServiceContainer:
         # Leaf services
         self._owns_storage_service = storage_service is None
         self.storage_service = storage_service if storage_service is not None else StorageService()
+        self.redaction_service = (
+            redaction_service if redaction_service is not None else RedactionService()
+        )
 
         # Storage-backed services
         self.world_service = WorldService(self.storage_service)
@@ -74,6 +80,7 @@ class ServiceContainer:
             self.world_service,
             artifact_store_config,
             artifact_source_resolver,
+            redaction_service=self.redaction_service,
         )
         self.evaluation_service = EvaluationService(self.query_service, self.artifact_service)
 

--- a/src/archetype/app/errors.py
+++ b/src/archetype/app/errors.py
@@ -44,6 +44,18 @@ class AvailabilityError(RuntimeError):
     public_detail = "Service is temporarily unavailable"
 
 
+class PayloadRejectedError(RuntimeError):
+    """A payload is well-formed but cannot cross a safety boundary.
+
+    Concrete services subclass this public contract so transport adapters can
+    reject unsafe content without importing the owning service family or
+    exposing internal findings. The internal exception message may contain
+    safe diagnostic context; adapters expose only ``public_detail``.
+    """
+
+    public_detail = "Payload rejected by safety policy"
+
+
 class WorldNotFoundError(LookupError):
     """Raised when a gated operation targets a ``world_id`` not in the registry.
 

--- a/src/archetype/app/redaction/__init__.py
+++ b/src/archetype/app/redaction/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared pre-durability secret scanning and redaction authority."""
+
+from archetype.app.redaction.interfaces import iRedactionService
+from archetype.app.redaction.models import (
+    RedactedFile,
+    RedactedRecord,
+    RedactedText,
+    RedactionPolicyConfig,
+    RedactionReceipt,
+    SecretQuarantineError,
+)
+from archetype.app.redaction.service import RedactionService
+
+__all__ = [
+    "RedactedFile",
+    "RedactedRecord",
+    "RedactedText",
+    "RedactionPolicyConfig",
+    "RedactionReceipt",
+    "RedactionService",
+    "SecretQuarantineError",
+    "iRedactionService",
+]

--- a/src/archetype/app/redaction/interfaces.py
+++ b/src/archetype/app/redaction/interfaces.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider-neutral ports for pre-durability redaction."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from pydantic import JsonValue
+
+from archetype.app.redaction.models import (
+    RedactedFile,
+    RedactedRecord,
+    RedactedText,
+    RedactionReceipt,
+)
+
+
+@runtime_checkable
+class iRedactionService(Protocol):
+    """Scan and sanitize values before a durable writer can observe them."""
+
+    @property
+    def policy_id(self) -> str: ...
+
+    def redact_text(self, value: str, *, scope: str) -> RedactedText: ...
+
+    def redact_record(
+        self,
+        value: Mapping[str, JsonValue],
+        *,
+        scope: str,
+    ) -> RedactedRecord: ...
+
+    def assert_safe_metadata(self, value: str, *, field: str) -> RedactionReceipt: ...
+
+    def sanitize_file(
+        self,
+        source: Path,
+        destination: Path,
+        *,
+        logical_path: str,
+    ) -> RedactedFile: ...

--- a/src/archetype/app/redaction/models.py
+++ b/src/archetype/app/redaction/models.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed values for the pre-durability secret-redaction boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, JsonValue, field_validator, model_validator
+
+from archetype.app.errors import PayloadRejectedError
+
+RedactionStatus = Literal["clean", "redacted"]
+
+
+class RedactionPolicyConfig(BaseModel):
+    """Bounded archive and stream policy for one scanner implementation.
+
+    Policy configuration is process-local. Only the derived ``policy_id`` is
+    permitted to cross a durable boundary.
+    """
+
+    model_config = dict(frozen=True)
+
+    max_archive_members: int = Field(default=10_000, ge=1)
+    max_archive_member_bytes: int = Field(default=1 << 30, ge=1)
+    max_archive_expanded_bytes: int = Field(default=4 << 30, ge=1)
+    scan_chunk_bytes: int = Field(default=1 << 20, ge=4096)
+    max_text_line_bytes: int = Field(default=8 << 20, ge=4096)
+
+    @model_validator(mode="after")
+    def _consistent_archive_limits(self) -> RedactionPolicyConfig:
+        if self.max_archive_expanded_bytes < self.max_archive_member_bytes:
+            raise ValueError("max_archive_expanded_bytes must be >= max_archive_member_bytes")
+        return self
+
+
+class RedactionReceipt(BaseModel):
+    """Safe evidence that one scope was scanned before durability.
+
+    Receipts contain rule identifiers and counts, never matched text.
+    """
+
+    model_config = dict(frozen=True)
+
+    policy_id: str
+    scope: str
+    status: RedactionStatus
+    scanned_bytes: int = Field(ge=0)
+    redaction_count: int = Field(ge=0)
+    rule_ids: tuple[str, ...] = ()
+
+    @field_validator("policy_id", "scope")
+    @classmethod
+    def _nonempty(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+    @field_validator("rule_ids")
+    @classmethod
+    def _canonical_rules(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if any(not rule.strip() for rule in value):
+            raise ValueError("redaction rule identifiers must not be empty")
+        return tuple(sorted(set(value)))
+
+    @model_validator(mode="after")
+    def _status_matches_findings(self) -> RedactionReceipt:
+        if self.status == "clean" and (self.redaction_count or self.rule_ids):
+            raise ValueError("a clean redaction receipt cannot contain findings")
+        if self.status == "redacted" and (self.redaction_count < 1 or not self.rule_ids):
+            raise ValueError("a redacted receipt requires findings")
+        return self
+
+
+class RedactedText(BaseModel):
+    """Sanitized text and its safe receipt."""
+
+    model_config = dict(frozen=True)
+
+    text: str
+    receipt: RedactionReceipt
+
+
+class RedactedRecord(BaseModel):
+    """Sanitized structured event/span attributes and their receipt."""
+
+    model_config = dict(frozen=True)
+
+    value: dict[str, JsonValue]
+    receipt: RedactionReceipt
+
+
+class RedactedFile(BaseModel):
+    """Controlled file snapshot containing exactly the bytes approved for upload."""
+
+    model_config = dict(frozen=True)
+
+    path: Path
+    receipt: RedactionReceipt
+
+
+class SecretQuarantineError(PayloadRejectedError):
+    """A safe failure raised when a payload cannot be rewritten safely.
+
+    The matched credential is deliberately not retained on the exception.
+    """
+
+    def __init__(self, scope: str, rule_ids: tuple[str, ...]) -> None:
+        # ``scope`` can originate in a path or provider diagnostic. It is an
+        # input to the decision, never part of the exception: retry catalogs,
+        # logs, and transport adapters may retain the exception string.
+        del scope
+        self.rule_ids = tuple(sorted(set(rule_ids)))
+        rules = ", ".join(self.rule_ids) or "unspecified-secret-rule"
+        super().__init__(f"secret-bearing payload quarantined; rules: {rules}")

--- a/src/archetype/app/redaction/service.py
+++ b/src/archetype/app/redaction/service.py
@@ -637,8 +637,6 @@ class RedactionService:
             self.assert_safe_metadata(normalized, field="archive.member_name")
         except SecretQuarantineError as exc:
             raise SecretQuarantineError(scope, exc.rule_ids) from None
-        if self._is_credential_path(normalized):
-            raise SecretQuarantineError(scope, ("credential-file-path",))
         if normalized.lower().endswith(_CONTAINER_SUFFIXES):
             raise SecretQuarantineError(scope, ("nested-archive-unsupported",))
         return f"{scope}:archive-member"

--- a/src/archetype/app/redaction/service.py
+++ b/src/archetype/app/redaction/service.py
@@ -1,0 +1,772 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic secret scanning and redaction before durable I/O."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import tarfile
+import zipfile
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import IO, cast
+from urllib.parse import parse_qsl, unquote, urlparse
+
+from pydantic import JsonValue
+
+from archetype.app.redaction.models import (
+    RedactedFile,
+    RedactedRecord,
+    RedactedText,
+    RedactionPolicyConfig,
+    RedactionReceipt,
+    SecretQuarantineError,
+)
+
+
+@dataclass(frozen=True)
+class _Rule:
+    rule_id: str
+    pattern: re.Pattern[str]
+
+
+def _compile(pattern: str, *, verbose: bool = False) -> re.Pattern[str]:
+    flags = re.IGNORECASE | (re.VERBOSE if verbose else 0)
+    return re.compile(pattern, flags)
+
+
+_RULES = (
+    _Rule(
+        "authorization-header",
+        _compile(
+            r"(?P<prefix>\b(?:authorization|proxy-authorization)\s*[:=]\s*"
+            r"(?:bearer|basic)\s+)(?P<secret>[A-Za-z0-9._~+/=-]{8,2048})"
+        ),
+    ),
+    _Rule(
+        "signed-url-query",
+        _compile(
+            r"(?P<prefix>[?&](?:access[_-]?token|refresh[_-]?token|api[_-]?key|"
+            r"x-amz-signature|x-goog-signature|signature|sig|token|accountkey)=)"
+            r"(?P<secret>[^&#\s]{4,2048})"
+        ),
+    ),
+    _Rule(
+        "cli-secret-argument",
+        _compile(
+            r"(?P<prefix>--(?:api[-_]?key|access[-_]?token|refresh[-_]?token|"
+            r"client[-_]?secret|token|secret|password)(?:=|\s+))"
+            r"(?P<secret>[^\s\"'`;]{6,2048})"
+        ),
+    ),
+    _Rule(
+        "sensitive-assignment",
+        _compile(
+            r"""
+            (?P<prefix>
+                [\"']?
+                (?:
+                    access[_-]?token|refresh[_-]?token|id[_-]?token|
+                    api[_-]?key|client[_-]?secret|secret[_-]?access[_-]?key|
+                    secret[_-]?key|password|passwd|private[_-]?key|credential|
+                    accountkey|modal(?:[_-][a-z0-9]+)*[_-]token[_-](?:id|secret)
+                )
+                [\"']?\s*(?:=|:)\s*[\"']?
+            )
+            (?P<secret>[^\"'\\\s,;}\]\[{]{6,2048})
+            """,
+            verbose=True,
+        ),
+    ),
+    _Rule(
+        "anthropic-api-key",
+        _compile(r"(?P<secret>sk-ant-[A-Za-z0-9_-]{20,256})"),
+    ),
+    _Rule(
+        "openrouter-api-key",
+        _compile(r"(?P<secret>sk-or-v1-[A-Za-z0-9_-]{20,256})"),
+    ),
+    _Rule(
+        "github-token",
+        _compile(
+            r"(?P<secret>(?:gh[pousr]_[A-Za-z0-9]{20,255}|"
+            r"github_pat_[A-Za-z0-9_]{20,255}))"
+        ),
+    ),
+    _Rule(
+        "openai-api-key",
+        _compile(r"(?P<secret>sk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,256})"),
+    ),
+    _Rule(
+        "modal-token",
+        _compile(r"(?P<secret>(?:ak|as)-[A-Za-z0-9_-]{20,128})"),
+    ),
+    _Rule(
+        "aws-access-key-id",
+        _compile(r"(?P<secret>(?:AKIA|ASIA)[A-Z0-9]{16})"),
+    ),
+    _Rule(
+        "google-api-key",
+        _compile(r"(?P<secret>AIza[0-9A-Za-z_-]{35})"),
+    ),
+    _Rule(
+        "jwt",
+        _compile(
+            r"(?P<secret>\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\."
+            r"[A-Za-z0-9_-]{8,}\b)"
+        ),
+    ),
+)
+
+_PRIVATE_BLOCK = re.compile(
+    r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY(?: BLOCK)?-----"
+    r".*?"
+    r"-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY(?: BLOCK)?-----",
+    re.IGNORECASE | re.DOTALL,
+)
+_PRIVATE_BEGIN_TO_EOF = re.compile(
+    r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY(?: BLOCK)?-----.*\Z",
+    re.IGNORECASE | re.DOTALL,
+)
+_PRIVATE_BEGIN = re.compile(
+    r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY(?: BLOCK)?-----",
+    re.IGNORECASE,
+)
+_PRIVATE_END = re.compile(
+    r"-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY(?: BLOCK)?-----",
+    re.IGNORECASE,
+)
+
+_SENSITIVE_RECORD_KEYS = frozenset(
+    {
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "api_key",
+        "client_secret",
+        "secret",
+        "secret_key",
+        "secret_access_key",
+        "password",
+        "passwd",
+        "private_key",
+        "credential",
+        "credentials",
+        "authorization",
+        "proxy_authorization",
+        "accountkey",
+        "token",
+    }
+)
+_SENSITIVE_QUERY_KEYS = _SENSITIVE_RECORD_KEYS | frozenset(
+    {"x_amz_signature", "x_goog_signature", "signature", "sig"}
+)
+_CREDENTIAL_PATH_SUFFIXES = (
+    (".codex", "auth.json"),
+    (".claude", ".credentials.json"),
+    (".config", "opencode", "auth.json"),
+    (".local", "share", "opencode", "auth.json"),
+    (".aws", "credentials"),
+    (".config", "gcloud", "application_default_credentials.json"),
+    (".config", "gcloud", "credentials.db"),
+    (".config", "gcloud", "access_tokens.db"),
+    (".config", "gh", "hosts.yml"),
+    (".docker", "config.json"),
+    (".kube", "config"),
+    (".azure", "accesstokens.json"),
+    (".cache", "huggingface", "token"),
+    (".huggingface", "token"),
+)
+_CREDENTIAL_BASENAMES = frozenset(
+    {
+        ".env",
+        ".env.local",
+        ".env.production",
+        ".env.development",
+        ".git-credentials",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        "id_rsa",
+        "id_ed25519",
+        "id_ecdsa",
+        "id_dsa",
+    }
+)
+_CONTAINER_SUFFIXES = (
+    ".tar",
+    ".tar.gz",
+    ".tgz",
+    ".tar.bz2",
+    ".tbz2",
+    ".tar.xz",
+    ".txz",
+    ".zip",
+    ".7z",
+    ".rar",
+    ".gz",
+    ".bz2",
+    ".xz",
+    ".zst",
+    ".lz4",
+    ".cab",
+    ".iso",
+    ".cpio",
+    ".ar",
+    ".deb",
+    ".rpm",
+    ".dmg",
+    ".wim",
+)
+_PLACEHOLDER_PREFIXES = (
+    "<redacted:",
+    "[redacted",
+    "{env:",
+    "${",
+    "$env:",
+    "***",
+)
+_CONTAINER_MAGIC_PREFIXES = (
+    b"PK\x03\x04",
+    b"PK\x05\x06",
+    b"PK\x07\x08",
+    b"\x1f\x8b",
+    b"BZh",
+    b"\xfd7zXZ\x00",
+    b"\x28\xb5\x2f\xfd",
+    b"7z\xbc\xaf\x27\x1c",
+    b"Rar!\x1a\x07",
+    b"\x04\x22\x4d\x18",
+    b"070701",
+    b"070702",
+    b"070707",
+    b"!<arch>\n",
+    b"MSCF",
+    b"MSWIM\x00\x00\x00",
+)
+
+
+class RedactionService:
+    """One deterministic scanner shared by artifact and telemetry adapters."""
+
+    def __init__(self, config: RedactionPolicyConfig | None = None) -> None:
+        self._config = config or RedactionPolicyConfig()
+        policy_material = {
+            "schema_version": 1,
+            "implementation_revision": 1,
+            "config": self._config.model_dump(mode="json"),
+            "rules": [(rule.rule_id, rule.pattern.pattern, rule.pattern.flags) for rule in _RULES],
+            "private_key_rules": (
+                _PRIVATE_BLOCK.pattern,
+                _PRIVATE_BEGIN_TO_EOF.pattern,
+                _PRIVATE_BEGIN.pattern,
+                _PRIVATE_END.pattern,
+            ),
+            "sensitive_record_keys": sorted(_SENSITIVE_RECORD_KEYS),
+            "sensitive_query_keys": sorted(_SENSITIVE_QUERY_KEYS),
+            "credential_path_suffixes": _CREDENTIAL_PATH_SUFFIXES,
+            "credential_basenames": sorted(_CREDENTIAL_BASENAMES),
+            "container_suffixes": _CONTAINER_SUFFIXES,
+            "container_magic_prefixes": [value.hex() for value in _CONTAINER_MAGIC_PREFIXES],
+            "placeholder_prefixes": _PLACEHOLDER_PREFIXES,
+            "nested_archive_behavior": "quarantine",
+            "archive_link_behavior": "quarantine",
+            "source_snapshot_behavior": "regular-file-no-follow",
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                policy_material,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode()
+        ).hexdigest()
+        self._policy_id = f"archetype-secret-redaction-v1:{digest}"
+
+    @property
+    def policy_id(self) -> str:
+        return self._policy_id
+
+    def redact_text(self, value: str, *, scope: str) -> RedactedText:
+        self._require_scope(scope)
+        sanitized, findings = self._redact_string(value)
+        return RedactedText(
+            text=sanitized,
+            receipt=self._receipt(
+                scope,
+                scanned_bytes=len(value.encode("utf-8")),
+                findings=findings,
+            ),
+        )
+
+    def redact_record(
+        self,
+        value: Mapping[str, JsonValue],
+        *,
+        scope: str,
+    ) -> RedactedRecord:
+        self._require_scope(scope)
+        findings: Counter[str] = Counter()
+
+        def visit_mapping(value: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+            sanitized: dict[str, JsonValue] = {}
+            for raw_key, item in value.items():
+                key, nested = self._redact_string(str(raw_key))
+                findings.update(nested)
+                if key in sanitized:
+                    findings["structured-key-collision"] += 1
+                    base = key
+                    index = 2
+                    while key in sanitized:
+                        key = f"{base}#{index}"
+                        index += 1
+                sanitized[key] = visit(item, str(raw_key))
+            return sanitized
+
+        def visit(item: JsonValue, key: str | None = None) -> JsonValue:
+            normalized_key = self._normalized_key(key) if key is not None else ""
+            if key is not None and self._is_sensitive_key(normalized_key) and item is not None:
+                findings["structured-sensitive-field"] += 1
+                return "<redacted:structured-sensitive-field>"
+            if isinstance(item, str):
+                sanitized, nested = self._redact_string(item)
+                findings.update(nested)
+                return sanitized
+            if isinstance(item, list):
+                return [visit(child) for child in item]
+            if isinstance(item, dict):
+                return visit_mapping(item)
+            return item
+
+        sanitized = visit_mapping(value)
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        return RedactedRecord(
+            value=cast(dict[str, JsonValue], sanitized),
+            receipt=self._receipt(
+                scope,
+                scanned_bytes=len(encoded.encode()),
+                findings=findings,
+            ),
+        )
+
+    def assert_safe_metadata(self, value: str, *, field: str) -> RedactionReceipt:
+        self._require_scope(field)
+        _, findings = self._redact_string(value)
+        findings.update(self._uri_findings(value))
+        if any(
+            marker in field.lower()
+            for marker in ("logical_path", "source_path", "source_ref", "member_name")
+        ) and self._is_credential_reference(value):
+            findings["credential-file-path"] += 1
+        if findings:
+            raise SecretQuarantineError(field, tuple(findings))
+        return self._receipt(
+            field,
+            scanned_bytes=len(value.encode("utf-8")),
+            findings=findings,
+        )
+
+    def sanitize_file(
+        self,
+        source: Path,
+        destination: Path,
+        *,
+        logical_path: str,
+    ) -> RedactedFile:
+        scope = f"artifact:{logical_path}"
+        self.assert_safe_metadata(logical_path, field="artifact.logical_path")
+        self.assert_safe_metadata(source.as_posix(), field="artifact.source_path")
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_name(f"{destination.name}.redacting")
+        findings: Counter[str] = Counter()
+        snapshot_bytes = 0
+        try:
+            snapshot_bytes = self._copy_snapshot(source, destination, scope=scope)
+            if zipfile.is_zipfile(destination):
+                self._scan_zip(destination, scope=scope)
+            elif tarfile.is_tarfile(destination):
+                self._scan_tar(destination, scope=scope)
+            elif self._is_text_file(destination):
+                try:
+                    findings = self._redact_text_file(destination, temporary)
+                except UnicodeError:
+                    raise SecretQuarantineError(
+                        scope,
+                        ("text-decode-failed",),
+                    ) from None
+                if findings:
+                    os.replace(temporary, destination)
+                else:
+                    temporary.unlink(missing_ok=True)
+            else:
+                with destination.open("rb") as stream:
+                    self._scan_binary_stream(
+                        stream,
+                        scope=scope,
+                        reject_container=True,
+                    )
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            destination.unlink(missing_ok=True)
+            raise
+
+        return RedactedFile(
+            path=destination,
+            receipt=self._receipt(
+                scope,
+                scanned_bytes=snapshot_bytes,
+                findings=findings,
+            ),
+        )
+
+    @staticmethod
+    def _copy_snapshot(source: Path, destination: Path, *, scope: str) -> int:
+        """Copy one stable regular-file handle without following a symlink."""
+        try:
+            original = source.lstat()
+        except FileNotFoundError:
+            raise
+        if not stat.S_ISREG(original.st_mode):
+            raise SecretQuarantineError(scope, ("unsupported-source-file",))
+
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(source, flags)
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise SecretQuarantineError(scope, ("unsupported-source-file",)) from None
+            raise
+        try:
+            opened = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_dev != original.st_dev
+                or opened.st_ino != original.st_ino
+            ):
+                raise SecretQuarantineError(scope, ("source-file-race",))
+            with (
+                os.fdopen(descriptor, "rb", closefd=False) as reader,
+                destination.open("wb") as writer,
+            ):
+                shutil.copyfileobj(reader, writer)
+        finally:
+            os.close(descriptor)
+        return destination.stat().st_size
+
+    def _redact_string(self, value: str) -> tuple[str, Counter[str]]:
+        findings: Counter[str] = Counter()
+
+        def private_replacement(match: re.Match[str]) -> str:
+            findings["private-key"] += 1
+            return "<redacted:private-key>"
+
+        value = _PRIVATE_BLOCK.sub(private_replacement, value)
+        value = _PRIVATE_BEGIN_TO_EOF.sub(private_replacement, value)
+        for rule in _RULES:
+
+            def replacement(match: re.Match[str], *, current: _Rule = rule) -> str:
+                secret = match.group("secret")
+                if self._is_placeholder(secret):
+                    return match.group(0)
+                findings[current.rule_id] += 1
+                prefix = match.groupdict().get("prefix") or ""
+                return f"{prefix}<redacted:{current.rule_id}>"
+
+            value = rule.pattern.sub(replacement, value)
+        return value, findings
+
+    def _redact_text_file(self, source: Path, destination: Path) -> Counter[str]:
+        findings: Counter[str] = Counter()
+        inside_private_key = False
+        with (
+            source.open("r", encoding="utf-8", newline="") as reader,
+            destination.open("w", encoding="utf-8", newline="") as writer,
+        ):
+            while True:
+                line = reader.readline(self._config.max_text_line_bytes + 1)
+                if not line:
+                    break
+                if len(line.encode("utf-8")) > self._config.max_text_line_bytes:
+                    raise SecretQuarantineError(
+                        "artifact:text-line",
+                        ("text-line-scan-limit",),
+                    )
+
+                if inside_private_key:
+                    end = _PRIVATE_END.search(line)
+                    if end is None:
+                        continue
+                    inside_private_key = False
+                    remainder = line[end.end() :]
+                    if remainder in {"\n", "\r", "\r\n"}:
+                        continue
+                    sanitized, nested = self._redact_string(remainder)
+                    findings.update(nested)
+                    writer.write(sanitized)
+                    continue
+
+                begin = _PRIVATE_BEGIN.search(line)
+                if begin is not None:
+                    before, remainder = line[: begin.start()], line[begin.end() :]
+                    sanitized, nested = self._redact_string(before)
+                    findings.update(nested)
+                    findings["private-key"] += 1
+                    writer.write(sanitized)
+                    writer.write("<redacted:private-key>")
+                    end = _PRIVATE_END.search(remainder)
+                    if end is None:
+                        inside_private_key = True
+                        if line.endswith("\r\n"):
+                            writer.write("\r\n")
+                        elif line.endswith(("\n", "\r")):
+                            writer.write(line[-1])
+                    else:
+                        trailing, nested = self._redact_string(remainder[end.end() :])
+                        findings.update(nested)
+                        writer.write(trailing)
+                    continue
+
+                sanitized, nested = self._redact_string(line)
+                findings.update(nested)
+                writer.write(sanitized)
+        return findings
+
+    def _scan_tar(self, path: Path, *, scope: str) -> None:
+        members = expanded = 0
+        try:
+            with tarfile.open(path, mode="r:*") as archive:
+                for member in archive:
+                    members += 1
+                    self._assert_archive_limits(members, 0, expanded, scope)
+                    member_scope = self._archive_member_scope(scope, member.name)
+                    if member.isdir():
+                        continue
+                    if not member.isfile():
+                        raise SecretQuarantineError(
+                            scope,
+                            ("unsupported-archive-member",),
+                        )
+                    self._assert_archive_limits(
+                        members,
+                        member.size,
+                        expanded + member.size,
+                        scope,
+                    )
+                    stream = archive.extractfile(member)
+                    if stream is None:
+                        raise SecretQuarantineError(scope, ("archive-member-unreadable",))
+                    remaining = self._config.max_archive_expanded_bytes - expanded
+                    with stream:
+                        actual = self._scan_binary_stream(
+                            stream,
+                            scope=member_scope,
+                            max_bytes=min(self._config.max_archive_member_bytes, remaining),
+                            reject_container=True,
+                        )
+                    if actual != member.size:
+                        raise SecretQuarantineError(scope, ("archive-size-mismatch",))
+                    expanded += actual
+        except SecretQuarantineError:
+            raise
+        except (tarfile.TarError, EOFError, OSError):
+            raise SecretQuarantineError(scope, ("archive-unreadable",)) from None
+
+    def _scan_zip(self, path: Path, *, scope: str) -> None:
+        members = expanded = 0
+        try:
+            with zipfile.ZipFile(path) as archive:
+                for member in archive.infolist():
+                    members += 1
+                    self._assert_archive_limits(members, 0, expanded, scope)
+                    member_scope = self._archive_member_scope(scope, member.filename)
+                    if member.is_dir():
+                        continue
+                    mode = member.external_attr >> 16
+                    if stat.S_ISLNK(mode) or (stat.S_IFMT(mode) and not stat.S_ISREG(mode)):
+                        raise SecretQuarantineError(
+                            scope,
+                            ("unsupported-archive-member",),
+                        )
+                    if member.flag_bits & 0x1:
+                        raise SecretQuarantineError(scope, ("encrypted-archive",))
+                    self._assert_archive_limits(
+                        members,
+                        member.file_size,
+                        expanded + member.file_size,
+                        scope,
+                    )
+                    remaining = self._config.max_archive_expanded_bytes - expanded
+                    with archive.open(member) as stream:
+                        actual = self._scan_binary_stream(
+                            stream,
+                            scope=member_scope,
+                            max_bytes=min(self._config.max_archive_member_bytes, remaining),
+                            reject_container=True,
+                        )
+                    if actual != member.file_size:
+                        raise SecretQuarantineError(scope, ("archive-size-mismatch",))
+                    expanded += actual
+        except SecretQuarantineError:
+            raise
+        except (
+            zipfile.BadZipFile,
+            zipfile.LargeZipFile,
+            EOFError,
+            NotImplementedError,
+            OSError,
+            RuntimeError,
+        ):
+            raise SecretQuarantineError(scope, ("archive-unreadable",)) from None
+
+    def _archive_member_scope(self, scope: str, member_name: str) -> str:
+        path = PurePosixPath(member_name.replace("\\", "/"))
+        if path.is_absolute() or not path.parts or ".." in path.parts:
+            raise SecretQuarantineError(scope, ("unsafe-archive-member",))
+        normalized = path.as_posix()
+        try:
+            self.assert_safe_metadata(normalized, field="archive.member_name")
+        except SecretQuarantineError as exc:
+            raise SecretQuarantineError(scope, exc.rule_ids) from None
+        if self._is_credential_path(normalized):
+            raise SecretQuarantineError(scope, ("credential-file-path",))
+        if normalized.lower().endswith(_CONTAINER_SUFFIXES):
+            raise SecretQuarantineError(scope, ("nested-archive-unsupported",))
+        return f"{scope}:archive-member"
+
+    def _assert_archive_limits(
+        self,
+        members: int,
+        member_bytes: int,
+        expanded_bytes: int,
+        scope: str,
+    ) -> None:
+        if (
+            members > self._config.max_archive_members
+            or member_bytes > self._config.max_archive_member_bytes
+            or expanded_bytes > self._config.max_archive_expanded_bytes
+        ):
+            raise SecretQuarantineError(scope, ("archive-scan-limit",))
+
+    def _scan_binary_stream(
+        self,
+        stream: IO[bytes],
+        *,
+        scope: str,
+        max_bytes: int | None = None,
+        reject_container: bool = False,
+    ) -> int:
+        overlap = ""
+        overlap_bytes = 4096
+        scanned = 0
+        while chunk := stream.read(self._config.scan_chunk_bytes):
+            scanned += len(chunk)
+            if max_bytes is not None and scanned > max_bytes:
+                raise SecretQuarantineError(scope, ("archive-scan-limit",))
+            if reject_container and scanned == len(chunk) and self._has_container_magic(chunk):
+                raise SecretQuarantineError(scope, ("nested-archive-unsupported",))
+            text = overlap + chunk.decode("latin-1")
+            _, findings = self._redact_string(text)
+            if findings:
+                raise SecretQuarantineError(scope, tuple(findings))
+            overlap = text[-overlap_bytes:]
+        return scanned
+
+    @staticmethod
+    def _has_container_magic(value: bytes) -> bool:
+        return value.startswith(_CONTAINER_MAGIC_PREFIXES) or (
+            len(value) >= 262 and value[257:262] == b"ustar"
+        )
+
+    @staticmethod
+    def _is_text_file(path: Path) -> bool:
+        with path.open("rb") as stream:
+            sample = stream.read(64 << 10)
+        if b"\x00" in sample:
+            return False
+        try:
+            text = sample.decode("utf-8")
+        except UnicodeDecodeError:
+            return False
+        if not text:
+            return True
+        controls = sum(ord(char) < 32 and char not in "\t\r\n\f\b" for char in text)
+        return controls / len(text) <= 0.01
+
+    def _uri_findings(self, value: str) -> Counter[str]:
+        findings: Counter[str] = Counter()
+        parsed = urlparse(value)
+        if parsed.username is not None or parsed.password is not None:
+            findings["uri-userinfo"] += 1
+        for key, item in parse_qsl(parsed.query, keep_blank_values=True):
+            if item and self._is_sensitive_key(self._normalized_key(key), query=True):
+                if not self._is_placeholder(item):
+                    findings["signed-url-query"] += 1
+        return findings
+
+    @staticmethod
+    def _normalized_key(value: str | None) -> str:
+        return re.sub(r"[^a-z0-9]+", "_", (value or "").strip().lower()).strip("_")
+
+    @staticmethod
+    def _is_sensitive_key(value: str, *, query: bool = False) -> bool:
+        keys = _SENSITIVE_QUERY_KEYS if query else _SENSITIVE_RECORD_KEYS
+        return value in keys or value.endswith(("_access_token", "_refresh_token", "_api_key"))
+
+    @staticmethod
+    def _is_credential_path(value: str) -> bool:
+        path = PurePosixPath(value.replace("\\", "/").strip("/").lower())
+        if not path.parts:
+            return False
+        if path.name in _CREDENTIAL_BASENAMES:
+            return True
+        return any(
+            len(path.parts) >= len(suffix) and tuple(path.parts[-len(suffix) :]) == suffix
+            for suffix in _CREDENTIAL_PATH_SUFFIXES
+        )
+
+    @classmethod
+    def _is_credential_reference(cls, value: str) -> bool:
+        parsed = urlparse(value)
+        candidates = (value, unquote(parsed.path), unquote(parsed.fragment))
+        return any(cls._is_credential_path(candidate) for candidate in candidates if candidate)
+
+    @staticmethod
+    def _is_placeholder(value: str) -> bool:
+        normalized = value.strip().lower()
+        return (
+            not normalized
+            or normalized.startswith(_PLACEHOLDER_PREFIXES)
+            or normalized in {"redacted", "none", "null", "changeme"}
+            or ("..." in normalized and len(normalized) <= 64)
+        )
+
+    def _receipt(
+        self,
+        scope: str,
+        *,
+        scanned_bytes: int,
+        findings: Counter[str],
+    ) -> RedactionReceipt:
+        return RedactionReceipt(
+            policy_id=self.policy_id,
+            scope=scope,
+            status="redacted" if findings else "clean",
+            scanned_bytes=scanned_bytes,
+            redaction_count=sum(findings.values()),
+            rule_ids=tuple(findings),
+        )
+
+    @staticmethod
+    def _require_scope(scope: str) -> None:
+        if not scope.strip():
+            raise ValueError("redaction scope must not be empty")

--- a/src/archetype/app/redaction/service.py
+++ b/src/archetype/app/redaction/service.py
@@ -262,7 +262,7 @@ class RedactionService:
         self._config = config or RedactionPolicyConfig()
         policy_material = {
             "schema_version": 1,
-            "implementation_revision": 1,
+            "implementation_revision": 2,
             "config": self._config.model_dump(mode="json"),
             "rules": [(rule.rule_id, rule.pattern.pattern, rule.pattern.flags) for rule in _RULES],
             "private_key_rules": (
@@ -280,6 +280,7 @@ class RedactionService:
             "placeholder_prefixes": _PLACEHOLDER_PREFIXES,
             "nested_archive_behavior": "quarantine",
             "archive_link_behavior": "quarantine",
+            "zip_envelope_behavior": "scan-raw-envelope-and-members",
             "source_snapshot_behavior": "regular-file-no-follow",
         }
         digest = hashlib.sha256(
@@ -584,6 +585,12 @@ class RedactionService:
     def _scan_zip(self, path: Path, *, scope: str) -> None:
         members = expanded = 0
         try:
+            # ZIP metadata is retained byte-for-byte in the approved snapshot.
+            # Scan the raw envelope as well as decoded member payloads so archive
+            # comments and local/central-directory comments or extra fields
+            # cannot carry an uninspected credential across the durable boundary.
+            with path.open("rb") as stream:
+                self._scan_binary_stream(stream, scope=scope)
             with zipfile.ZipFile(path) as archive:
                 for member in archive.infolist():
                     members += 1

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -13,7 +13,8 @@ from fastapi import HTTPException
 
 from archetype.api.errors import raise_api_error
 from archetype.app.audit.service import AuditBackpressureError
-from archetype.app.errors import AvailabilityError, ConflictError
+from archetype.app.errors import AvailabilityError, ConflictError, PayloadRejectedError
+from archetype.app.redaction import SecretQuarantineError
 from archetype.app.storage.catalog import (
     CatalogConflictError,
     CatalogSchemaMismatchError,
@@ -77,6 +78,23 @@ def test_availability_contract_defaults_to_a_safe_public_detail() -> None:
 
     assert raised.value.status_code == 503
     assert raised.value.detail == "Service is temporarily unavailable"
+
+
+def test_payload_rejection_contract_maps_to_safe_unprocessable_content() -> None:
+    secret = "sk-proj-" + "example-secret-never-expose"
+    error = SecretQuarantineError(
+        f"artifact metadata containing {secret}",
+        ("openai-api-key",),
+    )
+
+    assert isinstance(error, PayloadRejectedError)
+    assert secret not in str(error)
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(error)
+
+    assert raised.value.status_code == 422
+    assert raised.value.detail == "Payload rejected by safety policy"
+    assert secret not in raised.value.detail
 
 
 def test_catalog_schema_mismatch_remains_an_internal_error() -> None:

--- a/tests/app/test_artifact_bundle_models.py
+++ b/tests/app/test_artifact_bundle_models.py
@@ -118,6 +118,16 @@ def test_bundle_request_identity_is_canonical_across_artifact_order():
     assert forward.digest() == reverse.digest()
 
 
+def test_bundle_request_policy_identity_is_canonical_and_bound_at_service_time():
+    request = ArtifactBundleRequest(**_request_data())
+    assert request.redaction_policy_id == ""
+    bound = request.model_copy(
+        update={"redaction_policy_id": "archetype-secret-redaction-v1:" + "a" * 64}
+    )
+    assert bound.redaction_policy_id in bound.canonical_json()
+    assert bound.digest() == request.digest()
+
+
 def test_bundle_request_rejects_blank_identity():
     values = _request_data()
     values["checkpoint_provider"] = "  "

--- a/tests/app/test_artifact_bundle_service.py
+++ b/tests/app/test_artifact_bundle_service.py
@@ -865,6 +865,29 @@ async def test_retry_catalog_redacts_untrusted_failure_diagnostics(tmp_path, mon
         await container.shutdown()
 
 
+async def test_retry_diagnostic_fails_safe_when_the_scanner_itself_errors(
+    tmp_path,
+    monkeypatch,
+):
+    container = ServiceContainer(
+        artifact_store_config=ArtifactStoreConfig.local(tmp_path / "artifacts")
+    )
+    secret = "sk-ant-api03-" + "V" * 32
+
+    def fail_scanner(*_args, **_kwargs):
+        raise RuntimeError(f"scanner failed while handling {secret}")
+
+    monkeypatch.setattr(container.redaction_service, "redact_text", fail_scanner)
+    try:
+        detail = container.artifact_bundle_service._safe_failure_detail(
+            RuntimeError(f"provider returned {secret}")
+        )
+        assert detail == "RuntimeError: failure detail unavailable"
+        assert secret not in detail
+    finally:
+        await container.shutdown()
+
+
 async def test_upload_uses_the_controlled_snapshot_when_source_mutates_after_scan(
     tmp_path, monkeypatch
 ):

--- a/tests/app/test_artifact_bundle_service.py
+++ b/tests/app/test_artifact_bundle_service.py
@@ -4,6 +4,7 @@
 """ArtifactBundleService contracts: extraction, idempotency, recovery, and cold reads."""
 
 import hashlib
+import json
 import tarfile
 import time
 from dataclasses import replace
@@ -24,6 +25,11 @@ from archetype.app.artifacts.bundle_service import (
     CheckpointArtifactSourceResolver,
 )
 from archetype.app.container import ServiceContainer
+from archetype.app.redaction import (
+    RedactionPolicyConfig,
+    RedactionService,
+    SecretQuarantineError,
+)
 from archetype.app.storage.catalog import (
     ArtifactPublicationConflictError,
     artifact_publication_key,
@@ -659,3 +665,327 @@ async def test_durable_request_identity_and_digest_are_authenticated(tmp_path):
             )
     finally:
         await container.shutdown()
+
+
+async def test_secret_metadata_is_rejected_before_the_durable_claim(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "result.json"
+    source.write_text("{}")
+    secret = "signed-credential-" + "X" * 32
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source).model_copy(
+            update={"checkpoint_ref": "https://provider.invalid/checkpoint?" + "token=" + secret}
+        )
+        with pytest.raises(SecretQuarantineError) as error:
+            await container.artifact_bundle_service.publish(request, storage_config=storage)
+        assert secret not in str(error.value)
+
+        key = artifact_publication_key(
+            request.world_id,
+            request.run_id,
+            request.idempotency_key,
+        )
+        catalog = container.storage_service.get_control_catalog(storage)
+        assert await catalog.get_artifact_publication(request.world_id, key) is None
+    finally:
+        await container.shutdown()
+
+
+async def test_credential_source_path_is_rejected_before_the_durable_claim(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / ".codex" / "auth.json"
+    source.parent.mkdir()
+    source.write_text("otherwise-unrecognized-credential")
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source, logical_path="innocent-result.json")
+        with pytest.raises(SecretQuarantineError, match="credential-file-path"):
+            await container.artifact_bundle_service.publish(request, storage_config=storage)
+
+        key = artifact_publication_key(
+            request.world_id,
+            request.run_id,
+            request.idempotency_key,
+        )
+        catalog = container.storage_service.get_control_catalog(storage)
+        assert await catalog.get_artifact_publication(request.world_id, key) is None
+    finally:
+        await container.shutdown()
+
+
+async def test_caller_cannot_select_a_different_redaction_policy(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "result.json"
+    source.write_text("{}")
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source).model_copy(
+            update={"redaction_policy_id": "archetype-secret-redaction-v0:retired"}
+        )
+        with pytest.raises(ValueError, match="does not match the active policy"):
+            await container.artifact_bundle_service.publish(request, storage_config=storage)
+        key = artifact_publication_key(
+            request.world_id,
+            request.run_id,
+            request.idempotency_key,
+        )
+        catalog = container.storage_service.get_control_catalog(storage)
+        assert await catalog.get_artifact_publication(request.world_id, key) is None
+    finally:
+        await container.shutdown()
+
+
+async def test_text_secrets_are_redacted_before_hash_upload_manifest_and_index(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    secret = "codex-refresh-" + "Y" * 32
+    source = tmp_path / "session.jsonl"
+    source.write_text(f'{{"refresh_token":"{secret}","status":"complete"}}\n')
+    original = source.read_bytes()
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source, logical_path="sessions/session.jsonl")
+        receipt = await container.artifact_bundle_service.publish(
+            request,
+            storage_config=storage,
+        )
+
+        assert source.read_bytes() == original
+        payload = next(record for record in receipt.records if record.kind == "result")
+        uploaded = _local_uri_path(payload.object_uri).read_bytes()
+        assert secret.encode() not in uploaded
+        assert b"<redacted:sensitive-assignment>" in uploaded
+        assert payload.content_hash == hashlib.sha256(uploaded).hexdigest()
+
+        manifest_record = next(
+            record for record in receipt.records if record.kind == "bundle_manifest"
+        )
+        manifest_bytes = _local_uri_path(manifest_record.object_uri).read_bytes()
+        manifest = json.loads(manifest_bytes)
+        assert secret.encode() not in manifest_bytes
+        assert manifest["redaction"]["policy_id"] == container.redaction_service.policy_id
+        assert manifest["redaction"]["status"] == "redacted"
+        assert manifest["redaction"]["redaction_count"] == 1
+        assert manifest["redaction"]["rule_ids"] == ["sensitive-assignment"]
+
+        key = artifact_publication_key(
+            request.world_id,
+            request.run_id,
+            request.idempotency_key,
+        )
+        catalog = container.storage_service.get_control_catalog(storage)
+        publication = await catalog.get_artifact_publication(request.world_id, key)
+        assert publication is not None
+        assert secret not in publication.request_json
+        durable_request = ArtifactBundleRequest.model_validate_json(publication.request_json)
+        assert durable_request.redaction_policy_id == container.redaction_service.policy_id
+        assert secret not in publication.records_json
+    finally:
+        await container.shutdown()
+
+
+async def test_binary_secret_quarantine_has_no_object_or_index_visibility(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    secret = "ghp_" + "Z" * 36
+    source = tmp_path / "opaque.bin"
+    source.write_bytes(b"\x00binary" + secret.encode())
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source, logical_path="opaque.bin")
+        with pytest.raises(SecretQuarantineError) as error:
+            await container.artifact_bundle_service.publish(request, storage_config=storage)
+        assert secret not in str(error.value)
+
+        key = artifact_publication_key(
+            request.world_id,
+            request.run_id,
+            request.idempotency_key,
+        )
+        catalog = container.storage_service.get_control_catalog(storage)
+        publication = await catalog.get_artifact_publication(request.world_id, key)
+        assert publication is not None and publication.status == "PENDING"
+        assert "github-token" in publication.last_error
+        assert secret not in publication.last_error
+        object_root = Path(artifact_config.object_uri)
+        assert not object_root.exists() or not any(
+            path.is_file() for path in object_root.rglob("*")
+        )
+        indexed = await container.artifact_bundle_service.query(
+            request.world_id,
+            request.run_id,
+        )
+        assert indexed.collect().to_pylist() == []
+    finally:
+        await container.shutdown()
+
+
+async def test_retry_catalog_redacts_untrusted_failure_diagnostics(tmp_path, monkeypatch):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "result.txt"
+    source.write_text("safe input")
+    secret = "sk-ant-api03-" + "U" * 32
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source)
+
+        async def fail_with_untrusted_detail(*_args, **_kwargs):
+            raise RuntimeError(f"provider failed with {secret}")
+
+        monkeypatch.setattr(
+            container.artifact_bundle_service,
+            "_upload_bundle",
+            fail_with_untrusted_detail,
+        )
+        with pytest.raises(RuntimeError, match="provider failed"):
+            await container.artifact_bundle_service.publish(request, storage_config=storage)
+
+        key = artifact_publication_key(
+            request.world_id,
+            request.run_id,
+            request.idempotency_key,
+        )
+        catalog = container.storage_service.get_control_catalog(storage)
+        publication = await catalog.get_artifact_publication(request.world_id, key)
+        assert publication is not None and publication.status == "PENDING"
+        assert secret not in publication.last_error
+        assert "<redacted:anthropic-api-key>" in publication.last_error
+    finally:
+        await container.shutdown()
+
+
+async def test_upload_uses_the_controlled_snapshot_when_source_mutates_after_scan(
+    tmp_path, monkeypatch
+):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "result.txt"
+    source.write_text("approved-before-scan")
+    redaction = RedactionService()
+    real_sanitize = redaction.sanitize_file
+
+    def sanitize_then_mutate(*args, **kwargs):
+        result = real_sanitize(*args, **kwargs)
+        source.write_text("mutated-after-scan")
+        return result
+
+    monkeypatch.setattr(redaction, "sanitize_file", sanitize_then_mutate)
+    container = ServiceContainer(
+        artifact_store_config=artifact_config,
+        redaction_service=redaction,
+    )
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        receipt = await container.artifact_bundle_service.publish(
+            _request(world, source),
+            storage_config=storage,
+        )
+        payload = next(record for record in receipt.records if record.kind == "result")
+        assert source.read_text() == "mutated-after-scan"
+        assert _local_uri_path(payload.object_uri).read_text() == "approved-before-scan"
+    finally:
+        await container.shutdown()
+
+
+async def test_indexed_replay_remains_idempotent_across_scanner_upgrade(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "result.txt"
+    source.write_text("stable evidence")
+    first = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await first.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source)
+        original = await first.artifact_bundle_service.publish(request, storage_config=storage)
+    finally:
+        await first.shutdown()
+
+    upgraded = ServiceContainer(
+        artifact_store_config=artifact_config,
+        redaction_service=RedactionService(RedactionPolicyConfig(max_archive_members=9)),
+    )
+    try:
+        duplicate = await upgraded.artifact_bundle_service.publish(
+            request,
+            storage_config=storage,
+        )
+        assert duplicate.duplicate
+        assert duplicate.records == original.records
+    finally:
+        await upgraded.shutdown()
+
+
+async def test_uploaded_recovery_does_not_require_retired_scanner(tmp_path, monkeypatch):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts").model_copy(
+        update={"retry_delay_seconds": 0.0}
+    )
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "result.txt"
+    source.write_text("already sanitized")
+    first = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await first.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source)
+
+        async def fail_index(_records):
+            raise RuntimeError("index unavailable during old policy")
+
+        monkeypatch.setattr(first.artifact_bundle_service, "_index_records", fail_index)
+        with pytest.raises(RuntimeError, match="old policy"):
+            await first.artifact_bundle_service.publish(request, storage_config=storage)
+    finally:
+        await first.shutdown()
+
+    upgraded = ServiceContainer(
+        artifact_store_config=artifact_config,
+        redaction_service=RedactionService(RedactionPolicyConfig(max_archive_members=9)),
+    )
+    try:
+        recovered = await upgraded.artifact_bundle_service.publish(
+            request,
+            storage_config=storage,
+        )
+        assert recovered.status == "indexed"
+        assert not recovered.duplicate
+    finally:
+        await upgraded.shutdown()
+
+
+async def test_pending_recovery_requires_its_bound_scanner_policy(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts").model_copy(
+        update={"retry_delay_seconds": 0.0}
+    )
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    secret = "ghp_" + "P" * 36
+    source = tmp_path / "opaque.bin"
+    source.write_bytes(b"\x00" + secret.encode())
+    first = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await first.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source, logical_path="opaque.bin")
+        with pytest.raises(SecretQuarantineError):
+            await first.artifact_bundle_service.publish(request, storage_config=storage)
+    finally:
+        await first.shutdown()
+
+    upgraded = ServiceContainer(
+        artifact_store_config=artifact_config,
+        redaction_service=RedactionService(RedactionPolicyConfig(max_archive_members=9)),
+    )
+    try:
+        with pytest.raises(ValueError, match="unavailable redaction policy") as error:
+            await upgraded.artifact_bundle_service.publish(request, storage_config=storage)
+        assert secret not in str(error.value)
+    finally:
+        await upgraded.shutdown()

--- a/tests/app/test_redaction_service.py
+++ b/tests/app/test_redaction_service.py
@@ -1,0 +1,376 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the shared pre-durability redaction authority."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import stat
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from archetype.app.redaction import (
+    RedactionPolicyConfig,
+    RedactionService,
+    SecretQuarantineError,
+)
+from quality.secret_corpus import SAFE_REDACTION_CORPUS, SECRET_LEAK_CORPUS
+
+pytestmark = pytest.mark.contract("security.redaction.pre_durability")
+
+
+@pytest.mark.parametrize("case", SECRET_LEAK_CORPUS, ids=lambda case: case.name)
+def test_synthetic_provider_corpus_is_redacted_without_echoing_secrets(case) -> None:
+    service = RedactionService()
+    result = service.redact_text(case.payload, scope=f"corpus:{case.name}")
+
+    assert result.receipt.status == "redacted"
+    assert case.rule_id in result.receipt.rule_ids
+    assert case.payload not in result.text
+    assert "<redacted:" in result.text
+
+    with pytest.raises(SecretQuarantineError) as error:
+        service.assert_safe_metadata(case.payload, field=f"metadata:{case.name}")
+    assert case.payload not in str(error.value)
+    assert case.rule_id in error.value.rule_ids
+
+
+@pytest.mark.parametrize("value", SAFE_REDACTION_CORPUS)
+def test_placeholders_and_nonsecret_identity_are_stable(value: str) -> None:
+    service = RedactionService()
+    first = service.redact_text(value, scope="safe")
+    second = service.redact_text(first.text, scope="safe")
+    assert first.text == value
+    assert first.receipt.status == "clean"
+    assert second.text == value
+    assert second.receipt.status == "clean"
+
+
+def test_structured_events_redact_sensitive_keys_and_nested_token_shapes() -> None:
+    service = RedactionService()
+    token = "opaque-oauth-value-" + "Z" * 32
+    github = "ghp_" + "Y" * 36
+    result = service.redact_record(
+        {
+            "world_id": "world-1",
+            "auth": {"refresh_token": token},
+            "events": [{"message": f"received {github}"}],
+        },
+        scope="sandbox.live_event",
+    )
+    encoded = str(result.value)
+    assert token not in encoded
+    assert github not in encoded
+    assert result.receipt.status == "redacted"
+    assert set(result.receipt.rule_ids) == {
+        "github-token",
+        "structured-sensitive-field",
+    }
+
+
+def test_structured_event_keys_cannot_carry_secrets() -> None:
+    service = RedactionService()
+    secret = "ghp_" + "K" * 36
+    result = service.redact_record(
+        {f"provider.{secret}": "failed"},
+        scope="sandbox.live_event",
+    )
+
+    assert secret not in str(result.value)
+    assert "github-token" in result.receipt.rule_ids
+
+
+def test_quarantine_exception_never_retains_its_tainted_scope() -> None:
+    secret = "sk-proj-" + "T" * 32
+    error = SecretQuarantineError(
+        f"provider diagnostic containing {secret}",
+        ("openai-api-key",),
+    )
+
+    assert secret not in str(error)
+    assert secret not in repr(vars(error))
+
+
+def test_policy_identity_is_stable_and_binds_scan_limits() -> None:
+    first = RedactionService()
+    same = RedactionService()
+    changed = RedactionService(RedactionPolicyConfig(max_archive_members=9))
+    assert first.policy_id == same.policy_id
+    assert first.policy_id != changed.policy_id
+    assert first.policy_id.startswith("archetype-secret-redaction-v1:")
+
+    with pytest.raises(ValidationError, match="expanded_bytes must be"):
+        RedactionPolicyConfig(
+            max_archive_member_bytes=100,
+            max_archive_expanded_bytes=99,
+        )
+
+
+def test_text_file_is_snapshotted_and_redacted_without_mutating_source(tmp_path: Path) -> None:
+    service = RedactionService()
+    secret = "sk-proj-" + "Q" * 32
+    source = tmp_path / "session.jsonl"
+    source.write_text(f'{{"api_key":"{secret}"}}\n')
+    destination = tmp_path / "controlled" / "0001"
+
+    result = service.sanitize_file(
+        source,
+        destination,
+        logical_path="sessions/session.jsonl",
+    )
+    assert secret in source.read_text()
+    assert secret not in result.path.read_text()
+    assert "<redacted:sensitive-assignment>" in result.path.read_text()
+    assert result.receipt.status == "redacted"
+    assert result.receipt.scanned_bytes == source.stat().st_size
+
+
+@pytest.mark.parametrize(
+    "logical_path",
+    [
+        ".codex/auth.json",
+        ".claude/.credentials.json",
+        ".config/opencode/auth.json",
+        ".aws/credentials",
+        ".git-credentials",
+        "home/agent/.netrc",
+        "home/agent/.ssh/id_ed25519",
+    ],
+)
+def test_known_credential_files_are_quarantined_by_path(tmp_path: Path, logical_path: str) -> None:
+    source = tmp_path / "credential"
+    source.write_text("otherwise-unrecognized-credential")
+    destination = tmp_path / "output"
+    with pytest.raises(SecretQuarantineError, match="credential-file-path"):
+        RedactionService().sanitize_file(
+            source,
+            destination,
+            logical_path=logical_path,
+        )
+    assert not destination.exists()
+
+
+def test_source_symlink_is_never_followed_into_a_safe_logical_path(tmp_path: Path) -> None:
+    target = tmp_path / "credential"
+    target.write_text("otherwise-unrecognized-credential")
+    source = tmp_path / "innocent-result.txt"
+    source.symlink_to(target)
+    destination = tmp_path / "approved"
+
+    with pytest.raises(SecretQuarantineError, match="unsupported-source-file"):
+        RedactionService().sanitize_file(
+            source,
+            destination,
+            logical_path="result.txt",
+        )
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "file:///home/agent/.codex/auth.json",
+        "modal-volume://checkpoint#home/agent/.claude/.credentials.json",
+        "/home/agent/.local/share/opencode/auth.json",
+        "/home/agent/.config/gh/hosts.yml",
+        "/workspace/.env",
+    ],
+)
+def test_credential_source_references_are_metadata_quarantine(reference: str) -> None:
+    with pytest.raises(SecretQuarantineError, match="credential-file-path"):
+        RedactionService().assert_safe_metadata(
+            reference,
+            field="artifact_request.artifacts[0].source_ref",
+        )
+
+
+def test_opaque_binary_with_secret_is_quarantined_without_echo(tmp_path: Path) -> None:
+    secret = "ghp_" + "R" * 36
+    source = tmp_path / "opaque.bin"
+    source.write_bytes(b"\x00\xffprefix" + secret.encode() + b"suffix")
+    destination = tmp_path / "output"
+    with pytest.raises(SecretQuarantineError) as error:
+        RedactionService().sanitize_file(
+            source,
+            destination,
+            logical_path="opaque.bin",
+        )
+    assert secret not in str(error.value)
+    assert error.value.rule_ids == ("github-token",)
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("archive_kind", ["tar", "zip"])
+def test_archive_members_are_scanned_and_quarantined(tmp_path: Path, archive_kind: str) -> None:
+    secret = "sk-or-v1-" + "S" * 32
+    archive_path = tmp_path / f"worktree.{archive_kind}"
+    payload = f"OPENROUTER_API_KEY={secret}\n".encode()
+    if archive_kind == "tar":
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("repo/.context/session.log")
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    else:
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("repo/.context/session.log", payload)
+
+    destination = tmp_path / "approved"
+    with pytest.raises(SecretQuarantineError) as error:
+        RedactionService().sanitize_file(
+            archive_path,
+            destination,
+            logical_path=archive_path.name,
+        )
+    assert secret not in str(error.value)
+    assert "sensitive-assignment" in error.value.rule_ids
+    assert not destination.exists()
+
+
+def test_archive_scan_limits_and_nested_archives_fail_closed(tmp_path: Path) -> None:
+    oversized = tmp_path / "oversized.tar"
+    with tarfile.open(oversized, "w") as archive:
+        info = tarfile.TarInfo("large.txt")
+        info.size = 32
+        archive.addfile(info, io.BytesIO(b"x" * 32))
+    service = RedactionService(
+        RedactionPolicyConfig(
+            max_archive_member_bytes=16,
+            max_archive_expanded_bytes=16,
+        )
+    )
+    with pytest.raises(SecretQuarantineError, match="archive-scan-limit"):
+        service.sanitize_file(
+            oversized,
+            tmp_path / "oversized-approved",
+            logical_path="oversized.tar",
+        )
+
+    nested = tmp_path / "nested.zip"
+    with zipfile.ZipFile(nested, "w") as archive:
+        archive.writestr("inner.tar.gz", b"not-even-a-real-archive")
+    with pytest.raises(SecretQuarantineError, match="nested-archive-unsupported"):
+        RedactionService().sanitize_file(
+            nested,
+            tmp_path / "nested-approved",
+            logical_path="nested.zip",
+        )
+
+
+@pytest.mark.parametrize("archive_kind", ["tar", "zip"])
+def test_archive_links_are_not_treated_as_scanned_regular_files(
+    tmp_path: Path,
+    archive_kind: str,
+) -> None:
+    path = tmp_path / f"links.{archive_kind}"
+    if archive_kind == "tar":
+        with tarfile.open(path, "w") as archive:
+            member = tarfile.TarInfo("repo/session-link")
+            member.type = tarfile.SYMTYPE
+            member.linkname = ".codex/auth.json"
+            archive.addfile(member)
+    else:
+        with zipfile.ZipFile(path, "w") as archive:
+            member = zipfile.ZipInfo("repo/session-link")
+            member.create_system = 3
+            member.external_attr = (stat.S_IFLNK | 0o777) << 16
+            archive.writestr(member, ".codex/auth.json")
+
+    with pytest.raises(SecretQuarantineError, match="unsupported-archive-member"):
+        RedactionService().sanitize_file(
+            path,
+            tmp_path / "approved",
+            logical_path=path.name,
+        )
+
+
+def test_disguised_nested_and_unsupported_containers_fail_closed(tmp_path: Path) -> None:
+    inner = io.BytesIO()
+    with zipfile.ZipFile(inner, "w") as archive:
+        archive.writestr("secret.txt", b"compressed opaque content")
+    outer = tmp_path / "outer.zip"
+    with zipfile.ZipFile(outer, "w") as archive:
+        archive.writestr("renamed.bin", inner.getvalue())
+
+    with pytest.raises(SecretQuarantineError, match="nested-archive-unsupported"):
+        RedactionService().sanitize_file(
+            outer,
+            tmp_path / "outer-approved",
+            logical_path="outer.zip",
+        )
+
+    compressed = tmp_path / "opaque.bin"
+    compressed.write_bytes(gzip.compress(b"not semantically inspected"))
+    with pytest.raises(SecretQuarantineError, match="nested-archive-unsupported"):
+        RedactionService().sanitize_file(
+            compressed,
+            tmp_path / "compressed-approved",
+            logical_path="opaque.bin",
+        )
+
+
+def test_streamed_archive_limit_uses_observed_bytes_not_only_headers() -> None:
+    service = RedactionService()
+    with pytest.raises(SecretQuarantineError, match="archive-scan-limit"):
+        service._scan_binary_stream(
+            io.BytesIO(b"x" * 17),
+            scope="archive-member",
+            max_bytes=16,
+        )
+
+
+def test_safe_archive_and_private_key_text_have_explicit_dispositions(tmp_path: Path) -> None:
+    safe = tmp_path / "safe.tar"
+    with tarfile.open(safe, "w") as archive:
+        payload = b"validator passed\n"
+        info = tarfile.TarInfo("repo/result.txt")
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
+    clean = RedactionService().sanitize_file(
+        safe,
+        tmp_path / "safe-approved",
+        logical_path="safe.tar",
+    )
+    assert clean.receipt.status == "clean"
+    assert clean.path.read_bytes() == safe.read_bytes()
+
+    key = tmp_path / "debug.log"
+    key.write_text(
+        "before\n-----BEGIN " + "PRIVATE KEY-----\nabc123\n-----END " + "PRIVATE KEY-----\nafter\n"
+    )
+    redacted = RedactionService().sanitize_file(
+        key,
+        tmp_path / "key-approved",
+        logical_path="debug.log",
+    )
+    assert redacted.receipt.rule_ids == ("private-key",)
+    assert redacted.path.read_text() == "before\n<redacted:private-key>\nafter\n"
+
+
+def test_unbounded_text_line_is_quarantined(tmp_path: Path) -> None:
+    service = RedactionService(RedactionPolicyConfig(max_text_line_bytes=4096))
+    source = tmp_path / "one-line.json"
+    source.write_text("x" * 4097)
+    with pytest.raises(SecretQuarantineError, match="text-line-scan-limit"):
+        service.sanitize_file(
+            source,
+            tmp_path / "approved",
+            logical_path="one-line.json",
+        )
+
+
+def test_text_that_becomes_invalid_after_sampling_is_safely_quarantined(tmp_path: Path) -> None:
+    source = tmp_path / "late-invalid.log"
+    source.write_bytes(b"a" * (64 << 10) + b"\xff")
+
+    with pytest.raises(SecretQuarantineError, match="text-decode-failed"):
+        RedactionService().sanitize_file(
+            source,
+            tmp_path / "approved",
+            logical_path="late-invalid.log",
+        )

--- a/tests/app/test_redaction_service.py
+++ b/tests/app/test_redaction_service.py
@@ -5,18 +5,22 @@
 
 from __future__ import annotations
 
+import errno
 import gzip
 import io
 import stat
 import tarfile
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
 
+import archetype.app.redaction.service as redaction_module
 from archetype.app.redaction import (
     RedactionPolicyConfig,
+    RedactionReceipt,
     RedactionService,
     SecretQuarantineError,
 )
@@ -112,6 +116,75 @@ def test_policy_identity_is_stable_and_binds_scan_limits() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"policy_id": "", "scope": "scope", "status": "clean", "scanned_bytes": 0},
+        {"policy_id": "policy", "scope": " ", "status": "clean", "scanned_bytes": 0},
+        {
+            "policy_id": "policy",
+            "scope": "scope",
+            "status": "redacted",
+            "scanned_bytes": 0,
+            "redaction_count": 1,
+            "rule_ids": ("",),
+        },
+        {
+            "policy_id": "policy",
+            "scope": "scope",
+            "status": "clean",
+            "scanned_bytes": 0,
+            "redaction_count": 1,
+            "rule_ids": ("rule",),
+        },
+        {
+            "policy_id": "policy",
+            "scope": "scope",
+            "status": "redacted",
+            "scanned_bytes": 0,
+            "redaction_count": 1,
+            "rule_ids": (),
+        },
+    ],
+)
+def test_redaction_receipts_reject_inconsistent_or_unsafe_evidence(payload) -> None:
+    with pytest.raises(ValidationError):
+        RedactionReceipt.model_validate(payload)
+
+
+def test_redaction_receipt_rules_and_empty_quarantine_are_canonical() -> None:
+    receipt = RedactionReceipt(
+        policy_id=" policy ",
+        scope=" scope ",
+        status="redacted",
+        scanned_bytes=1,
+        redaction_count=2,
+        rule_ids=("z-rule", "a-rule", "z-rule"),
+    )
+    assert receipt.policy_id == "policy"
+    assert receipt.scope == "scope"
+    assert receipt.rule_ids == ("a-rule", "z-rule")
+    assert "unspecified-secret-rule" in str(SecretQuarantineError("scope", ()))
+
+
+def test_structured_key_collisions_are_preserved_without_leaking_keys() -> None:
+    first = "ghp_" + "A" * 36
+    second = "ghp_" + "B" * 36
+    result = RedactionService().redact_record(
+        {first: 1, second: False, "optional": None},
+        scope="sandbox.live_event",
+    )
+
+    assert first not in str(result.value)
+    assert second not in str(result.value)
+    assert set(result.value) == {
+        "<redacted:github-token>",
+        "<redacted:github-token>#2",
+        "optional",
+    }
+    assert "structured-key-collision" in result.receipt.rule_ids
+
+
 def test_text_file_is_snapshotted_and_redacted_without_mutating_source(tmp_path: Path) -> None:
     service = RedactionService()
     secret = "sk-proj-" + "Q" * 32
@@ -170,6 +243,74 @@ def test_source_symlink_is_never_followed_into_a_safe_logical_path(tmp_path: Pat
             logical_path="result.txt",
         )
     assert not destination.exists()
+
+
+def test_missing_source_preserves_retryable_file_not_found(tmp_path: Path) -> None:
+    destination = tmp_path / "approved"
+    with pytest.raises(FileNotFoundError):
+        RedactionService().sanitize_file(
+            tmp_path / "missing.txt",
+            destination,
+            logical_path="result.txt",
+        )
+    assert not destination.exists()
+
+
+def test_snapshot_open_rejects_a_symlink_race(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "result.txt"
+    source.write_text("safe")
+
+    def raced_open(*_args, **_kwargs):
+        raise OSError(errno.ELOOP, "synthetic no-follow rejection")
+
+    monkeypatch.setattr(redaction_module.os, "open", raced_open)
+    with pytest.raises(SecretQuarantineError, match="unsupported-source-file"):
+        RedactionService().sanitize_file(
+            source,
+            tmp_path / "approved",
+            logical_path="result.txt",
+        )
+
+
+def test_snapshot_open_preserves_non_symlink_io_errors(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "result.txt"
+    source.write_text("safe")
+
+    def denied_open(*_args, **_kwargs):
+        raise PermissionError(errno.EACCES, "synthetic permission denial")
+
+    monkeypatch.setattr(redaction_module.os, "open", denied_open)
+    with pytest.raises(PermissionError, match="synthetic permission denial"):
+        RedactionService().sanitize_file(
+            source,
+            tmp_path / "approved",
+            logical_path="result.txt",
+        )
+
+
+def test_snapshot_rejects_inode_replacement_between_inspection_and_open(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "result.txt"
+    source.write_text("safe")
+    real_fstat = redaction_module.os.fstat
+
+    def changed_inode(descriptor):
+        opened = real_fstat(descriptor)
+        return SimpleNamespace(
+            st_mode=opened.st_mode,
+            st_dev=opened.st_dev,
+            st_ino=opened.st_ino + 1,
+        )
+
+    monkeypatch.setattr(redaction_module.os, "fstat", changed_inode)
+    with pytest.raises(SecretQuarantineError, match="source-file-race"):
+        RedactionService().sanitize_file(
+            source,
+            tmp_path / "approved",
+            logical_path="result.txt",
+        )
 
 
 @pytest.mark.parametrize(
@@ -263,6 +404,102 @@ def test_archive_scan_limits_and_nested_archives_fail_closed(tmp_path: Path) -> 
 
 
 @pytest.mark.parametrize("archive_kind", ["tar", "zip"])
+def test_unsafe_or_secret_archive_member_names_are_quarantined(
+    tmp_path: Path,
+    archive_kind: str,
+) -> None:
+    path = tmp_path / f"unsafe.{archive_kind}"
+    secret = "ghp_" + "C" * 36
+    names = ("../escape.txt", f"repo/{secret}.txt")
+    for index, name in enumerate(names):
+        candidate = path.with_name(f"{path.stem}-{index}.{archive_kind}")
+        if archive_kind == "tar":
+            with tarfile.open(candidate, "w") as archive:
+                info = tarfile.TarInfo(name)
+                info.size = 1
+                archive.addfile(info, io.BytesIO(b"x"))
+        else:
+            with zipfile.ZipFile(candidate, "w") as archive:
+                archive.writestr(name, b"x")
+        with pytest.raises(SecretQuarantineError):
+            RedactionService().sanitize_file(
+                candidate,
+                tmp_path / f"approved-{archive_kind}-{index}",
+                logical_path=candidate.name,
+            )
+
+
+def test_encrypted_zip_metadata_fails_before_member_open(tmp_path: Path) -> None:
+    path = tmp_path / "encrypted.zip"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("result.txt", b"safe")
+    payload = bytearray(path.read_bytes())
+    payload[6] |= 0x01
+    central = payload.index(b"PK\x01\x02")
+    payload[central + 8] |= 0x01
+    path.write_bytes(payload)
+
+    with pytest.raises(SecretQuarantineError, match="encrypted-archive"):
+        RedactionService().sanitize_file(
+            path,
+            tmp_path / "approved",
+            logical_path="encrypted.zip",
+        )
+
+
+@pytest.mark.parametrize("archive_kind", ["tar", "zip"])
+def test_archive_stream_size_must_match_member_metadata(
+    tmp_path: Path,
+    monkeypatch,
+    archive_kind: str,
+) -> None:
+    path = tmp_path / f"mismatch.{archive_kind}"
+    if archive_kind == "tar":
+        with tarfile.open(path, "w") as archive:
+            info = tarfile.TarInfo("result.txt")
+            info.size = 4
+            archive.addfile(info, io.BytesIO(b"safe"))
+    else:
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr("result.txt", b"safe")
+    service = RedactionService()
+    monkeypatch.setattr(service, "_scan_binary_stream", lambda *_args, **_kwargs: 0)
+
+    with pytest.raises(SecretQuarantineError, match="archive-size-mismatch"):
+        if archive_kind == "tar":
+            service._scan_tar(path, scope="archive")
+        else:
+            service._scan_zip(path, scope="archive")
+
+
+def test_unreadable_tar_member_returns_safe_quarantine(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "unreadable.tar"
+    with tarfile.open(path, "w") as archive:
+        info = tarfile.TarInfo("result.txt")
+        info.size = 4
+        archive.addfile(info, io.BytesIO(b"safe"))
+    monkeypatch.setattr(tarfile.TarFile, "extractfile", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(SecretQuarantineError, match="archive-member-unreadable"):
+        RedactionService()._scan_tar(path, scope="archive")
+
+
+@pytest.mark.parametrize("archive_kind", ["tar", "zip"])
+def test_corrupt_archive_readers_return_safe_quarantine(
+    tmp_path: Path,
+    archive_kind: str,
+) -> None:
+    path = tmp_path / f"corrupt.{archive_kind}"
+    path.write_bytes(b"not an archive")
+    service = RedactionService()
+    with pytest.raises(SecretQuarantineError, match="archive-unreadable"):
+        if archive_kind == "tar":
+            service._scan_tar(path, scope="archive")
+        else:
+            service._scan_zip(path, scope="archive")
+
+
+@pytest.mark.parametrize("archive_kind", ["tar", "zip"])
 def test_archive_links_are_not_treated_as_scanned_regular_files(
     tmp_path: Path,
     archive_kind: str,
@@ -327,6 +564,9 @@ def test_streamed_archive_limit_uses_observed_bytes_not_only_headers() -> None:
 def test_safe_archive_and_private_key_text_have_explicit_dispositions(tmp_path: Path) -> None:
     safe = tmp_path / "safe.tar"
     with tarfile.open(safe, "w") as archive:
+        directory = tarfile.TarInfo("repo")
+        directory.type = tarfile.DIRTYPE
+        archive.addfile(directory)
         payload = b"validator passed\n"
         info = tarfile.TarInfo("repo/result.txt")
         info.size = len(payload)
@@ -350,6 +590,82 @@ def test_safe_archive_and_private_key_text_have_explicit_dispositions(tmp_path: 
     )
     assert redacted.receipt.rule_ids == ("private-key",)
     assert redacted.path.read_text() == "before\n<redacted:private-key>\nafter\n"
+
+    safe_zip = tmp_path / "safe.zip"
+    with zipfile.ZipFile(safe_zip, "w") as archive:
+        archive.mkdir("repo/")
+        archive.writestr("repo/result.txt", b"validator passed\n")
+    clean_zip = RedactionService().sanitize_file(
+        safe_zip,
+        tmp_path / "safe-zip-approved",
+        logical_path="safe.zip",
+    )
+    assert clean_zip.receipt.status == "clean"
+
+
+def test_private_key_redaction_handles_same_line_and_trailing_end_content(tmp_path: Path) -> None:
+    same_line = tmp_path / "same-line.log"
+    same_line.write_text(
+        "before -----BEGIN " + "PRIVATE KEY-----body-----END " + "PRIVATE KEY----- after\n"
+    )
+    same_result = RedactionService().sanitize_file(
+        same_line,
+        tmp_path / "same-line-approved",
+        logical_path="same-line.log",
+    )
+    assert same_result.path.read_text() == "before <redacted:private-key> after\n"
+
+    trailing = tmp_path / "trailing.log"
+    trailing.write_text(
+        "-----BEGIN " + "PRIVATE KEY-----\r\nbody\r\n-----END " + "PRIVATE KEY----- after\n"
+    )
+    trailing_result = RedactionService().sanitize_file(
+        trailing,
+        tmp_path / "trailing-approved",
+        logical_path="trailing.log",
+    )
+    assert trailing_result.path.read_bytes() == b"<redacted:private-key>\r\n after\n"
+
+    unclosed = tmp_path / "unclosed.log"
+    unclosed.write_text("before -----BEGIN " + "PRIVATE KEY-----body")
+    unclosed_result = RedactionService().sanitize_file(
+        unclosed,
+        tmp_path / "unclosed-approved",
+        logical_path="unclosed.log",
+    )
+    assert unclosed_result.path.read_text() == "before <redacted:private-key>"
+
+
+def test_empty_and_non_utf8_binary_files_have_explicit_clean_disposition(tmp_path: Path) -> None:
+    for name, payload in (("empty.bin", b""), ("opaque.bin", b"\xff\xfe")):
+        source = tmp_path / name
+        source.write_bytes(payload)
+        result = RedactionService().sanitize_file(
+            source,
+            tmp_path / f"{name}.approved",
+            logical_path=name,
+        )
+        assert result.receipt.status == "clean"
+        assert result.path.read_bytes() == payload
+
+
+def test_uri_metadata_and_empty_scope_branches_fail_closed() -> None:
+    service = RedactionService()
+    with pytest.raises(SecretQuarantineError, match="uri-userinfo"):
+        service.assert_safe_metadata(
+            "https://agent@provider.invalid/result",
+            field="artifact.source_ref",
+        )
+    for value in (
+        "https://provider.invalid/result?page=1",
+        "https://provider.invalid/result?token=",
+        "https://provider.invalid/result?token={env:PROVIDER_TOKEN}",
+    ):
+        assert service.assert_safe_metadata(value, field="artifact.source_ref").status == "clean"
+    assert not service._is_credential_path("/")
+    assert service._has_container_magic(b"x" * 257 + b"ustar" + b"x")
+    with pytest.raises(ValueError, match="scope must not be empty"):
+        service.redact_text("safe", scope=" ")
 
 
 def test_unbounded_text_line_is_quarantined(tmp_path: Path) -> None:

--- a/tests/app/test_redaction_service.py
+++ b/tests/app/test_redaction_service.py
@@ -447,6 +447,38 @@ def test_encrypted_zip_metadata_fails_before_member_open(tmp_path: Path) -> None
         )
 
 
+@pytest.mark.parametrize(
+    "metadata_field",
+    ["archive_comment", "member_comment", "member_extra"],
+)
+def test_zip_metadata_is_scanned_before_archive_approval(
+    tmp_path: Path,
+    metadata_field: str,
+) -> None:
+    path = tmp_path / f"secret-{metadata_field}.zip"
+    secret = ("ghp_" + "M" * 36).encode()
+    with zipfile.ZipFile(path, "w") as archive:
+        member = zipfile.ZipInfo("result.txt")
+        if metadata_field == "archive_comment":
+            archive.comment = secret
+        elif metadata_field == "member_comment":
+            member.comment = secret
+        else:
+            member.extra = b"\xfe\xca" + len(secret).to_bytes(2, "little") + secret
+        archive.writestr(member, b"safe")
+
+    destination = tmp_path / "approved"
+    with pytest.raises(SecretQuarantineError) as error:
+        RedactionService().sanitize_file(
+            path,
+            destination,
+            logical_path=path.name,
+        )
+    assert error.value.rule_ids == ("github-token",)
+    assert secret.decode() not in str(error.value)
+    assert not destination.exists()
+
+
 @pytest.mark.parametrize("archive_kind", ["tar", "zip"])
 def test_archive_stream_size_must_match_member_metadata(
     tmp_path: Path,

--- a/tests/app/test_service_protocols.py
+++ b/tests/app/test_service_protocols.py
@@ -11,7 +11,12 @@ import pytest
 
 from archetype.app.application.interfaces import iRuntimeApplication
 from archetype.app.application.service import RuntimeApplication
-from archetype.app.artifacts.interfaces import iArtifactService, iArtifactTableService
+from archetype.app.artifacts.bundle_service import ArtifactBundleService
+from archetype.app.artifacts.interfaces import (
+    iArtifactBundleService,
+    iArtifactService,
+    iArtifactTableService,
+)
 from archetype.app.artifacts.service import ArtifactService
 from archetype.app.artifacts.table_service import ArtifactTableService
 from archetype.app.audit.interfaces import iAuditLog
@@ -25,6 +30,8 @@ from archetype.app.gateway.interfaces import iCommandGateway
 from archetype.app.gateway.service import CommandGateway
 from archetype.app.query.interfaces import iQueryService
 from archetype.app.query.service import QueryService
+from archetype.app.redaction.interfaces import iRedactionService
+from archetype.app.redaction.service import RedactionService
 from archetype.app.research.interfaces import iResearchService
 from archetype.app.research.service import AutoResearchService
 from archetype.app.storage.interfaces import iStorageService
@@ -45,6 +52,8 @@ SERVICE_PROTOCOLS = (
     (QueryService, iQueryService),
     (ArtifactService, iArtifactService),
     (ArtifactTableService, iArtifactTableService),
+    (ArtifactBundleService, iArtifactBundleService),
+    (RedactionService, iRedactionService),
     (EvaluationService, iEvaluationService),
     (AutoResearchService, iResearchService),
     (AuditLog, iAuditLog),
@@ -80,6 +89,8 @@ async def test_container_wiring_conforms_to_every_family_protocol() -> None:
             (container.query_service, iQueryService),
             (container.artifact_service, iArtifactService),
             (container.artifact_table_service, iArtifactTableService),
+            (container.artifact_bundle_service, iArtifactBundleService),
+            (container.redaction_service, iRedactionService),
             (container.evaluation_service, iEvaluationService),
             (container.autoresearch_service, iResearchService),
             (container.audit_log, iAuditLog),

--- a/tests/scripts/test_check_pre_durability_redaction.py
+++ b/tests/scripts/test_check_pre_durability_redaction.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+CHECKER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_pre_durability_redaction.py"
+SPEC = importlib.util.spec_from_file_location("check_pre_durability_redaction", CHECKER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules["check_pre_durability_redaction"] = checker
+SPEC.loader.exec_module(checker)
+
+
+def test_negative_fixture_detects_claim_and_upload_bypasses(tmp_path: Path) -> None:
+    source = tmp_path / "bundle_service.py"
+    source.write_text(
+        """
+class ArtifactBundleService:
+    async def publish(self):
+        await self._control_catalog()
+        self._bind_redaction_policy()
+        self._safe_failure_detail()
+        self.fail_artifact_publication()
+
+    async def reconcile(self):
+        self._safe_failure_detail()
+        self.fail_artifact_publication()
+
+    async def _upload_bundle(self):
+        self._assert_materialized_metadata_safe()
+        self._file_metadata()
+        self._sanitize_materialized()
+        self._upload_files()
+        self._upload_bytes()
+        self._redaction_manifest()
+        self._assert_records_safe()
+""",
+        encoding="utf-8",
+    )
+    errors = checker.audit_path(source)
+    assert errors == [
+        "publish must call _bind_redaction_policy() before _control_catalog()",
+        "_upload_bundle must call _sanitize_materialized() before _file_metadata()",
+        "_upload_bundle must call _redaction_manifest() before _upload_bytes()",
+    ]
+
+
+def test_negative_fixture_detects_raw_durable_failure_details(tmp_path: Path) -> None:
+    source = tmp_path / "bundle_service.py"
+    source.write_text(
+        """
+class ArtifactBundleService:
+    async def publish(self):
+        self._bind_redaction_policy()
+        await self._control_catalog()
+        self.fail_artifact_publication()
+        self._safe_failure_detail()
+
+    async def reconcile(self):
+        self.fail_artifact_publication()
+
+    async def _upload_bundle(self):
+        self._assert_materialized_metadata_safe()
+        self._sanitize_materialized()
+        self._file_metadata()
+        self._upload_files()
+        self._redaction_manifest()
+        self._upload_bytes()
+        self._assert_records_safe()
+""",
+        encoding="utf-8",
+    )
+    assert checker.audit_path(source) == [
+        "publish must call _safe_failure_detail() before fail_artifact_publication()",
+        "reconcile must call _safe_failure_detail()",
+    ]
+
+
+def test_repository_redaction_order_passes() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(CHECKER_PATH)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "Pre-durability redaction audit passed" in completed.stdout


### PR DESCRIPTION
## Summary

- add the provider-neutral `iRedactionService` / `RedactionService` application family with deterministic policy identity, typed safe receipts, and quarantine errors
- make artifact finalization bind the active policy before its durable claim, snapshot and sanitize payloads before Daft hashing/upload, and validate manifests, index rows, object URIs, and retry diagnostics before their next durable write
- fail closed for credential paths, opaque binaries, archive links/special members, encrypted or nested/disguised containers, incomplete decoding, and bounded member/expanded-byte violations
- add no-follow regular-file snapshotting with inode verification so source mutation or symlink substitution cannot change the bytes hashed and uploaded
- codify the contract in architecture/contract registries, normative docs, a static ordering audit, synthetic provider corpus, focused tests, and a blocking capability eval

## Security and recovery contract

- UTF-8 text is deterministically redacted in a controlled copy; caller files and provider checkpoints are never mutated.
- Metadata findings quarantine before the claim. Payload quarantine leaves a retryable `PENDING` row with a bounded, redacted diagnostic and no object/index visibility.
- Quarantine exceptions retain rule IDs only and map to a fixed HTTP 422 detail.
- A persisted `PENDING` publication requires its exact bound scanner policy. `UPLOADED` recovery and `INDEXED` replay can proceed after current-policy metadata validation because their approved bytes/records are already durable.
- Legacy rows without a policy are explicitly documented: `PENDING` fails closed, `UPLOADED` may advance only after metadata validation, and historical `INDEXED` bytes are not retroactively certified.
- The producer request digest excludes the service-bound policy ID, preserving replay identity across scanner upgrades while the durable canonical request pins the policy used.

This establishes the shared authority and integrates the artifact durability boundary. Live events, sandbox spans, OTel/Logfire export, and L7 proxy capture still need to consume the same port, so this PR references rather than closes #498.

## Validation

- `make ci` on top of `b22f1052` (#495), exact head `8eb193c2`: **1,373 passed, 11 skipped**
- focused redaction models/service coverage: **100% line and branch coverage**
- adversarial ZIP metadata coverage includes archive comments, member comments, and local/central extra fields
- repository evals: regression **15/15**, spec **8/8**, capability **7/7**
- `security.pre_durability_redaction`: pass, score 1.0
- static architecture, outward-boundary, idempotency, gate-coverage, redaction-order, contract, traceability, and benchmark registry audits: pass
- packaging, examples, generated references, and docs build: pass
- staged patch scanned by the new authority: clean, zero findings

## Lazy execution audit

No new lazy-materialization exceptions were added. Five existing artifact external-I/O boundary entries only moved line numbers as the durability gate was inserted.

Refs #498
