### PR TITLE
docs: preserve coding-agent mission history

### DIFF
--- a/docs/guide/benchmark-runs/modal-opencode-single-h200-2026-07-18.md
+++ b/docs/guide/benchmark-runs/modal-opencode-single-h200-2026-07-18.md
@@ -1,0 +1,75 @@
+# Modal OpenCode single-H200 calibration — 2026-07-18
+
+This is a curated calibration note, not a regression baseline or production
+capacity guarantee. The run measured one independent Modal Sandbox and
+OpenCode session per agent against a Qwen endpoint declared to have one H200,
+one maximum container, and target concurrency 32.
+
+## Configuration
+
+| Field | Value |
+|---|---|
+| Model | `Qwen/Qwen3.6-35B-A3B-FP8` |
+| Workload | `one-sandbox-one-opencode-session-v1` |
+| Concurrency curve | `1, 4, 8, 16, 24, 32` |
+| Declared GPU | H200 |
+| Declared maximum containers | 1 |
+| Declared target concurrency | 32 |
+| Git revision | `64333356d028ff48eb62a7253f02f0940ba84868` |
+| Client runner | Darwin arm64, CPython 3.12.12 |
+| Raw report SHA-256 | `8c869a3d8a04c7b3e664b59938a2a2350b761a19f4eb2fe50568cd9e0a60e294` |
+
+Sweep snapshots and whole-filesystem manifests were disabled so provider
+checkpointing did not contaminate inference timing. The resumability preflight
+kept snapshots enabled.
+
+## Resumability preflight
+
+The preflight passed in 603.32 seconds. Phase A and phase B used distinct Modal
+sandboxes, continued the same OpenCode session, produced separate validated
+commits, and created two restorable filesystem checkpoints. The endpoint cold
+start consumed roughly seven minutes: `/v1/models` initially returned 503 and
+later returned 200 with the expected model. A one-token Chat Completions probe
+then returned 200 before the measured fanout levels.
+
+## Fanout results
+
+| Concurrency | Accepted | Execution (s) | p50 (s) | p95 (s) | Max (s) | Gross agents/s | Accepted agents/s |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 1/1 (100.00%) | 30.72 | 30.72 | 30.72 | 30.72 | 0.0325 | 0.0325 |
+| 4 | 4/4 (100.00%) | 46.76 | 34.31 | 45.18 | 46.75 | 0.0856 | 0.0856 |
+| 8 | 6/8 (75.00%) | 280.70 | 58.59 | 213.25 | 280.70 | 0.0285 | 0.0214 |
+| 16 | 13/16 (81.25%) | 65.33 | 44.98 | 62.47 | 65.33 | 0.2449 | 0.1990 |
+| 24 | 22/24 (91.67%) | 93.66 | 75.90 | 90.20 | 93.66 | **0.2562** | **0.2349** |
+| 32 | 29/32 (90.63%) | 164.05 | 107.66 | 127.20 | 164.05 | 0.1951 | 0.1768 |
+
+Across all measured levels, 75 of 85 agents passed (88.24%). All 85 OpenCode
+processes exited with return code 0. The authoritative validator rejected ten:
+eight did not create the required file, one created an additional misspelled
+file, and one produced incorrect content. Every sandbox teardown succeeded.
+
+## Interpretation
+
+For this short coding workload, concurrency 24 was the observed
+useful-throughput peak. Moving from 24 to 32:
+
+- reduced gross completion throughput by about 23.9%;
+- reduced accepted completion throughput by about 24.7%;
+- increased median latency by about 41.8%;
+- increased p95 latency by about 41.0%.
+
+The concurrency-8 point was an agent-behavior outlier rather than a monotonic
+capacity result. Seven agents reached terminal processing well before the final
+one. The outlier wrote the target, attempted an unnecessary `xxd` verification,
+found that `xxd` was unavailable, and entered additional model turns. Its
+280.70-second tail dominated the level.
+
+Acceptance did not degrade monotonically with concurrency, so strict task
+success is better treated as model-quality variance than direct evidence of
+endpoint overload. The throughput reversal and latency increase from 24 to 32
+are the stronger saturation signals. Repeat levels 16, 24, and 32 before
+treating 24 as a stable production limit.
+
+The raw JSON snapshot remains excluded from Git under the benchmark retention
+contract. Its checksum binds this note to the locally retained sample-level
+evidence without committing transient sandbox, session, and checkpoint IDs.

--- a/docs/history/agent-debriefs/2026-07-18-coding-agent-missions.md
+++ b/docs/history/agent-debriefs/2026-07-18-coding-agent-missions.md
@@ -1,0 +1,258 @@
+# From sandbox prototype to resumable coding-agent missions
+
+**Document type:** Agent engineering debrief, historical and non-normative.
+
+| Field | Value |
+|---|---|
+| Date | 2026-07-18 |
+| Status at capture | Implemented, pushed, and open as draft PR [#487](https://github.com/VangelisTech/archetype/pull/487) |
+| Submitted revision | `db9d52a7543cc895f7f6f058f967635f0e4d4810` |
+| Architectural base | Application-family refactor [#475](https://github.com/VangelisTech/archetype/pull/475), merged as `a6c6a812` |
+| Prototype lineage | Draft PR [#474](https://github.com/VangelisTech/archetype/pull/474) |
+| Boundary issue | [#477](https://github.com/VangelisTech/archetype/issues/477) |
+
+This record captures the point at which Archetype's coding-agent work stopped
+being a fake sandbox or an example-local state machine and became a tested
+application capability. Current contracts in [Agent missions and sandbox
+execution](../../guide/agent-missions.md), [Artifact
+finalization](../../guide/artifact-finalization.md), and [Application
+Architecture](../../guide/application-architecture.md) supersede this record.
+
+## 1. Outcome and lineage
+
+The initial work proved real Apple Container and Modal Sandbox execution,
+Codex, Claude Code, OpenCode, subscription authentication, monitoring,
+checkpoint recovery, artifact collection, and paid fanout. That capability was
+spread across experimental modules and one large example.
+
+While it was being developed, Archetype's application layer was reorganized
+around explicit families, an actor-free `RuntimeApplication`, an authorized
+`CommandGateway`, a durable command scheduler, and machine-enforced dependency
+direction. Discarding the working sandbox code would have lost expensive
+behavioral evidence. Merging it in its old shape would have recreated the flat
+service architecture the refactor removed.
+
+The formalization therefore preserved the provider behavior mechanically while
+moving ownership into new `missions`, `sandboxes`, and `coding_agents`
+families and extending `artifacts` for full attempt bundles. The resulting
+vertical slice changed 64 files with 13,860 additions and 19 deletions.
+
+The branch was first rebased onto the published head of #475. While final
+verification ran, #475 was squash-merged and its source branch was deleted.
+The publication guard stopped the push, verified that the published head and
+merged commit had identical Git trees, then transplanted the single agent
+mission commit onto the resulting `main`. The verified source tree did not
+change during that history rewrite.
+
+## 2. The authority split
+
+The central architectural result was separating four concerns that had been
+combined in the prototype:
+
+| Family | Authority | Explicit non-authority |
+|---|---|---|
+| `missions` | Stable mission/task/attempt identity, retry/exhaustion, validator policy, finalization gates, task advancement | Provider credentials and sandbox mechanics |
+| `sandboxes` | Provider registry, create, restore, authenticated resume, monitor, checkpoint, close, cleanup | Attempt acceptance and task advancement |
+| `coding_agents` | Repository-oriented composition of one mission attempt and one coding harness session | World persistence and gateway authorization |
+| `artifacts` | Durable publication claims, portable objects, content identity, queryable indexes, reconciliation | Provider-native checkpoint lifecycle and mission success |
+
+Existing boundaries remained intact:
+
+```text
+trusted script -> ArchetypeRuntime -> RuntimeApplication
+
+untrusted client -> API authentication -> CommandGateway authorization
+                                      -> RuntimeApplication
+
+RuntimeApplication -> family workflow ports -> durable storage / core
+```
+
+Concrete services and provider clients stayed internal. The container remained
+the sole cross-family construction root.
+
+## 3. Attempt semantics
+
+A world tick became a **durable orchestration opportunity**, not a synonym for
+one tool call or one state transition. The first processor still creates at
+most one model submission per entity per tick, but a future tick may only
+recover, reconcile, or finalize an existing attempt.
+
+`MissionService` became the sole task-transition authority. It derives a
+deterministic attempt key, validates receipt identity, requires non-vacuous
+validator evidence, persists accepted and rejected outcomes, and advances only
+when the accepted attempt has the required commit, restorable checkpoint, and
+finalization phase.
+
+A validator rejection does not abort the tick. It becomes durable data. The
+task gate stays on the current task and a later tick may create another
+attempt. This distinction removed the earlier ambiguity between “abort the
+tick” and “do not transition the task.”
+
+Exactly-once model execution was deliberately not claimed. Deterministic
+attempt identity detects replay, but a crash before a durable pre-execution
+claim may repeat a model submission.
+
+## 4. Real sandbox and harness capability
+
+Two concrete isolation providers were retained:
+
+- **Apple Container:** local, non-Docker execution with rehydratable root
+  filesystem exports.
+- **Modal Sandbox:** remote isolated execution with filesystem snapshots,
+  restorable image references, live file access, and authenticated continuation.
+
+Three coding harnesses were retained:
+
+- Codex;
+- Claude Code; and
+- OpenCode against an OpenAI-compatible endpoint.
+
+Codex and Claude subscription credentials use dedicated broker volumes. The
+broker stages only the selected credential for execution, persists a refresh,
+and removes the mission copy before validators, manifests, or snapshots.
+Credential-free recovery receives no model credential. Authenticated resume
+resolves it again from the named secret or broker volume.
+
+The live monitor can attach by sandbox ID without a model credential. It reads
+`session.json`, follows `events.jsonl`, preserves byte offsets across temporary
+snapshot interruptions, and reports explicit reconnect or disconnect results.
+Heartbeats distinguish a quiet but running CLI from a stuck monitor.
+
+## 5. Three complementary recovery records
+
+The implementation made a deliberate distinction among three records:
+
+| Record | System of record | Use |
+|---|---|---|
+| Archetype component rows | World storage | Mission, task gate, validator, commit, attempt, and finalization facts |
+| Provider checkpoint | Modal image or Apple rootfs export | Complete resumable sandbox substrate |
+| Portable artifact bundle | Object storage plus Iceberg index | Independently readable manifests, patches, Git bundle, `.context`, session logs, traces, and declared outputs |
+
+The full provider checkpoint is referenced in the artifact index but is not
+blindly copied into Parquet. Portable files are hashed, typed, uploaded, and
+indexed separately.
+
+Artifact publication gained a durable control-catalog state machine:
+
+```text
+PENDING -> UPLOADED -> INDEXED
+    |
+    +-> EXPIRED  (only after the retry window while still provider-dependent)
+```
+
+The publication claim is recorded before external I/O. Deterministic bundle
+and artifact identities make upload and index replay idempotent. SQLite, the
+remote catalog client, and the Cloudflare Durable Object implementation share
+the same protocol and schema version.
+
+This gave teardown a concrete meaning: persist attempt facts, record a
+recovery checkpoint, hand artifacts to a durable publication claim, collect
+the live event files, then close the provider handle. Telemetry remained
+operator evidence rather than the state authority.
+
+## 6. Queryability
+
+The example no longer treats terminal stdout as the result. It queries mission
+components and artifact index rows through the runtime/application path.
+
+The artifact index carries world, run, entity, tick, attempt, bundle, content,
+MIME, checkpoint, lifecycle, acceptance, and retention coordinates. R2 uses an
+S3-compatible Daft `IOConfig`; MIME detection and upload use Daft functions.
+Credentials remain process-local configuration and do not enter the request,
+catalog, manifest, or index.
+
+At this revision the example still initiated artifact publication after the
+episode. The artifact service was available through `RuntimeApplication`, but
+`indexed` had not yet become an authoritative in-transition task gate.
+
+## 7. Parallelism and the paid calibration
+
+The coding-agent processor materializes each mission row only at the explicit
+external-side-effect boundary and fans independent mission entities out with
+concurrent async tasks. The practical topology at this point was one mission,
+one sandbox, and one session per agent. Same-sandbox collaborative subagents
+were not implemented.
+
+A paid Modal/OpenCode calibration exercised concurrency levels 1, 4, 8, 16,
+24, and 32 against a Qwen3.6 35B-A3B FP8 endpoint declared to use one H200 and
+one maximum model replica.
+
+Across 85 agents, 75 passed the authoritative validator. Every OpenCode process
+exited successfully, but ten repository outcomes were rejected. Concurrency 24
+was the observed useful-throughput peak for that short workload. Moving to 32
+reduced accepted throughput and raised median and p95 latency. The result was
+retained as a calibration, not a production capacity guarantee; levels 16,
+24, and 32 still required repeated samples.
+
+See the [dated benchmark
+report](../../guide/benchmark-runs/modal-opencode-single-h200-2026-07-18.md)
+for configuration, timing, correctness, and caveats.
+
+## 8. Evidence at submission
+
+The exact submitted tree passed:
+
+- static formatting, lint, type, lock, architecture, API-boundary, lazy-DAG,
+  contract, and benchmark registry checks;
+- 1,303 tests with 19 credentialed/external skips;
+- 86.52% branch coverage;
+- all 15 regression and 8 specification conformance tasks;
+- all 6 capability evals, including mission transition authority;
+- package installation smoke;
+- normal example smoke, with the external coding-agent example explicitly
+  delegated to its path-gated workflow; and
+- the full documentation build.
+
+The Modal PR workflow detected that repository secrets were absent and skipped
+the paid steps. Its green result meant “credential-aware skip,” not a new live
+Modal proof. Paid evidence in this record came from the earlier explicit run.
+
+## 9. Honest limitations at capture
+
+The implementation was a substantial capability, not a finished production
+platform:
+
+- provider-neutral primitives were still physically located in the Modal
+  module and imported by Apple;
+- `run_attempt` still combined execution, validation, commit, evidence, and
+  checkpoint phases;
+- mission states were validated strings rather than one persisted enum graph;
+- artifact indexing was not yet part of the authoritative transition;
+- model calls remained at-least-once around a pre-claim crash;
+- reconciliation was bounded per world, without a fleet operator or garbage
+  collector;
+- there was no sandbox supervisor, network proxy, durable external event bus,
+  or sandbox-side OTel pipeline;
+- secrets had strong process isolation but no unified pre-durability redaction
+  scanner;
+- CLI/image versions were not yet pinned as evidence; and
+- six new lazy materializations marked real external-I/O boundaries that
+  deserved later decomposition rather than cosmetic removal.
+
+Those gaps are consolidated in the [dated production-readiness
+inventory](../readiness/2026-07-18-coding-agent-missions.md). The observability
+and evaluation designs were split into implementation-ready follow-ups:
+
+- [#488 — sandbox-side span semantics](https://github.com/VangelisTech/archetype/issues/488)
+- [#489 — Pydantic Evals integration](https://github.com/VangelisTech/archetype/issues/489)
+- [#490 — policy-controlled L7 traffic capture](https://github.com/VangelisTech/archetype/issues/490)
+- [#491 — durable external live-event bus](https://github.com/VangelisTech/archetype/issues/491)
+- [#492 — redacting Logfire/OTel collector](https://github.com/VangelisTech/archetype/issues/492)
+
+## 10. Why this record is retained
+
+Several architectural rules came from operating a real agent rather than
+designing an abstract service:
+
+- progress must be observable while the agent is running;
+- resumability and portable evidence are different requirements;
+- a rejected attempt is still valuable durable state;
+- task transition, tick commit, model submission, checkpoint, artifact index,
+  and PR merge are distinct state machines;
+- credentials are capabilities, not serializable configuration;
+- trace availability cannot become correctness authority; and
+- concurrency without authoritative validators measures process completion,
+  not useful agent throughput.
+
+That is the historical value of the work: the contracts were extracted from a
+working system and its failure modes, not inferred from a toy interface.

--- a/docs/history/index.md
+++ b/docs/history/index.md
@@ -1,0 +1,58 @@
+# Engineering history and agent debriefs
+
+**Document type:** Historical index, non-normative.
+
+Archetype keeps selected engineering debriefs, readiness inventories, and
+architecture reports when the path to a capability is itself useful evidence.
+These records explain what was known, what was proven, and what remained open
+at a particular revision. They are neither release notes nor an alternative
+specification.
+
+When a historical record conflicts with current behavior, use this authority
+order:
+
+1. the focused normative specification;
+2. executable contracts and evals;
+3. the umbrella [Specification](../guide/specification.md);
+4. current guides and examples;
+5. the dated historical record.
+
+Historical records are intentionally not rewritten to make old decisions look
+inevitable. Corrections should be appended with a date and a link to the newer
+authority.
+
+## Agent debriefs
+
+| Date | Record | Implementation anchor | Why it is retained |
+|---|---|---|---|
+| 2026-07-18 | [From sandbox prototype to resumable coding-agent missions](agent-debriefs/2026-07-18-coding-agent-missions.md) | Draft PR [#487](https://github.com/VangelisTech/archetype/pull/487), commit `db9d52a7` | Establishes the mission/sandbox/artifact boundaries, retained provider capability, durability evidence, benchmark result, and honest limitations after the application-family refactor. |
+
+## Readiness inventories
+
+| Date | Inventory | Scope |
+|---|---|---|
+| 2026-07-18 | [Coding-agent mission production-readiness inventory](readiness/2026-07-18-coding-agent-missions.md) | One deduplicated, priority-ordered list combining the original production checklist, architectural seams found during formalization, and observability/evaluation follow-ups. |
+
+## Architecture and program reports
+
+These older reports remain useful for understanding why later contracts were
+introduced. Their recommendations may have been superseded.
+
+- [Security program review — 2026-03-28](../reports/2026-03-28-security-program-review.md)
+- [Service-layer redesign — 2026-04-25](../reports/2026-04-25-service-layer-redesign.md)
+
+## What belongs here
+
+A record belongs in this section when it binds a consequential implementation
+or operational result to a date, revision, and evidence set. Routine PR
+summaries, speculative designs without an implementation anchor, and current
+normative contracts belong elsewhere.
+
+Every new agent debrief should state:
+
+- its date, status, scope, revision, and related issues/PRs;
+- what actually ran and what was only proposed;
+- systems of record and failure semantics;
+- quantitative evidence with the workload and caveats;
+- known gaps and the durable issues that own them; and
+- the current specifications that supersede it when behavior evolves.

--- a/docs/history/readiness/2026-07-18-coding-agent-missions.md
+++ b/docs/history/readiness/2026-07-18-coding-agent-missions.md
@@ -1,0 +1,216 @@
+# Coding-agent mission production-readiness inventory
+
+**Document type:** Dated readiness inventory, historical and non-normative.
+
+**Captured:** 2026-07-18, after draft PR
+[#487](https://github.com/VangelisTech/archetype/pull/487) was rebased onto the
+merged application-family architecture.
+
+This is the consolidated successor to two earlier lists: the eight seams found
+during formalization and the original “missing before production-ready”
+checklist. Duplicates have been merged, completed prerequisites have been
+removed from the numbered queue, and new observability/evaluation work has
+been placed behind its durability and security dependencies.
+
+The numbers are priority and dependency order at this date. GitHub issues own
+the live work; this page is the historical baseline against which reprioritizing
+can be explained.
+
+## Completed prerequisites
+
+- The repository-harness and application-family refactor landed in
+  [#475](https://github.com/VangelisTech/archetype/pull/475).
+- The coding-agent vertical slice was rebased onto that merged tree and the new
+  main verification profile passed.
+- The catalog-driven eval harness from
+  [#484](https://github.com/VangelisTech/archetype/pull/484) was retained
+  wholesale. `agent_mission_transition_authority` is registered as the sixth
+  blocking capability task without changing its contract-referenced ID or the
+  profile registry.
+- The base `ServiceContainer` is provider-neutral and accepts explicitly
+  registered sandbox backends. Normal example smoke uses example 11's
+  credential-free `--dry-run`; the paid workflow watches all mission/provider
+  implementation and live-harness paths rather than only the example file.
+- The prior prototype remains preserved in
+  [#474](https://github.com/VangelisTech/archetype/pull/474); draft PR #487 is
+  its architectural successor.
+- Same-world operation serialization from
+  [#457](https://github.com/VangelisTech/archetype/issues/457) has an
+  implementation in the refactor lineage, but the issue should be reconciled
+  and closed only after its published regression evidence is confirmed.
+
+## Remaining work, in priority order
+
+1. **Make the landing reviewable without losing the vertical proof.** Split
+   #487 in dependency order: (a) artifact publication substrate, (b) mission
+   transition authority, (c) provider-neutral sandbox kernel, (d) coding-agent
+   orchestration plus fake backend, (e) Modal and Apple provider adapters, and
+   (f) live evidence plus benchmarking. Modal and Apple may be separate adapter
+   PRs. Do not merge both #474 and #487, and do not separate code from the
+   contract tests that prove it. **Done when:** each review unit has a coherent
+   authority boundary, each child branch is based on its actual dependency,
+   and the full stacked tree still passes the same gate.
+
+2. **Extract provider-neutral execution primitives.** Move the shared harness,
+   validator, commit, evidence, checkpoint, and process records out of the
+   Modal module into a provider-neutral module. Apple must not import another
+   provider's implementation module. **Tracking:**
+   [#477](https://github.com/VangelisTech/archetype/issues/477). **Done when:**
+   import/architecture tests reject provider-to-provider implementation edges.
+
+3. **Decompose `run_attempt` into explicit phases.** Separate harness
+   execution, validation, repository finalization, evidence capture,
+   checkpointing, and artifact handoff behind typed records. **Done when:** a
+   crash/fault test can stop and resume at every phase without rerunning an
+   unrelated phase.
+
+4. **Persist one typed mission transition graph.** Replace state strings and
+   scattered validation with enums/typed records and a single fail-closed graph
+   for attempt, task, and mission transitions. **Done when:** every invalid
+   edge and invalid evidence combination has one executable rejection oracle.
+
+5. **Add a durable pre-execution claim.** Record ownership/lease and the
+   intended model submission before invoking a harness; document whether a
+   crash at each boundary may repeat execution. Do not claim exactly once
+   without provider support that proves it. **Done when:** recovery can
+   distinguish never-started, possibly-submitted, running, and completed work
+   without checkpoint reconciliation creating a new submission.
+
+6. **Move artifact projection and `indexed` gating into mission finalization.**
+   The application/mission path should construct `ArtifactBundleRequest` and
+   enforce the configured `checkpointed` or `indexed` threshold; the example
+   should not own the authoritative teardown loop. **Done when:** publication
+   retry never creates another model attempt and an `indexed` policy advances
+   atomically according to the documented transition contract.
+
+7. **Retire or further isolate the six lazy-materialization exceptions.** The
+   current sites represent external sandbox and object-store side effects, but
+   phase decomposition may narrow their row/column inputs or move them to
+   explicit adapter boundaries. **Done when:** every remaining `.collect()` or
+   `.to_pylist()` has the smallest justified execution boundary and a current
+   `lazy_audit.toml` owner.
+
+8. **Add one pre-durability secret scanning and redaction policy.** Apply it to
+   spans, live events, manifests, session logs, patches, worktree archives, and
+   declared artifacts before upload/export. Keep credential files out by
+   construction and use scanning as defense in depth. **Done when:** a shared
+   negative corpus covers Codex, Claude, GitHub, Modal, OpenRouter, cloud, and
+   generic bearer/key formats, with explicit quarantine/failure behavior.
+
+9. **Pin every executable environment.** Pin Codex, Claude Code, OpenCode,
+   provider SDK, base image, collector/proxy, and relevant package versions or
+   digests in attempt evidence. **Done when:** a run can be reproduced or
+   declared unavailable from recorded version identities, and upgrades have a
+   dedicated live compatibility proof.
+
+10. **Add a portable full-worktree archive.** Preserve ignored, untracked,
+    rejected, and uncommitted changes in addition to the sanitized Git bundle,
+    patches, `.context`, and declared outputs. **Done when:** a credential-free
+    restore test reconstructs the terminal worktree byte-for-byte while the
+    archive remains bounded, hashed, scanned, and retention-classified.
+
+11. **Dogfood R2 and the remote Iceberg index end to end.** Exercise real Daft
+    upload, content reuse, manifest publication, query, replay after injected
+    failure, retention metadata, and authorized download against R2 rather than
+    only the local object/Iceberg store. **Done when:** the remote proof covers
+    both an accepted and rejected attempt and survives a process restart.
+
+12. **Deploy the fleet reconciler and retention garbage collector.** Discover
+    due worlds, acquire/renew per-publication leases, complete pending/uploads,
+    expire provider-dependent claims, delete eligible object bytes and
+    provider snapshots, and retain/tombstone audit rows. **Done when:** multiple
+    reconcilers safely shard billions of indexed records without cross-world
+    locking and all crash points are idempotent.
+
+13. **Add an automatic sandbox supervisor.** Detect provider/process loss,
+    consult the durable attempt and latest checkpoint, choose restore versus
+    authenticated resume, and enforce retry/budget policy. **Done when:** fault
+    injection kills the controller and sandbox in every phase and the
+    supervisor converges without silently duplicating accepted work.
+
+14. **Define and emit correlated sandbox-side OTel spans.** Standardize the
+    attempt span tree, W3C context propagation, bounded heartbeat/output
+    events, semantic version, and content-off defaults across all harnesses.
+    **Tracking:** [#488](https://github.com/VangelisTech/archetype/issues/488).
+
+15. **Export through a redacting OTel collector to Logfire.** Keep the Logfire
+    credential outside the mission sandbox, use collector-side enrichment and
+    redaction, persistent sending queues/WAL, and backend-outage markers.
+    **Tracking:** [#492](https://github.com/VangelisTech/archetype/issues/492).
+    **Depends on:** items 8, 9, and 14.
+
+16. **Prove policy-controlled model/API traffic capture.** Prefer an explicit
+    L7 relay and provider network enforcement over transparent TLS
+    interception; publish a support matrix for each harness and credential
+    mode. Metadata is default; content is explicit and governed. **Tracking:**
+    [#490](https://github.com/VangelisTech/archetype/issues/490). **Depends
+    on:** items 8, 9, and 14.
+
+17. **Add a durable external event bus for live streams.** Persist a per-world
+    event/outbox record before at-least-once queue publication, provide
+    idempotent consumers, cursor replay, Hibernation WebSockets, archival
+    projection, and an active DLQ path. **Tracking:**
+    [#491](https://github.com/VangelisTech/archetype/issues/491). **Depends
+    on:** item 8; complements but does not replace items 10–15.
+
+18. **Integrate Pydantic Evals and span evaluators.** Map typed mission cases
+   to Archetype's dataset/evaluation ontology, grade outcome/process/efficiency,
+   and project experiments to Logfire without creating a second transition
+   authority. **Tracking:**
+   [#489](https://github.com/VangelisTech/archetype/issues/489). **Depends
+   on:** item 14 for stable process assertions. The current capability task is
+   intentionally narrower: it proves in-memory rejection, incomplete checkpoint
+   gating, and eventual advance only. Once item 5 exists, add
+   `evals/suites/idempotency/missions.py` tasks for claim replay, crash after
+   execution before settlement, duplicate tick delivery, settlement replay,
+   and restart/checkpoint reattachment.
+
+19. **Run and retain the paid Claude Code edit/resume proof.** Use subscription
+    authentication, make a material repository edit, checkpoint, restore in a
+    distinct sandbox, continue the same agent session, validate independently,
+    and publish its artifact/evaluation evidence. **Done when:** evidence is
+    queryable by world/run/attempt and no credential is present in snapshots or
+    artifacts.
+
+20. **Run the direct endpoint benchmark from a credentialed Modal load
+    generator.** Remove the local client/network as the load source and measure
+    endpoint queue, token throughput, first-token latency, completion latency,
+    error/retry rate, and validated repository outcomes. **Done when:** raw
+    sample evidence is durable and the report binds endpoint configuration,
+    model, replica limit, workload, and Git revision.
+
+21. **Repeat concurrency 16/24/32 to establish variance.** Run enough
+    independent repetitions to estimate confidence intervals and distinguish
+    agent-quality variance from endpoint saturation. **Done when:** the
+    recommended cap is based on accepted-throughput and tail-latency
+    distributions, not one sweep.
+
+22. **Add endpoint-level admission, budgets, and conservative capacity
+    defaults.** Schedule by provider/endpoint/model and enforce concurrent
+    sandbox, token, cost, wall-clock, retry, and tenant budgets. Start at 16 or
+    the repeated-evidence cap rather than the theoretical 32. **Done when:**
+    overload queues predictably, fairness and cancellation are tested, and the
+    operator can override a recorded default.
+
+23. **Implement actual PR creation and CI/frontier evaluation.** A successful
+    mission should push the sanitized branch, open a PR, observe CI/review
+    evidence, and represent `pr_ready`, `ci_passed`, `reviewed`, and `merged`
+    as separate delivery states. **Done when:** a live mission opens a material
+    Archetype PR and the mission cannot claim merge success from a local
+    validator alone.
+
+24. **Only then graduate to multi-task missions or HTN.** Define multi-task
+    transition and checkpoint semantics before same-sandbox multi-agent
+    collaboration. Benchmark one-sandbox/many-agent behavior separately from
+    the proven one-mission/one-sandbox/one-session fanout. **Done when:** task
+    dependencies, partial success, resume, budget allocation, and artifact
+    lineage have explicit contracts and failure tests.
+
+## Interpretation
+
+Items 1–7 stabilize authority and phase boundaries. Items 8–13 establish the
+security, reproducibility, and recovery floor. Items 14–18 add observability
+and evaluation without changing the system of record. Items 19–22 supply paid
+evidence and fleet capacity controls. Item 23 completes the software-delivery
+loop. Item 24 deliberately remains last: orchestration breadth is useful only
+after one mission is durably recoverable, observable, and governable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,12 +7,12 @@ repo_name: VangelisTech/archetype
 docs_dir: docs
 site_dir: site/docs
 
-# Design notes, planning records, and historical reports are retained in the
-# published source tree but are not part of the reader-facing documentation.
+# Design notes and planning records are retained in the published source tree
+# but are not part of the reader-facing documentation. Selected historical
+# reports are explicitly classified under the History section below.
 not_in_nav: |
   design/**
   planning/**
-  reports/**
 
 theme:
   name: material
@@ -107,6 +107,8 @@ nav:
       - Repository Harness: guide/repository-harness.md
       - Repository Checks: guide/evals.md
       - Performance Benchmarking: guide/benchmarking.md
+      - Benchmark Runs:
+          - Modal OpenCode Single-H200 (2026-07-18): guide/benchmark-runs/modal-opencode-single-h200-2026-07-18.md
       - Mutation Testing: guide/mutation-testing.md
       - CORE INTERNALS:
           - Archetypes: guide/archetype.md
@@ -117,6 +119,17 @@ nav:
           - Data Flow: guide/data-flow.md
           - Durable Commands: guide/durable-commands.md
           - Services: guide/services.md
+  - HISTORY:
+      - About Historical Records: history/index.md
+      - AGENT DEBRIEFS:
+          - Coding-Agent Missions (2026-07-18): history/agent-debriefs/2026-07-18-coding-agent-missions.md
+      - READINESS INVENTORIES:
+          - Coding-Agent Mission Readiness (2026-07-18): history/readiness/2026-07-18-coding-agent-missions.md
+      - ARCHITECTURE REPORTS:
+          - Security Program Review (2026-03-28): reports/2026-03-28-security-program-review.md
+          - Service-Layer Redesign (2026-04-25): reports/2026-04-25-service-layer-redesign.md
+          - Robot Evals Extraction (2026-07-16): reports/2026-07-16-robot-evals-extraction.md
+          - Contract-Centered Quality System (2026-07-17): reports/2026-07-17-contract-centered-quality-system.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

Preserves the historical evidence currently stranded on draft integration PR #487 before that superseded branch is closed:

- the full coding-agent mission engineering debrief;
- the dated 24-item production-readiness inventory;
- the paid Modal/OpenCode single-H200 calibration; and
- a first-class, explicitly non-normative History section in the published docs.

The History index records the authority order between current specifications, executable contracts, guides, and dated historical records. It also classifies the repository's existing architecture reports instead of leaving them outside the reader-facing navigation.

This PR deliberately does not revive the superseded implementation shape from #474 or #487. Current contracts remain owned by the focused specifications and landed slices #494, #495, #496, #497, and #499; remaining production work stays tracked by #477 and its child issues.

## Validation

- `make static`: passed
- `make ci`: passed; 1,385 tests passed, 7 credential-gated skips, 87.74% coverage, 15/15 regression tasks, 8/8 specification tasks, and 7/7 capability tasks
- `make docs`: passed with all historical pages included in navigation
- local `make docs-lint` could not start because the optional `typos` binary is not installed; GitHub's spelling, Markdown, and link checks own that evidence

Refs #474, #477, #487.
