### PR TITLE
feat: define safe observability signals

### DIFF
--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -126,6 +126,22 @@ Forbidden reverse edges include:
 - experiments importing the container or concrete app services; and
 - CLI command implementations bypassing HTTP.
 
+### Observability dependency boundary
+
+Core and application families may emit only through the private,
+vendor-neutral `archetype._obs` API and stdlib logging. They may not import an
+OTel SDK, exporter, collector, or vendor package. Runtime and server process
+hosts own provider/exporter and handler configuration. Because core imports
+`_obs`, the signal boundary cannot import the application redaction family; it
+uses the closed schema defined by the normative
+[Observability contract](observability.md). Content-bearing outer adapters
+still consume the redaction port before their own durable or external write.
+
+Telemetry is never an authority edge. It cannot authorize a command, prove a
+commit, settle a durable outcome, or choose a retry. The owning family's typed
+result and durable record remain authoritative when telemetry is disabled,
+dropped, or failing.
+
 ## 5. Core world and application-family ownership
 
 `StorageService` resolves and pools an `iAsyncStore`. `WorldService` owns the

--- a/docs/guide/artifact-finalization.md
+++ b/docs/guide/artifact-finalization.md
@@ -166,11 +166,19 @@ never serialized into requests, control rows, manifests, or the index.
 
 ## 4. Pre-durability secret redaction
 
-`RedactionService` is the single provider-neutral authority for data that may
-cross from an agent or sandbox into a durable control row, object, index,
-trace, or external event stream. Artifact publication consumes only its
-`iRedactionService` port. Provider adapters, collectors, and proxies must use
-the same port rather than implementing separate regular-expression filters.
+`RedactionService` is the single provider-neutral authority for content-bearing
+data that may cross from an agent or sandbox into a durable control row,
+object, index, or external event record. Artifact publication consumes only
+its `iRedactionService` port. Provider adapters, collectors, and proxies must
+use the same port rather than implementing separate regular-expression
+filters.
+
+The lower `archetype._obs` signal boundary is also imported by core and cannot
+depend on this application family. It prevents signal leakage structurally:
+fixed names, fixed keys, exact value validators, bounded enums, no arbitrary
+string conversion, and no raw exception recording. A content-bearing outer
+export adapter applies `iRedactionService` as defense in depth before its own
+external write. See the [Observability contract](observability.md).
 
 The artifact handoff applies the following dispositions:
 
@@ -245,10 +253,11 @@ Payload quarantine leaves a retryable `PENDING` claim with a safe diagnostic,
 no object/index visibility, and the original provider checkpoint available for
 operator recovery.
 
-Sandbox live events, sandbox-side spans, OTel export, and policy-controlled L7
-traffic capture are required to consume this same authority before their
-respective durable/external writes. Those integrations extend this contract;
-they do not weaken the artifact gate while their transports are developed.
+Content-bearing sandbox live events, portable sandbox-side span records, and
+policy-controlled L7 capture consume this same authority before their durable
+or external writes. Closed-schema `_obs` signals carry no such content. Those
+integrations extend this contract; they do not weaken the artifact gate while
+their transports are developed.
 
 ## 5. Publication state machine
 
@@ -360,15 +369,18 @@ branch resume policy still references them.
   lower-level service accepts explicit world/run keys and works after world
   destruction or process restart.
 - `artifact.publish`, `artifact.upload`, and `artifact.index` OpenTelemetry
-  spans carry `world_id`, `run_id`, `entity_id`, `tick`, `attempt_id`, and
-  `idempotency_key`; stage spans also carry bundle and artifact counts.
+  spans carry validated canonical world/run UUIDs and entity/tick values.
+  Upload/index stage spans also carry the bundle digest and bounded artifact
+  count. Raw attempt IDs and idempotency keys are omitted; no attempt or
+  idempotency digest is claimed until the owning family supplies one explicitly.
 - Agent CLI JSONL and sandbox-side OTel output are portable artifacts. Shipping
   live sandbox spans to an OTel collector is complementary and must use the
   same correlation attributes. It is not required for publication correctness.
 - Every portable payload and generated manifest passes the pre-durability gate
-  in section 4. Live telemetry exporters must apply the same policy before
-  enqueueing or sending a span; an observability outage or quarantine never
-  changes mission state authority.
+  in section 4. Content-bearing live-event/export adapters apply the same
+  policy before their external write, while `_obs` signals admit no content by
+  schema. An observability outage or quarantine never changes mission state
+  authority.
 - Provider and model secrets are process capabilities. They must not appear in
   sandbox manifests, artifact requests, control rows, object paths, traces, or
   index rows.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -172,7 +172,7 @@ methods commonly build lazy expressions whose work runs at a later terminal
 boundary. Telemetry must not add `.collect()`, `.to_pylist()`, or any other
 materialization to manufacture a duration.
 
-#518 must characterize Daft execution attribution and worker context with the
+Issue #518 must characterize Daft execution attribution and worker context with the
 locked version and supported runner. #519 then replaces or redefines these
 world phases from that evidence. Until then, no processor planning duration may
 be described as processor execution duration.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -1,0 +1,178 @@
+# Observability
+
+**Document type:** Normative.
+
+**Scope:** Safe trace, metric, outcome, and correlation semantics; process-host
+provider ownership; and the boundary between advisory telemetry and durable
+application authority.
+
+## 1. Safe signal contract
+
+Telemetry is advisory. Durable records, typed results, exceptions, receipts,
+and state transitions remain authoritative. No Archetype signal operation or
+Archetype-owned adapter failure may change an application result, retry
+decision, commit, authorization decision, or exception identity. A process
+host remains responsible for failure behavior in handlers it installs itself.
+
+Family and core code emit through the private `archetype._obs` boundary using
+OpenTelemetry APIs and stdlib logging only. They do not import an OTel SDK,
+exporter, collector, or vendor integration. Process hosts own provider and
+exporter installation. `archetype._obs` remains internal and does not expand
+the supported Python or REST surface.
+
+The signal boundary cannot import `app.redaction`: core imports `_obs`, so that
+edge would invert the application dependency direction. Instead, `_obs` is
+safe by construction through a closed schema. An outer adapter handling a
+content-bearing event or export record still consumes `iRedactionService`
+before its own durable or external write. These protections are complementary.
+
+## 2. Vocabulary and validation
+
+`SIGNAL_SCHEMA_VERSION`, `SPAN_NAMES`, `LEGACY_SPAN_NAMES`,
+`TRACE_ATTRIBUTE_KEYS`, `METRIC_NAMES`, `METRIC_LABEL_KEYS`, `EVENT_NAMES`,
+`ERROR_TYPES`, `FAILURE_DISPOSITIONS`, `OUTCOMES`, `SPAN_NAME_ALIASES`, and
+`TRACE_ATTRIBUTE_ALIASES` in `archetype._obs` are the single machine-readable
+vocabulary. The repository audit consumes these literals; it must not maintain
+a second allowlist.
+
+Signal names are fixed. Unknown or dynamic names are no-ops. Custom attributes
+use the `archetype.*` namespace; `error.type` is the approved standard semantic
+key. Unknown keys, secret/content keys, unsupported mappings, and invalid
+values are omitted without calling arbitrary `str()`, `repr()`, iteration, or
+object properties.
+
+| Attribute class | Accepted representation |
+|---|---|
+| World, run, actor, or command ID | Canonical lowercase, hyphenated UUID string |
+| Bundle, attempt, idempotency, or correlation digest | Precomputed lowercase 64-character hexadecimal digest |
+| Entity ID, tick, or count | Exact non-boolean integer from zero through signed 64-bit maximum |
+| Component signature | Canonical `a_<count>c_s<16 lowercase hex>` storage signature |
+| Failure disposition, outcome, operation, or error type | Exact member of its immutable literal vocabulary |
+| Redaction rule IDs | Non-empty exact tuple of at most 16 bounded rule identifiers |
+
+Raw attempt IDs, idempotency keys, and arbitrary correlation strings are not
+aliases and are not hashed at the signal boundary, even when their text happens
+to look like a digest. A producer may supply an explicitly named semantic
+digest only after its owning layer has validated the source value. This avoids
+turning a credential or PII value into a stable, offline-guessable telemetry
+identifier. Canonical attributes take precedence when a temporary legacy alias
+is also present.
+
+Approved metric labels are only bounded operation, outcome, failure
+disposition, and error categories. World, run, actor, command, artifact,
+attempt, idempotency, mission, task, evaluation, and entity identifiers are
+never metric labels.
+
+The current canonical span vocabulary is:
+
+- `gateway.create_entity`, `gateway.create_world`, and
+  `gateway.get_world_info`;
+- `artifact.publish`, `artifact.upload`, and `artifact.index`; and
+- the existing bounded `world.query` and `world.update` scopes, without an
+  execution-attribution claim; and
+- the legacy `world.materialize` and `world.execute` phases listed in section 7
+  pending measured attribution.
+
+`gate.create_world` and `gate.get_world_info` temporarily normalize to the
+canonical `gateway.*` names. The deterministic audit introduced by #514 owns
+their source migration and expiry.
+
+## 3. Failure and outcome semantics
+
+A span helper yields `None`; callers never receive a raw OTel span that could
+bypass validation. The OTel current context contains a non-recording view with
+the same span context, retaining child-span parentage without exposing mutable
+attributes, events, or status. OpenTelemetry automatic exception recording and
+automatic status derivation are disabled.
+
+When an application `Exception` propagates through a span, `_obs`:
+
+1. preserves and re-raises the identical exception object;
+2. sets `ERROR` status without a description;
+3. records only a bounded `error.type`; and
+4. records no exception message, stack, object representation, or exception
+   event.
+
+Application control flow represented by `BaseException` outside `Exception`,
+including cancellation, `KeyboardInterrupt`, and `SystemExit`, propagates
+unchanged and leaves span status unset.
+
+`record_failure(..., disposition="handled" | "retrying")` emits a fixed safe
+event and bounded counter. It does not mark a successful enclosing operation
+as failed. `record_outcome()` emits only an approved advisory outcome. Neither
+helper replaces the family-owned result, receipt, retry row, or durable
+settlement that proves what happened.
+
+Failures while starting, entering, mutating, ending, exporting, or incrementing
+a signal are isolated at that exact signal operation. This rule does not permit
+broad suppression of application work under an “observability” label.
+
+## 4. Context and metric semantics
+
+`bind_context()` stores only validated canonical correlation coordinates in a
+`ContextVar`; nested bindings restore their predecessor on normal return or
+failure. `capture_context()` returns a detached copy suitable for #326's
+structured logging adapter. Context never contains payloads, prompts, paths,
+URLs, headers, exception text, or arbitrary object strings.
+
+Proxy tracers and counters may be created before a provider. Once a host
+registers a provider, future calls use it. Signals emitted before registration
+are dropped rather than buffered or replayed. Durable evidence is therefore
+the only source for recovery or retrospective truth.
+
+## 5. Process-host ownership
+
+Importing `_obs` installs no provider, exporter, logging handler, or vendor
+integration. `configure_tracing()` is an explicit process-host adapter used by
+runtime/server startup:
+
+- an existing host provider is respected and never replaced or shut down;
+- a no-backend decision remains unlatched so a later host can configure;
+- an Archetype-created provider candidate is installed once under a lock;
+- a candidate that loses every global signal-provider registration is shut down
+  without touching the host; a Logfire meter or logger that won its independent
+  global slot is never shut down merely because an external tracer won;
+- adapter failures produce only fixed diagnostics and remain retryable; and
+- Archetype-owned processors snapshot and revalidate approved Archetype scope,
+  names, attributes, events, status, context, and resource before enqueue or
+  export. Foreign fields, links, trace state, and status descriptions are
+  discarded.
+
+The SDK bundled for the explicit debug-console host path is not permission for
+family imports. Optional OTLP and Logfire integrations remain host concerns.
+`RunConfig.debug` controls execution diagnostics and is not a telemetry-export
+switch. #326 owns removing API import-time setup and correlating stdlib logs.
+
+## 6. Family dispositions
+
+| Family or layer | Current signal disposition | Authoritative outcome |
+|---|---|---|
+| Runtime host | Explicit provider/log-handler configuration; no family workflow span | Runtime lifecycle and returned/raised result |
+| CLI and API | No family-owned signals in this contract; #326 owns host/log correlation | HTTP result and gateway/domain result |
+| Gateway | Child spans for the three currently decorated operations | RBAC decision, typed application result, and access-audit evidence |
+| RuntimeApplication | No direct signal yet; lower owning family remains visible | Typed family result/exception |
+| Commands | No direct signal yet | Durable command ledger and settlement |
+| World lifecycle, mutation, simulation | Existing query/update scopes without execution-attribution claims; materialize/execute names are legacy pending #518/#519 | Tick manifest, world record, and typed result/exception |
+| Storage and query | No direct signal yet | Store/catalog state and returned frame |
+| Redaction | No direct signal; safe rule IDs may be carried by approved callers | Redaction receipt or quarantine exception |
+| Artifacts | Child spans for publish, upload, and index | Publication row, object/index state, and publish receipt |
+| Evaluation and research | No direct signal yet | Snapshot-pinned evaluation/research receipts |
+| Audit | Logging only; no direct signal yet | Journal/outbox and projection watermark |
+| Missions and sandboxes | No direct signal yet | Typed transition rows, attempt state, checkpoints, and artifacts |
+
+`none` means no new signal has been approved, not that an operation lacks an
+outcome. #514 turns these dispositions into per-family machine manifests and
+requires rationale for every `none` row.
+
+## 7. Lazy execution honesty
+
+`world.materialize` and `world.execute` are retained legacy names, not claims
+that Daft work was materialized or executed inside those spans. Processor
+methods commonly build lazy expressions whose work runs at a later terminal
+boundary. Telemetry must not add `.collect()`, `.to_pylist()`, or any other
+materialization to manufacture a duration.
+
+#518 must characterize Daft execution attribution and worker context with the
+locked version and supported runner. #519 then replaces or redefines these
+world phases from that evidence. Until then, no processor planning duration may
+be described as processor execution duration.

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -161,7 +161,11 @@ boundary. Core and app layers emit records but configure no handlers.
 
 Tracing uses the OpenTelemetry API. A host-registered provider is respected;
 optional Logfire or OTLP backends are selected only at the host/runtime
-boundary. With no configured backend the API remains a no-op.
+boundary. With no configured backend the API remains a no-op and does not
+prevent a later host from registering one. Signal names, safe attributes,
+failure handling, and metric cardinality follow the normative
+[Observability contract](observability.md); telemetry never changes a runtime
+result or exception.
 
 ### R14 — Public callables do not accept raw services
 

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -16,6 +16,7 @@ The current contract set is split across design docs and executable tests.
 |---|---|---|
 | `docs/guide/specification.md` | Umbrella contract overview | This page. Broad contracts plus links to focused specifications. |
 | [Runtime](runtime.md) | Trusted script boundary | `ArchetypeRuntime`, `RuntimeWorld`, sync parity, lifecycle, and actor-free application access. |
+| [Observability](observability.md) | Safe advisory signals | Vendor-neutral trace/metric vocabulary, bounded failure semantics, context, and process-host provider ownership. |
 | [Application Architecture](application-architecture.md) | Supported boundaries and dependency policy | Normative ownership, composition, encapsulation, and lint inputs. |
 | [Service Protocols](service-protocols.md) | Internal application ports | Active family interfaces behind `iRuntimeApplication` and `iCommandGateway`. |
 | [Command Gate](command-gate.md) | Authorization and roles | Four-role model, permissions matrix, audit emission shape. |

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -7,6 +7,7 @@ machine authority; this page is its review surface.
 
 | Contract | Owner | Risk | Normative source | Executable evidence | Profiles |
 | --- | --- | --- | --- | --- | --- |
+| `observability.signals.safe` | `observability` | high | [docs/guide/observability.md](../guide/observability.md) — 1. Safe signal contract | pytest: 2 | `pr`, `main`, `release` |
 | `sandboxes.attempt.phase_order` | `sandboxes` | high | [docs/guide/sandbox-execution.md](../guide/sandbox-execution.md) — 3. Six-phase attempt protocol | pytest: 2; static: 1; eval: 1 | `pr`, `main`, `release` |
 | `architecture.dependencies.enforced` | `app` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 11. Static enforcement | pytest: 1; static: 1; eval: 2 | `pr`, `main`, `release` |
 | `architecture.protocols.complete` | `app` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 8. Protocol policy and wiring | pytest: 1; static: 1; eval: 1 | `pr`, `main`, `release` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - Architecture Overview: guide/architecture.md
       - Application Architecture: guide/application-architecture.md
       - Runtime Contract: guide/runtime.md
+      - Observability: guide/observability.md
       - Specifications: guide/specification.md
       - Service Protocols: guide/service-protocols.md
       - Execution Hierarchy: guide/execution-hierarchy.md

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -1,6 +1,18 @@
 version = 1
 
 [[contract]]
+id = "observability.signals.safe"
+source = "docs/guide/observability.md"
+section = "1. Safe signal contract"
+owner = "observability"
+risk = "high"
+pytest = ["tests/app/test_obs.py", "tests/app/test_obs_process.py"]
+static = []
+evals = []
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
 id = "sandboxes.attempt.phase_order"
 source = "docs/guide/sandbox-execution.md"
 section = "3. Six-phase attempt protocol"

--- a/src/archetype/_obs.py
+++ b/src/archetype/_obs.py
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Archetype's observability boundary: vanilla OpenTelemetry, no vendor.
+"""Safe, vendor-neutral observability signals for Archetype.
 
-Every span archetype emits goes through this module and the OpenTelemetry
-*API* only. With no SDK configured the API is a no-op, so `import archetype`
-costs nothing and requires no telemetry vendor. Any OTel SDK that registers
-the global tracer provider — the runtime's own setup, a host application's,
-or Logfire's (which is an OTel SDK) — receives the same spans.
+Production code emits only through the OpenTelemetry API and this closed
+vocabulary.  Process hosts may install an SDK/provider; without one, proxy
+tracers and instruments are semantic no-ops.  Telemetry is diagnostic only:
+it never owns behavior, failure classification, retry, or durable authority.
 
-Nothing under ``src/`` may import ``logfire``; the only logfire-aware code
-paths are the optional backend selection in :func:`configure_tracing` (via
-importlib, never a hard import) and ``contrib/logfire_observer.py``, which
-is explicitly a Logfire integration.
+This module is imported by ``archetype.core`` and therefore cannot consume the
+application redaction family.  It is safe by construction instead: unknown
+names and keys are ignored, values are validated without arbitrary conversion,
+and exception messages/stacks are never handed to OpenTelemetry.
 """
 
 from __future__ import annotations
@@ -31,166 +30,912 @@ from __future__ import annotations
 import functools
 import inspect
 import logging
+import math
 import os
+import re
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
-from typing import Any, TypeVar, cast
+from contextvars import ContextVar
+from threading import Lock
+from types import MappingProxyType
+from typing import Any, Final, Literal, TypeVar, cast
+from uuid import UUID
 
-from opentelemetry import trace
+from opentelemetry import metrics, trace
+from opentelemetry.trace import Status, StatusCode
 
 logger = logging.getLogger(__name__)
 
-# The proxy tracer resolves the global provider at span time, so module
-# import order never matters: configure_tracing (or a host SDK) can run
-# before or after any instrumented module is imported.
-_tracer = trace.get_tracer("archetype")
+SIGNAL_SCHEMA_VERSION: Final = 1
+
+# Literal, runtime-readable vocabularies are intentionally declared here so
+# the deterministic audit introduced by #514 can consume the same authority.
+SPAN_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "artifact.index",
+        "artifact.publish",
+        "artifact.upload",
+        "gateway.create_entity",
+        "gateway.create_world",
+        "gateway.get_world_info",
+        "world.execute",
+        "world.materialize",
+        "world.query",
+        "world.update",
+    }
+)
+
+# ``world.execute`` and ``world.materialize`` describe legacy lazy-plan phases,
+# not proven execution timing.  #518/#519 own their replacement.  ``gate.*``
+# is normalized until #514 updates and expires the old call sites.
+LEGACY_SPAN_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "gate.create_world",
+        "gate.get_world_info",
+        "world.execute",
+        "world.materialize",
+    }
+)
+SPAN_NAME_ALIASES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "gate.create_world": "gateway.create_world",
+        "gate.get_world_info": "gateway.get_world_info",
+    }
+)
+
+TRACE_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "archetype.actor.id",
+        "archetype.artifact.bundle.digest",
+        "archetype.artifact.count",
+        "archetype.attempt.digest",
+        "archetype.command.id",
+        "archetype.component.signature",
+        "archetype.correlation.digest",
+        "archetype.entity.id",
+        "archetype.failure.disposition",
+        "archetype.idempotency.digest",
+        "archetype.operation",
+        "archetype.outcome",
+        "archetype.redaction.rule_ids",
+        "archetype.run.id",
+        "archetype.tick",
+        "archetype.world.id",
+        "error.type",
+    }
+)
+
+TRACE_ATTRIBUTE_ALIASES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "actor_id": "archetype.actor.id",
+        "artifact_count": "archetype.artifact.count",
+        "attempt_digest": "archetype.attempt.digest",
+        "bundle_id": "archetype.artifact.bundle.digest",
+        "command_id": "archetype.command.id",
+        "correlation_digest": "archetype.correlation.digest",
+        "entity_id": "archetype.entity.id",
+        "error_type": "error.type",
+        "failure_disposition": "archetype.failure.disposition",
+        "idempotency_digest": "archetype.idempotency.digest",
+        "operation": "archetype.operation",
+        "outcome": "archetype.outcome",
+        "redaction_rule_ids": "archetype.redaction.rule_ids",
+        "run_id": "archetype.run.id",
+        "sig": "archetype.component.signature",
+        "tick": "archetype.tick",
+        "world_id": "archetype.world.id",
+    }
+)
+
+METRIC_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "archetype.operation.failures",
+        "archetype.operation.outcomes",
+    }
+)
+METRIC_LABEL_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "archetype.failure.disposition",
+        "archetype.operation",
+        "archetype.outcome",
+        "error.type",
+    }
+)
+EVENT_NAMES: Final[frozenset[str]] = frozenset({"archetype.failure", "archetype.outcome"})
+FAILURE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"handled", "retrying"})
+OUTCOMES: Final[frozenset[str]] = frozenset({"duplicate", "expired", "rejected", "succeeded"})
+ERROR_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "authorization",
+        "conflict",
+        "internal",
+        "io",
+        "multiple",
+        "not_found",
+        "rate_limit",
+        "rejected",
+        "timeout",
+        "unavailable",
+        "validation",
+    }
+)
+
+FailureDisposition = Literal["handled", "retrying"]
+Outcome = Literal["duplicate", "expired", "rejected", "succeeded"]
+AttributeValue = str | bool | int | float | tuple[str, ...]
 
 _F = TypeVar("_F", bound=Callable[..., Any])
+_MAX_INT = (1 << 63) - 1
+_MAX_RULE_IDS = 16
+_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+_DIGEST_RE = re.compile(r"[0-9a-f]{64}")
+_SIGNATURE_RE = re.compile(r"a_(?:0|[1-9][0-9]{0,3})c_s[0-9a-f]{16}")
+_RULE_ID_RE = re.compile(r"[a-z0-9][a-z0-9_.-]{0,63}")
+_SERVICE_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,63}")
 
-# OTel attribute values must be str/bool/int/float or sequences thereof.
-_ATTR_TYPES = (str, bool, int, float)
+
+def _canonical_span_name(name: object) -> str | None:
+    if type(name) is not str:
+        return None
+    canonical = SPAN_NAME_ALIASES.get(name, name)
+    return canonical if canonical in SPAN_NAMES else None
 
 
-def _attributes(values: Mapping[str, Any]) -> dict[str, Any]:
-    return {
-        key: value if isinstance(value, _ATTR_TYPES) else str(value)
-        for key, value in values.items()
-        if value is not None
-    }
+def _uuid(value: object) -> str | None:
+    if type(value) is not str or not _UUID_RE.fullmatch(value):
+        return None
+    try:
+        parsed = UUID(value)
+    except ValueError:
+        return None
+    return value if str(parsed) == value else None
+
+
+def _digest(value: object) -> str | None:
+    if type(value) is not str or len(value) != 64:
+        return None
+    return value if _DIGEST_RE.fullmatch(value) else None
+
+
+def _nonnegative_int(value: object) -> int | None:
+    if type(value) is not int or value < 0 or value > _MAX_INT:
+        return None
+    return value
+
+
+def _rule_ids(value: object) -> tuple[str, ...] | None:
+    if type(value) is not tuple or not 0 < len(value) <= _MAX_RULE_IDS:
+        return None
+    if any(type(item) is not str or not _RULE_ID_RE.fullmatch(item) for item in value):
+        return None
+    return cast(tuple[str, ...], tuple(dict.fromkeys(value)))
+
+
+def _attribute_value(key: str, value: object) -> AttributeValue | None:
+    if key in {
+        "archetype.actor.id",
+        "archetype.command.id",
+        "archetype.run.id",
+        "archetype.world.id",
+    }:
+        return _uuid(value)
+    if key in {
+        "archetype.artifact.bundle.digest",
+        "archetype.attempt.digest",
+        "archetype.correlation.digest",
+        "archetype.idempotency.digest",
+    }:
+        return _digest(value)
+    if key in {"archetype.artifact.count", "archetype.entity.id", "archetype.tick"}:
+        return _nonnegative_int(value)
+    if key == "archetype.component.signature":
+        return value if type(value) is str and _SIGNATURE_RE.fullmatch(value) else None
+    if key == "archetype.failure.disposition":
+        return value if type(value) is str and value in FAILURE_DISPOSITIONS else None
+    if key == "archetype.operation":
+        return _canonical_span_name(value)
+    if key == "archetype.outcome":
+        return value if type(value) is str and value in OUTCOMES else None
+    if key == "archetype.redaction.rule_ids":
+        return _rule_ids(value)
+    if key == "error.type":
+        return value if type(value) is str and value in ERROR_TYPES else None
+    return None
+
+
+def _attributes(values: Mapping[str, Any]) -> dict[str, AttributeValue]:
+    """Return validated canonical trace attributes without coercion.
+
+    Only exact dictionaries are inspected.  This prevents a custom mapping,
+    key, value, ``__str__``, or iterator from running merely because telemetry
+    is enabled.  Internal immutable context is copied before reaching here.
+    """
+    if type(values) is not dict:
+        return {}
+
+    result: dict[str, AttributeValue] = {}
+    items = tuple(values.items())
+
+    # Canonical keys win regardless of insertion order when a legacy alias is
+    # supplied alongside its replacement.
+    for source, value in items:
+        if type(source) is not str or source not in TRACE_ATTRIBUTE_KEYS:
+            continue
+        normalized = _attribute_value(source, value)
+        if normalized is not None:
+            result[source] = normalized
+
+    for source, value in items:
+        if type(source) is not str:
+            continue
+        target = TRACE_ATTRIBUTE_ALIASES.get(source)
+        if target is None or target in result:
+            continue
+        normalized = _attribute_value(target, value)
+        if normalized is not None:
+            result[target] = normalized
+    return result
+
+
+def _metric_attributes(values: Mapping[str, Any] | None) -> dict[str, AttributeValue]:
+    if values is None:
+        return {}
+    return {key: value for key, value in _attributes(values).items() if key in METRIC_LABEL_KEYS}
+
+
+_signal_context: ContextVar[Mapping[str, AttributeValue]] = ContextVar(
+    "archetype_signal_context", default=MappingProxyType({})
+)
+_active_signal_span: ContextVar[Any | None] = ContextVar(
+    "archetype_active_signal_span", default=None
+)
+
+
+def capture_context() -> dict[str, AttributeValue]:
+    """Return a detached snapshot of the current safe correlation context."""
+    try:
+        return dict(_signal_context.get())
+    except BaseException:
+        return {}
 
 
 @contextmanager
-def span(name: str, **attributes: Any) -> Iterator[trace.Span]:
-    """Open one span around a block. No-op without a configured SDK."""
-    with _tracer.start_as_current_span(name, attributes=_attributes(attributes)) as active:
-        yield active
+def bind_context(
+    attributes: dict[str, Any] | None = None,
+    **legacy_attributes: Any,
+) -> Iterator[None]:
+    """Bind validated correlation fields for nested spans and structured logs."""
+    candidates: dict[str, Any] = {}
+    if type(attributes) is dict:
+        candidates.update(attributes)
+    candidates.update(legacy_attributes)
+    bound = capture_context()
+    bound.update(_attributes(candidates))
+    try:
+        token = _signal_context.set(MappingProxyType(bound))
+    except BaseException:
+        yield None
+        return
+    try:
+        yield None
+    finally:
+        try:
+            _signal_context.reset(token)
+        except BaseException:
+            pass
+
+
+# Proxy API objects resolve providers installed after this module is imported.
+_tracer = trace.get_tracer("archetype")
+_meter = metrics.get_meter("archetype")
+_counter_lock = Lock()
+_counters: dict[str, Any] = {}
+
+
+def _exception_mro(value: object) -> tuple[type, ...]:
+    try:
+        return cast(tuple[type, ...], type.__getattribute__(type(value), "__mro__"))
+    except BaseException:
+        return ()
+
+
+def _classify_error(error: BaseException) -> str:
+    bases = _exception_mro(error)
+    names: set[str] = set()
+    for base in bases:
+        try:
+            name = type.__getattribute__(base, "__name__")
+        except BaseException:
+            continue
+        if type(name) is str:
+            names.add(name)
+    if BaseExceptionGroup in bases:
+        return "multiple"
+    if "RateLimitError" in names:
+        return "rate_limit"
+    if "GuardrailError" in names or PermissionError in bases:
+        return "authorization"
+    if "SecretQuarantineError" in names or "PayloadRejectedError" in names:
+        return "rejected"
+    if "ConflictError" in names or "ClaimConflictError" in names:
+        return "conflict"
+    if "AvailabilityError" in names or ConnectionError in bases:
+        return "unavailable"
+    if TimeoutError in bases:
+        return "timeout"
+    if "WorldNotFoundError" in names or FileNotFoundError in bases or LookupError in bases:
+        return "not_found"
+    if TypeError in bases or ValueError in bases:
+        return "validation"
+    if OSError in bases:
+        return "io"
+    return "internal"
+
+
+def _mark_propagated_failure(active: Any, error: Exception) -> None:
+    category = _classify_error(error)
+    try:
+        active.set_attribute("error.type", category)
+    except BaseException:
+        pass
+    try:
+        active.set_status(Status(StatusCode.ERROR))
+    except BaseException:
+        pass
+
+
+@contextmanager
+def span(
+    name: str,
+    attributes: object = None,
+    **legacy_attributes: Any,
+) -> Iterator[None]:
+    """Open one safe span, or execute as a no-op when telemetry fails.
+
+    The current OTel context receives only a read-only non-recording view, so
+    child spans retain parent correlation without exposing the mutable span.
+    OpenTelemetry never observes an application exception, so it cannot record
+    a message or stack.  Callers receive no raw span handle.
+    """
+    canonical_name = _canonical_span_name(name)
+    if canonical_name is None:
+        yield None
+        return
+
+    candidates = capture_context()
+    if type(attributes) is dict:
+        candidates.update(cast(dict[str, Any], attributes))
+    candidates.update(legacy_attributes)
+    safe_attributes = _attributes(candidates)
+
+    active: Any = None
+    current_manager: Any = None
+    current_entered = False
+    active_token: Any = None
+    try:
+        active = _tracer.start_span(
+            canonical_name,
+            attributes=safe_attributes,
+        )
+    except BaseException:
+        active = None
+    if active is not None:
+        active_context: Any = None
+        try:
+            candidate_context = active.get_span_context()
+            if candidate_context.is_valid:
+                active_context = candidate_context
+        except BaseException:
+            active_context = None
+        if active_context is not None:
+            try:
+                safe_current = trace.NonRecordingSpan(active_context)
+                current_manager = trace.use_span(
+                    safe_current,
+                    end_on_exit=False,
+                    record_exception=False,
+                    set_status_on_exception=False,
+                )
+                current_manager.__enter__()
+                current_entered = True
+            except BaseException:
+                current_manager = None
+            try:
+                active_token = _active_signal_span.set(active)
+            except BaseException:
+                active_token = None
+
+    try:
+        yield None
+    except Exception as error:
+        if active is not None:
+            _mark_propagated_failure(active, error)
+        raise
+    finally:
+        if active_token is not None:
+            try:
+                _active_signal_span.reset(active_token)
+            except BaseException:
+                pass
+        if current_entered and current_manager is not None:
+            try:
+                current_manager.__exit__(None, None, None)
+            except BaseException:
+                pass
+        if active is not None:
+            try:
+                active.end()
+            except BaseException:
+                pass
 
 
 def instrument(name: str) -> Callable[[_F], _F]:
-    """Wrap a sync or async callable in one span of the given name."""
+    """Wrap a sync or async callable in one safe span."""
 
     def decorate(fn: _F) -> _F:
         if inspect.iscoroutinefunction(fn):
 
             @functools.wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                with _tracer.start_as_current_span(name):
+                with span(name):
                     return await fn(*args, **kwargs)
 
-            return cast(_F, async_wrapper)  # wraps preserves the signature
+            return cast(_F, async_wrapper)
 
         @functools.wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            with _tracer.start_as_current_span(name):
+            with span(name):
                 return fn(*args, **kwargs)
 
-        return cast(_F, wrapper)  # wraps preserves the signature
+        return cast(_F, wrapper)
 
     return decorate
 
 
+def counter_add(
+    name: str,
+    amount: int | float = 1,
+    *,
+    attributes: dict[str, Any] | None = None,
+) -> None:
+    """Add to one approved counter with bounded labels, otherwise no-op."""
+    if type(name) is not str or name not in METRIC_NAMES:
+        return
+    if type(amount) is int:
+        valid_amount = 0 < amount <= _MAX_INT
+    elif type(amount) is float:
+        valid_amount = math.isfinite(amount) and 0 < amount <= float(_MAX_INT)
+    else:
+        valid_amount = False
+    if not valid_amount:
+        return
+
+    try:
+        counter = _counters.get(name)
+        if counter is None:
+            with _counter_lock:
+                counter = _counters.get(name)
+                if counter is None:
+                    counter = _meter.create_counter(name)
+                    _counters[name] = counter
+        counter.add(amount, attributes=_metric_attributes(attributes))
+    except BaseException:
+        # A failed creation is retryable; do not retain a partially initialized
+        # instrument.  An add failure leaves a valid proxy/SDK counter cached.
+        if name not in _counters:
+            return
+
+
+def _safe_event(name: str, attributes: dict[str, Any]) -> None:
+    if type(name) is not str or name not in EVENT_NAMES:
+        return
+    try:
+        active = _active_signal_span.get()
+        if active is not None:
+            active.add_event(name, attributes=_attributes(attributes))
+    except BaseException:
+        pass
+
+
+def record_failure(error: BaseException, *, disposition: FailureDisposition) -> None:
+    """Record a handled/retrying failure without failing the enclosing span."""
+    if (
+        Exception not in _exception_mro(error)
+        or type(disposition) is not str
+        or disposition not in FAILURE_DISPOSITIONS
+    ):
+        return
+    category = _classify_error(error)
+    attributes = {
+        "error.type": category,
+        "archetype.failure.disposition": disposition,
+    }
+    _safe_event("archetype.failure", attributes)
+    counter_add("archetype.operation.failures", attributes=attributes)
+
+
+def record_outcome(outcome: Outcome, *, operation: str | None = None) -> None:
+    """Record a bounded advisory outcome; durable records remain authoritative."""
+    if type(outcome) is not str or outcome not in OUTCOMES:
+        return
+    attributes: dict[str, Any] = {"archetype.outcome": outcome}
+    if operation is not None:
+        attributes["archetype.operation"] = operation
+    _safe_event("archetype.outcome", attributes)
+    counter_add("archetype.operation.outcomes", attributes=attributes)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
-# Provider setup — called once, by the runtime (the script boundary)
+# Provider setup — explicit process-host adapter, never an import side effect
 # ─────────────────────────────────────────────────────────────────────────────
 
+_configuration_lock = Lock()
 _configured = False
+_owned_tracer_provider: object | None = None
+
+
+def _warn_fixed(message: str) -> None:
+    try:
+        logger.warning(message)
+    except BaseException:
+        pass
+
+
+def _safe_shutdown(provider: Any) -> None:
+    try:
+        provider.shutdown()
+    except BaseException:
+        pass
+
+
+def _logfire_provider_state(instance: Any) -> tuple[object | None, bool, bool]:
+    """Settle Logfire provider races without shutting down a winning signal."""
+    try:
+        installed_trace: object | None = trace.get_tracer_provider()
+    except BaseException:
+        installed_trace = None
+    if instance is None:
+        return installed_trace, False, False
+
+    candidate_trace: Any = None
+    candidate_meter: Any = None
+    candidate_logger: Any = None
+    installed_meter: Any = None
+    installed_logger: Any = None
+    try:
+        candidate_trace = getattr(instance, "_tracer_provider", None)
+    except BaseException:
+        pass
+    try:
+        candidate_meter = getattr(instance, "_meter_provider", None)
+        installed_meter = metrics.get_meter_provider()
+    except BaseException:
+        pass
+    try:
+        from opentelemetry import _logs
+
+        config = getattr(instance, "config", None)
+        candidate_logger = getattr(instance, "_logger_provider", None) or getattr(
+            config, "_logger_provider", None
+        )
+        installed_logger = _logs.get_logger_provider()
+    except BaseException:
+        pass
+
+    trace_won = candidate_trace is not None and installed_trace is candidate_trace
+    meter_won = candidate_meter is not None and installed_meter is candidate_meter
+    logger_won = candidate_logger is not None and installed_logger is candidate_logger
+    any_won = trace_won or meter_won or logger_won
+
+    if not any_won:
+        try:
+            instance.shutdown(flush=False)
+        except BaseException:
+            pass
+    for candidate, won in (
+        (candidate_trace, trace_won),
+        (candidate_meter, meter_won),
+        (candidate_logger, logger_won),
+    ):
+        if candidate is not None and not won:
+            _safe_shutdown(candidate)
+    return installed_trace, trace_won, any_won
+
+
+def _install_candidate(provider: Any) -> bool:
+    """Install our candidate or discard it if an external host won the race."""
+    global _owned_tracer_provider
+    try:
+        trace.set_tracer_provider(cast(trace.TracerProvider, provider))
+    except BaseException:
+        _safe_shutdown(provider)
+        return False
+
+    try:
+        installed = trace.get_tracer_provider()
+    except BaseException:
+        _safe_shutdown(provider)
+        return False
+    if installed is provider:
+        _owned_tracer_provider = provider
+        return True
+    _safe_shutdown(provider)
+    return type(installed) is not trace.ProxyTracerProvider
 
 
 def configure_tracing(*, service_name: str, debug_console: bool = False) -> None:
-    """Register a global tracer provider for this process, once.
+    """Configure tracing from an explicit process host.
 
-    Backend selection, in order:
-
-    1. A host application already registered a provider → respect it and do
-       nothing. Archetype is a library; the application owns the pipeline.
-    2. Logfire installed AND explicitly opted into (``LOGFIRE_TOKEN`` /
-       ``LOGFIRE_API_KEY`` / ``LOGFIRE_SEND_TO_LOGFIRE`` truthy) →
-       ``logfire.configure()``. Logfire is an OTel SDK: it registers the
-       global provider and every archetype span lands there.
-    3. ``OTEL_EXPORTER_OTLP_ENDPOINT`` / ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT``
-       set → SDK provider with the standard OTLP/HTTP exporter (which reads
-       the ``OTEL_*`` environment variables itself). Works with any
-       collector: Jaeger, Grafana, Honeycomb, a Logfire endpoint, ...
-    4. ``debug_console`` (ARCHETYPE_LOG=debug) → SDK provider with a terse
-       one-line console exporter on stderr, keeping stdout for the script.
-    5. Otherwise → leave the no-op OTel API in place: zero overhead, zero
-       output.
+    A prior host provider is never replaced or shut down.  With no requested
+    backend this leaves the API proxy in place and, importantly, does not latch:
+    a later runtime or external host can still install a provider.  Adapter
+    failures emit only fixed diagnostics and remain retryable.
     """
     global _configured
-    if _configured:
-        return
-    _configured = True
-
-    if not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider):
-        return  # path 1: the application already owns the pipeline
-
-    has_token = bool(os.environ.get("LOGFIRE_TOKEN") or os.environ.get("LOGFIRE_API_KEY"))
-    send_env = os.environ.get("LOGFIRE_SEND_TO_LOGFIRE", "").lower()
-    if has_token or send_env in ("1", "true", "yes"):
-        try:
-            import logfire
-
-            logfire.configure(
-                service_name=service_name,
-                send_to_logfire=True,
-                console=None if debug_console else False,
-            )
-            return  # path 2
-        except ImportError:
-            logger.warning(
-                "LOGFIRE_* environment set but logfire is not installed; "
-                "install archetype-ecs[logfire] to send there. Falling back."
-            )
-
-    otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or os.environ.get(
-        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+    safe_service_name = (
+        service_name
+        if type(service_name) is str and _SERVICE_NAME_RE.fullmatch(service_name)
+        else "archetype"
     )
-    if otlp_endpoint:
-        try:
-            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-            from opentelemetry.sdk.resources import Resource
-            from opentelemetry.sdk.trace import TracerProvider
-            from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-            provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
-            provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
-            if debug_console:
-                provider.add_span_processor(_console_processor())
-            trace.set_tracer_provider(provider)
-            return  # path 3
-        except ImportError:
-            logger.warning(
-                "OTEL_EXPORTER_OTLP_*ENDPOINT set but no OTLP exporter is "
-                "installed; install archetype-ecs[otlp]. Falling back."
+    with _configuration_lock:
+        if _configured:
+            return
+        try:
+            existing = trace.get_tracer_provider()
+        except BaseException:
+            return
+        if type(existing) is not trace.ProxyTracerProvider:
+            _configured = True
+            return
+
+        has_token = bool(os.environ.get("LOGFIRE_TOKEN") or os.environ.get("LOGFIRE_API_KEY"))
+        send_env = os.environ.get("LOGFIRE_SEND_TO_LOGFIRE", "").lower()
+        if has_token or send_env in {"1", "true", "yes"}:
+            logfire_instance: Any = None
+            try:
+                import logfire
+
+                logfire_instance = logfire.configure(
+                    service_name=safe_service_name,
+                    send_to_logfire=True,
+                    console=None if debug_console else False,
+                    add_baggage_to_attributes=False,
+                    inspect_arguments=False,
+                )
+            except ImportError:
+                _warn_fixed(
+                    "Logfire telemetry was requested but its optional adapter is unavailable."
+                )
+            except BaseException:
+                _warn_fixed("Logfire telemetry initialization failed; tracing remains retryable.")
+            else:
+                installed, trace_won, any_won = _logfire_provider_state(logfire_instance)
+                if trace_won:
+                    _configured = True
+                    return
+                if installed is not None and type(installed) is not trace.ProxyTracerProvider:
+                    _configured = True
+                    return
+
+        otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or os.environ.get(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+        )
+        if otlp_endpoint:
+            candidate: object | None = None
+            try:
+                from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                    OTLPSpanExporter,
+                )
+                from opentelemetry.sdk.resources import Resource
+                from opentelemetry.sdk.trace import TracerProvider
+                from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+                candidate = TracerProvider(resource=Resource({"service.name": safe_service_name}))
+                processor = BatchSpanProcessor(OTLPSpanExporter())
+                candidate.add_span_processor(
+                    _filtered_processor(processor, service_name=safe_service_name)
+                )
+                if debug_console:
+                    candidate.add_span_processor(_console_processor(service_name=safe_service_name))
+            except ImportError:
+                if candidate is not None:
+                    _safe_shutdown(candidate)
+                _warn_fixed("OTLP telemetry was requested but its optional adapter is unavailable.")
+            except BaseException:
+                if candidate is not None:
+                    _safe_shutdown(candidate)
+                _warn_fixed("OTLP telemetry initialization failed; tracing remains retryable.")
+            else:
+                if _install_candidate(candidate):
+                    _configured = True
+                    return
+
+        if debug_console:
+            candidate = None
+            try:
+                from opentelemetry.sdk.resources import Resource
+                from opentelemetry.sdk.trace import TracerProvider
+
+                candidate = TracerProvider(resource=Resource({"service.name": safe_service_name}))
+                candidate.add_span_processor(_console_processor(service_name=safe_service_name))
+            except BaseException:
+                if candidate is not None:
+                    _safe_shutdown(candidate)
+                _warn_fixed("Console telemetry initialization failed; tracing remains retryable.")
+            else:
+                if _install_candidate(candidate):
+                    _configured = True
+
+
+def _safe_span_context(value: object) -> Any | None:
+    """Clone IDs and sampling only, omitting arbitrary trace-state values."""
+    from opentelemetry.trace import SpanContext, TraceFlags, TraceState
+
+    if type(value) is not SpanContext or not value.is_valid:
+        return None
+    sampled = TraceFlags.SAMPLED if value.trace_flags.sampled else TraceFlags.DEFAULT
+    return SpanContext(
+        trace_id=value.trace_id,
+        span_id=value.span_id,
+        is_remote=value.is_remote,
+        trace_flags=TraceFlags(sampled),
+        trace_state=TraceState(),
+    )
+
+
+def _sanitized_sdk_span(value: object, *, service_name: str) -> Any | None:
+    """Return an exporter-safe immutable SDK snapshot, or drop the span."""
+    from opentelemetry.attributes import BoundedAttributes
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import Event, ReadableSpan
+    from opentelemetry.sdk.util import BoundedList
+    from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+
+    if type(value) is not ReadableSpan:
+        return None
+    try:
+        scope = value.instrumentation_scope
+        if type(scope) is not InstrumentationScope or scope.name != "archetype":
+            return None
+        canonical_name = _canonical_span_name(value.name)
+        context = _safe_span_context(value.context)
+        if canonical_name is None or context is None:
+            return None
+        if type(value.start_time) is not int or type(value.end_time) is not int:
+            return None
+        if not 0 <= value.start_time <= value.end_time <= _MAX_INT:
+            return None
+
+        parent = None
+        if value.parent is not None:
+            parent = _safe_span_context(value.parent)
+            if parent is None:
+                return None
+
+        attributes = _attributes(dict(value.attributes or {}))
+        events: list[Event] = []
+        for event in value.events:
+            if (
+                type(event) is not Event
+                or type(event.name) is not str
+                or event.name not in EVENT_NAMES
+            ):
+                continue
+            if type(event.timestamp) is not int or not 0 <= event.timestamp <= _MAX_INT:
+                continue
+            event_attributes = _attributes(dict(event.attributes or {}))
+            events.append(
+                Event(
+                    event.name,
+                    attributes=BoundedAttributes(attributes=event_attributes),
+                    timestamp=event.timestamp,
+                )
             )
 
-    if debug_console:
-        from opentelemetry.sdk.resources import Resource
-        from opentelemetry.sdk.trace import TracerProvider
+        status_code = value.status.status_code
+        if status_code not in {StatusCode.UNSET, StatusCode.OK, StatusCode.ERROR}:
+            status_code = StatusCode.UNSET
+        safe_service_name = (
+            service_name
+            if type(service_name) is str and _SERVICE_NAME_RE.fullmatch(service_name)
+            else "archetype"
+        )
+        return ReadableSpan(
+            name=canonical_name,
+            context=context,
+            parent=parent,
+            resource=Resource({"service.name": safe_service_name}),
+            attributes=BoundedAttributes(attributes=attributes),
+            events=BoundedList.from_seq(128, events),
+            links=BoundedList.from_seq(128, ()),
+            kind=trace.SpanKind.INTERNAL,
+            instrumentation_info=None,
+            status=Status(status_code),
+            start_time=value.start_time,
+            end_time=value.end_time,
+            instrumentation_scope=InstrumentationScope("archetype"),
+        )
+    except BaseException:
+        return None
 
-        provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
-        provider.add_span_processor(_console_processor())
-        trace.set_tracer_provider(provider)  # path 4
-    # path 5: no-op API stays
+
+def _approved_sdk_span(value: object) -> bool:
+    try:
+        scope = getattr(value, "instrumentation_scope", None)
+        return (
+            getattr(scope, "name", None) == "archetype"
+            and _canonical_span_name(getattr(value, "name", None)) is not None
+        )
+    except BaseException:
+        return False
 
 
-def _console_processor():
-    """One line per span on stderr: name, duration, attributes."""
+def _filtered_processor(processor: Any, *, service_name: str = "archetype") -> Any:
+    """Snapshot safe Archetype spans before any owned enqueue or export."""
+    from opentelemetry.sdk.trace import SpanProcessor
+
+    class _ArchetypeSpanProcessor(SpanProcessor):
+        def on_start(self, span: Any, parent_context: Any = None) -> None:
+            # BatchSpanProcessor and SimpleSpanProcessor have no start work.
+            # Never expose their wrapped processor to a mutable SDK span.
+            return None
+
+        def on_end(self, span: Any) -> None:
+            safe_span = _sanitized_sdk_span(span, service_name=service_name)
+            if safe_span is not None:
+                try:
+                    processor.on_end(safe_span)
+                except BaseException:
+                    pass
+
+        def shutdown(self) -> None:
+            try:
+                processor.shutdown()
+            except BaseException:
+                pass
+
+        def force_flush(self, timeout_millis: int = 30_000) -> bool:
+            try:
+                return bool(processor.force_flush(timeout_millis))
+            except BaseException:
+                return False
+
+    return _ArchetypeSpanProcessor()
+
+
+def _console_processor(*, service_name: str = "archetype") -> Any:
+    """Return a safe, Archetype-only one-line console span processor."""
     import sys
 
     from opentelemetry.sdk.trace import ReadableSpan
-    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+    from opentelemetry.sdk.trace.export import (
+        SimpleSpanProcessor,
+        SpanExporter,
+        SpanExportResult,
+    )
 
     class _OneLineExporter(SpanExporter):
         def export(self, spans: Any) -> SpanExportResult:
-            for s in spans:
-                assert isinstance(s, ReadableSpan)
-                dur_ms = ((s.end_time or 0) - (s.start_time or 0)) / 1e6
-                attrs = " ".join(f"{k}={v}" for k, v in (s.attributes or {}).items())
-                print(f"· {s.name} {dur_ms:.1f}ms {attrs}".rstrip(), file=sys.stderr)
+            try:
+                for finished in spans:
+                    if type(finished) is not ReadableSpan or not _approved_sdk_span(finished):
+                        continue
+                    name = _canonical_span_name(finished.name)
+                    if name is None:
+                        continue
+                    duration_ms = ((finished.end_time or 0) - (finished.start_time or 0)) / 1e6
+                    attributes = _attributes(dict(finished.attributes or {}))
+                    rendered = " ".join(f"{key}={value}" for key, value in attributes.items())
+                    print(
+                        f"· {name} {duration_ms:.1f}ms {rendered}".rstrip(),
+                        file=sys.stderr,
+                    )
+            except BaseException:
+                return SpanExportResult.FAILURE
             return SpanExportResult.SUCCESS
 
         def shutdown(self) -> None:
             return None
 
-    return SimpleSpanProcessor(_OneLineExporter())
+    return _filtered_processor(SimpleSpanProcessor(_OneLineExporter()), service_name=service_name)

--- a/tests/app/test_obs.py
+++ b/tests/app/test_obs.py
@@ -11,16 +11,25 @@ global provider, so no test poisons the process-wide OTel state.
 
 import asyncio
 import inspect
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any, cast
 
+import pytest
+from opentelemetry import context, trace
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, Status, StatusCode
 from uuid_utils import uuid7
 
 from archetype import _obs
 from archetype.app.container import ServiceContainer
 from archetype.app.gateway.auth.models import ActorCtx
 from archetype.core.config import WorldConfig
+
+pytestmark = pytest.mark.contract("observability.signals.safe")
 
 
 def _capture(monkeypatch) -> InMemorySpanExporter:
@@ -46,19 +55,498 @@ def test_instrument_is_a_noop_without_any_provider():
     assert add.__name__ == "add" and mul.__name__ == "mul"
 
 
-def test_span_coerces_attributes_and_drops_none(monkeypatch):
+def test_span_accepts_only_key_specific_safe_attributes(monkeypatch):
     exporter = _capture(monkeypatch)
+    world_id = str(uuid7())
+    idempotency_key = "Bearer should-not-be-exported"
+    bundle_digest = "0123456789abcdef" * 4
 
     class Opaque:
         def __str__(self) -> str:
-            return "opaque-repr"
+            raise AssertionError("telemetry must not stringify arbitrary objects")
 
-    with _obs.span("unit.attrs", sig="a_1", tick=3, obj=Opaque(), skipped=None):
+    with _obs.span(
+        "world.query",
+        sig="a_1c_s0123456789abcdef",
+        tick=3,
+        world_id=world_id,
+        idempotency_key=idempotency_key,
+        bundle_id=bundle_digest,
+        obj=Opaque(),
+        password="not-exported",
+        skipped=None,
+    ) as active:
+        assert active is None, "callers must not receive a raw OTel span handle"
         pass
 
     (span,) = exporter.get_finished_spans()
-    assert span.name == "unit.attrs"
-    assert span.attributes == {"sig": "a_1", "tick": 3, "obj": "opaque-repr"}
+    assert span.name == "world.query"
+    assert span.attributes == {
+        "archetype.artifact.bundle.digest": bundle_digest,
+        "archetype.component.signature": "a_1c_s0123456789abcdef",
+        "archetype.tick": 3,
+        "archetype.world.id": world_id,
+    }
+
+
+def test_invalid_names_and_values_are_safe_noops(monkeypatch):
+    exporter = _capture(monkeypatch)
+
+    with _obs.span("dynamic.secret.Bearer-token", tick=True, world_id="not-a-uuid"):
+        result = "application-result"
+
+    assert result == "application-result"
+    assert exporter.get_finished_spans() == ()
+
+
+def test_keyword_attribute_mapping_and_legacy_keywords_are_both_supported(monkeypatch):
+    exporter = _capture(monkeypatch)
+    world_id = str(uuid7())
+
+    with _obs.span("world.query", attributes={"world_id": world_id}, tick=4):
+        pass
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes == {
+        "archetype.tick": 4,
+        "archetype.world.id": world_id,
+    }
+
+
+def test_current_span_is_read_only_but_nested_spans_keep_parentage(monkeypatch):
+    exporter = _capture(monkeypatch)
+
+    with _obs.span("artifact.publish"):
+        visible = trace.get_current_span()
+        assert isinstance(visible, trace.NonRecordingSpan)
+        visible.set_attribute("password", "Bearer should-not-be-exported")
+        visible.add_event("exception", {"exception.message": "Bearer should-not-be-exported"})
+        with _obs.span("artifact.index"):
+            pass
+
+    inner, outer = exporter.get_finished_spans()
+    assert inner.name == "artifact.index"
+    assert outer.name == "artifact.publish"
+    assert inner.parent == outer.context
+    assert outer.attributes == {}
+    assert outer.events == ()
+
+
+def test_propagated_failure_records_only_bounded_error_type(monkeypatch):
+    exporter = _capture(monkeypatch)
+
+    class SecretError(RuntimeError):
+        def __str__(self) -> str:
+            return "Bearer should-not-be-exported"
+
+    error = SecretError()
+    with pytest.raises(SecretError) as captured:
+        with _obs.span("artifact.publish"):
+            raise error
+
+    assert captured.value is error
+    (finished,) = exporter.get_finished_spans()
+    assert finished.status.status_code is StatusCode.ERROR
+    assert finished.status.description is None
+    assert finished.attributes == {"error.type": "internal"}
+    assert finished.events == ()
+    assert "Bearer" not in repr(finished.to_json())
+
+
+def test_exception_class_metadata_cannot_replace_application_exception(monkeypatch):
+    exporter = _capture(monkeypatch)
+
+    class HostileMeta(type):
+        def __getattribute__(cls, name):
+            if name == "__name__":
+                raise RuntimeError("secret class metadata")
+            return super().__getattribute__(name)
+
+    class HostileError(RuntimeError, metaclass=HostileMeta):
+        def __str__(self):
+            raise RuntimeError("secret string")
+
+        def __repr__(self):
+            raise RuntimeError("secret representation")
+
+    error = HostileError()
+    with pytest.raises(HostileError) as captured:
+        with _obs.span("artifact.publish"):
+            raise error
+
+    assert captured.value is error
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes == {"error.type": "internal"}
+
+
+def test_exception_instance_metadata_cannot_replace_application_exception(monkeypatch):
+    exporter = _capture(monkeypatch)
+
+    class HostileError(RuntimeError):
+        def __getattribute__(self, name):
+            if name == "__class__":
+                raise RuntimeError("telemetry replacement")
+            return super().__getattribute__(name)
+
+    error = HostileError()
+    with pytest.raises(HostileError) as captured:
+        with _obs.span("artifact.publish"):
+            raise error
+
+    assert captured.value is error
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes == {"error.type": "internal"}
+
+    with _obs.span("artifact.upload"):
+        _obs.record_failure(error, disposition="handled")
+
+
+def test_handled_and_retried_failures_do_not_mark_successful_span_failed(monkeypatch):
+    exporter = _capture(monkeypatch)
+
+    class SecretError(RuntimeError):
+        def __str__(self) -> str:
+            raise AssertionError("failure telemetry must not inspect exception messages")
+
+    with _obs.span("artifact.upload"):
+        _obs.record_failure(SecretError(), disposition="handled")
+        _obs.record_failure(TimeoutError(), disposition="retrying")
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.status.status_code is StatusCode.UNSET
+    assert [event.name for event in finished.events] == [
+        "archetype.failure",
+        "archetype.failure",
+    ]
+    assert [dict(event.attributes or {}) for event in finished.events] == [
+        {"archetype.failure.disposition": "handled", "error.type": "internal"},
+        {"archetype.failure.disposition": "retrying", "error.type": "timeout"},
+    ]
+
+
+def test_cancellation_propagates_without_error_telemetry(monkeypatch):
+    exporter = _capture(monkeypatch)
+    cancellation = asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError) as captured:
+        with _obs.span("artifact.index"):
+            raise cancellation
+
+    assert captured.value is cancellation
+    (finished,) = exporter.get_finished_spans()
+    assert finished.status.status_code is StatusCode.UNSET
+    assert finished.attributes == {}
+    assert finished.events == ()
+
+
+def test_context_binding_is_nested_safe_and_restored(monkeypatch):
+    exporter = _capture(monkeypatch)
+    world_id = str(uuid7())
+    run_id = str(uuid7())
+    correlation = "arbitrary possibly secret correlation value"
+    correlation_digest = "abcdef0123456789" * 4
+
+    assert _obs.capture_context() == {}
+    with _obs.bind_context(
+        world_id=world_id,
+        correlation_id=correlation,
+        correlation_digest=correlation_digest,
+        payload=object(),
+    ):
+        assert _obs.capture_context() == {
+            "archetype.correlation.digest": correlation_digest,
+            "archetype.world.id": world_id,
+        }
+        with _obs.bind_context(run_id=run_id):
+            assert _obs.capture_context() == {
+                "archetype.correlation.digest": correlation_digest,
+                "archetype.run.id": run_id,
+                "archetype.world.id": world_id,
+            }
+        assert _obs.capture_context() == {
+            "archetype.correlation.digest": correlation_digest,
+            "archetype.world.id": world_id,
+        }
+        with pytest.raises(ValueError):
+            with _obs.bind_context(command_id=str(uuid7())):
+                raise ValueError("application failure")
+        assert _obs.capture_context() == {
+            "archetype.correlation.digest": correlation_digest,
+            "archetype.world.id": world_id,
+        }
+        with _obs.span("gate.get_world_info"):
+            pass
+    assert _obs.capture_context() == {}
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes == {
+        "archetype.correlation.digest": correlation_digest,
+        "archetype.world.id": world_id,
+    }
+
+
+def test_signal_emission_failure_never_changes_application_behavior(monkeypatch):
+    class BrokenTracer:
+        def start_span(self, *args, **kwargs):
+            raise RuntimeError("provider diagnostic with secret")
+
+    monkeypatch.setattr(_obs, "_tracer", BrokenTracer())
+
+    with _obs.span("artifact.publish"):
+        result = 42
+
+    assert result == 42
+
+
+def test_provider_control_flow_failures_cannot_replace_application_control_flow(monkeypatch):
+    provider_interrupt = KeyboardInterrupt("provider only")
+
+    class StartFailureTracer:
+        def start_span(self, *args, **kwargs):
+            raise provider_interrupt
+
+    monkeypatch.setattr(_obs, "_tracer", StartFailureTracer())
+    with _obs.span("artifact.publish"):
+        result = "body-ran"
+    assert result == "body-ran"
+
+    class EndFailureActive:
+        def get_span_context(self):
+            return trace.INVALID_SPAN_CONTEXT
+
+        def end(self):
+            raise KeyboardInterrupt("provider cleanup only")
+
+    class EndFailureTracer:
+        def start_span(self, *args, **kwargs):
+            return EndFailureActive()
+
+    application_cancellation = asyncio.CancelledError()
+    monkeypatch.setattr(_obs, "_tracer", EndFailureTracer())
+    with pytest.raises(asyncio.CancelledError) as captured:
+        with _obs.span("artifact.publish"):
+            raise application_cancellation
+    assert captured.value is application_cancellation
+
+
+def test_signal_context_and_end_failures_are_semantic_noops(monkeypatch):
+    class BrokenActive:
+        def get_span_context(self):
+            return trace.SpanContext(
+                trace_id=1,
+                span_id=2,
+                is_remote=False,
+                trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+            )
+
+        def end(self):
+            raise RuntimeError("secret end diagnostic")
+
+    class BrokenTracer:
+        def start_span(self, *args, **kwargs):
+            return BrokenActive()
+
+    class BrokenManager:
+        def __enter__(self):
+            raise RuntimeError("secret context diagnostic")
+
+        def __exit__(self, *exc_info):
+            raise RuntimeError("secret exit diagnostic")
+
+    monkeypatch.setattr(_obs, "_tracer", BrokenTracer())
+    monkeypatch.setattr(_obs.trace, "use_span", lambda *args, **kwargs: BrokenManager())
+
+    with _obs.span("artifact.publish"):
+        result = 3
+
+    assert result == 3
+
+
+def test_status_failures_cannot_replace_application_exception(monkeypatch):
+    application_error = ValueError("application secret")
+
+    class BrokenActive:
+        def get_span_context(self):
+            return trace.INVALID_SPAN_CONTEXT
+
+        def set_attribute(self, *args, **kwargs):
+            raise RuntimeError("attribute secret")
+
+        def set_status(self, *args, **kwargs):
+            raise RuntimeError("status secret")
+
+        def end(self):
+            raise RuntimeError("exit secret")
+
+    class Tracer:
+        def start_span(self, *args, **kwargs):
+            return BrokenActive()
+
+    monkeypatch.setattr(_obs, "_tracer", Tracer())
+
+    with pytest.raises(ValueError) as captured:
+        with _obs.span("artifact.publish"):
+            raise application_error
+    assert captured.value is application_error
+
+
+def test_counter_creation_and_add_failures_are_semantic_noops(monkeypatch):
+    class BrokenMeter:
+        def create_counter(self, name):
+            raise RuntimeError("counter creation secret")
+
+    monkeypatch.setattr(_obs, "_meter", BrokenMeter())
+    monkeypatch.setattr(_obs, "_counters", {})
+    _obs.counter_add("archetype.operation.failures")
+
+    class BrokenCounter:
+        def add(self, amount, *, attributes):
+            raise KeyboardInterrupt("counter add control flow")
+
+    monkeypatch.setattr(_obs, "_counters", {"archetype.operation.failures": BrokenCounter()})
+    _obs.counter_add(
+        "archetype.operation.failures",
+        attributes={"world_id": str(uuid7()), "error_type": "internal"},
+    )
+
+    class BrokenEvent:
+        def add_event(self, *args, **kwargs):
+            raise KeyboardInterrupt("event control flow")
+
+    token = _obs._active_signal_span.set(BrokenEvent())
+    try:
+        _obs.record_failure(RuntimeError(), disposition="handled")
+    finally:
+        _obs._active_signal_span.reset(token)
+
+
+def test_losing_provider_candidate_is_shutdown_without_touching_host(monkeypatch):
+    class Candidate:
+        def __init__(self) -> None:
+            self.shutdown_calls = 0
+
+        def shutdown(self) -> None:
+            self.shutdown_calls += 1
+
+    class Host:
+        def __init__(self) -> None:
+            self.shutdown_calls = 0
+
+        def shutdown(self) -> None:
+            self.shutdown_calls += 1
+
+    candidate = Candidate()
+    host = Host()
+    monkeypatch.setattr(_obs.trace, "set_tracer_provider", lambda provider: None)
+    monkeypatch.setattr(_obs.trace, "get_tracer_provider", lambda: host)
+    monkeypatch.setattr(_obs, "_owned_tracer_provider", None)
+
+    assert _obs._install_candidate(candidate) is True
+    assert candidate.shutdown_calls == 1
+    assert host.shutdown_calls == 0
+    assert _obs._owned_tracer_provider is None
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ({"tick": True, "entity_id": -1, "artifact_count": 1 << 63}, {}),
+        ({"world_id": "NOT-A-UUID", "run_id": str(uuid7()).upper()}, {}),
+        ({"attempt_id": "attempt-1", "idempotency_key": "publish-1"}, {}),
+        (
+            {
+                "attempt_id": "a" * 64,
+                "correlation_id": "b" * 64,
+                "idempotency_key": "c" * 64,
+                "sig": "a_0001c_s0123456789abcdef",
+            },
+            {},
+        ),
+        (
+            {
+                "redaction_rule_ids": ("provider.openai", "provider.openai"),
+                "sig": "a_2c_s0123456789abcdef",
+            },
+            {
+                "archetype.component.signature": "a_2c_s0123456789abcdef",
+                "archetype.redaction.rule_ids": ("provider.openai",),
+            },
+        ),
+        (
+            {"sig": "a_0c_s0123456789abcdef"},
+            {"archetype.component.signature": "a_0c_s0123456789abcdef"},
+        ),
+    ],
+)
+def test_attribute_validators_are_exact_and_bounded(values, expected):
+    assert _obs._attributes(values) == expected
+
+
+def test_hostile_mapping_proxy_and_malformed_unicode_are_omitted(monkeypatch):
+    class HostileMapping(Mapping):
+        def __getitem__(self, key):
+            raise AssertionError("telemetry must not inspect a hostile mapping")
+
+        def __iter__(self):
+            raise AssertionError("telemetry must not iterate a hostile mapping")
+
+        def __len__(self):
+            raise AssertionError("telemetry must not size a hostile mapping")
+
+        def items(self):
+            raise AssertionError("telemetry must not call hostile mapping methods")
+
+    proxy = MappingProxyType(HostileMapping())
+    assert _obs._attributes(proxy) == {}
+
+    exporter = _capture(monkeypatch)
+    malformed = "\ud800" * 64
+    with _obs.bind_context(bundle_id=malformed):
+        assert _obs.capture_context() == {}
+        with _obs.span("artifact.publish", bundle_id=malformed):
+            result = "unchanged"
+
+    assert result == "unchanged"
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes == {}
+
+
+def test_signal_vocabulary_is_immutable_and_namespaced():
+    assert isinstance(_obs.SPAN_NAMES, frozenset)
+    assert isinstance(_obs.LEGACY_SPAN_NAMES, frozenset)
+    assert isinstance(_obs.TRACE_ATTRIBUTE_KEYS, frozenset)
+    assert isinstance(_obs.METRIC_NAMES, frozenset)
+    assert isinstance(_obs.METRIC_LABEL_KEYS, frozenset)
+    assert isinstance(_obs.EVENT_NAMES, frozenset)
+    assert isinstance(_obs.SPAN_NAME_ALIASES, MappingProxyType)
+    assert isinstance(_obs.TRACE_ATTRIBUTE_ALIASES, MappingProxyType)
+    assert all(name.startswith("archetype.") for name in _obs.METRIC_NAMES)
+    assert all(
+        key.startswith("archetype.") or key == "error.type" for key in _obs.TRACE_ATTRIBUTE_KEYS
+    )
+    assert {
+        "archetype.world.id",
+        "archetype.run.id",
+        "archetype.entity.id",
+        "archetype.attempt.digest",
+        "archetype.idempotency.digest",
+    }.isdisjoint(_obs.METRIC_LABEL_KEYS)
+
+
+def test_outcome_helper_is_bounded_and_advisory(monkeypatch):
+    exporter = _capture(monkeypatch)
+
+    with _obs.span("artifact.publish"):
+        _obs.record_outcome("duplicate", operation="artifact.publish")
+        _obs.record_outcome(cast(Any, "user-controlled"), operation="secret.dynamic")
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.status.status_code is StatusCode.UNSET
+    assert [event.name for event in finished.events] == ["archetype.outcome"]
+    assert dict(finished.events[0].attributes or {}) == {
+        "archetype.operation": "artifact.publish",
+        "archetype.outcome": "duplicate",
+    }
 
 
 def test_gate_operations_emit_otel_spans(monkeypatch):
@@ -77,8 +565,8 @@ def test_gate_operations_emit_otel_spans(monkeypatch):
     asyncio.run(drive())
 
     names = {s.name for s in exporter.get_finished_spans()}
-    assert "gate.create_world" in names
-    assert "gate.get_world_info" in names
+    assert "gateway.create_world" in names
+    assert "gateway.get_world_info" in names
 
 
 def test_console_processor_prints_one_line_per_span(monkeypatch, capsys):
@@ -86,9 +574,99 @@ def test_console_processor_prints_one_line_per_span(monkeypatch, capsys):
     provider.add_span_processor(_obs._console_processor())
     monkeypatch.setattr(_obs, "_tracer", provider.get_tracer("archetype"))
 
-    with _obs.span("debug.line", tick=7):
+    with _obs.span("world.query", tick=7):
         pass
 
     err = capsys.readouterr().err
-    assert "debug.line" in err and "tick=7" in err
-    assert "\n" == err[-1] and err.count("debug.line") == 1
+    assert "world.query" in err and "archetype.tick=7" in err
+    assert "\n" == err[-1] and err.count("world.query") == 1
+
+
+def test_console_processor_drops_foreign_secret_bearing_spans(capsys):
+    provider = TracerProvider()
+    provider.add_span_processor(_obs._console_processor())
+    foreign = provider.get_tracer("foreign")
+
+    with foreign.start_as_current_span(
+        "foreign.request", attributes={"password": "Bearer should-not-be-exported"}
+    ):
+        pass
+
+    assert capsys.readouterr().err == ""
+
+
+def test_owned_processor_snapshots_same_scope_spans_before_export():
+    secret = "Bearer should-not-be-exported"
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(
+        resource=Resource({"service.name": "unsafe-host", "password": secret})
+    )
+    provider.add_span_processor(
+        _obs._filtered_processor(SimpleSpanProcessor(exporter), service_name="archetype-test")
+    )
+    direct = provider.get_tracer(
+        "archetype", instrumenting_library_version=secret, schema_url=f"https://{secret}"
+    )
+    parent_context = trace.SpanContext(
+        trace_id=1,
+        span_id=2,
+        is_remote=True,
+        trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+        trace_state=trace.TraceState((("vendor", "secret-trace-state"),)),
+    )
+    link_context = trace.SpanContext(trace_id=3, span_id=4, is_remote=True)
+    token = context.attach(trace.set_span_in_context(trace.NonRecordingSpan(parent_context)))
+    try:
+        with direct.start_as_current_span(
+            "artifact.publish",
+            attributes={"archetype.tick": 5, "password": secret},
+            links=(trace.Link(link_context, {"password": secret}),),
+            kind=SpanKind.CLIENT,
+        ) as active:
+            active.set_status(Status(StatusCode.ERROR, secret))
+            active.add_event("exception", {"exception.message": secret})
+            active.add_event(
+                "archetype.failure",
+                {"error.type": "timeout", "password": secret},
+            )
+    finally:
+        context.detach(token)
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.name == "artifact.publish"
+    assert finished.attributes == {"archetype.tick": 5}
+    assert finished.kind is SpanKind.INTERNAL
+    assert finished.status.status_code is StatusCode.ERROR
+    assert finished.status.description is None
+    assert finished.resource.attributes == {"service.name": "archetype-test"}
+    scope = finished.instrumentation_scope
+    assert scope is not None
+    assert scope.name == "archetype"
+    assert scope.version is None
+    assert not scope.schema_url
+    assert finished.links == ()
+    assert finished.context.trace_state == trace.TraceState()
+    assert finished.parent is not None
+    assert finished.parent.trace_state == trace.TraceState()
+    assert [event.name for event in finished.events] == ["archetype.failure"]
+    assert dict(finished.events[0].attributes or {}) == {"error.type": "timeout"}
+    assert hasattr(finished._attributes, "dropped")
+    assert hasattr(finished._events, "dropped")
+    assert hasattr(finished.events[0]._attributes, "dropped")
+    assert secret not in finished.to_json()
+
+
+def test_owned_processor_drops_malformed_same_scope_span_timestamps():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(_obs._filtered_processor(SimpleSpanProcessor(exporter)))
+    direct = provider.get_tracer("archetype")
+
+    class HostileTimestamp:
+        def __repr__(self):
+            raise AssertionError("export must not render a hostile timestamp")
+
+    active = direct.start_span("artifact.publish", start_time=cast(Any, HostileTimestamp()))
+    active.end(end_time=cast(Any, HostileTimestamp()))
+
+    assert exporter.get_finished_spans() == ()

--- a/tests/app/test_obs_process.py
+++ b/tests/app/test_obs_process.py
@@ -1,0 +1,381 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-global provider contracts for the internal signal boundary."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = [
+    pytest.mark.contract("observability.signals.safe"),
+    pytest.mark.process,
+]
+
+
+def _run(source: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in tuple(env):
+        if key.startswith(("LOGFIRE_", "OTEL_")) or key == "ARCHETYPE_LOG":
+            env.pop(key)
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_noop_configuration_does_not_block_later_host_configuration() -> None:
+    result = _run(
+        """
+        from opentelemetry import trace
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        assert _obs._configured is False
+        assert isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+
+        _obs.configure_tracing(service_name="archetype-test", debug_console=True)
+        assert _obs._configured is True
+        assert not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_host_provider_is_respected() -> None:
+    result = _run(
+        """
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry import trace
+
+        host = TracerProvider()
+        trace.set_tracer_provider(host)
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test", debug_console=True)
+        assert trace.get_tracer_provider() is host
+        assert _obs._owned_tracer_provider is None
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_host_adapter_failure_is_safe_and_does_not_latch() -> None:
+    result = _run(
+        """
+        import os
+        import sys
+        import types
+        from archetype import _obs
+
+        def fail(**kwargs):
+            raise RuntimeError("Bearer should-not-be-exported")
+
+        sys.modules["logfire"] = types.SimpleNamespace(configure=fail)
+        os.environ["LOGFIRE_SEND_TO_LOGFIRE"] = "true"
+        _obs.configure_tracing(service_name="archetype-test")
+        assert _obs._configured is False
+
+        del os.environ["LOGFIRE_SEND_TO_LOGFIRE"]
+        _obs.configure_tracing(service_name="archetype-test", debug_console=True)
+        assert _obs._configured is True
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Bearer should-not-be-exported" not in result.stderr
+
+
+def test_noop_logfire_adapter_does_not_latch_configuration() -> None:
+    result = _run(
+        """
+        import os
+        import sys
+        import types
+        from opentelemetry import trace
+        from archetype import _obs
+
+        sys.modules["logfire"] = types.SimpleNamespace(configure=lambda **kwargs: None)
+        os.environ["LOGFIRE_SEND_TO_LOGFIRE"] = "true"
+        _obs.configure_tracing(service_name="archetype-test")
+        assert _obs._configured is False
+        assert isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+
+        del os.environ["LOGFIRE_SEND_TO_LOGFIRE"]
+        _obs.configure_tracing(service_name="archetype-test", debug_console=True)
+        assert _obs._configured is True
+        assert not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_logfire_adapter_disables_implicit_content_capture() -> None:
+    result = _run(
+        """
+        import os
+        import sys
+        import types
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from archetype import _obs
+
+        captured = {}
+        candidate = TracerProvider()
+
+        class Instance:
+            _tracer_provider = candidate
+
+            def shutdown(self, *, flush):
+                raise AssertionError("installed provider must not be shut down")
+
+        def configure(**kwargs):
+            captured.update(kwargs)
+            trace.set_tracer_provider(candidate)
+            return Instance()
+
+        sys.modules["logfire"] = types.SimpleNamespace(configure=configure)
+        os.environ["LOGFIRE_SEND_TO_LOGFIRE"] = "true"
+        _obs.configure_tracing(service_name="archetype-test")
+
+        assert _obs._configured is True
+        assert captured["add_baggage_to_attributes"] is False
+        assert captured["inspect_arguments"] is False
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_losing_logfire_candidate_is_shutdown_and_host_is_respected() -> None:
+    result = _run(
+        """
+        import os
+        import sys
+        import types
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from archetype import _obs
+
+        host = TracerProvider()
+        candidate = TracerProvider()
+
+        class Instance:
+            _tracer_provider = candidate
+            shutdown_calls = 0
+
+            def shutdown(self, *, flush):
+                assert flush is False
+                self.shutdown_calls += 1
+
+        instance = Instance()
+
+        def configure(**kwargs):
+            trace.set_tracer_provider(host)
+            return instance
+
+        sys.modules["logfire"] = types.SimpleNamespace(configure=configure)
+        os.environ["LOGFIRE_SEND_TO_LOGFIRE"] = "true"
+        _obs.configure_tracing(service_name="archetype-test")
+
+        assert trace.get_tracer_provider() is host
+        assert instance.shutdown_calls == 1
+        assert _obs._configured is True
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_logfire_meter_winner_is_not_shutdown_when_host_trace_wins() -> None:
+    result = _run(
+        """
+        import os
+        import sys
+        import types
+        from opentelemetry import metrics, trace
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.trace import TracerProvider
+        from archetype import _obs
+
+        host_trace = TracerProvider()
+        candidate_trace = TracerProvider()
+        candidate_meter = MeterProvider()
+
+        class Instance:
+            _tracer_provider = candidate_trace
+            _meter_provider = candidate_meter
+            shutdown_calls = 0
+
+            def shutdown(self, *, flush):
+                self.shutdown_calls += 1
+                candidate_meter.shutdown()
+
+        instance = Instance()
+
+        def configure(**kwargs):
+            trace.set_tracer_provider(host_trace)
+            metrics.set_meter_provider(candidate_meter)
+            return instance
+
+        sys.modules["logfire"] = types.SimpleNamespace(configure=configure)
+        os.environ["LOGFIRE_SEND_TO_LOGFIRE"] = "true"
+        _obs.configure_tracing(service_name="archetype-test")
+
+        assert trace.get_tracer_provider() is host_trace
+        assert metrics.get_meter_provider() is candidate_meter
+        assert instance.shutdown_calls == 0
+        assert _obs._configured is True
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_real_logfire_losing_logger_provider_is_explicitly_shutdown() -> None:
+    result = _run(
+        """
+        import os
+        import logfire
+        from opentelemetry import _logs, metrics, trace
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.trace import TracerProvider
+        from archetype import _obs
+
+        host_trace = TracerProvider()
+        host_meter = MeterProvider()
+        host_logger = LoggerProvider()
+        real_configure = logfire.configure
+        state = {"logger_shutdown_calls": 0}
+
+        def configure(**kwargs):
+            trace.set_tracer_provider(host_trace)
+            metrics.set_meter_provider(host_meter)
+            _logs.set_logger_provider(host_logger)
+            kwargs["send_to_logfire"] = False
+            kwargs["metrics"] = False
+            instance = real_configure(**kwargs)
+            candidate_logger = instance.config._logger_provider
+            original_shutdown = candidate_logger.shutdown
+
+            def counted_shutdown(*args, **inner_kwargs):
+                state["logger_shutdown_calls"] += 1
+                return original_shutdown(*args, **inner_kwargs)
+
+            candidate_logger.shutdown = counted_shutdown
+            return instance
+
+        logfire.configure = configure
+        os.environ["LOGFIRE_SEND_TO_LOGFIRE"] = "true"
+        _obs.configure_tracing(service_name="archetype-test")
+
+        assert trace.get_tracer_provider() is host_trace
+        assert metrics.get_meter_provider() is host_meter
+        assert _logs.get_logger_provider() is host_logger
+        assert state["logger_shutdown_calls"] >= 1
+        assert _obs._configured is True
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_proxy_tracer_records_after_external_host_registers() -> None:
+    result = _run(
+        """
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        assert _obs._configured is False
+
+        exporter = InMemorySpanExporter()
+        host = TracerProvider()
+        host.add_span_processor(SimpleSpanProcessor(exporter))
+        trace.set_tracer_provider(host)
+
+        with _obs.span("artifact.publish"):
+            pass
+        assert [span.name for span in exporter.get_finished_spans()] == ["artifact.publish"]
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_noop_tracer_preserves_incoming_host_context() -> None:
+    result = _run(
+        """
+        from opentelemetry import context, trace
+        from archetype import _obs
+
+        incoming = trace.SpanContext(
+            trace_id=1,
+            span_id=2,
+            is_remote=True,
+            trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+        )
+        token = context.attach(
+            trace.set_span_in_context(trace.NonRecordingSpan(incoming))
+        )
+        try:
+            with _obs.span("artifact.publish"):
+                assert trace.get_current_span().get_span_context() == incoming
+        finally:
+            context.detach(token)
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_proxy_counter_created_before_provider_records_after_registration() -> None:
+    result = _run(
+        """
+        from opentelemetry import metrics
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from archetype import _obs
+
+        _obs.counter_add(
+            "archetype.operation.failures",
+            attributes={
+                "operation": "artifact.publish",
+                "failure_disposition": "handled",
+                "error_type": "internal",
+                "world_id": "019b6b64-74d5-7bb0-bf10-4bdc6c5e9e31",
+            },
+        )
+
+        reader = InMemoryMetricReader()
+        provider = MeterProvider(metric_readers=(reader,))
+        metrics.set_meter_provider(provider)
+
+        _obs.counter_add(
+            "archetype.operation.failures",
+            attributes={
+                "operation": "artifact.publish",
+                "failure_disposition": "handled",
+                "error_type": "internal",
+                "world_id": "019b6b64-74d5-7bb0-bf10-4bdc6c5e9e31",
+            },
+        )
+
+        data = reader.get_metrics_data()
+        assert data is not None
+        metric = data.resource_metrics[0].scope_metrics[0].metrics[0]
+        point = metric.data.data_points[0]
+        assert point.value == 1
+        assert dict(point.attributes) == {
+            "archetype.failure.disposition": "handled",
+            "archetype.operation": "artifact.publish",
+            "error.type": "internal",
+        }
+        """
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/app/test_obs_process.py
+++ b/tests/app/test_obs_process.py
@@ -68,6 +68,116 @@ def test_host_provider_is_respected() -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_otlp_configuration_installs_a_sanitizing_owned_provider() -> None:
+    result = _run(
+        """
+        import os
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http import trace_exporter
+        from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+        class CapturingExporter(SpanExporter):
+            instances = []
+
+            def __init__(self):
+                self.spans = []
+                self.shutdown_calls = 0
+                self.instances.append(self)
+
+            def export(self, spans):
+                self.spans.extend(spans)
+                return SpanExportResult.SUCCESS
+
+            def shutdown(self):
+                self.shutdown_calls += 1
+
+        trace_exporter.OTLPSpanExporter = CapturingExporter
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://collector.invalid/v1/traces"
+
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        provider = trace.get_tracer_provider()
+        assert _obs._configured is True
+        assert _obs._owned_tracer_provider is provider
+
+        with provider.get_tracer("archetype").start_as_current_span(
+            "artifact.publish",
+            attributes={
+                "archetype.operation": "artifact.publish",
+                "authorization": "Bearer should-not-be-exported",
+            },
+        ):
+            pass
+
+        assert provider.force_flush()
+        (exporter,) = CapturingExporter.instances
+        (finished,) = exporter.spans
+        assert finished.name == "artifact.publish"
+        assert dict(finished.attributes) == {
+            "archetype.operation": "artifact.publish",
+        }
+        assert dict(finished.resource.attributes) == {
+            "service.name": "archetype-test",
+        }
+        provider.shutdown()
+        assert exporter.shutdown_calls == 1
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Bearer should-not-be-exported" not in result.stderr
+
+
+def test_otlp_initialization_failure_is_safe_shutdown_and_retryable() -> None:
+    result = _run(
+        """
+        import os
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http import trace_exporter
+        import opentelemetry.sdk.trace as sdk_trace
+
+        real_provider = sdk_trace.TracerProvider
+
+        class TrackingProvider(real_provider):
+            instances = []
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.shutdown_calls = 0
+                self.instances.append(self)
+
+            def shutdown(self):
+                self.shutdown_calls += 1
+                return super().shutdown()
+
+        class FailingExporter:
+            def __init__(self):
+                raise RuntimeError("Bearer should-not-be-exported")
+
+        sdk_trace.TracerProvider = TrackingProvider
+        trace_exporter.OTLPSpanExporter = FailingExporter
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://collector.invalid/v1/traces"
+
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        assert _obs._configured is False
+        assert isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+        (failed_candidate,) = TrackingProvider.instances
+        assert failed_candidate.shutdown_calls == 1
+
+        sdk_trace.TracerProvider = real_provider
+        del os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"]
+        _obs.configure_tracing(service_name="archetype-test", debug_console=True)
+        assert _obs._configured is True
+        assert not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+        trace.get_tracer_provider().shutdown()
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Bearer should-not-be-exported" not in result.stderr
+
+
 def test_host_adapter_failure_is_safe_and_does_not_latch() -> None:
     result = _run(
         """


### PR DESCRIPTION
## Summary

- define one immutable, versioned trace/metric/event vocabulary with key-specific validation and bounded metric labels
- preserve typed application outcomes while distinguishing propagated, handled, and retrying failures without exporting exception text
- keep parent correlation through a read-only current-span view and sanitize immutable SDK snapshots before Archetype-owned enqueue/export
- make no-op, host-owned, OTLP, console, and Logfire provider configuration retryable and race-safe across trace, metric, and logger providers
- add normative observability guidance, family dispositions, contract traceability, and deterministic process/adversarial regressions

Durable records and typed outcomes remain authoritative. This does not add a Python public API or REST surface, and it does not introduce Daft materialization or claim processor execution timing.

## Validation

- `uv run pytest -q tests/app/test_obs.py tests/app/test_obs_process.py` — 44 passed
- focused runtime/artifact/gateway compatibility profile — 114 passed
- `make static` — passed, including architecture, lazy, redaction, contract, traceability, and benchmark audits
- `make verify-pr` — 1,466 passed, 7 skipped; 87.22% coverage
- repository evals — regression 15/15, specification 8/8, capability 8/8
- package smoke, examples, and documentation build — passed
- isolated OpenTelemetry 1.20 OTLP encoder compatibility probe — passed

Closes #513