### PR TITLE
[codex] enforce top-level family ownership policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,10 @@ libraries, and only lower top-level family contracts declared in
 `cli`; application families may consume their contracts in the other
 direction. Use `components.py`, `processors.py`, `contracts.py`,
 `transitions.py`, `interfaces.py`, and `service.py` according to those semantic
-roles. Package placement never makes a symbol public by itself.
+roles. Every first-party top-level package must be classified as reserved
+infrastructure or a registered family, and the family graph must remain
+acyclic. Root-facade imports receive the disposition of their owning module.
+Package placement never makes a symbol public by itself.
 
 ## Layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ libraries, and only lower top-level family contracts declared in
 `cli`; application families may consume their contracts in the other
 direction. Use `components.py`, `processors.py`, `contracts.py`,
 `transitions.py`, `interfaces.py`, and `service.py` according to those semantic
-roles. Every first-party top-level package must be classified as reserved
-infrastructure or a registered family, and the family graph must remain
-acyclic. Root-facade imports receive the disposition of their owning module.
+roles. Every first-party top-level package or module must be classified as
+reserved infrastructure or a registered family, and the family graph must
+remain acyclic. Root-facade imports receive the disposition of their owning module.
 Package placement never makes a symbol public by itself.
 
 ## Layout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,32 @@
 
 Repo-specific guidance for AI collaborators. For normative behavior, read the specification group under `docs/guide/`, starting with `docs/guide/specification.md`.
 
+## Package ownership
+
+Choose the owning package before adding a type or behavior:
+
+| Kind | Canonical location |
+|---|---|
+| Components, processors, pure DataFrame transforms, transition graphs, and reusable projections | `archetype.<family>` |
+| Supported family value contracts | `archetype.<family>.contracts` or another specifically named family module |
+| Durable authority, cross-family orchestration, internal service ports, and concrete implementations | `archetype.app.<family>` |
+| Transport, authentication, application facade, and composition | `archetype.api`, `archetype.app.gateway`, `archetype.app.application`, and `archetype.app.container` |
+
+Top-level families may import `archetype.core`, themselves, third-party
+libraries, and only lower top-level family contracts declared in
+`quality/architecture.toml`. They never import `app`, `runtime`, `api`, or
+`cli`; application families may consume their contracts in the other
+direction. Use `components.py`, `processors.py`, `contracts.py`,
+`transitions.py`, `interfaces.py`, and `service.py` according to those semantic
+roles. Package placement never makes a symbol public by itself.
+
 ## Layout
 
 ```text
 archetype/
 ├── src/archetype/
 │   ├── core/           # ECS engine (Daft + Arrow + LanceDB)
+│   ├── <family>/       # Reusable ECS/domain state and pure behavior
 │   ├── app/            # Internal application families
 │   │   ├── application/ #   Actor-free RuntimeApplication facade
 │   │   ├── gateway/     #   CommandGateway + RBAC/auth
@@ -33,7 +53,8 @@ archetype/
 | Layer | Access |
 |-------|--------|
 | `core/` | Modify only after discussion. It holds the hard invariants; breakage there cascades everywhere. |
-| `app/` | Extend carefully. Internal service implementation; contracts are in the specification. |
+| `<family>/` | Reusable domain contracts and pure behavior. Follow the declared top-level family DAG. |
+| `app/` | Extend carefully. Internal authority, orchestration, service ports, and concrete implementations. |
 | `runtime/` | Recommended top-level API (`ArchetypeRuntime`). Contract changes require focused specs/tests. |
 | `api/`, `cli/` | Write freely, subject to the contracts they wrap. |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,12 @@ the contracts that tests enforce.
 Top-level domain families depend inward on core and only explicitly declared
 lower family contracts. They never import app, runtime, API, or CLI packages;
 application authority may consume their contracts in the other direction.
-Every first-party top-level package is classified explicitly, and the declared
-family graph must remain acyclic. Importing a root-facade name has the same
-architectural disposition as importing its owning module. Package placement
-does not make a symbol public. See the normative
+Every first-party top-level package or module is classified explicitly, and the
+declared family graph must remain acyclic. Importing a root-facade name has the
+same architectural disposition as importing its owning module. Package
+placement does not make a symbol public. See the normative
 [Application Architecture](docs/guide/application-architecture.md) before
-adding a package or moving a domain type.
+adding a package or module, or moving a domain type.
 
 ## Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,10 @@ the contracts that tests enforce.
 Top-level domain families depend inward on core and only explicitly declared
 lower family contracts. They never import app, runtime, API, or CLI packages;
 application authority may consume their contracts in the other direction.
-Package placement does not make a symbol public. See the normative
+Every first-party top-level package is classified explicitly, and the declared
+family graph must remain acyclic. Importing a root-facade name has the same
+architectural disposition as importing its owning module. Package placement
+does not make a symbol public. See the normative
 [Application Architecture](docs/guide/application-architecture.md) before
 adding a package or moving a domain type.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,22 @@ This guide covers the local workflow, CI, and pull requests. Read
 `LEARNINGS.md` before changing engine behavior; the specification pages define
 the contracts that tests enforce.
 
+## Choose Package Ownership First
+
+| Kind | Canonical location |
+|---|---|
+| Components, processors, pure DataFrame transforms, transition graphs, and reusable projections | `archetype.<family>` |
+| Supported family value contracts | `archetype.<family>.contracts` or another specifically named family module |
+| Durable authority, cross-family orchestration, internal service ports, and concrete implementations | `archetype.app.<family>` |
+| Transport, authentication, application facade, and composition | `archetype.api`, `archetype.app.gateway`, `archetype.app.application`, and `archetype.app.container` |
+
+Top-level domain families depend inward on core and only explicitly declared
+lower family contracts. They never import app, runtime, API, or CLI packages;
+application authority may consume their contracts in the other direction.
+Package placement does not make a symbol public. See the normative
+[Application Architecture](docs/guide/application-architecture.md) before
+adding a package or moving a domain type.
+
 ## Prerequisites
 
 - **Python 3.12+**

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -79,7 +79,43 @@ leak into the server.
 
 ## 4. Package direction and family layout
 
-The application layout is:
+Repository package ownership is normative:
+
+| Kind | Canonical location |
+|---|---|
+| Components, processors, pure DataFrame transforms, transition graphs, and reusable projections | `archetype.<family>` |
+| Supported family value contracts | `archetype.<family>.contracts` or another specifically named family module |
+| Durable authority, cross-family orchestration, internal service ports, and concrete implementations | `archetype.app.<family>` |
+| Transport, authentication, application facade, and composition | `archetype.api`, `archetype.app.gateway`, `archetype.app.application`, and `archetype.app.container` |
+
+A top-level domain-family package owns reusable ECS state and pure domain
+behavior. It may depend on `archetype.core`, itself, third-party libraries, and
+only reviewed lower top-level family contracts declared in
+`quality/architecture.toml`. It must not import `archetype.app`,
+`archetype.runtime`, `archetype.api`, or `archetype.cli`, and it does not
+configure providers, exporters, storage backends, process hosts, or the
+service container. The application layer may import a registered top-level
+family contract; the reverse edge is forbidden. Undeclared top-level
+family-to-family dependencies are denied.
+
+Naming states semantic ownership:
+
+- `components.py` contains `Component` subclasses and component-local
+  construction helpers;
+- `processors.py` contains processor implementations;
+- `contracts.py` contains supported Pydantic or dataclass value contracts;
+- `interfaces.py` contains internal application ports;
+- `transitions.py` contains pure typed transition graphs; and
+- `service.py` contains application authority or orchestration.
+
+A `Component` is persistent ECS schema even though its implementation uses
+Pydantic. It is not an application DTO and does not belong in an app
+`models.py`. Conversely, a top-level path does not automatically make a symbol
+public. Supported names remain an explicit classification owned by
+[API Stability](api-stability.md); concrete services and `ServiceContainer`
+remain internal.
+
+The application-authority layout is:
 
 ```text
 src/archetype/app/
@@ -87,23 +123,24 @@ src/archetype/app/
   world/             world lifecycle, mutation, and simulation
   storage/           stores, catalog/control authority, backend construction
   query/             persisted ECS read paths
-  artifacts/         ingestion, publication claims, content and indexes
+  artifacts/         ingestion, publication claims, storage and indexes
   redaction/         pre-durability secret scanning, receipts and quarantine
-  evaluation/        graders, snapshot pinning, receipts
+  evaluation/        grading orchestration, snapshot pinning and receipt writes
   commands/          durable ledger, scheduling, dispatch, settlement
   gateway/           authorization policy boundary
   audit/             journals, outboxes, projections
   research/          autoresearch and multi-run research workflows
-  missions/          transitions, redaction-gated attempt claims, fenced orchestration
+  missions/          redaction-gated claims, fencing and orchestration
   sandboxes/         provider-neutral isolated execution and live-handle lifetime
   errors.py          cross-family application error contracts
   container.py       sole concrete cross-family wiring root
 ```
 
-Every family co-locates its protocols, safe models, and implementation. A
-family package exports only the contracts intended for other families. A
-generic `services/` bucket and a monolithic `app/interfaces.py` are prohibited;
-the architecture checker rejects edges that recreate them.
+Every application family co-locates its internal protocols, boundary models,
+and authority implementation. It imports reusable domain values from their
+top-level family once those values have moved. A generic `services/` bucket
+and a monolithic `app/interfaces.py` are prohibited; the architecture checker
+rejects edges that recreate them.
 
 The allowed outer-package direction is:
 
@@ -113,18 +150,28 @@ CLI              -> REST API over HTTP
 runtime          -> app.application contracts and safe models
 API              -> app.gateway contracts, safe models, and app errors
 gateway          -> app.application port plus auth/audit ports
-app families     -> approved lower app-family ports and core
+app families     -> top-level family contracts, approved app-family ports, core
+top-level family -> core and explicitly declared lower top-level families
 core             -> foundation and third-party libraries only
 ```
 
 Forbidden reverse edges include:
 
-- core importing app, runtime, API, CLI, or experiments;
-- app importing runtime, API, CLI, or experiments;
+- core importing app, runtime, API, CLI, or registered domain families;
+- a top-level family importing app, runtime, API, or CLI;
+- a top-level family importing another registered family without a declared
+  lower-family edge;
+- app importing runtime, API, or CLI;
 - runtime importing gateway, auth, concrete app services, or API;
 - API routes importing `RuntimeApplication` or concrete app services;
-- experiments importing the container or concrete app services; and
 - CLI command implementations bypassing HTTP.
+
+The proposed graph-family design in
+[PR #545](https://github.com/VangelisTech/archetype/pull/545) is a supporting
+design record, not a competing normative source. Its graph and projection
+stages ([#546](https://github.com/VangelisTech/archetype/issues/546) and
+[#547](https://github.com/VangelisTech/archetype/issues/547)) consume this
+package policy and register any reviewed family edge here before importing it.
 
 ### Observability dependency boundary
 
@@ -319,7 +366,15 @@ belongs to the workflow and its validators.
 Together, the repository's architecture and observability checkers must:
 
 - cover every declared source scope and fail if a required scope is empty;
-- enforce outer package and family dependency rules;
+- reject missing, stale, duplicate, or empty top-level family registrations;
+- require one exact cross-family dependency disposition for every registered
+  top-level family;
+- reject top-level-family imports of app, runtime, API, or CLI and reject
+  undeclared top-level family-to-family imports;
+- allow application authority to consume registered top-level family
+  contracts without treating that path as public-API promotion;
+- reject direct `Component` subclasses in any app-family `models.py`;
+- enforce the existing outer-package and application-family dependency rules;
 - confine `ActorCtx` to gateway/auth code and approved adapter construction;
 - restrict concrete cross-family construction to `container.py`;
 - reject concrete-service inheritance;
@@ -328,7 +383,8 @@ Together, the repository's architecture and observability checkers must:
 - confine provider/exporter and logging configuration to explicit process-host
   callables and require one exact observation disposition for every callable
   application-family protocol member;
-- support exact, owned migration exceptions with objective expiry conditions;
+- support only exact, issue-owned migration exceptions with release deadlines
+  and objective expiry conditions; wildcard package exceptions are invalid;
 - report the forbidden edge, governing rule, and supported alternative.
 
 Representative invalid fixtures prove every rule fires. Passing the current
@@ -342,9 +398,19 @@ evaluation ownership, and co-located protocols are implemented. Runtime calls
 do not fabricate `ActorCtx`; API routes depend on `iCommandGateway`; concrete
 services and the container are not top-level exports.
 
-`quality/architecture.toml` contains the complete allowed family DAG and zero
-migration exceptions. `scripts/check_architecture.py` enforces package
-direction, protocol imports, concrete construction, and concrete inheritance.
+`quality/architecture.toml` contains both the application-family DAG and the
+registered top-level family dispositions for `datasets`, `experiments`, and
+`htn`. `scripts/check_architecture.py` enforces their package direction,
+protocol imports, concrete construction, concrete inheritance, and persistent
+Component placement.
+
+The current reverse edges from provisional `archetype.experiments` and the
+current Components under app-family `models.py` are preserved only by exact
+migration entries. Evaluation, artifacts, and missions point to relocation
+issues #557, #558, and #559. Research and provisional experiment ownership
+point temporarily to design gate #561; every such expiry condition requires
+Issue #561 to replace itself with the concrete implementation issue it creates.
+These entries move no code and make no app symbol supported.
 
 Independent manifests under `quality/observability/` declare each family's
 operation dispositions. `scripts/check_observability.py` enforces their exact
@@ -403,7 +469,7 @@ family consumes only the mission-owned immutable execution authorization,
 callbacks, and recovery action; it does not import the claim service or storage
 catalog.
 
-Two deliberately retained implementation seams are documented rather than
+Other deliberately retained implementation seams are documented rather than
 hidden: `QueryService` uses `iAuditLog` for compatibility history reads, and
 the root `app/models.py` holds cross-family boundary models. Changing either is
 a separate contract/model-ownership decision, not undocumented drift.

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -377,6 +377,8 @@ Together, the repository's architecture and observability checkers must:
 - require one exact cross-family dependency disposition for every registered
   top-level family;
 - reject cycles in the complete registered top-level family graph;
+- derive core's ban on domain-family imports from that registry, so registering
+  a family cannot bypass the reverse-dependency rule;
 - reject top-level-family imports of app, runtime, API, or CLI and reject
   undeclared top-level family-to-family imports;
 - resolve root-facade package and symbol imports to their owning module before

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -96,7 +96,12 @@ only reviewed lower top-level family contracts declared in
 configure providers, exporters, storage backends, process hosts, or the
 service container. The application layer may import a registered top-level
 family contract; the reverse edge is forbidden. Undeclared top-level
-family-to-family dependencies are denied.
+family-to-family dependencies are denied. Every first-party package directly
+beneath `archetype` is classified as reserved infrastructure or registered as
+a domain family with one exact dependency disposition. Unclassified packages
+fail the architecture audit, and the complete registered family graph must be
+acyclic. Imports through the `archetype` root facade are resolved to the module
+that owns the exported package or symbol before these rules are applied.
 
 Naming states semantic ownership:
 
@@ -109,9 +114,9 @@ Naming states semantic ownership:
 - `service.py` contains application authority or orchestration.
 
 A `Component` is persistent ECS schema even though its implementation uses
-Pydantic. It is not an application DTO and does not belong in an app
-`models.py`. Conversely, a top-level path does not automatically make a symbol
-public. Supported names remain an explicit classification owned by
+Pydantic. It is not an application DTO and does not belong anywhere under
+`archetype.app`. Conversely, a top-level path does not automatically make a
+symbol public. Supported names remain an explicit classification owned by
 [API Stability](api-stability.md); concrete services and `ServiceContainer`
 remain internal.
 
@@ -367,13 +372,18 @@ Together, the repository's architecture and observability checkers must:
 
 - cover every declared source scope and fail if a required scope is empty;
 - reject missing, stale, duplicate, or empty top-level family registrations;
+- reject any first-party top-level package that lacks an explicit reserved-
+  infrastructure or registered-family classification;
 - require one exact cross-family dependency disposition for every registered
   top-level family;
+- reject cycles in the complete registered top-level family graph;
 - reject top-level-family imports of app, runtime, API, or CLI and reject
   undeclared top-level family-to-family imports;
+- resolve root-facade package and symbol imports to their owning module before
+  enforcing package direction;
 - allow application authority to consume registered top-level family
   contracts without treating that path as public-API promotion;
-- reject direct `Component` subclasses in any app-family `models.py`;
+- reject direct `Component` subclasses anywhere under `archetype.app`;
 - enforce the existing outer-package and application-family dependency rules;
 - confine `ActorCtx` to gateway/auth code and approved adapter construction;
 - restrict concrete cross-family construction to `container.py`;

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -96,12 +96,14 @@ only reviewed lower top-level family contracts declared in
 configure providers, exporters, storage backends, process hosts, or the
 service container. The application layer may import a registered top-level
 family contract; the reverse edge is forbidden. Undeclared top-level
-family-to-family dependencies are denied. Every first-party package directly
-beneath `archetype` is classified as reserved infrastructure or registered as
-a domain family with one exact dependency disposition. Unclassified packages
-fail the architecture audit, and the complete registered family graph must be
-acyclic. Imports through the `archetype` root facade are resolved to the module
-that owns the exported package or symbol before these rules are applied.
+family-to-family dependencies are denied. Every first-party package or module
+directly beneath `archetype` is classified as reserved infrastructure or
+registered as a domain family with one exact dependency disposition.
+Unclassified scopes fail the architecture audit, and the complete registered
+family graph must be acyclic. Imports through the `archetype` root facade are
+resolved to the module that owns the exported package or symbol before these
+rules are applied. If its static export map cannot be parsed exactly, the audit
+fails rather than degrading root-facade enforcement.
 
 Naming states semantic ownership:
 
@@ -372,8 +374,8 @@ Together, the repository's architecture and observability checkers must:
 
 - cover every declared source scope and fail if a required scope is empty;
 - reject missing, stale, duplicate, or empty top-level family registrations;
-- reject any first-party top-level package that lacks an explicit reserved-
-  infrastructure or registered-family classification;
+- reject any first-party top-level package or module that lacks an explicit
+  reserved-infrastructure or registered-family classification;
 - require one exact cross-family dependency disposition for every registered
   top-level family;
 - reject cycles in the complete registered top-level family graph;
@@ -383,6 +385,8 @@ Together, the repository's architecture and observability checkers must:
   undeclared top-level family-to-family imports;
 - resolve root-facade package and symbol imports to their owning module before
   enforcing package direction;
+- fail closed when the root-facade export map is missing a valid static
+  disposition for any declared entry;
 - allow application authority to consume registered top-level family
   contracts without treating that path as public-API promotion;
 - reject direct `Component` subclasses anywhere under `archetype.app`;

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -26,10 +26,10 @@ libraries, and only reviewed lower top-level family contracts declared in
 `quality/architecture.toml`. It never imports `archetype.app`,
 `archetype.runtime`, `archetype.api`, or `archetype.cli`. The application layer
 may consume top-level family contracts; the reverse edge is forbidden.
-Every first-party top-level package must be classified as reserved
+Every first-party top-level package or module must be classified as reserved
 infrastructure or registered as a family with one exact dependency
 disposition. The complete family graph is acyclic, and root-facade imports are
-checked against the package that owns the exported name.
+checked against the module that owns the exported name.
 
 Use semantic module names: `components.py` for persistent ECS schema,
 `processors.py` for processors, `contracts.py` for supported value contracts,

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -26,6 +26,10 @@ libraries, and only reviewed lower top-level family contracts declared in
 `quality/architecture.toml`. It never imports `archetype.app`,
 `archetype.runtime`, `archetype.api`, or `archetype.cli`. The application layer
 may consume top-level family contracts; the reverse edge is forbidden.
+Every first-party top-level package must be classified as reserved
+infrastructure or registered as a family with one exact dependency
+disposition. The complete family graph is acyclic, and root-facade imports are
+checked against the package that owns the exported name.
 
 Use semantic module names: `components.py` for persistent ECS schema,
 `processors.py` for processors, `contracts.py` for supported value contracts,

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -10,6 +10,30 @@ the problem, the relevant contract, the likely owner, and what will count as
 done. Direct commits remain appropriate for typo fixes and small documentation
 edits whose behavior is not in question.
 
+## Choose the Owning Package First
+
+Package location states architectural ownership before any symbol is exported:
+
+| Kind | Canonical location |
+|---|---|
+| Components, processors, pure DataFrame transforms, transition graphs, and reusable projections | `archetype.<family>` |
+| Supported family value contracts | `archetype.<family>.contracts` or another specifically named family module |
+| Durable authority, cross-family orchestration, internal service ports, and concrete implementations | `archetype.app.<family>` |
+| Transport, authentication, application facade, and composition | `archetype.api`, `archetype.app.gateway`, `archetype.app.application`, and `archetype.app.container` |
+
+A top-level family may depend on `archetype.core`, itself, third-party
+libraries, and only reviewed lower top-level family contracts declared in
+`quality/architecture.toml`. It never imports `archetype.app`,
+`archetype.runtime`, `archetype.api`, or `archetype.cli`. The application layer
+may consume top-level family contracts; the reverse edge is forbidden.
+
+Use semantic module names: `components.py` for persistent ECS schema,
+`processors.py` for processors, `contracts.py` for supported value contracts,
+`transitions.py` for pure typed transition graphs, `interfaces.py` for internal
+application ports, and `service.py` for application authority. A top-level
+location does not make every symbol public; supported exports remain explicit
+under [API Stability](api-stability.md).
+
 ## Source of Truth
 
 When repository sources disagree, use this order:
@@ -85,7 +109,8 @@ This repository is opinionated about where changes should land.
 | Area | Guidance |
 |---|---|
 | `src/archetype/core/` | Treat as curated and effectively read-only unless the change has been explicitly approved |
-| `src/archetype/app/` | Internal implementation layer; extend carefully behind the supported runtime or adapter boundary |
+| `src/archetype/<family>/` | Reusable domain state and pure behavior; obey the declared top-level family DAG |
+| `src/archetype/app/` | Internal application authority and orchestration; extend carefully behind the supported runtime or adapter boundary |
 | `src/archetype/api/`, `src/archetype/cli/`, `docs/`, `examples/`, `tests/` | Good contribution targets |
 
 If you are proposing a core behavior change, you should document the contract

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -13,6 +13,9 @@ purpose and active mapping of each family port.
 
 Application protocols are internal dependency boundaries unless a focused
 specification explicitly promotes one. Importability does not make them public.
+Their value types may live in a supported top-level domain family without
+promoting the protocol, its implementation, or the service container. Port
+ownership and value-contract ownership are separate decisions.
 
 Every active protocol has:
 
@@ -232,25 +235,38 @@ uses the injected admission callback rather than importing the claim service.
 It emits typed phase evidence without importing Modal, Apple Container, or
 another provider SDK. See [Sandbox Execution](sandbox-execution.md).
 
-## 5. Models crossing families
+## 5. Values crossing family ports
 
-Cross-family models are immutable or frozen where identity matters. The root
-`app/models.py` intentionally owns command envelopes and broadly shared
-runtime/application result records. Family-specific models remain with their
-owners:
+Cross-family values are immutable or frozen where identity matters, but their
+Python modeling technology does not decide their layer. Persistent ECS schema
+is a `Component` and belongs in `archetype.<family>.components`. Supported
+reusable Pydantic/dataclass values belong in the top-level family's
+`contracts.py` or another specifically named family module. Application
+commands, authority records, backend state, authorization values, and service
+ports remain under `archetype.app.<family>`.
 
-- artifact descriptors and receipts: `app/artifacts/models.py`;
-- artifact bundle requests and publication receipts: `app/artifacts/bundle_models.py`;
-- mission facts, attempt requests, and typed states: `app/missions/`;
-- redaction policy configuration, safe receipts, and quarantine errors: `app/redaction/models.py`;
-- evaluation contracts, outcomes, and receipts: `app/evaluation/models.py`;
-- research contracts and ledger components: `app/research/`;
-- audit access events: `app/audit/models.py`;
-- public cross-family errors: `app/errors.py`.
-- sandbox validator, phase, command, checkpoint, and handoff values:
-  `app/sandboxes/models.py`.
+An internal app protocol may therefore accept or return a top-level family
+value. The protocol still lives in `archetype.app.<family>.interfaces`, its
+concrete service remains internal, and `ServiceContainer` remains unsupported.
+The top-level family never imports that port in return. Public classification
+is explicit and is not inferred from either side of the annotation.
 
-No app model is owned by the outward `experiments` package.
+Current paths that predate this rule are migration state, not alternate
+ownership:
+
+- evaluation receipt Components and value contracts move under #557;
+- artifact Components and reusable bundle/value contracts move under #558;
+- mission Components and pure world-transition definitions move under #559;
+- research ledger Components and provisional experiment dependencies await the
+  #561 design gate, which must replace its temporary architecture entries with
+  concrete implementation issues before it closes; and
+- the root `app/models.py` boundary-model split remains owned by #560.
+
+The exact temporary edges are recorded in `quality/architecture.toml`; no
+wildcard compatibility package is implied. Redaction, audit, sandbox,
+command, world, and other authority-specific models remain with their app
+owners unless a focused specification classifies an individual value as a
+reusable family contract.
 
 ## 6. Construction and shutdown
 

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -1,4 +1,4 @@
-version = 2
+version = 3
 source_root = "src"
 
 [concrete_services]
@@ -30,6 +30,32 @@ composition_roots = [
   "archetype.runtime.runtime",
 ]
 
+[top_level_family_policy]
+forbidden_outward = [
+  "archetype.app",
+  "archetype.runtime",
+  "archetype.api",
+  "archetype.cli",
+]
+
+# Top-level domain families may import core and themselves implicitly. Every
+# reviewed family-to-family edge must name the exact lower family here.
+
+[[top_level_family_rule]]
+name = "datasets-domain-family"
+consumer = "archetype.datasets"
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "experiments-domain-family"
+consumer = "archetype.experiments"
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "htn-domain-family"
+consumer = "archetype.htn"
+allowed_families = []
+
 [[package_rule]]
 name = "core-does-not-import-outward"
 consumer = "archetype.core"
@@ -38,7 +64,9 @@ forbidden = [
   "archetype.runtime",
   "archetype.api",
   "archetype.cli",
+  "archetype.datasets",
   "archetype.experiments",
+  "archetype.htn",
 ]
 
 [[package_rule]]
@@ -48,7 +76,6 @@ forbidden = [
   "archetype.runtime",
   "archetype.api",
   "archetype.cli",
-  "archetype.experiments",
 ]
 
 # Family rules apply to every module in the package, not only service.py.
@@ -415,3 +442,226 @@ allowed_app = [
   "archetype.app.gateway.auth.models",
   "archetype.app.models",
 ]
+
+# Exact migration edges. These preserve current behavior while the sequenced
+# family relocations move each definition once, without compatibility copies.
+
+[[exception]]
+rule = "top_level_family_outward_dependency"
+consumer = "archetype.experiments"
+target = "archetype.app.research.models"
+owner = "experiments"
+issue = 561
+reason = "The provisional experiments package re-exports research ledger components from app."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue eliminates the reverse import."
+expires = "v0.5"
+
+[[exception]]
+rule = "top_level_family_outward_dependency"
+consumer = "archetype.experiments.loaders"
+target = "archetype.app.research.models"
+owner = "experiments"
+issue = 561
+reason = "The provisional runner-state loader imports the app-owned Run component."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue gives the loader a top-level domain owner."
+expires = "v0.5"
+
+[[exception]]
+rule = "top_level_family_outward_dependency"
+consumer = "archetype.experiments.recorders"
+target = "archetype.app.models"
+owner = "experiments"
+issue = 561
+reason = "The provisional recorder imports application command and episode result models."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue separates domain recording from app boundaries."
+expires = "v0.5"
+
+[[exception]]
+rule = "top_level_family_outward_dependency"
+consumer = "archetype.experiments.eval_rollouts"
+target = "archetype.app.models"
+owner = "experiments"
+issue = 561
+reason = "The provisional rollout helper imports an application episode contract."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue assigns the helper a non-reverse dependency boundary."
+expires = "v0.5"
+
+[[exception]]
+rule = "top_level_family_outward_dependency"
+consumer = "archetype.experiments.eval_rollouts"
+target = "archetype.runtime"
+owner = "experiments"
+issue = 561
+reason = "The provisional rollout helper carries a type-only runtime dependency."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue replaces the runtime type with an inward domain port."
+expires = "v0.5"
+
+[[exception]]
+rule = "top_level_family_outward_dependency"
+consumer = "archetype.experiments.instruction_sweep"
+target = "archetype.app.models"
+owner = "experiments"
+issue = 561
+reason = "The provisional instruction sweep imports an application episode contract."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue assigns the sweep a non-reverse dependency boundary."
+expires = "v0.5"
+
+[[exception]]
+rule = "top_level_family_outward_dependency"
+consumer = "archetype.experiments.instruction_sweep"
+target = "archetype.runtime"
+owner = "experiments"
+issue = 561
+reason = "The provisional instruction sweep carries a type-only runtime dependency."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue replaces the runtime type with an inward domain port."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.evaluation.models"
+target = "archetype.app.evaluation.models.EvalReceipt"
+owner = "evaluation"
+issue = 557
+reason = "EvalReceipt is persistent ECS schema still colocated with evaluation app authority."
+expiry_condition = "Remove when #557 moves EvalReceipt to archetype.evaluation.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.artifacts.models"
+target = "archetype.app.artifacts.models.ArtifactMeta"
+owner = "artifacts"
+issue = 558
+reason = "ArtifactMeta is persistent ECS schema still colocated with artifact app authority."
+expiry_condition = "Remove when #558 moves ArtifactMeta to archetype.artifacts.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.artifacts.models"
+target = "archetype.app.artifacts.models.AssetRef"
+owner = "artifacts"
+issue = 558
+reason = "AssetRef is persistent ECS schema still colocated with artifact app authority."
+expiry_condition = "Remove when #558 moves AssetRef to archetype.artifacts.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.missions.models"
+target = "archetype.app.missions.models.Mission"
+owner = "missions"
+issue = 559
+reason = "Mission is persistent ECS schema still colocated with mission app authority."
+expiry_condition = "Remove when #559 moves Mission to archetype.missions.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.missions.models"
+target = "archetype.app.missions.models.TaskGate"
+owner = "missions"
+issue = 559
+reason = "TaskGate is persistent ECS schema still colocated with mission app authority."
+expiry_condition = "Remove when #559 moves TaskGate to archetype.missions.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.missions.models"
+target = "archetype.app.missions.models.Attempt"
+owner = "missions"
+issue = 559
+reason = "Attempt is persistent ECS schema still colocated with mission app authority."
+expiry_condition = "Remove when #559 moves Attempt to archetype.missions.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.missions.models"
+target = "archetype.app.missions.models.Checkpoint"
+owner = "missions"
+issue = 559
+reason = "Checkpoint is persistent ECS schema still colocated with mission app authority."
+expiry_condition = "Remove when #559 moves Checkpoint to archetype.missions.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.missions.models"
+target = "archetype.app.missions.models.Finalization"
+owner = "missions"
+issue = 559
+reason = "Finalization is persistent ECS schema still colocated with mission app authority."
+expiry_condition = "Remove when #559 moves Finalization to archetype.missions.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.missions.models"
+target = "archetype.app.missions.models.Commit"
+owner = "missions"
+issue = 559
+reason = "Commit is persistent ECS schema still colocated with mission app authority."
+expiry_condition = "Remove when #559 moves Commit to archetype.missions.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.missions.models"
+target = "archetype.app.missions.models.Evidence"
+owner = "missions"
+issue = 559
+reason = "Evidence is persistent ECS schema still colocated with mission app authority."
+expiry_condition = "Remove when #559 moves Evidence to archetype.missions.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.missions.models"
+target = "archetype.app.missions.models.FrictionLog"
+owner = "missions"
+issue = 559
+reason = "FrictionLog is persistent ECS schema still colocated with mission app authority."
+expiry_condition = "Remove when #559 moves FrictionLog to archetype.missions.components without duplicating its class identity."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.research.models"
+target = "archetype.app.research.models.Experiment"
+owner = "research"
+issue = 561
+reason = "Experiment is persistent ECS schema whose final family awaits the research design gate."
+expiry_condition = "Before #561 closes, replace this entry with the concrete implementation issue created by that design; remove it when that issue gives Experiment a top-level family owner."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.research.models"
+target = "archetype.app.research.models.Run"
+owner = "research"
+issue = 561
+reason = "Run is persistent ECS schema whose final family awaits the research design gate."
+expiry_condition = "Before #561 closes, replace this entry with the concrete implementation issue created by that design; remove it when that issue gives Run a top-level family owner."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.research.models"
+target = "archetype.app.research.models.Result"
+owner = "research"
+issue = 561
+reason = "Result is persistent ECS schema whose final family awaits the research design gate."
+expiry_condition = "Before #561 closes, replace this entry with the concrete implementation issue created by that design; remove it when that issue gives Result a top-level family owner."
+expires = "v0.5"
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.research.models"
+target = "archetype.app.research.models.BranchHead"
+owner = "research"
+issue = 561
+reason = "BranchHead is persistent ECS schema whose final family awaits the research design gate."
+expiry_condition = "Before #561 closes, replace this entry with the concrete implementation issue created by that design; remove it when that issue gives BranchHead a top-level family owner."
+expires = "v0.5"

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -69,14 +69,13 @@ allowed_families = []
 [[package_rule]]
 name = "core-does-not-import-outward"
 consumer = "archetype.core"
+# The checker adds every registered top-level family to this forbidden set.
+# Keep the registry as the single source of truth for domain-family scopes.
 forbidden = [
   "archetype.app",
   "archetype.runtime",
   "archetype.api",
   "archetype.cli",
-  "archetype.datasets",
-  "archetype.experiments",
-  "archetype.htn",
 ]
 
 [[package_rule]]

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -38,6 +38,10 @@ forbidden_outward = [
   "archetype.cli",
 ]
 reserved_infrastructure = [
+  "archetype._api",
+  "archetype._logging",
+  "archetype._obs",
+  "archetype._storage_uri",
   "archetype.api",
   "archetype.app",
   "archetype.cli",
@@ -46,10 +50,10 @@ reserved_infrastructure = [
   "archetype.runtime",
 ]
 
-# Every first-party top-level package is classified above or registered as a
-# domain family below. Domain families may import core and themselves
-# implicitly. Every reviewed family-to-family edge must name the exact lower
-# family here, and the complete graph must remain acyclic.
+# Every first-party top-level package or module is classified above or
+# registered as a domain family below. Domain families may import core and
+# themselves implicitly. Every reviewed family-to-family edge must name the
+# exact lower family here, and the complete graph must remain acyclic.
 
 [[top_level_family_rule]]
 name = "datasets-domain-family"

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -37,9 +37,19 @@ forbidden_outward = [
   "archetype.api",
   "archetype.cli",
 ]
+reserved_infrastructure = [
+  "archetype.api",
+  "archetype.app",
+  "archetype.cli",
+  "archetype.contrib",
+  "archetype.core",
+  "archetype.runtime",
+]
 
-# Top-level domain families may import core and themselves implicitly. Every
-# reviewed family-to-family edge must name the exact lower family here.
+# Every first-party top-level package is classified above or registered as a
+# domain family below. Domain families may import core and themselves
+# implicitly. Every reviewed family-to-family edge must name the exact lower
+# family here, and the complete graph must remain acyclic.
 
 [[top_level_family_rule]]
 name = "datasets-domain-family"
@@ -514,6 +524,26 @@ owner = "experiments"
 issue = 561
 reason = "The provisional instruction sweep carries a type-only runtime dependency."
 expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue replaces the runtime type with an inward domain port."
+expires = "v0.5"
+
+[[exception]]
+rule = "top_level_family_dependency"
+consumer = "archetype.experiments.eval_rollouts"
+target = "archetype._api"
+owner = "experiments"
+issue = 561
+reason = "The provisional rollout helper imports the root public-API marker from infrastructure."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue assigns public classification without a domain-to-infrastructure edge."
+expires = "v0.5"
+
+[[exception]]
+rule = "top_level_family_dependency"
+consumer = "archetype.experiments.instruction_sweep"
+target = "archetype._api"
+owner = "experiments"
+issue = 561
+reason = "The provisional instruction sweep imports the root public-API marker from infrastructure."
+expiry_condition = "Before #561 closes, replace this design-gate entry with its concrete implementation issue; remove it when that issue assigns public classification without a domain-to-infrastructure edge."
 expires = "v0.5"
 
 [[exception]]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -98,9 +98,18 @@ def _imports(
     root_scopes: frozenset[str],
 ) -> list[tuple[str, int]]:
     found: list[tuple[str, int]] = []
+    root_bindings = {
+        alias.asname or "archetype"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+        if alias.name == "archetype"
+    }
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            found.extend((alias.name, node.lineno) for alias in node.names)
+            found.extend(
+                (alias.name, node.lineno) for alias in node.names if alias.name != "archetype"
+            )
         elif isinstance(node, ast.ImportFrom):
             module = _resolve_import_from(node, consumer, is_package)
             if module != "archetype":
@@ -124,6 +133,23 @@ def _imports(
                     # Unknown root names remain first-party dependencies and
                     # are denied by registered-family default-deny handling.
                     found.append((candidate, node.lineno))
+        elif isinstance(node, ast.Attribute) and root_bindings:
+            dotted = _dotted_name(node)
+            binding, separator, attribute_path = dotted.partition(".")
+            if not separator or binding not in root_bindings:
+                continue
+            root_name = attribute_path.split(".", 1)[0]
+            owner = root_export_owners.get(root_name)
+            candidate = f"archetype.{root_name}"
+            if owner:
+                found.append((owner, node.lineno))
+            elif candidate in root_scopes:
+                found.append((candidate, node.lineno))
+            else:
+                # Attribute access after a bare root import is another root-
+                # facade dependency form. Keep unknown names first-party so
+                # registered-family default deny remains exhaustive.
+                found.append((candidate, node.lineno))
     return found
 
 
@@ -693,8 +719,14 @@ def audit_repository(
         for rule in package_rules:
             if not _matches_prefix(consumer, str(rule["consumer"])):
                 continue
+            forbidden = {str(prefix) for prefix in rule["forbidden"]}
+            if policy_version >= 3 and str(rule["consumer"]) == "archetype.core":
+                # The domain-family registry is the source of truth for the
+                # foundation's reverse-dependency ban. A newly registered
+                # family must be forbidden without a second manifest edit.
+                forbidden.update(registered_family_scopes)
             for dependency, line in imports:
-                if any(_matches_prefix(dependency, str(prefix)) for prefix in rule["forbidden"]):
+                if any(_matches_prefix(dependency, prefix) for prefix in forbidden):
                     _add_once(
                         findings,
                         seen,

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -25,6 +25,9 @@ TOP_LEVEL_FAMILY_OUTWARD_PACKAGES = frozenset(
     }
 )
 REQUIRED_TOP_LEVEL_INFRASTRUCTURE = TOP_LEVEL_FAMILY_OUTWARD_PACKAGES | {"archetype.core"}
+ROOT_EXPORT_POLICY_ERROR = (
+    "unable to statically parse archetype._EXPORTS; root-facade import enforcement is degraded"
+)
 COMPONENT_BASES = frozenset(
     {
         "archetype.Component",
@@ -211,24 +214,27 @@ def _source_files(source_root: Path) -> list[Path]:
     return sorted(path for path in source_root.rglob("*.py") if path.is_file())
 
 
-def _top_level_package_scopes(source_root: Path) -> frozenset[str]:
+def _top_level_first_party_scopes(source_root: Path) -> frozenset[str]:
     package_root = source_root / "archetype"
     if not package_root.is_dir():
         return frozenset()
-    return frozenset(
-        f"archetype.{path.name}"
-        for path in package_root.iterdir()
-        if path.is_dir()
-        and not path.name.startswith(".")
-        and any(candidate.is_file() for candidate in path.rglob("*.py"))
-    )
+    scopes: set[str] = set()
+    for path in package_root.iterdir():
+        if path.is_dir():
+            if not path.name.startswith(".") and any(
+                candidate.is_file() for candidate in path.rglob("*.py")
+            ):
+                scopes.add(f"archetype.{path.name}")
+        elif path.is_file() and path.suffix == ".py" and path.name != "__init__.py":
+            scopes.add(f"archetype.{path.stem}")
+    return frozenset(scopes)
 
 
-def _root_export_owners(tree: ast.AST | None) -> dict[str, str]:
+def _root_export_owners(tree: ast.AST | None) -> tuple[dict[str, str], str | None]:
     """Read the lazy root-facade export map without importing the package."""
 
     if tree is None:
-        return {}
+        return {}, None
     for node in getattr(tree, "body", []):
         value: ast.AST | None = None
         if (
@@ -246,20 +252,22 @@ def _root_export_owners(tree: ast.AST | None) -> dict[str, str]:
         try:
             exports = ast.literal_eval(value)
         except (TypeError, ValueError):
-            return {}
+            return {}, ROOT_EXPORT_POLICY_ERROR
         if not isinstance(exports, dict):
-            return {}
+            return {}, ROOT_EXPORT_POLICY_ERROR
         owners: dict[str, str] = {}
         for name, export in exports.items():
-            if (
+            if not (
                 isinstance(name, str)
+                and bool(name)
                 and isinstance(export, tuple)
                 and len(export) == 2
-                and isinstance(export[0], str)
+                and all(isinstance(value, str) and bool(value) for value in export)
             ):
-                owners[name] = export[0]
-        return owners
-    return {}
+                return {}, ROOT_EXPORT_POLICY_ERROR
+            owners[name] = export[0]
+        return owners, None
+    return {}, ROOT_EXPORT_POLICY_ERROR
 
 
 def _load_policy(policy_path: Path) -> dict[str, Any]:
@@ -358,10 +366,12 @@ def audit_repository(
             path.name == "__init__.py",
         )
 
-    actual_top_level_packages = _top_level_package_scopes(source_root)
+    actual_top_level_scopes = _top_level_first_party_scopes(source_root)
     root_tree = parsed.get("archetype", (None, None, False))[1]
-    root_export_owners = _root_export_owners(root_tree)
-    first_party_root_scopes = actual_top_level_packages | frozenset(
+    root_export_owners, root_export_error = _root_export_owners(root_tree)
+    if root_export_error is not None:
+        result.policy_errors.append(root_export_error)
+    first_party_root_scopes = actual_top_level_scopes | frozenset(
         module for module in parsed if module.startswith("archetype.") and module.count(".") == 1
     )
 
@@ -560,12 +570,12 @@ def audit_repository(
                 "top-level scopes classified as both family and reserved infrastructure: "
                 + ", ".join(overlapping_scopes)
             )
-        unclassified_packages = sorted(
-            actual_top_level_packages - registered_family_scopes - reserved_infrastructure
+        unclassified_scopes = sorted(
+            actual_top_level_scopes - registered_family_scopes - reserved_infrastructure
         )
-        if unclassified_packages:
+        if unclassified_scopes:
             result.policy_errors.append(
-                "unclassified first-party top-level packages: " + ", ".join(unclassified_packages)
+                "unclassified first-party top-level scopes: " + ", ".join(unclassified_scopes)
             )
 
         graph = {

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -16,6 +16,21 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_POLICY = ROOT / "quality" / "architecture.toml"
+TOP_LEVEL_FAMILY_OUTWARD_PACKAGES = frozenset(
+    {
+        "archetype.app",
+        "archetype.runtime",
+        "archetype.api",
+        "archetype.cli",
+    }
+)
+COMPONENT_BASES = frozenset(
+    {
+        "archetype.Component",
+        "archetype.core.Component",
+        "archetype.core.component.Component",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -146,9 +161,33 @@ def _source_files(source_root: Path) -> list[Path]:
 def _load_policy(policy_path: Path) -> dict[str, Any]:
     with policy_path.open("rb") as handle:
         policy = tomllib.load(handle)
-    if policy.get("version") not in {1, 2}:
-        raise ValueError("architecture policy version must be 1 or 2")
+    if policy.get("version") not in {1, 2, 3}:
+        raise ValueError("architecture policy version must be 1, 2, or 3")
     return policy
+
+
+def _top_level_family_imports(
+    tree: ast.AST,
+    consumer: str,
+    is_package: bool,
+    relevant_scopes: frozenset[str],
+) -> list[tuple[str, int]]:
+    """Return imports relevant to registered top-level-family boundaries."""
+
+    found = _imports(tree, consumer, is_package)
+    root_packages = {scope.partition(".")[2] for scope in relevant_scopes}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        module = _resolve_import_from(node, consumer, is_package)
+        if module != "archetype":
+            continue
+        found.extend(
+            (f"archetype.{alias.name}", node.lineno)
+            for alias in node.names
+            if alias.name in root_packages
+        )
+    return found
 
 
 def _release_version(value: str) -> tuple[int, int, int] | None:
@@ -203,8 +242,13 @@ def audit_repository(
             path.name == "__init__.py",
         )
 
+    policy_version = int(policy["version"])
     package_rules = policy.get("package_rule", [])
     family_rules = policy.get("family_rule", [])
+    top_level_family_rules = policy.get("top_level_family_rule", [])
+    if not isinstance(top_level_family_rules, list):
+        result.policy_errors.append("top_level_family_rule must be an array of tables")
+        top_level_family_rules = []
     module_rules = policy.get("module_rule", [])
     concrete = policy.get("concrete_services", {})
     concrete_values = [str(value) for value in concrete.get("types", [])]
@@ -212,6 +256,144 @@ def audit_repository(
     composition_roots = set(concrete.get("composition_roots", []))
     if len(concrete_values) != len(concrete_types):
         result.policy_errors.append("concrete_services.types contains duplicate entries")
+
+    top_level_family_config = policy.get("top_level_family_policy", {})
+    if not isinstance(top_level_family_config, dict):
+        result.policy_errors.append("top_level_family_policy must be a table")
+        top_level_family_config = {}
+    configured_outward = top_level_family_config.get("forbidden_outward", [])
+    if not isinstance(configured_outward, list):
+        result.policy_errors.append("top_level_family_policy.forbidden_outward must be a list")
+        configured_outward = []
+    outward_values = [str(value).strip() for value in configured_outward]
+    outward_packages = frozenset(value for value in outward_values if value)
+    if len(outward_values) != len(outward_packages):
+        result.policy_errors.append(
+            "top_level_family_policy.forbidden_outward contains empty or duplicate entries"
+        )
+    invalid_outward = sorted(
+        value
+        for value in outward_packages
+        if re.fullmatch(r"archetype\.[A-Za-z_][A-Za-z0-9_]*", value) is None
+    )
+    if invalid_outward:
+        result.policy_errors.append(
+            "top_level_family_policy.forbidden_outward has non-top-level scopes: "
+            + ", ".join(invalid_outward)
+        )
+    if policy_version >= 3:
+        missing_outward = sorted(TOP_LEVEL_FAMILY_OUTWARD_PACKAGES - outward_packages)
+        if missing_outward:
+            result.policy_errors.append(
+                "top_level_family_policy.forbidden_outward omits required packages: "
+                + ", ".join(missing_outward)
+            )
+        if not top_level_family_rules:
+            result.policy_errors.append("architecture policy registers no top-level family scopes")
+    if not outward_packages:
+        outward_packages = TOP_LEVEL_FAMILY_OUTWARD_PACKAGES
+
+    top_level_family_names: set[str] = set()
+    top_level_family_scopes: dict[str, frozenset[str]] = {}
+    pending_allowed_families: dict[str, list[str]] = {}
+    reserved_family_scopes = TOP_LEVEL_FAMILY_OUTWARD_PACKAGES | {"archetype.core"}
+    for index, rule in enumerate(top_level_family_rules):
+        name = str(rule.get("name", "")).strip()
+        label = repr(name) if name else f"at index {index}"
+        if not name:
+            result.policy_errors.append(f"top-level family rule {label} has an empty name")
+        elif name in top_level_family_names:
+            result.policy_errors.append(f"duplicate top-level family rule name: {name}")
+        else:
+            top_level_family_names.add(name)
+
+        if "consumer" not in rule:
+            result.policy_errors.append(
+                f"top-level family rule {label} is missing its consumer scope"
+            )
+            continue
+        consumer_scope = str(rule.get("consumer", "")).strip()
+        if not consumer_scope:
+            result.policy_errors.append(
+                f"top-level family rule {label} has an empty consumer scope"
+            )
+            continue
+        if re.fullmatch(r"archetype\.[A-Za-z_][A-Za-z0-9_]*", consumer_scope) is None:
+            result.policy_errors.append(
+                f"top-level family rule {label} has non-top-level scope: {consumer_scope}"
+            )
+            continue
+        if consumer_scope in reserved_family_scopes:
+            result.policy_errors.append(
+                f"top-level family rule {label} uses reserved scope: {consumer_scope}"
+            )
+            continue
+        if consumer_scope in top_level_family_scopes:
+            result.policy_errors.append(f"duplicate top-level family scope: {consumer_scope}")
+            continue
+
+        matched = [
+            tree
+            for module, (_path, tree, _is_package) in parsed.items()
+            if _matches_prefix(module, consumer_scope)
+        ]
+        if not matched:
+            result.policy_errors.append(
+                f"top-level family rule {label} references stale scope: {consumer_scope}"
+            )
+        elif not any(getattr(tree, "body", []) for tree in matched):
+            result.policy_errors.append(
+                f"top-level family rule {label} matched an empty source scope: {consumer_scope}"
+            )
+
+        if "allowed_families" not in rule:
+            result.policy_errors.append(
+                f"top-level family rule {label} lacks an exact allowed_families disposition"
+            )
+            allowed_values: list[Any] = []
+        else:
+            configured_allowed = rule.get("allowed_families")
+            if not isinstance(configured_allowed, list):
+                result.policy_errors.append(
+                    f"top-level family rule {label} allowed_families must be a list"
+                )
+                allowed_values = []
+            else:
+                allowed_values = configured_allowed
+        allowed_families = [str(value).strip() for value in allowed_values]
+        if any(not value for value in allowed_families):
+            result.policy_errors.append(
+                f"top-level family rule {label} has an empty allowed family scope"
+            )
+        if len(allowed_families) != len(set(allowed_families)):
+            result.policy_errors.append(
+                f"top-level family rule {label} has duplicate allowed family scopes"
+            )
+        top_level_family_scopes[consumer_scope] = frozenset()
+        pending_allowed_families[consumer_scope] = allowed_families
+
+    registered_family_scopes = frozenset(top_level_family_scopes)
+    for consumer_scope, allowed_values in pending_allowed_families.items():
+        label = next(
+            (
+                str(rule.get("name", consumer_scope))
+                for rule in top_level_family_rules
+                if str(rule.get("consumer", "")).strip() == consumer_scope
+            ),
+            consumer_scope,
+        )
+        allowed = frozenset(value for value in allowed_values if value)
+        unknown = sorted(allowed - registered_family_scopes)
+        if unknown:
+            result.policy_errors.append(
+                f"top-level family rule {label!r} allows unregistered family scopes: "
+                + ", ".join(unknown)
+            )
+        if consumer_scope in allowed:
+            result.policy_errors.append(
+                f"top-level family rule {label!r} redundantly allows its own scope"
+            )
+        top_level_family_scopes[consumer_scope] = allowed
 
     for rule in package_rules:
         consumer_prefix = str(rule["consumer"])
@@ -271,6 +453,67 @@ def audit_repository(
     seen: set[tuple[str, str, str]] = set()
     for consumer, (path, tree, is_package) in parsed.items():
         imports = _imports(tree, consumer, is_package)
+
+        consumer_family_scope = next(
+            (scope for scope in registered_family_scopes if _matches_prefix(consumer, scope)),
+            None,
+        )
+        if consumer_family_scope is not None:
+            allowed_families = top_level_family_scopes[consumer_family_scope]
+            family_imports = _top_level_family_imports(
+                tree,
+                consumer,
+                is_package,
+                registered_family_scopes | outward_packages,
+            )
+            for dependency, line in family_imports:
+                if any(_matches_prefix(dependency, prefix) for prefix in outward_packages):
+                    _add_once(
+                        findings,
+                        seen,
+                        Violation(
+                            rule="top_level_family_outward_dependency",
+                            consumer=consumer,
+                            target=dependency,
+                            path=path,
+                            line=line,
+                            detail=(
+                                f"{consumer} imports outward package {dependency}; "
+                                "top-level domain families may depend only on core, "
+                                "themselves, and declared lower family contracts"
+                            ),
+                        ),
+                    )
+                    continue
+
+                dependency_family_scope = next(
+                    (
+                        scope
+                        for scope in registered_family_scopes
+                        if _matches_prefix(dependency, scope)
+                    ),
+                    None,
+                )
+                if dependency_family_scope in {None, consumer_family_scope}:
+                    continue
+                if dependency_family_scope in allowed_families:
+                    continue
+                _add_once(
+                    findings,
+                    seen,
+                    Violation(
+                        rule="top_level_family_dependency",
+                        consumer=consumer,
+                        target=dependency,
+                        path=path,
+                        line=line,
+                        detail=(
+                            f"{consumer} imports undeclared top-level family "
+                            f"{dependency}; declare the reviewed lower-family contract "
+                            "edge in quality/architecture.toml"
+                        ),
+                    ),
+                )
 
         for rule in package_rules:
             if not _matches_prefix(consumer, str(rule["consumer"])):
@@ -386,6 +629,27 @@ def audit_repository(
                     )
 
             elif isinstance(node, ast.ClassDef):
+                if _matches_prefix(consumer, "archetype.app") and path.name == "models.py":
+                    for base in node.bases:
+                        if _resolved_name(base, bindings) not in COMPONENT_BASES:
+                            continue
+                        _add_once(
+                            findings,
+                            seen,
+                            Violation(
+                                rule="app_component_model",
+                                consumer=consumer,
+                                target=f"{consumer}.{node.name}",
+                                path=path,
+                                line=node.lineno,
+                                detail=(
+                                    f"{consumer}.{node.name} is a persistent Component "
+                                    "declared in an application models.py; move reusable ECS "
+                                    "schema to archetype.<family>.components"
+                                ),
+                            ),
+                        )
+
                 for base in node.bases:
                     target = _resolved_name(base, bindings).rsplit(".", 1)[-1]
                     if target in concrete_types:
@@ -453,15 +717,28 @@ def audit_repository(
         if key in declared:
             result.policy_errors.append(f"duplicate architecture exception: {key}")
             continue
+        if policy_version >= 3 and any("*" in coordinate for coordinate in key):
+            result.policy_errors.append(
+                f"architecture exception {key} uses a wildcard instead of an exact edge"
+            )
+        required_metadata = ["owner", "reason", "expires"]
+        if policy_version >= 3:
+            required_metadata.extend(["issue", "expiry_condition"])
         missing_metadata = [
             field_name
-            for field_name in ("owner", "reason", "expires")
+            for field_name in required_metadata
             if not str(exception.get(field_name, "")).strip()
         ]
         if missing_metadata:
             result.policy_errors.append(
                 f"architecture exception {key} lacks {', '.join(missing_metadata)}"
             )
+        if policy_version >= 3 and "issue" in exception:
+            issue = exception.get("issue")
+            if isinstance(issue, bool) or not isinstance(issue, int) or issue <= 0:
+                result.policy_errors.append(
+                    f"architecture exception {key} has invalid tracking issue: {issue!r}"
+                )
         expires = _release_version(str(exception.get("expires", "")))
         if expires is None:
             result.policy_errors.append(

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -24,6 +24,7 @@ TOP_LEVEL_FAMILY_OUTWARD_PACKAGES = frozenset(
         "archetype.cli",
     }
 )
+REQUIRED_TOP_LEVEL_INFRASTRUCTURE = TOP_LEVEL_FAMILY_OUTWARD_PACKAGES | {"archetype.core"}
 COMPONENT_BASES = frozenset(
     {
         "archetype.Component",
@@ -88,15 +89,41 @@ def _resolve_import_from(node: ast.ImportFrom, consumer: str, is_package: bool) 
     return ".".join(parts)
 
 
-def _imports(tree: ast.AST, consumer: str, is_package: bool) -> list[tuple[str, int]]:
+def _imports(
+    tree: ast.AST,
+    consumer: str,
+    is_package: bool,
+    *,
+    root_export_owners: dict[str, str],
+    root_scopes: frozenset[str],
+) -> list[tuple[str, int]]:
     found: list[tuple[str, int]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             found.extend((alias.name, node.lineno) for alias in node.names)
         elif isinstance(node, ast.ImportFrom):
             module = _resolve_import_from(node, consumer, is_package)
-            if module:
-                found.append((module, node.lineno))
+            if module != "archetype":
+                if module:
+                    found.append((module, node.lineno))
+                continue
+
+            # Root-facade imports must receive the same disposition as their
+            # owning modules. Python also permits ``from archetype import app``
+            # for package attributes, so resolve both lazy public exports and
+            # first-party root modules/packages here for every architecture
+            # rule, not only the top-level-family rules.
+            for alias in node.names:
+                owner = root_export_owners.get(alias.name)
+                candidate = f"archetype.{alias.name}"
+                if owner:
+                    found.append((owner, node.lineno))
+                elif candidate in root_scopes:
+                    found.append((candidate, node.lineno))
+                else:
+                    # Unknown root names remain first-party dependencies and
+                    # are denied by registered-family default-deny handling.
+                    found.append((candidate, node.lineno))
     return found
 
 
@@ -158,6 +185,57 @@ def _source_files(source_root: Path) -> list[Path]:
     return sorted(path for path in source_root.rglob("*.py") if path.is_file())
 
 
+def _top_level_package_scopes(source_root: Path) -> frozenset[str]:
+    package_root = source_root / "archetype"
+    if not package_root.is_dir():
+        return frozenset()
+    return frozenset(
+        f"archetype.{path.name}"
+        for path in package_root.iterdir()
+        if path.is_dir()
+        and not path.name.startswith(".")
+        and any(candidate.is_file() for candidate in path.rglob("*.py"))
+    )
+
+
+def _root_export_owners(tree: ast.AST | None) -> dict[str, str]:
+    """Read the lazy root-facade export map without importing the package."""
+
+    if tree is None:
+        return {}
+    for node in getattr(tree, "body", []):
+        value: ast.AST | None = None
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "_EXPORTS"
+        ):
+            value = node.value
+        elif isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "_EXPORTS" for target in node.targets
+        ):
+            value = node.value
+        if value is None:
+            continue
+        try:
+            exports = ast.literal_eval(value)
+        except (TypeError, ValueError):
+            return {}
+        if not isinstance(exports, dict):
+            return {}
+        owners: dict[str, str] = {}
+        for name, export in exports.items():
+            if (
+                isinstance(name, str)
+                and isinstance(export, tuple)
+                and len(export) == 2
+                and isinstance(export[0], str)
+            ):
+                owners[name] = export[0]
+        return owners
+    return {}
+
+
 def _load_policy(policy_path: Path) -> dict[str, Any]:
     with policy_path.open("rb") as handle:
         policy = tomllib.load(handle)
@@ -166,36 +244,48 @@ def _load_policy(policy_path: Path) -> dict[str, Any]:
     return policy
 
 
-def _top_level_family_imports(
-    tree: ast.AST,
-    consumer: str,
-    is_package: bool,
-    relevant_scopes: frozenset[str],
-) -> list[tuple[str, int]]:
-    """Return imports relevant to registered top-level-family boundaries."""
-
-    found = _imports(tree, consumer, is_package)
-    root_packages = {scope.partition(".")[2] for scope in relevant_scopes}
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ImportFrom):
-            continue
-        module = _resolve_import_from(node, consumer, is_package)
-        if module != "archetype":
-            continue
-        found.extend(
-            (f"archetype.{alias.name}", node.lineno)
-            for alias in node.names
-            if alias.name in root_packages
-        )
-    return found
-
-
 def _release_version(value: str) -> tuple[int, int, int] | None:
     match = re.fullmatch(r"v?(\d+)(?:\.(\d+))?(?:\.(\d+))?", value.strip())
     if match is None:
         return None
     major, minor, patch = match.groups()
     return (int(major), int(minor or 0), int(patch or 0))
+
+
+def _dependency_cycle(
+    graph: dict[str, frozenset[str]],
+) -> tuple[str, ...] | None:
+    """Return one deterministic cycle from a directed dependency graph."""
+
+    state: dict[str, int] = {}
+    stack: list[str] = []
+    stack_indexes: dict[str, int] = {}
+
+    def visit(node: str) -> tuple[str, ...] | None:
+        state[node] = 1
+        stack_indexes[node] = len(stack)
+        stack.append(node)
+        for dependency in sorted(graph.get(node, frozenset())):
+            dependency_state = state.get(dependency, 0)
+            if dependency_state == 0:
+                cycle = visit(dependency)
+                if cycle is not None:
+                    return cycle
+            elif dependency_state == 1:
+                start = stack_indexes[dependency]
+                return (*stack[start:], dependency)
+        stack.pop()
+        stack_indexes.pop(node)
+        state[node] = 2
+        return None
+
+    for node in sorted(graph):
+        if state.get(node, 0) != 0:
+            continue
+        cycle = visit(node)
+        if cycle is not None:
+            return cycle
+    return None
 
 
 def _project_version(repo_root: Path) -> tuple[int, int, int] | None:
@@ -242,6 +332,13 @@ def audit_repository(
             path.name == "__init__.py",
         )
 
+    actual_top_level_packages = _top_level_package_scopes(source_root)
+    root_tree = parsed.get("archetype", (None, None, False))[1]
+    root_export_owners = _root_export_owners(root_tree)
+    first_party_root_scopes = actual_top_level_packages | frozenset(
+        module for module in parsed if module.startswith("archetype.") and module.count(".") == 1
+    )
+
     policy_version = int(policy["version"])
     package_rules = policy.get("package_rule", [])
     family_rules = policy.get("family_rule", [])
@@ -281,12 +378,47 @@ def audit_repository(
             "top_level_family_policy.forbidden_outward has non-top-level scopes: "
             + ", ".join(invalid_outward)
         )
+
+    configured_infrastructure = top_level_family_config.get("reserved_infrastructure", [])
+    if not isinstance(configured_infrastructure, list):
+        result.policy_errors.append(
+            "top_level_family_policy.reserved_infrastructure must be a list"
+        )
+        configured_infrastructure = []
+    infrastructure_values = [str(value).strip() for value in configured_infrastructure]
+    reserved_infrastructure = frozenset(value for value in infrastructure_values if value)
+    if len(infrastructure_values) != len(reserved_infrastructure):
+        result.policy_errors.append(
+            "top_level_family_policy.reserved_infrastructure contains empty or duplicate entries"
+        )
+    invalid_infrastructure = sorted(
+        value
+        for value in reserved_infrastructure
+        if re.fullmatch(r"archetype\.[A-Za-z_][A-Za-z0-9_]*", value) is None
+    )
+    if invalid_infrastructure:
+        result.policy_errors.append(
+            "top_level_family_policy.reserved_infrastructure has non-top-level scopes: "
+            + ", ".join(invalid_infrastructure)
+        )
     if policy_version >= 3:
         missing_outward = sorted(TOP_LEVEL_FAMILY_OUTWARD_PACKAGES - outward_packages)
         if missing_outward:
             result.policy_errors.append(
                 "top_level_family_policy.forbidden_outward omits required packages: "
                 + ", ".join(missing_outward)
+            )
+        missing_infrastructure = sorted(REQUIRED_TOP_LEVEL_INFRASTRUCTURE - reserved_infrastructure)
+        if missing_infrastructure:
+            result.policy_errors.append(
+                "top_level_family_policy.reserved_infrastructure omits required packages: "
+                + ", ".join(missing_infrastructure)
+            )
+        outward_not_reserved = sorted(outward_packages - reserved_infrastructure)
+        if outward_not_reserved:
+            result.policy_errors.append(
+                "top_level_family_policy.forbidden_outward has unclassified packages: "
+                + ", ".join(outward_not_reserved)
             )
         if not top_level_family_rules:
             result.policy_errors.append("architecture policy registers no top-level family scopes")
@@ -296,7 +428,7 @@ def audit_repository(
     top_level_family_names: set[str] = set()
     top_level_family_scopes: dict[str, frozenset[str]] = {}
     pending_allowed_families: dict[str, list[str]] = {}
-    reserved_family_scopes = TOP_LEVEL_FAMILY_OUTWARD_PACKAGES | {"archetype.core"}
+    reserved_family_scopes = reserved_infrastructure | REQUIRED_TOP_LEVEL_INFRASTRUCTURE
     for index, rule in enumerate(top_level_family_rules):
         name = str(rule.get("name", "")).strip()
         label = repr(name) if name else f"at index {index}"
@@ -395,6 +527,40 @@ def audit_repository(
             )
         top_level_family_scopes[consumer_scope] = allowed
 
+    if policy_version >= 3:
+        overlapping_scopes = sorted(registered_family_scopes & reserved_infrastructure)
+        if overlapping_scopes:
+            result.policy_errors.append(
+                "top-level scopes classified as both family and reserved infrastructure: "
+                + ", ".join(overlapping_scopes)
+            )
+        unclassified_packages = sorted(
+            actual_top_level_packages - registered_family_scopes - reserved_infrastructure
+        )
+        if unclassified_packages:
+            result.policy_errors.append(
+                "unclassified first-party top-level packages: " + ", ".join(unclassified_packages)
+            )
+
+        graph = {
+            consumer_scope: frozenset(
+                dependency
+                for dependency in allowed
+                if dependency in registered_family_scopes and dependency != consumer_scope
+            )
+            for consumer_scope, allowed in top_level_family_scopes.items()
+        }
+        cycle = _dependency_cycle(graph)
+        if cycle is not None:
+            result.policy_errors.append("top-level family dependency cycle: " + " -> ".join(cycle))
+
+    governed_root_scopes = (
+        first_party_root_scopes
+        | registered_family_scopes
+        | reserved_infrastructure
+        | outward_packages
+    )
+
     for rule in package_rules:
         consumer_prefix = str(rule["consumer"])
         if not any(_matches_prefix(module, consumer_prefix) for module in parsed):
@@ -452,7 +618,13 @@ def audit_repository(
     findings: list[Violation] = []
     seen: set[tuple[str, str, str]] = set()
     for consumer, (path, tree, is_package) in parsed.items():
-        imports = _imports(tree, consumer, is_package)
+        imports = _imports(
+            tree,
+            consumer,
+            is_package,
+            root_export_owners=root_export_owners,
+            root_scopes=governed_root_scopes,
+        )
 
         consumer_family_scope = next(
             (scope for scope in registered_family_scopes if _matches_prefix(consumer, scope)),
@@ -460,13 +632,7 @@ def audit_repository(
         )
         if consumer_family_scope is not None:
             allowed_families = top_level_family_scopes[consumer_family_scope]
-            family_imports = _top_level_family_imports(
-                tree,
-                consumer,
-                is_package,
-                registered_family_scopes | outward_packages,
-            )
-            for dependency, line in family_imports:
+            for dependency, line in imports:
                 if any(_matches_prefix(dependency, prefix) for prefix in outward_packages):
                     _add_once(
                         findings,
@@ -486,6 +652,11 @@ def audit_repository(
                     )
                     continue
 
+                if _matches_prefix(dependency, "archetype.core") or _matches_prefix(
+                    dependency, consumer_family_scope
+                ):
+                    continue
+
                 dependency_family_scope = next(
                     (
                         scope
@@ -494,9 +665,12 @@ def audit_repository(
                     ),
                     None,
                 )
-                if dependency_family_scope in {None, consumer_family_scope}:
+                if (
+                    dependency_family_scope is not None
+                    and dependency_family_scope in allowed_families
+                ):
                     continue
-                if dependency_family_scope in allowed_families:
+                if not _matches_prefix(dependency, "archetype"):
                     continue
                 _add_once(
                     findings,
@@ -508,9 +682,10 @@ def audit_repository(
                         path=path,
                         line=line,
                         detail=(
-                            f"{consumer} imports undeclared top-level family "
-                            f"{dependency}; declare the reviewed lower-family contract "
-                            "edge in quality/architecture.toml"
+                            f"{consumer} imports undeclared first-party dependency "
+                            f"{dependency}; classify every top-level package and declare "
+                            "each reviewed lower-family contract edge in "
+                            "quality/architecture.toml"
                         ),
                     ),
                 )
@@ -629,7 +804,7 @@ def audit_repository(
                     )
 
             elif isinstance(node, ast.ClassDef):
-                if _matches_prefix(consumer, "archetype.app") and path.name == "models.py":
+                if _matches_prefix(consumer, "archetype.app"):
                     for base in node.bases:
                         if _resolved_name(base, bindings) not in COMPONENT_BASES:
                             continue
@@ -644,7 +819,7 @@ def audit_repository(
                                 line=node.lineno,
                                 detail=(
                                     f"{consumer}.{node.name} is a persistent Component "
-                                    "declared in an application models.py; move reusable ECS "
+                                    "declared in the application layer; move reusable ECS "
                                     "schema to archetype.<family>.components"
                                 ),
                             ),

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -107,6 +107,7 @@ def _imports(
         if isinstance(node, ast.Import)
         for alias in node.names
         if alias.name == "archetype"
+        or (alias.name.startswith("archetype.") and alias.asname is None)
     }
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -16,6 +16,7 @@ receipts — against the remote catalog via ARCHETYPE_CONTROL_CATALOG_URL.
 """
 
 import asyncio
+import os
 import shutil
 import socket
 import subprocess
@@ -200,13 +201,24 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
+def _isolated_npx_env(cache_path: Path) -> dict[str, str]:
+    """Keep concurrent xdist workers from racing in npx's install cache."""
+
+    cache_path.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.pop("NPM_CONFIG_CACHE", None)
+    env["npm_config_cache"] = str(cache_path)
+    return env
+
+
 @pytest.fixture(scope="module")
-def worker_url():
+def worker_url(tmp_path_factory):
     if shutil.which("npx") is None:
         pytest.skip("npx unavailable; wrangler dev harness skipped")
     port = _free_port()
     inspector_port = _free_port()
     worker_log = tempfile.TemporaryFile(mode="w+")
+    npx_env = _isolated_npx_env(tmp_path_factory.mktemp("wrangler-npm-cache"))
     proc = subprocess.Popen(
         [
             "npx",
@@ -225,6 +237,7 @@ def worker_url():
         stdout=worker_log,
         stderr=subprocess.STDOUT,
         text=True,
+        env=npx_env,
     )
     url = f"http://127.0.0.1:{port}"
     try:
@@ -307,6 +320,7 @@ async def test_worker_recovers_interrupted_legacy_eligibility_backfill(tmp_path)
     source_path = source_dir / "index.ts"
     source_path.write_text(_INTERRUPTED_LEGACY_WORKER_SOURCE)
     persistence = tmp_path / "wrangler-state"
+    npx_env = _isolated_npx_env(tmp_path / "npm-cache")
 
     def start_worker():
         port = _free_port()
@@ -332,6 +346,7 @@ async def test_worker_recovers_interrupted_legacy_eligibility_backfill(tmp_path)
             stdout=worker_log,
             stderr=subprocess.STDOUT,
             text=True,
+            env=npx_env,
         )
         url = f"http://127.0.0.1:{port}"
         deadline = time.time() + 120

--- a/tests/scripts/test_check_architecture.py
+++ b/tests/scripts/test_check_architecture.py
@@ -15,6 +15,15 @@ checker = importlib.util.module_from_spec(SPEC)
 sys.modules["check_architecture"] = checker
 SPEC.loader.exec_module(checker)
 
+DEFAULT_RESERVED_INFRASTRUCTURE = (
+    "archetype.api",
+    "archetype.app",
+    "archetype.cli",
+    "archetype.contrib",
+    "archetype.core",
+    "archetype.runtime",
+)
+
 
 def _write_policy(root: Path, *, exception: str = "") -> Path:
     (root / "pyproject.toml").write_text(
@@ -52,14 +61,16 @@ def _write_family_policy(
     *,
     rules: str,
     exception: str = "",
+    reserved_infrastructure: tuple[str, ...] = DEFAULT_RESERVED_INFRASTRUCTURE,
 ) -> Path:
     (root / "pyproject.toml").write_text(
         '[project]\nname = "fixture"\nversion = "0.4.0"\n',
         encoding="utf-8",
     )
     policy = root / "architecture.toml"
+    reserved = "\n".join(f'  "{scope}",' for scope in reserved_infrastructure)
     policy.write_text(
-        """
+        f"""
 version = 3
 source_root = "src"
 
@@ -70,12 +81,27 @@ forbidden_outward = [
   "archetype.api",
   "archetype.cli",
 ]
+reserved_infrastructure = [
+{reserved}
+]
 """
         + rules
         + exception,
         encoding="utf-8",
     )
     return policy
+
+
+def _write_root_export_fixture(root: Path) -> None:
+    package = root / "src" / "archetype"
+    runtime = package / "runtime" / "__init__.py"
+    package.mkdir(parents=True, exist_ok=True)
+    runtime.parent.mkdir(parents=True, exist_ok=True)
+    (package / "__init__.py").write_text(
+        '_EXPORTS = {"ArchetypeRuntime": ("archetype.runtime", "ArchetypeRuntime")}\n',
+        encoding="utf-8",
+    )
+    runtime.write_text("class ArchetypeRuntime:\n    pass\n", encoding="utf-8")
 
 
 def _write_component_family_fixture(root: Path) -> str:
@@ -249,6 +275,61 @@ allowed_families = []
     }
 
 
+def test_root_package_and_facade_imports_match_explicit_forbidden_imports(
+    tmp_path: Path,
+) -> None:
+    import_forms = (
+        "from archetype import runtime\n",
+        "from archetype import ArchetypeRuntime\n",
+        "from archetype.runtime import ArchetypeRuntime\n",
+    )
+    consumers = {
+        "core": "package_dependency",
+        "app": "package_dependency",
+        "alpha": "top_level_family_outward_dependency",
+    }
+
+    for consumer_scope, expected_rule in consumers.items():
+        for index, statement in enumerate(import_forms):
+            root = tmp_path / f"{consumer_scope}-{index}"
+            _write_root_export_fixture(root)
+            alpha = root / "src" / "archetype" / "alpha" / "contracts.py"
+            alpha.parent.mkdir(parents=True, exist_ok=True)
+            alpha.write_text("value = 1\n", encoding="utf-8")
+            consumer = root / "src" / "archetype" / consumer_scope / "probe.py"
+            consumer.parent.mkdir(parents=True, exist_ok=True)
+            consumer.write_text(statement, encoding="utf-8")
+            package_rule = ""
+            if consumer_scope in {"core", "app"}:
+                package_rule = f"""
+
+[[package_rule]]
+name = "{consumer_scope}-outward"
+consumer = "archetype.{consumer_scope}"
+forbidden = ["archetype.runtime"]
+"""
+            rules = (
+                """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+"""
+                + package_rule
+            )
+
+            result = checker.audit_repository(
+                _write_family_policy(root, rules=rules),
+                repo_root=root,
+            )
+
+            assert not result.policy_errors
+            assert [(violation.rule, violation.target) for violation in result.violations] == [
+                (expected_rule, "archetype.runtime")
+            ]
+
+
 def test_undeclared_top_level_family_dependency_fails(tmp_path: Path) -> None:
     alpha = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
     beta = tmp_path / "src" / "archetype" / "beta" / "contracts.py"
@@ -284,6 +365,162 @@ allowed_families = []
             "archetype.beta",
         )
     ]
+
+
+def test_unclassified_top_level_package_fails_and_reserved_package_passes(
+    tmp_path: Path,
+) -> None:
+    for name, reserved, expected_error in (
+        ("unclassified", DEFAULT_RESERVED_INFRASTRUCTURE, True),
+        (
+            "classified",
+            (*DEFAULT_RESERVED_INFRASTRUCTURE, "archetype.graph"),
+            False,
+        ),
+    ):
+        root = tmp_path / name
+        alpha = root / "src" / "archetype" / "alpha" / "contracts.py"
+        graph = root / "src" / "archetype" / "graph" / "contracts.py"
+        alpha.parent.mkdir(parents=True)
+        graph.parent.mkdir(parents=True)
+        alpha.write_text("value = 1\n", encoding="utf-8")
+        graph.write_text("value = 1\n", encoding="utf-8")
+        rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+"""
+
+        result = checker.audit_repository(
+            _write_family_policy(
+                root,
+                rules=rules,
+                reserved_infrastructure=reserved,
+            ),
+            repo_root=root,
+        )
+
+        if expected_error:
+            assert result.policy_errors == [
+                "unclassified first-party top-level packages: archetype.graph"
+            ]
+        else:
+            assert result.ok
+
+
+def test_unclassified_internal_import_fails_and_declared_lower_family_passes(
+    tmp_path: Path,
+) -> None:
+    reserved = tuple(
+        scope for scope in DEFAULT_RESERVED_INFRASTRUCTURE if scope != "archetype.contrib"
+    )
+    for name, declare_contrib, should_pass in (
+        ("unclassified", False, False),
+        ("declared", True, True),
+    ):
+        root = tmp_path / name
+        alpha = root / "src" / "archetype" / "alpha" / "contracts.py"
+        contrib = root / "src" / "archetype" / "contrib" / "contracts.py"
+        alpha.parent.mkdir(parents=True)
+        contrib.parent.mkdir(parents=True)
+        alpha.write_text("from archetype.contrib import contracts\n", encoding="utf-8")
+        contrib.write_text("value = 1\n", encoding="utf-8")
+        allowed = '["archetype.contrib"]' if declare_contrib else "[]"
+        rules = f"""
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = {allowed}
+"""
+        if declare_contrib:
+            rules += """
+
+[[top_level_family_rule]]
+name = "contrib"
+consumer = "archetype.contrib"
+allowed_families = []
+"""
+
+        result = checker.audit_repository(
+            _write_family_policy(
+                root,
+                rules=rules,
+                reserved_infrastructure=reserved,
+            ),
+            repo_root=root,
+        )
+
+        if should_pass:
+            assert result.ok
+        else:
+            assert result.policy_errors == [
+                "unclassified first-party top-level packages: archetype.contrib"
+            ]
+            assert [(violation.rule, violation.target) for violation in result.violations] == [
+                ("top_level_family_dependency", "archetype.contrib")
+            ]
+
+
+def test_top_level_family_dependency_cycle_fails(tmp_path: Path) -> None:
+    for family in ("alpha", "beta"):
+        module = tmp_path / "src" / "archetype" / family / "contracts.py"
+        module.parent.mkdir(parents=True)
+        module.write_text("value = 1\n", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = ["archetype.beta"]
+
+[[top_level_family_rule]]
+name = "beta"
+consumer = "archetype.beta"
+allowed_families = ["archetype.alpha"]
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert result.policy_errors == [
+        "top-level family dependency cycle: archetype.alpha -> archetype.beta -> archetype.alpha"
+    ]
+
+
+def test_multi_level_top_level_family_dag_passes(tmp_path: Path) -> None:
+    for family in ("alpha", "beta", "gamma"):
+        module = tmp_path / "src" / "archetype" / family / "contracts.py"
+        module.parent.mkdir(parents=True)
+        module.write_text("value = 1\n", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = ["archetype.beta"]
+
+[[top_level_family_rule]]
+name = "beta"
+consumer = "archetype.beta"
+allowed_families = ["archetype.gamma"]
+
+[[top_level_family_rule]]
+name = "gamma"
+consumer = "archetype.gamma"
+allowed_families = []
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert result.ok
 
 
 def test_declared_family_edge_and_app_contract_import_pass(tmp_path: Path) -> None:
@@ -326,18 +563,23 @@ forbidden = [
     assert result.ok
 
 
-def test_direct_component_in_app_models_fails(tmp_path: Path) -> None:
+def test_direct_component_anywhere_in_app_fails(tmp_path: Path) -> None:
     family = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
     models = tmp_path / "src" / "archetype" / "app" / "widgets" / "models.py"
+    components = tmp_path / "src" / "archetype" / "app" / "widgets" / "components.py"
     family.parent.mkdir(parents=True)
     models.parent.mkdir(parents=True)
     family.write_text("value = 1\n", encoding="utf-8")
-    models.write_text(
-        "from archetype.core.component import Component as ECSComponent\n\n"
-        "class DurableWidget(ECSComponent):\n"
-        "    value: int = 0\n",
-        encoding="utf-8",
-    )
+    for path, class_name in (
+        (models, "DurableWidgetModel"),
+        (components, "DurableWidgetComponent"),
+    ):
+        path.write_text(
+            "from archetype.core.component import Component as ECSComponent\n\n"
+            f"class {class_name}(ECSComponent):\n"
+            "    value: int = 0\n",
+            encoding="utf-8",
+        )
     rules = """
 
 [[top_level_family_rule]]
@@ -355,8 +597,12 @@ allowed_families = []
     assert [(violation.rule, violation.target) for violation in result.violations] == [
         (
             "app_component_model",
-            "archetype.app.widgets.models.DurableWidget",
-        )
+            "archetype.app.widgets.components.DurableWidgetComponent",
+        ),
+        (
+            "app_component_model",
+            "archetype.app.widgets.models.DurableWidgetModel",
+        ),
     ]
 
 

--- a/tests/scripts/test_check_architecture.py
+++ b/tests/scripts/test_check_architecture.py
@@ -288,6 +288,8 @@ def test_root_package_and_facade_imports_match_explicit_forbidden_imports(
         "from archetype.runtime import ArchetypeRuntime\n",
         "import archetype\nvalue = archetype.ArchetypeRuntime\n",
         "import archetype as root\nvalue = root.ArchetypeRuntime\n",
+        "import archetype.core\nvalue = archetype.ArchetypeRuntime\n",
+        "import archetype.core\nvalue = archetype.runtime.ArchetypeRuntime\n",
     )
     consumers = {
         "core": "package_dependency",

--- a/tests/scripts/test_check_architecture.py
+++ b/tests/scripts/test_check_architecture.py
@@ -282,6 +282,8 @@ def test_root_package_and_facade_imports_match_explicit_forbidden_imports(
         "from archetype import runtime\n",
         "from archetype import ArchetypeRuntime\n",
         "from archetype.runtime import ArchetypeRuntime\n",
+        "import archetype\nvalue = archetype.ArchetypeRuntime\n",
+        "import archetype as root\nvalue = root.ArchetypeRuntime\n",
     )
     consumers = {
         "core": "package_dependency",
@@ -328,6 +330,52 @@ allowed_families = []
             assert [(violation.rule, violation.target) for violation in result.violations] == [
                 (expected_rule, "archetype.runtime")
             ]
+
+
+def test_core_rejects_every_registered_family_without_static_enumeration(
+    tmp_path: Path,
+) -> None:
+    core = tmp_path / "src" / "archetype" / "core" / "probe.py"
+    alpha = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
+    graph = tmp_path / "src" / "archetype" / "graph" / "contracts.py"
+    core.parent.mkdir(parents=True)
+    alpha.parent.mkdir(parents=True)
+    graph.parent.mkdir(parents=True)
+    core.write_text("from archetype.graph import contracts\n", encoding="utf-8")
+    alpha.write_text("value = 1\n", encoding="utf-8")
+    graph.write_text("value = 1\n", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "graph"
+consumer = "archetype.graph"
+allowed_families = []
+
+[[package_rule]]
+name = "core-outward"
+consumer = "archetype.core"
+forbidden = [
+  "archetype.app",
+  "archetype.runtime",
+  "archetype.api",
+  "archetype.cli",
+]
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert not result.policy_errors
+    assert [(violation.rule, violation.target) for violation in result.violations] == [
+        ("package_dependency", "archetype.graph")
+    ]
 
 
 def test_undeclared_top_level_family_dependency_fails(tmp_path: Path) -> None:

--- a/tests/scripts/test_check_architecture.py
+++ b/tests/scripts/test_check_architecture.py
@@ -16,6 +16,10 @@ sys.modules["check_architecture"] = checker
 SPEC.loader.exec_module(checker)
 
 DEFAULT_RESERVED_INFRASTRUCTURE = (
+    "archetype._api",
+    "archetype._logging",
+    "archetype._obs",
+    "archetype._storage_uri",
     "archetype.api",
     "archetype.app",
     "archetype.cli",
@@ -332,6 +336,49 @@ allowed_families = []
             ]
 
 
+def test_unparsable_root_export_map_fails_closed(tmp_path: Path) -> None:
+    invalid_exports = (
+        "value = 1\n",
+        '_EXPORTS = dict(ArchetypeRuntime=("archetype.runtime", "ArchetypeRuntime"))\n',
+        "_EXPORTS = []\n",
+        '_EXPORTS = {"ArchetypeRuntime": ("archetype.runtime",)}\n',
+        '_EXPORTS = {"": ("archetype.runtime", "ArchetypeRuntime")}\n',
+    )
+    for index, source in enumerate(invalid_exports):
+        root = tmp_path / str(index)
+        _write_root_export_fixture(root)
+        package = root / "src" / "archetype"
+        (package / "__init__.py").write_text(source, encoding="utf-8")
+        alpha = package / "alpha" / "contracts.py"
+        core = package / "core" / "probe.py"
+        alpha.parent.mkdir(parents=True)
+        core.parent.mkdir(parents=True)
+        alpha.write_text("value = 1\n", encoding="utf-8")
+        core.write_text("from archetype import ArchetypeRuntime\n", encoding="utf-8")
+        rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+
+[[package_rule]]
+name = "core-outward"
+consumer = "archetype.core"
+forbidden = ["archetype.runtime"]
+"""
+
+        result = checker.audit_repository(
+            _write_family_policy(root, rules=rules),
+            repo_root=root,
+        )
+
+        assert result.policy_errors == [
+            "unable to statically parse archetype._EXPORTS; "
+            "root-facade import enforcement is degraded"
+        ]
+
+
 def test_core_rejects_every_registered_family_without_static_enumeration(
     tmp_path: Path,
 ) -> None:
@@ -452,10 +499,82 @@ allowed_families = []
 
         if expected_error:
             assert result.policy_errors == [
-                "unclassified first-party top-level packages: archetype.graph"
+                "unclassified first-party top-level scopes: archetype.graph"
             ]
         else:
             assert result.ok
+
+
+def test_unclassified_top_level_module_fails_and_reserved_module_passes(
+    tmp_path: Path,
+) -> None:
+    for name, reserved, expected_error in (
+        ("unclassified", DEFAULT_RESERVED_INFRASTRUCTURE, True),
+        (
+            "classified",
+            (*DEFAULT_RESERVED_INFRASTRUCTURE, "archetype.helpers"),
+            False,
+        ),
+    ):
+        root = tmp_path / name
+        alpha = root / "src" / "archetype" / "alpha" / "contracts.py"
+        helpers = root / "src" / "archetype" / "helpers.py"
+        alpha.parent.mkdir(parents=True)
+        alpha.write_text("value = 1\n", encoding="utf-8")
+        helpers.write_text("from archetype import app\n", encoding="utf-8")
+        rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+"""
+
+        result = checker.audit_repository(
+            _write_family_policy(
+                root,
+                rules=rules,
+                reserved_infrastructure=reserved,
+            ),
+            repo_root=root,
+        )
+
+        if expected_error:
+            assert result.policy_errors == [
+                "unclassified first-party top-level scopes: archetype.helpers"
+            ]
+        else:
+            assert result.ok
+
+
+def test_registered_top_level_module_enforces_family_direction(tmp_path: Path) -> None:
+    alpha = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
+    helpers = tmp_path / "src" / "archetype" / "helpers.py"
+    alpha.parent.mkdir(parents=True)
+    alpha.write_text("value = 1\n", encoding="utf-8")
+    helpers.write_text("from archetype import app\n", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "helpers"
+consumer = "archetype.helpers"
+allowed_families = []
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert not result.policy_errors
+    assert [(violation.rule, violation.target) for violation in result.violations] == [
+        ("top_level_family_outward_dependency", "archetype.app")
+    ]
 
 
 def test_unclassified_internal_import_fails_and_declared_lower_family_passes(
@@ -505,7 +624,7 @@ allowed_families = []
             assert result.ok
         else:
             assert result.policy_errors == [
-                "unclassified first-party top-level packages: archetype.contrib"
+                "unclassified first-party top-level scopes: archetype.contrib"
             ]
             assert [(violation.rule, violation.target) for violation in result.violations] == [
                 ("top_level_family_dependency", "archetype.contrib")
@@ -664,7 +783,10 @@ def test_version_three_requires_registered_family_scope(tmp_path: Path) -> None:
         repo_root=tmp_path,
     )
 
-    assert result.policy_errors == ["architecture policy registers no top-level family scopes"]
+    assert result.policy_errors == [
+        "architecture policy registers no top-level family scopes",
+        "unclassified first-party top-level scopes: archetype.unrelated",
+    ]
 
 
 def test_registered_family_scopes_reject_missing_empty_stale_and_duplicate(

--- a/tests/scripts/test_check_architecture.py
+++ b/tests/scripts/test_check_architecture.py
@@ -47,6 +47,58 @@ allowed_app = []
     return policy
 
 
+def _write_family_policy(
+    root: Path,
+    *,
+    rules: str,
+    exception: str = "",
+) -> Path:
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "fixture"\nversion = "0.4.0"\n',
+        encoding="utf-8",
+    )
+    policy = root / "architecture.toml"
+    policy.write_text(
+        """
+version = 3
+source_root = "src"
+
+[top_level_family_policy]
+forbidden_outward = [
+  "archetype.app",
+  "archetype.runtime",
+  "archetype.api",
+  "archetype.cli",
+]
+"""
+        + rules
+        + exception,
+        encoding="utf-8",
+    )
+    return policy
+
+
+def _write_component_family_fixture(root: Path) -> str:
+    family = root / "src" / "archetype" / "alpha" / "contracts.py"
+    models = root / "src" / "archetype" / "app" / "widgets" / "models.py"
+    family.parent.mkdir(parents=True)
+    models.parent.mkdir(parents=True)
+    family.write_text("value = 1\n", encoding="utf-8")
+    models.write_text(
+        "from archetype.core.component import Component\n\n"
+        "class DurableWidget(Component):\n"
+        "    value: int = 0\n",
+        encoding="utf-8",
+    )
+    return """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+"""
+
+
 def test_negative_fixture_detects_each_enforced_rule(tmp_path: Path) -> None:
     probe = tmp_path / "src" / "archetype" / "app" / "probe.py"
     probe.parent.mkdir(parents=True)
@@ -161,6 +213,334 @@ def test_every_concrete_service_requires_a_module_rule(tmp_path: Path) -> None:
         "module rule references missing module: archetype.app.probe",
         "concrete service WorldService in archetype.app.service has no module rule",
     ]
+
+
+def test_top_level_family_rejects_every_outward_package(tmp_path: Path) -> None:
+    contracts = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
+    contracts.parent.mkdir(parents=True)
+    contracts.write_text(
+        """
+from archetype import app
+from archetype.api import deps
+from archetype.cli import main
+from archetype.runtime import ArchetypeRuntime
+""",
+        encoding="utf-8",
+    )
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert not result.policy_errors
+    assert {(violation.rule, violation.target) for violation in result.violations} == {
+        ("top_level_family_outward_dependency", "archetype.app"),
+        ("top_level_family_outward_dependency", "archetype.api"),
+        ("top_level_family_outward_dependency", "archetype.cli"),
+        ("top_level_family_outward_dependency", "archetype.runtime"),
+    }
+
+
+def test_undeclared_top_level_family_dependency_fails(tmp_path: Path) -> None:
+    alpha = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
+    beta = tmp_path / "src" / "archetype" / "beta" / "contracts.py"
+    alpha.parent.mkdir(parents=True)
+    beta.parent.mkdir(parents=True)
+    alpha.write_text("from archetype import beta\n", encoding="utf-8")
+    beta.write_text("value = 1\n", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "beta"
+consumer = "archetype.beta"
+allowed_families = []
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert not result.policy_errors
+    assert [
+        (violation.rule, violation.consumer, violation.target) for violation in result.violations
+    ] == [
+        (
+            "top_level_family_dependency",
+            "archetype.alpha.contracts",
+            "archetype.beta",
+        )
+    ]
+
+
+def test_declared_family_edge_and_app_contract_import_pass(tmp_path: Path) -> None:
+    alpha = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
+    beta = tmp_path / "src" / "archetype" / "beta" / "contracts.py"
+    app = tmp_path / "src" / "archetype" / "app" / "consumer.py"
+    alpha.parent.mkdir(parents=True)
+    beta.parent.mkdir(parents=True)
+    app.parent.mkdir(parents=True)
+    alpha.write_text("from archetype.beta import contracts\n", encoding="utf-8")
+    beta.write_text("value = 1\n", encoding="utf-8")
+    app.write_text("from archetype.alpha import contracts\n", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = ["archetype.beta"]
+
+[[top_level_family_rule]]
+name = "beta"
+consumer = "archetype.beta"
+allowed_families = []
+
+[[package_rule]]
+name = "app-outward"
+consumer = "archetype.app"
+forbidden = [
+  "archetype.runtime",
+  "archetype.api",
+  "archetype.cli",
+]
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert result.ok
+
+
+def test_direct_component_in_app_models_fails(tmp_path: Path) -> None:
+    family = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
+    models = tmp_path / "src" / "archetype" / "app" / "widgets" / "models.py"
+    family.parent.mkdir(parents=True)
+    models.parent.mkdir(parents=True)
+    family.write_text("value = 1\n", encoding="utf-8")
+    models.write_text(
+        "from archetype.core.component import Component as ECSComponent\n\n"
+        "class DurableWidget(ECSComponent):\n"
+        "    value: int = 0\n",
+        encoding="utf-8",
+    )
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert not result.policy_errors
+    assert [(violation.rule, violation.target) for violation in result.violations] == [
+        (
+            "app_component_model",
+            "archetype.app.widgets.models.DurableWidget",
+        )
+    ]
+
+
+def test_version_three_requires_registered_family_scope(tmp_path: Path) -> None:
+    module = tmp_path / "src" / "archetype" / "unrelated.py"
+    module.parent.mkdir(parents=True)
+    module.write_text("value = 1\n", encoding="utf-8")
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=""),
+        repo_root=tmp_path,
+    )
+
+    assert result.policy_errors == ["architecture policy registers no top-level family scopes"]
+
+
+def test_registered_family_scopes_reject_missing_empty_stale_and_duplicate(
+    tmp_path: Path,
+) -> None:
+    alpha = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
+    alpha.parent.mkdir(parents=True)
+    alpha.write_text("value = 1\n", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "missing"
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "empty"
+consumer = ""
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "stale"
+consumer = "archetype.stale"
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+allowed_families = []
+
+[[top_level_family_rule]]
+name = "duplicate"
+consumer = "archetype.alpha"
+allowed_families = []
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert "top-level family rule 'missing' is missing its consumer scope" in result.policy_errors
+    assert "top-level family rule 'empty' has an empty consumer scope" in result.policy_errors
+    assert (
+        "top-level family rule 'stale' references stale scope: archetype.stale"
+        in result.policy_errors
+    )
+    assert "duplicate top-level family scope: archetype.alpha" in result.policy_errors
+
+
+def test_registered_family_rejects_empty_source_scope(tmp_path: Path) -> None:
+    empty = tmp_path / "src" / "archetype" / "empty" / "__init__.py"
+    empty.parent.mkdir(parents=True)
+    empty.write_text("", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "empty"
+consumer = "archetype.empty"
+allowed_families = []
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert result.policy_errors == [
+        "top-level family rule 'empty' matched an empty source scope: archetype.empty"
+    ]
+
+
+def test_registered_family_requires_exact_dependency_disposition(tmp_path: Path) -> None:
+    alpha = tmp_path / "src" / "archetype" / "alpha" / "contracts.py"
+    alpha.parent.mkdir(parents=True)
+    alpha.write_text("value = 1\n", encoding="utf-8")
+    rules = """
+
+[[top_level_family_rule]]
+name = "alpha"
+consumer = "archetype.alpha"
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules),
+        repo_root=tmp_path,
+    )
+
+    assert result.policy_errors == [
+        "top-level family rule 'alpha' lacks an exact allowed_families disposition"
+    ]
+
+
+def test_version_three_exception_requires_issue_and_expiry_condition(tmp_path: Path) -> None:
+    rules = _write_component_family_fixture(tmp_path)
+    exception = """
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.widgets.models"
+target = "archetype.app.widgets.models.DurableWidget"
+owner = "widgets"
+reason = "fixture"
+expires = "v1"
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules, exception=exception),
+        repo_root=tmp_path,
+    )
+
+    assert not result.violations
+    assert result.policy_errors == [
+        "architecture exception ('app_component_model', "
+        "'archetype.app.widgets.models', "
+        "'archetype.app.widgets.models.DurableWidget') lacks issue, expiry_condition"
+    ]
+
+
+def test_version_three_exact_issue_owned_exception_passes(tmp_path: Path) -> None:
+    rules = _write_component_family_fixture(tmp_path)
+    exception = """
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.widgets.models"
+target = "archetype.app.widgets.models.DurableWidget"
+owner = "widgets"
+issue = 999
+reason = "fixture"
+expiry_condition = "Remove when #999 relocates the fixture component."
+expires = "v1"
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules, exception=exception),
+        repo_root=tmp_path,
+    )
+
+    assert result.ok
+    assert [violation.target for violation in result.exempted] == [
+        "archetype.app.widgets.models.DurableWidget"
+    ]
+
+
+def test_version_three_rejects_wildcard_exception(tmp_path: Path) -> None:
+    rules = _write_component_family_fixture(tmp_path)
+    exception = """
+
+[[exception]]
+rule = "app_component_model"
+consumer = "archetype.app.widgets.models"
+target = "archetype.app.widgets.models.*"
+owner = "widgets"
+issue = 999
+reason = "fixture"
+expiry_condition = "Remove when #999 relocates the fixture component."
+expires = "v1"
+"""
+
+    result = checker.audit_repository(
+        _write_family_policy(tmp_path, rules=rules, exception=exception),
+        repo_root=tmp_path,
+    )
+
+    assert [violation.target for violation in result.violations] == [
+        "archetype.app.widgets.models.DurableWidget"
+    ]
+    assert any(
+        "uses a wildcard instead of an exact edge" in error for error in result.policy_errors
+    )
 
 
 def test_repository_architecture_policy_passes() -> None:


### PR DESCRIPTION
Closes #556.

## Context

Archetype already distinguished reusable domain families from internal application services, but that ownership boundary was distributed across prose and broad package-direction rules. Contributors could not reliably determine whether a new component, processor, value contract, or service belonged under `archetype.<family>` or `archetype.app.<family>`, and the architecture audit did not fail closed on undeclared family dependencies. That ambiguity made accidental reverse dependencies and authority leakage possible.

## What changed

This change makes the package taxonomy normative in the contributor and architecture guides. Reusable components, processors, pure DataFrame transforms, transitions, projections, and supported family value contracts live in top-level family packages. Authority, orchestration, internal ports, and concrete services remain under `archetype.app`, while API, gateway, application facade, and container packages retain their transport and composition roles. PR #545 is linked only as a supporting design record.

The architecture manifest is upgraded to policy version 3 and explicitly registers the `datasets`, `experiments`, and `htn` families. The checker now rejects family imports of `app`, `runtime`, `api`, or `cli`; rejects undeclared family-to-family edges; permits the intended app-to-family value dependency; and detects direct `Component` subclasses anywhere under the application layer. Registry configuration also fails closed for missing, empty, stale, duplicate, or otherwise invalid family scopes and dispositions.

Review hardening makes the policy exhaustive: every first-party top-level package is classified as reserved infrastructure or as a registered family, the complete family dependency graph must remain acyclic, and imports through the root facade resolve to the owning package before every direction rule is applied. This closes equivalent bypasses such as `from archetype import runtime`, `from archetype import ArchetypeRuntime`, `import archetype; archetype.ArchetypeRuntime`, and imports of unclassified internal packages. Core's ban on domain-family imports is derived from the family registry, so registering a new family cannot weaken the foundation boundary. The exhaustive inventory covers direct top-level modules as well as packages, and malformed or non-literal root export maps fail the audit instead of degrading facade resolution.

Existing violations are represented by 24 exact, issue-owned migration exceptions tied to #557, #558, #559, and #561. Each exception names its precise source and target, owner, issue, reason, expiry, and cleanup condition. No family implementation was moved in this PR.

## Validation

- `uv run pytest -q tests/scripts/test_check_architecture.py` — 26 passed
- `uv run pytest -q -n 2 --dist loadgroup tests/app/test_remote_catalog_parity.py` — 23 passed
- `uv run python scripts/check_architecture.py` — 143 files audited, 24 owned migration exceptions
- `make static`
- full test stage — 1832 passed, 1 skipped, 86.02% coverage
- conformance/specification evaluations — 15/15 and 8/8
- capability evaluation — 10/10
- `make package-smoke examples-smoke docs`
- Markdown lint and `git diff --check`