### PR TITLE
chore(quality): enforce observability contracts

### DIFF
--- a/.claude/skills/footgun-detector/SKILL.md
+++ b/.claude/skills/footgun-detector/SKILL.md
@@ -128,6 +128,12 @@ Component fields containing `dict`, `list[dict]`, custom objects, or other non-A
 #### Tick-boundary violations
 Reading messages or state written in the same tick they were produced. Outbox at tick N should only be readable from Inbox at tick N+1.
 
+#### Observability boundary and authority
+Telemetry introduced at the wrong ownership boundary or allowed to become application authority: family code importing a provider, exporter, SDK, or vendor integration; lower-layer work opening a new logical root instead of a child; or signal success/failure deciding authorization, retry, settlement, commit, or the returned exception/result. Telemetry must remain vendor-neutral below process hosts and semantically inert when disabled or failing. Verify the typed result and durable family record still own every operational outcome.
+
+#### Telemetry safety and cardinality
+Signals that export content or create unbounded dimensions despite superficially valid instrumentation: data-derived names or keys, secrets/payloads/prompts/paths, raw exception messages or stacks, arbitrary object strings, per-request or workflow-instance identifiers (world, run, actor, command, artifact, attempt, task, evaluation, or entity IDs) used as metric labels, or handled/retried failures reported as propagated failures. Fixed names from the approved `archetype.operation` vocabulary remain valid bounded labels. Check values flowing indirectly under approved keys as well as direct calls; fixed vocabulary and bounded labels are necessary but do not make an unsafe producer value safe.
+
 ## Step 4: Report findings
 
 For each footgun found, output exactly this format:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo "  make contract-audit Validate normative sources and executable oracles"
 	@echo "  make benchmark-audit Validate benchmark ownership and policies"
 	@echo "  make architecture-audit  Enforce dependency and encapsulation policy"
+	@echo "  make observability-audit Enforce signal safety and family dispositions"
 	@echo "  make lint-fix       Lint and auto-fix"
 	@echo "  make check          Format + lint"
 	@echo "  make complexity     Cyclomatic complexity / maintainability report (radon)"
@@ -97,7 +98,7 @@ format:
 	@uv run ruff format $(RUFF_PATHS)
 
 .PHONY: lint
-lint: lazy-audit architecture-audit sandbox-phase-audit api-boundary-audit idempotency-audit gate-coverage-audit redaction-audit
+lint: lazy-audit architecture-audit observability-audit sandbox-phase-audit api-boundary-audit idempotency-audit gate-coverage-audit redaction-audit
 	@uv run ruff check $(RUFF_PATHS)
 
 .PHONY: lint-fix
@@ -142,6 +143,10 @@ api-boundary-audit:
 .PHONY: architecture-audit
 architecture-audit:
 	@uv run python scripts/check_architecture.py
+
+.PHONY: observability-audit
+observability-audit:
+	@uv run python scripts/check_observability.py
 
 .PHONY: sandbox-phase-audit
 sandbox-phase-audit:

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -146,6 +146,13 @@ commit, settle a durable outcome, or choose a retry. The owning family's typed
 result and durable record remain authoritative when telemetry is disabled,
 dropped, or failing.
 
+Every callable member of every application-family `Protocol`, wherever that
+protocol is declared inside the family package, has one exact observation
+disposition in `quality/observability/<family>.toml`. The manifest records
+intent without turning telemetry into a dependency or authority edge. See
+[Observability](observability.md#6-family-dispositions) for the complete
+manifest and root/child policy.
+
 ## 5. Core world and application-family ownership
 
 `StorageService` resolves and pools an `iAsyncStore`. `WorldService` owns the
@@ -299,7 +306,7 @@ belongs to the workflow and its validators.
 
 ## 11. Static enforcement
 
-The architecture checker must:
+Together, the repository's architecture and observability checkers must:
 
 - cover every declared source scope and fail if a required scope is empty;
 - enforce outer package and family dependency rules;
@@ -308,7 +315,10 @@ The architecture checker must:
 - reject concrete-service inheritance;
 - reject live-world, container, backend-client, and concrete-service leaks;
 - verify active protocol consumer/implementation mappings;
-- support exact, owned, release-expiring migration exceptions; and
+- confine provider/exporter and logging configuration to explicit process-host
+  callables and require one exact observation disposition for every callable
+  application-family protocol member;
+- support exact, owned migration exceptions with objective expiry conditions;
 - report the forbidden edge, governing rule, and supported alternative.
 
 Representative invalid fixtures prove every rule fires. Passing the current
@@ -325,6 +335,14 @@ services and the container are not top-level exports.
 `quality/architecture.toml` contains the complete allowed family DAG and zero
 migration exceptions. `scripts/check_architecture.py` enforces package
 direction, protocol imports, concrete construction, and concrete inheritance.
+
+Independent manifests under `quality/observability/` declare each family's
+operation dispositions. `scripts/check_observability.py` enforces their exact
+coverage and the vendor-neutral signal/configuration boundary without a live
+collector. It validates root syntax and exclusivity but does not invent
+runtime topology: the three existing gateway decorators remain children, and
+#515 owns coherent ingress roots. The existing footgun reviewer complements
+this deterministic audit with semantic observability review.
 
 `MissionService` remains pure transition authority over persisted row values.
 The same family now owns `MissionAttemptClaimService`, a control-catalog-backed

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -341,7 +341,7 @@ operation dispositions. `scripts/check_observability.py` enforces their exact
 coverage and the vendor-neutral signal/configuration boundary without a live
 collector. It validates root syntax and exclusivity but does not invent
 runtime topology: the three existing gateway decorators remain children, and
-#515 owns coherent ingress roots. The existing footgun reviewer complements
+Issue #515 owns coherent ingress roots. The existing footgun reviewer complements
 this deterministic audit with semantic observability review.
 
 `MissionService` remains pure transition authority over persisted row values.

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -338,11 +338,12 @@ direction, protocol imports, concrete construction, and concrete inheritance.
 
 Independent manifests under `quality/observability/` declare each family's
 operation dispositions. `scripts/check_observability.py` enforces their exact
-coverage and the vendor-neutral signal/configuration boundary without a live
-collector. It validates root syntax and exclusivity but does not invent
-runtime topology: the three existing gateway decorators remain children, and
-Issue #515 owns coherent ingress roots. The existing footgun reviewer complements
-this deterministic audit with semantic observability review.
+coverage, source-backed positive signal claims, and the vendor-neutral
+signal/configuration boundary without a live collector. It validates root
+syntax and exclusivity but does not invent call graphs or runtime topology: the
+three existing gateway decorators remain children, and Issue #515 owns
+coherent ingress roots. The existing footgun reviewer complements this
+deterministic audit with semantic observability review.
 
 `MissionService` remains pure transition authority over persisted row values.
 The same family now owns `MissionAttemptClaimService`, a control-catalog-backed

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -66,6 +66,7 @@ These documents are the current orientation pack for contributors:
 | [Repository Harness](repository-harness.md) | Evidence types, dependency boundary, and how to choose the smallest executable oracle |
 | [Specification Overview](specification.md) | Umbrella contract and historical context |
 | [Application Architecture](application-architecture.md) | Normative supported boundaries, service ownership, dependency order, and lint inputs |
+| [Observability](observability.md) | Safe signal vocabulary, family dispositions, process-host ownership, and telemetry authority boundaries |
 | [Command Gate](command-gate.md) | Policy enforcement point, roles, and audit emission |
 | [Service Protocols](service-protocols.md) | Normative app service interfaces |
 | [Runtime](runtime.md) | Script-boundary runtime contract |
@@ -192,6 +193,7 @@ make test             # full parallel pytest suite
 make test-contract    # tests carrying approved contract IDs
 make test-integration # multi-layer tests
 make test-process     # subprocess/crash/independent-writer tests
+make observability-audit # signal safety and exact family dispositions
 make static           # format, lint, types, lock, contracts, benchmarks
 make eval-conformance # blocking regression + specification evidence
 make eval-reliability # blocking retry/replay/crash/recovery evidence
@@ -207,6 +209,14 @@ Test directories identify the owning subsystem. Orthogonal markers identify
 evidence type and cost: `unit`, `contract(<id>)`, `integration`, `race`,
 `process`, `smoke`, `external`, and `slow`. Do not move a test merely to make a
 profile select it; mark it and keep it beside its owner.
+
+Adding, removing, or renaming a callable member of any `Protocol` anywhere
+under an application family also updates that family's exact
+`quality/observability/<family>.toml` disposition. Do not use wildcard or
+class-wide rows. Add an internal workflow row only when that exact non-protocol
+operation is intentionally instrumented. The deterministic audit owns syntax
+and declared coverage; the existing footgun reviewer owns semantic
+observability boundary, authority, safety, and cardinality review.
 
 ### Before you open a PR
 

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -213,9 +213,12 @@ profile select it; mark it and keep it beside its owner.
 Adding, removing, or renaming a callable member of any `Protocol` anywhere
 under an application family also updates that family's exact
 `quality/observability/<family>.toml` disposition. Do not use wildcard or
-class-wide rows. Add an internal workflow row only when that exact non-protocol
-operation is intentionally instrumented. The deterministic audit owns syntax
-and declared coverage; the existing footgun reviewer owns semantic
+class-wide rows. A positive span or metric disposition names same-owner
+`emission_workflows`; each referenced workflow is checked against the literal
+signals emitted by its exact callable, and the disposition must equal their
+union. Workflow rows remain optional for unrelated internal emitters, and the
+audit never infers a call graph. The deterministic audit owns syntax, declared
+coverage, and that source binding; the existing footgun reviewer owns semantic
 observability boundary, authority, safety, and cardinality review.
 
 ### Before you open a PR

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -232,7 +232,7 @@ roots, while `RuntimeApplication` and lower families own children. The
 repository audit enforces the vocabulary, declared ownership, and
 root/child/none exclusivity, but it does not prove runtime topology. This
 change leaves the three existing gateway decorators as child dispositions;
-#515 owns the coherent root model and any corresponding instrumentation.
+Issue #515 owns the coherent root model and any corresponding instrumentation.
 
 `scripts/check_observability.py` provides deterministic syntax and disposition
 enforcement from source and these manifests. It does not parse exported

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -74,9 +74,10 @@ The current canonical span vocabulary is:
 - the legacy `world.materialize` and `world.execute` phases listed in section 7
   pending measured attribution.
 
-`gate.create_world` and `gate.get_world_info` temporarily normalize to the
-canonical `gateway.*` names. The deterministic audit introduced by #514 owns
-their source migration and expiry.
+Gateway source uses only the canonical `gateway.*` names. The former
+`gate.create_world` and `gate.get_world_info` spellings are neither accepted
+legacy names nor aliases. `SPAN_NAME_ALIASES` remains part of the versioned
+vocabulary and is currently empty.
 
 ## 3. Failure and outcome semantics
 
@@ -188,7 +189,7 @@ retain an open-span table, or bypass the safe signal boundary.
 |---|---|---|
 | Runtime host | Explicit construction-time provider and owned-handler setup; no family workflow span | Runtime lifecycle and returned/raised result |
 | CLI and API | `serve` and worker lifespan configure the host; imports and `create_app()` remain inert | HTTP result and gateway/domain result |
-| Gateway | Child spans for the three currently decorated operations | RBAC decision, typed application result, and access-audit evidence |
+| Gateway | Child spans for the three currently decorated operations; #515 owns a coherent ingress-root design | RBAC decision, typed application result, and access-audit evidence |
 | RuntimeApplication | No direct signal yet; lower owning family remains visible | Typed family result/exception |
 | Commands | No direct signal yet | Durable command ledger and settlement |
 | World lifecycle, mutation, simulation | Existing query/update scopes without execution-attribution claims; materialize/execute names are legacy pending #518/#519 | Tick manifest, world record, and typed result/exception |
@@ -199,9 +200,47 @@ retain an open-span table, or bypass the safe signal boundary.
 | Audit | Logging only; no direct signal yet | Journal/outbox and projection watermark |
 | Missions and sandboxes | No direct signal yet | Typed transition rows, attempt state, checkpoints, and artifacts |
 
-`none` means no new signal has been approved, not that an operation lacks an
-outcome. #514 turns these dispositions into per-family machine manifests and
-requires rationale for every `none` row.
+The machine authority is one independently owned manifest per family under
+`quality/observability/<family>.toml`. The required universe is every callable
+member — method, async method, or property — of every `Protocol` declared
+anywhere under `src/archetype/app/<family>/`, not only protocols co-located in
+`interfaces.py`. Every such member has exactly one disposition row in its
+owning family manifest. Rows use exact qualified names; wildcards, method
+ranges, and inherited blanket dispositions are forbidden. A family may add an
+exact workflow row for an instrumented internal operation that is not a
+protocol member.
+
+Each row declares plural signals and outcomes, its authoritative durable or
+typed evidence when one exists, and only the fixed names, fields, and bounded
+metric labels it uses. `root` and `child` are mutually exclusive. `none` is
+exclusive, requires a rationale, and means no new signal has been approved —
+not that the operation lacks an outcome. A temporary legacy exception names
+one exact rule, path, qualified scope, and target together with its owner,
+issue, reason, and objective expiry condition. A missing, duplicate, phantom,
+wildcard, or stale row fails the audit.
+
+An owner cannot absorb another package's workflow or legacy debt. The sole
+current cross-package ownership is the `world` family's two explicit
+`AsyncWorld` compute/commit workflows. Host capabilities live only in
+`hosts.toml`: provider setup and console export remain in `_obs`, logging
+configuration remains in `_logging`, and runtime/API/CLI hosts may only invoke
+those private adapters.
+
+`root` describes Archetype's logical ingress ownership; it does not discard an
+upstream distributed parent. Runtime and gateway ingress workflows may own
+roots, while `RuntimeApplication` and lower families own children. The
+repository audit enforces the vocabulary, declared ownership, and
+root/child/none exclusivity, but it does not prove runtime topology. This
+change leaves the three existing gateway decorators as child dispositions;
+#515 owns the coherent root model and any corresponding instrumentation.
+
+`scripts/check_observability.py` provides deterministic syntax and disposition
+enforcement from source and these manifests. It does not parse exported
+telemetry or depend on a collector. The existing footgun reviewer separately
+checks semantic boundary/authority and safety/cardinality mistakes that syntax
+cannot prove, including values smuggled under an approved key and telemetry
+used as application authority. Focused behavior contracts still prove typed
+failure identity, retry behavior, and durable evidence.
 
 ## 7. Lazy execution honesty
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -31,10 +31,11 @@ before its own durable or external write. These protections are complementary.
 
 `SIGNAL_SCHEMA_VERSION`, `SPAN_NAMES`, `LEGACY_SPAN_NAMES`,
 `TRACE_ATTRIBUTE_KEYS`, `METRIC_NAMES`, `METRIC_LABEL_KEYS`, `EVENT_NAMES`,
-`ERROR_TYPES`, `FAILURE_DISPOSITIONS`, `OUTCOMES`, `SPAN_NAME_ALIASES`, and
-`TRACE_ATTRIBUTE_ALIASES` in `archetype._obs` are the single machine-readable
-vocabulary. The repository audit consumes these literals; it must not maintain
-a second allowlist.
+`ERROR_TYPES`, `FAILURE_DISPOSITIONS`, `OUTCOMES`, `SPAN_NAME_ALIASES`,
+`TRACE_ATTRIBUTE_ALIASES`, `RECORDER_METRIC_NAMES`, and
+`RECORDER_METRIC_LABEL_KEYS` in `archetype._obs` are the single
+machine-readable vocabulary. The repository audit consumes these literals; it
+must not maintain a second allowlist.
 
 Signal names are fixed. Unknown or dynamic names are no-ops. Custom attributes
 use the `archetype.*` namespace; `error.type` is the approved standard semantic
@@ -208,16 +209,31 @@ anywhere under `src/archetype/app/<family>/`, not only protocols co-located in
 owning family manifest. Rows use exact qualified names; wildcards, method
 ranges, and inherited blanket dispositions are forbidden. A family may add an
 exact workflow row for an instrumented internal operation that is not a
-protocol member.
+protocol member; there is no reverse requirement that every safe internal
+emitter have a workflow row.
 
 Each row declares plural signals and outcomes, its authoritative durable or
 typed evidence when one exists, and only the fixed names, fields, and bounded
-metric labels it uses. `root` and `child` are mutually exclusive. `none` is
-exclusive, requires a rationale, and means no new signal has been approved —
-not that the operation lacks an outcome. A temporary legacy exception names
-one exact rule, path, qualified scope, and target together with its owner,
-issue, reason, and objective expiry condition. A missing, duplicate, phantom,
-wildcard, or stale row fails the audit.
+metric labels it uses. Every workflow claim must exactly match literal
+emissions in its declared callable. Context-manager factories count only when
+entered directly and decorator factories only when applied directly; merely
+constructing either object is not an emission. Called helpers and nested
+callables are not attributed transitively. The fixed metric contract of
+`record_failure()` and `record_outcome()` comes from `_obs`'s machine-readable
+recorder vocabulary. A positive protocol disposition lists same-owner
+`emission_workflows` and its fixed signal claims must equal the union of those
+source-backed workflows. This binds positive intent to source without
+inventing protocol-to-implementation mappings or requiring a workflow for
+every internal emitter.
+
+`root` and `child` are mutually exclusive. `none` is exclusive, requires a
+rationale, and records approval intent: no new signal is approved for that
+contract. It does not claim the operation lacks an outcome, nor does it pretend
+to prove source absence without a protocol-to-implementation registry. A
+temporary legacy exception names one exact rule, path, qualified scope, and
+target together with its owner, issue, reason, and objective expiry condition.
+A missing, duplicate, phantom, wildcard, stale, cross-owner, or
+source-divergent row fails the audit.
 
 An owner cannot absorb another package's workflow or legacy debt. The sole
 current cross-package ownership is the `world` family's two explicit
@@ -230,9 +246,10 @@ those private adapters.
 upstream distributed parent. Runtime and gateway ingress workflows may own
 roots, while `RuntimeApplication` and lower families own children. The
 repository audit enforces the vocabulary, declared ownership, and
-root/child/none exclusivity, but it does not prove runtime topology. This
-change leaves the three existing gateway decorators as child dispositions;
-Issue #515 owns the coherent root model and any corresponding instrumentation.
+root/child/none exclusivity. It also binds fixed workflow fields to exact
+lexical source emissions, but it does not prove runtime topology. This change
+leaves the three existing gateway decorators as child dispositions; Issue #515
+owns the coherent root model and any corresponding instrumentation.
 
 `scripts/check_observability.py` provides deterministic syntax and disposition
 enforcement from source and these manifests. It does not parse exported

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -93,6 +93,24 @@ record measurements; they do not become CI regression gates without a stable
 runner, durable retention, a comparison window, and an owner who will respond
 to the signal.
 
+## Observability enforcement
+
+Observability uses two complementary repository oracles. Independent family
+manifests under `quality/observability/` declare an exact disposition for every
+callable application-family protocol member and any explicitly instrumented
+internal workflow. `scripts/check_observability.py` deterministically validates
+that coverage plus obvious boundary, vocabulary, secret-safety, logging, and
+cardinality violations. It consumes the literal vocabulary in
+`archetype._obs`; it does not copy an allowlist, inspect exported telemetry, or
+require a live collector.
+
+The existing footgun reviewer owns the semantic remainder: whether telemetry
+has become authority, whether a value is unsafe despite using an approved key,
+and whether dimensions are bounded in the actual workflow. It adds that review
+to the current reviewer rather than introducing a second model, check, or
+required context. Focused contract tests remain the oracle for durable outcome
+authority and retry/failure behavior.
+
 ## Gate ownership
 
 The ordinary Python matrix owns product tests and static checks. Repository
@@ -104,6 +122,7 @@ Use these entry points:
 
 ```bash
 make ci          # static checks + pytest with coverage
+make observability-audit # signal safety and exact family dispositions
 make eval        # all current repository-check groups
 make bench       # supported local ECS snapshot
 make bench-query # supported local query snapshot

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -9,6 +9,7 @@ machine authority; this page is its review surface.
 | --- | --- | --- | --- | --- | --- |
 | `observability.signals.safe` | `observability` | high | [docs/guide/observability.md](../guide/observability.md) — 1. Safe signal contract | pytest: 2 | `pr`, `main`, `release` |
 | `observability.logging.correlated` | `observability` | medium | [docs/guide/observability.md](../guide/observability.md) — 5. Process-host ownership | pytest: 3 | `pr`, `main`, `release` |
+| `observability.repository.enforced` | `observability` | high | [docs/guide/observability.md](../guide/observability.md) — 6. Family dispositions | pytest: 2; static: 1 | `pr`, `main`, `release` |
 | `sandboxes.attempt.phase_order` | `sandboxes` | high | [docs/guide/sandbox-execution.md](../guide/sandbox-execution.md) — 3. Six-phase attempt protocol | pytest: 2; static: 1; eval: 1 | `pr`, `main`, `release` |
 | `architecture.dependencies.enforced` | `app` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 11. Static enforcement | pytest: 1; static: 1; eval: 2 | `pr`, `main`, `release` |
 | `architecture.protocols.complete` | `app` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 8. Protocol policy and wiring | pytest: 1; static: 1; eval: 1 | `pr`, `main`, `release` |

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -29,6 +29,21 @@ benchmarks = []
 profiles = ["pr", "main", "release"]
 
 [[contract]]
+id = "observability.repository.enforced"
+source = "docs/guide/observability.md"
+section = "6. Family dispositions"
+owner = "observability"
+risk = "high"
+pytest = [
+    "tests/scripts/test_check_observability.py",
+    "tests/scripts/test_footgun_review_gate.py",
+]
+static = ["scripts/check_observability.py"]
+evals = []
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
 id = "sandboxes.attempt.phase_order"
 source = "docs/guide/sandbox-execution.md"
 section = "3. Six-phase attempt protocol"

--- a/quality/observability/api.toml
+++ b/quality/observability/api.toml
@@ -1,0 +1,12 @@
+version = 1
+owner = "api"
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/api/errors.py"
+qualified_scope = "archetype.api.errors.raise_api_error"
+target = "log:exception:'Unhandled API exception':exception"
+owner = "api"
+issue = 515
+reason = "The existing API fallback logger still exports exception stack details pending ingress observability remediation."
+expiry_condition = "Remove when #515 replaces this fallback with safe bounded error diagnostics."

--- a/quality/observability/application.toml
+++ b/quality/observability/application.toml
@@ -1,0 +1,76 @@
+version = 1
+owner = "application"
+family = "application"
+
+[[disposition]]
+operations = [
+  "interfaces.iRuntimeApplication.stop_admission",
+  "interfaces.iRuntimeApplication.create_entity",
+  "interfaces.iRuntimeApplication.create_entities",
+  "interfaces.iRuntimeApplication.reserve_entity_ids",
+  "interfaces.iRuntimeApplication.spawn_with_reserved_id",
+  "interfaces.iRuntimeApplication.remove_entity",
+  "interfaces.iRuntimeApplication.update_entity",
+  "interfaces.iRuntimeApplication.add_components",
+  "interfaces.iRuntimeApplication.remove_components",
+  "interfaces.iRuntimeApplication.add_processor",
+  "interfaces.iRuntimeApplication.remove_processor",
+  "interfaces.iRuntimeApplication.create_world",
+  "interfaces.iRuntimeApplication.fork_world",
+  "interfaces.iRuntimeApplication.destroy_world",
+  "interfaces.iRuntimeApplication.get_world_info",
+  "interfaces.iRuntimeApplication.list_worlds",
+  "interfaces.iRuntimeApplication.discover_worlds",
+  "interfaces.iRuntimeApplication.open_world_readonly",
+  "interfaces.iRuntimeApplication.resume_world",
+  "interfaces.iRuntimeApplication.step",
+  "interfaces.iRuntimeApplication.run",
+  "interfaces.iRuntimeApplication.run_episode",
+  "interfaces.iRuntimeApplication.run_rollout",
+  "interfaces.iRuntimeApplication.autoresearch",
+  "interfaces.iRuntimeApplication.query_components",
+  "interfaces.iRuntimeApplication.query_archetype",
+  "interfaces.iRuntimeApplication.list_signatures",
+  "interfaces.iRuntimeApplication.add_resource",
+  "interfaces.iRuntimeApplication.add_hook",
+  "interfaces.iRuntimeApplication.remove_hook",
+  "interfaces.iRuntimeApplication.list_processors",
+  "interfaces.iRuntimeApplication.list_hooks",
+  "interfaces.iRuntimeApplication.list_resources",
+  "interfaces.iRuntimeApplication.get_audit_history",
+  "interfaces.iRuntimeApplication.ingest_artifact",
+  "interfaces.iRuntimeApplication.ingest_files",
+  "interfaces.iRuntimeApplication.write_artifacts",
+  "interfaces.iRuntimeApplication.query_artifacts",
+  "interfaces.iRuntimeApplication.publish_artifact_bundle",
+  "interfaces.iRuntimeApplication.query_artifact_bundles",
+  "interfaces.iRuntimeApplication.reconcile_artifact_bundles",
+  "interfaces.iRuntimeApplication.run_graders",
+  "interfaces.iRuntimeApplication.evaluate",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "The typed owning-family result or exception and its family-owned durable record remain authoritative."
+evidence = [
+  "docs/guide/application-architecture.md",
+  "tests/app/test_application_contracts.py",
+]
+rationale = "RuntimeApplication is an actor-free facade; duplicate facade signals would obscure the owning family."
+
+[[disposition]]
+operations = [
+  "interfaces.iRuntimeApplication.require_world",
+  "interfaces.iRuntimeApplication.validate_deferred_command",
+  "interfaces.iRuntimeApplication.submit",
+  "interfaces.iRuntimeApplication.submit_batch",
+  "interfaces.iRuntimeApplication.submit_spawn",
+  "interfaces.iRuntimeApplication.drain_and_apply",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The durable command ledger, settlement row, and typed scheduler result remain authoritative."
+evidence = [
+  "docs/guide/durable-commands.md",
+  "tests/app/test_durable_commands.py",
+]
+rationale = "The facade delegates deferred admission and settlement to the command family without emitting a second signal."

--- a/quality/observability/artifacts.toml
+++ b/quality/observability/artifacts.toml
@@ -7,6 +7,7 @@ operations = [
   "interfaces.iArtifactBundleService.publish",
 ]
 signals = ["child"]
+emission_workflows = ["artifact.bundle.publish", "artifact.bundle.resume"]
 outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
 authority = "The artifact publication row, object/index state, and publish receipt remain authoritative."
 evidence = [

--- a/quality/observability/artifacts.toml
+++ b/quality/observability/artifacts.toml
@@ -1,0 +1,98 @@
+version = 1
+owner = "artifacts"
+family = "artifacts"
+
+[[disposition]]
+operations = [
+  "interfaces.iArtifactBundleService.publish",
+]
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The artifact publication row, object/index state, and publish receipt remain authoritative."
+evidence = [
+  "docs/guide/artifact-finalization.md",
+  "tests/app/test_artifact_publication.py",
+]
+span_names = ["artifact.publish", "artifact.upload", "artifact.index"]
+attribute_keys = [
+  "archetype.world.id",
+  "archetype.run.id",
+  "archetype.entity.id",
+  "archetype.tick",
+  "archetype.artifact.bundle.digest",
+  "archetype.artifact.count",
+]
+
+[[disposition]]
+operations = [
+  "interfaces.iArtifactBundleService.reconcile",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The artifact publication lease and durable publication row prove reconciliation progress."
+evidence = [
+  "docs/guide/artifact-finalization.md",
+  "tests/app/test_artifact_publication.py",
+]
+rationale = "Reconciliation reuses durable publication state; no additional signal has been approved."
+
+[[disposition]]
+operations = [
+  "bundle_models.ArtifactSourceResolver.materialize",
+  "bundle_models.BoundedArtifactSourceResolver.materialize_bounded",
+  "interfaces.iArtifactService.publish",
+  "interfaces.iArtifactService.publish_evaluation",
+  "interfaces.iArtifactService.snapshot_ref",
+  "interfaces.iArtifactTableService.ingest_files",
+  "interfaces.iArtifactTableService.write_artifacts",
+  "interfaces.iArtifactTableService.read_artifacts",
+  "interfaces.iArtifactBundleService.enabled",
+  "interfaces.iArtifactBundleService.query",
+  "models.ArtifactProcessor.process",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "Validated artifact records, immutable object references, returned frames, and typed exceptions remain authoritative."
+evidence = [
+  "docs/guide/artifacts.md",
+  "tests/app/test_artifact_tables.py",
+]
+rationale = "No direct signal is approved for these artifact helpers and persisted read/write primitives."
+
+[[workflow]]
+id = "artifact.bundle.publish"
+qualified_scope = "archetype.app.artifacts.bundle_service.ArtifactBundleService.publish"
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The durable publication row and ArtifactPublishReceipt prove the operation outcome."
+evidence = [
+  "docs/guide/artifact-finalization.md",
+  "tests/app/test_artifact_publication.py",
+]
+span_names = ["artifact.publish"]
+attribute_keys = [
+  "archetype.world.id",
+  "archetype.run.id",
+  "archetype.entity.id",
+  "archetype.tick",
+]
+
+[[workflow]]
+id = "artifact.bundle.resume"
+qualified_scope = "archetype.app.artifacts.bundle_service.ArtifactBundleService._resume"
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The upload/index state in the publication row and final receipt prove resumed progress."
+evidence = [
+  "docs/guide/artifact-finalization.md",
+  "tests/app/test_artifact_publication.py",
+]
+span_names = ["artifact.upload", "artifact.index"]
+attribute_keys = [
+  "archetype.world.id",
+  "archetype.run.id",
+  "archetype.entity.id",
+  "archetype.tick",
+  "archetype.artifact.bundle.digest",
+  "archetype.artifact.count",
+]

--- a/quality/observability/audit.toml
+++ b/quality/observability/audit.toml
@@ -1,0 +1,26 @@
+version = 1
+owner = "audit"
+family = "audit"
+
+[[disposition]]
+operations = [
+  "interfaces.iAuditLog.set_outbox_source",
+  "interfaces.iAuditLog.record",
+  "interfaces.iAuditLog.flush",
+  "interfaces.iAuditLog.project_outbox",
+  "interfaces.iAuditLog.query",
+  "interfaces.iAuditLog.shutdown",
+]
+signals = ["log_only"]
+outcomes = [
+  "propagated_failure",
+  "handled_outcome",
+  "retryable_attempt",
+  "advisory_suppression",
+]
+authority = "The append-only audit journal, durable outbox, projection watermark, and returned rows remain authoritative."
+evidence = [
+  "docs/guide/audit-log.md",
+  "tests/app/test_audit_contracts.py",
+]
+rationale = "Audit projection failures may be suppressed only where durable outbox state remains authoritative and retryable."

--- a/quality/observability/commands.toml
+++ b/quality/observability/commands.toml
@@ -1,0 +1,28 @@
+version = 1
+owner = "commands"
+family = "commands"
+
+[[disposition]]
+operations = [
+  "interfaces.iCommandScheduler.validate_deferred",
+  "interfaces.iCommandScheduler.require_world",
+  "interfaces.iCommandScheduler.admit",
+  "interfaces.iCommandScheduler.admit_batch",
+  "interfaces.iCommandScheduler.admit_spawn",
+  "interfaces.iCommandScheduler.drain_and_apply",
+  "interfaces.iCommandScheduler.pending_count",
+  "interfaces.iCommandScheduler.records",
+  "interfaces.iCommandScheduler.history",
+  "interfaces.iCommandScheduler.cancel_world",
+  "interfaces.iCommandScheduler.read_outbox",
+  "interfaces.iCommandScheduler.mark_outbox_projected",
+  "interfaces.iCommandScheduler.outbox_progress",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The durable command ledger, lease/settlement state, and transactional outbox remain authoritative."
+evidence = [
+  "docs/guide/durable-commands.md",
+  "tests/app/test_durable_commands.py",
+]
+rationale = "The scheduler has no approved direct signal; durable admission and settlement are the recovery authority."

--- a/quality/observability/core.toml
+++ b/quality/observability/core.toml
@@ -1,0 +1,362 @@
+version = 1
+owner = "core"
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_lancedb_store.py"
+qualified_scope = "archetype.core.aio.async_lancedb_store.AsyncLancedbStore._ensure_table"
+target = "log:error:f'Error creating LanceDB table {table_name}: {e}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "unsafe_log_value"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._debug_log"
+target = "log:debug:f'[archetype] {json.dumps(payload)}':sensitive-value"
+owner = "core"
+issue = 530
+reason = "The pre-existing debug diagnostic exports a serialized payload; #530 owns its removal without changing core execution behavior."
+expiry_condition = "Remove when #530 replaces payload export with bounded event categories or removes the diagnostic."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/aio/async_lancedb_store.py"
+qualified_scope = "archetype.core.aio.async_lancedb_store.AsyncLancedbStore._ensure_table"
+target = "log:error:f'Error creating LanceDB table {table_name}: {e}':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/aio/async_lancedb_store.py"
+qualified_scope = "archetype.core.aio.async_lancedb_store.AsyncLancedbStore.get_existing_table_df"
+target = "log:error:'Error reading existing table %s: %s':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_lancedb_store.py"
+qualified_scope = "archetype.core.aio.async_lancedb_store.AsyncLancedbStore.get_archetype_df"
+target = "log:error:f'Error reading archetype table {table_name}: {e}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/aio/async_lancedb_store.py"
+qualified_scope = "archetype.core.aio.async_lancedb_store.AsyncLancedbStore.get_archetype_df"
+target = "log:error:f'Error reading archetype table {table_name}: {e}':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_lancedb_store.py"
+qualified_scope = "archetype.core.aio.async_lancedb_store.AsyncLancedbStore.append"
+target = "log:info:f'Append skipped (lancedb): archetype={table_id} empty schema':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_lancedb_store.py"
+qualified_scope = "archetype.core.aio.async_lancedb_store.AsyncLancedbStore.append"
+target = "log:info:f'Append skipped (lancedb): archetype={table_id} rows=0':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_store.py"
+qualified_scope = "archetype.core.aio.async_store.AsyncStore.append"
+target = "log:info:f'Append skipped (store): archetype={table_id} empty schema':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_store.py"
+qualified_scope = "archetype.core.aio.async_store.AsyncStore.append"
+target = "log:error:f'Append collect failed for {table_id}: {e}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/aio/async_store.py"
+qualified_scope = "archetype.core.aio.async_store.AsyncStore.append"
+target = "log:error:f'Append collect failed for {table_id}: {e}':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_store.py"
+qualified_scope = "archetype.core.aio.async_store.AsyncStore.append"
+target = "log:info:f'Append skipped (store): archetype={table_id} rows=0':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_system.py"
+qualified_scope = "archetype.core.aio.async_system.AsyncSystem.execute"
+target = "log:debug:f'[archetype] processor_start: {proc_name} (priority={proc_instance.priority}, archetype={archetype_name})':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_system.py"
+qualified_scope = "archetype.core.aio.async_system.AsyncSystem.execute"
+target = "log:debug:f'[archetype] processor_end: {proc_name} (rows_out={row_count})':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_system.py"
+qualified_scope = "archetype.core.aio.async_system.AsyncSystem.execute"
+target = "log:error:f'Error processing archetype {sig}: {e} with processor {proc_instance} of type {type(proc_instance)}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/aio/async_system.py"
+qualified_scope = "archetype.core.aio.async_system.AsyncSystem.execute"
+target = "log:error:f'Error processing archetype {sig}: {e} with processor {proc_instance} of type {type(proc_instance)}':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_updater.py"
+qualified_scope = "archetype.core.aio.async_updater.AsyncUpdateManager.update"
+target = "log:info:f'Update skipped (empty schema): archetype={Archetype.get_name(sig)}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_updater.py"
+qualified_scope = "archetype.core.aio.async_updater.AsyncUpdateManager.update"
+target = "log:info:f'Append committed: archetype={Archetype.get_name(sig)} world_id={world_id} run_id={run_id} tick={tick} duration_ms={duration_ms:.3f}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_updater.py"
+qualified_scope = "archetype.core.aio.async_updater.AsyncUpdateManager.update"
+target = "log:error:f'Error updating table {Archetype.get_name(sig)}: {e}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/aio/async_updater.py"
+qualified_scope = "archetype.core.aio.async_updater.AsyncUpdateManager.update"
+target = "log:error:f'Error updating table {Archetype.get_name(sig)}: {e}':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._move_entity"
+target = "log:warning:f'World {self.name} ({self.world_id}): Entity Migration Failed: No entity: {entity_id}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._move_entity"
+target = "log:warning:f'World {self.name} ({self.world_id}): Entity Migration Failed: Multiple entities: {entity_id}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._debug_log"
+target = "log:debug:f'[archetype] {json.dumps(payload)}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/hooks.py"
+qualified_scope = "archetype.core.hooks.HookRegistry.fire"
+target = "log:warning:'Hook %s failed on %s: %s':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/hooks.py"
+qualified_scope = "archetype.core.hooks.SyncHookRegistry.fire"
+target = "log:warning:'Hook %s failed on %s: %s':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/hooks.py"
+qualified_scope = "archetype.core.hooks._fire_detached"
+target = "log:warning:'Detached hook %s failed on %s: %s':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/sync/querier.py"
+qualified_scope = "archetype.core.sync.querier.QueryManager.query_archetype"
+target = "log:info:f'Querying {Archetype.get_name(sig)} with {df.count_rows()} rows':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/sync/system.py"
+qualified_scope = "archetype.core.sync.system.SyncSystem.execute"
+target = "log:exception:f'Error processing archetype {sig}: {e} with processor {proc_instance} of type {type(proc_instance)}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/sync/system.py"
+qualified_scope = "archetype.core.sync.system.SyncSystem.execute"
+target = "log:exception:f'Error processing archetype {sig}: {e} with processor {proc_instance} of type {type(proc_instance)}':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/sync/updater.py"
+qualified_scope = "archetype.core.sync.updater.UpdateManager.update"
+target = "log:info:f'Update skipped (empty schema): archetype={Archetype.get_name(sig)}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/sync/updater.py"
+qualified_scope = "archetype.core.sync.updater.UpdateManager.update"
+target = "log:error:f'Error updating table {Archetype.get_name(sig)}: {e}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/core/sync/updater.py"
+qualified_scope = "archetype.core.sync.updater.UpdateManager.update"
+target = "log:error:f'Error updating table {Archetype.get_name(sig)}: {e}':exception"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic exports raw exception text or stack details."
+expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/sync/world.py"
+qualified_scope = "archetype.core.sync.world.SyncWorld._move_entity"
+target = "log:warning:f'World {self.name} ({self.world_id}): Entity Migration ambiguous: {len(rows)} rows for entity {entity_id} at tick {self.tick - 1}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/sync/world.py"
+qualified_scope = "archetype.core.sync.world.SyncWorld.remove_entity"
+target = "log:warning:f'World {self.name} ({self.world_id}): Entity Removal Failed: No entity: {entity_id}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/sync/world.py"
+qualified_scope = "archetype.core.sync.world.SyncWorld.add_components"
+target = "log:warning:f'add_components: entity {entity_id} not found':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
+
+[[legacy]]
+rule = "eager_log_interpolation"
+path = "src/archetype/core/sync/world.py"
+qualified_scope = "archetype.core.sync.world.SyncWorld.add_components"
+target = "log:debug:f'add_components: components already in archetype for entity {entity_id}':interpolation"
+owner = "core"
+issue = 530
+reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
+expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."

--- a/quality/observability/evaluation.toml
+++ b/quality/observability/evaluation.toml
@@ -1,0 +1,22 @@
+version = 1
+owner = "evaluation"
+family = "evaluation"
+
+[[disposition]]
+operations = [
+  "interfaces.iEvaluationService.evaluate",
+  "interfaces.iEvaluationService.query_components",
+  "interfaces.iEvaluationService.query_episode",
+  "interfaces.iEvaluationService.query_trajectory_component",
+  "interfaces.iEvaluationService.run_graders",
+  "interfaces.iEvaluationService.grade_trajectory_component",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "Snapshot-pinned evaluation inputs, grader results, and durable evaluation receipts remain authoritative."
+evidence = [
+  "docs/guide/service-protocols.md",
+  "tests/app/test_eval_receipts.py",
+  "tests/app/test_eval_service.py",
+]
+rationale = "Evaluation has no approved direct signal; receipts and typed grader outcomes carry product truth."

--- a/quality/observability/experiments.toml
+++ b/quality/observability/experiments.toml
@@ -1,0 +1,22 @@
+version = 1
+owner = "experiments"
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/experiments/claude_sessions.py"
+qualified_scope = "archetype.experiments.claude_sessions.load_claude_session"
+target = "log:warning:'unreadable session %s: %s':exception"
+owner = "experiments"
+issue = 530
+reason = "The existing experiment-session loader records raw exception text while reporting unreadable input."
+expiry_condition = "Remove when #530 replaces this call with a bounded error type and safe path diagnostic."
+
+[[legacy]]
+rule = "unsafe_log_value"
+path = "src/archetype/experiments/claude_sessions.py"
+qualified_scope = "archetype.experiments.claude_sessions.load_claude_session"
+target = "log:warning:'unreadable session %s: %s':sensitive-value"
+owner = "experiments"
+issue = 530
+reason = "The pre-existing session diagnostic exports a filesystem path; #530 owns a bounded replacement or removal with the experiments helper."
+expiry_condition = "Remove when #530 replaces the path with a bounded session-read category or removes the helper."

--- a/quality/observability/gateway.toml
+++ b/quality/observability/gateway.toml
@@ -9,6 +9,11 @@ operations = [
   "interfaces.iCommandGateway.get_world_info",
 ]
 signals = ["child"]
+emission_workflows = [
+  "gateway.create_entity",
+  "gateway.create_world",
+  "gateway.get_world_info",
+]
 outcomes = ["propagated_failure", "handled_outcome"]
 authority = "The RBAC decision, typed application result, and access-audit evidence remain authoritative."
 evidence = [

--- a/quality/observability/gateway.toml
+++ b/quality/observability/gateway.toml
@@ -1,0 +1,133 @@
+version = 1
+owner = "gateway"
+family = "gateway"
+
+[[disposition]]
+operations = [
+  "interfaces.iCommandGateway.create_entity",
+  "interfaces.iCommandGateway.create_world",
+  "interfaces.iCommandGateway.get_world_info",
+]
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "The RBAC decision, typed application result, and access-audit evidence remain authoritative."
+evidence = [
+  "docs/guide/command-gate.md",
+  "tests/app/test_gateway_delegation.py",
+  "tests/app/test_permissions.py",
+]
+span_names = [
+  "gateway.create_entity",
+  "gateway.create_world",
+  "gateway.get_world_info",
+]
+
+[[disposition]]
+operations = [
+  "interfaces.iCommandGateway.submit",
+  "interfaces.iCommandGateway.submit_batch",
+  "interfaces.iCommandGateway.submit_spawn",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The RBAC decision and durable command admission record remain authoritative."
+evidence = [
+  "docs/guide/command-gate.md",
+  "docs/guide/durable-commands.md",
+  "tests/app/test_durable_commands.py",
+]
+rationale = "Deferred gateway calls delegate durable admission to the scheduler; no gateway signal is approved."
+
+[[disposition]]
+operations = [
+  "interfaces.iCommandGateway.create_entities",
+  "interfaces.iCommandGateway.reserve_entity_ids",
+  "interfaces.iCommandGateway.spawn_with_reserved_id",
+  "interfaces.iCommandGateway.remove_entity",
+  "interfaces.iCommandGateway.update_entity",
+  "interfaces.iCommandGateway.add_components",
+  "interfaces.iCommandGateway.remove_components",
+  "interfaces.iCommandGateway.add_processor",
+  "interfaces.iCommandGateway.remove_processor",
+  "interfaces.iCommandGateway.fork_world",
+  "interfaces.iCommandGateway.destroy_world",
+  "interfaces.iCommandGateway.list_worlds",
+  "interfaces.iCommandGateway.discover_worlds",
+  "interfaces.iCommandGateway.open_world_readonly",
+  "interfaces.iCommandGateway.resume_world",
+  "interfaces.iCommandGateway.step",
+  "interfaces.iCommandGateway.run",
+  "interfaces.iCommandGateway.run_episode",
+  "interfaces.iCommandGateway.run_rollout",
+  "interfaces.iCommandGateway.autoresearch",
+  "interfaces.iCommandGateway.query_components",
+  "interfaces.iCommandGateway.query_archetype",
+  "interfaces.iCommandGateway.list_signatures",
+  "interfaces.iCommandGateway.get_audit_history",
+  "interfaces.iCommandGateway.add_resource",
+  "interfaces.iCommandGateway.add_hook",
+  "interfaces.iCommandGateway.remove_hook",
+  "interfaces.iCommandGateway.list_processors",
+  "interfaces.iCommandGateway.list_hooks",
+  "interfaces.iCommandGateway.list_resources",
+  "interfaces.iCommandGateway.ingest_artifact",
+  "interfaces.iCommandGateway.ingest_files",
+  "interfaces.iCommandGateway.write_artifacts",
+  "interfaces.iCommandGateway.query_artifacts",
+  "interfaces.iCommandGateway.evaluate",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "The RBAC decision, typed application result, and owning-family durable evidence remain authoritative."
+evidence = [
+  "docs/guide/command-gate.md",
+  "tests/app/test_gateway_delegation.py",
+  "tests/app/test_permissions.py",
+]
+rationale = "No direct gateway signal has been approved for these delegated operations."
+
+[[workflow]]
+id = "gateway.create_entity"
+qualified_scope = "archetype.app.gateway.service.CommandGateway.create_entity"
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "The authorization decision, application result, and access-audit evidence prove the outcome."
+evidence = [
+  "docs/guide/command-gate.md",
+  "tests/app/test_gateway_delegation.py",
+]
+span_names = ["gateway.create_entity"]
+
+[[workflow]]
+id = "gateway.create_world"
+qualified_scope = "archetype.app.gateway.service.CommandGateway.create_world"
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "The authorization decision, WorldInfo result, and access-audit evidence prove the outcome."
+evidence = [
+  "docs/guide/command-gate.md",
+  "tests/app/test_gateway_delegation.py",
+]
+span_names = ["gateway.create_world"]
+
+[[workflow]]
+id = "gateway.get_world_info"
+qualified_scope = "archetype.app.gateway.service.CommandGateway.get_world_info"
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "The authorization decision, returned WorldInfo, and access-audit evidence prove the outcome."
+evidence = [
+  "docs/guide/command-gate.md",
+  "tests/app/test_gateway_delegation.py",
+]
+span_names = ["gateway.get_world_info"]
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/app/gateway/service.py"
+qualified_scope = "archetype.app.gateway.service.CommandGateway._emit"
+target = "log:warning:'audit emission failed':exception"
+owner = "gateway"
+issue = 515
+reason = "The gateway audit sidecar warning currently includes raw exception details pending ingress observability remediation."
+expiry_condition = "Remove when #515 emits a bounded audit-failure diagnostic without exception content."

--- a/quality/observability/hosts.toml
+++ b/quality/observability/hosts.toml
@@ -1,0 +1,89 @@
+version = 1
+owner = "hosts"
+
+[[host_callable]]
+qualified_scope = "archetype._obs._install_candidate"
+capabilities = ["provider_configuration"]
+evidence = ["docs/guide/observability.md"]
+rationale = "This adapter installs one validated provider candidate and discards a candidate that loses the host race."
+
+[[host_callable]]
+qualified_scope = "archetype._obs.configure_tracing"
+capabilities = ["provider_configuration"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_obs_process.py",
+]
+rationale = "This is the private provider/exporter adapter invoked only from an explicit process host."
+
+[[host_callable]]
+qualified_scope = "archetype._obs._console_processor"
+capabilities = ["provider_configuration"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_obs.py",
+]
+rationale = "This private factory constructs the approved debug-console processor after host configuration is requested."
+
+[[host_callable]]
+qualified_scope = "archetype._obs._console_processor._OneLineExporter.export"
+capabilities = ["console_export"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_obs.py",
+]
+rationale = "This is the sole approved shipped non-CLI console export boundary and emits only sanitized spans."
+
+[[host_callable]]
+qualified_scope = "archetype._logging._ArchetypeHandler.__init__"
+capabilities = ["logging_configuration"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_logging_contracts.py",
+]
+rationale = "This private handler constructor installs only the package-owned safe formatter and correlation filter."
+
+[[host_callable]]
+qualified_scope = "archetype._logging.configure_archetype_logging"
+capabilities = ["logging_configuration"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_logging_contracts.py",
+]
+rationale = "This private adapter performs idempotent package-handler configuration on behalf of an explicit host."
+
+[[host_callable]]
+qualified_scope = "archetype._logging.configure_host_observability"
+capabilities = ["invoke_configuration"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_runtime_observability.py",
+]
+rationale = "This private coordinator invokes tracing and logging configuration only when called by an explicit host."
+
+[[host_callable]]
+qualified_scope = "archetype.runtime.runtime.ArchetypeRuntime.__init__"
+capabilities = ["invoke_configuration"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_runtime_observability.py",
+]
+rationale = "Runtime construction is the explicit trusted-script process-host boundary."
+
+[[host_callable]]
+qualified_scope = "archetype.api.app.lifespan"
+capabilities = ["invoke_configuration"]
+evidence = [
+  "docs/guide/api-layer.md",
+  "tests/app/test_runtime_observability.py",
+]
+rationale = "FastAPI lifespan is the serving-worker process-host boundary; importing or creating the app remains inert."
+
+[[host_callable]]
+qualified_scope = "archetype.cli.main.serve"
+capabilities = ["invoke_configuration"]
+evidence = [
+  "docs/guide/api-layer.md",
+  "tests/app/test_runtime_observability.py",
+]
+rationale = "The serve command is the CLI-owned server process-host boundary."

--- a/quality/observability/missions.toml
+++ b/quality/observability/missions.toml
@@ -1,0 +1,29 @@
+version = 1
+owner = "missions"
+family = "missions"
+
+[[disposition]]
+operations = [
+  "interfaces.iMissionService.prepare_attempt",
+  "interfaces.iMissionService.apply_attempt",
+  "interfaces.iMissionAttemptClaimService.acquire",
+  "interfaces.iMissionAttemptClaimService.decide_recovery",
+  "interfaces.iMissionAttemptClaimService.renew",
+  "interfaces.iMissionAttemptClaimService.acknowledge_provider",
+  "interfaces.iMissionAttemptClaimService.settle",
+  "interfaces.iMissionAttemptClaimService.consume_execution",
+  "interfaces.iMissionAttemptClaimService.prepare_durable_outcome",
+  "interfaces.iMissionAttemptClaimService.settled_outcome",
+  "interfaces.iMissionAttemptExecutionService.run",
+  "models.FencedAttemptRunner.provider_execution_capabilities",
+  "models.FencedAttemptRunner.run_attempt",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "Fenced attempt-claim rows, validated mission transitions, provider receipts, and durable outcomes remain authoritative."
+evidence = [
+  "docs/guide/agent-missions.md",
+  "tests/app/test_mission_attempt_claims.py",
+  "tests/app/test_mission_transition_authority.py",
+]
+rationale = "Mission and attempt workflows have no approved direct signal; durable claims and transition validators own truth."

--- a/quality/observability/query.toml
+++ b/quality/observability/query.toml
@@ -1,0 +1,30 @@
+version = 1
+owner = "query"
+family = "query"
+
+[[disposition]]
+operations = [
+  "interfaces.iQueryService.query_archetype",
+  "interfaces.iQueryService.query_components",
+  "interfaces.iQueryService.get_lineage",
+  "interfaces.iQueryService.list_signatures",
+  "interfaces.iQueryService.get_command_history",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "advisory_suppression"]
+authority = "Persisted store/catalog state and the returned lazy frame or typed history result remain authoritative."
+evidence = [
+  "docs/guide/service-protocols.md",
+  "tests/app/test_durable_discovery.py",
+]
+rationale = "The query family has no approved direct signal; bounded discovery degradation remains explicit in its returned result."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/app/query/service.py"
+qualified_scope = "archetype.app.query.service.QueryService._signature_records"
+target = "log:exception:'control catalog unavailable for durable signature discovery':exception"
+owner = "query"
+issue = 520
+reason = "The durable-signature fallback currently logs a raw control-catalog exception."
+expiry_condition = "Remove when #520 introduces bounded query failure diagnostics at the materialization boundary."

--- a/quality/observability/redaction.toml
+++ b/quality/observability/redaction.toml
@@ -1,0 +1,20 @@
+version = 1
+owner = "redaction"
+family = "redaction"
+
+[[disposition]]
+operations = [
+  "interfaces.iRedactionService.policy_id",
+  "interfaces.iRedactionService.redact_text",
+  "interfaces.iRedactionService.redact_record",
+  "interfaces.iRedactionService.assert_safe_metadata",
+  "interfaces.iRedactionService.sanitize_file",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "The redaction receipt, safe output, or quarantine/rejection exception remains authoritative."
+evidence = [
+  "docs/guide/artifact-finalization.md",
+  "tests/app/test_redaction_service.py",
+]
+rationale = "Redaction has no direct signal; approved callers may carry only bounded rule identifiers after redaction completes."

--- a/quality/observability/research.toml
+++ b/quality/observability/research.toml
@@ -1,0 +1,27 @@
+version = 1
+owner = "research"
+family = "research"
+
+[[disposition]]
+operations = [
+  "interfaces.iResearchService.run",
+  "interfaces.iResearchService.sweep",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "Snapshot-pinned experiment state, branch-head rows, iteration records, and typed research results remain authoritative."
+evidence = [
+  "docs/guide/autoresearch.md",
+  "tests/app/test_autoresearch_ledger.py",
+]
+rationale = "Research workflows have no approved direct signal; durable experiment records prove resumable progress."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/app/research/service.py"
+qualified_scope = "archetype.app.research.service.AutoResearchService.run"
+target = "log:exception:'failed to persist autoresearch crash transition for %s':exception"
+owner = "research"
+issue = 523
+reason = "Crash-transition persistence currently records the propagated exception stack in a research workflow log."
+expiry_condition = "Remove when #523 emits a bounded persistence-failure diagnostic tied to durable attempt evidence."

--- a/quality/observability/sandboxes.toml
+++ b/quality/observability/sandboxes.toml
@@ -1,0 +1,31 @@
+version = 1
+owner = "sandboxes"
+family = "sandboxes"
+
+[[disposition]]
+operations = [
+  "interfaces.iSandboxSession.sandbox_id",
+  "interfaces.iSandboxSession.provider_execution_capabilities",
+  "interfaces.iSandboxSession.run_attempt",
+  "interfaces.iSandboxSession.close",
+  "interfaces.iSandboxBackend.create",
+  "interfaces.iSandboxBackend.restore",
+  "interfaces.iSandboxBackend.resume",
+  "interfaces.iSandboxBackend.authenticate",
+  "interfaces.iSandboxService.register_backend",
+  "interfaces.iSandboxService.create",
+  "interfaces.iSandboxService.restore",
+  "interfaces.iSandboxService.resume",
+  "interfaces.iSandboxService.authenticate",
+  "interfaces.iSandboxService.session",
+  "interfaces.iSandboxService.close",
+  "interfaces.iSandboxService.shutdown",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "Typed sandbox session state, provider receipts, checkpoints, and mission attempt records remain authoritative."
+evidence = [
+  "docs/guide/sandbox-execution.md",
+  "tests/app/test_sandbox_kernel.py",
+]
+rationale = "Sandbox lifecycle and execution have no approved direct signal; provider and durable mission evidence own state transitions."

--- a/quality/observability/storage.toml
+++ b/quality/observability/storage.toml
@@ -1,0 +1,85 @@
+version = 1
+owner = "storage"
+family = "storage"
+
+[[disposition]]
+operations = [
+  "catalog.ControlCatalog.register_world",
+  "catalog.ControlCatalog.set_world_status",
+  "catalog.ControlCatalog.set_world_run",
+  "catalog.ControlCatalog.get_world",
+  "catalog.ControlCatalog.list_worlds",
+  "catalog.ControlCatalog.register_signature",
+  "catalog.ControlCatalog.list_signatures",
+  "catalog.ControlCatalog.max_manifest_tick",
+  "catalog.ControlCatalog.acquire_attempt_claim",
+  "catalog.ControlCatalog.transition_attempt_claim",
+  "catalog.ControlCatalog.consume_attempt_execution",
+  "catalog.ControlCatalog.renew_attempt_claim",
+  "catalog.ControlCatalog.get_attempt_claim",
+  "catalog.ControlCatalog.list_due_attempt_claims",
+  "catalog.ControlCatalog.acquire_artifact_publication",
+  "catalog.ControlCatalog.get_artifact_publication",
+  "catalog.ControlCatalog.renew_artifact_publication",
+  "catalog.ControlCatalog.record_artifact_uploads",
+  "catalog.ControlCatalog.complete_artifact_publication",
+  "catalog.ControlCatalog.fail_artifact_publication",
+  "catalog.ControlCatalog.expire_artifact_publication",
+  "catalog.ControlCatalog.list_due_artifact_publications",
+  "catalog.ControlCatalog.admit_commands",
+  "catalog.ControlCatalog.lease_commands",
+  "catalog.ControlCatalog.fail_command",
+  "catalog.ControlCatalog.release_commands",
+  "catalog.ControlCatalog.list_commands",
+  "catalog.ControlCatalog.pending_command_count",
+  "catalog.ControlCatalog.max_reserved_entity_id",
+  "catalog.ControlCatalog.read_outbox",
+  "catalog.ControlCatalog.mark_outbox_projected",
+  "catalog.ControlCatalog.close",
+  "interfaces.iStorageService.has_injected_session",
+  "interfaces.iStorageService.require_iceberg_identity",
+  "interfaces.iStorageService.get_control_catalog",
+  "interfaces.iStorageService.get_or_create_store",
+  "interfaces.iStorageService.get_iceberg_context",
+  "interfaces.iStorageService.shutdown",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "Store/catalog state, fencing epochs, leases, transactional rows, and durable receipts remain authoritative."
+evidence = [
+  "docs/guide/atomic-visibility.md",
+  "docs/guide/service-protocols.md",
+  "tests/app/test_atomic_visibility.py",
+  "tests/app/test_remote_catalog_parity.py",
+]
+rationale = "Storage has no approved direct signal; catalog transactions and backend receipts are the durability authority."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/app/storage/service.py"
+qualified_scope = "archetype.app.storage.service.StorageService.shutdown"
+target = "log:exception:'Failed to shut down store %r':exception"
+owner = "storage"
+issue = 517
+reason = "Best-effort store shutdown currently exports raw exception stack details."
+expiry_condition = "Remove when #517 records a bounded store-shutdown failure without backend or exception content."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/app/storage/service.py"
+qualified_scope = "archetype.app.storage.service.StorageService.shutdown"
+target = "log:exception:'Failed to close control catalog %r':exception"
+owner = "storage"
+issue = 517
+reason = "Best-effort control-catalog shutdown currently exports raw exception stack details."
+expiry_condition = "Remove when #517 records a bounded catalog-shutdown failure without backend or exception content."
+
+[[legacy]]
+rule = "unsafe_log_value"
+path = "src/archetype/app/storage/catalog.py"
+qualified_scope = "archetype.app.storage.catalog.SqliteControlCatalog._connect_sync"
+target = "log:warning:'catalog %s: journal_mode=%s (WAL unavailable)':sensitive-value"
+owner = "storage"
+issue = 517
+reason = "The existing WAL fallback diagnostic exports a catalog path; #517 owns a bounded replacement that preserves catalog behavior."
+expiry_condition = "Remove when #517 replaces the path value with a bounded storage-backend category."

--- a/quality/observability/world.toml
+++ b/quality/observability/world.toml
@@ -10,6 +10,7 @@ operations = [
   "interfaces.iSimulationService.run_rollout",
 ]
 signals = ["child"]
+emission_workflows = ["world.compute_archetype", "world.commit_archetype"]
 outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
 authority = "The tick manifest, append receipts, world record, and typed simulation result remain authoritative."
 evidence = [

--- a/quality/observability/world.toml
+++ b/quality/observability/world.toml
@@ -1,0 +1,230 @@
+version = 1
+owner = "world"
+family = "world"
+
+[[disposition]]
+operations = [
+  "interfaces.iSimulationService.step",
+  "interfaces.iSimulationService.run",
+  "interfaces.iSimulationService.run_episode",
+  "interfaces.iSimulationService.run_rollout",
+]
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The tick manifest, append receipts, world record, and typed simulation result remain authoritative."
+evidence = [
+  "docs/guide/atomic-visibility.md",
+  "docs/guide/worlds.md",
+  "tests/app/test_atomic_visibility.py",
+]
+span_names = [
+  "world.query",
+  "world.materialize",
+  "world.execute",
+  "world.update",
+]
+attribute_keys = [
+  "archetype.component.signature",
+  "archetype.tick",
+]
+
+[[disposition]]
+operations = [
+  "interfaces.iWorldService.create_world",
+  "interfaces.iWorldService.get_world",
+  "interfaces.iWorldService.get_world_by_name",
+  "interfaces.iWorldService.has_world",
+  "interfaces.iWorldService.list_worlds",
+  "interfaces.iWorldService.storage_record",
+  "interfaces.iWorldService.catalog_world_ids",
+  "interfaces.iWorldService.control_catalog",
+  "interfaces.iWorldService.fork_world",
+  "interfaces.iWorldService.destroy_world",
+  "interfaces.iWorldService.discover_worlds",
+  "interfaces.iWorldService.open_world_readonly",
+  "interfaces.iWorldService.open_world_mutable",
+  "interfaces.iWorldService.record_step",
+  "interfaces.iWorldService.add_resource",
+  "interfaces.iWorldService.add_hook",
+  "interfaces.iWorldService.remove_hook",
+  "interfaces.iWorldService.list_processors",
+  "interfaces.iWorldService.list_hooks",
+  "interfaces.iWorldService.list_resources",
+  "interfaces.iWorldService.shutdown",
+  "interfaces.iMutationService.create_entity",
+  "interfaces.iMutationService.create_entities",
+  "interfaces.iMutationService.reserve_entity_ids",
+  "interfaces.iMutationService.spawn_with_reserved_id",
+  "interfaces.iMutationService.remove_entity",
+  "interfaces.iMutationService.update_entity",
+  "interfaces.iMutationService.add_components",
+  "interfaces.iMutationService.remove_components",
+  "interfaces.iMutationService.add_processor",
+  "interfaces.iMutationService.remove_processor",
+  "interfaces.iSimulationService.set_command_drain",
+  "interfaces.iSimulationService.set_quota_reset",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "World registry/catalog state, staged mutations, tick manifests, and typed lifecycle results remain authoritative."
+evidence = [
+  "docs/guide/world-lifecycle.md",
+  "docs/guide/atomic-visibility.md",
+  "tests/app/test_world_resume.py",
+  "tests/app/test_mutation_service.py",
+]
+rationale = "No direct signal is approved for these lifecycle, mutation, and simulation-configuration operations."
+
+[[workflow]]
+id = "world.compute_archetype"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+signals = ["child"]
+outcomes = ["propagated_failure", "retryable_attempt"]
+authority = "The eventual tick manifest and append receipts, not planning spans, prove successful computation."
+evidence = [
+  "docs/guide/observability.md",
+  "docs/guide/atomic-visibility.md",
+  "tests/app/test_atomic_visibility.py",
+]
+span_names = ["world.query", "world.materialize", "world.execute"]
+attribute_keys = [
+  "archetype.component.signature",
+  "archetype.tick",
+]
+
+[[workflow]]
+id = "world.commit_archetype"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._commit_archetype"
+signals = ["child"]
+outcomes = ["propagated_failure", "retryable_attempt"]
+authority = "The append receipt and published tick manifest prove durable visibility."
+evidence = [
+  "docs/guide/observability.md",
+  "docs/guide/atomic-visibility.md",
+  "tests/app/test_atomic_visibility.py",
+]
+span_names = ["world.update"]
+attribute_keys = [
+  "archetype.component.signature",
+  "archetype.tick",
+]
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/app/world/service.py"
+qualified_scope = "archetype.app.world.service.WorldService.open_world_mutable"
+target = "log:exception:'resume for world %s acquired fence epoch %d but failed before installing its replacement writer; the previous writer is now stale':exception"
+owner = "world"
+issue = 519
+reason = "The fenced-resume recovery path currently exports the raw exception stack while preserving retry semantics."
+expiry_condition = "Remove when #519 emits a bounded resume-failure diagnostic with durable catalog evidence."
+
+[[legacy]]
+rule = "raw_exception_logging"
+path = "src/archetype/app/world/service.py"
+qualified_scope = "archetype.app.world.service.WorldService.record_step"
+target = "log:exception:'catalog run update failed for world %s':exception"
+owner = "world"
+issue = 519
+reason = "The post-step catalog projection warning currently exports a raw exception stack."
+expiry_condition = "Remove when #519 emits a bounded projection-failure diagnostic distinct from tick durability."
+
+[[legacy]]
+rule = "legacy_attribute_key"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+target = "span:world.query:attribute:sig"
+owner = "world"
+issue = 519
+reason = "The query child span still emits the pre-canonical component-signature alias during tick computation."
+expiry_condition = "Remove when #519 replaces sig with archetype.component.signature at the truthful tick boundary."
+
+[[legacy]]
+rule = "legacy_attribute_key"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+target = "span:world.query:attribute:tick"
+owner = "world"
+issue = 519
+reason = "The query child span still emits the pre-canonical tick alias during tick computation."
+expiry_condition = "Remove when #519 replaces tick with archetype.tick at the truthful tick boundary."
+
+[[legacy]]
+rule = "legacy_attribute_key"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+target = "span:world.materialize:attribute:sig"
+owner = "world"
+issue = 519
+reason = "The legacy materialization span still emits the pre-canonical component-signature alias."
+expiry_condition = "Remove when #519 replaces sig with archetype.component.signature while correcting execution attribution."
+
+[[legacy]]
+rule = "legacy_attribute_key"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+target = "span:world.materialize:attribute:tick"
+owner = "world"
+issue = 519
+reason = "The legacy materialization span still emits the pre-canonical tick alias."
+expiry_condition = "Remove when #519 replaces tick with archetype.tick while correcting execution attribution."
+
+[[legacy]]
+rule = "legacy_span_name"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+target = "span:world.materialize"
+owner = "world"
+issue = 519
+reason = "The current materialization span predates the evidence-backed world execution boundary."
+expiry_condition = "Remove when #519 replaces world.materialize according to the #518 execution-attribution conclusion."
+
+[[legacy]]
+rule = "legacy_attribute_key"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+target = "span:world.execute:attribute:sig"
+owner = "world"
+issue = 519
+reason = "The legacy execution span still emits the pre-canonical component-signature alias."
+expiry_condition = "Remove when #519 replaces sig with archetype.component.signature at the measured execution boundary."
+
+[[legacy]]
+rule = "legacy_attribute_key"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+target = "span:world.execute:attribute:tick"
+owner = "world"
+issue = 519
+reason = "The legacy execution span still emits the pre-canonical tick alias."
+expiry_condition = "Remove when #519 replaces tick with archetype.tick at the measured execution boundary."
+
+[[legacy]]
+rule = "legacy_span_name"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._compute_archetype"
+target = "span:world.execute"
+owner = "world"
+issue = 519
+reason = "The current execution span reports processor planning as execution and is retained only for migration tracking."
+expiry_condition = "Remove when #519 replaces world.execute according to the #518 execution-attribution conclusion."
+
+[[legacy]]
+rule = "legacy_attribute_key"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._commit_archetype"
+target = "span:world.update:attribute:sig"
+owner = "world"
+issue = 519
+reason = "The update child span still emits the pre-canonical component-signature alias at commit."
+expiry_condition = "Remove when #519 replaces sig with archetype.component.signature at the durable commit boundary."
+
+[[legacy]]
+rule = "legacy_attribute_key"
+path = "src/archetype/core/aio/async_world.py"
+qualified_scope = "archetype.core.aio.async_world.AsyncWorld._commit_archetype"
+target = "span:world.update:attribute:tick"
+owner = "world"
+issue = 519
+reason = "The update child span still emits the pre-canonical tick alias at commit."
+expiry_condition = "Remove when #519 replaces tick with archetype.tick at the durable commit boundary."

--- a/scripts/check_observability.py
+++ b/scripts/check_observability.py
@@ -1,0 +1,1914 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Enforce safe observability syntax and exact family dispositions.
+
+The audit is deliberately AST-only: it never imports shipped code and it reads
+the literal signal vocabulary from ``archetype._obs`` rather than maintaining
+a second allowlist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+import tomllib
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST_ROOT = ROOT / "quality" / "observability"
+
+SIGNALS = frozenset({"root", "child", "metric", "log_only", "none"})
+OUTCOME_DISPOSITIONS = frozenset(
+    {"propagated_failure", "handled_outcome", "retryable_attempt", "advisory_suppression"}
+)
+HOST_CAPABILITIES = frozenset(
+    {
+        "invoke_configuration",
+        "provider_configuration",
+        "logging_configuration",
+        "console_export",
+    }
+)
+VOCABULARY_SETS = (
+    "SPAN_NAMES",
+    "LEGACY_SPAN_NAMES",
+    "TRACE_ATTRIBUTE_KEYS",
+    "METRIC_NAMES",
+    "METRIC_LABEL_KEYS",
+    "EVENT_NAMES",
+    "FAILURE_DISPOSITIONS",
+    "OUTCOMES",
+    "ERROR_TYPES",
+)
+VOCABULARY_MAPS = ("SPAN_NAME_ALIASES", "TRACE_ATTRIBUTE_ALIASES")
+OBS_EMITTERS = frozenset(
+    {"span", "instrument", "counter_add", "record_failure", "record_outcome", "bind_context"}
+)
+LOG_METHODS = frozenset({"debug", "info", "warning", "error", "critical", "exception"})
+VENDOR_PREFIXES = ("opentelemetry", "logfire")
+PRIVATE_ADAPTER_MODULES = frozenset({"archetype._obs", "archetype._logging"})
+AMBIGUOUS_OBSERVABILITY_BINDING = "__observability_sensitive__"
+INVOKE_CONFIGURATION_CALLS = frozenset(
+    {
+        "archetype._obs.configure_tracing",
+        "archetype._logging.configure_archetype_logging",
+        "archetype._logging.configure_host_observability",
+    }
+)
+PROVIDER_MUTATOR_NAMES = frozenset(
+    {
+        "add_span_processor",
+        "add_log_record_processor",
+        "add_metric_reader",
+        "set_tracer_provider",
+        "set_meter_provider",
+        "set_logger_provider",
+    }
+)
+SENSITIVE_LOG_COORDINATES = frozenset(
+    {"body", "content", "password", "path", "payload", "prompt", "secret", "token", "uri", "url"}
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One exact source violation eligible for an exact legacy entry."""
+
+    rule: str
+    path: str
+    qualified_scope: str
+    target: str
+    line: int
+    detail: str
+
+    @property
+    def key(self) -> tuple[str, str, str, str]:
+        return (self.rule, self.path, self.qualified_scope, self.target)
+
+
+@dataclass
+class AuditResult:
+    violations: list[Violation] = field(default_factory=list)
+    exempted: list[Violation] = field(default_factory=list)
+    policy_errors: list[str] = field(default_factory=list)
+    files_scanned: int = 0
+    protocols_scanned: int = 0
+    operations_scanned: int = 0
+    workflows_scanned: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations and not self.policy_errors
+
+
+@dataclass(frozen=True)
+class SourceUnit:
+    path: Path
+    relative_path: str
+    module: str
+    tree: ast.Module
+    bindings: dict[str, str]
+
+
+@dataclass(frozen=True)
+class Vocabulary:
+    sets: dict[str, frozenset[str]]
+    maps: dict[str, dict[str, str]]
+
+    @property
+    def span_names(self) -> frozenset[str]:
+        return self.sets["SPAN_NAMES"]
+
+    @property
+    def legacy_span_names(self) -> frozenset[str]:
+        return self.sets["LEGACY_SPAN_NAMES"]
+
+    @property
+    def attribute_keys(self) -> frozenset[str]:
+        return self.sets["TRACE_ATTRIBUTE_KEYS"]
+
+    @property
+    def metric_names(self) -> frozenset[str]:
+        return self.sets["METRIC_NAMES"]
+
+    @property
+    def metric_label_keys(self) -> frozenset[str]:
+        return self.sets["METRIC_LABEL_KEYS"]
+
+
+@dataclass
+class ManifestState:
+    operations: dict[str, dict[str, list[str]]] = field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(list))
+    )
+    workflows: list[dict[str, Any]] = field(default_factory=list)
+    hosts: dict[str, frozenset[str]] = field(default_factory=dict)
+    legacy: dict[tuple[str, str, str, str], dict[str, Any]] = field(default_factory=dict)
+
+
+def _module_name(path: Path, source_root: Path) -> str:
+    relative = path.relative_to(source_root).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _resolve_import_from(node: ast.ImportFrom, consumer: str) -> str:
+    if node.level == 0:
+        return node.module or ""
+    package = consumer.split(".")[:-1]
+    keep = len(package) - (node.level - 1)
+    prefix = package[: max(keep, 0)]
+    if node.module:
+        prefix.extend(node.module.split("."))
+    return ".".join(prefix)
+
+
+def _bindings(tree: ast.AST, module: str) -> dict[str, str]:
+    return _scope_bindings(tree.body, {}, module, module)
+
+
+def _dotted_name(node: ast.AST | None) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    return ""
+
+
+def _resolved_name(node: ast.AST | None, bindings: dict[str, str]) -> str:
+    dotted = _dotted_name(node)
+    if not dotted:
+        return ""
+    parts = dotted.split(".")
+    for end in range(len(parts), 0, -1):
+        prefix = ".".join(parts[:end])
+        if prefix in bindings:
+            tail = parts[end:]
+            return ".".join((bindings[prefix], *tail)) if tail else bindings[prefix]
+    return dotted
+
+
+def _same_scope_nodes(statements: list[ast.stmt]) -> list[ast.AST]:
+    nodes: list[ast.AST] = []
+    stack: list[ast.AST] = list(reversed(statements))
+    boundaries = (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+    while stack:
+        node = stack.pop()
+        nodes.append(node)
+        if isinstance(node, boundaries):
+            continue
+        stack.extend(reversed(list(ast.iter_child_nodes(node))))
+    return nodes
+
+
+def _target_nodes(node: ast.Assign | ast.AnnAssign) -> list[ast.AST]:
+    return list(node.targets) if isinstance(node, ast.Assign) else [node.target]
+
+
+def _import_binding(node: ast.Import | ast.ImportFrom, module: str) -> dict[str, str]:
+    bindings: dict[str, str] = {}
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".")[0]
+            bindings[local] = alias.name if alias.asname else local
+        return bindings
+    base = _resolve_import_from(node, module)
+    for alias in node.names:
+        if alias.name == "*":
+            continue
+        local = alias.asname or alias.name
+        bindings[local] = ".".join(part for part in (base, alias.name) if part)
+    return bindings
+
+
+def _assignment_binding(value: ast.AST | None, bindings: dict[str, str]) -> str:
+    if isinstance(value, ast.Call):
+        factory = _resolved_name(value.func, bindings)
+        if factory in {"logging.getLogger", "logging.Logger", "logging.LoggerAdapter"}:
+            return "logging.Logger"
+        if factory.startswith((*VENDOR_PREFIXES, "logging.")):
+            return factory
+        return ""
+    if not isinstance(value, (ast.Name, ast.Attribute)):
+        return ""
+    dotted = _dotted_name(value)
+    if dotted.rsplit(".", 1)[-1] in PROVIDER_MUTATOR_NAMES:
+        return AMBIGUOUS_OBSERVABILITY_BINDING
+    parts = dotted.split(".")
+    if any(".".join(parts[:end]) in bindings for end in range(1, len(parts) + 1)):
+        return _resolved_name(value, bindings)
+    return ""
+
+
+def _sensitive_binding(value: str | None) -> bool:
+    if value is None:
+        return False
+    tail = value.rsplit(".", 1)[-1]
+    return (
+        value == AMBIGUOUS_OBSERVABILITY_BINDING
+        or value.startswith((*VENDOR_PREFIXES, "logging."))
+        or value in INVOKE_CONFIGURATION_CALLS
+        or tail in PROVIDER_MUTATOR_NAMES
+    )
+
+
+def _join_binding_states(states: list[dict[str, str]]) -> dict[str, str]:
+    if not states:
+        return {}
+    joined: dict[str, str] = {}
+    keys = set().union(*(state.keys() for state in states))
+    for key in keys:
+        values = [state.get(key) for state in states]
+        if all(value == values[0] for value in values):
+            if values[0] is not None:
+                joined[key] = values[0]
+            continue
+        sensitive = [value for value in values if _sensitive_binding(value)]
+        if sensitive:
+            joined[key] = AMBIGUOUS_OBSERVABILITY_BINDING
+    return joined
+
+
+def _prefix_binding_states(
+    statements: list[ast.stmt],
+    initial: dict[str, str],
+    module: str,
+    scope: str,
+) -> list[dict[str, str]]:
+    states = [dict(initial)]
+    current = dict(initial)
+    for statement in statements:
+        current = _flow_bindings([statement], current, module, scope)
+        states.append(current)
+    return states
+
+
+def _nested_statement_blocks(node: ast.stmt) -> list[list[ast.stmt]]:
+    if isinstance(node, ast.If):
+        return [node.body, node.orelse]
+    if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+        return [node.body, node.orelse]
+    if isinstance(node, (ast.Try, ast.TryStar)):
+        return [
+            node.body,
+            node.orelse,
+            *(handler.body for handler in node.handlers),
+            node.finalbody,
+        ]
+    if isinstance(node, (ast.With, ast.AsyncWith)):
+        return [node.body]
+    if isinstance(node, ast.Match):
+        return [case.body for case in node.cases]
+    return []
+
+
+def _exception_binding_states(
+    statements: list[ast.stmt],
+    initial: dict[str, str],
+    module: str,
+    scope: str,
+) -> list[dict[str, str]]:
+    states = [dict(initial)]
+    current = dict(initial)
+    for statement in statements:
+        for block in _nested_statement_blocks(statement):
+            states.extend(_exception_binding_states(block, current, module, scope))
+        current = _flow_bindings([statement], current, module, scope)
+        states.append(current)
+    return states
+
+
+def _contains_control_transfer(statements: list[ast.stmt]) -> bool:
+    return any(
+        isinstance(node, (ast.Break, ast.Continue))
+        for statement in statements
+        for node in ast.walk(statement)
+    )
+
+
+def _flow_bindings(
+    statements: list[ast.stmt],
+    initial: dict[str, str],
+    module: str,
+    scope: str,
+) -> dict[str, str]:
+    state = dict(initial)
+    for node in statements:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            state.update(_import_binding(node, module))
+        elif isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            state[node.name] = f"{scope}.{node.name}"
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)) and node.value is not None:
+            binding = _assignment_binding(node.value, state)
+            for target in _target_nodes(node):
+                target_name = _dotted_name(target)
+                if not target_name:
+                    continue
+                if binding:
+                    state[target_name] = binding
+                else:
+                    state.pop(target_name, None)
+        elif isinstance(node, ast.If):
+            body = _flow_bindings(node.body, state, module, scope)
+            otherwise = (
+                _flow_bindings(node.orelse, state, module, scope) if node.orelse else dict(state)
+            )
+            state = _join_binding_states([body, otherwise])
+        elif isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+            body_states = _prefix_binding_states(node.body, state, module, scope)
+            loop_states = [state, body_states[-1]]
+            if _contains_control_transfer(node.body):
+                loop_states.extend(body_states)
+            loop = _join_binding_states(loop_states)
+            otherwise = _flow_bindings(node.orelse, loop, module, scope) if node.orelse else loop
+            state = _join_binding_states([loop, otherwise])
+        elif isinstance(node, (ast.Try, ast.TryStar)):
+            body_states = _exception_binding_states(node.body, state, module, scope)
+            success = _flow_bindings(node.orelse, body_states[-1], module, scope)
+            exception_entry = _join_binding_states(body_states)
+            outcomes = [success]
+            outcomes.extend(
+                _flow_bindings(handler.body, exception_entry, module, scope)
+                for handler in node.handlers
+            )
+            state = _join_binding_states(outcomes)
+            state = _flow_bindings(node.finalbody, state, module, scope)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            state = _flow_bindings(node.body, state, module, scope)
+        elif isinstance(node, ast.Match):
+            outcomes = [_flow_bindings(case.body, state, module, scope) for case in node.cases]
+            outcomes.append(dict(state))
+            state = _join_binding_states(outcomes)
+    return state
+
+
+def _scope_bindings(
+    statements: list[ast.stmt],
+    parent: dict[str, str],
+    module: str,
+    scope: str,
+    *,
+    parameters: frozenset[str] = frozenset(),
+) -> dict[str, str]:
+    nodes = _same_scope_nodes(statements)
+    imports = [node for node in nodes if isinstance(node, (ast.Import, ast.ImportFrom))]
+    definitions = [
+        node
+        for node in nodes
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    assignments = [node for node in nodes if isinstance(node, (ast.Assign, ast.AnnAssign))]
+
+    local_names = set(parameters)
+    for node in imports:
+        local_names.update(_import_binding(node, module))
+    local_names.update(node.name for node in definitions)
+    for node in assignments:
+        local_names.update(
+            target.id for target in _target_nodes(node) if isinstance(target, ast.Name)
+        )
+
+    initial = {name: value for name, value in parent.items() if name not in local_names}
+    return _flow_bindings(statements, initial, module, scope)
+
+
+def _parameter_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> frozenset[str]:
+    arguments = node.args
+    names = {
+        argument.arg
+        for argument in (*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs)
+    }
+    if arguments.vararg is not None:
+        names.add(arguments.vararg.arg)
+    if arguments.kwarg is not None:
+        names.add(arguments.kwarg.arg)
+    return frozenset(names)
+
+
+def _function_bindings(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    parent: dict[str, str],
+    module: str,
+    scope: str,
+) -> dict[str, str]:
+    nodes = _same_scope_nodes(node.body)
+    local_names = set(_parameter_names(node))
+    for child in nodes:
+        if isinstance(child, (ast.Import, ast.ImportFrom)):
+            local_names.update(_import_binding(child, module))
+        elif isinstance(child, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            local_names.add(child.name)
+        elif isinstance(child, (ast.Assign, ast.AnnAssign)):
+            local_names.update(
+                target.id for target in _target_nodes(child) if isinstance(target, ast.Name)
+            )
+    return {name: value for name, value in parent.items() if name not in local_names}
+
+
+def _class_bindings(
+    node: ast.ClassDef,
+    parent: dict[str, str],
+    module: str,
+    scope: str,
+) -> dict[str, str]:
+    class_parent = {
+        name: value for name, value in parent.items() if not name.startswith(("self.", "cls."))
+    }
+    result = _scope_bindings(node.body, class_parent, module, scope)
+    methods = [
+        member
+        for member in node.body
+        if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    changed = True
+    while changed:
+        changed = False
+        for method in methods:
+            bindings = _scope_bindings(
+                method.body,
+                result,
+                module,
+                f"{scope}.{method.name}",
+                parameters=_parameter_names(method),
+            )
+            for name, value in bindings.items():
+                if name.startswith(("self.", "cls.")) and name not in result:
+                    result[name] = value
+                    changed = True
+    return result
+
+
+def _parse_sources(repo_root: Path, result: AuditResult) -> tuple[Path, list[SourceUnit]]:
+    source_root = repo_root / "src"
+    package_root = source_root / "archetype"
+    units: list[SourceUnit] = []
+    if not package_root.is_dir():
+        result.policy_errors.append("missing source package: src/archetype")
+        return source_root, units
+    for path in sorted(package_root.rglob("*.py")):
+        relative = path.relative_to(repo_root).as_posix()
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        except (OSError, SyntaxError) as error:
+            result.policy_errors.append(f"cannot parse {relative}: {error}")
+            continue
+        module = _module_name(path, source_root)
+        units.append(SourceUnit(path, relative, module, tree, _bindings(tree, module)))
+    result.files_scanned = len(units)
+    return source_root, units
+
+
+class _ScopeCollector(ast.NodeVisitor):
+    def __init__(self, module: str) -> None:
+        self.parts = [module]
+        self.scopes: set[str] = set()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.parts.append(node.name)
+        self.generic_visit(node)
+        self.parts.pop()
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.parts.append(node.name)
+        self.scopes.add(".".join(self.parts))
+        self.generic_visit(node)
+        self.parts.pop()
+
+    visit_FunctionDef = _visit_function
+    visit_AsyncFunctionDef = _visit_function
+
+
+def _callable_scope_paths(units: list[SourceUnit]) -> dict[str, str]:
+    scopes: dict[str, str] = {}
+    for unit in units:
+        collector = _ScopeCollector(unit.module)
+        collector.visit(unit.tree)
+        for scope in collector.scopes:
+            scopes[scope] = unit.relative_path
+    return scopes
+
+
+def _natural_owner(path: str) -> str:
+    parts = Path(path).parts
+    try:
+        package_index = parts.index("archetype")
+    except ValueError:
+        return ""
+    package_parts = parts[package_index + 1 :]
+    if not package_parts:
+        return ""
+    if package_parts[0] == "app" and len(package_parts) >= 2:
+        return package_parts[1]
+    return package_parts[0].removesuffix(".py")
+
+
+def _owner_may_claim_source(owner: str, path: str, scope: str) -> bool:
+    if owner == _natural_owner(path):
+        return True
+    return (
+        owner == "world"
+        and path == "src/archetype/core/aio/async_world.py"
+        and scope
+        in {
+            "archetype.core.aio.async_world.AsyncWorld._compute_archetype",
+            "archetype.core.aio.async_world.AsyncWorld._commit_archetype",
+        }
+    )
+
+
+def _host_scope_allowed(scope: str, capability: str) -> bool:
+    if capability == "provider_configuration":
+        return scope.startswith("archetype._obs.")
+    if capability == "logging_configuration":
+        return scope.startswith("archetype._logging.")
+    if capability == "console_export":
+        return scope.startswith("archetype._obs.")
+    if capability == "invoke_configuration":
+        return scope.startswith(
+            (
+                "archetype._logging.",
+                "archetype.api.",
+                "archetype.cli.",
+                "archetype.runtime.",
+            )
+        )
+    return False
+
+
+def _is_protocol(node: ast.ClassDef, bindings: dict[str, str]) -> bool:
+    return any(
+        _resolved_name(base, bindings) in {"Protocol", "typing.Protocol"} for base in node.bases
+    )
+
+
+def _protocol_operations(
+    units: list[SourceUnit], source_root: Path, result: AuditResult
+) -> dict[str, set[str]]:
+    operations: dict[str, set[str]] = defaultdict(set)
+    protocols = 0
+    app_root = source_root / "archetype" / "app"
+    for unit in units:
+        try:
+            relative = unit.path.relative_to(app_root)
+        except ValueError:
+            continue
+        if len(relative.parts) < 2:
+            continue
+        family = relative.parts[0]
+        module_parts = list(relative.with_suffix("").parts[1:])
+        if module_parts and module_parts[-1] == "__init__":
+            module_parts.pop()
+        module_prefix = ".".join(module_parts)
+        for node in unit.tree.body:
+            if not isinstance(node, ast.ClassDef) or not _is_protocol(node, unit.bindings):
+                continue
+            protocols += 1
+            for member in node.body:
+                if not isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                prefix = ".".join(part for part in (module_prefix, node.name) if part)
+                operations[family].add(f"{prefix}.{member.name}")
+    result.protocols_scanned = protocols
+    result.operations_scanned = sum(len(values) for values in operations.values())
+    return operations
+
+
+def _assignment(tree: ast.Module, name: str) -> ast.AST | None:
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == name:
+                return node.value
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return node.value
+    return None
+
+
+def _unwrap_literal(node: ast.AST | None, wrappers: frozenset[str]) -> ast.AST | None:
+    current = node
+    while isinstance(current, ast.Call):
+        if _dotted_name(current.func).split(".")[-1] not in wrappers or len(current.args) != 1:
+            return None
+        current = current.args[0]
+    return current
+
+
+def _literal_string_set(node: ast.AST | None, name: str) -> frozenset[str]:
+    literal = _unwrap_literal(node, frozenset({"frozenset", "set", "tuple", "list"}))
+    if not isinstance(literal, (ast.Set, ast.List, ast.Tuple)):
+        raise ValueError(f"{name} must be a literal string collection")
+    values: list[str] = []
+    for item in literal.elts:
+        if not isinstance(item, ast.Constant) or not isinstance(item.value, str):
+            raise ValueError(f"{name} must contain only literal strings")
+        values.append(item.value)
+    if len(values) != len(set(values)):
+        raise ValueError(f"{name} contains duplicate entries")
+    return frozenset(values)
+
+
+def _literal_string_map(node: ast.AST | None, name: str) -> dict[str, str]:
+    literal = _unwrap_literal(node, frozenset({"MappingProxyType", "dict"}))
+    if not isinstance(literal, ast.Dict):
+        raise ValueError(f"{name} must be a literal string mapping")
+    result: dict[str, str] = {}
+    for key_node, value_node in zip(literal.keys, literal.values, strict=True):
+        if (
+            not isinstance(key_node, ast.Constant)
+            or not isinstance(key_node.value, str)
+            or not isinstance(value_node, ast.Constant)
+            or not isinstance(value_node.value, str)
+        ):
+            raise ValueError(f"{name} must contain only literal string pairs")
+        if key_node.value in result:
+            raise ValueError(f"{name} contains duplicate key {key_node.value!r}")
+        result[key_node.value] = value_node.value
+    return result
+
+
+def _load_vocabulary(repo_root: Path, result: AuditResult) -> Vocabulary:
+    path = repo_root / "src" / "archetype" / "_obs.py"
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=path.as_posix())
+    except (OSError, SyntaxError) as error:
+        result.policy_errors.append(f"cannot parse observability vocabulary: {error}")
+        return Vocabulary({name: frozenset() for name in VOCABULARY_SETS}, {})
+
+    sets: dict[str, frozenset[str]] = {}
+    maps: dict[str, dict[str, str]] = {}
+    for name in VOCABULARY_SETS:
+        try:
+            sets[name] = _literal_string_set(_assignment(tree, name), name)
+        except ValueError as error:
+            result.policy_errors.append(str(error))
+            sets[name] = frozenset()
+    for name in VOCABULARY_MAPS:
+        try:
+            maps[name] = _literal_string_map(_assignment(tree, name), name)
+        except ValueError as error:
+            result.policy_errors.append(str(error))
+            maps[name] = {}
+
+    if not sets["LEGACY_SPAN_NAMES"] <= sets["SPAN_NAMES"]:
+        result.policy_errors.append("LEGACY_SPAN_NAMES must be a subset of SPAN_NAMES")
+    if not set(maps["SPAN_NAME_ALIASES"].values()) <= sets["SPAN_NAMES"]:
+        result.policy_errors.append("SPAN_NAME_ALIASES targets must be canonical SPAN_NAMES")
+    if not set(maps["TRACE_ATTRIBUTE_ALIASES"].values()) <= sets["TRACE_ATTRIBUTE_KEYS"]:
+        result.policy_errors.append(
+            "TRACE_ATTRIBUTE_ALIASES targets must be canonical TRACE_ATTRIBUTE_KEYS"
+        )
+    if not sets["METRIC_LABEL_KEYS"] <= sets["TRACE_ATTRIBUTE_KEYS"]:
+        result.policy_errors.append("METRIC_LABEL_KEYS must be a subset of TRACE_ATTRIBUTE_KEYS")
+    return Vocabulary(sets, maps)
+
+
+def _nonblank(value: Any, label: str, errors: list[str]) -> str:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{label} must be a non-empty string")
+        return ""
+    return value
+
+
+def _string_array(
+    value: Any,
+    label: str,
+    errors: list[str],
+    *,
+    required: bool = True,
+) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        errors.append(f"{label} must be an array of strings")
+        return []
+    if required and not value:
+        errors.append(f"{label} must not be empty")
+    if len(value) != len(set(value)):
+        errors.append(f"{label} must not contain duplicates")
+    return list(value)
+
+
+def _evidence(
+    value: Any,
+    label: str,
+    repo_root: Path,
+    errors: list[str],
+) -> list[str]:
+    entries = _string_array(value, label, errors)
+    for entry in entries:
+        candidate = (repo_root / entry).resolve()
+        if not candidate.is_relative_to(repo_root):
+            errors.append(f"{label} path must be repository-relative: {entry}")
+        elif not candidate.is_file():
+            errors.append(f"{label} path does not exist: {entry}")
+    return entries
+
+
+def _validate_semantics(
+    row: dict[str, Any],
+    label: str,
+    vocabulary: Vocabulary,
+    repo_root: Path,
+    errors: list[str],
+    *,
+    root_allowed: bool,
+) -> None:
+    signals = _string_array(row.get("signals"), f"{label}.signals", errors)
+    unknown_signals = sorted(set(signals) - SIGNALS)
+    if unknown_signals:
+        errors.append(f"{label}.signals contains unknown values: {unknown_signals}")
+    if "root" in signals and "child" in signals:
+        errors.append(f"{label}.signals cannot contain both root and child")
+    if "root" in signals and not root_allowed:
+        errors.append(f"{label}.signals root is reserved for runtime or gateway ingress")
+    if "none" in signals and len(signals) != 1:
+        errors.append(f"{label}.signals none must be exclusive")
+
+    outcomes = _string_array(row.get("outcomes"), f"{label}.outcomes", errors)
+    unknown_outcomes = sorted(set(outcomes) - OUTCOME_DISPOSITIONS)
+    if unknown_outcomes:
+        errors.append(f"{label}.outcomes contains unknown values: {unknown_outcomes}")
+    _nonblank(row.get("authority"), f"{label}.authority", errors)
+    _evidence(row.get("evidence"), f"{label}.evidence", repo_root, errors)
+
+    if "none" in signals or "advisory_suppression" in outcomes:
+        _nonblank(row.get("rationale"), f"{label}.rationale", errors)
+
+    span_names = _string_array(
+        row.get("span_names", []), f"{label}.span_names", errors, required=False
+    )
+    span_signal = bool({"root", "child"} & set(signals))
+    if span_signal and not span_names:
+        errors.append(f"{label}.span_names is required for root/child signals")
+    if span_names and not span_signal:
+        errors.append(f"{label}.span_names requires a root or child signal")
+    unknown_spans = sorted(set(span_names) - vocabulary.span_names)
+    if unknown_spans:
+        errors.append(f"{label}.span_names contains unknown names: {unknown_spans}")
+
+    attribute_keys = _string_array(
+        row.get("attribute_keys", []), f"{label}.attribute_keys", errors, required=False
+    )
+    unknown_attributes = sorted(set(attribute_keys) - vocabulary.attribute_keys)
+    if unknown_attributes:
+        errors.append(f"{label}.attribute_keys contains unknown keys: {unknown_attributes}")
+    if attribute_keys and not span_signal:
+        errors.append(f"{label}.attribute_keys requires a root or child signal")
+
+    metric_names = _string_array(
+        row.get("metric_names", []), f"{label}.metric_names", errors, required=False
+    )
+    metric_labels = _string_array(
+        row.get("metric_label_keys", []),
+        f"{label}.metric_label_keys",
+        errors,
+        required=False,
+    )
+    if "metric" in signals and not metric_names:
+        errors.append(f"{label}.metric_names is required for metric signals")
+    if metric_names and "metric" not in signals:
+        errors.append(f"{label}.metric_names requires a metric signal")
+    if metric_labels and "metric" not in signals:
+        errors.append(f"{label}.metric_label_keys requires a metric signal")
+    unknown_metrics = sorted(set(metric_names) - vocabulary.metric_names)
+    if unknown_metrics:
+        errors.append(f"{label}.metric_names contains unknown names: {unknown_metrics}")
+    unbounded_labels = sorted(set(metric_labels) - vocabulary.metric_label_keys)
+    if unbounded_labels:
+        errors.append(f"{label}.metric_label_keys contains unbounded keys: {unbounded_labels}")
+
+
+def _load_manifests(
+    manifest_root: Path,
+    repo_root: Path,
+    vocabulary: Vocabulary,
+    protocols: dict[str, set[str]],
+    callable_paths: dict[str, str],
+    result: AuditResult,
+) -> ManifestState:
+    state = ManifestState()
+    paths = sorted(manifest_root.glob("*.toml")) if manifest_root.is_dir() else []
+    if not paths:
+        result.policy_errors.append(f"no observability manifests found under {manifest_root}")
+        return state
+
+    seen_owners: set[str] = set()
+    for path in paths:
+        relative = (
+            path.relative_to(repo_root).as_posix() if path.is_relative_to(repo_root) else str(path)
+        )
+        try:
+            document = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as error:
+            result.policy_errors.append(f"cannot parse {relative}: {error}")
+            continue
+        local_errors: list[str] = []
+        if document.get("version") != 1:
+            local_errors.append(f"{relative}.version must equal 1")
+        owner = _nonblank(document.get("owner"), f"{relative}.owner", local_errors)
+        if owner in seen_owners:
+            local_errors.append(f"duplicate observability owner {owner!r}")
+        seen_owners.add(owner)
+        if path.stem != owner:
+            local_errors.append(f"{relative} filename must match owner {owner!r}")
+
+        family_value = document.get("family")
+        if owner in protocols:
+            if family_value != owner:
+                local_errors.append(f"{relative}.family must equal {owner!r}")
+        elif family_value is not None:
+            local_errors.append(f"{relative} is not an application-family manifest")
+
+        dispositions = document.get("disposition", [])
+        if not isinstance(dispositions, list) or any(
+            not isinstance(row, dict) for row in dispositions
+        ):
+            local_errors.append(f"{relative}.disposition must be an array of tables")
+            dispositions = []
+        if dispositions and owner not in protocols:
+            local_errors.append(f"{relative}.disposition is allowed only for a real app family")
+        for index, row in enumerate(dispositions):
+            label = f"{relative}.disposition[{index}]"
+            operations = _string_array(row.get("operations"), f"{label}.operations", local_errors)
+            _validate_semantics(
+                row,
+                label,
+                vocabulary,
+                repo_root,
+                local_errors,
+                root_allowed=owner in {"gateway", "runtime"},
+            )
+            for operation in operations:
+                state.operations[owner][operation].append(label)
+
+        workflows = document.get("workflow", [])
+        if not isinstance(workflows, list) or any(not isinstance(row, dict) for row in workflows):
+            local_errors.append(f"{relative}.workflow must be an array of tables")
+            workflows = []
+        for index, row in enumerate(workflows):
+            label = f"{relative}.workflow[{index}]"
+            workflow_id = _nonblank(row.get("id"), f"{label}.id", local_errors)
+            scope = _nonblank(row.get("qualified_scope"), f"{label}.qualified_scope", local_errors)
+            _validate_semantics(
+                row,
+                label,
+                vocabulary,
+                repo_root,
+                local_errors,
+                root_allowed=owner in {"gateway", "runtime"},
+            )
+            if scope and scope not in callable_paths:
+                local_errors.append(f"{label}.qualified_scope is not a shipped callable: {scope}")
+            elif scope and not _owner_may_claim_source(owner, callable_paths[scope], scope):
+                local_errors.append(
+                    f"{label}.qualified_scope belongs to {_natural_owner(callable_paths[scope])!r}, "
+                    f"not owner {owner!r}"
+                )
+            state.workflows.append({**row, "owner": owner, "_label": label, "id": workflow_id})
+
+        hosts = document.get("host_callable", [])
+        if not isinstance(hosts, list) or any(not isinstance(row, dict) for row in hosts):
+            local_errors.append(f"{relative}.host_callable must be an array of tables")
+            hosts = []
+        for index, row in enumerate(hosts):
+            label = f"{relative}.host_callable[{index}]"
+            scope = _nonblank(row.get("qualified_scope"), f"{label}.qualified_scope", local_errors)
+            capabilities = _string_array(
+                row.get("capabilities"), f"{label}.capabilities", local_errors
+            )
+            unknown = sorted(set(capabilities) - HOST_CAPABILITIES)
+            if unknown:
+                local_errors.append(f"{label}.capabilities contains unknown values: {unknown}")
+            _nonblank(row.get("rationale"), f"{label}.rationale", local_errors)
+            _evidence(row.get("evidence"), f"{label}.evidence", repo_root, local_errors)
+            if owner != "hosts":
+                local_errors.append(f"{label} must be declared by quality/observability/hosts.toml")
+            if scope and scope not in callable_paths:
+                local_errors.append(f"{label}.qualified_scope is not a shipped callable: {scope}")
+            for capability in capabilities:
+                if scope and not _host_scope_allowed(scope, capability):
+                    local_errors.append(
+                        f"{label} cannot grant {capability!r} to non-host scope {scope!r}"
+                    )
+            if scope in state.hosts:
+                local_errors.append(f"duplicate host callable: {scope}")
+            state.hosts[scope] = frozenset(capabilities)
+
+        legacy_rows = document.get("legacy", [])
+        if not isinstance(legacy_rows, list) or any(
+            not isinstance(row, dict) for row in legacy_rows
+        ):
+            local_errors.append(f"{relative}.legacy must be an array of tables")
+            legacy_rows = []
+        for index, row in enumerate(legacy_rows):
+            label = f"{relative}.legacy[{index}]"
+            rule = _nonblank(row.get("rule"), f"{label}.rule", local_errors)
+            source_path = _nonblank(row.get("path"), f"{label}.path", local_errors)
+            scope = _nonblank(row.get("qualified_scope"), f"{label}.qualified_scope", local_errors)
+            target = _nonblank(row.get("target"), f"{label}.target", local_errors)
+            if row.get("owner") != owner:
+                local_errors.append(f"{label}.owner must equal manifest owner {owner!r}")
+            issue = row.get("issue")
+            if not isinstance(issue, int) or isinstance(issue, bool) or issue <= 0:
+                local_errors.append(f"{label}.issue must be a positive integer")
+            _nonblank(row.get("reason"), f"{label}.reason", local_errors)
+            _nonblank(row.get("expiry_condition"), f"{label}.expiry_condition", local_errors)
+            source_candidate = (repo_root / source_path).resolve() if source_path else repo_root
+            if source_path and not source_candidate.is_relative_to(repo_root):
+                local_errors.append(f"{label}.path must be repository-relative: {source_path}")
+            elif source_path and not source_candidate.is_file():
+                local_errors.append(f"{label}.path does not exist: {source_path}")
+            elif source_path and not _owner_may_claim_source(owner, source_path, scope):
+                local_errors.append(
+                    f"{label}.path belongs to {_natural_owner(source_path)!r}, not owner {owner!r}"
+                )
+            key = (rule, source_path, scope, target)
+            if key in state.legacy:
+                local_errors.append(f"duplicate legacy exception key: {key!r}")
+            state.legacy[key] = {**row, "_label": label}
+
+        if owner not in protocols and not workflows and not hosts and not legacy_rows:
+            local_errors.append(
+                f"{relative} must own a real workflow, host callable, or legacy exception"
+            )
+        result.policy_errors.extend(local_errors)
+
+    for family, expected in sorted(protocols.items()):
+        declared = state.operations.get(family, {})
+        if family not in seen_owners:
+            result.policy_errors.append(f"missing observability manifest for family {family!r}")
+        for operation in sorted(expected - set(declared)):
+            result.policy_errors.append(f"missing disposition for {family}:{operation}")
+        for operation in sorted(set(declared) - expected):
+            result.policy_errors.append(f"phantom disposition for {family}:{operation}")
+        for operation, locations in sorted(declared.items()):
+            if len(locations) != 1:
+                result.policy_errors.append(
+                    f"duplicate disposition for {family}:{operation}: {', '.join(locations)}"
+                )
+
+    workflow_ids = Counter(str(row.get("id", "")) for row in state.workflows)
+    for workflow_id, count in sorted(workflow_ids.items()):
+        if workflow_id and count != 1:
+            result.policy_errors.append(f"duplicate workflow id {workflow_id!r}")
+    workflow_scopes = Counter(str(row.get("qualified_scope", "")) for row in state.workflows)
+    for scope, count in sorted(workflow_scopes.items()):
+        if scope and count != 1:
+            result.policy_errors.append(f"duplicate workflow qualified_scope {scope!r}")
+    result.workflows_scanned = len(state.workflows)
+    return state
+
+
+def _literal_name(node: ast.AST | None) -> str | None:
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
+def _call_argument(node: ast.Call, position: int, keyword: str) -> ast.AST | None:
+    for item in node.keywords:
+        if item.arg == keyword:
+            return item.value
+    return node.args[position] if len(node.args) > position else None
+
+
+def _obs_emitter(node: ast.Call, bindings: dict[str, str]) -> str | None:
+    resolved = _resolved_name(node.func, bindings)
+    if not resolved.startswith("archetype._obs."):
+        return None
+    name = resolved.rsplit(".", 1)[-1]
+    return name if name in OBS_EMITTERS else None
+
+
+def _looks_like_logger(node: ast.Call, bindings: dict[str, str]) -> bool:
+    if not isinstance(node.func, ast.Attribute) or node.func.attr not in LOG_METHODS:
+        return False
+    if isinstance(node.func.value, ast.Call):
+        factory = _resolved_name(node.func.value.func, bindings)
+        if factory in {"logging.getLogger", "logging.Logger", "logging.LoggerAdapter"}:
+            return True
+    receiver = _resolved_name(node.func.value, bindings)
+    tail = receiver.rsplit(".", 1)[-1].lower()
+    return (
+        receiver == AMBIGUOUS_OBSERVABILITY_BINDING
+        or receiver.startswith("logging")
+        or tail in {"log", "logger", "_logger"}
+    )
+
+
+def _is_eager_log_expression(node: ast.AST) -> bool:
+    if isinstance(node, ast.JoinedStr):
+        return True
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Mod)):
+        return not (
+            isinstance(node.left, ast.Constant)
+            and isinstance(node.left.value, str)
+            and isinstance(node.right, ast.Constant)
+            and isinstance(node.right.value, str)
+        )
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "format"
+    )
+
+
+def _is_safe_exception_type_name(node: ast.AST, caught: set[str]) -> bool:
+    if not isinstance(node, ast.Attribute) or node.attr != "__name__":
+        return False
+    value = node.value
+    if isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "type":
+        return (
+            len(value.args) == 1
+            and isinstance(value.args[0], ast.Name)
+            and value.args[0].id in caught
+        )
+    if isinstance(value, ast.Attribute) and value.attr == "__class__":
+        return isinstance(value.value, ast.Name) and value.value.id in caught
+    return False
+
+
+def _contains_raw_exception(node: ast.AST, caught: set[str]) -> bool:
+    if _is_safe_exception_type_name(node, caught):
+        return False
+    if isinstance(node, ast.Name) and node.id in caught:
+        return True
+    return any(_contains_raw_exception(child, caught) for child in ast.iter_child_nodes(node))
+
+
+def _contains_debug_coordinate(node: ast.AST) -> bool:
+    return any(
+        (isinstance(child, ast.Attribute) and child.attr == "debug")
+        or (isinstance(child, ast.Name) and child.id in {"debug", "run_debug"})
+        for child in ast.walk(node)
+    )
+
+
+def _broad_handler(node: ast.ExceptHandler) -> bool:
+    if node.type is None:
+        return True
+    name = _dotted_name(node.type)
+    return name in {"Exception", "BaseException", "builtins.Exception", "builtins.BaseException"}
+
+
+def _handler_reraises(node: ast.ExceptHandler) -> bool:
+    return len(node.body) == 1 and isinstance(node.body[0], ast.Raise) and node.body[0].exc is None
+
+
+def _contains_sensitive_log_coordinate(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name):
+            value = child.id
+        elif isinstance(child, ast.Attribute):
+            value = child.attr
+        else:
+            continue
+        tokens = {token for token in re.split(r"[^a-z0-9]+", value.lower()) if token}
+        if tokens & SENSITIVE_LOG_COORDINATES:
+            return True
+    return False
+
+
+class _ReturnMapCollector(ast.NodeVisitor):
+    def __init__(self, module: str) -> None:
+        self.parts = [module]
+        self.maps: dict[str, ast.Dict] = {}
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.parts.append(node.name)
+        self.generic_visit(node)
+        self.parts.pop()
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.parts.append(node.name)
+        returns = [
+            statement.value
+            for statement in node.body
+            if isinstance(statement, ast.Return) and isinstance(statement.value, ast.Dict)
+        ]
+        if len(returns) == 1:
+            self.maps[".".join(self.parts)] = returns[0]
+        self.parts.pop()
+
+    visit_FunctionDef = _visit_function
+    visit_AsyncFunctionDef = _visit_function
+
+
+class _AssignmentCollector(ast.NodeVisitor):
+    def __init__(self, root: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.root = root
+        self.values: dict[str, list[ast.AST]] = defaultdict(list)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        if node is self.root:
+            self.generic_visit(node)
+
+    visit_FunctionDef = _visit_function
+    visit_AsyncFunctionDef = _visit_function
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                self.values[target.id].append(node.value)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if isinstance(node.target, ast.Name) and node.value is not None:
+            self.values[node.target.id].append(node.value)
+        self.generic_visit(node)
+
+
+def _function_assignments(node: ast.FunctionDef | ast.AsyncFunctionDef) -> dict[str, ast.AST]:
+    collector = _AssignmentCollector(node)
+    collector.visit(node)
+    return {name: values[0] for name, values in collector.values.items() if len(values) == 1}
+
+
+class _SourceAnalyzer(ast.NodeVisitor):
+    def __init__(
+        self,
+        unit: SourceUnit,
+        vocabulary: Vocabulary,
+        hosts: dict[str, frozenset[str]],
+    ) -> None:
+        self.unit = unit
+        self.vocabulary = vocabulary
+        self.hosts = hosts
+        self.parts = [unit.module]
+        self.caught: list[set[str]] = []
+        self.assignments: list[dict[str, ast.AST]] = []
+        self.binding_scopes: list[dict[str, str]] = [unit.bindings]
+        self.violations: list[Violation] = []
+        collector = _ReturnMapCollector(unit.module)
+        collector.visit(unit.tree)
+        self.return_maps = collector.maps
+
+    @property
+    def scope(self) -> str:
+        return ".".join(self.parts)
+
+    @property
+    def bindings(self) -> dict[str, str]:
+        return self.binding_scopes[-1]
+
+    def _add(self, rule: str, target: str, node: ast.AST, detail: str) -> None:
+        self.violations.append(
+            Violation(
+                rule=rule,
+                path=self.unit.relative_path,
+                qualified_scope=self.scope,
+                target=target,
+                line=getattr(node, "lineno", 0),
+                detail=detail,
+            )
+        )
+
+    def _approved(self, capability: str) -> bool:
+        return capability in self.hosts.get(self.scope, frozenset())
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.parts.append(node.name)
+        definition_scope = self.scope
+        self.binding_scopes.append(
+            _class_bindings(node, self.bindings, self.unit.module, self.scope)
+        )
+        self.generic_visit(node)
+        self.binding_scopes.pop()
+        self.parts.pop()
+        self.bindings[node.name] = definition_scope
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.parts.append(node.name)
+        definition_scope = self.scope
+        self.binding_scopes.append(
+            _function_bindings(node, self.bindings, self.unit.module, self.scope)
+        )
+        self.assignments.append(_function_assignments(node))
+        self.generic_visit(node)
+        self.assignments.pop()
+        self.binding_scopes.pop()
+        self.parts.pop()
+        self.bindings[node.name] = definition_scope
+
+    visit_FunctionDef = _visit_function
+    visit_AsyncFunctionDef = _visit_function
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        names = {node.name} if isinstance(node.name, str) else set()
+        self.caught.append(names)
+        self.generic_visit(node)
+        self.caught.pop()
+
+    def _current_caught(self) -> set[str]:
+        result: set[str] = set()
+        for names in self.caught:
+            result.update(names)
+        return result
+
+    def _resolve_local_expression(self, node: ast.AST, seen: set[str] | None = None) -> ast.AST:
+        visited = set() if seen is None else seen
+        if not isinstance(node, ast.Name) or node.id in visited:
+            return node
+        for assignments in reversed(self.assignments):
+            if node.id in assignments:
+                return self._resolve_local_expression(
+                    assignments[node.id],
+                    visited | {node.id},
+                )
+        return node
+
+    def _vendor_import(self, imported: str, node: ast.AST) -> None:
+        if not imported.startswith(VENDOR_PREFIXES):
+            return
+        if self.unit.module in PRIVATE_ADAPTER_MODULES or self.unit.module.startswith(
+            "archetype.contrib."
+        ):
+            return
+        if not self._approved("provider_configuration"):
+            self._add(
+                "vendor_observability_import",
+                f"import:{imported}",
+                node,
+                "vendor telemetry imports are confined to an approved provider host",
+            )
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._vendor_import(alias.name, node)
+        self.bindings.update(_import_binding(node, self.unit.module))
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        base = _resolve_import_from(node, self.unit.module)
+        for alias in node.names:
+            imported = ".".join(part for part in (base, alias.name) if part)
+            self._vendor_import(imported, node)
+        self.bindings.update(_import_binding(node, self.unit.module))
+
+    def _update_assignment_bindings(
+        self,
+        targets: list[ast.AST],
+        value: ast.AST | None,
+    ) -> None:
+        binding = _assignment_binding(value, self.bindings)
+        for target in targets:
+            target_name = _dotted_name(target)
+            if not target_name:
+                continue
+            if binding:
+                self.bindings[target_name] = binding
+            else:
+                self.bindings.pop(target_name, None)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        for target in node.targets:
+            self.visit(target)
+        self._update_assignment_bindings(list(node.targets), node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            self.visit(node.value)
+        self.visit(node.annotation)
+        self.visit(node.target)
+        if node.value is not None:
+            self._update_assignment_bindings([node.target], node.value)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self.visit(node.target)
+        self.visit(node.value)
+        self._update_assignment_bindings([node.target], None)
+
+    def _visit_branch(
+        self,
+        statements: list[ast.stmt],
+        initial: dict[str, str],
+    ) -> dict[str, str]:
+        outer = self.binding_scopes[-1]
+        branch = dict(initial)
+        self.binding_scopes[-1] = branch
+        try:
+            for statement in statements:
+                self.visit(statement)
+            return dict(branch)
+        finally:
+            self.binding_scopes[-1] = outer
+
+    def _replace_bindings(self, state: dict[str, str]) -> None:
+        self.bindings.clear()
+        self.bindings.update(state)
+
+    def visit_If(self, node: ast.If) -> None:
+        self.visit(node.test)
+        initial = dict(self.bindings)
+        body = self._visit_branch(node.body, initial)
+        otherwise = self._visit_branch(node.orelse, initial) if node.orelse else initial
+        self._replace_bindings(_join_binding_states([body, otherwise]))
+
+    def visit_Try(self, node: ast.Try | ast.TryStar) -> None:
+        if self.unit.module not in PRIVATE_ADAPTER_MODULES:
+            try_bindings = _scope_bindings(
+                node.body,
+                self.bindings,
+                self.unit.module,
+                self.scope,
+            )
+            has_emitter = any(
+                isinstance(child, ast.Call) and _obs_emitter(child, try_bindings) is not None
+                for statement in node.body
+                for child in ast.walk(statement)
+            )
+            if has_emitter:
+                for handler in node.handlers:
+                    if _broad_handler(handler) and not _handler_reraises(handler):
+                        exception_name = _dotted_name(handler.type) or "bare"
+                        target = f"except:{exception_name}:telemetry-suppression"
+                        self._add(
+                            "broad_telemetry_suppression",
+                            target,
+                            handler,
+                            "broad suppression around telemetry requires an exact migration entry",
+                        )
+        initial = dict(self.bindings)
+        projected = _flow_bindings([node], initial, self.unit.module, self.scope)
+        body = self._visit_branch(node.body, initial)
+        success = self._visit_branch(node.orelse, body)
+        outcomes = [success]
+        outcomes.extend(self._visit_branch([handler], initial) for handler in node.handlers)
+        joined = _join_binding_states(outcomes)
+        self._visit_branch(node.finalbody, joined)
+        self._replace_bindings(projected)
+
+    visit_TryStar = visit_Try
+
+    def _visit_loop(
+        self,
+        node: ast.For | ast.AsyncFor | ast.While,
+    ) -> None:
+        if isinstance(node, (ast.For, ast.AsyncFor)):
+            self.visit(node.iter)
+            self.visit(node.target)
+        else:
+            self.visit(node.test)
+        initial = dict(self.bindings)
+        projected = _flow_bindings([node], initial, self.unit.module, self.scope)
+        iteration = dict(initial)
+        if isinstance(node, (ast.For, ast.AsyncFor)):
+            target_name = _dotted_name(node.target)
+            if target_name:
+                iteration.pop(target_name, None)
+        body = self._visit_branch(node.body, iteration)
+        loop = _join_binding_states([initial, body])
+        if node.orelse:
+            self._visit_branch(node.orelse, loop)
+        self._replace_bindings(projected)
+
+    visit_For = _visit_loop
+    visit_AsyncFor = _visit_loop
+    visit_While = _visit_loop
+
+    def _visit_with(self, node: ast.With | ast.AsyncWith) -> None:
+        initial = dict(self.bindings)
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self.visit(item.optional_vars)
+                target_name = _dotted_name(item.optional_vars)
+                if target_name:
+                    initial.pop(target_name, None)
+        self._replace_bindings(self._visit_branch(node.body, initial))
+
+    visit_With = _visit_with
+    visit_AsyncWith = _visit_with
+
+    def visit_Match(self, node: ast.Match) -> None:
+        self.visit(node.subject)
+        initial = dict(self.bindings)
+        outcomes = [self._visit_branch(case.body, initial) for case in node.cases]
+        outcomes.append(initial)
+        self._replace_bindings(_join_binding_states(outcomes))
+
+    def _configuration_capability(self, node: ast.Call, resolved: str) -> str | None:
+        tail = resolved.rsplit(".", 1)[-1]
+        local = f"{self.unit.module}.{resolved}" if "." not in resolved else resolved
+        if local in INVOKE_CONFIGURATION_CALLS:
+            return "invoke_configuration"
+        if resolved == AMBIGUOUS_OBSERVABILITY_BINDING or tail in PROVIDER_MUTATOR_NAMES:
+            return "provider_configuration"
+        if resolved.startswith(VENDOR_PREFIXES) and tail in {
+            "TracerProvider",
+            "MeterProvider",
+            "LoggerProvider",
+            "OTLPSpanExporter",
+            "OTLPMetricExporter",
+            "OTLPLogExporter",
+            "ConsoleSpanExporter",
+            "ConsoleMetricExporter",
+            "ConsoleLogExporter",
+            "BatchSpanProcessor",
+            "SimpleSpanProcessor",
+            "BatchLogRecordProcessor",
+            "SimpleLogRecordProcessor",
+            "PeriodicExportingMetricReader",
+        }:
+            return "provider_configuration"
+        if resolved in {
+            "logging.basicConfig",
+            "logging.config.dictConfig",
+            "logging.config.fileConfig",
+            "logging.setLogRecordFactory",
+            "logging.captureWarnings",
+            "logging.disable",
+            "logging.config.listen",
+            "logging.config.stopListening",
+        }:
+            return "logging_configuration"
+        receiver = (
+            _resolved_name(node.func.value, self.bindings)
+            if isinstance(node.func, ast.Attribute)
+            else ""
+        )
+        if tail in {
+            "addFilter",
+            "removeFilter",
+            "addHandler",
+            "removeHandler",
+            "setFilter",
+            "setFormatter",
+            "setLevel",
+        } and (
+            receiver.startswith("logging.")
+            or (self.unit.module == "archetype._logging" and receiver == "self")
+        ):
+            return "logging_configuration"
+        return None
+
+    def _check_configuration(self, node: ast.Call, resolved: str) -> None:
+        capability = self._configuration_capability(node, resolved)
+        if capability and not self._approved(capability):
+            rule = (
+                "logging_basic_config"
+                if resolved.rsplit(".", 1)[-1] == "basicConfig"
+                else "configuration_boundary"
+            )
+            self._add(
+                rule,
+                f"call:{resolved}:{ast.unparse(node)}",
+                node,
+                f"{capability} is not approved for this exact callable",
+            )
+        if resolved.endswith(".configure_tracing"):
+            for keyword in node.keywords:
+                if keyword.arg == "debug_console" and _contains_debug_coordinate(keyword.value):
+                    self._add(
+                        "debug_export_configuration",
+                        f"configure_tracing:debug_console:{ast.unparse(keyword.value)}",
+                        keyword.value,
+                        "run/debug state cannot select telemetry export configuration",
+                    )
+
+    def _check_print(self, node: ast.Call, resolved: str) -> None:
+        if resolved not in {"print", "builtins.print"}:
+            return
+        cli_prefix = "src/archetype/cli/"
+        if not self.unit.relative_path.startswith(cli_prefix) and not self._approved(
+            "console_export"
+        ):
+            self._add(
+                "shipped_print",
+                f"call:print:{ast.unparse(node)}",
+                node,
+                "shipped print calls are confined to CLI or an exact console exporter",
+            )
+
+    def _check_logging(self, node: ast.Call) -> None:
+        if not _looks_like_logger(node, self.bindings):
+            return
+        method = node.func.attr if isinstance(node.func, ast.Attribute) else "log"
+        message = ast.unparse(node.args[0]) if node.args else "<no-message>"
+        site = f"log:{method}:{message}"
+        resolved_arguments = [self._resolve_local_expression(argument) for argument in node.args]
+        if resolved_arguments and _is_eager_log_expression(resolved_arguments[0]):
+            self._add(
+                "eager_log_interpolation",
+                f"{site}:interpolation",
+                node,
+                "use parameterized stdlib logging instead of eager interpolation",
+            )
+
+        caught = self._current_caught()
+        raw = method == "exception"
+        raw = raw or any(
+            keyword.arg in {"exc_info", "stack_info"}
+            and not (
+                isinstance(keyword.value, ast.Constant) and keyword.value.value in {False, None}
+            )
+            for keyword in node.keywords
+        )
+        raw = raw or any(
+            _contains_raw_exception(argument, caught) for argument in resolved_arguments
+        )
+        raw = raw or any(
+            keyword.arg != "exc_info" and _contains_raw_exception(keyword.value, caught)
+            for keyword in node.keywords
+        )
+        if raw:
+            self._add(
+                "raw_exception_logging",
+                f"{site}:exception",
+                node,
+                "raw exceptions, messages, and stacks must not be exported",
+            )
+
+        if any(_contains_sensitive_log_coordinate(argument) for argument in resolved_arguments):
+            self._add(
+                "unsafe_log_value",
+                f"{site}:sensitive-value",
+                node,
+                "logs must not export payload, prompt, secret, or path values",
+            )
+
+        for keyword in node.keywords:
+            if keyword.arg != "extra":
+                continue
+            extra = self._resolve_local_expression(keyword.value)
+            if not isinstance(extra, ast.Dict):
+                self._add(
+                    "dynamic_attribute_key",
+                    f"{site}:extra:*",
+                    keyword.value,
+                    "structured log fields must use literal keys",
+                )
+                continue
+            for key_node in extra.keys:
+                key = _literal_name(key_node)
+                if key is None:
+                    self._add(
+                        "dynamic_attribute_key",
+                        f"{site}:extra:<dynamic>",
+                        key_node or extra,
+                        "structured log field keys must be literal",
+                    )
+                    continue
+                tokens = {token for token in re.split(r"[^a-z0-9]+", key.lower()) if token}
+                if tokens & SENSITIVE_LOG_COORDINATES:
+                    self._add(
+                        "unsafe_attribute_key",
+                        f"{site}:extra:{key}",
+                        key_node,
+                        "structured log field is an obvious secret or content key",
+                    )
+
+    def _attribute_pairs(
+        self,
+        node: ast.Call,
+        emitter: str,
+        site: str,
+    ) -> list[tuple[str | None, ast.AST, str]]:
+        pairs: list[tuple[str | None, ast.AST, str]] = []
+        for keyword in node.keywords:
+            if keyword.arg is None:
+                self._add(
+                    "dynamic_attribute_key",
+                    f"{site}:attributes:**:{ast.unparse(keyword.value)}",
+                    keyword.value,
+                    "telemetry calls cannot expand keyword mappings with unproven keys",
+                )
+        attributes = _call_argument(node, 1, "attributes") if emitter == "span" else None
+        if emitter == "counter_add":
+            attributes = _call_argument(node, 2, "attributes")
+        elif emitter == "bind_context":
+            attributes = _call_argument(node, 0, "attributes")
+        if attributes is not None:
+            if isinstance(attributes, ast.Constant) and attributes.value is None:
+                pass
+            else:
+                mapping = self._resolve_attribute_mapping(attributes, set())
+                if mapping is None:
+                    self._add(
+                        "dynamic_attribute_key",
+                        f"{site}:attributes:*",
+                        attributes,
+                        "attribute mappings must expose literal keys at the emission site",
+                    )
+                else:
+                    for key, value_node in mapping:
+                        pairs.append((key, value_node, f"{site}:attribute:{key or '<dynamic>'}"))
+
+        if emitter in {"span", "bind_context"}:
+            for keyword in node.keywords:
+                reserved = (
+                    {None, "attributes", "name"} if emitter == "span" else {None, "attributes"}
+                )
+                if keyword.arg not in reserved:
+                    pairs.append((keyword.arg, keyword.value, f"{site}:attribute:{keyword.arg}"))
+        return pairs
+
+    def _resolve_attribute_mapping(
+        self,
+        node: ast.AST,
+        seen: set[str],
+    ) -> list[tuple[str | None, ast.AST]] | None:
+        if isinstance(node, ast.Name):
+            if node.id in seen:
+                return None
+            for assignments in reversed(self.assignments):
+                if node.id in assignments:
+                    return self._resolve_attribute_mapping(
+                        assignments[node.id],
+                        seen | {node.id},
+                    )
+            return None
+        if isinstance(node, ast.Call):
+            dotted = _dotted_name(node.func)
+            if dotted.startswith("self.") and len(self.parts) >= 2:
+                scope = ".".join((*self.parts[:-1], dotted.removeprefix("self.")))
+            else:
+                scope = _resolved_name(node.func, self.bindings)
+            returned = self.return_maps.get(scope)
+            if returned is None or scope in seen:
+                return None
+            return self._resolve_attribute_mapping(returned, seen | {scope})
+        if not isinstance(node, ast.Dict):
+            return None
+
+        pairs: list[tuple[str | None, ast.AST]] = []
+        for key_node, value_node in zip(node.keys, node.values, strict=True):
+            if key_node is None:
+                unpacked = self._resolve_attribute_mapping(value_node, seen)
+                if unpacked is None:
+                    return None
+                pairs.extend(unpacked)
+            else:
+                pairs.append((_literal_name(key_node), value_node))
+        return pairs
+
+    def _check_attributes(self, node: ast.Call, emitter: str, site: str) -> None:
+        caught = self._current_caught()
+        for key, value, target in self._attribute_pairs(node, emitter, site):
+            if key is None:
+                self._add(
+                    "dynamic_attribute_key",
+                    target,
+                    node,
+                    "telemetry attribute keys must be literal",
+                )
+                continue
+            if key in self.vocabulary.maps.get("TRACE_ATTRIBUTE_ALIASES", {}):
+                self._add(
+                    "legacy_attribute_key",
+                    target,
+                    node,
+                    "legacy attribute aliases require an exact migration entry",
+                )
+            elif key not in self.vocabulary.attribute_keys:
+                self._add(
+                    "unsafe_attribute_key",
+                    target,
+                    node,
+                    "attribute key is outside the safe literal vocabulary",
+                )
+            elif emitter == "counter_add" and key not in self.vocabulary.metric_label_keys:
+                self._add(
+                    "high_cardinality_metric_label",
+                    target,
+                    node,
+                    "metric labels must use the bounded label vocabulary",
+                )
+            if _contains_raw_exception(value, caught):
+                self._add(
+                    "raw_exception_attribute",
+                    f"{target}:exception",
+                    value,
+                    "raw exception values must not be exported as telemetry attributes",
+                )
+
+    def _check_emitter(self, node: ast.Call, emitter: str) -> None:
+        if self.unit.module in PRIVATE_ADAPTER_MODULES:
+            return
+        if emitter == "bind_context":
+            self._check_attributes(node, emitter, "context:bind")
+            return
+        if emitter in {"span", "instrument"}:
+            kind = "span"
+            allowed = self.vocabulary.span_names
+            legacy = self.vocabulary.legacy_span_names
+        elif emitter == "counter_add":
+            kind = "metric"
+            allowed = self.vocabulary.metric_names
+            legacy = frozenset()
+        else:
+            return
+
+        name_node = _call_argument(node, 0, "name")
+        name = _literal_name(name_node)
+        category = f"{kind}:{name if name is not None else '<dynamic>'}"
+        site = category
+        if name is None:
+            self._add(
+                "dynamic_signal_name",
+                site,
+                name_node or node,
+                f"{kind} names must be literal",
+            )
+        elif name not in allowed:
+            self._add(
+                "unknown_signal_name",
+                site,
+                name_node or node,
+                f"unknown {kind} name {name!r}",
+            )
+        elif name in legacy:
+            self._add(
+                "legacy_span_name",
+                site,
+                name_node or node,
+                f"legacy {kind} name {name!r} requires an exact migration entry",
+            )
+        self._check_attributes(node, emitter, site)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        resolved = _resolved_name(node.func, self.bindings)
+        self._check_configuration(node, resolved)
+        self._check_print(node, resolved)
+        self._check_logging(node)
+        emitter = _obs_emitter(node, self.bindings)
+        if emitter is not None:
+            self._check_emitter(node, emitter)
+        self.generic_visit(node)
+
+
+def _analyze_sources(
+    units: list[SourceUnit],
+    vocabulary: Vocabulary,
+    hosts: dict[str, frozenset[str]],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    for unit in units:
+        analyzer = _SourceAnalyzer(unit, vocabulary, hosts)
+        analyzer.visit(unit.tree)
+        violations.extend(analyzer.violations)
+    return violations
+
+
+def _reconcile_legacy(
+    findings: list[Violation],
+    legacy: dict[tuple[str, str, str, str], dict[str, Any]],
+    result: AuditResult,
+) -> None:
+    by_key: dict[tuple[str, str, str, str], list[Violation]] = defaultdict(list)
+    for finding in findings:
+        by_key[finding.key].append(finding)
+
+    for key, matching in sorted(by_key.items()):
+        if len(matching) > 1:
+            locations = ", ".join(f"{item.path}:{item.line}" for item in matching)
+            result.policy_errors.append(
+                f"source findings collide on exact legacy key {key!r}: {locations}"
+            )
+
+    for key, finding_list in sorted(by_key.items()):
+        if key in legacy and len(finding_list) == 1:
+            result.exempted.append(finding_list[0])
+        else:
+            result.violations.extend(finding_list)
+
+    for key, row in sorted(legacy.items()):
+        matching = by_key.get(key, [])
+        if len(matching) == 0:
+            result.policy_errors.append(f"stale legacy exception {row['_label']}: {key!r}")
+        elif len(matching) > 1:
+            result.policy_errors.append(
+                f"legacy exception {row['_label']} matches {len(matching)} findings: {key!r}"
+            )
+
+    result.violations.sort(
+        key=lambda item: (item.path, item.line, item.rule, item.qualified_scope, item.target)
+    )
+    result.exempted.sort(
+        key=lambda item: (item.path, item.line, item.rule, item.qualified_scope, item.target)
+    )
+    result.policy_errors.sort()
+
+
+def audit_repository(
+    manifest_root: Path = DEFAULT_MANIFEST_ROOT,
+    *,
+    repo_root: Path = ROOT,
+) -> AuditResult:
+    """Audit one repository without importing any shipped module."""
+
+    root = repo_root.resolve()
+    manifests = manifest_root.resolve()
+    result = AuditResult()
+    source_root, units = _parse_sources(root, result)
+    vocabulary = _load_vocabulary(root, result)
+    protocols = _protocol_operations(units, source_root, result)
+    callable_paths = _callable_scope_paths(units)
+    state = _load_manifests(
+        manifests,
+        root,
+        vocabulary,
+        protocols,
+        callable_paths,
+        result,
+    )
+    findings = _analyze_sources(units, vocabulary, state.hosts)
+    _reconcile_legacy(findings, state.legacy, result)
+    return result
+
+
+def _print_result(result: AuditResult) -> None:
+    if result.ok:
+        print(
+            "Observability audit passed: "
+            f"{result.files_scanned} files, "
+            f"{result.protocols_scanned} protocols, "
+            f"{result.operations_scanned} operations, "
+            f"{result.workflows_scanned} workflows, "
+            f"{len(result.exempted)} owned legacy exceptions."
+        )
+        return
+
+    print("Observability audit failed.", file=sys.stderr)
+    for error in result.policy_errors:
+        print(f"POLICY: {error}", file=sys.stderr)
+    for violation in result.violations:
+        print(
+            f"{violation.path}:{violation.line}: {violation.rule}: {violation.detail} "
+            f"[scope={violation.qualified_scope}; target={violation.target}]",
+            file=sys.stderr,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifests",
+        type=Path,
+        default=DEFAULT_MANIFEST_ROOT,
+        help="observability manifest directory",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=ROOT,
+        help="repository root",
+    )
+    args = parser.parse_args(argv)
+    result = audit_repository(args.manifests, repo_root=args.repo_root)
+    _print_result(result)
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_observability.py
+++ b/scripts/check_observability.py
@@ -47,11 +47,25 @@ VOCABULARY_SETS = (
     "OUTCOMES",
     "ERROR_TYPES",
 )
-VOCABULARY_MAPS = ("SPAN_NAME_ALIASES", "TRACE_ATTRIBUTE_ALIASES")
+VOCABULARY_MAPS = (
+    "SPAN_NAME_ALIASES",
+    "TRACE_ATTRIBUTE_ALIASES",
+    "RECORDER_METRIC_NAMES",
+    "RECORDER_METRIC_LABEL_KEYS",
+)
+RECORDER_EMITTERS = frozenset({"record_failure", "record_outcome"})
+RECORDER_LABEL_COORDINATES = frozenset(
+    {
+        "record_failure.disposition",
+        "record_failure.error_type",
+        "record_outcome.operation",
+        "record_outcome.outcome",
+    }
+)
 OBS_EMITTERS = frozenset(
     {"span", "instrument", "counter_add", "record_failure", "record_outcome", "bind_context"}
 )
-LOG_METHODS = frozenset({"debug", "info", "warning", "error", "critical", "exception"})
+LOG_METHODS = frozenset({"debug", "info", "warning", "error", "critical", "exception", "log"})
 VENDOR_PREFIXES = ("opentelemetry", "logfire")
 PRIVATE_ADAPTER_MODULES = frozenset({"archetype._obs", "archetype._logging"})
 AMBIGUOUS_OBSERVABILITY_BINDING = "__observability_sensitive__"
@@ -142,12 +156,40 @@ class Vocabulary:
     def metric_label_keys(self) -> frozenset[str]:
         return self.sets["METRIC_LABEL_KEYS"]
 
+    def recorder_metric_name(self, emitter: str) -> str | None:
+        return self.maps["RECORDER_METRIC_NAMES"].get(emitter)
+
+    def recorder_metric_labels(self, emitter: str) -> dict[str, str]:
+        prefix = f"{emitter}."
+        return {
+            coordinate.removeprefix(prefix): key
+            for coordinate, key in self.maps["RECORDER_METRIC_LABEL_KEYS"].items()
+            if coordinate.startswith(prefix)
+        }
+
+
+@dataclass
+class ScopeEmissions:
+    """Literal signal vocabulary observed in one exact callable scope."""
+
+    span_names: set[str] = field(default_factory=set)
+    attribute_keys: set[str] = field(default_factory=set)
+    metric_names: set[str] = field(default_factory=set)
+    metric_label_keys: set[str] = field(default_factory=set)
+
+    def update(self, other: ScopeEmissions) -> None:
+        self.span_names.update(other.span_names)
+        self.attribute_keys.update(other.attribute_keys)
+        self.metric_names.update(other.metric_names)
+        self.metric_label_keys.update(other.metric_label_keys)
+
 
 @dataclass
 class ManifestState:
     operations: dict[str, dict[str, list[str]]] = field(
         default_factory=lambda: defaultdict(lambda: defaultdict(list))
     )
+    dispositions: list[dict[str, Any]] = field(default_factory=list)
     workflows: list[dict[str, Any]] = field(default_factory=list)
     hosts: dict[str, frozenset[str]] = field(default_factory=dict)
     legacy: dict[tuple[str, str, str, str], dict[str, Any]] = field(default_factory=dict)
@@ -408,6 +450,7 @@ def _scope_bindings(
         if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
     ]
     assignments = [node for node in nodes if isinstance(node, (ast.Assign, ast.AnnAssign))]
+    named_expressions = [node for node in nodes if isinstance(node, ast.NamedExpr)]
 
     local_names = set(parameters)
     for node in imports:
@@ -417,12 +460,17 @@ def _scope_bindings(
         local_names.update(
             target.id for target in _target_nodes(node) if isinstance(target, ast.Name)
         )
+    local_names.update(
+        node.target.id for node in named_expressions if isinstance(node.target, ast.Name)
+    )
 
     initial = {name: value for name, value in parent.items() if name not in local_names}
     return _flow_bindings(statements, initial, module, scope)
 
 
-def _parameter_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> frozenset[str]:
+def _parameter_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
+) -> frozenset[str]:
     arguments = node.args
     names = {
         argument.arg
@@ -452,6 +500,8 @@ def _function_bindings(
             local_names.update(
                 target.id for target in _target_nodes(child) if isinstance(target, ast.Name)
             )
+        elif isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name):
+            local_names.add(child.target.id)
     return {name: value for name, value in parent.items() if name not in local_names}
 
 
@@ -710,6 +760,22 @@ def _load_vocabulary(repo_root: Path, result: AuditResult) -> Vocabulary:
         )
     if not sets["METRIC_LABEL_KEYS"] <= sets["TRACE_ATTRIBUTE_KEYS"]:
         result.policy_errors.append("METRIC_LABEL_KEYS must be a subset of TRACE_ATTRIBUTE_KEYS")
+    recorder_metrics = maps["RECORDER_METRIC_NAMES"]
+    if set(recorder_metrics) != RECORDER_EMITTERS:
+        result.policy_errors.append(
+            "RECORDER_METRIC_NAMES must define record_failure and record_outcome exactly"
+        )
+    if not set(recorder_metrics.values()) <= sets["METRIC_NAMES"]:
+        result.policy_errors.append("RECORDER_METRIC_NAMES targets must be canonical METRIC_NAMES")
+    recorder_labels = maps["RECORDER_METRIC_LABEL_KEYS"]
+    if set(recorder_labels) != RECORDER_LABEL_COORDINATES:
+        result.policy_errors.append(
+            "RECORDER_METRIC_LABEL_KEYS must define the fixed recorder coordinates exactly"
+        )
+    if not set(recorder_labels.values()) <= sets["METRIC_LABEL_KEYS"]:
+        result.policy_errors.append(
+            "RECORDER_METRIC_LABEL_KEYS targets must be canonical METRIC_LABEL_KEYS"
+        )
     return Vocabulary(sets, maps)
 
 
@@ -887,8 +953,37 @@ def _load_manifests(
                 local_errors,
                 root_allowed=owner in {"gateway", "runtime"},
             )
+            signal_values = row.get("signals", [])
+            signals = (
+                {item for item in signal_values if isinstance(item, str)}
+                if isinstance(signal_values, list)
+                else set()
+            )
+            source_bound = bool({"root", "child", "metric"} & signals)
+            emission_workflows = _string_array(
+                row.get("emission_workflows", []),
+                f"{label}.emission_workflows",
+                local_errors,
+                required=source_bound,
+            )
+            if source_bound and not emission_workflows:
+                local_errors.append(
+                    f"{label}.emission_workflows is required for root/child/metric signals"
+                )
+            if emission_workflows and not source_bound:
+                local_errors.append(
+                    f"{label}.emission_workflows requires a root, child, or metric signal"
+                )
             for operation in operations:
                 state.operations[owner][operation].append(label)
+            state.dispositions.append(
+                {
+                    **row,
+                    "owner": owner,
+                    "_label": label,
+                    "emission_workflows": emission_workflows,
+                }
+            )
 
         workflows = document.get("workflow", [])
         if not isinstance(workflows, list) or any(not isinstance(row, dict) for row in workflows):
@@ -1000,6 +1095,25 @@ def _load_manifests(
     for workflow_id, count in sorted(workflow_ids.items()):
         if workflow_id and count != 1:
             result.policy_errors.append(f"duplicate workflow id {workflow_id!r}")
+    workflows_by_id = {
+        str(row.get("id")): row
+        for row in state.workflows
+        if workflow_ids[str(row.get("id", ""))] == 1
+    }
+    for row in state.dispositions:
+        label = str(row["_label"])
+        owner = str(row["owner"])
+        for workflow_id in row.get("emission_workflows", []):
+            workflow = workflows_by_id.get(workflow_id)
+            if workflow is None:
+                result.policy_errors.append(
+                    f"{label}.emission_workflows references unknown workflow {workflow_id!r}"
+                )
+            elif workflow.get("owner") != owner:
+                result.policy_errors.append(
+                    f"{label}.emission_workflows references workflow {workflow_id!r} "
+                    f"owned by {workflow.get('owner')!r}, not {owner!r}"
+                )
     workflow_scopes = Counter(str(row.get("qualified_scope", "")) for row in state.workflows)
     for scope, count in sorted(workflow_scopes.items()):
         if scope and count != 1:
@@ -1108,6 +1222,8 @@ def _contains_sensitive_log_coordinate(node: ast.AST) -> bool:
             value = child.id
         elif isinstance(child, ast.Attribute):
             value = child.attr
+        elif isinstance(child, ast.Constant) and isinstance(child.value, str):
+            value = child.value
         else:
             continue
         tokens = {token for token in re.split(r"[^a-z0-9]+", value.lower()) if token}
@@ -1189,6 +1305,21 @@ class _SourceAnalyzer(ast.NodeVisitor):
         self.assignments: list[dict[str, ast.AST]] = []
         self.binding_scopes: list[dict[str, str]] = [unit.bindings]
         self.violations: list[Violation] = []
+        self.emissions: dict[str, ScopeEmissions] = defaultdict(ScopeEmissions)
+        self.entered_context_calls = {
+            id(item.context_expr)
+            for candidate in ast.walk(unit.tree)
+            if isinstance(candidate, ast.With)
+            for item in candidate.items
+            if isinstance(item.context_expr, ast.Call)
+        }
+        self.decorator_calls = {
+            id(decorator)
+            for candidate in ast.walk(unit.tree)
+            if isinstance(candidate, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+            for decorator in candidate.decorator_list
+            if isinstance(decorator, ast.Call)
+        }
         collector = _ReturnMapCollector(unit.module)
         collector.visit(unit.tree)
         self.return_maps = collector.maps
@@ -1242,6 +1373,29 @@ class _SourceAnalyzer(ast.NodeVisitor):
 
     visit_FunctionDef = _visit_function
     visit_AsyncFunctionDef = _visit_function
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        # Defaults execute in the enclosing scope; the lambda body is a distinct
+        # callable boundary and must never donate emissions to its parent.
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
+        self.parts.append(f"<lambda>@L{node.lineno}C{node.col_offset}")
+        local_names = set(_parameter_names(node))
+        local_names.update(
+            child.target.id
+            for child in _same_scope_nodes([node.body])
+            if isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name)
+        )
+        self.binding_scopes.append(
+            {name: value for name, value in self.bindings.items() if name not in local_names}
+        )
+        self.assignments.append({})
+        self.visit(node.body)
+        self.assignments.pop()
+        self.binding_scopes.pop()
+        self.parts.pop()
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         names = {node.name} if isinstance(node.name, str) else set()
@@ -1327,6 +1481,11 @@ class _SourceAnalyzer(ast.NodeVisitor):
         self.visit(node.target)
         self.visit(node.value)
         self._update_assignment_bindings([node.target], None)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.visit(node.value)
+        self.visit(node.target)
+        self._update_assignment_bindings([node.target], node.value)
 
     def _visit_branch(
         self,
@@ -1534,10 +1693,16 @@ class _SourceAnalyzer(ast.NodeVisitor):
         if not _looks_like_logger(node, self.bindings):
             return
         method = node.func.attr if isinstance(node.func, ast.Attribute) else "log"
-        message = ast.unparse(node.args[0]) if node.args else "<no-message>"
+        message_position = 1 if method == "log" else 0
+        message_node = _call_argument(node, message_position, "msg")
+        message = ast.unparse(message_node) if message_node is not None else "<no-message>"
         site = f"log:{method}:{message}"
         resolved_arguments = [self._resolve_local_expression(argument) for argument in node.args]
-        if resolved_arguments and _is_eager_log_expression(resolved_arguments[0]):
+        logged_arguments = resolved_arguments[1:] if method == "log" else resolved_arguments
+        resolved_message = (
+            self._resolve_local_expression(message_node) if message_node is not None else None
+        )
+        if resolved_message is not None and _is_eager_log_expression(resolved_message):
             self._add(
                 "eager_log_interpolation",
                 f"{site}:interpolation",
@@ -1554,9 +1719,7 @@ class _SourceAnalyzer(ast.NodeVisitor):
             )
             for keyword in node.keywords
         )
-        raw = raw or any(
-            _contains_raw_exception(argument, caught) for argument in resolved_arguments
-        )
+        raw = raw or any(_contains_raw_exception(argument, caught) for argument in logged_arguments)
         raw = raw or any(
             keyword.arg != "exc_info" and _contains_raw_exception(keyword.value, caught)
             for keyword in node.keywords
@@ -1569,7 +1732,10 @@ class _SourceAnalyzer(ast.NodeVisitor):
                 "raw exceptions, messages, and stacks must not be exported",
             )
 
-        if any(_contains_sensitive_log_coordinate(argument) for argument in resolved_arguments):
+        sensitive_arguments = list(logged_arguments)
+        if resolved_message is not None:
+            sensitive_arguments.append(resolved_message)
+        if any(_contains_sensitive_log_coordinate(argument) for argument in sensitive_arguments):
             self._add(
                 "unsafe_log_value",
                 f"{site}:sensitive-value",
@@ -1692,8 +1858,9 @@ class _SourceAnalyzer(ast.NodeVisitor):
                 pairs.append((_literal_name(key_node), value_node))
         return pairs
 
-    def _check_attributes(self, node: ast.Call, emitter: str, site: str) -> None:
+    def _check_attributes(self, node: ast.Call, emitter: str, site: str) -> set[str]:
         caught = self._current_caught()
+        observed: set[str] = set()
         for key, value, target in self._attribute_pairs(node, emitter, site):
             if key is None:
                 self._add(
@@ -1704,6 +1871,7 @@ class _SourceAnalyzer(ast.NodeVisitor):
                 )
                 continue
             if key in self.vocabulary.maps.get("TRACE_ATTRIBUTE_ALIASES", {}):
+                observed.add(self.vocabulary.maps["TRACE_ATTRIBUTE_ALIASES"][key])
                 self._add(
                     "legacy_attribute_key",
                     target,
@@ -1717,13 +1885,15 @@ class _SourceAnalyzer(ast.NodeVisitor):
                     node,
                     "attribute key is outside the safe literal vocabulary",
                 )
-            elif emitter == "counter_add" and key not in self.vocabulary.metric_label_keys:
-                self._add(
-                    "high_cardinality_metric_label",
-                    target,
-                    node,
-                    "metric labels must use the bounded label vocabulary",
-                )
+            else:
+                observed.add(key)
+                if emitter == "counter_add" and key not in self.vocabulary.metric_label_keys:
+                    self._add(
+                        "high_cardinality_metric_label",
+                        target,
+                        node,
+                        "metric labels must use the bounded label vocabulary",
+                    )
             if _contains_raw_exception(value, caught):
                 self._add(
                     "raw_exception_attribute",
@@ -1731,12 +1901,38 @@ class _SourceAnalyzer(ast.NodeVisitor):
                     value,
                     "raw exception values must not be exported as telemetry attributes",
                 )
+        return observed
 
     def _check_emitter(self, node: ast.Call, emitter: str) -> None:
         if self.unit.module in PRIVATE_ADAPTER_MODULES:
             return
+        emission: ScopeEmissions | None = self.emissions[self.scope]
+        if emitter == "instrument" and id(node) not in self.decorator_calls:
+            emission = None
+        elif emitter in {"bind_context", "span"} and id(node) not in (
+            self.entered_context_calls | self.decorator_calls
+        ):
+            emission = None
+
         if emitter == "bind_context":
-            self._check_attributes(node, emitter, "context:bind")
+            attributes = self._check_attributes(node, emitter, "context:bind")
+            if emission is not None:
+                emission.attribute_keys.update(attributes)
+            return
+        if emitter in RECORDER_EMITTERS:
+            if emission is None:
+                return
+            metric_name = self.vocabulary.recorder_metric_name(emitter)
+            if metric_name is not None:
+                emission.metric_names.add(metric_name)
+            labels = self.vocabulary.recorder_metric_labels(emitter)
+            if emitter == "record_outcome":
+                operation = _call_argument(node, 1, "operation")
+                if operation is None or (
+                    isinstance(operation, ast.Constant) and operation.value is None
+                ):
+                    labels.pop("operation", None)
+            emission.metric_label_keys.update(labels.values())
             return
         if emitter in {"span", "instrument"}:
             kind = "span"
@@ -1751,6 +1947,9 @@ class _SourceAnalyzer(ast.NodeVisitor):
 
         name_node = _call_argument(node, 0, "name")
         name = _literal_name(name_node)
+        canonical_name = name
+        if kind == "span" and name is not None:
+            canonical_name = self.vocabulary.maps.get("SPAN_NAME_ALIASES", {}).get(name, name)
         category = f"{kind}:{name if name is not None else '<dynamic>'}"
         site = category
         if name is None:
@@ -1760,21 +1959,38 @@ class _SourceAnalyzer(ast.NodeVisitor):
                 name_node or node,
                 f"{kind} names must be literal",
             )
-        elif name not in allowed:
+        elif canonical_name not in allowed:
             self._add(
                 "unknown_signal_name",
                 site,
                 name_node or node,
                 f"unknown {kind} name {name!r}",
             )
-        elif name in legacy:
+        elif name in self.vocabulary.maps.get("SPAN_NAME_ALIASES", {}):
+            self._add(
+                "legacy_span_name",
+                site,
+                name_node or node,
+                f"legacy {kind} alias {name!r} requires an exact migration entry",
+            )
+        elif canonical_name in legacy:
             self._add(
                 "legacy_span_name",
                 site,
                 name_node or node,
                 f"legacy {kind} name {name!r} requires an exact migration entry",
             )
-        self._check_attributes(node, emitter, site)
+        if canonical_name in allowed and emission is not None:
+            if kind == "span":
+                emission.span_names.add(canonical_name)
+            else:
+                emission.metric_names.add(canonical_name)
+        attributes = self._check_attributes(node, emitter, site)
+        if emission is not None:
+            if kind == "span":
+                emission.attribute_keys.update(attributes)
+            else:
+                emission.metric_label_keys.update(attributes)
 
     def visit_Call(self, node: ast.Call) -> None:
         resolved = _resolved_name(node.func, self.bindings)
@@ -1791,13 +2007,127 @@ def _analyze_sources(
     units: list[SourceUnit],
     vocabulary: Vocabulary,
     hosts: dict[str, frozenset[str]],
-) -> list[Violation]:
+) -> tuple[list[Violation], dict[str, ScopeEmissions]]:
     violations: list[Violation] = []
+    emissions: dict[str, ScopeEmissions] = defaultdict(ScopeEmissions)
     for unit in units:
         analyzer = _SourceAnalyzer(unit, vocabulary, hosts)
         analyzer.visit(unit.tree)
         violations.extend(analyzer.violations)
-    return violations
+        for scope, observed in analyzer.emissions.items():
+            emissions[scope].update(observed)
+    return violations, dict(emissions)
+
+
+_EMISSION_FIELDS = (
+    "span_names",
+    "attribute_keys",
+    "metric_names",
+    "metric_label_keys",
+)
+
+
+def _manifest_string_set(row: dict[str, Any], field_name: str) -> set[str]:
+    value = row.get(field_name, [])
+    if not isinstance(value, list):
+        return set()
+    return {item for item in value if isinstance(item, str)}
+
+
+def _observed_emissions(
+    scopes: list[str],
+    emissions: dict[str, ScopeEmissions],
+) -> ScopeEmissions:
+    observed = ScopeEmissions()
+    for scope in scopes:
+        current = emissions.get(scope)
+        if current is not None:
+            observed.update(current)
+    return observed
+
+
+def _validate_emission_fields(
+    row: dict[str, Any],
+    scopes: list[str],
+    emissions: dict[str, ScopeEmissions],
+    result: AuditResult,
+) -> None:
+    if not scopes:
+        return
+    label = str(row["_label"])
+    observed = _observed_emissions(scopes, emissions)
+    for field_name in _EMISSION_FIELDS:
+        declared = _manifest_string_set(row, field_name)
+        actual = set(getattr(observed, field_name))
+        if declared == actual:
+            continue
+        result.policy_errors.append(
+            f"{label}.{field_name} does not match source emissions for {scopes!r}: "
+            f"declared-only={sorted(declared - actual)!r}, "
+            f"observed-only={sorted(actual - declared)!r}"
+        )
+
+
+def _validate_manifest_emissions(
+    state: ManifestState,
+    emissions: dict[str, ScopeEmissions],
+    result: AuditResult,
+) -> None:
+    """Bind optional workflow claims and positive dispositions to exact source."""
+
+    workflow_counts = Counter(str(row.get("id", "")) for row in state.workflows)
+    workflows_by_id = {
+        str(row.get("id")): row
+        for row in state.workflows
+        if isinstance(row.get("id"), str)
+        and row.get("id")
+        and workflow_counts[str(row.get("id"))] == 1
+    }
+    for workflow in state.workflows:
+        scope = workflow.get("qualified_scope")
+        _validate_emission_fields(
+            workflow,
+            [scope] if isinstance(scope, str) and scope else [],
+            emissions,
+            result,
+        )
+
+    for disposition in state.dispositions:
+        workflow_ids = disposition.get("emission_workflows", [])
+        if not isinstance(workflow_ids, list) or not workflow_ids:
+            continue
+        workflows = [
+            workflows_by_id[workflow_id]
+            for workflow_id in workflow_ids
+            if isinstance(workflow_id, str)
+            and workflow_id in workflows_by_id
+            and workflows_by_id[workflow_id].get("owner") == disposition.get("owner")
+        ]
+        if len(workflows) != len(workflow_ids):
+            continue
+        scopes = [
+            scope
+            for workflow in workflows
+            if isinstance((scope := workflow.get("qualified_scope")), str) and scope
+        ]
+        _validate_emission_fields(disposition, scopes, emissions, result)
+
+        declared_signals = _manifest_string_set(disposition, "signals") & {
+            "root",
+            "child",
+            "metric",
+        }
+        workflow_signals: set[str] = set()
+        for workflow in workflows:
+            workflow_signals.update(
+                _manifest_string_set(workflow, "signals") & {"root", "child", "metric"}
+            )
+        if declared_signals != workflow_signals:
+            result.policy_errors.append(
+                f"{disposition['_label']}.signals does not match referenced workflows: "
+                f"declared-only={sorted(declared_signals - workflow_signals)!r}, "
+                f"workflow-only={sorted(workflow_signals - declared_signals)!r}"
+            )
 
 
 def _reconcile_legacy(
@@ -1862,7 +2192,8 @@ def audit_repository(
         callable_paths,
         result,
     )
-    findings = _analyze_sources(units, vocabulary, state.hosts)
+    findings, emissions = _analyze_sources(units, vocabulary, state.hosts)
+    _validate_manifest_emissions(state, emissions, result)
     _reconcile_legacy(findings, state.legacy, result)
     return result
 

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -56,6 +56,8 @@ REQUIRED_CATEGORIES = (
     "deprecated-daft-apis",
     "arrow-serialization-violations",
     "tick-boundary-violations",
+    "observability-boundary-and-authority",
+    "telemetry-safety-and-cardinality",
 )
 
 _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")

--- a/src/archetype/_obs.py
+++ b/src/archetype/_obs.py
@@ -66,22 +66,14 @@ SPAN_NAMES: Final[frozenset[str]] = frozenset(
 )
 
 # ``world.execute`` and ``world.materialize`` describe legacy lazy-plan phases,
-# not proven execution timing.  #518/#519 own their replacement.  ``gate.*``
-# is normalized until #514 updates and expires the old call sites.
+# not proven execution timing.  #518/#519 own their replacement.
 LEGACY_SPAN_NAMES: Final[frozenset[str]] = frozenset(
     {
-        "gate.create_world",
-        "gate.get_world_info",
         "world.execute",
         "world.materialize",
     }
 )
-SPAN_NAME_ALIASES: Final[Mapping[str, str]] = MappingProxyType(
-    {
-        "gate.create_world": "gateway.create_world",
-        "gate.get_world_info": "gateway.get_world_info",
-    }
-)
+SPAN_NAME_ALIASES: Final[Mapping[str, str]] = MappingProxyType({})
 
 TRACE_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
     {

--- a/src/archetype/_obs.py
+++ b/src/archetype/_obs.py
@@ -133,6 +133,20 @@ METRIC_LABEL_KEYS: Final[frozenset[str]] = frozenset(
         "error.type",
     }
 )
+RECORDER_METRIC_NAMES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "record_failure": "archetype.operation.failures",
+        "record_outcome": "archetype.operation.outcomes",
+    }
+)
+RECORDER_METRIC_LABEL_KEYS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "record_failure.disposition": "archetype.failure.disposition",
+        "record_failure.error_type": "error.type",
+        "record_outcome.operation": "archetype.operation",
+        "record_outcome.outcome": "archetype.outcome",
+    }
+)
 EVENT_NAMES: Final[frozenset[str]] = frozenset({"archetype.failure", "archetype.outcome"})
 FAILURE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"handled", "retrying"})
 OUTCOMES: Final[frozenset[str]] = frozenset({"duplicate", "expired", "rejected", "succeeded"})
@@ -539,22 +553,22 @@ def record_failure(error: BaseException, *, disposition: FailureDisposition) -> 
         return
     category = _classify_error(error)
     attributes = {
-        "error.type": category,
-        "archetype.failure.disposition": disposition,
+        RECORDER_METRIC_LABEL_KEYS["record_failure.error_type"]: category,
+        RECORDER_METRIC_LABEL_KEYS["record_failure.disposition"]: disposition,
     }
     _safe_event("archetype.failure", attributes)
-    counter_add("archetype.operation.failures", attributes=attributes)
+    counter_add(RECORDER_METRIC_NAMES["record_failure"], attributes=attributes)
 
 
 def record_outcome(outcome: Outcome, *, operation: str | None = None) -> None:
     """Record a bounded advisory outcome; durable records remain authoritative."""
     if type(outcome) is not str or outcome not in OUTCOMES:
         return
-    attributes: dict[str, Any] = {"archetype.outcome": outcome}
+    attributes: dict[str, Any] = {RECORDER_METRIC_LABEL_KEYS["record_outcome.outcome"]: outcome}
     if operation is not None:
-        attributes["archetype.operation"] = operation
+        attributes[RECORDER_METRIC_LABEL_KEYS["record_outcome.operation"]] = operation
     _safe_event("archetype.outcome", attributes)
-    counter_add("archetype.operation.outcomes", attributes=attributes)
+    counter_add(RECORDER_METRIC_NAMES["record_outcome"], attributes=attributes)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/archetype/app/artifacts/bundle_service.py
+++ b/src/archetype/app/artifacts/bundle_service.py
@@ -461,7 +461,7 @@ class ArtifactBundleService:
             retry_until_ms = min(retry_until_ms, request.checkpoint_expires_at_ms)
         attributes = self._span_attributes(request)
 
-        with _obs.span("artifact.publish", **attributes):
+        with _obs.span("artifact.publish", attributes=attributes):
             outcome, publication = await catalog.acquire_artifact_publication(
                 world_id=request.world_id,
                 run_id=request.run_id,
@@ -678,11 +678,11 @@ class ArtifactBundleService:
             async with self._lease_heartbeat(
                 catalog, request.world_id, publication.publication_key, claimant
             ):
-                with _obs.span(
-                    "artifact.upload",
-                    bundle_id=publication.publication_key,
+                upload_attributes = {
                     **self._span_attributes(request),
-                ):
+                    "archetype.artifact.bundle.digest": publication.publication_key,
+                }
+                with _obs.span("artifact.upload", attributes=upload_attributes):
                     records, manifest_uri = await self._upload_bundle(
                         request,
                         publication.publication_key,
@@ -712,12 +712,12 @@ class ArtifactBundleService:
         async with self._lease_heartbeat(
             catalog, request.world_id, publication.publication_key, claimant
         ):
-            with _obs.span(
-                "artifact.index",
-                bundle_id=publication.publication_key,
-                artifact_count=len(records),
+            index_attributes = {
                 **self._span_attributes(request),
-            ):
+                "archetype.artifact.bundle.digest": publication.publication_key,
+                "archetype.artifact.count": len(records),
+            }
+            with _obs.span("artifact.index", attributes=index_attributes):
                 snapshot_id = await self._index_records(records)
         await catalog.complete_artifact_publication(
             request.world_id,
@@ -1213,12 +1213,10 @@ class ArtifactBundleService:
     @staticmethod
     def _span_attributes(request: ArtifactBundleRequest) -> dict[str, object]:
         return {
-            "world_id": request.world_id,
-            "run_id": request.run_id,
-            "entity_id": request.entity_id,
-            "tick": request.tick,
-            "attempt_id": request.attempt_id,
-            "idempotency_key": request.idempotency_key,
+            "archetype.world.id": request.world_id,
+            "archetype.run.id": request.run_id,
+            "archetype.entity.id": request.entity_id,
+            "archetype.tick": request.tick,
         }
 
     @asynccontextmanager

--- a/src/archetype/app/gateway/service.py
+++ b/src/archetype/app/gateway/service.py
@@ -147,7 +147,7 @@ class CommandGateway:
 
     # Lifecycle ------------------------------------------------------
 
-    @instrument("gate.create_world")
+    @instrument("gateway.create_world")
     async def create_world(self, ctx, config, storage_config=None, cache_config=None):
         self._gate(Command(type=CommandType.CREATE_WORLD), ctx)
         info = await self._application.create_world(config, storage_config, cache_config)
@@ -178,7 +178,7 @@ class CommandGateway:
         await self._application.destroy_world(world_id)
         await self._emit(ctx, "destroy_world", world_id)
 
-    @instrument("gate.get_world_info")
+    @instrument("gateway.get_world_info")
     async def get_world_info(self, ctx, world_id):
         self._gate(Command(type=CommandType.GET_WORLD_INFO), ctx)
         info = await self._application.get_world_info(world_id)

--- a/tests/app/test_artifact_bundle_service.py
+++ b/tests/app/test_artifact_bundle_service.py
@@ -14,8 +14,11 @@ from urllib.parse import unquote, urlparse
 
 import daft
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from archetype import ArchetypeRuntime, Component
+from archetype import ArchetypeRuntime, Component, _obs
 from archetype.app.artifacts.bundle_models import (
     ArtifactBundleRequest,
     ArtifactCandidate,
@@ -24,6 +27,7 @@ from archetype.app.artifacts.bundle_models import (
 )
 from archetype.app.artifacts.bundle_service import (
     _ARTIFACT_INDEX_TABLE,
+    ArtifactBundleService,
     CheckpointArtifactSourceResolver,
 )
 from archetype.app.container import ServiceContainer
@@ -129,6 +133,84 @@ def _local_uri_path(uri: str) -> Path:
     parsed = urlparse(uri)
     assert parsed.scheme == "file"
     return Path(unquote(parsed.path))
+
+
+async def test_span_attributes_use_only_canonical_safe_coordinates(tmp_path):
+    request = ArtifactBundleRequest(
+        world_id="019bf5a0-4f24-7000-8000-000000000001",
+        run_id="019bf5a0-4f24-7000-8000-000000000002",
+        entity_id=7,
+        tick=3,
+        attempt_id="raw-attempt-must-not-be-exported",
+        idempotency_key="raw-idempotency-key-must-not-be-exported",
+        checkpoint_ref="test-checkpoint://snapshot-1",
+        checkpoint_provider="test",
+        artifacts=(
+            ArtifactCandidate(
+                source_ref=str(tmp_path / "result.json"),
+                logical_path="results/result.json",
+                kind="result",
+            ),
+        ),
+    )
+
+    assert ArtifactBundleService._span_attributes(request) == {
+        "archetype.world.id": request.world_id,
+        "archetype.run.id": request.run_id,
+        "archetype.entity.id": 7,
+        "archetype.tick": 3,
+    }
+
+
+async def test_publication_spans_emit_only_canonical_safe_coordinates(tmp_path, monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(_obs, "_tracer", provider.get_tracer("archetype"))
+
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    world_storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "result.json"
+    source.write_text('{"passed":true}\n')
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(
+            WorldConfig(name="artifact-span-world"), world_storage
+        )
+        request = _request(
+            world,
+            source,
+            idempotency_key="raw-idempotency-must-not-be-exported",
+        ).model_copy(update={"attempt_id": "raw-attempt-must-not-be-exported"})
+
+        receipt = await container.artifact_bundle_service.publish(
+            request,
+            storage_config=world_storage,
+        )
+    finally:
+        await container.shutdown()
+
+    spans = {span.name: span for span in exporter.get_finished_spans()}
+    assert set(spans) == {"artifact.publish", "artifact.upload", "artifact.index"}
+    coordinates = {
+        "archetype.world.id": request.world_id,
+        "archetype.run.id": request.run_id,
+        "archetype.entity.id": request.entity_id,
+        "archetype.tick": request.tick,
+    }
+    assert dict(spans["artifact.publish"].attributes or {}) == coordinates
+    assert dict(spans["artifact.upload"].attributes or {}) == {
+        **coordinates,
+        "archetype.artifact.bundle.digest": receipt.bundle_id,
+    }
+    assert dict(spans["artifact.index"].attributes or {}) == {
+        **coordinates,
+        "archetype.artifact.bundle.digest": receipt.bundle_id,
+        "archetype.artifact.count": len(receipt.records),
+    }
+    exported = repr([span.attributes for span in spans.values()])
+    assert request.attempt_id not in exported
+    assert request.idempotency_key not in exported
 
 
 async def test_publish_is_idempotent_and_queryable_after_cold_restart(tmp_path):

--- a/tests/app/test_obs.py
+++ b/tests/app/test_obs.py
@@ -94,6 +94,8 @@ def test_invalid_names_and_values_are_safe_noops(monkeypatch):
 
     with _obs.span("dynamic.secret.Bearer-token", tick=True, world_id="not-a-uuid"):
         result = "application-result"
+    with _obs.span("gate.get_world_info"):
+        pass
 
     assert result == "application-result"
     assert exporter.get_finished_spans() == ()
@@ -274,7 +276,7 @@ def test_context_binding_is_nested_safe_and_restored(monkeypatch):
             "archetype.correlation.digest": correlation_digest,
             "archetype.world.id": world_id,
         }
-        with _obs.span("gate.get_world_info"):
+        with _obs.span("gateway.get_world_info"):
             pass
     assert _obs.capture_context() == {}
 
@@ -531,6 +533,8 @@ def test_signal_vocabulary_is_immutable_and_namespaced():
         "archetype.attempt.digest",
         "archetype.idempotency.digest",
     }.isdisjoint(_obs.METRIC_LABEL_KEYS)
+    assert _obs.LEGACY_SPAN_NAMES == frozenset({"world.execute", "world.materialize"})
+    assert dict(_obs.SPAN_NAME_ALIASES) == {}
 
 
 def test_outcome_helper_is_bounded_and_advisory(monkeypatch):

--- a/tests/app/test_obs.py
+++ b/tests/app/test_obs.py
@@ -522,6 +522,8 @@ def test_signal_vocabulary_is_immutable_and_namespaced():
     assert isinstance(_obs.EVENT_NAMES, frozenset)
     assert isinstance(_obs.SPAN_NAME_ALIASES, MappingProxyType)
     assert isinstance(_obs.TRACE_ATTRIBUTE_ALIASES, MappingProxyType)
+    assert isinstance(_obs.RECORDER_METRIC_NAMES, MappingProxyType)
+    assert isinstance(_obs.RECORDER_METRIC_LABEL_KEYS, MappingProxyType)
     assert all(name.startswith("archetype.") for name in _obs.METRIC_NAMES)
     assert all(
         key.startswith("archetype.") or key == "error.type" for key in _obs.TRACE_ATTRIBUTE_KEYS
@@ -535,6 +537,8 @@ def test_signal_vocabulary_is_immutable_and_namespaced():
     }.isdisjoint(_obs.METRIC_LABEL_KEYS)
     assert _obs.LEGACY_SPAN_NAMES == frozenset({"world.execute", "world.materialize"})
     assert dict(_obs.SPAN_NAME_ALIASES) == {}
+    assert set(_obs.RECORDER_METRIC_NAMES.values()) <= _obs.METRIC_NAMES
+    assert set(_obs.RECORDER_METRIC_LABEL_KEYS.values()) <= _obs.METRIC_LABEL_KEYS
 
 
 def test_outcome_helper_is_bounded_and_advisory(monkeypatch):

--- a/tests/scripts/test_check_observability.py
+++ b/tests/scripts/test_check_observability.py
@@ -27,14 +27,41 @@ SPAN_NAMES: Final[frozenset[str]] = frozenset({"probe.run", "probe.legacy"})
 LEGACY_SPAN_NAMES: Final[frozenset[str]] = frozenset({"probe.legacy"})
 SPAN_NAME_ALIASES: Final[Mapping[str, str]] = MappingProxyType({})
 TRACE_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
-    {"archetype.operation", "archetype.outcome", "archetype.world.id", "error.type"}
+    {
+        "archetype.failure.disposition",
+        "archetype.operation",
+        "archetype.outcome",
+        "archetype.world.id",
+        "error.type",
+    }
 )
 TRACE_ATTRIBUTE_ALIASES: Final[Mapping[str, str]] = MappingProxyType(
     {"operation": "archetype.operation"}
 )
-METRIC_NAMES: Final[frozenset[str]] = frozenset({"archetype.operation.outcomes"})
+METRIC_NAMES: Final[frozenset[str]] = frozenset(
+    {"archetype.operation.failures", "archetype.operation.outcomes"}
+)
 METRIC_LABEL_KEYS: Final[frozenset[str]] = frozenset(
-    {"archetype.operation", "archetype.outcome", "error.type"}
+    {
+        "archetype.failure.disposition",
+        "archetype.operation",
+        "archetype.outcome",
+        "error.type",
+    }
+)
+RECORDER_METRIC_NAMES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "record_failure": "archetype.operation.failures",
+        "record_outcome": "archetype.operation.outcomes",
+    }
+)
+RECORDER_METRIC_LABEL_KEYS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "record_failure.disposition": "archetype.failure.disposition",
+        "record_failure.error_type": "error.type",
+        "record_outcome.operation": "archetype.operation",
+        "record_outcome.outcome": "archetype.outcome",
+    }
 )
 EVENT_NAMES: Final[frozenset[str]] = frozenset({"archetype.outcome"})
 FAILURE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"handled", "retrying"})
@@ -42,7 +69,10 @@ OUTCOMES: Final[frozenset[str]] = frozenset({"rejected", "succeeded"})
 ERROR_TYPES: Final[frozenset[str]] = frozenset({"internal", "validation"})
 
 def span(name: str, attributes: object = None, **values: object) -> object: ...
+def instrument(name: str) -> object: ...
 def counter_add(name: str, amount: int = 1, *, attributes: object = None) -> None: ...
+def record_failure(error: BaseException, *, disposition: str) -> None: ...
+def record_outcome(outcome: str, *, operation: str | None = None) -> None: ...
 def configure_tracing(*, service_name: str, debug_console: bool = False) -> None: ...
 """
 
@@ -58,13 +88,15 @@ class iProbe(Protocol):
 
 SERVICE = """
 from typing import Protocol
+from archetype import _obs
 
 class LocalPort(Protocol):
     def flush(self) -> None: ...
 
 class Probe:
     async def run(self) -> None:
-        return None
+        with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):
+            return None
 """
 
 MANIFEST = """
@@ -79,11 +111,33 @@ operations = [
   "service.LocalPort.flush",
 ]
 signals = ["child"]
+emission_workflows = ["probe.run"]
 outcomes = ["propagated_failure", "handled_outcome"]
 authority = "The fixture receipt and typed result remain authoritative."
 evidence = ["docs/evidence.md"]
 span_names = ["probe.run"]
 attribute_keys = ["archetype.outcome"]
+
+[[workflow]]
+id = "probe.run"
+qualified_scope = "archetype.app.probe.service.Probe.run"
+signals = [
+  "child",
+]
+outcomes = [
+  "propagated_failure",
+  "handled_outcome",
+]
+authority = "The fixture workflow receipt and typed result remain authoritative."
+evidence = [
+  "docs/evidence.md",
+]
+span_names = [
+  "probe.run",
+]
+attribute_keys = [
+  "archetype.outcome",
+]
 """
 
 HOSTS = """
@@ -142,6 +196,31 @@ def _assert_rejected(result) -> None:
 def _replace_once(value: str, old: str, new: str) -> str:
     assert value.count(old) == 1
     return value.replace(old, new)
+
+
+def _with_metric_claims(manifest: str, metric_name: str, labels: tuple[str, ...]) -> str:
+    inline_labels = ", ".join(f'"{label}"' for label in labels)
+    block_labels = "".join(f'  "{label}",\n' for label in labels)
+    result = _replace_once(manifest, 'signals = ["child"]', 'signals = ["child", "metric"]')
+    result = _replace_once(
+        result,
+        'signals = [\n  "child",\n]\n',
+        'signals = [\n  "child",\n  "metric",\n]\n',
+    )
+    result = _replace_once(
+        result,
+        'attribute_keys = ["archetype.outcome"]\n',
+        'attribute_keys = ["archetype.outcome"]\n'
+        f'metric_names = ["{metric_name}"]\n'
+        f"metric_label_keys = [{inline_labels}]\n",
+    )
+    return _replace_once(
+        result,
+        'attribute_keys = [\n  "archetype.outcome",\n]\n',
+        'attribute_keys = [\n  "archetype.outcome",\n]\n'
+        f'metric_names = [\n  "{metric_name}",\n]\n'
+        f"metric_label_keys = [\n{block_labels}]\n",
+    )
 
 
 def _with_host(
@@ -264,8 +343,11 @@ def test_gateway_workflow_may_declare_an_ingress_root(tmp_path: Path) -> None:
         tmp_path,
         "app/gateway/service.py",
         """
+from archetype import _obs
+
 def ingress() -> None:
-    pass
+    with _obs.span("probe.run"):
+        pass
 """,
     )
     gateway = """
@@ -292,14 +374,18 @@ span_names = ["probe.run"]
 def test_none_disposition_requires_rationale_and_accepts_one(tmp_path: Path) -> None:
     without_rationale = (
         _replace_once(MANIFEST, 'signals = ["child"]', 'signals = ["none"]')
+        .replace('emission_workflows = ["probe.run"]\n', "")
         .replace('span_names = ["probe.run"]\n', "")
         .replace('attribute_keys = ["archetype.outcome"]\n', "")
     )
     _write_fixture(tmp_path, manifest=without_rationale)
     _assert_rejected(_audit(tmp_path))
 
-    with_rationale = without_rationale + (
-        'rationale = "No direct signal is approved; the typed result remains authoritative."\n'
+    with_rationale = _replace_once(
+        without_rationale,
+        'evidence = ["docs/evidence.md"]\n',
+        'evidence = ["docs/evidence.md"]\n'
+        'rationale = "No direct signal is approved; the typed result remains authoritative."\n',
     )
     (tmp_path / "quality" / "observability" / "probe.toml").write_text(
         with_rationale,
@@ -309,12 +395,38 @@ def test_none_disposition_requires_rationale_and_accepts_one(tmp_path: Path) -> 
 
 
 def test_metric_disposition_requires_fixed_names_and_bounded_labels(tmp_path: Path) -> None:
-    valid = (
-        _replace_once(MANIFEST, 'signals = ["child"]', 'signals = ["child", "metric"]')
-        + 'metric_names = ["archetype.operation.outcomes"]\n'
-        + 'metric_label_keys = ["archetype.outcome"]\n'
+    valid = _replace_once(MANIFEST, 'signals = ["child"]', 'signals = ["child", "metric"]')
+    valid = _replace_once(
+        valid,
+        'attribute_keys = ["archetype.outcome"]\n',
+        'attribute_keys = ["archetype.outcome"]\n'
+        'metric_names = ["archetype.operation.outcomes"]\n'
+        'metric_label_keys = ["archetype.outcome"]\n',
     )
-    _write_fixture(tmp_path, manifest=valid)
+    valid = _replace_once(
+        valid,
+        'signals = [\n  "child",\n]\n',
+        'signals = [\n  "child",\n  "metric",\n]\n',
+    )
+    valid = _replace_once(
+        valid,
+        'attribute_keys = [\n  "archetype.outcome",\n]\n',
+        'attribute_keys = [\n  "archetype.outcome",\n]\n'
+        'metric_names = [\n  "archetype.operation.outcomes",\n]\n'
+        'metric_label_keys = [\n  "archetype.outcome",\n]\n',
+    )
+    metric_service = _replace_once(
+        SERVICE,
+        '        with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):\n'
+        "            return None\n",
+        '        with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):\n'
+        "            _obs.counter_add(\n"
+        '                "archetype.operation.outcomes",\n'
+        '                attributes={"archetype.outcome": "succeeded"},\n'
+        "            )\n"
+        "            return None\n",
+    )
+    _write_fixture(tmp_path, manifest=valid, service=metric_service)
     assert _audit(tmp_path).ok
 
     invalid_name = _replace_once(
@@ -339,27 +451,29 @@ def test_metric_disposition_requires_fixed_names_and_bounded_labels(tmp_path: Pa
     )
     _assert_rejected(_audit(tmp_path))
 
+    wrong_bounded_label = _replace_once(
+        valid,
+        'metric_label_keys = ["archetype.outcome"]',
+        'metric_label_keys = ["error.type"]',
+    )
+    (tmp_path / "quality" / "observability" / "probe.toml").write_text(
+        wrong_bounded_label,
+        encoding="utf-8",
+    )
+    result = _audit(tmp_path)
+    _assert_rejected(result)
+    assert any(
+        "disposition[0].metric_label_keys does not match source emissions" in error
+        for error in result.policy_errors
+    )
+
 
 def test_workflow_scope_must_exist_and_be_callable(tmp_path: Path) -> None:
-    valid = (
-        MANIFEST
-        + """
-
-[[workflow]]
-id = "probe.run"
-qualified_scope = "archetype.app.probe.service.Probe.run"
-signals = ["child"]
-outcomes = ["propagated_failure"]
-authority = "The fixture typed result remains authoritative."
-evidence = ["docs/evidence.md"]
-span_names = ["probe.run"]
-"""
-    )
-    _write_fixture(tmp_path, manifest=valid)
+    _write_fixture(tmp_path)
     assert _audit(tmp_path).ok
 
     stale = _replace_once(
-        valid,
+        MANIFEST,
         "archetype.app.probe.service.Probe.run",
         "archetype.app.probe.service.Probe.missing",
     )
@@ -368,6 +482,367 @@ span_names = ["probe.run"]
         encoding="utf-8",
     )
     _assert_rejected(_audit(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "field_name"),
+    [
+        (
+            'span_names = [\n  "probe.run",\n]',
+            'span_names = [\n  "probe.legacy",\n]',
+            "span_names",
+        ),
+        (
+            'attribute_keys = [\n  "archetype.outcome",\n]',
+            'attribute_keys = [\n  "archetype.world.id",\n]',
+            "attribute_keys",
+        ),
+    ],
+    ids=["globally-valid-span", "globally-safe-attribute"],
+)
+def test_workflow_signal_claims_match_their_exact_source_scope(
+    tmp_path: Path,
+    old: str,
+    new: str,
+    field_name: str,
+) -> None:
+    manifest = _replace_once(MANIFEST, old, new)
+    _write_fixture(tmp_path, manifest=manifest)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any(
+        f"workflow[0].{field_name} does not match source emissions" in error
+        for error in result.policy_errors
+    )
+
+
+def test_disposition_signal_claims_are_backed_by_referenced_workflows(tmp_path: Path) -> None:
+    manifest = _replace_once(
+        MANIFEST,
+        'span_names = ["probe.run"]',
+        'span_names = ["probe.legacy"]',
+    )
+    _write_fixture(tmp_path, manifest=manifest)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any(
+        "disposition[0].span_names does not match source emissions" in error
+        for error in result.policy_errors
+    )
+
+
+def test_declared_but_absent_workflow_signal_is_rejected(tmp_path: Path) -> None:
+    service = _replace_once(
+        SERVICE,
+        '        with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):\n'
+        "            return None\n",
+        "        return None\n",
+    )
+    _write_fixture(tmp_path, service=service)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any("declared-only=['probe.run']" in error for error in result.policy_errors)
+
+
+def test_emitted_but_undeclared_workflow_field_is_rejected(tmp_path: Path) -> None:
+    manifest = _replace_once(
+        MANIFEST,
+        'attribute_keys = [\n  "archetype.outcome",\n]\n',
+        "attribute_keys = []\n",
+    )
+    _write_fixture(tmp_path, manifest=manifest)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any("observed-only=['archetype.outcome']" in error for error in result.policy_errors)
+
+
+def test_instrument_decorator_is_attributed_to_the_decorated_callable(tmp_path: Path) -> None:
+    service = """
+from typing import Protocol
+from archetype import _obs
+
+class LocalPort(Protocol):
+    def flush(self) -> None: ...
+
+class Probe:
+    @_obs.instrument("probe.run")
+    async def run(self) -> None:
+        return None
+"""
+    manifest = _replace_once(MANIFEST, 'attribute_keys = ["archetype.outcome"]\n', "")
+    manifest = _replace_once(
+        manifest,
+        'attribute_keys = [\n  "archetype.outcome",\n]\n',
+        "",
+    )
+    _write_fixture(tmp_path, service=service, manifest=manifest)
+
+    assert _audit(tmp_path).ok
+
+
+@pytest.mark.parametrize(
+    "inactive_call",
+    [
+        '_obs.span("probe.run", attributes={"archetype.outcome": "succeeded"})',
+        '_obs.instrument("probe.run")',
+    ],
+    ids=["span-context-factory", "instrument-decorator-factory"],
+)
+def test_inactive_emitter_factories_do_not_satisfy_workflow_claims(
+    tmp_path: Path,
+    inactive_call: str,
+) -> None:
+    service = _replace_once(
+        SERVICE,
+        '        with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):\n'
+        "            return None\n",
+        f"        {inactive_call}\n        return None\n",
+    )
+    _write_fixture(tmp_path, service=service)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any("declared-only=['probe.run']" in error for error in result.policy_errors)
+
+
+def test_workflow_attribution_does_not_follow_called_helpers(tmp_path: Path) -> None:
+    service = """
+from typing import Protocol
+from archetype import _obs
+
+class LocalPort(Protocol):
+    def flush(self) -> None: ...
+
+class Probe:
+    async def run(self) -> None:
+        self._emit()
+
+    def _emit(self) -> None:
+        with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):
+            pass
+"""
+    _write_fixture(tmp_path, service=service)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any("declared-only=['probe.run']" in error for error in result.policy_errors)
+
+
+def test_workflow_attribution_does_not_absorb_nested_lambda_emissions(tmp_path: Path) -> None:
+    service = _replace_once(
+        SERVICE,
+        "    async def run(self) -> None:\n",
+        "    async def run(self) -> None:\n"
+        "        callback = lambda: _obs.counter_add(\n"
+        '            "archetype.operation.outcomes",\n'
+        '            attributes={"archetype.outcome": "succeeded"},\n'
+        "        )\n"
+        "        callback()\n",
+    )
+    _write_fixture(tmp_path, service=service)
+
+    assert _audit(tmp_path).ok
+
+
+def test_nested_lambda_emissions_remain_safety_checked(tmp_path: Path) -> None:
+    service = _replace_once(
+        SERVICE,
+        "    async def run(self) -> None:\n",
+        "    async def run(self) -> None:\n"
+        '        callback = lambda suffix: _obs.counter_add(f"probe.{suffix}")\n'
+        '        callback("dynamic")\n',
+    )
+    _write_fixture(tmp_path, service=service)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    violation = next(item for item in result.violations if item.rule == "dynamic_signal_name")
+    assert ".<lambda>@L" in violation.qualified_scope
+
+
+def test_lambda_walrus_alias_to_obs_remains_safety_checked(tmp_path: Path) -> None:
+    service = _replace_once(
+        SERVICE,
+        "    async def run(self) -> None:\n",
+        "    async def run(self) -> None:\n"
+        "        callback = lambda suffix: (\n"
+        "            (emit := _obs),\n"
+        '            emit.counter_add(f"probe.{suffix}"),\n'
+        "        )\n"
+        '        callback("dynamic")\n',
+    )
+    _write_fixture(tmp_path, service=service)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    violation = next(item for item in result.violations if item.rule == "dynamic_signal_name")
+    assert ".<lambda>@L" in violation.qualified_scope
+
+
+def test_lambda_parameter_shadowing_does_not_impersonate_obs_adapter(tmp_path: Path) -> None:
+    service = _replace_once(
+        SERVICE,
+        "    async def run(self) -> None:\n",
+        "    async def run(self) -> None:\n"
+        '        callback = lambda _obs: _obs.counter_add(f"probe.{self}")\n'
+        "        del callback\n",
+    )
+    _write_fixture(tmp_path, service=service)
+
+    assert _audit(tmp_path).ok
+
+
+def test_lambda_walrus_shadowing_does_not_impersonate_obs_adapter(tmp_path: Path) -> None:
+    service = _replace_once(
+        SERVICE,
+        "    async def run(self) -> None:\n",
+        "    async def run(self) -> None:\n"
+        "        fake = object()\n"
+        "        callback = lambda: (\n"
+        "            (_obs := fake),\n"
+        '            _obs.counter_add("archetype.operation.outcomes"),\n'
+        "        )\n"
+        "        del callback\n",
+    )
+    _write_fixture(tmp_path, service=service)
+
+    assert _audit(tmp_path).ok
+
+
+@pytest.mark.parametrize(
+    ("call", "metric_name", "labels"),
+    [
+        (
+            '_obs.record_outcome("succeeded")',
+            "archetype.operation.outcomes",
+            ("archetype.outcome",),
+        ),
+        (
+            '_obs.record_outcome("succeeded", operation="probe.run")',
+            "archetype.operation.outcomes",
+            ("archetype.operation", "archetype.outcome"),
+        ),
+        (
+            '_obs.record_failure(ValueError(), disposition="handled")',
+            "archetype.operation.failures",
+            ("archetype.failure.disposition", "error.type"),
+        ),
+    ],
+    ids=["outcome", "outcome-with-operation", "failure"],
+)
+def test_safe_recorders_contribute_their_fixed_metric_contract(
+    tmp_path: Path,
+    call: str,
+    metric_name: str,
+    labels: tuple[str, ...],
+) -> None:
+    service = _replace_once(
+        SERVICE,
+        '        with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):\n',
+        '        with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):\n'
+        f"            {call}\n",
+    )
+    manifest = _with_metric_claims(MANIFEST, metric_name, labels)
+    _write_fixture(tmp_path, service=service, manifest=manifest)
+
+    assert _audit(tmp_path).ok
+
+    undeclared = manifest.replace(f'metric_names = ["{metric_name}"]', "metric_names = []", 1)
+    (tmp_path / "quality" / "observability" / "probe.toml").write_text(
+        undeclared,
+        encoding="utf-8",
+    )
+    result = _audit(tmp_path)
+    _assert_rejected(result)
+    assert any(
+        "disposition[0].metric_names does not match source emissions" in error
+        for error in result.policy_errors
+    )
+
+
+def test_safe_unregistered_internal_emitter_remains_allowed(tmp_path: Path) -> None:
+    service = (
+        SERVICE
+        + """
+
+def internal_observation() -> None:
+    with _obs.span("probe.run", attributes={"archetype.outcome": "succeeded"}):
+        pass
+"""
+    )
+    _write_fixture(tmp_path, service=service)
+
+    assert _audit(tmp_path).ok
+
+
+def test_stale_emission_workflow_reference_is_rejected(tmp_path: Path) -> None:
+    manifest = _replace_once(
+        MANIFEST,
+        'emission_workflows = ["probe.run"]',
+        'emission_workflows = ["probe.missing"]',
+    )
+    _write_fixture(tmp_path, manifest=manifest)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any(
+        "references unknown workflow 'probe.missing'" in error for error in result.policy_errors
+    )
+
+
+def test_cross_owner_emission_workflow_reference_is_rejected(tmp_path: Path) -> None:
+    manifest = _replace_once(
+        MANIFEST,
+        'emission_workflows = ["probe.run"]',
+        'emission_workflows = ["gateway.ingress"]',
+    )
+    _write_fixture(tmp_path, manifest=manifest)
+    _write_source_module(
+        tmp_path,
+        "app/gateway/service.py",
+        """
+from archetype import _obs
+
+def ingress() -> None:
+    with _obs.span("probe.run"):
+        pass
+""",
+    )
+    gateway = """
+version = 1
+owner = "gateway"
+
+[[workflow]]
+id = "gateway.ingress"
+qualified_scope = "archetype.app.gateway.service.ingress"
+signals = ["root"]
+outcomes = ["propagated_failure"]
+authority = "The typed gateway result remains authoritative."
+evidence = ["docs/evidence.md"]
+span_names = ["probe.run"]
+"""
+    (tmp_path / "quality" / "observability" / "gateway.toml").write_text(
+        dedent(gateway).lstrip(),
+        encoding="utf-8",
+    )
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any("owned by 'gateway', not 'probe'" in error for error in result.policy_errors)
 
 
 def test_vocabulary_must_be_literal_and_fail_closed(tmp_path: Path) -> None:
@@ -389,18 +864,8 @@ def test_checker_consumes_new_literal_vocabulary_without_a_duplicate_allowlist(
         '{"probe.run", "probe.legacy"}',
         '{"probe.run", "probe.new", "probe.legacy"}',
     )
-    manifest = _replace_once(MANIFEST, '["probe.run"]', '["probe.new"]')
-    service = (
-        SERVICE
-        + """
-
-from archetype import _obs
-
-def observed() -> None:
-    with _obs.span("probe.new", attributes={"archetype.outcome": "succeeded"}):
-        pass
-"""
-    )
+    manifest = MANIFEST.replace('"probe.run"', '"probe.new"')
+    service = SERVICE.replace('"probe.run"', '"probe.new"')
     _write_fixture(tmp_path, obs=obs, manifest=manifest, service=service)
 
     assert _audit(tmp_path).ok
@@ -828,6 +1293,7 @@ diagnostics = logging.getLogger(__name__)
 
 def observed(world_id: str) -> None:
     diagnostics.info("world=%s", world_id)
+    diagnostics.log(logging.INFO, "world=%s", world_id)
 """
     )
     _write_fixture(tmp_path, service=safe)
@@ -842,6 +1308,51 @@ def observed(world_id: str) -> None:
         encoding="utf-8",
     )
     _assert_rejected(_audit(tmp_path))
+
+
+def test_logger_log_audits_its_message_after_the_level(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+import logging
+diagnostics = logging.getLogger(__name__)
+
+def observed(value: str) -> None:
+    diagnostics.log(logging.ERROR, f"payload={value}", exc_info=True)
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert {
+        "eager_log_interpolation",
+        "raw_exception_logging",
+        "unsafe_log_value",
+    } <= {violation.rule for violation in result.violations}
+    assert any("f'payload={value}'" in violation.target for violation in result.violations)
+
+
+def test_logger_log_keyword_message_is_audited(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+import logging
+diagnostics = logging.getLogger(__name__)
+
+def observed(world_id: str) -> None:
+    diagnostics.log(level=logging.INFO, msg=f"world={world_id}")
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any(violation.rule == "eager_log_interpolation" for violation in result.violations)
 
 
 @pytest.mark.parametrize(
@@ -1020,7 +1531,7 @@ def observed(
     "statement",
     [
         'diagnostics.info("event", extra={"password": secret})',
-        'diagnostics.info("payload=%s", payload)',
+        'diagnostics.info("payload=%s", value)',
     ],
     ids=["unsafe-extra-key", "obvious-payload-value"],
 )
@@ -1035,7 +1546,7 @@ def test_structured_logging_rejects_obvious_content_export(
 import logging
 diagnostics = logging.getLogger(__name__)
 
-def observed(secret: str, payload: str) -> None:
+def observed(secret: str, value: str) -> None:
     {statement}
 """
     )

--- a/tests/scripts/test_check_observability.py
+++ b/tests/scripts/test_check_observability.py
@@ -1,0 +1,1280 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+CHECKER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_observability.py"
+SPEC = importlib.util.spec_from_file_location("check_observability", CHECKER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules["check_observability"] = checker
+SPEC.loader.exec_module(checker)
+
+
+OBS_VOCABULARY = """
+from types import MappingProxyType
+from typing import Final, Mapping
+
+SPAN_NAMES: Final[frozenset[str]] = frozenset({"probe.run", "probe.legacy"})
+LEGACY_SPAN_NAMES: Final[frozenset[str]] = frozenset({"probe.legacy"})
+SPAN_NAME_ALIASES: Final[Mapping[str, str]] = MappingProxyType({})
+TRACE_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
+    {"archetype.operation", "archetype.outcome", "archetype.world.id", "error.type"}
+)
+TRACE_ATTRIBUTE_ALIASES: Final[Mapping[str, str]] = MappingProxyType(
+    {"operation": "archetype.operation"}
+)
+METRIC_NAMES: Final[frozenset[str]] = frozenset({"archetype.operation.outcomes"})
+METRIC_LABEL_KEYS: Final[frozenset[str]] = frozenset(
+    {"archetype.operation", "archetype.outcome", "error.type"}
+)
+EVENT_NAMES: Final[frozenset[str]] = frozenset({"archetype.outcome"})
+FAILURE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"handled", "retrying"})
+OUTCOMES: Final[frozenset[str]] = frozenset({"rejected", "succeeded"})
+ERROR_TYPES: Final[frozenset[str]] = frozenset({"internal", "validation"})
+
+def span(name: str, attributes: object = None, **values: object) -> object: ...
+def counter_add(name: str, amount: int = 1, *, attributes: object = None) -> None: ...
+def configure_tracing(*, service_name: str, debug_console: bool = False) -> None: ...
+"""
+
+INTERFACES = """
+from typing import Protocol
+
+class iProbe(Protocol):
+    @property
+    def enabled(self) -> bool: ...
+
+    async def run(self) -> None: ...
+"""
+
+SERVICE = """
+from typing import Protocol
+
+class LocalPort(Protocol):
+    def flush(self) -> None: ...
+
+class Probe:
+    async def run(self) -> None:
+        return None
+"""
+
+MANIFEST = """
+version = 1
+owner = "probe"
+family = "probe"
+
+[[disposition]]
+operations = [
+  "interfaces.iProbe.enabled",
+  "interfaces.iProbe.run",
+  "service.LocalPort.flush",
+]
+signals = ["child"]
+outcomes = ["propagated_failure", "handled_outcome"]
+authority = "The fixture receipt and typed result remain authoritative."
+evidence = ["docs/evidence.md"]
+span_names = ["probe.run"]
+attribute_keys = ["archetype.outcome"]
+"""
+
+HOSTS = """
+version = 1
+owner = "hosts"
+"""
+
+
+def _write_fixture(
+    root: Path,
+    *,
+    interfaces: str = INTERFACES,
+    service: str = SERVICE,
+    manifest: str = MANIFEST,
+    hosts: str | None = None,
+    obs: str = OBS_VOCABULARY,
+) -> Path:
+    source = root / "src" / "archetype"
+    family = source / "app" / "probe"
+    manifests = root / "quality" / "observability"
+    family.mkdir(parents=True)
+    manifests.mkdir(parents=True)
+    (root / "docs").mkdir()
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "fixture"\nversion = "0.4.0"\n',
+        encoding="utf-8",
+    )
+    (root / "docs" / "evidence.md").write_text("# Fixture evidence\n", encoding="utf-8")
+    (source / "_obs.py").write_text(dedent(obs).lstrip(), encoding="utf-8")
+    (family / "interfaces.py").write_text(dedent(interfaces).lstrip(), encoding="utf-8")
+    (family / "service.py").write_text(dedent(service).lstrip(), encoding="utf-8")
+    (manifests / "probe.toml").write_text(dedent(manifest).lstrip(), encoding="utf-8")
+    if hosts is not None:
+        (manifests / "hosts.toml").write_text(dedent(hosts).lstrip(), encoding="utf-8")
+    return manifests
+
+
+def _write_source_module(root: Path, relative_path: str, source: str) -> None:
+    path = root / "src" / "archetype" / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(source).lstrip(), encoding="utf-8")
+
+
+def _audit(root: Path):
+    return checker.audit_repository(
+        manifest_root=root / "quality" / "observability",
+        repo_root=root,
+    )
+
+
+def _assert_rejected(result) -> None:
+    assert not result.ok
+    assert result.violations or result.policy_errors
+
+
+def _replace_once(value: str, old: str, new: str) -> str:
+    assert value.count(old) == 1
+    return value.replace(old, new)
+
+
+def _with_host(
+    qualified_scope: str,
+    capability: str,
+    *,
+    rationale: str = "The fixture process host explicitly owns this configuration.",
+) -> str:
+    return (
+        HOSTS
+        + f'''
+
+[[host_callable]]
+qualified_scope = "{qualified_scope}"
+capabilities = ["{capability}"]
+evidence = ["docs/evidence.md"]
+rationale = "{rationale}"
+'''
+    )
+
+
+def test_valid_fixture_covers_properties_and_protocols_outside_interfaces(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+
+    result = _audit(tmp_path)
+
+    assert result.ok, result.violations + result.policy_errors
+    assert not result.violations
+    assert not result.policy_errors
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        _replace_once(MANIFEST, '  "interfaces.iProbe.enabled",\n', ""),
+        _replace_once(
+            MANIFEST,
+            '  "interfaces.iProbe.enabled",\n',
+            '  "interfaces.iProbe.enabled",\n  "interfaces.iProbe.enabled",\n',
+        ),
+        _replace_once(
+            MANIFEST,
+            '  "interfaces.iProbe.enabled",\n',
+            '  "interfaces.iProbe.missing",\n',
+        ),
+        _replace_once(MANIFEST, '  "service.LocalPort.flush",\n', ""),
+    ],
+    ids=["missing", "duplicate", "phantom", "non-interfaces-protocol"],
+)
+def test_protocol_manifest_is_an_exact_bijection(tmp_path: Path, manifest: str) -> None:
+    _write_fixture(tmp_path, manifest=manifest)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        _replace_once(MANIFEST, 'signals = ["child"]', 'signals = ["root", "child"]'),
+        _replace_once(MANIFEST, 'signals = ["child"]', 'signals = ["none", "metric"]'),
+        _replace_once(MANIFEST, 'signals = ["child"]', 'signals = ["unknown"]'),
+        _replace_once(
+            MANIFEST,
+            'outcomes = ["propagated_failure", "handled_outcome"]',
+            'outcomes = ["mystery"]',
+        ),
+        _replace_once(
+            MANIFEST,
+            'authority = "The fixture receipt and typed result remain authoritative."',
+            'authority = ""',
+        ),
+        _replace_once(MANIFEST, 'evidence = ["docs/evidence.md"]', "evidence = []"),
+        _replace_once(
+            MANIFEST, 'evidence = ["docs/evidence.md"]', 'evidence = ["docs/missing.md"]'
+        ),
+        _replace_once(MANIFEST, 'span_names = ["probe.run"]', "span_names = []"),
+        _replace_once(MANIFEST, 'span_names = ["probe.run"]', 'span_names = ["probe.unknown"]'),
+        _replace_once(
+            MANIFEST, 'attribute_keys = ["archetype.outcome"]', 'attribute_keys = ["password"]'
+        ),
+    ],
+    ids=[
+        "root-child-exclusive",
+        "none-exclusive",
+        "signal-vocabulary",
+        "outcome-vocabulary",
+        "authority-required",
+        "evidence-required",
+        "evidence-must-exist",
+        "span-name-required",
+        "span-name-vocabulary",
+        "attribute-key-vocabulary",
+    ],
+)
+def test_disposition_schema_rejects_invalid_rows(tmp_path: Path, manifest: str) -> None:
+    _write_fixture(tmp_path, manifest=manifest)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_root_disposition_is_reserved_for_runtime_or_gateway_ingress(tmp_path: Path) -> None:
+    lower_family_root = _replace_once(
+        MANIFEST,
+        'signals = ["child"]',
+        'signals = ["root"]',
+    )
+    _write_fixture(tmp_path, manifest=lower_family_root)
+
+    result = _audit(tmp_path)
+
+    _assert_rejected(result)
+    assert any(
+        "root is reserved for runtime or gateway ingress" in error for error in result.policy_errors
+    )
+
+
+def test_gateway_workflow_may_declare_an_ingress_root(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    _write_source_module(
+        tmp_path,
+        "app/gateway/service.py",
+        """
+def ingress() -> None:
+    pass
+""",
+    )
+    gateway = """
+version = 1
+owner = "gateway"
+
+[[workflow]]
+id = "gateway.ingress"
+qualified_scope = "archetype.app.gateway.service.ingress"
+signals = ["root"]
+outcomes = ["propagated_failure"]
+authority = "The typed gateway result remains authoritative."
+evidence = ["docs/evidence.md"]
+span_names = ["probe.run"]
+"""
+    (tmp_path / "quality" / "observability" / "gateway.toml").write_text(
+        dedent(gateway).lstrip(),
+        encoding="utf-8",
+    )
+
+    assert _audit(tmp_path).ok
+
+
+def test_none_disposition_requires_rationale_and_accepts_one(tmp_path: Path) -> None:
+    without_rationale = (
+        _replace_once(MANIFEST, 'signals = ["child"]', 'signals = ["none"]')
+        .replace('span_names = ["probe.run"]\n', "")
+        .replace('attribute_keys = ["archetype.outcome"]\n', "")
+    )
+    _write_fixture(tmp_path, manifest=without_rationale)
+    _assert_rejected(_audit(tmp_path))
+
+    with_rationale = without_rationale + (
+        'rationale = "No direct signal is approved; the typed result remains authoritative."\n'
+    )
+    (tmp_path / "quality" / "observability" / "probe.toml").write_text(
+        with_rationale,
+        encoding="utf-8",
+    )
+    assert _audit(tmp_path).ok
+
+
+def test_metric_disposition_requires_fixed_names_and_bounded_labels(tmp_path: Path) -> None:
+    valid = (
+        _replace_once(MANIFEST, 'signals = ["child"]', 'signals = ["child", "metric"]')
+        + 'metric_names = ["archetype.operation.outcomes"]\n'
+        + 'metric_label_keys = ["archetype.outcome"]\n'
+    )
+    _write_fixture(tmp_path, manifest=valid)
+    assert _audit(tmp_path).ok
+
+    invalid_name = _replace_once(
+        valid,
+        'metric_names = ["archetype.operation.outcomes"]',
+        'metric_names = ["probe.dynamic"]',
+    )
+    (tmp_path / "quality" / "observability" / "probe.toml").write_text(
+        invalid_name,
+        encoding="utf-8",
+    )
+    _assert_rejected(_audit(tmp_path))
+
+    invalid_label = _replace_once(
+        valid,
+        'metric_label_keys = ["archetype.outcome"]',
+        'metric_label_keys = ["archetype.world.id"]',
+    )
+    (tmp_path / "quality" / "observability" / "probe.toml").write_text(
+        invalid_label,
+        encoding="utf-8",
+    )
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_workflow_scope_must_exist_and_be_callable(tmp_path: Path) -> None:
+    valid = (
+        MANIFEST
+        + """
+
+[[workflow]]
+id = "probe.run"
+qualified_scope = "archetype.app.probe.service.Probe.run"
+signals = ["child"]
+outcomes = ["propagated_failure"]
+authority = "The fixture typed result remains authoritative."
+evidence = ["docs/evidence.md"]
+span_names = ["probe.run"]
+"""
+    )
+    _write_fixture(tmp_path, manifest=valid)
+    assert _audit(tmp_path).ok
+
+    stale = _replace_once(
+        valid,
+        "archetype.app.probe.service.Probe.run",
+        "archetype.app.probe.service.Probe.missing",
+    )
+    (tmp_path / "quality" / "observability" / "probe.toml").write_text(
+        stale,
+        encoding="utf-8",
+    )
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_vocabulary_must_be_literal_and_fail_closed(tmp_path: Path) -> None:
+    dynamic_vocabulary = _replace_once(
+        OBS_VOCABULARY,
+        'SPAN_NAMES: Final[frozenset[str]] = frozenset({"probe.run", "probe.legacy"})',
+        "SPAN_NAMES: Final[frozenset[str]] = frozenset(_span_names())",
+    )
+    _write_fixture(tmp_path, obs=dynamic_vocabulary)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_checker_consumes_new_literal_vocabulary_without_a_duplicate_allowlist(
+    tmp_path: Path,
+) -> None:
+    obs = _replace_once(
+        OBS_VOCABULARY,
+        '{"probe.run", "probe.legacy"}',
+        '{"probe.run", "probe.new", "probe.legacy"}',
+    )
+    manifest = _replace_once(MANIFEST, '["probe.run"]', '["probe.new"]')
+    service = (
+        SERVICE
+        + """
+
+from archetype import _obs
+
+def observed() -> None:
+    with _obs.span("probe.new", attributes={"archetype.outcome": "succeeded"}):
+        pass
+"""
+    )
+    _write_fixture(tmp_path, obs=obs, manifest=manifest, service=service)
+
+    assert _audit(tmp_path).ok
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+def observed(tick: int) -> None:
+    with _obs.span(f"probe.{tick}"):
+        pass
+""",
+        """
+def observed() -> None:
+    with _obs.span("probe.unknown"):
+        pass
+""",
+        """
+def observed() -> None:
+    with _obs.span("probe.legacy"):
+        pass
+""",
+        """
+def observed(field: str) -> None:
+    with _obs.span("probe.run", attributes={field: "succeeded"}):
+        pass
+""",
+        """
+def observed() -> None:
+    with _obs.span("probe.run", attributes={"password": "secret"}):
+        pass
+""",
+        """
+def observed() -> None:
+    with _obs.span("probe.run", operation="probe.run"):
+        pass
+""",
+        """
+def observed(secret: str) -> None:
+    with _obs.span("probe.run", **{"password": secret}):
+        pass
+""",
+        """
+def observed(name: str) -> None:
+    _obs.counter_add(name)
+""",
+        """
+def observed() -> None:
+    _obs.counter_add("probe.unknown")
+""",
+        """
+def observed(world_id: str) -> None:
+    _obs.counter_add(
+        "archetype.operation.outcomes",
+        attributes={"archetype.world.id": world_id},
+    )
+""",
+    ],
+    ids=[
+        "dynamic-span",
+        "unknown-span",
+        "legacy-span",
+        "dynamic-attribute-key",
+        "unsafe-attribute-key",
+        "legacy-attribute-key",
+        "expanded-attribute-keys",
+        "dynamic-metric",
+        "unknown-metric",
+        "high-cardinality-metric-label",
+    ],
+)
+def test_signal_sites_require_literal_safe_bounded_vocabulary(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    service = SERVICE + "\nfrom archetype import _obs\n" + source
+    _write_fixture(tmp_path, service=service)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "vendor_import",
+    [
+        "from opentelemetry.sdk.trace import TracerProvider",
+        "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter",
+        "import logfire",
+    ],
+    ids=["otel-sdk", "otel-exporter", "vendor-adapter"],
+)
+def test_family_modules_cannot_import_vendor_telemetry(
+    tmp_path: Path,
+    vendor_import: str,
+) -> None:
+    _write_fixture(tmp_path, service=SERVICE + "\n" + vendor_import + "\n")
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_host_configuration_approval_is_exact_to_the_callable(tmp_path: Path) -> None:
+    approved_obs = (
+        OBS_VOCABULARY
+        + """
+
+def approved() -> None:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    trace.set_tracer_provider(TracerProvider())
+"""
+    )
+    hosts = _with_host(
+        "archetype._obs.approved",
+        "provider_configuration",
+    )
+    _write_fixture(tmp_path, obs=approved_obs, hosts=hosts)
+    assert _audit(tmp_path).ok
+
+    unapproved_obs = (
+        approved_obs
+        + """
+
+def sibling() -> None:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    trace.set_tracer_provider(TracerProvider())
+"""
+    )
+    _write_source_module(tmp_path, "_obs.py", unapproved_obs)
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_provider_configuration_alias_is_exact_to_the_callable(tmp_path: Path) -> None:
+    source = (
+        OBS_VOCABULARY
+        + """
+
+def approved() -> None:
+    pass
+
+def sibling(provider: object) -> None:
+    from opentelemetry import trace
+    setter = trace.set_tracer_provider
+    setter(provider)
+"""
+    )
+    hosts = _with_host(
+        "archetype._obs.approved",
+        "provider_configuration",
+    )
+    _write_fixture(tmp_path, obs=source, hosts=hosts)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_configuration_aliases_obey_lexical_shadowing(tmp_path: Path) -> None:
+    source = (
+        OBS_VOCABULARY
+        + """
+
+from opentelemetry import trace
+setter = trace.set_tracer_provider
+
+def approved(provider: object) -> None:
+    setter(provider)
+
+def ordinary(setter, value: object) -> None:
+    setter(value)
+"""
+    )
+    hosts = _with_host(
+        "archetype._obs.approved",
+        "provider_configuration",
+    )
+    _write_fixture(tmp_path, obs=source, hosts=hosts)
+
+    assert _audit(tmp_path).ok
+
+
+def test_local_configuration_alias_shadows_a_same_named_definition(tmp_path: Path) -> None:
+    source = (
+        OBS_VOCABULARY
+        + """
+
+def setter(value: object) -> None:
+    pass
+
+def sibling(provider: object) -> None:
+    from opentelemetry import trace
+    setter = trace.set_tracer_provider
+    setter(provider)
+"""
+    )
+    _write_fixture(tmp_path, obs=source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_configuration_alias_uses_the_latest_assignment(tmp_path: Path) -> None:
+    unsafe = (
+        OBS_VOCABULARY
+        + """
+
+def ordinary(value: object) -> None:
+    pass
+
+def sibling(provider: object) -> None:
+    from opentelemetry import trace
+    setter = ordinary
+    setter = trace.set_tracer_provider
+    setter(provider)
+"""
+    )
+    _write_fixture(tmp_path, obs=unsafe)
+    _assert_rejected(_audit(tmp_path))
+
+    safe = unsafe.replace(
+        "setter = ordinary\n    setter = trace.set_tracer_provider",
+        "setter = trace.set_tracer_provider\n    setter = ordinary",
+    )
+    _write_source_module(tmp_path, "_obs.py", safe)
+    assert _audit(tmp_path).ok
+
+
+@pytest.mark.parametrize(
+    "control_flow",
+    [
+        """
+    if enabled:
+        setter = trace.set_tracer_provider
+    else:
+        setter = ordinary
+""",
+        """
+    setter = ordinary
+    for _item in items:
+        setter = trace.set_tracer_provider
+""",
+        """
+    try:
+        setter = trace.set_tracer_provider
+    except RuntimeError:
+        setter = ordinary
+""",
+        """
+    setter = ordinary
+    try:
+        setter = trace.set_tracer_provider
+        risky()
+        setter = ordinary
+    except RuntimeError:
+        pass
+""",
+        """
+    setter = ordinary
+    for _item in items:
+        setter = trace.set_tracer_provider
+        if enabled:
+            break
+        setter = ordinary
+""",
+        """
+    setter = ordinary
+    try:
+        if enabled:
+            setter = trace.set_tracer_provider
+            risky()
+            setter = ordinary
+        else:
+            setter = ordinary
+    except RuntimeError:
+        pass
+""",
+    ],
+    ids=[
+        "if-join",
+        "loop-join",
+        "try-join",
+        "exception-prefix",
+        "break-prefix",
+        "nested-exception-prefix",
+    ],
+)
+def test_configuration_alias_joins_control_flow_conservatively(
+    tmp_path: Path,
+    control_flow: str,
+) -> None:
+    source = (
+        OBS_VOCABULARY
+        + """
+
+def ordinary(value: object) -> None:
+    pass
+
+def sibling(enabled: bool, items: list[object], provider: object) -> None:
+    from opentelemetry import trace
+"""
+        + control_flow
+        + "    setter(provider)\n"
+    )
+    _write_fixture(tmp_path, obs=source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_provider_mutator_requires_an_exact_host_without_import_provenance(
+    tmp_path: Path,
+) -> None:
+    source = (
+        SERVICE
+        + """
+
+def configure(provider: object, processor: object) -> None:
+    provider.add_span_processor(processor)
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_family_callable_cannot_self_declare_as_provider_host(tmp_path: Path) -> None:
+    service = (
+        SERVICE
+        + """
+
+def approved() -> None:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    trace.set_tracer_provider(TracerProvider())
+"""
+    )
+    hosts = _with_host(
+        "archetype.app.probe.service.approved",
+        "provider_configuration",
+    )
+    _write_fixture(tmp_path, service=service, hosts=hosts)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_logging_configuration_is_host_owned(tmp_path: Path) -> None:
+    approved_source = """
+from __future__ import annotations
+
+def approved() -> None:
+    import logging
+    logging.basicConfig()
+"""
+    hosts = _with_host(
+        "archetype._logging.approved",
+        "logging_configuration",
+    )
+    _write_fixture(tmp_path, hosts=hosts)
+    _write_source_module(tmp_path, "_logging.py", approved_source)
+    assert _audit(tmp_path).ok
+
+    unapproved_source = (
+        approved_source
+        + """
+
+def sibling() -> None:
+    import logging
+    import logging.config
+    logging.config.dictConfig({})
+"""
+    )
+    _write_source_module(tmp_path, "_logging.py", unapproved_source)
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_unrelated_configuration_method_name_is_not_logging(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+class Feature:
+    def disable(self) -> None:
+        pass
+
+def update(feature: Feature) -> None:
+    feature.disable()
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    assert _audit(tmp_path).ok
+
+
+def test_print_is_confined_to_cli_or_an_exact_console_export_callable(tmp_path: Path) -> None:
+    approved_obs = (
+        OBS_VOCABULARY
+        + """
+
+def export() -> None:
+    print("safe fixed console line")
+"""
+    )
+    hosts = _with_host(
+        "archetype._obs.export",
+        "console_export",
+    )
+    _write_fixture(tmp_path, obs=approved_obs, hosts=hosts)
+    assert _audit(tmp_path).ok
+
+    unapproved_obs = (
+        approved_obs
+        + """
+
+def sibling() -> None:
+    print("not an approved console boundary")
+"""
+    )
+    _write_source_module(tmp_path, "_obs.py", unapproved_obs)
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_parameterized_logging_passes_but_eager_f_strings_fail(tmp_path: Path) -> None:
+    safe = (
+        SERVICE
+        + """
+
+import logging
+diagnostics = logging.getLogger(__name__)
+
+def observed(world_id: str) -> None:
+    diagnostics.info("world=%s", world_id)
+"""
+    )
+    _write_fixture(tmp_path, service=safe)
+    assert _audit(tmp_path).ok
+
+    eager = safe.replace(
+        'diagnostics.info("world=%s", world_id)',
+        'message = f"world={world_id}"\n    diagnostics.info(message)',
+    )
+    (tmp_path / "src" / "archetype" / "app" / "probe" / "service.py").write_text(
+        dedent(eager).lstrip(),
+        encoding="utf-8",
+    )
+    _assert_rejected(_audit(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+import logging
+base = logging.getLogger(__name__)
+diagnostics = base
+
+def observed(world_id: str) -> None:
+    diagnostics.info(f"world={world_id}")
+""",
+        """
+import logging
+
+class Observer:
+    def __init__(self) -> None:
+        self.diagnostics = logging.getLogger(__name__)
+
+    def observed(self, world_id: str) -> None:
+        self.diagnostics.info(f"world={world_id}")
+""",
+    ],
+    ids=["assigned-alias", "member-binding"],
+)
+def test_eager_log_interpolation_follows_logger_aliases(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    _write_fixture(tmp_path, service=SERVICE + source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_logger_member_bindings_do_not_leak_between_classes(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+import logging
+
+class LoggerOwner:
+    def __init__(self) -> None:
+        self.channel = logging.getLogger(__name__)
+
+class DomainOwner:
+    def observed(self, world_id: str) -> None:
+        self.channel.info(f"domain={world_id}")
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    assert _audit(tmp_path).ok
+
+
+def test_local_logger_binding_shadows_a_same_named_definition(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+import logging
+
+def diagnostics() -> None:
+    pass
+
+def observed(world_id: str) -> None:
+    diagnostics = logging.getLogger(__name__)
+    diagnostics.info(f"world={world_id}")
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_logger_alias_uses_the_latest_assignment(tmp_path: Path) -> None:
+    unsafe = (
+        SERVICE
+        + """
+
+import logging
+
+def helper() -> None:
+    pass
+
+def observed(world_id: str) -> None:
+    diagnostics = helper
+    diagnostics = logging.getLogger(__name__)
+    diagnostics.info(f"world={world_id}")
+"""
+    )
+    _write_fixture(tmp_path, service=unsafe)
+    _assert_rejected(_audit(tmp_path))
+
+    safe = unsafe.replace(
+        "diagnostics = helper\n    diagnostics = logging.getLogger(__name__)",
+        "diagnostics = logging.getLogger(__name__)\n    diagnostics = helper",
+    )
+    (tmp_path / "src" / "archetype" / "app" / "probe" / "service.py").write_text(
+        dedent(safe).lstrip(),
+        encoding="utf-8",
+    )
+    assert _audit(tmp_path).ok
+
+
+def test_logger_alias_joins_mutually_exclusive_branches(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+import logging
+
+def observed(enabled: bool, domain: object, world_id: str) -> None:
+    if enabled:
+        diagnostics = logging.getLogger(__name__)
+    else:
+        diagnostics = domain
+    diagnostics.info(f"world={world_id}")
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "control_flow",
+    [
+        """
+    diagnostics = domain
+    try:
+        diagnostics = logging.getLogger(__name__)
+        risky()
+        diagnostics = domain
+    except RuntimeError:
+        pass
+""",
+        """
+    diagnostics = domain
+    for _item in items:
+        diagnostics = logging.getLogger(__name__)
+        if enabled:
+            break
+        diagnostics = domain
+""",
+    ],
+    ids=["exception-prefix", "break-prefix"],
+)
+def test_logger_alias_retains_reachable_early_exit_bindings(
+    tmp_path: Path,
+    control_flow: str,
+) -> None:
+    source = (
+        SERVICE
+        + """
+
+import logging
+
+def observed(
+    enabled: bool,
+    items: list[object],
+    domain: object,
+    world_id: str,
+) -> None:
+"""
+        + control_flow
+        + '    diagnostics.info(f"world={world_id}")\n'
+    )
+    _write_fixture(tmp_path, service=source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        'diagnostics.info("event", extra={"password": secret})',
+        'diagnostics.info("payload=%s", payload)',
+    ],
+    ids=["unsafe-extra-key", "obvious-payload-value"],
+)
+def test_structured_logging_rejects_obvious_content_export(
+    tmp_path: Path,
+    statement: str,
+) -> None:
+    source = (
+        SERVICE
+        + f"""
+
+import logging
+diagnostics = logging.getLogger(__name__)
+
+def observed(secret: str, payload: str) -> None:
+    {statement}
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        'diagnostics.exception("probe failed")',
+        'diagnostics.error("probe failed", exc_info=True)',
+        'diagnostics.error("probe failed: %s", exc)',
+    ],
+    ids=["logger-exception", "exc-info", "caught-exception-object"],
+)
+def test_raw_exception_logging_is_rejected(tmp_path: Path, statement: str) -> None:
+    source = (
+        SERVICE
+        + f"""
+
+import logging
+diagnostics = logging.getLogger(__name__)
+
+def observed() -> None:
+    try:
+        raise ValueError("payload must stay local")
+    except ValueError as exc:
+        {statement}
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_raw_exception_attribute_is_rejected(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+from archetype import _obs
+
+def observed() -> None:
+    try:
+        raise ValueError("payload must stay local")
+    except ValueError as exc:
+        with _obs.span("probe.run", attributes={"archetype.outcome": exc}):
+            pass
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    result = _audit(tmp_path)
+    _assert_rejected(result)
+    assert {violation.rule for violation in result.violations} == {"raw_exception_attribute"}
+
+
+def test_broad_suppression_around_telemetry_requires_an_exact_exception(
+    tmp_path: Path,
+) -> None:
+    source = (
+        SERVICE
+        + """
+
+from archetype import _obs
+
+def observed() -> None:
+    try:
+        _obs.counter_add("archetype.operation.outcomes")
+    except Exception:
+        pass
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    result = _audit(tmp_path)
+    _assert_rejected(result)
+    assert len(result.violations) == 1
+
+
+def test_conditional_reraise_does_not_hide_a_telemetry_suppression_path(
+    tmp_path: Path,
+) -> None:
+    source = (
+        SERVICE
+        + """
+
+from archetype import _obs
+
+def observed(reraise: bool) -> None:
+    try:
+        _obs.counter_add("archetype.operation.outcomes")
+    except Exception:
+        if reraise:
+            raise
+        return None
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+
+    result = _audit(tmp_path)
+    _assert_rejected(result)
+    assert {violation.rule for violation in result.violations} == {"broad_telemetry_suppression"}
+
+
+def test_run_debug_cannot_select_telemetry_export_configuration(tmp_path: Path) -> None:
+    source = """
+from __future__ import annotations
+
+from archetype import _obs
+
+class RunConfig:
+    debug: bool
+
+def host(config: RunConfig) -> None:
+    _obs.configure_tracing(service_name="fixture", debug_console=config.debug)
+"""
+    hosts = _with_host(
+        "archetype.runtime.host.host",
+        "invoke_configuration",
+    )
+    _write_fixture(tmp_path, hosts=hosts)
+    _write_source_module(tmp_path, "runtime/host.py", source)
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def _legacy_exception(*, rule: str, scope: str, target: str) -> str:
+    return f'''
+
+[[legacy]]
+rule = "{rule}"
+path = "src/archetype/app/probe/service.py"
+qualified_scope = "{scope}"
+target = "{target}"
+owner = "probe"
+issue = 999
+reason = "The fixture models an exact migration entry."
+expiry_condition = "Remove when probe.legacy is deleted."
+'''
+
+
+def test_legacy_exception_requires_an_exact_match_and_then_exempts(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+from archetype import _obs
+
+def observed() -> None:
+    with _obs.span("probe.legacy"):
+        pass
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+    initial = _audit(tmp_path)
+    assert len(initial.violations) == 1
+    violation = initial.violations[0]
+
+    manifest = MANIFEST + _legacy_exception(
+        rule=violation.rule,
+        scope="archetype.app.probe.service.observed",
+        target=violation.target,
+    )
+    (tmp_path / "quality" / "observability" / "probe.toml").write_text(
+        manifest,
+        encoding="utf-8",
+    )
+
+    assert _audit(tmp_path).ok
+
+
+def test_legacy_exception_cannot_be_owned_by_another_family(tmp_path: Path) -> None:
+    source = (
+        SERVICE
+        + """
+
+from archetype import _obs
+
+def observed() -> None:
+    with _obs.span("probe.legacy"):
+        pass
+"""
+    )
+    _write_fixture(tmp_path, service=source)
+    violation = _audit(tmp_path).violations[0]
+    other = f'''
+version = 1
+owner = "other"
+
+[[legacy]]
+rule = "{violation.rule}"
+path = "src/archetype/app/probe/service.py"
+qualified_scope = "archetype.app.probe.service.observed"
+target = "{violation.target}"
+owner = "other"
+issue = 999
+reason = "Another owner must not absorb probe debt."
+expiry_condition = "This row must be rejected immediately."
+'''
+    (tmp_path / "quality" / "observability" / "other.toml").write_text(
+        other,
+        encoding="utf-8",
+    )
+
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_stale_or_colliding_legacy_exceptions_fail_policy(tmp_path: Path) -> None:
+    stale = MANIFEST + _legacy_exception(
+        rule="legacy_signal_name",
+        scope="archetype.app.probe.service.observed",
+        target="span:probe.legacy",
+    )
+    _write_fixture(tmp_path, manifest=stale)
+    _assert_rejected(_audit(tmp_path))
+
+    collision = stale + _legacy_exception(
+        rule="legacy_signal_name",
+        scope="archetype.app.probe.service.observed",
+        target="span:probe.legacy",
+    )
+    (tmp_path / "quality" / "observability" / "probe.toml").write_text(
+        collision,
+        encoding="utf-8",
+    )
+    _assert_rejected(_audit(tmp_path))
+
+
+def test_repository_observability_policy_passes_for_all_protocol_operations() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(CHECKER_PATH)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "244 operations" in completed.stdout
+    assert "Observability audit passed" in completed.stdout

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -338,7 +338,7 @@ def test_rendered_no_findings_evidence_is_specific_and_digest_bound():
     rendered = render_evidence(normalized, digest)
 
     assert "no findings" in rendered
-    assert "2 changed file(s), 22 detector categories" in rendered
+    assert "2 changed file(s), 24 detector categories" in rendered
     assert "old.py" in rendered
     assert evidence_marker(HEAD_SHA, 0, digest) in rendered
 
@@ -589,3 +589,13 @@ def test_required_categories_track_the_skill_rulebook():
     other silently changes what the gate enforces — so drift fails here.
     """
     assert _skill_category_slugs() == REQUIRED_CATEGORIES
+
+
+def test_observability_categories_extend_failure_and_unwind_review():
+    assert len(REQUIRED_CATEGORIES) == 24
+    assert REQUIRED_CATEGORIES[-2:] == (
+        "observability-boundary-and-authority",
+        "telemetry-safety-and-cardinality",
+    )
+    assert "fail-open-failure-paths" in REQUIRED_CATEGORIES
+    assert "error-path-unwind" in REQUIRED_CATEGORIES

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -11,6 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 QUALITY_WORKFLOW = ROOT / ".github" / "workflows" / "python-tests.yml"
 AUTOMERGE_WORKFLOW = ROOT / ".github" / "workflows" / "automerge.yml"
+MAKEFILE = ROOT / "Makefile"
 
 
 def _job(workflow: str, job_id: str) -> str:
@@ -49,6 +50,22 @@ def test_quality_workflow_keeps_fail_loud_coverage_and_infrastructure() -> None:
     assert "make eval-reliability" in evals
     assert "make eval-capability" in evals
     assert "make package-smoke" in evals
+
+
+def test_observability_audit_uses_the_existing_required_format_context() -> None:
+    workflow = QUALITY_WORKFLOW.read_text(encoding="utf-8")
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    format_job = _job(workflow, "format")
+
+    assert "- run: make lint" in format_job
+    lint_target = re.search(r"^lint:(?P<dependencies>[^\n]*)$", makefile, re.MULTILINE)
+    assert lint_target is not None
+    assert "observability-audit" in lint_target.group("dependencies").split()
+    assert re.search(
+        r"^observability-audit:\n\t@uv run python scripts/check_observability\.py$",
+        makefile,
+        re.MULTILINE,
+    )
 
 
 def test_quality_gate_aggregates_every_applicable_job() -> None:


### PR DESCRIPTION
## Summary

- add an AST-only observability checker with independent family, host, redaction, and legacy-debt manifests
- bind registered workflow emissions and positive family dispositions to their exact lexical source scopes, including effective factory use, nested-callable isolation, and fixed safe-recorder metrics
- wire deterministic enforcement into the required static profile and extend the existing footgun reviewer with exactly the two observability categories from #514
- normalize gateway and artifact signal vocabulary, including an exporter-backed proof of canonical safe fields
- document manifest authority, root-span ownership, workflow optionality, and exact temporary legacy exceptions

The registered legacy debt remains explicitly owned by follow-up issues, including #530; this PR does not close those follow-ups.

## Validation

- focused checker, signal, artifact-export, footgun-gate, and quality-workflow tests — **203 passed**
- repository audit — **141 files, 27 protocols, 244 operations, 7 workflows, 57 exact legacy exceptions**
- `make static`
- `make verify-pr` — **1,661 passed, 11 skipped, 86.58% coverage; 15/15 regression, 8/8 specification, 9/9 capability; package, examples, generated references, and docs passed**

Closes #514