### PR TITLE
docs: make the fork example a real counterfactual (butterfly effect)

### DIFF
--- a/examples/02_fork_counterfactual.py
+++ b/examples/02_fork_counterfactual.py
@@ -1,12 +1,21 @@
-# Copyright 2025 Vangelis Technologies Inc.
+# Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Fork for Counterfactuals
-=========================
+Fork a Counterfactual: The Butterfly Effect
+============================================
 
-Fork a world three times with different physics parameters,
-run each fork, and compare the results.
+Every tick persists as immutable rows, so a counterfactual is a fork plus a
+join — not a re-run. One logistic-map processor (a pure column expression)
+drives three entities in different dynamical regimes:
+
+    fixed-point  r=2.9     perturbations decay (~0.9x per tick)
+    period-2     r=3.2     perturbations are erased (0.16x per cycle)
+    chaos        r=3.9999  perturbations double every tick
+
+We run the prime world, fork it, nudge every entity by 1e-9 in the fork, run
+both branches forward, and diff the two histories tick-by-tick with a single
+join over the shared append-only ledger.
 
 No external dependencies — runs entirely in-process.
 
@@ -15,49 +24,107 @@ Usage:
 """
 
 import asyncio
-from dataclasses import dataclass
 
-from archetype import ArchetypeRuntime
-from archetype.core.component import Component
-from archetype.core.config import StorageConfig
+from daft import DataFrame, col
+
+from archetype import ArchetypeRuntime, AsyncProcessor, Component, StorageConfig
+
+REGIMES = {"fixed-point": 2.9, "period-2": 3.2, "chaos": 3.9999}
+NUDGE = 1e-9
+PRE_TICKS = 12
+POST_TICKS = 36
+CHECKPOINTS = (0, 6, 12, 18, 24, 30, 36)
 
 
-@dataclass
-class PhysicsConfig:
-    gravity: float = 9.8
-    drag: float = 0.1
+class Node(Component):
+    r: float = 0.0
+    x: float = 0.5
 
 
-class Probe(Component):
-    label: str = ""
+class LogisticMap(AsyncProcessor):
+    components = (Node,)
+    priority = 10
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        x = col("node__x")
+        return df.with_column("node__x", col("node__r") * x * (1.0 - x))
 
 
 async def main():
     storage = StorageConfig(uri="./archetype_data", namespace="counterfactuals")
 
     async with ArchetypeRuntime() as runtime:
-        base = runtime.world("base", storage=storage, resources=[PhysicsConfig()])
+        # ── 1. PRIME TIMELINE ─────────────────────────────────────────────────
+        prime = runtime.world("prime", storage=storage, processors=[LogisticMap()])
+        eids = {name: await prime.spawn(Node(r=r)) for name, r in REGIMES.items()}
+        await prime.step()  # persist tick 0: raw initial conditions
+        await prime.run(steps=PRE_TICKS)
 
-        await base.spawn(Probe(label="seed"))
-        await base.run(steps=1)
+        fork_tick = (await prime.info()).tick  # the fork continues from here
+        last = fork_tick - 1  # latest persisted tick
+        at_fork = {
+            row["entity_id"]: row["node__x"]
+            for row in (await prime.query(Node))
+            .where(col("tick") == last)
+            .select("entity_id", "node__x")
+            .to_pylist()
+        }
+        print(f"1. PRIME TIMELINE: {fork_tick} ticks persisted; forking at tick {last}")
 
-        base_info = await base.info()
-        print(f"Base world: {base_info.world_id}")
-        print(f"Base state: tick={base_info.tick}\n")
+        # ── 2. FORK AND NUDGE ─────────────────────────────────────────────────
+        # An update overlays raw given-state at the fork's next persisted tick;
+        # dynamics resume one tick later. So fork tick t+1 corresponds to prime
+        # tick t, and k=0 below compares x against exactly x + NUDGE.
+        fork = await prime.fork("nudged")
+        for name, r in REGIMES.items():
+            await fork.update(eids[name], Node(r=r, x=at_fork[eids[name]] + NUDGE))
+        print(f"2. FORK AND NUDGE: every entity perturbed by {NUDGE:g} in the fork")
 
-        branches_run = 0
-        for gravity in [1.0, 9.8, 25.0]:
-            fork = await base.fork(f"gravity-{gravity}", storage=storage)
-            # Resources are shared from the base world at fork time.
-            # To vary per-fork, we use a fresh world with the resource instead.
-            # For this demo we just run the fork forward.
-            result = await fork.run(steps=10)
-            df = await fork.query(Probe)
-            branches_run += 1
-            print(f"\ngravity={gravity:>5.1f}: tick={result.final_tick}")
-            df.show()
+        # ── 3. RESUME BOTH BRANCHES ───────────────────────────────────────────
+        await prime.run(steps=POST_TICKS)
+        await fork.run(steps=POST_TICKS + 1)
 
-        print(f"\nRan {branches_run} counterfactual branches from the same base state.")
+        # ── 4. DIFF THE HISTORIES ─────────────────────────────────────────────
+        # Both branches are immutable rows keyed by tick — the counterfactual
+        # comparison is one join, aligned on tick offset k from the fork point.
+        prime_run = (
+            (await prime.query(Node))
+            .where(col("tick") >= last)
+            .select(
+                (col("tick") - last).alias("k"),
+                col("node__r").alias("r"),
+                col("node__x").alias("x_prime"),
+            )
+        )
+        fork_hist = await fork.query(Node)
+        fork_run = fork_hist.where(col("tick") >= fork_tick).select(
+            (col("tick") - fork_tick).alias("k"),
+            col("node__r").alias("r"),
+            col("node__x").alias("x_fork"),
+        )
+        diverged = (
+            prime_run.join(fork_run, on=["k", "r"])
+            .with_column("delta", (col("x_prime") - col("x_fork")).abs())
+            .where(col("k").is_in(list(CHECKPOINTS)))
+            .sort(["r", "k"])
+        )
+        by_regime: dict[float, dict[int, float]] = {}
+        for row in diverged.to_pylist():
+            by_regime.setdefault(row["r"], {})[row["k"]] = row["delta"]
+
+        print("3. DIVERGENCE |x_prime - x_fork| by tick offset k from the fork point:")
+        print(f"{'regime':>14} {'r':>7} |" + "".join(f"{f'k={k}':>10}" for k in CHECKPOINTS))
+        for name, r in sorted(REGIMES.items(), key=lambda kv: kv[1]):
+            cells = "".join(f"{by_regime[r][k]:>10.1e}" for k in CHECKPOINTS)
+            print(f"{name:>14} {r:>7.4f} |{cells}")
+
+        amplified = by_regime[REGIMES["chaos"]][POST_TICKS] / NUDGE
+        inherited = fork_hist.where(col("tick") < fork_tick).count_rows()
+        print(f"\nchaos amplified the nudge {amplified:.2g}x in {POST_TICKS} ticks;")
+        print(
+            f"the fork read {inherited} pre-fork rows through lineage — one shared "
+            "append-only past, never copied, never overwritten."
+        )
 
 
 if __name__ == "__main__":

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ uv run python examples/<filename>.py
 |---|---------|-------------|----------|
 | 0 | [`00_quickstart.py`](00_quickstart.py) | Smallest complete component + processor + runtime simulation | None |
 | 1 | [`01_world_mutations.py`](01_world_mutations.py) | Every mutation type: spawn, despawn, add_processor, RBAC, fork, audit history | None |
-| 2 | [`02_fork_counterfactual.py`](02_fork_counterfactual.py) | Fork a world three times, run each branch, compare results | None |
+| 2 | [`02_fork_counterfactual.py`](02_fork_counterfactual.py) | Butterfly effect: fork a branch, nudge it by 1e-9, and diff the two append-only histories with a single join — three dynamical regimes, three fates | None |
 | 3 | [`03_time_travel.py`](03_time_travel.py) | Rewind to any past tick by filtering the `tick` column, then fork a counterfactual branch and diff it against the source | None |
 | 4 | [`04_messaging.py`](04_messaging.py) | Agent-to-agent messaging via an application-local mailbox resource, priority-ordered processors, and lifecycle hooks | None |
 | 5 | [`05_llm_agents.py`](05_llm_agents.py) | LLM-powered agents — each entity gets a parallel LLM call every tick via `daft.functions.prompt` | `OPENAI_API_KEY` |


### PR DESCRIPTION
## Why

`02_fork_counterfactual.py` forked three branches and then varied nothing between them — the in-file comment admitted the per-fork physics never diverged. The example demonstrating the framework's signature capability demonstrated nothing counterfactual.

## What

Replace it with a butterfly-effect demo shaped like the framework:

- One logistic-map processor (pure column expression, no UDF) drives three entities in different dynamical regimes: fixed-point r=2.9, period-2 r=3.2, chaos r=3.9999.
- Run 13 ticks, `fork`, nudge every entity by 1e-9 via `update` overlay, resume both branches.
- Diff the two append-only histories with a **single join** aligned on tick offset from the fork point — a counterfactual is a join, not a re-run.

```
        regime       r |       k=0       k=6      k=12      k=18      k=24      k=30      k=36
   fixed-point  2.9000 |   1.0e-09   4.9e-10   2.5e-10   1.3e-10   7.1e-11   3.7e-11   2.0e-11
      period-2  3.2000 |   1.0e-09   4.1e-12   1.7e-14   2.2e-16   0.0e+00   0.0e+00   0.0e+00
         chaos  3.9999 |   1.0e-09   3.3e-08   1.1e-06   2.6e-04   1.7e-02   7.0e-01   1.4e-01
```

The output is falsifiable physics: decay at |2−r| per tick, period-2 erasure to exact float zero, ln(2)-rate doubling to 1.4e8x amplification. The example also demonstrates the documented overlay-lands-raw tick semantics (fork tick t+1 aligns with prime tick t — called out in a comment, since that is the one place a naive fork-and-diff silently breaks) and lineage reads of the 39 shared pre-fork rows.

## Verification

- Ran twice locally: deterministic, rerun-safe with the fixed `counterfactuals` namespace, 2.4s wall — well within `examples-smoke` budget, no credentials required.
- `make check` green (format, lint, lazy-audit, architecture audits).
- README row for example 2 updated to match.

_Note: this PR merged with the example replacement only; the top-level README usage-pattern change follows in a separate PR. (The body briefly described both — corrected.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)