### PR TITLE
feat: add host-owned correlated logging

### DIFF
--- a/docs/guide/api-layer.md
+++ b/docs/guide/api-layer.md
@@ -13,6 +13,7 @@ used by the trusted runtime.
 ```python
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    configure_host_observability(service_name="archetype-api")
     container = get_container()
     try:
         yield
@@ -20,6 +21,12 @@ async def lifespan(app: FastAPI):
         await container.shutdown()
         set_container(None)
 ```
+
+Imports and `create_app()` perform no logging or telemetry setup. Each worker
+configures its host from the lifespan path, which keeps reload and multi-worker
+startup explicit and idempotent. The factory does not automatically invoke
+Logfire FastAPI instrumentation; optional Logfire or OTLP export is selected
+through the vendor-neutral host adapter.
 
 All worlds live in the server event loop. CLI invocations and remote clients talk to that process over HTTP.
 
@@ -140,6 +147,10 @@ The route does not construct a lifecycle command or bypass the gate.
 ## CLI
 
 The CLI (`archetype` command) is a thin HTTP client.
+
+`serve` is the sole CLI process-host path: it configures observability before
+starting Uvicorn. Every other CLI command remains an HTTP client and performs
+no local provider or handler setup.
 
 ```text
 archetype serve              Starts uvicorn with the FastAPI app

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -131,9 +131,13 @@ Forbidden reverse edges include:
 Core and application families may emit only through the private,
 vendor-neutral `archetype._obs` API and stdlib logging. They may not import an
 OTel SDK, exporter, collector, or vendor package. Runtime and server process
-hosts own provider/exporter and handler configuration. Because core imports
-`_obs`, the signal boundary cannot import the application redaction family; it
-uses the closed schema defined by the normative
+hosts own provider/exporter and handler configuration. Module import and API
+factory construction are not host boundaries; trusted runtime construction,
+CLI server startup, and worker lifespan are. The host adapter may attach its
+filter only to its own package handler and may not replace the global
+`LogRecordFactory` or mutate root logging. Because core imports `_obs`, the
+signal boundary cannot import the application redaction family; it uses the
+closed schema defined by the normative
 [Observability contract](observability.md). Content-bearing outer adapters
 still consume the redaction port before their own durable or external write.
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -14,11 +14,12 @@ Archetype-owned adapter failure may change an application result, retry
 decision, commit, authorization decision, or exception identity. A process
 host remains responsible for failure behavior in handlers it installs itself.
 
-Family and core code emit through the private `archetype._obs` boundary using
-OpenTelemetry APIs and stdlib logging only. They do not import an OTel SDK,
-exporter, collector, or vendor integration. Process hosts own provider and
-exporter installation. `archetype._obs` remains internal and does not expand
-the supported Python or REST surface.
+Family and core code emit telemetry through the private `archetype._obs`
+boundary and diagnostics through stdlib logging. They do not import an OTel
+SDK, exporter, collector, or vendor integration. Process hosts own provider,
+exporter, and handler installation through the private `archetype._logging`
+adapter. Both modules remain internal and do not expand the supported Python
+or REST surface.
 
 The signal boundary cannot import `app.redaction`: core imports `_obs`, so that
 edge would invert the application dependency direction. Instead, `_obs` is
@@ -111,9 +112,10 @@ broad suppression of application work under an “observability” label.
 
 `bind_context()` stores only validated canonical correlation coordinates in a
 `ContextVar`; nested bindings restore their predecessor on normal return or
-failure. `capture_context()` returns a detached copy suitable for #326's
-structured logging adapter. Context never contains payloads, prompts, paths,
-URLs, headers, exception text, or arbitrary object strings.
+failure. `capture_context()` returns a detached copy that the private host
+logging adapter revalidates before enriching a record. Context never contains
+payloads, prompts, paths, URLs, headers, exception text, or arbitrary object
+strings.
 
 Proxy tracers and counters may be created before a provider. Once a host
 registers a provider, future calls use it. Signals emitted before registration
@@ -141,14 +143,51 @@ runtime/server startup:
 The SDK bundled for the explicit debug-console host path is not permission for
 family imports. Optional OTLP and Logfire integrations remain host concerns.
 `RunConfig.debug` controls execution diagnostics and is not a telemetry-export
-switch. #326 owns removing API import-time setup and correlating stdlib logs.
+switch.
+
+Importing Archetype, its runtime, or its API installs no handler or provider;
+`create_app()` is also inert. The explicit configuration points are runtime
+construction for trusted scripts, CLI `serve` startup for the server process,
+and each FastAPI lifespan for the serving worker. Repeated worker setup is
+safe. `create_app()` does not automatically invoke Logfire FastAPI
+instrumentation; explicit backend selection continues through the
+vendor-neutral host adapter.
+
+When `ARCHETYPE_LOG=debug|info|warning|error` or the runtime's `log=` argument
+enables logging, the host adapter owns at most one `archetype` package stderr
+handler. Otherwise the explicit host boundary installs a package-owned null
+handler so Python's `lastResort` handler cannot emit warnings or errors; any
+handler the host explicitly installed remains authoritative through normal
+propagation. Later quiet/default setup does not downgrade an already enabled
+owned stderr handler. The adapter does not alter root handlers, root filters,
+root level, the global `LogRecordFactory`, or foreign handlers and filters. Its
+fail-open filter first
+removes forged reserved fields and then restores only valid lowercase
+`trace_id` and `span_id` coordinates plus revalidated
+`TRACE_ATTRIBUTE_KEYS`. `LOG_RECORD_FIELDS` is exactly that derived union, not
+a second attribute vocabulary. With no active context the fields are absent.
+Correlation never reads or renders payloads, prompts, arbitrary objects,
+exception objects, traceback text, or exception messages. The default
+formatter suppresses traceback rendering and writes human diagnostics to
+stderr, then restores the producer's message, arguments, and exception/stack
+fields for later host-owned handlers. It cannot sanitize sensitive text already
+embedded in a primitive string; producer-side policy and foreign-handler export
+safety remain host responsibilities. Stdout remains owned by application and
+machine-result output. When enabled, the stderr handler runs first, so a host
+handler attached to the `archetype` package logger receives the same enriched
+correlation fields without moving the filter onto that foreign handler or the
+root logger.
+
+The old `contrib.logfire_observer.logfire_hooks()` entry point is a deprecated,
+warning-only shim that returns no hooks. It cannot create a second tick root,
+retain an open-span table, or bypass the safe signal boundary.
 
 ## 6. Family dispositions
 
 | Family or layer | Current signal disposition | Authoritative outcome |
 |---|---|---|
-| Runtime host | Explicit provider/log-handler configuration; no family workflow span | Runtime lifecycle and returned/raised result |
-| CLI and API | No family-owned signals in this contract; #326 owns host/log correlation | HTTP result and gateway/domain result |
+| Runtime host | Explicit construction-time provider and owned-handler setup; no family workflow span | Runtime lifecycle and returned/raised result |
+| CLI and API | `serve` and worker lifespan configure the host; imports and `create_app()` remain inert | HTTP result and gateway/domain result |
 | Gateway | Child spans for the three currently decorated operations | RBAC decision, typed application result, and access-audit evidence |
 | RuntimeApplication | No direct signal yet; lower owning family remains visible | Typed family result/exception |
 | Commands | No direct signal yet | Durable command ledger and settlement |

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -157,7 +157,22 @@ surfaces to remove after the artifact-family cutover.
 
 Scripts own stdout. `ARCHETYPE_LOG=debug|info|warning|error` or
 `ArchetypeRuntime(log=...)` configures the `archetype` logger at the runtime
-boundary. Core and app layers emit records but configure no handlers.
+boundary. Core and app layers emit records but configure no handlers. Imports
+remain silent. At construction an otherwise unconfigured runtime owns at most
+one package handler: a null handler by default, or a stderr handler when
+logging is enabled. A later default runtime preserves an already enabled
+handler. The adapter does not alter root logging, the global `LogRecordFactory`,
+or foreign handlers and filters, so machine-readable stdout remains
+deterministic.
+
+When logging is enabled, the owned handler's fail-open filter replaces reserved
+correlation fields with the active lowercase trace/span IDs and the validated
+safe signal context. Callers cannot forge those fields through `extra`; with no
+active context the fields are absent. Its formatter omits exception and stack
+metadata from its own stderr rendering and substitutes placeholders for
+non-primitive arguments, then restores those producer fields for later
+host-owned handlers. Correlation fields remain enriched. Producer-side policy
+remains responsible for sensitive text already supplied as a primitive string.
 
 Tracing uses the OpenTelemetry API. A host-registered provider is respected;
 optional Logfire or OTLP backends are selected only at the host/runtime

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -8,6 +8,7 @@ machine authority; this page is its review surface.
 | Contract | Owner | Risk | Normative source | Executable evidence | Profiles |
 | --- | --- | --- | --- | --- | --- |
 | `observability.signals.safe` | `observability` | high | [docs/guide/observability.md](../guide/observability.md) — 1. Safe signal contract | pytest: 2 | `pr`, `main`, `release` |
+| `observability.logging.correlated` | `observability` | medium | [docs/guide/observability.md](../guide/observability.md) — 5. Process-host ownership | pytest: 3 | `pr`, `main`, `release` |
 | `sandboxes.attempt.phase_order` | `sandboxes` | high | [docs/guide/sandbox-execution.md](../guide/sandbox-execution.md) — 3. Six-phase attempt protocol | pytest: 2; static: 1; eval: 1 | `pr`, `main`, `release` |
 | `architecture.dependencies.enforced` | `app` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 11. Static enforcement | pytest: 1; static: 1; eval: 2 | `pr`, `main`, `release` |
 | `architecture.protocols.complete` | `app` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 8. Protocol policy and wiring | pytest: 1; static: 1; eval: 1 | `pr`, `main`, `release` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,9 +122,8 @@ dev = [
     "mutmut>=3.5",
     "mujoco>=3.2",  # physics parity tests (tests/experiments/test_mujoco_rollout.py)
     "pytest-xdist>=3.8.0",
-    # Dev keeps the optional logfire backend installed so CI can exercise
-    # contrib/logfire_observer (tests/contrib) and the api instrumentation path; the
-    # published package depends only on the OTel API + SDK.
+    # Dev keeps the optional Logfire backend installed so CI can exercise the
+    # explicit host adapter; the published base package remains vendor-neutral.
     "logfire[fastapi]>=4.32.0",
     "python-dotenv>=1.2.2",
 ]

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -13,6 +13,22 @@ benchmarks = []
 profiles = ["pr", "main", "release"]
 
 [[contract]]
+id = "observability.logging.correlated"
+source = "docs/guide/observability.md"
+section = "5. Process-host ownership"
+owner = "observability"
+risk = "medium"
+pytest = [
+    "tests/app/test_logging_contracts.py",
+    "tests/app/test_logging_process.py",
+    "tests/contrib/test_logfire_observer.py",
+]
+static = []
+evals = []
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
 id = "sandboxes.attempt.phase_order"
 source = "docs/guide/sandbox-execution.md"
 section = "3. Six-phase attempt protocol"

--- a/src/archetype/_logging.py
+++ b/src/archetype/_logging.py
@@ -1,0 +1,276 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private, host-owned stdlib logging configuration.
+
+Library and family modules only create normal stdlib log records. Explicit
+process hosts may install the one handler in this module; imports never do.
+Correlation is advisory and fail-open, while durable records and typed
+application outcomes remain authoritative.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from threading import Lock
+from typing import Final
+
+from opentelemetry import trace
+
+from archetype import _obs
+
+_LOG_LEVELS: Final[dict[str, int]] = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+}
+
+# The #513 trace vocabulary remains the sole attribute authority. Trace/span
+# IDs are log correlation coordinates layered on top; they are never metric
+# labels. Callers cannot forge any reserved field through ``extra``: the owned
+# filter clears them all, then restores only trusted current values.
+LOG_RECORD_FIELDS: Final[frozenset[str]] = _obs.TRACE_ATTRIBUTE_KEYS | frozenset(
+    {"span_id", "trace_id"}
+)
+
+_configuration_lock = Lock()
+_HANDLER_MARKER = "archetype.host.v1"
+_OMITTED_ARGUMENT = "<value omitted>"
+_SAFE_ARGUMENT_TYPES: Final[frozenset[type]] = frozenset({bool, float, int, str, type(None)})
+
+
+def resolve_log_level(env: str | None = None) -> int | None:
+    """Map an explicit value or ``ARCHETYPE_LOG`` to one stdlib level."""
+    try:
+        value = env if env is not None else os.environ.get("ARCHETYPE_LOG", "")
+        if type(value) is not str:
+            return None
+        return _LOG_LEVELS.get(value.strip().lower())
+    except BaseException:
+        return None
+
+
+class _CorrelationFilter(logging.Filter):
+    """Replace reserved fields with trusted current correlation coordinates."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            fields = vars(record)
+            for key in LOG_RECORD_FIELDS:
+                fields.pop(key, None)
+        except BaseException:
+            return True
+
+        try:
+            current = trace.get_current_span().get_span_context()
+            if type(current) is trace.SpanContext and current.is_valid:
+                fields["trace_id"] = f"{current.trace_id:032x}"
+                fields["span_id"] = f"{current.span_id:016x}"
+        except BaseException:
+            pass
+
+        try:
+            captured = _obs.capture_context()
+            safe = _obs._attributes(captured) if type(captured) is dict else {}
+            for key, value in safe.items():
+                if key in LOG_RECORD_FIELDS:
+                    fields[key] = value
+        except BaseException:
+            pass
+        return True
+
+
+def _safe_arguments(value: object) -> tuple[object, ...] | dict[str, object]:
+    """Copy exact logging args without invoking arbitrary object rendering."""
+
+    def safe(item: object) -> object:
+        return item if type(item) in _SAFE_ARGUMENT_TYPES else _OMITTED_ARGUMENT
+
+    if type(value) is tuple:
+        return tuple(safe(item) for item in value)
+    if type(value) is dict:
+        return {key: safe(item) for key, item in value.items() if type(key) is str}
+    return ()
+
+
+class _SafeFormatter(logging.Formatter):
+    """Format diagnostics without traceback text or arbitrary object calls."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        sentinel = object()
+        fields: dict[str, object]
+        originals: dict[str, object] = {}
+        try:
+            fields = vars(record)
+            for key in ("args", "exc_info", "exc_text", "msg", "stack_info"):
+                originals[key] = fields.get(key, sentinel)
+            message = fields.get("msg")
+            fields["msg"] = message if type(message) is str else "<unsafe log message omitted>"
+            fields["args"] = _safe_arguments(fields.get("args"))
+            fields["exc_info"] = None
+            fields["exc_text"] = None
+            fields["stack_info"] = None
+            return super().format(record)
+        finally:
+            try:
+                for key, original in originals.items():
+                    if original is sentinel:
+                        fields.pop(key, None)
+                    else:
+                        fields[key] = original
+            except BaseException:
+                pass
+
+
+class _ArchetypeHandler(logging.StreamHandler):
+    """Marker for the sole stderr handler owned by an Archetype host."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._archetype_handler_marker = _HANDLER_MARKER
+        self.setFormatter(_SafeFormatter("%(levelname).1s %(name)s: %(message)s"))
+        self.addFilter(_CorrelationFilter())
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Write one diagnostic, dropping only handler/formatting failures."""
+        try:
+            message = self.format(record)
+            stream = self.stream
+            stream.write(message + self.terminator)
+            self.flush()
+        except BaseException:
+            pass
+
+
+class _ArchetypeNullHandler(logging.NullHandler):
+    """Suppress ``lastResort`` output until a host explicitly enables logs."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._archetype_handler_marker = _HANDLER_MARKER
+
+
+def _owned_handler_kind(handler: object) -> str | None:
+    """Classify this adapter's handler across an in-process module reload."""
+    try:
+        handler_type = type(handler)
+        if (
+            type.__getattribute__(handler_type, "__module__") != __name__
+            or vars(handler).get("_archetype_handler_marker") != _HANDLER_MARKER
+        ):
+            return None
+        return {
+            "_ArchetypeHandler": "stderr",
+            "_ArchetypeNullHandler": "null",
+        }.get(type.__getattribute__(handler_type, "__qualname__"))
+    except BaseException:
+        return None
+
+
+def _is_owned_handler(handler: object) -> bool:
+    """Return whether a handler belongs to this private host adapter."""
+    return _owned_handler_kind(handler) is not None
+
+
+def configure_archetype_logging(level: int | None) -> None:
+    """Idempotently install one enabled or quiet package-owned handler."""
+    if level is not None and (type(level) is not int or level not in _LOG_LEVELS.values()):
+        return
+
+    try:
+        with _configuration_lock:
+            package = logging.getLogger("archetype")
+            previous_level = package.level
+            previous_propagate = package.propagate
+            previous_handlers = tuple(package.handlers)
+            candidate: logging.Handler | None = None
+            replaced: logging.Handler | None = None
+            duplicates: list[logging.Handler] = []
+            try:
+                recognized = [handler for handler in package.handlers if _is_owned_handler(handler)]
+                if level is None:
+                    owned = next(
+                        (
+                            handler
+                            for handler in recognized
+                            if _owned_handler_kind(handler) == "stderr"
+                        ),
+                        recognized[0] if recognized else None,
+                    )
+                else:
+                    owned = recognized[0] if recognized else None
+                duplicates = [handler for handler in recognized if handler is not owned]
+                desired_type: type[logging.Handler] = (
+                    _ArchetypeNullHandler if level is None else _ArchetypeHandler
+                )
+                if owned is None:
+                    candidate = desired_type()
+                    package.addHandler(candidate)
+                    owned = candidate
+                elif (level is not None or _owned_handler_kind(owned) == "null") and type(
+                    owned
+                ) is not desired_type:
+                    candidate = desired_type()
+                    owned_index = next(
+                        index for index, handler in enumerate(package.handlers) if handler is owned
+                    )
+                    package.handlers[owned_index] = candidate
+                    replaced = owned
+                    owned = candidate
+                for duplicate in duplicates:
+                    duplicate_index = next(
+                        index
+                        for index, handler in enumerate(package.handlers)
+                        if handler is duplicate
+                    )
+                    package.handlers.pop(duplicate_index)
+                if level is not None:
+                    owned_index = next(
+                        index for index, handler in enumerate(package.handlers) if handler is owned
+                    )
+                    if owned_index:
+                        package.handlers.insert(0, package.handlers.pop(owned_index))
+                    package.setLevel(level)
+                    package.propagate = False
+            except BaseException:
+                try:
+                    package.handlers[:] = previous_handlers
+                except BaseException:
+                    pass
+                try:
+                    package.setLevel(previous_level)
+                    package.propagate = previous_propagate
+                except BaseException:
+                    pass
+                if candidate is not None:
+                    try:
+                        candidate.close()
+                    except BaseException:
+                        pass
+            else:
+                for obsolete in ([replaced] if replaced is not None else []) + duplicates:
+                    try:
+                        obsolete.close()
+                    except BaseException:
+                        pass
+    except BaseException:
+        pass
+
+
+def configure_host_observability(*, service_name: str, log: str | None = None) -> int | None:
+    """Configure logging/tracing only when called by an explicit process host."""
+    level = resolve_log_level(log)
+    try:
+        configure_archetype_logging(level)
+    except BaseException:
+        pass
+    try:
+        _obs.configure_tracing(
+            service_name=service_name,
+            debug_console=level == logging.DEBUG,
+        )
+    except BaseException:
+        pass
+    return level

--- a/src/archetype/api/app.py
+++ b/src/archetype/api/app.py
@@ -15,23 +15,19 @@
 """FastAPI application factory."""
 
 from contextlib import asynccontextmanager
-from logging import basicConfig
 
 from fastapi import FastAPI
 
-from archetype import __version__, _obs
+from archetype import __version__
+from archetype._logging import configure_host_observability
 from archetype.api.deps import get_container, set_container
 from archetype.api.routes import commands, entities, query, simulation, worlds
-
-# Vendor-neutral tracing: backend selection (host provider, LOGFIRE_* opt-in,
-# OTEL_* endpoint, or no-op) lives in archetype._obs. Logfire is optional.
-_obs.configure_tracing(service_name="archetype-ecs")
-basicConfig()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan: initialize and shutdown ServiceContainer."""
+    configure_host_observability(service_name="archetype-api")
     container = get_container()
     app.state.container = container
     try:
@@ -50,15 +46,6 @@ def create_app() -> FastAPI:
         version=__version__,
         lifespan=lifespan,
     )
-    # Route-level tracing is optional: use it when logfire is installed,
-    # skip it otherwise — the gate spans below the routes always exist.
-    try:
-        import logfire
-
-        logfire.instrument_fastapi(app)
-    except ImportError:
-        pass
-
     app.include_router(worlds.router)
     app.include_router(entities.router)
     app.include_router(commands.router)

--- a/src/archetype/cli/main.py
+++ b/src/archetype/cli/main.py
@@ -31,6 +31,8 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from archetype._logging import configure_host_observability
+
 DEFAULT_BASE_URL = "http://localhost:8000"
 ENV_BASE_URL = "ARCHETYPE_URL"
 
@@ -246,6 +248,7 @@ def serve(
     """Start the FastAPI server."""
     import uvicorn
 
+    configure_host_observability(service_name="archetype-api")
     uvicorn.run("archetype.api.app:create_app", host=host, port=port, reload=reload, factory=True)
 
 

--- a/src/archetype/contrib/logfire_observer.py
+++ b/src/archetype/contrib/logfire_observer.py
@@ -12,115 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Logfire observability hooks for Archetype simulations.
+"""Deprecated compatibility surface for the former Logfire hook observer.
 
-Usage:
-    from archetype.contrib.logfire_observer import logfire_hooks
-
-    world = runtime.world(
-        "demo",
-        processors=[Movement()],
-        hooks=logfire_hooks(),
-    )
-
-This gives you per-tick spans in Logfire showing:
-- Tick number
-- Active entity count
-- Spawn/despawn pending counts
-- Per-tick duration (via PreTick → PostTick span)
+The former implementation opened dynamic tick spans, retained global span
+state, and sent content-bearing hook values directly to a vendor SDK. Hosts
+now select an exporter through the vendor-neutral observability adapter. Tick
+execution attribution remains owned by the world path and #518/#519 rather
+than by an optional hook list.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-import logfire
-
-from archetype.core.hooks import (
-    OnComponentAdded,
-    OnComponentRemoved,
-    OnDespawn,
-    OnDestroy,
-    OnSpawn,
-    PostTick,
-    PreTick,
-)
-
-# Open logfire spans keyed by world_id (LogfireSpan; Any avoids a hard
-# dependency on logfire's stub types in this optional contrib module).
-_tick_spans: dict[str, Any] = {}
-
-
-async def _on_pre_tick(event: PreTick) -> None:
-    """Start a span for this tick."""
-    span = logfire.span("tick.{tick}", tick=event.tick, world_id=str(event.world_id))
-    span.__enter__()
-    _tick_spans[str(event.world_id)] = span
-
-
-async def _on_post_tick(event: PostTick) -> None:
-    """End the tick span with result metadata."""
-    span = _tick_spans.pop(str(event.world_id), None)
-    if span is not None:
-        logfire.info(
-            "tick.complete",
-            tick=event.tick,
-            world_id=str(event.world_id),
-            archetypes_processed=len(event.results) if event.results else 0,
-        )
-        span.__exit__(None, None, None)
-
-
-async def _on_spawn(event: OnSpawn) -> None:
-    logfire.debug(
-        "entity.spawn",
-        entity_id=event.entity_id,
-        world_id=str(event.world_id),
-        components=[type(c).__name__ for c in event.components],
-    )
-
-
-async def _on_despawn(event: OnDespawn) -> None:
-    logfire.debug(
-        "entity.despawn",
-        entity_id=event.entity_id,
-        world_id=str(event.world_id),
-    )
-
-
-async def _on_component_added(event: OnComponentAdded) -> None:
-    logfire.debug(
-        "entity.add_components",
-        entity_id=event.entity_id,
-        world_id=str(event.world_id),
-        components=[type(c).__name__ for c in event.components],
-    )
-
-
-async def _on_component_removed(event: OnComponentRemoved) -> None:
-    logfire.debug(
-        "entity.remove_components",
-        entity_id=event.entity_id,
-        world_id=str(event.world_id),
-        component_types=[t.__name__ for t in event.component_types],
-    )
-
-
-async def _on_destroy(event: OnDestroy) -> None:
-    logfire.info("world.destroy", world_id=str(event.world_id))
+import warnings
 
 
 def logfire_hooks() -> list[tuple]:
-    """Return the full set of Logfire observability hooks.
-
-    Pass to ``runtime.world(..., hooks=logfire_hooks())``.
-    """
-    return [
-        (PreTick, _on_pre_tick),
-        (PostTick, _on_post_tick),
-        (OnSpawn, _on_spawn),
-        (OnDespawn, _on_despawn),
-        (OnComponentAdded, _on_component_added),
-        (OnComponentRemoved, _on_component_removed),
-        (OnDestroy, _on_destroy),
-    ]
+    """Return no alternate hooks; configure observability at the host."""
+    warnings.warn(
+        "logfire_hooks() is deprecated; configure Logfire or OTLP at the "
+        "Archetype process-host boundary instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return []

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -17,15 +17,13 @@
 from __future__ import annotations
 
 import asyncio
-import logging
-import os
 from pathlib import Path
 from typing import Any
 from weakref import WeakSet
 
 from uuid_utils import UUID
 
-from archetype import _obs
+from archetype._logging import configure_host_observability
 from archetype.app.application.interfaces import iRuntimeApplication
 from archetype.app.artifacts.bundle_models import ArtifactSourceResolver, ArtifactStoreConfig
 from archetype.app.container import ServiceContainer
@@ -34,38 +32,6 @@ from archetype.core.config import CacheConfig, StorageConfig
 from archetype.core.hooks import HookEvent
 from archetype.runtime._config import coerce_cache, coerce_storage
 from archetype.runtime.world import RuntimeWorld, SyncRuntimeWorld, _RuntimeWorldState
-
-_LOG_LEVELS = {
-    "debug": logging.DEBUG,
-    "info": logging.INFO,
-    "warning": logging.WARNING,
-    "error": logging.ERROR,
-}
-
-
-def _resolve_log_level(env: str | None = None) -> int | None:
-    """Map ARCHETYPE_LOG (or an explicit override) to a stdlib level."""
-    value = (env if env is not None else os.environ.get("ARCHETYPE_LOG", "")).strip().lower()
-    return _LOG_LEVELS.get(value)
-
-
-def _configure_archetype_logging(level: int) -> None:
-    """Wire the ``archetype`` logger hierarchy at the script boundary.
-
-    Every layer emits on module loggers and never configures handlers; the
-    runtime is the application boundary, so the one user-facing flag lives
-    here. Root logging is left untouched.
-    """
-    pkg_logger = logging.getLogger("archetype")
-    pkg_logger.setLevel(level)
-    if not pkg_logger.handlers:
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter("%(levelname).1s %(name)s: %(message)s"))
-        pkg_logger.addHandler(handler)
-        # This handler now owns archetype records. Without this, a host that
-        # configured root logging (basicConfig, a Logfire root handler, ...)
-        # would emit every record a second time through the root sinks.
-        pkg_logger.propagate = False
 
 
 class ArchetypeRuntime:
@@ -100,21 +66,12 @@ class ArchetypeRuntime:
             artifact_source_resolver: Optional provider resolver used to copy
                 immutable sandbox references into portable bundle objects.
         """
-        # One user-facing verbosity flag: ARCHETYPE_LOG=debug|info|warning|error
-        # (or ArchetypeRuntime(log=...)). It wires the stdlib "archetype"
-        # logger hierarchy, and at debug it also turns on console span output.
-        # Quiet is the default: span walls interleave with script output and
-        # drown the program's own voice — legibility of the script wins.
-        level = _resolve_log_level(log)
-        if level is not None:
-            _configure_archetype_logging(level)
-
-        # Tracing is vendor-neutral OpenTelemetry (see archetype._obs):
-        # a host-registered provider is respected, LOGFIRE_*/OTEL_* env vars
-        # select a backend, and with neither the API stays a no-op.
-        _obs.configure_tracing(
+        # This constructor is an explicit trusted-script process host. Quiet
+        # remains the default; stdlib logging and vendor-neutral tracing are
+        # configured together only here, never by an imported family module.
+        configure_host_observability(
             service_name="archetype-runtime",
-            debug_console=level == logging.DEBUG,
+            log=log,
         )
 
         self._container = ServiceContainer(

--- a/tests/app/test_logging_contracts.py
+++ b/tests/app/test_logging_contracts.py
@@ -1,0 +1,552 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structured stdlib logging and explicit-host ownership contracts."""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+import types
+from typing import cast
+
+import pytest
+from fastapi.testclient import TestClient
+from opentelemetry import context, trace
+from uuid_utils import uuid7
+
+from archetype import _logging, _obs
+
+pytestmark = pytest.mark.contract("observability.logging.correlated")
+
+
+def _record() -> logging.LogRecord:
+    return logging.LogRecord(
+        name="archetype.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="fixed diagnostic",
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_log_record_vocabulary_is_immutable_and_exact() -> None:
+    assert _logging.LOG_RECORD_FIELDS == frozenset(
+        {
+            "archetype.actor.id",
+            "archetype.artifact.bundle.digest",
+            "archetype.artifact.count",
+            "archetype.attempt.digest",
+            "archetype.command.id",
+            "archetype.component.signature",
+            "archetype.correlation.digest",
+            "archetype.entity.id",
+            "archetype.failure.disposition",
+            "archetype.idempotency.digest",
+            "archetype.operation",
+            "archetype.outcome",
+            "archetype.redaction.rule_ids",
+            "archetype.run.id",
+            "archetype.tick",
+            "archetype.world.id",
+            "error.type",
+            "span_id",
+            "trace_id",
+        }
+    )
+
+
+def test_logging_configuration_rejects_hostile_or_unsupported_inputs(monkeypatch) -> None:
+    assert _logging.resolve_log_level(cast(str, object())) is None
+
+    class FailingLevels(dict[str, int]):
+        def get(self, key: str, default: int | None = None) -> int | None:
+            raise KeyboardInterrupt("level lookup must not escape")
+
+    monkeypatch.setattr(_logging, "_LOG_LEVELS", FailingLevels())
+    assert _logging.resolve_log_level("info") is None
+    assert _logging._is_owned_handler(object()) is False
+
+    package = logging.getLogger("archetype")
+    before = (tuple(package.handlers), package.level, package.propagate)
+    _logging.configure_archetype_logging(cast(int, True))
+    _logging.configure_archetype_logging(1_000_000)
+    assert (tuple(package.handlers), package.level, package.propagate) == before
+
+
+def test_filter_replaces_forged_fields_from_trusted_current_context() -> None:
+    record = _record()
+    for field in _logging.LOG_RECORD_FIELDS:
+        record.__dict__[field] = "forged"
+
+    world_id = str(uuid7())
+    run_id = str(uuid7())
+    correlation_digest = "a" * 64
+
+    class Secret:
+        def __str__(self) -> str:
+            raise AssertionError("logging correlation must not stringify payloads")
+
+        def __repr__(self) -> str:
+            raise AssertionError("logging correlation must not render payloads")
+
+    span_context = trace.SpanContext(
+        trace_id=0x1234,
+        span_id=0x5678,
+        is_remote=False,
+        trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+    )
+    token = context.attach(trace.set_span_in_context(trace.NonRecordingSpan(span_context)))
+    try:
+        with _obs.bind_context(
+            {
+                "archetype.world.id": world_id,
+                "archetype.run.id": run_id,
+                "archetype.correlation.digest": correlation_digest,
+                "archetype.operation": "artifact.publish",
+                "archetype.outcome": Secret(),
+                "payload": Secret(),
+            }
+        ):
+            assert _logging._CorrelationFilter().filter(record) is True
+    finally:
+        context.detach(token)
+
+    assert record.trace_id == f"{span_context.trace_id:032x}"
+    assert record.span_id == f"{span_context.span_id:016x}"
+    assert record.__dict__["archetype.world.id"] == world_id
+    assert record.__dict__["archetype.run.id"] == run_id
+    assert record.__dict__["archetype.correlation.digest"] == correlation_digest
+    assert record.__dict__["archetype.operation"] == "artifact.publish"
+    assert "archetype.outcome" not in record.__dict__
+    assert "archetype.actor.id" not in record.__dict__
+
+
+def test_filter_removes_forged_fields_without_valid_context() -> None:
+    record = _record()
+    for field in _logging.LOG_RECORD_FIELDS:
+        record.__dict__[field] = "forged"
+
+    assert _logging._CorrelationFilter().filter(record) is True
+    assert not (_logging.LOG_RECORD_FIELDS & record.__dict__.keys())
+
+
+def test_filter_is_fail_open_when_context_providers_fail(monkeypatch) -> None:
+    record = _record()
+    record.__dict__["trace_id"] = "forged"
+    record.__dict__["archetype.world.id"] = "forged"
+
+    def fail_span():
+        raise KeyboardInterrupt("Bearer should-not-be-exported")
+
+    def fail_context():
+        raise SystemExit("Bearer should-not-be-exported")
+
+    monkeypatch.setattr(_logging.trace, "get_current_span", fail_span)
+    monkeypatch.setattr(_logging._obs, "capture_context", fail_context)
+
+    assert _logging._CorrelationFilter().filter(record) is True
+    assert record.getMessage() == "fixed diagnostic"
+    assert "trace_id" not in record.__dict__
+    assert "archetype.world.id" not in record.__dict__
+
+
+def test_owned_handler_omits_exception_text_and_arbitrary_object_strings() -> None:
+    stream = io.StringIO()
+    handler = _logging._ArchetypeHandler()
+    handler.setStream(stream)
+
+    class Secret:
+        def __str__(self) -> str:
+            raise AssertionError("owned logging must not render arbitrary objects")
+
+        def __repr__(self) -> str:
+            raise AssertionError("owned logging must not represent arbitrary objects")
+
+    try:
+        raise RuntimeError("Bearer raw-exception-must-not-be-exported")
+    except RuntimeError:
+        exception_record = logging.LogRecord(
+            name="archetype.test",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="fixed failure diagnostic",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+    object_record = logging.LogRecord(
+        name="archetype.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="unsafe argument %s",
+        args=(Secret(),),
+        exc_info=None,
+    )
+    mapping_record = logging.LogRecord(
+        name="archetype.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="mapping %(safe)s %(unsafe)s",
+        args={"safe": 7, "unsafe": Secret(), 1: Secret()},
+        exc_info=None,
+    )
+
+    handler.handle(exception_record)
+    handler.handle(object_record)
+    handler.handle(mapping_record)
+    handler.close()
+
+    assert stream.getvalue() == (
+        "E archetype.test: fixed failure diagnostic\n"
+        "I archetype.test: unsafe argument <value omitted>\n"
+        "I archetype.test: mapping 7 <value omitted>\n"
+    )
+
+
+def test_owned_handler_failure_does_not_escape() -> None:
+    class FailingStream:
+        def write(self, value: str) -> None:
+            raise KeyboardInterrupt("handler output failure must not escape")
+
+        def flush(self) -> None:
+            raise SystemExit("handler flush failure must not escape")
+
+    handler = _logging._ArchetypeHandler()
+    handler.stream = FailingStream()
+    handler.handle(_record())
+    handler.close()
+
+
+def test_partial_handler_install_rolls_back_under_the_configuration_lock(
+    monkeypatch,
+) -> None:
+    package = logging.getLogger("archetype")
+    package_state = (tuple(package.handlers), package.level, package.propagate)
+    for handler in list(package.handlers):
+        package.removeHandler(handler)
+
+    def add_then_fail(handler: logging.Handler) -> None:
+        package.handlers.append(handler)
+        raise KeyboardInterrupt("partial install")
+
+    monkeypatch.setattr(package, "addHandler", add_then_fail)
+    try:
+        _logging.configure_archetype_logging(logging.INFO)
+        assert package.handlers == []
+        assert package.level == package_state[1]
+        assert package.propagate is package_state[2]
+    finally:
+        package.handlers.clear()
+        package.handlers.extend(package_state[0])
+        package.setLevel(package_state[1])
+        package.propagate = package_state[2]
+
+
+def test_stale_and_duplicate_owned_handlers_are_replaced_atomically() -> None:
+    package = logging.getLogger("archetype")
+    package_state = (tuple(package.handlers), package.level, package.propagate)
+    for handler in list(package.handlers):
+        package.removeHandler(handler)
+
+    stale_type = type(
+        "_ArchetypeHandler",
+        (logging.StreamHandler,),
+        {"__module__": _logging.__name__},
+    )
+    stale = stale_type(io.StringIO())
+    duplicate = stale_type(io.StringIO())
+    stale._archetype_handler_marker = _logging._HANDLER_MARKER
+    duplicate._archetype_handler_marker = _logging._HANDLER_MARKER
+    foreign = logging.NullHandler()
+    package.handlers.extend([foreign, stale, duplicate])
+    try:
+        _logging.configure_archetype_logging(logging.INFO)
+        owned = [handler for handler in package.handlers if _logging._is_owned_handler(handler)]
+        assert len(owned) == 1
+        assert type(owned[0]) is _logging._ArchetypeHandler
+        assert package.handlers == [owned[0], foreign]
+        assert stale._closed is True
+        assert duplicate._closed is True
+    finally:
+        for handler in list(package.handlers):
+            package.removeHandler(handler)
+            if handler not in package_state[0]:
+                handler.close()
+        package.handlers.extend(package_state[0])
+        package.setLevel(package_state[1])
+        package.propagate = package_state[2]
+
+
+def test_configuration_owns_only_its_package_handler() -> None:
+    root = logging.getLogger()
+    package = logging.getLogger("archetype")
+    root_state = (tuple(root.handlers), tuple(root.filters), root.level)
+    factory = logging.getLogRecordFactory()
+    package_state = (
+        tuple(package.handlers),
+        tuple(package.filters),
+        package.level,
+        package.propagate,
+    )
+    for handler in list(package.handlers):
+        package.removeHandler(handler)
+    for existing_filter in list(package.filters):
+        package.removeFilter(existing_filter)
+
+    foreign = logging.StreamHandler(io.StringIO())
+    foreign_filter = logging.Filter("foreign")
+    foreign.addFilter(foreign_filter)
+    package.addHandler(foreign)
+    try:
+        _logging.configure_archetype_logging(logging.INFO)
+        _logging.configure_archetype_logging(logging.DEBUG)
+
+        owned = [handler for handler in package.handlers if _logging._is_owned_handler(handler)]
+        assert len(owned) == 1
+        assert package.handlers[0] is owned[0]
+        assert package.level == logging.DEBUG
+        assert package.propagate is False
+        assert foreign.filters == [foreign_filter]
+        assert len(owned[0].filters) == 1
+        assert type(owned[0].filters[0]) is _logging._CorrelationFilter
+        assert (tuple(root.handlers), tuple(root.filters), root.level) == root_state
+        assert logging.getLogRecordFactory() is factory
+    finally:
+        for handler in list(package.handlers):
+            package.removeHandler(handler)
+            if handler not in package_state[0]:
+                handler.close()
+        for handler in package_state[0]:
+            package.addHandler(handler)
+        for existing_filter in package_state[1]:
+            package.addFilter(existing_filter)
+        package.setLevel(package_state[2])
+        package.propagate = package_state[3]
+
+
+def test_quiet_host_owns_only_a_null_handler() -> None:
+    root = logging.getLogger()
+    package = logging.getLogger("archetype")
+    root_state = (tuple(root.handlers), tuple(root.filters), root.level)
+    factory = logging.getLogRecordFactory()
+    package_state = (tuple(package.handlers), package.level, package.propagate)
+    for handler in list(package.handlers):
+        package.removeHandler(handler)
+    package.setLevel(logging.ERROR)
+    package.propagate = False
+
+    try:
+        _logging.configure_archetype_logging(None)
+        owned = [handler for handler in package.handlers if _logging._is_owned_handler(handler)]
+        assert len(owned) == 1
+        assert type(owned[0]) is _logging._ArchetypeNullHandler
+        assert package.handlers == owned
+        assert package.level == logging.ERROR
+        assert package.propagate is False
+        assert (tuple(root.handlers), tuple(root.filters), root.level) == root_state
+        assert logging.getLogRecordFactory() is factory
+    finally:
+        for handler in list(package.handlers):
+            package.removeHandler(handler)
+            if handler not in package_state[0]:
+                handler.close()
+        package.handlers.extend(package_state[0])
+        package.setLevel(package_state[1])
+        package.propagate = package_state[2]
+
+
+def test_quiet_host_preserves_explicit_root_capture() -> None:
+    root = logging.getLogger()
+    package = logging.getLogger("archetype")
+    root_state = (tuple(root.handlers), root.level)
+    package_state = (tuple(package.handlers), package.level, package.propagate)
+    for handler in list(package.handlers):
+        package.removeHandler(handler)
+
+    captured: list[logging.LogRecord] = []
+
+    class CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    capture = CaptureHandler()
+    root.addHandler(capture)
+    root.setLevel(logging.WARNING)
+    package.setLevel(logging.NOTSET)
+    package.propagate = True
+    try:
+        _logging.configure_archetype_logging(None)
+        logging.getLogger("archetype.test").warning("host-owned capture")
+    finally:
+        root.removeHandler(capture)
+        root.handlers[:] = root_state[0]
+        root.setLevel(root_state[1])
+        for handler in list(package.handlers):
+            package.removeHandler(handler)
+            if handler not in package_state[0]:
+                handler.close()
+        package.handlers.extend(package_state[0])
+        package.setLevel(package_state[1])
+        package.propagate = package_state[2]
+
+    assert [record.getMessage() for record in captured] == ["host-owned capture"]
+
+
+def test_quiet_setup_enables_but_never_downgrades_owned_stderr() -> None:
+    package = logging.getLogger("archetype")
+    package_state = (tuple(package.handlers), package.level, package.propagate)
+    for handler in list(package.handlers):
+        package.removeHandler(handler)
+
+    try:
+        _logging.configure_archetype_logging(None)
+        quiet = next(handler for handler in package.handlers if _logging._is_owned_handler(handler))
+        assert type(quiet) is _logging._ArchetypeNullHandler
+
+        _logging.configure_archetype_logging(logging.INFO)
+        enabled = next(
+            handler for handler in package.handlers if _logging._is_owned_handler(handler)
+        )
+        assert type(enabled) is _logging._ArchetypeHandler
+        assert enabled is not quiet
+        assert quiet._closed is True
+
+        _logging.configure_archetype_logging(None)
+        assert package.handlers == [enabled]
+        assert package.level == logging.INFO
+        assert package.propagate is False
+    finally:
+        for handler in list(package.handlers):
+            package.removeHandler(handler)
+            if handler not in package_state[0]:
+                handler.close()
+        package.handlers.extend(package_state[0])
+        package.setLevel(package_state[1])
+        package.propagate = package_state[2]
+
+
+def test_host_package_handler_receives_trusted_enriched_record() -> None:
+    package = logging.getLogger("archetype")
+    package_state = (tuple(package.handlers), package.level, package.propagate)
+    for handler in list(package.handlers):
+        package.removeHandler(handler)
+
+    captured: list[dict[str, object]] = []
+
+    class CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(dict(vars(record)))
+
+    foreign = CaptureHandler()
+    package.addHandler(foreign)
+    world_id = str(uuid7())
+    span_context = trace.SpanContext(
+        trace_id=0x1234,
+        span_id=0x5678,
+        is_remote=False,
+        trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+    )
+    token = context.attach(trace.set_span_in_context(trace.NonRecordingSpan(span_context)))
+    try:
+        _logging.configure_archetype_logging(logging.INFO)
+        owned = next(handler for handler in package.handlers if _logging._is_owned_handler(handler))
+        owned.setStream(io.StringIO())
+        assert package.handlers == [owned, foreign]
+        with _obs.bind_context({"archetype.world.id": world_id}):
+            logging.getLogger("archetype.test").info("fixed diagnostic")
+    finally:
+        context.detach(token)
+        for handler in list(package.handlers):
+            package.removeHandler(handler)
+            if handler not in package_state[0]:
+                handler.close()
+        package.handlers.extend(package_state[0])
+        package.setLevel(package_state[1])
+        package.propagate = package_state[2]
+
+    assert len(captured) == 1
+    assert captured[0]["trace_id"] == f"{span_context.trace_id:032x}"
+    assert captured[0]["span_id"] == f"{span_context.span_id:016x}"
+    assert captured[0]["archetype.world.id"] == world_id
+
+
+def test_host_configuration_is_a_semantic_noop_when_setup_fails(monkeypatch) -> None:
+    def fail_logging(level: int) -> None:
+        raise KeyboardInterrupt("logging setup should-not-escape")
+
+    def fail_tracing(**kwargs: object) -> None:
+        raise SystemExit("tracing setup should-not-escape")
+
+    monkeypatch.setattr(_logging, "configure_archetype_logging", fail_logging)
+    monkeypatch.setattr(_logging._obs, "configure_tracing", fail_tracing)
+
+    assert (
+        _logging.configure_host_observability(
+            service_name="archetype-test",
+            log="info",
+        )
+        == logging.INFO
+    )
+
+
+def test_api_factory_defers_host_configuration_to_each_lifespan(monkeypatch) -> None:
+    from archetype.api import app as api_app
+    from archetype.api.deps import set_container
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        api_app,
+        "configure_host_observability",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    first = api_app.create_app()
+    second = api_app.create_app()
+    assert calls == []
+    try:
+        with TestClient(first):
+            pass
+        with TestClient(second):
+            pass
+    finally:
+        set_container(None)
+
+    assert calls == [
+        {"service_name": "archetype-api"},
+        {"service_name": "archetype-api"},
+    ]
+
+
+def test_cli_serve_configures_the_server_host_before_uvicorn(monkeypatch) -> None:
+    from archetype.cli import main as cli
+
+    events: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        cli,
+        "configure_host_observability",
+        lambda **kwargs: events.append(("configure", kwargs)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "uvicorn",
+        types.SimpleNamespace(run=lambda *args, **kwargs: events.append(("run", (args, kwargs)))),
+    )
+
+    cli.serve(host="127.0.0.1", port=8123, reload=False)
+
+    assert events == [
+        ("configure", {"service_name": "archetype-api"}),
+        (
+            "run",
+            (
+                ("archetype.api.app:create_app",),
+                {"host": "127.0.0.1", "port": 8123, "reload": False, "factory": True},
+            ),
+        ),
+    ]

--- a/tests/app/test_logging_process.py
+++ b/tests/app/test_logging_process.py
@@ -1,0 +1,228 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fresh-process quiet-import and stdout/stderr logging contracts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = [
+    pytest.mark.contract("observability.logging.correlated"),
+    pytest.mark.process,
+]
+
+
+def _run(source: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in tuple(env):
+        if key.startswith(("LOGFIRE_", "OTEL_")) or key == "ARCHETYPE_LOG":
+            env.pop(key)
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_imports_do_not_mutate_logging_or_telemetry() -> None:
+    result = _run(
+        """
+        import logging
+        import sys
+        from opentelemetry import _logs, metrics, trace
+
+        root = logging.getLogger()
+        package = logging.getLogger("archetype")
+        root_state = (tuple(root.handlers), tuple(root.filters), root.level, root.disabled)
+        package_state = (
+            tuple(package.handlers),
+            tuple(package.filters),
+            package.level,
+            package.propagate,
+            package.disabled,
+        )
+        manager_disabled = logging.root.manager.disable
+        factory = logging.getLogRecordFactory()
+        trace_provider = trace.get_tracer_provider()
+        meter_provider = metrics.get_meter_provider()
+        logger_provider = _logs.get_logger_provider()
+
+        import archetype
+        import archetype.runtime.runtime
+        import archetype.api.app
+
+        assert (
+            tuple(root.handlers),
+            tuple(root.filters),
+            root.level,
+            root.disabled,
+        ) == root_state
+        assert (
+            tuple(package.handlers),
+            tuple(package.filters),
+            package.level,
+            package.propagate,
+            package.disabled,
+        ) == package_state
+        assert logging.root.manager.disable == manager_disabled
+        assert logging.getLogRecordFactory() is factory
+        assert trace.get_tracer_provider() is trace_provider
+        assert metrics.get_meter_provider() is meter_provider
+        assert _logs.get_logger_provider() is logger_provider
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_api_factory_does_not_instrument_or_warn_about_logfire() -> None:
+    result = _run(
+        """
+        import warnings
+
+        from archetype.api.app import create_app
+        import logfire
+
+        calls = []
+        logfire.instrument_fastapi = lambda *args, **kwargs: calls.append((args, kwargs))
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            create_app()
+        assert calls == []
+        assert not [warning for warning in caught if "logfire" in str(warning.message).lower()]
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_deprecated_contrib_import_is_quiet_and_vendor_free() -> None:
+    result = _run(
+        """
+        import sys
+
+        import archetype.contrib.logfire_observer
+
+        assert "logfire" not in sys.modules
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_explicit_host_configuration_is_reload_safe() -> None:
+    result = _run(
+        """
+        import importlib
+        import logging
+
+        import archetype._logging as host_logging
+
+        package = logging.getLogger("archetype")
+        host_logging.configure_archetype_logging(logging.INFO)
+        before = [
+            handler for handler in package.handlers
+            if host_logging._is_owned_handler(handler)
+        ]
+        assert len(before) == 1
+
+        host_logging = importlib.reload(host_logging)
+        host_logging.configure_archetype_logging(logging.DEBUG)
+        after = [
+            handler for handler in package.handlers
+            if host_logging._is_owned_handler(handler)
+        ]
+        assert len(after) == 1
+        assert after[0] is not before[0]
+        assert type(after[0]) is host_logging._ArchetypeHandler
+        assert type(after[0].formatter) is host_logging._SafeFormatter
+        assert len(after[0].filters) == 1
+        assert type(after[0].filters[0]) is host_logging._CorrelationFilter
+        assert package.level == logging.DEBUG
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_quiet_host_configuration_is_reload_safe() -> None:
+    result = _run(
+        """
+        import importlib
+        import logging
+
+        import archetype._logging as host_logging
+
+        package = logging.getLogger("archetype")
+        host_logging.configure_archetype_logging(None)
+        before = [
+            handler for handler in package.handlers
+            if host_logging._is_owned_handler(handler)
+        ]
+        assert len(before) == 1
+        assert type(before[0]) is host_logging._ArchetypeNullHandler
+
+        host_logging = importlib.reload(host_logging)
+        host_logging.configure_archetype_logging(None)
+        after = [
+            handler for handler in package.handlers
+            if host_logging._is_owned_handler(handler)
+        ]
+        assert len(after) == 1
+        assert after[0] is not before[0]
+        assert type(after[0]) is host_logging._ArchetypeNullHandler
+        assert before[0]._closed is True
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_runtime_without_log_suppresses_last_resort_output() -> None:
+    result = _run(
+        """
+        import asyncio
+        import logging
+
+        from archetype import ArchetypeRuntime
+
+        async def main():
+            async with ArchetypeRuntime():
+                logging.getLogger("archetype.test").warning("must stay quiet")
+
+        asyncio.run(main())
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_enabled_host_logs_use_stderr_and_leave_stdout_machine_readable() -> None:
+    result = _run(
+        """
+        import logging
+        from archetype._logging import configure_host_observability
+
+        configure_host_observability(service_name="archetype-test", log="info")
+        logging.getLogger("archetype.test").info("diagnostic %s", 7)
+        print('{"result":7}')
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == '{"result":7}\n'
+    assert result.stderr == "I archetype.test: diagnostic 7\n"

--- a/tests/app/test_runtime_observability.py
+++ b/tests/app/test_runtime_observability.py
@@ -1,18 +1,17 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Runtime observability contract (runtime.md R16).
+"""Runtime observability contract (runtime.md R13).
 
-Scripts own their stdout: the runtime configures nothing unless asked, and
-one flag — ARCHETYPE_LOG / ArchetypeRuntime(log=...) — wires the stdlib
-``archetype`` hierarchy at the script boundary.
+Scripts own stdout: the explicit runtime host keeps package diagnostics quiet
+unless ARCHETYPE_LOG / ArchetypeRuntime(log=...) enables its stderr handler.
 """
 
 import logging
 
 import pytest
 
-from archetype.runtime.runtime import _configure_archetype_logging, _resolve_log_level
+from archetype._logging import configure_archetype_logging, resolve_log_level
 
 
 @pytest.mark.parametrize(
@@ -27,14 +26,14 @@ from archetype.runtime.runtime import _configure_archetype_logging, _resolve_log
     ],
 )
 def test_resolve_log_level(value, expected):
-    assert _resolve_log_level(value) == expected
+    assert resolve_log_level(value) == expected
 
 
 def test_env_var_is_the_default_source(monkeypatch):
     monkeypatch.setenv("ARCHETYPE_LOG", "info")
-    assert _resolve_log_level() == logging.INFO
+    assert resolve_log_level() == logging.INFO
     monkeypatch.delenv("ARCHETYPE_LOG")
-    assert _resolve_log_level() is None
+    assert resolve_log_level() is None
 
 
 def test_configure_wires_package_logger_idempotently():
@@ -43,8 +42,8 @@ def test_configure_wires_package_logger_idempotently():
     before_level = pkg.level
     before_propagate = pkg.propagate
     try:
-        _configure_archetype_logging(logging.INFO)
-        _configure_archetype_logging(logging.DEBUG)
+        configure_archetype_logging(logging.INFO)
+        configure_archetype_logging(logging.DEBUG)
         added = [h for h in pkg.handlers if h not in before_handlers]
         assert len(added) <= 1, "repeat configuration must not stack handlers"
         assert pkg.level == logging.DEBUG

--- a/tests/contrib/test_logfire_observer.py
+++ b/tests/contrib/test_logfire_observer.py
@@ -1,52 +1,15 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Smoke coverage for contrib/logfire_observer (issue #278).
-
-Runs only when the optional ``[logfire]`` extra is installed — the dev
-group carries it so CI exercises this path; a bare install skips cleanly.
-"""
+"""Compatibility coverage for the deprecated Logfire hook observer."""
 
 import pytest
 
-logfire = pytest.importorskip("logfire")
+from archetype.contrib.logfire_observer import logfire_hooks
 
-from archetype.contrib.logfire_observer import _tick_spans, logfire_hooks  # noqa: E402
-from archetype.core.component import Component  # noqa: E402
-
-
-class Blip(Component):
-    x: float = 0.0
+pytestmark = pytest.mark.contract("observability.logging.correlated")
 
 
-def test_logfire_hooks_shape():
-    """One (event_type, handler) pair per lifecycle event, all coroutine fns."""
-    import inspect
-
-    from archetype.core.hooks import HookEvent
-
-    hooks = logfire_hooks()
-    assert hooks, "the observer must register at least the tick span pair"
-    for event_type, handler in hooks:
-        assert issubclass(event_type, HookEvent)
-        assert inspect.iscoroutinefunction(handler)
-
-
-@pytest.mark.asyncio
-async def test_observer_rides_a_real_world_without_sending(monkeypatch, tmp_path):
-    """Attach the hooks to a real runtime world, step it, and verify the
-    span bookkeeping opens and closes — with network sending disabled."""
-    monkeypatch.setenv("LOGFIRE_SEND_TO_LOGFIRE", "false")
-
-    from archetype import ArchetypeRuntime
-    from archetype.core.config import StorageConfig
-
-    async with ArchetypeRuntime() as runtime:
-        world = runtime.world(
-            "observed",
-            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns"),
-            hooks=logfire_hooks(),
-        )
-        await world.spawn(Blip(x=1.0))
-        await world.run(steps=2)
-        assert _tick_spans == {}, "every PreTick span must be closed by PostTick"
+def test_logfire_hooks_is_a_warning_only_compatibility_shim() -> None:
+    with pytest.warns(DeprecationWarning, match="process-host boundary"):
+        assert logfire_hooks() == []


### PR DESCRIPTION
Closes #326

## Summary

- Add a private, vendor-neutral host logging adapter with trusted trace/context correlation, safe owned formatting, fail-open setup, and monotonic quiet-to-enabled configuration.
- Move runtime, CLI server, and API worker setup to explicit host boundaries; remove API import-time root logging, telemetry setup, and automatic Logfire instrumentation.
- Retire the unsafe contrib tick observer as a warning-only compatibility shim and register the logging behavior in the contract registry and normative guides.

## Why

The API module configured root logging and telemetry during import, while the optional Logfire hook path created dynamic tick spans and retained global open-span state. Logging ownership was split across runtime and API code, correlation had no safe contract, and an otherwise quiet runtime could still leak warnings through Python's `lastResort` handler.

The new adapter keeps imports and `create_app()` inert. Explicit hosts install a package-owned null handler when logging is disabled, preserving deliberate host capture while suppressing only `lastResort`; enabling logging atomically upgrades to one owned stderr handler. Later default runtimes do not downgrade an already enabled process.

## Safety and boundaries

- Durable outcomes remain authoritative; telemetry and logging setup are fail-open and never drive behavior.
- Root logging, the global `LogRecordFactory`, and foreign handlers/filters are not mutated.
- Reserved correlation fields are cleared and rebuilt only from valid OpenTelemetry context and the #513-safe vocabulary.
- The owned stderr formatter omits traceback rendering and arbitrary non-primitive argument strings from its output.
- No public Python API or REST surface is added.
- Static legacy accounting remains assigned to #514; Daft execution attribution and world/tick semantics remain assigned to #518/#519.

## Validation

- `uv run pytest -q tests/app/test_logging_contracts.py tests/app/test_logging_process.py tests/app/test_runtime_observability.py tests/contrib/test_logfire_observer.py` — 33 passed.
- Targeted compatibility slice for existing host/caplog contracts — 47 passed.
- `make static` — passed.
- `make verify-pr` — 1,486 passed, 10 skipped, 24 known warnings; 87.26% coverage; regression 15/15, spec 8/8, capability 8/8; package smoke, examples, generated references, docs, and Cloudflare artifact passed.
- Independent semantic and final quiet-default reviews — no remaining high- or medium-severity findings.
- `git diff --check` — passed.
