### PR TITLE
test(observability): characterize Daft execution attribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ coverage.xml
 .wrangler/
 bench-results.json
 query-bench-results.json
+daft-attribution-results.json
 eval-results.json
 
 # mutmut: working tree of generated mutants and its on-disk cache

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ help:
 	@echo "  make bench          Run ECS microbenchmarks (1 step)"
 	@echo "  make bench-full     Run ECS microbenchmarks (3 steps)"
 	@echo "  make bench-query    Run QueryService latency benchmarks"
+	@echo "  make bench-daft-attribution  Characterize lazy Daft execution attribution"
 	@echo "  make eval           Run all repository-check groups"
 	@echo "  make eval-reg       Run regression checks only"
 	@echo "  make eval-idem      Run idempotency checks only"
@@ -277,6 +278,11 @@ bench-full:
 bench-query:
 	@PYTHONPATH=$(PYTHONPATH) uv run python -m bench.core.query_latency --out query-bench-results.json
 	@echo "Query benchmark results written to query-bench-results.json"
+
+.PHONY: bench-daft-attribution
+bench-daft-attribution:
+	@PYTHONPATH=$(PYTHONPATH) uv run python -m bench.observability.daft_attribution --out daft-attribution-results.json
+	@echo "Daft attribution results written to daft-attribution-results.json"
 
 .PHONY: eval
 eval:

--- a/bench/observability/__init__.py
+++ b/bench/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Observability characterization workloads for the repository harness."""

--- a/bench/observability/daft_attribution.py
+++ b/bench/observability/daft_attribution.py
@@ -1,0 +1,526 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Characterize lazy Daft execution without changing Archetype production code.
+
+The workload proves that an AsyncProcessor.process() call builds a lazy plan
+while the delayed Python UDF runs only at the synthetic ``DataFrame.collect``
+boundary. Daft's experimental Subscriber API is intentionally confined to this
+repository-harness module. Raw plans, operator names, query identifiers, node
+identifiers, and trace identifiers never enter the report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import statistics
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import daft
+from daft import DataFrame, DataType, col, lit
+from daft.subscribers import Subscriber
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+from archetype.core.aio.async_processor import AsyncProcessor
+from bench.core.report import build_report, capture_environment, write_report
+
+PINNED_DAFT_VERSION = "0.7.19"
+WORKLOAD_ID = "daft-execution-attribution-v1"
+
+_SYNTHETIC_TRACE_ID = 0x1234567890ABCDEF1234567890ABCDEF
+_SYNTHETIC_SPAN_ID = 0x1234567890ABCDEF
+_PROBE_DTYPE = DataType.struct(
+    {
+        "value": DataType.int64(),
+        "context_valid": DataType.bool(),
+        "context_matches_synthetic": DataType.bool(),
+    }
+)
+
+
+@daft.func(return_dtype=_PROBE_DTYPE)
+def _delayed_probe(
+    value: int,
+    delay_seconds: float,
+    started_marker_path: str,
+    finished_marker_path: str,
+) -> dict[str, Any]:
+    """Perform visible work only when Daft executes the lazy UDF."""
+    span_context = trace.get_current_span().get_span_context()
+    if started_marker_path:
+        Path(started_marker_path).touch(exist_ok=True)
+    time.sleep(delay_seconds)
+    if finished_marker_path:
+        Path(finished_marker_path).touch(exist_ok=True)
+    return {
+        "value": value + 1,
+        "context_valid": span_context.is_valid,
+        "context_matches_synthetic": (
+            span_context.trace_id == _SYNTHETIC_TRACE_ID
+            and span_context.span_id == _SYNTHETIC_SPAN_ID
+        ),
+    }
+
+
+@dataclass(frozen=True)
+class AttributionConfig:
+    """Comparable dimensions for the retained characterization workload."""
+
+    rows: int = 3
+    delay_seconds: float = 0.05
+    repetitions: int = 2
+
+    def validate(self) -> None:
+        if self.rows < 1:
+            raise ValueError("rows must be positive")
+        if self.delay_seconds < 0:
+            raise ValueError("delay_seconds must be non-negative")
+        if self.repetitions < 2:
+            raise ValueError("repetitions must be at least 2")
+
+
+class IncrementProbeProcessor(AsyncProcessor):
+    """First processor in an optimizer-fusion characterization."""
+
+    async def process(self, df: DataFrame, **input_kwargs: Any) -> DataFrame:
+        del input_kwargs
+        return df.with_column("value", col("value") + lit(1))
+
+
+class DoubleProbeProcessor(AsyncProcessor):
+    """Second processor in an optimizer-fusion characterization."""
+
+    async def process(self, df: DataFrame, **input_kwargs: Any) -> DataFrame:
+        del input_kwargs
+        return df.with_column("value", col("value") * lit(2))
+
+
+class DelayedProbeProcessor(AsyncProcessor):
+    """Synthetic processor whose expensive operation remains inside the Daft DAG."""
+
+    def __init__(
+        self,
+        *,
+        delay_seconds: float,
+        started_marker_path: Path | None,
+        finished_marker_path: Path | None,
+    ):
+        self.delay_seconds = delay_seconds
+        self.started_marker_path = started_marker_path
+        self.finished_marker_path = finished_marker_path
+
+    async def process(self, df: DataFrame, **input_kwargs: Any) -> DataFrame:
+        del input_kwargs
+        return df.with_column(
+            "probe",
+            _delayed_probe(
+                col("value"),
+                lit(self.delay_seconds),
+                lit(str(self.started_marker_path) if self.started_marker_path is not None else ""),
+                lit(
+                    str(self.finished_marker_path) if self.finished_marker_path is not None else ""
+                ),
+            ),
+        )
+
+
+_PROCESSOR_CLASSES = (
+    IncrementProbeProcessor,
+    DoubleProbeProcessor,
+    DelayedProbeProcessor,
+)
+
+
+class _ExecutionCapture(Subscriber):
+    """Reduce experimental Daft events to bounded characterization evidence."""
+
+    def __init__(self) -> None:
+        self._queries: dict[str, dict[str, Any]] = {}
+
+    def _query(self, query_id: str) -> dict[str, Any]:
+        return self._queries.setdefault(
+            query_id,
+            {
+                "optimized": False,
+                "physical": False,
+                "processor_class_name_literal": False,
+                "node_ids": set(),
+                "udf_node_ids": set(),
+                "origin_node": False,
+                "metric_names": set(),
+                "udf_duration_by_node": {},
+                "transform_node_count": 0,
+                "execution_duration_reported": False,
+            },
+        )
+
+    @property
+    def query_count(self) -> int:
+        return len(self._queries)
+
+    def on_query_started(self, event: Any) -> None:
+        self._query(event.query_id)
+
+    def on_optimization_completed(self, event: Any) -> None:
+        query = self._query(event.query_id)
+        query["optimized"] = True
+        query["processor_class_name_literal"] = query["processor_class_name_literal"] or any(
+            cls.__name__ in event.optimized_plan for cls in _PROCESSOR_CLASSES
+        )
+
+    def on_execution_started(self, event: Any) -> None:
+        query = self._query(event.query_id)
+        query["physical"] = True
+        query["processor_class_name_literal"] = query["processor_class_name_literal"] or any(
+            cls.__name__ in event.physical_plan for cls in _PROCESSOR_CLASSES
+        )
+        try:
+            physical_plan = json.loads(event.physical_plan)
+        except (TypeError, ValueError):
+            return
+        query["transform_node_count"] = _count_transform_nodes(physical_plan)
+
+    def on_operator_start(self, event: Any) -> None:
+        query = self._query(event.query_id)
+        query["node_ids"].add(event.node_id)
+        if event.name.startswith("UDF "):
+            query["udf_node_ids"].add(event.node_id)
+        query["origin_node"] = query["origin_node"] or event.origin_node_id is not None
+
+    def on_stats(self, event: Any) -> None:
+        query = self._query(event.query_id)
+        for node_id, stats in event.stats.items():
+            query["metric_names"].update(stats)
+            if node_id not in query["udf_node_ids"] or "duration" not in stats:
+                continue
+            duration = stats["duration"][1]
+            total_seconds = getattr(duration, "total_seconds", None)
+            if callable(total_seconds):
+                observed = total_seconds()
+                previous = query["udf_duration_by_node"].get(node_id, 0.0)
+                query["udf_duration_by_node"][node_id] = max(previous, observed)
+
+    def on_execution_finished(self, event: Any) -> None:
+        query = self._query(event.query_id)
+        query["execution_duration_reported"] = event.duration_ms is not None
+
+    def summary(self) -> dict[str, Any]:
+        queries = list(self._queries.values())
+        node_sets = [frozenset(query["node_ids"]) for query in queries]
+        metric_names = {name for query in queries for name in query["metric_names"]}
+        udf_durations = [sum(query["udf_duration_by_node"].values()) for query in queries]
+        transform_counts = [query["transform_node_count"] for query in queries]
+        return {
+            "query_count": len(queries),
+            "optimization_event_observed": bool(queries)
+            and all(query["optimized"] for query in queries),
+            "execution_plan_event_observed": bool(queries)
+            and all(query["physical"] for query in queries),
+            "udf_operator_observed": bool(queries)
+            and all(query["udf_node_ids"] for query in queries),
+            "processor_class_name_literal_observed": any(
+                query["processor_class_name_literal"] for query in queries
+            ),
+            "query_local_node_positions_reused": len(node_sets) >= 2
+            and len(set(node_sets)) < len(node_sets),
+            "origin_node_id_seen_by_driver_subscriber": any(
+                query["origin_node"] for query in queries
+            ),
+            "execution_duration_event_reported": any(
+                query["execution_duration_reported"] for query in queries
+            ),
+            "duration_stat_observed": "duration" in metric_names,
+            "row_stats_observed": any(name.startswith("rows.") for name in metric_names),
+            "byte_stats_observed": any(name.startswith("bytes.") for name in metric_names),
+            "task_counter_stat_observed": any(name.startswith("task.") for name in metric_names),
+            "processor_count": len(_PROCESSOR_CLASSES),
+            "transform_node_count_median": (
+                statistics.median(transform_counts) if transform_counts else 0
+            ),
+            "processor_count_matches_transform_nodes": bool(transform_counts)
+            and all(count == len(_PROCESSOR_CLASSES) for count in transform_counts),
+            "udf_operator_accumulated_duration_median_s": (
+                statistics.median(udf_durations) if udf_durations else 0.0
+            ),
+        }
+
+
+def _count_transform_nodes(node: object) -> int:
+    if not isinstance(node, dict):
+        return 0
+    own = int(node.get("type") in {"Project", "UDFProject"})
+    children = node.get("children", [])
+    if not isinstance(children, list):
+        return own
+    return own + sum(_count_transform_nodes(child) for child in children)
+
+
+def _synthetic_parent() -> NonRecordingSpan:
+    context = SpanContext(
+        trace_id=_SYNTHETIC_TRACE_ID,
+        span_id=_SYNTHETIC_SPAN_ID,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    return NonRecordingSpan(context)
+
+
+def _ray_disposition(*, runner: str, ray_available: bool) -> str:
+    if runner == "ray":
+        if ray_available:
+            return "exercised_external_ray_environment"
+        return "invalid_ray_runner_without_dependency"
+    return "not_exercised_ray_extra_not_locked"
+
+
+def _validate_environment() -> str:
+    if daft.__version__ != PINNED_DAFT_VERSION:
+        raise RuntimeError(
+            "Daft execution attribution must be re-characterized when the locked "
+            f"version changes: expected {PINNED_DAFT_VERSION}, observed {daft.__version__}"
+        )
+    runner = daft.get_or_infer_runner_type()
+    if runner not in {"native", "ray"}:
+        raise RuntimeError(f"unsupported Daft runner for attribution probe: {runner}")
+    return runner
+
+
+def _correct_probe_rows(rows: list[dict[str, Any]], expected_rows: int) -> bool:
+    if len(rows) != expected_rows:
+        return False
+    return all(row["probe"]["value"] == row["value"] + 1 for row in rows)
+
+
+async def _run_in_directory(
+    config: AttributionConfig,
+    marker_root: Path,
+) -> tuple[dict[str, Any], str]:
+    runner = _validate_environment()
+    ray_available = importlib.util.find_spec("ray") is not None
+    runner_disposition = _ray_disposition(
+        runner=runner,
+        ray_available=ray_available,
+    )
+    if runner == "ray" and not ray_available:
+        raise RuntimeError("Daft Ray runner was configured but Ray is not installed")
+    capture = _ExecutionCapture()
+    plan_durations: list[float] = []
+    collect_durations: list[float] = []
+    conversion_durations: list[float] = []
+    deferred: list[bool] = []
+    outputs_correct: list[bool] = []
+    driver_context_active: list[bool] = []
+    driver_context_matches: list[bool] = []
+    udf_context_active: list[bool] = []
+    udf_context_matches: list[bool] = []
+
+    with daft.with_subscriber("archetype-issue-518", capture):
+        for repetition in range(config.repetitions):
+            started_marker = (
+                marker_root / f"execution-{repetition}.started" if runner == "native" else None
+            )
+            finished_marker = (
+                marker_root / f"execution-{repetition}.finished" if runner == "native" else None
+            )
+            for marker in (started_marker, finished_marker):
+                if marker is not None:
+                    marker.unlink(missing_ok=True)
+            processors = (
+                IncrementProbeProcessor(),
+                DoubleProbeProcessor(),
+                DelayedProbeProcessor(
+                    delay_seconds=config.delay_seconds,
+                    started_marker_path=started_marker,
+                    finished_marker_path=finished_marker,
+                ),
+            )
+            source_values = list(range(config.rows))
+            planned = daft.from_pydict({"value": source_values})
+
+            with trace.use_span(_synthetic_parent(), end_on_exit=False):
+                context = trace.get_current_span().get_span_context()
+                driver_context_active.append(context.is_valid)
+                driver_context_matches.append(
+                    context.trace_id == _SYNTHETIC_TRACE_ID
+                    and context.span_id == _SYNTHETIC_SPAN_ID
+                )
+
+                started = time.perf_counter()
+                for processor in processors:
+                    planned = await processor.process(planned)
+                plan_durations.append(time.perf_counter() - started)
+                no_execution_event = capture.query_count == repetition
+                no_started_side_effect = started_marker is None or not started_marker.exists()
+                deferred.append(no_execution_event and no_started_side_effect)
+
+                started = time.perf_counter()
+                collected = planned.collect()
+                collect_durations.append(time.perf_counter() - started)
+
+                started = time.perf_counter()
+                materialized = collected.to_pylist()
+                conversion_durations.append(time.perf_counter() - started)
+
+            if capture.query_count != repetition + 1:
+                raise RuntimeError("terminal collect did not emit one Daft query")
+            if started_marker is not None and not started_marker.exists():
+                raise RuntimeError("delayed UDF did not start at terminal collect")
+            if finished_marker is not None and not finished_marker.exists():
+                raise RuntimeError("delayed UDF did not finish at terminal collect")
+            expected = [((value + 1) * 2) + 1 for value in source_values]
+            outputs_correct.append(
+                _correct_probe_rows(materialized, config.rows)
+                and [row["probe"]["value"] for row in materialized] == expected
+            )
+            udf_context_active.extend(row["probe"]["context_valid"] for row in materialized)
+            udf_context_matches.extend(
+                row["probe"]["context_matches_synthetic"] for row in materialized
+            )
+
+    if not all(deferred):
+        raise RuntimeError("delayed UDF executed while the processor was building its plan")
+    if not all(outputs_correct):
+        raise RuntimeError("attribution workload produced an incorrect result")
+
+    subscriber_evidence = capture.summary()
+    context_evidence = {
+        "driver_observation_count": len(driver_context_active),
+        "driver_active_count": sum(driver_context_active),
+        "driver_matching_count": sum(driver_context_matches),
+        "udf_observation_count": len(udf_context_active),
+        "udf_active_count": sum(udf_context_active),
+        "udf_matching_count": sum(udf_context_matches),
+    }
+    return (
+        {
+            "name": "lazy_processor_execution_attribution",
+            "daft_version": PINNED_DAFT_VERSION,
+            "runner": runner,
+            "distributed_runner_disposition": runner_disposition,
+            "rows": config.rows,
+            "repetitions": config.repetitions,
+            "plan_build_s": statistics.median(plan_durations),
+            "terminal_collect_s": statistics.median(collect_durations),
+            "python_conversion_s": statistics.median(conversion_durations),
+            "udf_operator_accumulated_duration_median_s": subscriber_evidence[
+                "udf_operator_accumulated_duration_median_s"
+            ],
+            "work_deferred_until_collect": all(deferred),
+            "output_correct": all(outputs_correct),
+            "context_propagation": context_evidence,
+            "experimental_subscriber_evidence": subscriber_evidence,
+        },
+        runner,
+    )
+
+
+async def run_attribution_characterization(
+    config: AttributionConfig,
+    *,
+    marker_root: Path | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    """Run the correctness-first attribution workload on the configured runner."""
+    config.validate()
+    if marker_root is not None:
+        marker_root.mkdir(parents=True, exist_ok=True)
+        result, runner = await _run_in_directory(config, marker_root)
+        return [result], runner
+
+    with tempfile.TemporaryDirectory(prefix="archetype-daft-attribution-") as temp:
+        result, runner = await _run_in_directory(config, Path(temp))
+        return [result], runner
+
+
+def build_attribution_report(
+    results: list[dict[str, Any]],
+    *,
+    config: AttributionConfig,
+    runner: str,
+    runner_id: str | None = None,
+) -> dict[str, Any]:
+    """Attach version, runner, and distributed-support disposition."""
+    ray_available = importlib.util.find_spec("ray") is not None
+    return build_report(
+        results,
+        suite="daft_attribution",
+        config={
+            **asdict(config),
+            "workload": WORKLOAD_ID,
+            "pinned_daft_version": PINNED_DAFT_VERSION,
+            "configured_runner": runner,
+            "synthetic_execution_boundary": "DataFrame.collect",
+            "python_conversion_boundary": "DataFrame.to_pylist",
+            "production_persistence_boundary": "not_measured",
+            "subscriber_api": "experimental_harness_only",
+            "execution_signal_source": "experimental_subscriber_stats",
+            "ray_disposition": _ray_disposition(
+                runner=runner,
+                ray_available=ray_available,
+            ),
+        },
+        environment=capture_environment(runner_id=runner_id),
+    )
+
+
+def _int_at_least(minimum: int) -> Any:
+    def parse(value: str) -> int:
+        parsed = int(value)
+        if parsed < minimum:
+            raise argparse.ArgumentTypeError(f"value must be at least {minimum}")
+        return parsed
+
+    return parse
+
+
+def _non_negative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return parsed
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=_int_at_least(1), default=3)
+    parser.add_argument("--delay-ms", type=_non_negative_float, default=50.0)
+    parser.add_argument("--repetitions", type=_int_at_least(2), default=2)
+    parser.add_argument("--out", default=None, help="Write a JSON snapshot here")
+    parser.add_argument(
+        "--runner-id",
+        default=None,
+        help="Stable machine identity; defaults to ARCHETYPE_BENCH_RUNNER or hostname",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = AttributionConfig(
+        rows=args.rows,
+        delay_seconds=args.delay_ms / 1000,
+        repetitions=args.repetitions,
+    )
+    results, runner = asyncio.run(run_attribution_characterization(config))
+    report = build_attribution_report(
+        results,
+        config=config,
+        runner=runner,
+        runner_id=args.runner_id,
+    )
+    if args.out is None:
+        print(json.dumps(report, allow_nan=False, indent=2, sort_keys=True))
+    else:
+        write_report(report, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/guide/benchmarking.md
+++ b/docs/guide/benchmarking.md
@@ -15,12 +15,14 @@ Benchmarks are the measurement arm of the
 make bench        # five ECS microbenchmarks, one simulation step
 make bench-full   # the same workloads, three simulation steps
 make bench-query  # four materialized QueryService read shapes
+make bench-daft-attribution  # version-pinned lazy execution characterization
 ```
 
 The ECS commands write `bench-results.json`; the query command writes
-`query-bench-results.json`. Both files are gitignored local snapshots. Pass a
-different `--out` path to the corresponding Python module when retaining a
-named run.
+`query-bench-results.json`; and the Daft characterization writes
+`daft-attribution-results.json`. All three are gitignored local snapshots.
+Pass a different `--out` path to the corresponding Python module when
+retaining a named run.
 
 Set `ARCHETYPE_BENCH_RUNNER` to a stable machine name when snapshots may be
 compared manually:
@@ -68,6 +70,17 @@ Setup is outside the timed region. Lazy plan construction and terminal
 measured query must return the expected row count before the snapshot is
 written. The default workload uses 100 entities per signature, three history
 ticks, one warmup, and five measured repetitions.
+
+### Daft execution attribution
+
+`make bench-daft-attribution` retains the synthetic oracle from issue #518. It
+pins the Daft version, records the configured runner, proves that the synthetic
+delayed UDF remains deferred until `DataFrame.collect`, separates Python
+conversion time, and reduces experimental Subscriber events to bounded
+booleans and counts. It does
+not retain raw plans, operator names, query/node identifiers, trace identifiers,
+or temporary marker paths. The workload measures no persistence backend and
+does not make the Subscriber API a production dependency.
 
 ## Trend tracking is an operational decision
 

--- a/quality/benchmarks.toml
+++ b/quality/benchmarks.toml
@@ -31,3 +31,20 @@ metrics = [
   { name = "steps_per_sec", direction = "higher" },
   { name = "entities_per_sec", direction = "higher" },
 ]
+
+[[benchmark]]
+id = "observability.daft_attribution"
+suite = "daft_attribution"
+owner = "observability"
+entrypoint = "bench/observability/daft_attribution.py"
+correctness_oracles = ["tests/bench/test_daft_attribution.py"]
+report_schema = "bench.core.report/v1"
+comparison_policy = "advisory"
+stable_runner = false
+profiles = ["nightly"]
+metrics = [
+  { name = "plan_build_s", direction = "lower" },
+  { name = "terminal_collect_s", direction = "lower" },
+  { name = "python_conversion_s", direction = "lower" },
+  { name = "udf_operator_accumulated_duration_median_s", direction = "lower" },
+]

--- a/tests/bench/test_daft_attribution.py
+++ b/tests/bench/test_daft_attribution.py
@@ -1,0 +1,214 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the version-pinned Daft execution-attribution workload."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import daft
+import pytest
+
+from bench.observability.daft_attribution import (
+    PINNED_DAFT_VERSION,
+    AttributionConfig,
+    _ray_disposition,
+    build_attribution_report,
+    run_attribution_characterization,
+)
+
+
+def _all_mapping_keys(value: object) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | {key for child in value.values() for key in _all_mapping_keys(child)}
+    if isinstance(value, list):
+        return {key for child in value for key in _all_mapping_keys(child)}
+    return set()
+
+
+@pytest.mark.asyncio
+async def test_delayed_udf_runs_only_at_terminal_collect(tmp_path: Path) -> None:
+    config = AttributionConfig(rows=1, delay_seconds=0.01, repetitions=2)
+
+    results, runner = await run_attribution_characterization(
+        config,
+        marker_root=tmp_path,
+    )
+
+    assert runner == "native"
+    assert len(results) == 1
+    result = results[0]
+    assert result["work_deferred_until_collect"] is True
+    assert result["output_correct"] is True
+    assert result["daft_version"] == PINNED_DAFT_VERSION
+    assert result["runner"] == "native"
+    assert result["distributed_runner_disposition"] == "not_exercised_ray_extra_not_locked"
+    assert result["plan_build_s"] > 0
+    assert result["terminal_collect_s"] > 0
+    assert result["python_conversion_s"] > 0
+
+    context = result["context_propagation"]
+    assert context == {
+        "driver_observation_count": 2,
+        "driver_active_count": 2,
+        "driver_matching_count": 2,
+        "udf_observation_count": 2,
+        "udf_active_count": 0,
+        "udf_matching_count": 0,
+    }
+
+    events = result["experimental_subscriber_evidence"]
+    assert events["query_count"] == config.repetitions
+    assert events["optimization_event_observed"] is True
+    assert events["execution_plan_event_observed"] is True
+    assert events["udf_operator_observed"] is True
+    assert events["processor_class_name_literal_observed"] is False
+    assert events["query_local_node_positions_reused"] is True
+    assert events["origin_node_id_seen_by_driver_subscriber"] is False
+    assert events["duration_stat_observed"] is True
+    assert events["row_stats_observed"] is True
+    assert events["byte_stats_observed"] is True
+    assert events["task_counter_stat_observed"] is True
+    assert events["processor_count"] == 3
+    assert events["transform_node_count_median"] == 2
+    assert events["processor_count_matches_transform_nodes"] is False
+    assert result["udf_operator_accumulated_duration_median_s"] > 0
+
+
+@pytest.mark.asyncio
+async def test_report_is_pinned_and_contains_only_reduced_plan_evidence(
+    tmp_path: Path,
+) -> None:
+    config = AttributionConfig(rows=1, delay_seconds=0, repetitions=2)
+    results, runner = await run_attribution_characterization(
+        config,
+        marker_root=tmp_path,
+    )
+
+    report = build_attribution_report(
+        results,
+        config=config,
+        runner=runner,
+        runner_id="contract-runner",
+    )
+
+    assert daft.__version__ == PINNED_DAFT_VERSION
+    assert report["suite"] == "daft_attribution"
+    assert report["config"]["pinned_daft_version"] == PINNED_DAFT_VERSION
+    assert report["config"]["configured_runner"] == "native"
+    assert report["config"]["ray_disposition"] == "not_exercised_ray_extra_not_locked"
+    result = report["results"][0]
+    assert set(result) == {
+        "name",
+        "daft_version",
+        "runner",
+        "distributed_runner_disposition",
+        "rows",
+        "repetitions",
+        "plan_build_s",
+        "terminal_collect_s",
+        "python_conversion_s",
+        "udf_operator_accumulated_duration_median_s",
+        "work_deferred_until_collect",
+        "output_correct",
+        "context_propagation",
+        "experimental_subscriber_evidence",
+    }
+    assert set(result["context_propagation"]) == {
+        "driver_observation_count",
+        "driver_active_count",
+        "driver_matching_count",
+        "udf_observation_count",
+        "udf_active_count",
+        "udf_matching_count",
+    }
+    assert set(result["experimental_subscriber_evidence"]) == {
+        "query_count",
+        "optimization_event_observed",
+        "execution_plan_event_observed",
+        "udf_operator_observed",
+        "processor_class_name_literal_observed",
+        "query_local_node_positions_reused",
+        "origin_node_id_seen_by_driver_subscriber",
+        "execution_duration_event_reported",
+        "duration_stat_observed",
+        "row_stats_observed",
+        "byte_stats_observed",
+        "task_counter_stat_observed",
+        "processor_count",
+        "transform_node_count_median",
+        "processor_count_matches_transform_nodes",
+        "udf_operator_accumulated_duration_median_s",
+    }
+    assert set(report["config"]) == {
+        "rows",
+        "delay_seconds",
+        "repetitions",
+        "workload",
+        "pinned_daft_version",
+        "configured_runner",
+        "synthetic_execution_boundary",
+        "python_conversion_boundary",
+        "production_persistence_boundary",
+        "subscriber_api",
+        "execution_signal_source",
+        "ray_disposition",
+    }
+    rendered = json.dumps(report, sort_keys=True)
+    assert not any(
+        class_name in rendered
+        for class_name in (
+            "IncrementProbeProcessor",
+            "DoubleProbeProcessor",
+            "DelayedProbeProcessor",
+        )
+    )
+    assert "_delayed_probe" not in rendered
+    assert str(tmp_path) not in rendered
+    assert not _all_mapping_keys(report).intersection(
+        {
+            "optimized_plan",
+            "physical_plan",
+            "operator_name",
+            "query_id",
+            "node_id",
+            "trace_id",
+            "span_id",
+            "marker_path",
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (AttributionConfig(rows=0), "rows"),
+        (AttributionConfig(delay_seconds=-0.1), "delay_seconds"),
+        (AttributionConfig(repetitions=1), "repetitions"),
+    ],
+)
+def test_attribution_config_rejects_degenerate_workloads(
+    config: AttributionConfig,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        config.validate()
+
+
+@pytest.mark.parametrize(
+    ("runner", "ray_available", "expected"),
+    [
+        ("native", False, "not_exercised_ray_extra_not_locked"),
+        ("native", True, "not_exercised_ray_extra_not_locked"),
+        ("ray", True, "exercised_external_ray_environment"),
+        ("ray", False, "invalid_ray_runner_without_dependency"),
+    ],
+)
+def test_ray_disposition_is_explicit(
+    runner: str,
+    ray_available: bool,
+    expected: str,
+) -> None:
+    assert _ray_disposition(runner=runner, ray_available=ray_available) == expected


### PR DESCRIPTION
## Summary

- retain a Daft 0.7.19/native-runner characterization that separates processor plan construction, terminal `collect`, and Python conversion;
- add deterministic correctness, lazy-execution, worker-context, optimizer-fusion, and report-redaction oracles;
- reduce the experimental Subscriber API to bounded harness-only evidence and register the workload as an advisory nightly benchmark;
- document the command and its explicit non-production/non-persistence scope.

## Conclusion

The evidence selects **option 1**: use Daft-native metrics for physical execution detail and Archetype spans only for truthful workflow phases. Do not add per-processor execution spans or a processor/node identity bridge.

Full evidence—including native OTLP capture, local overhead measurements, production terminal-boundary audit, context-propagation result, cardinality/safety findings, and the required #519 phase model—is recorded in [#518's decision comment](https://github.com/VangelisTech/archetype/issues/518#issuecomment-5014271766).

Retained default result on the rebased candidate:

- plan build: 1.18 ms;
- terminal collect: 169.40 ms;
- Python conversion: 0.19 ms;
- accumulated UDF operator duration: 164.88 ms;
- driver parent active/matching: 2/2; UDF active/matching: 0/6;
- 3 logical processors optimized to 2 transform nodes.

No production `src/` code changes, new materialization, exporter/provider, public API, or REST surface are introduced. Temporary collector/export and overhead-probe scaffolding was removed.

## Validation

- `uv run pytest -q tests/bench/test_daft_attribution.py tests/bench/test_benchmark_reports.py` — 14 passed
- `make bench-daft-attribution` — passed
- `make static` — passed
- `make verify-pr` — 1,670 passed, 11 skipped, 86.71% coverage; regression 15/15, spec 8/8, capability 9/9; package smoke, examples, generated references, and docs build passed

Closes #518
