### PR TITLE
fix(artifacts): make recovery catalog-clock authoritative

### DIFF
--- a/docs/guide/artifact-finalization.md
+++ b/docs/guide/artifact-finalization.md
@@ -402,18 +402,39 @@ direct artifact caller enters at the artifact-publication claim row.
 ## 6. Reconciler contract
 
 `ArtifactBundleService.reconcile(world_id, limit=N)` is one bounded,
-idempotent pass.
-It does not run forever inside an API request.
+idempotent pass. It does not run forever inside an API request.
 
-1. Enumerate nonterminal publications whose lease is due.
-2. CAS-acquire one publication, retaining its current phase and incrementing
-   `attempt_count`.
-3. If `PENDING`, expire it only when `retry_until_ms` has elapsed; otherwise
-   materialize the recorded sources, reuse/upload objects, and atomically store
-   `records_json` as `UPLOADED`.
-4. If `UPLOADED`, append or verify all deterministic Iceberg rows.
-5. Mark `INDEXED`; on a transient error, record `last_error` and a new
-   `lease_expires_at` for backoff.
+1. Ask the catalog for a digest-only page of nonterminal publications whose
+   lease is due according to the catalog clock. Discovery accepts no caller
+   clock and returns no replay request.
+2. CAS-acquire one exact publication by world ID and publication digest,
+   retaining its current phase and incrementing `attempt_count` on takeover.
+   The source row returned after acquisition is the only replay authority.
+3. Immediately before external I/O, repeat that exact acquisition. This
+   reauthorizes a claimant that stalled after discovery or initial acquisition
+   and closes the race with lease takeover or retry-window expiry.
+4. If `PENDING`, expire it only when the catalog clock proves
+   `retry_until_ms` elapsed; otherwise materialize the recorded sources,
+   reuse/upload objects, and atomically store `records_json` as `UPLOADED`.
+5. If `UPLOADED`, append or verify all deterministic Iceberg rows. An uploaded
+   publication never expires because it no longer depends on the checkpoint.
+6. Mark `INDEXED`; on a transient error, send a bounded retry duration and let
+   the catalog derive the new `lease_expires_at` from its own clock.
+
+Initial publication likewise sends a retry-window duration and an optional
+provider checkpoint `not-after` bound. The catalog derives the persisted
+`retry_until_ms` from its clock, capped by that external deadline. Recovery
+never echoes `request_json`, supplies an absolute retry time, or asserts what
+time it is; it carries only the publication digest, claimant, and bounded
+durations. The durable row is reread and authenticated after every successful
+acquisition before files, objects, or the index are touched.
+
+The artifact row's source-native guard is a lease plus an invocation-unique
+claimant token, not the fleet sweep's monotonic fence epoch. Built-in publishers
+and reconcilers generate a fresh claimant for every invocation and never reuse
+one after takeover. Any future adapter calling this internal catalog contract
+MUST preserve that uniqueness; a public or mutually untrusted claimant API
+would require adding a source-native fence token before exposure.
 
 The SQLite catalog is the single-host reference implementation. The remote
 catalog implements the same CAS transitions in the per-world Durable Object.
@@ -421,12 +442,19 @@ Iceberg snapshot identity is an exact Python `int` in the range
 `1..2^63-1`; booleans, floats, numeric strings, zero, and larger values are
 rejected before completion. The remote catalog transports and stores that
 identity as canonical decimal text under `artifact_snapshot_decimal_v1`.
-Before each mutation, `GET /status` must report
-`catalog_protocol_version >= 3` and that capability. The versioned
-`acquire-v2`, `renew-v2`, `uploads-v2`, `complete-v2`, `fail-v2`, and
-`expire-v2` routes therefore fail closed before artifact I/O against an older
-Worker that could round the snapshot through a JavaScript number or accept a
-write without the current protocol semantics.
+Before snapshot-bearing mutations, `GET /status` must report
+`catalog_protocol_version >= 3` and that capability; `renew-v2`, `uploads-v2`,
+`complete-v2`, and `expire-v2` therefore fail closed against a Worker that
+could round the snapshot through a JavaScript number.
+
+Server-clock publication scheduling additionally requires
+`catalog_protocol_version >= 6` and
+`artifact_publication_server_clock_v1`. The `acquire-v3`, `due-v1`,
+`recover-v1`, and `fail-v3` routes fail closed against an older Worker that
+accepts a caller-derived clock, request echo, or absolute retry instant. The
+SQLite reference and per-world Durable Object apply the same status, deadline,
+lease-owner, and retry-duration transitions.
+
 A fleet reconciler enumerates worlds from the directory object, then performs
 bounded per-world passes. It can shard by world without cross-world locking.
 

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -35,6 +35,7 @@ machine authority; this page is its review surface.
 | `release.package.installable` | `release` | high | [docs/guide/api-stability.md](../guide/api-stability.md) — What counts as public | pytest: 2; static: 1 | `release` |
 | `storage.remote.control_parity` | `storage` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 10. Supported durability profile | pytest: 2; static: 1 | `main`, `release` |
 | `artifacts.bundle.publication_replay` | `artifacts` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — 5. Publication state machine | pytest: 4 | `pr`, `main`, `release` |
+| `artifacts.bundle.recovery_server_clock` | `artifacts` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — 6. Reconciler contract | pytest: 4 | `pr`, `main`, `release` |
 | `missions.transition.evidence_gated` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 2. Typed mission/task/attempt transition graph | pytest: 2; static: 1; eval: 1 | `pr`, `main`, `release` |
 | `missions.attempt.claim_fenced` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 5. Durable pre-execution claim and recovery | pytest: 6; static: 1; eval: 1 | `pr`, `main`, `release` |
 | `missions.attempt.indexed_finalization` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 5. Durable pre-execution claim and recovery | pytest: 9; static: 2; eval: 1 | `pr`, `main`, `release` |

--- a/evals/suites/capability/indexed_finalization.py
+++ b/evals/suites/capability/indexed_finalization.py
@@ -112,8 +112,8 @@ class _ReceiptArtifactBundlePort:
             request_digest=prepared.producer_digest,
             request_json=prepared.request_json,
             claimant=claimant,
-            retry_until_ms=10**15,
-            lease_seconds=0.05,
+            retry_window_ms=60_000,
+            lease_ms=50,
         )
         if publication.status == "PENDING":
             await self._catalog.record_artifact_uploads(

--- a/infra/control-catalog/src/index.ts
+++ b/infra/control-catalog/src/index.ts
@@ -551,7 +551,7 @@ export class CatalogDirectoryDO implements DurableObject {
     }
 
     if (route[0] === "worlds" && route.length === 2) {
-      const worldId = route[1];
+      const worldId = decodeURIComponent(route[1]);
       if (method === "GET") {
         const rows = this.sql.exec("SELECT * FROM worlds WHERE world_id = ?", worldId).toArray();
         return rows.length ? json(rows[0]) : json({ error: "not_found" }, 404);

--- a/infra/control-catalog/src/index.ts
+++ b/infra/control-catalog/src/index.ts
@@ -24,12 +24,19 @@ export interface Env {
 }
 
 const JSON_HEADERS = { "content-type": "application/json" };
-const CATALOG_PROTOCOL_VERSION = 4;
+const CATALOG_PROTOCOL_VERSION = 6;
 const ATTEMPT_FINALIZATION_CAPABILITY = "attempt_claim_finalization_v2";
 const ATTEMPT_CLAIM_CAPABILITY = "attempt_claim_execution_v2";
 const ARTIFACT_SNAPSHOT_CAPABILITY = "artifact_snapshot_decimal_v1";
+const ARTIFACT_SERVER_CLOCK_CAPABILITY = "artifact_publication_server_clock_v1";
 const MAX_SIGNED_64_BIT = 9223372036854775807n;
 const LEGACY_UNBOUND_MIGRATION = "mission_attempt_legacy_unbound_v8";
+const MAX_ARTIFACT_LEASE_MS = 24 * 60 * 60 * 1000;
+const MAX_ARTIFACT_RETRY_WINDOW_MS = 365 * 24 * 60 * 60 * 1000;
+const MAX_ARTIFACT_RETRY_DELAY_MS = 365 * 24 * 60 * 60 * 1000;
+const ARTIFACT_RETRY_EXPIRED_DETAIL =
+  "artifact publication retry window elapsed before upload";
+const CATALOG_DIGEST_DOMAIN = "archetype.catalog.v1";
 const ATTEMPT_CLAIM_EDGES = new Set([
   "claimed->possibly_submitted",
   "possibly_submitted->provider_acknowledged",
@@ -46,6 +53,131 @@ function json(data: unknown, status = 200): Response {
 
 function conflict(kind: string, message: string): Response {
   return json({ error: kind, message }, 409);
+}
+
+class RecoveryInputError extends Error {}
+
+function recoveryInteger(
+  value: unknown,
+  field: string,
+  minimum: number,
+  maximum: number,
+): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw new RecoveryInputError(`${field} must be an integer`);
+  }
+  if (value < minimum || value > maximum) {
+    throw new RecoveryInputError(
+      `${field} must be between ${minimum} and ${maximum}`,
+    );
+  }
+  return value;
+}
+
+function recoveryText(
+  value: unknown,
+  field: string,
+  maximum: number,
+  allowEmpty = false,
+): string {
+  if (typeof value !== "string") {
+    throw new RecoveryInputError(`${field} must be a string`);
+  }
+  if ((!allowEmpty && !value.trim()) || value.length > maximum) {
+    throw new RecoveryInputError(
+      !allowEmpty && !value.trim()
+        ? `${field} must not be empty`
+        : `${field} exceeds ${maximum} characters`,
+    );
+  }
+  return value;
+}
+
+function recoverySha256(value: unknown, field: string): string {
+  const digest = recoveryText(value, field, 64);
+  if (!/^[0-9a-f]{64}$/.test(digest)) {
+    throw new RecoveryInputError(`${field} must be a lowercase SHA-256 digest`);
+  }
+  return digest;
+}
+
+function recoveryObject(value: unknown, field: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new RecoveryInputError(`${field} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function recoveryExactFields(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  field: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      throw new RecoveryInputError(`${field} contains unsupported field ${key}`);
+    }
+  }
+}
+
+function recoveryExactQuery(url: URL, allowed: ReadonlySet<string>, field: string): void {
+  for (const key of url.searchParams.keys()) {
+    if (!allowed.has(key)) {
+      throw new RecoveryInputError(`${field} contains unsupported parameter ${key}`);
+    }
+    if (url.searchParams.getAll(key).length !== 1) {
+      throw new RecoveryInputError(`${field} contains duplicate parameter ${key}`);
+    }
+  }
+}
+
+function recoveryQueryInteger(
+  raw: string | null,
+  fallback: number,
+  field: string,
+  minimum: number,
+  maximum: number,
+): number {
+  if (raw === null) return fallback;
+  if (!/^(0|[1-9][0-9]*)$/.test(raw)) {
+    throw new RecoveryInputError(`${field} must be canonical decimal text`);
+  }
+  return recoveryInteger(Number(raw), field, minimum, maximum);
+}
+
+function pythonAsciiJsonString(value: string): string {
+  return JSON.stringify(value).replace(/[^\x00-\x7f]/gu, (character) => {
+    let codePoint = character.codePointAt(0) as number;
+    if (codePoint <= 0xffff) return `\\u${codePoint.toString(16).padStart(4, "0")}`;
+    codePoint -= 0x10000;
+    const high = 0xd800 + (codePoint >> 10);
+    const low = 0xdc00 + (codePoint & 0x3ff);
+    return `\\u${high.toString(16).padStart(4, "0")}\\u${low
+      .toString(16)
+      .padStart(4, "0")}`;
+  });
+}
+
+async function artifactPublicationKey(
+  worldId: string,
+  runId: string,
+  idempotencyKey: string,
+): Promise<string> {
+  // Match Python json.dumps(sort_keys=True, separators=(",", ":")) including
+  // its default ensure_ascii=True behavior for non-ASCII identities.
+  const payload =
+    `{"domain":${pythonAsciiJsonString(CATALOG_DIGEST_DOMAIN)},` +
+    `"idempotency_key":${pythonAsciiJsonString(idempotencyKey)},` +
+    `"kind":"artifact-publication",` +
+    `"run_id":${pythonAsciiJsonString(runId)},` +
+    `"world_id":${pythonAsciiJsonString(worldId)}}`;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(payload),
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
 }
 
 function attemptClaimView(
@@ -65,6 +197,34 @@ function artifactPublicationView(
   view.index_snapshot_id = String(row.index_snapshot_id_text ?? "0");
   delete view.index_snapshot_id_text;
   return view;
+}
+
+function artifactPublicationAuthorityError(
+  row: Record<string, unknown>,
+  publicationKey: string,
+): Response | null {
+  if (!["PENDING", "UPLOADED", "INDEXED", "EXPIRED"].includes(String(row.status))) {
+    return conflict(
+      "artifact_publication_conflict",
+      `artifact publication ${publicationKey} has invalid durable status`,
+    );
+  }
+  if (
+    !Number.isSafeInteger(row.retry_until_ms) ||
+    Number(row.retry_until_ms) < 0 ||
+    !Number.isSafeInteger(row.attempt_count) ||
+    Number(row.attempt_count) < 1 ||
+    typeof row.lease_expires_at !== "number" ||
+    !Number.isFinite(row.lease_expires_at) ||
+    row.lease_expires_at < 0 ||
+    row.lease_expires_at > Number.MAX_SAFE_INTEGER
+  ) {
+    return conflict(
+      "artifact_publication_conflict",
+      `artifact publication ${publicationKey} has invalid durable clock or counter state`,
+    );
+  }
+  return null;
 }
 
 function attemptClaimTransitionReplayMatches(
@@ -224,7 +384,7 @@ export default {
     if (parts[0] !== "ns" || parts.length < 3) {
       return json({ error: "bad_route", message: url.pathname }, 404);
     }
-    const namespace = parts[1];
+    const namespace = decodeURIComponent(parts[1]);
     const directory = env.DIRECTORY.get(env.DIRECTORY.idFromName(namespace));
 
     // World status is mirrored into the per-world authority before command
@@ -252,7 +412,7 @@ export default {
     if (parts[2] === "worlds" && parts.length === 4 && request.method === "PATCH") {
       const patch = (await request.clone().json()) as Record<string, unknown>;
       if (typeof patch.status === "string") {
-        const worldId = parts[3];
+        const worldId = decodeURIComponent(parts[3]);
         const world = env.WORLD.get(env.WORLD.idFromName(`${namespace}:${worldId}`));
         const statusResponse = await world.fetch(
           new Request(`${url.origin}/ns/${namespace}/w/${worldId}/status`, {
@@ -267,7 +427,7 @@ export default {
     }
 
     if (parts[2] === "w" && parts.length >= 4) {
-      const worldId = parts[3];
+      const worldId = decodeURIComponent(parts[3]);
       const stub = env.WORLD.get(env.WORLD.idFromName(`${namespace}:${worldId}`));
       // Manifest publication also advances the directory's world head. The
       // SQLite reference does both in one transaction; across two Durable
@@ -362,6 +522,31 @@ export class CatalogDirectoryDO implements DurableObject {
     }
 
     if (route[0] === "worlds" && route.length === 1 && method === "GET") {
+      if (
+        url.searchParams.has("after_world_id") ||
+        url.searchParams.has("limit")
+      ) {
+        const afterWorldId = url.searchParams.get("after_world_id") ?? "";
+        const rawLimit = Number(url.searchParams.get("limit") ?? 1000);
+        if (!Number.isSafeInteger(rawLimit) || rawLimit < 1 || rawLimit > 10_000) {
+          return json(
+            {
+              error: "invalid_request",
+              message: "world discovery page limit must be between 1 and 10000",
+            },
+            422,
+          );
+        }
+        return json(
+          this.sql
+            .exec(
+              "SELECT * FROM worlds WHERE world_id > ? ORDER BY world_id LIMIT ?",
+              afterWorldId,
+              rawLimit,
+            )
+            .toArray(),
+        );
+      }
       return json(this.sql.exec("SELECT * FROM worlds ORDER BY world_id").toArray());
     }
 
@@ -653,12 +838,435 @@ export class WorldCommitDO implements DurableObject {
     });
   }
 
+  private recoverArtifactPublication(
+    publicationKey: string,
+    claimant: string,
+    leaseMs: number,
+    nowMs: number,
+  ): Response {
+    const rows = this.sql
+      .exec(
+        "SELECT * FROM artifact_publications WHERE publication_key = ?",
+        publicationKey,
+      )
+      .toArray();
+    if (!rows.length) {
+      return json({ outcome: "obsolete", publication: null });
+    }
+    const row = rows[0] as Record<string, unknown>;
+    const authorityError = artifactPublicationAuthorityError(row, publicationKey);
+    if (authorityError) return authorityError;
+    if (row.status === "INDEXED") {
+      return json({ outcome: "duplicate", publication: artifactPublicationView(row) });
+    }
+    if (row.status === "EXPIRED") {
+      return json({ outcome: "expired", publication: artifactPublicationView(row) });
+    }
+    if (row.status !== "PENDING" && row.status !== "UPLOADED") {
+      return conflict(
+        "artifact_publication_conflict",
+        `artifact publication ${publicationKey} has invalid status ${row.status}`,
+      );
+    }
+    const nowSec = nowMs / 1000;
+    const nowText = new Date(nowMs).toISOString();
+    if (row.status === "PENDING" && Number(row.retry_until_ms) <= nowMs) {
+      const expiredWrite = this.sql.exec(
+        "UPDATE artifact_publications SET status = 'EXPIRED', lease_expires_at = 0, " +
+          "last_error = ?, updated_at = ?, completed_at = ? " +
+          "WHERE publication_key = ? AND status = 'PENDING'",
+        ARTIFACT_RETRY_EXPIRED_DETAIL,
+        nowText,
+        nowText,
+        publicationKey,
+      );
+      if (expiredWrite.rowsWritten < 1) {
+        return conflict(
+          "artifact_publication_conflict",
+          `artifact publication ${publicationKey} changed before expiry`,
+        );
+      }
+      const expired = this.sql
+        .exec(
+          "SELECT * FROM artifact_publications WHERE publication_key = ?",
+          publicationKey,
+        )
+        .toArray();
+      return json({
+        outcome: "expired",
+        publication: artifactPublicationView(expired[0] as Record<string, unknown>),
+      });
+    }
+    if (Number(row.lease_expires_at) > nowSec) {
+      if (row.claimant === claimant) {
+        const renewed = this.sql.exec(
+          "UPDATE artifact_publications SET lease_expires_at = ?, updated_at = ? " +
+            "WHERE publication_key = ? AND status = ? AND claimant = ?",
+          (nowMs + leaseMs) / 1000,
+          nowText,
+          publicationKey,
+          row.status,
+          claimant,
+        );
+        if (renewed.rowsWritten < 1) {
+          return json(
+            {
+              error: "artifact_publication_pending",
+              message: `artifact publication ${publicationKey} changed before renewal`,
+            },
+            423,
+          );
+        }
+        const owned = this.sql
+          .exec(
+            "SELECT * FROM artifact_publications WHERE publication_key = ?",
+            publicationKey,
+          )
+          .toArray();
+        return json({
+          outcome: "owned",
+          publication: artifactPublicationView(owned[0] as Record<string, unknown>),
+        });
+      }
+      return json(
+        { error: "artifact_publication_pending", message: "a live publication lease exists" },
+        423,
+      );
+    }
+    if (Number(row.attempt_count) >= Number.MAX_SAFE_INTEGER) {
+      return conflict(
+        "artifact_publication_conflict",
+        `artifact publication ${publicationKey} exhausted its portable attempt counter`,
+      );
+    }
+    const updated = this.sql.exec(
+      "UPDATE artifact_publications SET claimant = ?, lease_expires_at = ?, " +
+        "attempt_count = attempt_count + 1, updated_at = ? " +
+        "WHERE publication_key = ? AND status = ? AND lease_expires_at <= ?",
+      claimant,
+      (nowMs + leaseMs) / 1000,
+      nowText,
+      publicationKey,
+      row.status,
+      nowSec,
+    );
+    if (updated.rowsWritten < 1) {
+      return json(
+        {
+          error: "artifact_publication_pending",
+          message: `artifact publication ${publicationKey} changed before recovery`,
+        },
+        423,
+      );
+    }
+    const recovered = this.sql
+      .exec(
+        "SELECT * FROM artifact_publications WHERE publication_key = ?",
+        publicationKey,
+      )
+      .toArray();
+    return json({
+      outcome: "recovered",
+      publication: artifactPublicationView(recovered[0] as Record<string, unknown>),
+    });
+  }
+
+  private async handleArtifactServerClock(
+    request: Request,
+    url: URL,
+    route: string[],
+    worldId: string,
+  ): Promise<Response> {
+    const method = request.method;
+
+    if (route.length === 2 && route[1] === "acquire-v3" && method === "POST") {
+      const p = recoveryObject(await request.json(), "artifact acquisition body");
+      recoveryExactFields(
+        p,
+        new Set([
+          "publication_key",
+          "run_id",
+          "attempt_id",
+          "idempotency_key",
+          "request_digest",
+          "request_json",
+          "claimant",
+          "retry_window_ms",
+          "retry_not_after_ms",
+          "lease_ms",
+        ]),
+        "artifact acquisition body",
+      );
+      const publicationKey = recoverySha256(p.publication_key, "publication_key");
+      const runId = recoveryText(p.run_id, "run_id", 4096);
+      const attemptId = recoveryText(p.attempt_id, "attempt_id", 4096);
+      const idempotencyKey = recoveryText(p.idempotency_key, "idempotency_key", 4096);
+      const requestDigest = recoveryText(p.request_digest, "request_digest", 4096);
+      const requestJson = recoveryText(p.request_json, "request_json", 16 * 1024 * 1024);
+      const claimant = recoveryText(p.claimant, "artifact publication claimant", 1024);
+      const retryWindowMs = recoveryInteger(
+        p.retry_window_ms,
+        "artifact retry_window_ms",
+        0,
+        MAX_ARTIFACT_RETRY_WINDOW_MS,
+      );
+      const leaseMs = recoveryInteger(
+        p.lease_ms,
+        "artifact lease_ms",
+        1,
+        MAX_ARTIFACT_LEASE_MS,
+      );
+      let retryNotAfterMs: number | null = null;
+      if (Object.prototype.hasOwnProperty.call(p, "retry_not_after_ms")) {
+        retryNotAfterMs = recoveryInteger(
+          p.retry_not_after_ms,
+          "artifact retry_not_after_ms",
+          0,
+          Number.MAX_SAFE_INTEGER,
+        );
+      }
+      const expectedPublicationKey = await artifactPublicationKey(
+        worldId,
+        runId,
+        idempotencyKey,
+      );
+      if (publicationKey !== expectedPublicationKey) {
+        throw new RecoveryInputError(
+          "publication_key does not match world_id/run_id/idempotency_key",
+        );
+      }
+      const existing = this.sql
+        .exec(
+          "SELECT * FROM artifact_publications WHERE publication_key = ?",
+          publicationKey,
+        )
+        .toArray();
+      if (existing.length) {
+        const row = existing[0] as Record<string, unknown>;
+        if (row.request_digest !== requestDigest) {
+          return conflict(
+            "artifact_publication_conflict",
+            `${idempotencyKey} was reused with a different publication request`,
+          );
+        }
+        return this.recoverArtifactPublication(
+          publicationKey,
+          claimant,
+          leaseMs,
+          Date.now(),
+        );
+      }
+      const nowMs = Date.now();
+      const retryUntilMs = retryNotAfterMs === null
+        ? nowMs + retryWindowMs
+        : Math.min(nowMs + retryWindowMs, retryNotAfterMs);
+      const initiallyExpired = retryUntilMs <= nowMs;
+      const nowText = new Date(nowMs).toISOString();
+      this.sql.exec(
+        "INSERT INTO artifact_publications (publication_key, run_id, attempt_id, " +
+          "idempotency_key, request_digest, status, request_json, records_json, claimant, " +
+          "lease_expires_at, retry_until_ms, attempt_count, last_error, created_at, " +
+          "updated_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?, '[]', ?, ?, ?, 1, " +
+          "?, ?, ?, ?)",
+        publicationKey,
+        runId,
+        attemptId,
+        idempotencyKey,
+        requestDigest,
+        initiallyExpired ? "EXPIRED" : "PENDING",
+        requestJson,
+        claimant,
+        initiallyExpired ? 0 : (nowMs + leaseMs) / 1000,
+        retryUntilMs,
+        initiallyExpired ? ARTIFACT_RETRY_EXPIRED_DETAIL : "",
+        nowText,
+        nowText,
+        initiallyExpired ? nowText : null,
+      );
+      const created = this.sql
+        .exec(
+          "SELECT * FROM artifact_publications WHERE publication_key = ?",
+          publicationKey,
+        )
+        .toArray();
+      return json({
+        outcome: initiallyExpired ? "expired" : "acquired",
+        publication: artifactPublicationView(created[0] as Record<string, unknown>),
+      });
+    }
+
+    if (route.length === 2 && route[1] === "due-v1" && method === "GET") {
+      if (url.searchParams.has("due")) {
+        throw new RecoveryInputError("artifact due listing does not accept a caller clock");
+      }
+      recoveryExactQuery(
+        url,
+        new Set(["limit", "after_publication_key"]),
+        "artifact due listing",
+      );
+      const limit = recoveryQueryInteger(
+        url.searchParams.get("limit"),
+        100,
+        "artifact publication page limit",
+        1,
+        10_000,
+      );
+      const rawCursor = url.searchParams.get("after_publication_key") ?? "";
+      const cursor = rawCursor === ""
+        ? ""
+        : recoverySha256(rawCursor, "after_publication_key");
+      const dueRows = this.sql
+        .exec(
+          "SELECT publication_key FROM artifact_publications " +
+            "WHERE status IN ('PENDING', 'UPLOADED') " +
+            "AND lease_expires_at <= ? AND publication_key > ? " +
+            "ORDER BY publication_key LIMIT ?",
+          Date.now() / 1000,
+          cursor,
+          limit,
+        )
+        .toArray();
+      return json(
+        dueRows.map((row) => ({
+          publication_key: String((row as Record<string, unknown>).publication_key),
+        })),
+      );
+    }
+
+    if (route.length === 3 && route[2] === "recover-v1" && method === "POST") {
+      const publicationKey = recoverySha256(route[1], "publication_key");
+      const p = recoveryObject(await request.json(), "artifact recovery body");
+      recoveryExactFields(
+        p,
+        new Set(["claimant", "lease_ms"]),
+        "artifact recovery body",
+      );
+      const claimant = recoveryText(p.claimant, "artifact publication claimant", 1024);
+      const leaseMs = recoveryInteger(
+        p.lease_ms,
+        "artifact lease_ms",
+        1,
+        MAX_ARTIFACT_LEASE_MS,
+      );
+      return this.recoverArtifactPublication(publicationKey, claimant, leaseMs, Date.now());
+    }
+
+    if (route.length === 3 && route[2] === "fail-v3" && method === "POST") {
+      const publicationKey = recoverySha256(route[1], "publication_key");
+      const p = recoveryObject(await request.json(), "artifact failure body");
+      recoveryExactFields(
+        p,
+        new Set(["claimant", "error", "retry_delay_ms"]),
+        "artifact failure body",
+      );
+      const claimant = recoveryText(p.claimant, "artifact publication claimant", 1024);
+      const error = recoveryText(p.error, "artifact publication error", 8000, true);
+      const retryDelayMs = recoveryInteger(
+        p.retry_delay_ms,
+        "artifact retry_delay_ms",
+        0,
+        MAX_ARTIFACT_RETRY_DELAY_MS,
+      );
+      const rows = this.sql
+        .exec(
+          "SELECT * FROM artifact_publications WHERE publication_key = ?",
+          publicationKey,
+        )
+        .toArray();
+      if (!rows.length) return json({ ok: true });
+      const row = rows[0] as Record<string, unknown>;
+      const authorityError = artifactPublicationAuthorityError(row, publicationKey);
+      if (authorityError) return authorityError;
+      if (row.status === "INDEXED" || row.status === "EXPIRED") return json({ ok: true });
+      if (row.claimant !== claimant) {
+        return json(
+          {
+            error: "artifact_publication_pending",
+            message: `artifact publication ${publicationKey} was taken over`,
+          },
+          423,
+        );
+      }
+      const nowMs = Date.now();
+      if (row.status === "PENDING" && Number(row.retry_until_ms) <= nowMs) {
+        const nowText = new Date(nowMs).toISOString();
+        this.sql.exec(
+          "UPDATE artifact_publications SET status = 'EXPIRED', lease_expires_at = 0, " +
+            "last_error = ?, updated_at = ?, completed_at = ? " +
+            "WHERE publication_key = ? AND status = 'PENDING'",
+          ARTIFACT_RETRY_EXPIRED_DETAIL,
+          nowText,
+          nowText,
+          publicationKey,
+        );
+        return json({ ok: true });
+      }
+      if (Number(row.lease_expires_at) <= nowMs / 1000) {
+        return json(
+          {
+            error: "artifact_publication_pending",
+            message: `artifact publication ${publicationKey} lease expired before failure`,
+          },
+          423,
+        );
+      }
+      this.sql.exec(
+        "UPDATE artifact_publications SET last_error = ?, lease_expires_at = ?, " +
+          "updated_at = ? WHERE publication_key = ?",
+        error,
+        (nowMs + retryDelayMs) / 1000,
+        new Date(nowMs).toISOString(),
+        publicationKey,
+      );
+      return json({ ok: true });
+    }
+
+    return json({ error: "bad_route" }, 404);
+  }
+
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
     const parts = url.pathname.split("/").filter(Boolean); // ns,:namespace,w,:world,...
     const route = parts.slice(4);
     const method = request.method;
     const now = new Date().toISOString();
+    const worldId = decodeURIComponent(parts[3]);
+
+    const artifactServerClockRoute =
+      route[0] === "artifact-publications" &&
+      (
+        (route.length === 2 && ["acquire-v3", "due-v1"].includes(route[1])) ||
+        (route.length === 3 && ["recover-v1", "fail-v3"].includes(route[2]))
+      );
+    if (artifactServerClockRoute) {
+      try {
+        return await this.handleArtifactServerClock(request, url, route, worldId);
+      } catch (error) {
+        if (error instanceof RecoveryInputError) {
+          return json({ error: "invalid", message: error.message }, 400);
+        }
+        throw error;
+      }
+    }
+
+    const legacyArtifactClockRoute =
+      route[0] === "artifact-publications" &&
+      (
+        (route.length === 1 && method === "GET") ||
+        (route.length === 2 && ["acquire", "acquire-v2"].includes(route[1])) ||
+        (route.length === 3 && ["fail", "fail-v2"].includes(route[2]))
+      );
+    if (legacyArtifactClockRoute) {
+      if (method === "POST") await request.arrayBuffer();
+      return json(
+        {
+          error: "upgrade_required",
+          message: "artifact publication clock authority requires the v3/v1 routes",
+        },
+        426,
+      );
+    }
+
 
     if (
       route[0] === "attempt-claims" &&
@@ -1364,11 +1972,24 @@ export class WorldCommitDO implements DurableObject {
     if (route[0] === "artifact-publications" && route.length === 1 && method === "GET") {
       const due = Number(url.searchParams.get("due") ?? Date.now() / 1000);
       const limit = Math.max(0, Number(url.searchParams.get("limit") ?? 100));
+      const rawCursor = url.searchParams.get("after_publication_key") ?? "";
+      if (rawCursor && !/^[0-9a-f]{64}$/.test(rawCursor)) {
+        return json(
+          {
+            error: "invalid",
+            message: "after_publication_key must be a lowercase SHA-256 digest",
+          },
+          400,
+        );
+      }
+      const afterPublicationKey = rawCursor;
       const dueRows = this.sql
           .exec(
             "SELECT * FROM artifact_publications WHERE status IN ('PENDING', 'UPLOADED') " +
-              "AND lease_expires_at <= ? ORDER BY lease_expires_at, publication_key LIMIT ?",
+              "AND lease_expires_at <= ? AND publication_key > ? " +
+              "ORDER BY publication_key LIMIT ?",
             due,
+            afterPublicationKey,
             limit,
           )
           .toArray();
@@ -1413,25 +2034,85 @@ export class WorldCommitDO implements DurableObject {
         return json({ error: "not_found" }, 404);
       }
       const row = rows[0] as Record<string, unknown>;
+      const authorityError = artifactPublicationAuthorityError(row, key);
+      if (authorityError) return authorityError;
 
       if (route.length === 2 && method === "GET") return json(artifactPublicationView(row));
 
       if ((route[2] === "renew" || route[2] === "renew-v2") && method === "POST") {
-        const body = (await request.json()) as { claimant: string; lease_seconds: number };
+        let claimant: string;
+        let leaseSeconds: number;
+        try {
+          const body = recoveryObject(await request.json(), "artifact renewal body");
+          if (route[2] === "renew-v2") {
+            recoveryExactFields(
+              body,
+              new Set(["claimant", "lease_seconds"]),
+              "artifact renewal body",
+            );
+          }
+          claimant = recoveryText(
+            body.claimant,
+            "artifact publication claimant",
+            1024,
+          );
+          if (
+            typeof body.lease_seconds !== "number" ||
+            !Number.isFinite(body.lease_seconds) ||
+            body.lease_seconds <= 0 ||
+            body.lease_seconds > MAX_ARTIFACT_LEASE_MS / 1000
+          ) {
+            throw new RecoveryInputError(
+              "artifact lease_seconds must be a finite positive bounded number",
+            );
+          }
+          leaseSeconds = body.lease_seconds;
+        } catch (error) {
+          if (error instanceof RecoveryInputError) {
+            return json({ error: "invalid", message: error.message }, 400);
+          }
+          throw error;
+        }
         if (row.status === "INDEXED" || row.status === "EXPIRED") {
           return json(artifactPublicationView(row));
         }
-        if (row.claimant !== body.claimant) {
+        if (row.claimant !== claimant) {
           return json(
             { error: "artifact_publication_pending", message: "publication was taken over" },
+            423,
+          );
+        }
+        const nowMs = Date.now();
+        const nowText = new Date(nowMs).toISOString();
+        if (row.status === "PENDING" && Number(row.retry_until_ms) <= nowMs) {
+          this.sql.exec(
+            "UPDATE artifact_publications SET status = 'EXPIRED', lease_expires_at = 0, " +
+              "last_error = ?, updated_at = ?, completed_at = ? " +
+              "WHERE publication_key = ? AND status = 'PENDING'",
+            ARTIFACT_RETRY_EXPIRED_DETAIL,
+            nowText,
+            nowText,
+            key,
+          );
+          const expired = this.sql
+            .exec("SELECT * FROM artifact_publications WHERE publication_key = ?", key)
+            .toArray();
+          return json(artifactPublicationView(expired[0] as Record<string, unknown>));
+        }
+        if (Number(row.lease_expires_at) <= nowMs / 1000) {
+          return json(
+            {
+              error: "artifact_publication_pending",
+              message: "publication lease expired before renewal",
+            },
             423,
           );
         }
         this.sql.exec(
           "UPDATE artifact_publications SET lease_expires_at = ?, updated_at = ? " +
             "WHERE publication_key = ?",
-          Date.now() / 1000 + Number(body.lease_seconds),
-          now,
+          nowMs / 1000 + leaseSeconds,
+          nowText,
           key,
         );
         const updated = this.sql
@@ -1441,43 +2122,114 @@ export class WorldCommitDO implements DurableObject {
       }
 
       if ((route[2] === "uploads" || route[2] === "uploads-v2") && method === "POST") {
-        const body = (await request.json()) as {
-          claimant: string;
-          records_json: string;
-          manifest_uri: string;
-        };
+        let claimant: string;
+        let recordsJson: string;
+        let manifestUri: string;
+        try {
+          const body = recoveryObject(await request.json(), "artifact uploads body");
+          if (route[2] === "uploads-v2") {
+            recoveryExactFields(
+              body,
+              new Set(["claimant", "records_json", "manifest_uri"]),
+              "artifact uploads body",
+            );
+          }
+          claimant = recoveryText(
+            body.claimant,
+            "artifact publication claimant",
+            1024,
+          );
+          recordsJson = recoveryText(
+            body.records_json,
+            "artifact records_json",
+            16 * 1024 * 1024,
+            true,
+          );
+          manifestUri = recoveryText(
+            body.manifest_uri,
+            "artifact manifest_uri",
+            16 * 1024,
+            true,
+          );
+        } catch (error) {
+          if (error instanceof RecoveryInputError) {
+            return json({ error: "invalid", message: error.message }, 400);
+          }
+          throw error;
+        }
         if (row.status === "INDEXED") return json({ ok: true, idempotent: true });
         if (row.status === "EXPIRED") {
           return conflict("artifact_publication_expired", `publication ${key} expired`);
         }
-        if (row.claimant !== body.claimant) {
+        if (row.claimant !== claimant) {
           return json(
             { error: "artifact_publication_pending", message: "publication was taken over" },
             423,
           );
         }
         if (row.status === "UPLOADED") {
-          if (row.records_json === body.records_json && row.manifest_uri === body.manifest_uri) {
+          if (row.records_json === recordsJson && row.manifest_uri === manifestUri) {
             return json({ ok: true, idempotent: true });
           }
           return conflict("artifact_publication_conflict", "different uploads already recorded");
         }
+        const nowMs = Date.now();
+        const nowText = new Date(nowMs).toISOString();
+        if (Number(row.retry_until_ms) <= nowMs) {
+          this.sql.exec(
+            "UPDATE artifact_publications SET status = 'EXPIRED', lease_expires_at = 0, " +
+              "last_error = ?, updated_at = ?, completed_at = ? " +
+              "WHERE publication_key = ? AND status = 'PENDING'",
+            ARTIFACT_RETRY_EXPIRED_DETAIL,
+            nowText,
+            nowText,
+            key,
+          );
+          return conflict("artifact_publication_expired", `publication ${key} expired`);
+        }
+        if (Number(row.lease_expires_at) <= nowMs / 1000) {
+          return json(
+            {
+              error: "artifact_publication_pending",
+              message: "publication lease expired before uploads",
+            },
+            423,
+          );
+        }
         this.sql.exec(
           "UPDATE artifact_publications SET status = 'UPLOADED', records_json = ?, " +
             "manifest_uri = ?, last_error = '', updated_at = ? WHERE publication_key = ?",
-          body.records_json,
-          body.manifest_uri,
-          now,
+          recordsJson,
+          manifestUri,
+          nowText,
           key,
         );
         return json({ ok: true });
       }
 
       if ((route[2] === "complete" || route[2] === "complete-v2") && method === "POST") {
-        const body = (await request.json()) as {
-          claimant: string;
-          index_snapshot_id: unknown;
-        };
+        let body: Record<string, unknown>;
+        let claimant: string;
+        try {
+          body = recoveryObject(await request.json(), "artifact completion body");
+          if (route[2] === "complete-v2") {
+            recoveryExactFields(
+              body,
+              new Set(["claimant", "index_snapshot_id"]),
+              "artifact completion body",
+            );
+          }
+          claimant = recoveryText(
+            body.claimant,
+            "artifact publication claimant",
+            1024,
+          );
+        } catch (error) {
+          if (error instanceof RecoveryInputError) {
+            return json({ error: "invalid", message: error.message }, 400);
+          }
+          throw error;
+        }
         let snapshotId: string;
         if (route[2] === "complete-v2") {
           const supplied = body.index_snapshot_id;
@@ -1529,18 +2281,29 @@ export class WorldCommitDO implements DurableObject {
             `publication ${key} cannot move from ${row.status} to INDEXED`,
           );
         }
-        if (row.claimant !== body.claimant) {
+        if (row.claimant !== claimant) {
           return json(
             { error: "artifact_publication_pending", message: "publication was taken over" },
             423,
           );
         }
+        const nowMs = Date.now();
+        if (Number(row.lease_expires_at) <= nowMs / 1000) {
+          return json(
+            {
+              error: "artifact_publication_pending",
+              message: "publication lease expired before completion",
+            },
+            423,
+          );
+        }
+        const completedAt = new Date(nowMs).toISOString();
         this.sql.exec(
           "UPDATE artifact_publications SET status = 'INDEXED', index_snapshot_id_text = ?, " +
             "last_error = '', updated_at = ?, completed_at = ? WHERE publication_key = ?",
           snapshotId,
-          now,
-          now,
+          completedAt,
+          completedAt,
           key,
         );
         return json({ ok: true });
@@ -1571,7 +2334,34 @@ export class WorldCommitDO implements DurableObject {
       }
 
       if ((route[2] === "expire" || route[2] === "expire-v2") && method === "POST") {
-        const body = (await request.json()) as { claimant: string; error: string };
+        let claimant: string;
+        let errorDetail: string;
+        try {
+          const body = recoveryObject(await request.json(), "artifact expiry body");
+          if (route[2] === "expire-v2") {
+            recoveryExactFields(
+              body,
+              new Set(["claimant", "error"]),
+              "artifact expiry body",
+            );
+          }
+          claimant = recoveryText(
+            body.claimant,
+            "artifact publication claimant",
+            1024,
+          );
+          errorDetail = recoveryText(
+            body.error,
+            "artifact publication error",
+            8000,
+            true,
+          );
+        } catch (error) {
+          if (error instanceof RecoveryInputError) {
+            return json({ error: "invalid", message: error.message }, 400);
+          }
+          throw error;
+        }
         if (row.status === "INDEXED" || row.status === "EXPIRED") return json({ ok: true });
         if (row.status === "UPLOADED") {
           return conflict(
@@ -1579,18 +2369,29 @@ export class WorldCommitDO implements DurableObject {
             "uploaded publications must be indexed, not expired",
           );
         }
-        if (row.claimant !== body.claimant) {
+        if (row.claimant !== claimant) {
           return json(
             { error: "artifact_publication_pending", message: "publication was taken over" },
             423,
           );
         }
+        const nowMs = Date.now();
+        if (Number(row.lease_expires_at) <= nowMs / 1000) {
+          return json(
+            {
+              error: "artifact_publication_pending",
+              message: "publication lease expired before expiry",
+            },
+            423,
+          );
+        }
+        const completedAt = new Date(nowMs).toISOString();
         this.sql.exec(
           "UPDATE artifact_publications SET status = 'EXPIRED', last_error = ?, " +
             "updated_at = ?, completed_at = ? WHERE publication_key = ?",
-          String(body.error).slice(0, 8000),
-          now,
-          now,
+          errorDetail,
+          completedAt,
+          completedAt,
           key,
         );
         return json({ ok: true });
@@ -1608,6 +2409,7 @@ export class WorldCommitDO implements DurableObject {
             ATTEMPT_FINALIZATION_CAPABILITY,
             ATTEMPT_CLAIM_CAPABILITY,
             ARTIFACT_SNAPSHOT_CAPABILITY,
+            ARTIFACT_SERVER_CLOCK_CAPABILITY,
           ],
         };
         return rows.length
@@ -1648,7 +2450,7 @@ export class WorldCommitDO implements DurableObject {
       if (admissions.length === 0) return json([]);
       try {
         const records = this.state.storage.transactionSync(() => {
-          requireActiveWorld(this.sql, parts[3]);
+          requireActiveWorld(this.sql, worldId);
           const seen = new Map<string, string>();
           for (const admission of admissions) {
             const commandId = String(admission.command_id);
@@ -1728,7 +2530,7 @@ export class WorldCommitDO implements DurableObject {
       const nowSec = Date.now() / 1000;
       try {
         const records = this.state.storage.transactionSync(() => {
-          requireActiveWorld(this.sql, parts[3]);
+          requireActiveWorld(this.sql, worldId);
           const rows = this.sql
             .exec(
               "SELECT * FROM commands WHERE scheduled_tick <= ? AND (status IN ('PENDING', 'RETRYABLE') OR (status = 'LEASED' AND (lease_owner = ? OR lease_expires_at <= ?))) ORDER BY scheduled_tick, priority, sequence LIMIT ?",

--- a/infra/control-catalog/src/index.ts
+++ b/infra/control-catalog/src/index.ts
@@ -146,7 +146,7 @@ function recoveryQueryInteger(
 }
 
 function pythonAsciiJsonString(value: string): string {
-  return JSON.stringify(value).replace(/[^\x00-\x7f]/gu, (character) => {
+  return JSON.stringify(value).replace(/[^\x00-\x7e]/gu, (character) => {
     let codePoint = character.codePointAt(0) as number;
     if (codePoint <= 0xffff) return `\\u${codePoint.toString(16).padStart(4, "0")}`;
     codePoint -= 0x10000;
@@ -1967,35 +1967,6 @@ export class WorldCommitDO implements DurableObject {
         outcome: "acquired",
         publication: artifactPublicationView(created[0] as Record<string, unknown>),
       });
-    }
-
-    if (route[0] === "artifact-publications" && route.length === 1 && method === "GET") {
-      const due = Number(url.searchParams.get("due") ?? Date.now() / 1000);
-      const limit = Math.max(0, Number(url.searchParams.get("limit") ?? 100));
-      const rawCursor = url.searchParams.get("after_publication_key") ?? "";
-      if (rawCursor && !/^[0-9a-f]{64}$/.test(rawCursor)) {
-        return json(
-          {
-            error: "invalid",
-            message: "after_publication_key must be a lowercase SHA-256 digest",
-          },
-          400,
-        );
-      }
-      const afterPublicationKey = rawCursor;
-      const dueRows = this.sql
-          .exec(
-            "SELECT * FROM artifact_publications WHERE status IN ('PENDING', 'UPLOADED') " +
-              "AND lease_expires_at <= ? AND publication_key > ? " +
-              "ORDER BY publication_key LIMIT ?",
-            due,
-            afterPublicationKey,
-            limit,
-          )
-          .toArray();
-      return json(
-        dueRows.map((row) => artifactPublicationView(row as Record<string, unknown>)),
-      );
     }
 
     if (route[0] === "artifact-publications" && route.length >= 2) {

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -140,36 +140,36 @@ reason = "same grading-boundary site as the collect above: per-entity terminal r
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1251
+line = 1321
 method = "to_pylist"
 reason = "Artifact-manifest boundary: the caller-declared, size-bounded file set has already been hashed and MIME-classified by native Daft expressions; scalar metadata must enter Python to construct validated immutable index records and the canonical bundle manifest."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1303
+line = 1373
 method = "to_pylist"
 reason = "Object-store completion boundary: each caller-declared, size-bounded upload has executed through Daft and its returned object URI must enter Python to construct the portable manifest and deterministic artifact-index rows."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1316
+line = 1386
 method = "to_pylist"
 reason = "Single-object upload boundary: one generated bundle-manifest byte value is uploaded through Daft and its sole destination URI must enter the durable publication receipt and control-catalog record."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1370
+line = 1440
 method = "to_pylist"
 reason = "Existing-object metadata authorization boundary: only paths and sizes beneath one deterministic content-addressed destination enter Python so each candidate URI can pass shared redaction policy and exact-size eligibility before any remote byte read."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1403
+line = 1473
 method = "to_pylist"
 reason = "Existing-object byte-integrity boundary: one size-eligible, metadata-approved remote candidate is read through Daft and its bytes enter Python solely to verify exact size and SHA-256 before durable reuse."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1419
+line = 1489
 method = "to_pylist"
 reason = "Bundle-index idempotency boundary: the Iceberg query is filtered to one deterministic bundle and its bounded artifact rows must enter Python for exact conflict detection and missing-row selection before an append."

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -402,6 +402,23 @@ benchmarks = []
 profiles = ["pr", "main", "release"]
 
 [[contract]]
+id = "artifacts.bundle.recovery_server_clock"
+source = "docs/guide/artifact-finalization.md"
+section = "6. Reconciler contract"
+owner = "artifacts"
+risk = "high"
+pytest = [
+  "tests/app/test_artifact_bundle_service.py",
+  "tests/app/test_artifact_publication_catalog.py",
+  "tests/app/test_remote_catalog_client.py",
+  "tests/app/test_remote_catalog_parity.py",
+]
+static = []
+evals = []
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
 id = "missions.transition.evidence_gated"
 source = "docs/guide/agent-missions.md"
 section = "2. Typed mission/task/attempt transition graph"

--- a/quality/observability/artifacts.toml
+++ b/quality/observability/artifacts.toml
@@ -28,6 +28,8 @@ attribute_keys = [
 [[disposition]]
 operations = [
   "interfaces.iArtifactBundleService.reconcile",
+  "interfaces.iArtifactBundleService.list_due_publications",
+  "interfaces.iArtifactBundleService.reconcile_publication",
 ]
 signals = ["none"]
 outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]

--- a/quality/observability/storage.toml
+++ b/quality/observability/storage.toml
@@ -19,6 +19,7 @@ operations = [
   "catalog.ControlCatalog.get_attempt_claim",
   "catalog.ControlCatalog.list_due_attempt_claims",
   "catalog.ControlCatalog.acquire_artifact_publication",
+  "catalog.ControlCatalog.recover_artifact_publication",
   "catalog.ControlCatalog.get_artifact_publication",
   "catalog.ControlCatalog.renew_artifact_publication",
   "catalog.ControlCatalog.record_artifact_uploads",

--- a/scripts/check_pre_durability_redaction.py
+++ b/scripts/check_pre_durability_redaction.py
@@ -58,6 +58,7 @@ def audit_path(path: Path = DEFAULT_TARGET) -> list[str]:
         "publish",
         "publish_prepared",
         "reconcile",
+        "reconcile_publication",
         "_resume",
         "_upload_bundle",
     }
@@ -69,7 +70,7 @@ def audit_path(path: Path = DEFAULT_TARGET) -> list[str]:
     prepare = methods["prepare"]
     publish = methods["publish"]
     publish_prepared = methods["publish_prepared"]
-    reconcile = methods["reconcile"]
+    reconcile_publication = methods["reconcile_publication"]
     resume = methods["_resume"]
     upload_bundle = methods["_upload_bundle"]
     _require_order(
@@ -102,8 +103,8 @@ def audit_path(path: Path = DEFAULT_TARGET) -> list[str]:
     )
     _require_order(
         errors,
-        reconcile,
-        "reconcile",
+        reconcile_publication,
+        "reconcile_publication",
         "_safe_failure_detail",
         "fail_artifact_publication",
     )

--- a/src/archetype/app/artifacts/bundle_models.py
+++ b/src/archetype/app/artifacts/bundle_models.py
@@ -139,11 +139,11 @@ class ArtifactBundleRequest(BaseModel):
     checkpoint_ref: str
     checkpoint_provider: str
     checkpoint_restorable: bool = True
-    checkpoint_created_at_ms: int = Field(default=0, ge=0)
-    checkpoint_expires_at_ms: int = Field(default=0, ge=0)
+    checkpoint_created_at_ms: int = Field(default=0, ge=0, le=(1 << 53) - 1, strict=True)
+    checkpoint_expires_at_ms: int = Field(default=0, ge=0, le=(1 << 53) - 1, strict=True)
     accepted: bool = False
     retention: ArtifactRetention = "attempt"
-    artifact_expires_at_ms: int = Field(default=0, ge=0)
+    artifact_expires_at_ms: int = Field(default=0, ge=0, le=(1 << 53) - 1, strict=True)
     artifacts: tuple[ArtifactCandidate, ...]
 
     @field_validator(
@@ -408,6 +408,49 @@ class ArtifactReconcileResult(BaseModel):
     bundle_ids: tuple[str, ...] = ()
 
 
+class ArtifactReconcileDisposition(StrEnum):
+    """Outcome of reconciling one exact durable publication."""
+
+    INDEXED = "indexed"
+    EXPIRED = "expired"
+    OBSOLETE = "obsolete"
+
+
+class ArtifactReconcileCandidate(BaseModel):
+    """Digest-only reference safe for the fleet recovery scheduler."""
+
+    model_config = dict(frozen=True)
+
+    publication_key: str
+
+    @field_validator("publication_key")
+    @classmethod
+    def _publication_digest(cls, value: str) -> str:
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("publication_key must be a lowercase SHA-256 digest")
+        return value
+
+
+class ArtifactReconcileItemResult(BaseModel):
+    """Typed feedback for one item-scoped publication recovery attempt.
+
+    This value is orchestration feedback. The artifact publication row remains
+    the authority for INDEXED or EXPIRED state.
+    """
+
+    model_config = dict(frozen=True)
+
+    publication_key: str
+    disposition: ArtifactReconcileDisposition
+
+    @field_validator("publication_key")
+    @classmethod
+    def _result_publication_digest(cls, value: str) -> str:
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("publication_key must be a lowercase SHA-256 digest")
+        return value
+
+
 class ArtifactStoreConfig(BaseModel):
     """Object destination, Iceberg index, and retry/lifecycle policy.
 
@@ -421,9 +464,24 @@ class ArtifactStoreConfig(BaseModel):
     index_storage: StorageConfig
     io_config: IOConfig | None = None
     max_connections: int = Field(default=32, ge=1)
-    lease_seconds: float = Field(default=900.0, gt=0)
-    retry_delay_seconds: float = Field(default=30.0, ge=0)
-    retry_window_seconds: int = Field(default=7 * 24 * 60 * 60, ge=60)
+    lease_seconds: float = Field(
+        default=900.0,
+        gt=0,
+        le=24 * 60 * 60,
+        allow_inf_nan=False,
+    )
+    retry_delay_seconds: float = Field(
+        default=30.0,
+        ge=0,
+        le=365 * 24 * 60 * 60,
+        allow_inf_nan=False,
+    )
+    retry_window_seconds: int = Field(
+        default=7 * 24 * 60 * 60,
+        ge=60,
+        le=365 * 24 * 60 * 60,
+        strict=True,
+    )
     attempt_retention_seconds: int = Field(default=30 * 24 * 60 * 60, ge=0)
     run_retention_seconds: int = Field(default=180 * 24 * 60 * 60, ge=0)
     max_artifact_bytes: int = Field(default=1 << 30, gt=0)

--- a/src/archetype/app/artifacts/bundle_service.py
+++ b/src/archetype/app/artifacts/bundle_service.py
@@ -9,11 +9,11 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import mimetypes
 import shutil
 import tarfile
 import tempfile
-import time
 from collections import defaultdict
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -36,6 +36,9 @@ from archetype.app.artifacts.bundle_models import (
     ArtifactIndexRecord,
     ArtifactPublicationStatus,
     ArtifactPublishReceipt,
+    ArtifactReconcileCandidate,
+    ArtifactReconcileDisposition,
+    ArtifactReconcileItemResult,
     ArtifactReconcileResult,
     ArtifactSourceResolver,
     ArtifactStoreConfig,
@@ -640,6 +643,18 @@ class ArtifactBundleService:
             return f"{type(exc).__name__}: failure detail unavailable"
         return result.text[:_MAX_FAILURE_DETAIL_CHARS]
 
+    @staticmethod
+    def _lease_ms(seconds: float) -> int:
+        """Convert validated configuration to a non-shortening wire duration."""
+
+        return max(1, math.ceil(seconds * 1000))
+
+    @staticmethod
+    def _delay_ms(seconds: float) -> int:
+        """Convert validated retry configuration to an exact wire duration."""
+
+        return max(0, math.ceil(seconds * 1000))
+
     async def publish(
         self,
         request: ArtifactBundleRequest,
@@ -663,10 +678,6 @@ class ArtifactBundleService:
         request = self._request_from_preparation(prepared)
         catalog = await self._control_catalog(request, storage_config)
         claimant = f"artifact-{uuid7()}"
-        now_ms = int(time.time() * 1000)
-        retry_until_ms = now_ms + config.retry_window_seconds * 1000
-        if request.checkpoint_expires_at_ms:
-            retry_until_ms = min(retry_until_ms, request.checkpoint_expires_at_ms)
         attributes = self._span_attributes(request)
 
         with _obs.span("artifact.publish", attributes=attributes):
@@ -678,8 +689,11 @@ class ArtifactBundleService:
                 request_digest=prepared.producer_digest,
                 request_json=prepared.request_json,
                 claimant=claimant,
-                retry_until_ms=retry_until_ms,
-                lease_seconds=config.lease_seconds,
+                retry_window_ms=config.retry_window_seconds * 1000,
+                retry_not_after_ms=(
+                    request.checkpoint_expires_at_ms if request.checkpoint_expires_at_ms else None
+                ),
+                lease_ms=self._lease_ms(config.lease_seconds),
             )
             if outcome == "duplicate":
                 return self._receipt(publication, duplicate=True)
@@ -703,7 +717,7 @@ class ArtifactBundleService:
                         publication.publication_key,
                         claimant,
                         failure_detail,
-                        retry_at=time.time() + config.retry_delay_seconds,
+                        retry_delay_ms=self._delay_ms(config.retry_delay_seconds),
                     )
                 except Exception as record_error:
                     exc.add_note(
@@ -745,96 +759,151 @@ class ArtifactBundleService:
         limit: int = 100,
     ) -> ArtifactReconcileResult:
         """Run one bounded pass over expired leases for a single world."""
-        if limit < 1:
-            raise ValueError("artifact reconciliation limit must be at least 1")
-        config = self._require_config()
-        storage, catalog = await self._catalog_for_world(world_id, storage_config)
-        del storage
-        due = await catalog.list_due_artifact_publications(
-            str(world_id), now=time.time(), limit=limit
+        candidates = await self.list_due_publications(
+            world_id,
+            storage_config=storage_config,
+            limit=limit,
         )
         indexed = expired = failed = 0
-        bundle_ids: list[str] = []
-        for stale in due:
-            bundle_ids.append(stale.publication_key)
-            claimant = f"artifact-reconciler-{uuid7()}"
-            owned = False
+        for candidate in candidates:
             try:
-                outcome, publication = await catalog.acquire_artifact_publication(
-                    world_id=stale.world_id,
-                    run_id=stale.run_id,
-                    attempt_id=stale.attempt_id,
-                    idempotency_key=stale.idempotency_key,
-                    request_digest=stale.request_digest,
-                    request_json=stale.request_json,
-                    claimant=claimant,
-                    retry_until_ms=stale.retry_until_ms,
-                    lease_seconds=config.lease_seconds,
+                result = await self.reconcile_publication(
+                    world_id,
+                    candidate.publication_key,
+                    storage_config=storage_config,
                 )
-                if outcome == "duplicate":
-                    indexed += 1
-                    continue
-                if outcome == "expired":
-                    expired += 1
-                    continue
-                owned = True
-                if publication.status == "PENDING" and (
-                    int(time.time() * 1000) > publication.retry_until_ms
-                ):
-                    await catalog.expire_artifact_publication(
-                        publication.world_id,
-                        publication.publication_key,
-                        claimant,
-                        "artifact publication retry window elapsed before upload",
-                    )
-                    expired += 1
-                    continue
-                request = self._request_from_publication(
-                    publication,
-                    require_policy=publication.status == "PENDING",
-                )
-                receipt = await self._resume(request, publication, claimant, catalog)
-                if receipt.status is ArtifactPublicationStatus.EXPIRED:
-                    expired += 1
-                else:
-                    indexed += 1
             except Exception as exc:
                 failed += 1
-                if not owned:
-                    logger.error(
-                        "artifact reconciliation failed before lease acquisition for %s (%s)",
-                        stale.publication_key,
-                        type(exc).__name__,
-                    )
-                    continue
-                failure_detail = self._safe_failure_detail(exc)
-                try:
-                    await catalog.fail_artifact_publication(
-                        publication.world_id,
-                        publication.publication_key,
-                        claimant,
-                        failure_detail,
-                        retry_at=time.time() + config.retry_delay_seconds,
-                    )
-                except Exception as record_error:
-                    exc.add_note(
-                        "failed to record artifact reconciliation retry state: "
-                        f"{type(record_error).__name__}"
-                    )
-                    logger.error(
-                        "artifact reconciler failed to record retry state for %s after %s; "
-                        "retry-state recording also failed (%s)",
-                        publication.publication_key,
-                        type(exc).__name__,
-                        type(record_error).__name__,
-                    )
+                logger.error(
+                    "artifact reconciliation failed for %s (%s)",
+                    candidate.publication_key,
+                    type(exc).__name__,
+                )
+                continue
+            if result.disposition is ArtifactReconcileDisposition.INDEXED:
+                indexed += 1
+            elif result.disposition is ArtifactReconcileDisposition.EXPIRED:
+                expired += 1
         return ArtifactReconcileResult(
-            examined=len(due),
+            examined=len(candidates),
             indexed=indexed,
             expired=expired,
             failed=failed,
-            bundle_ids=tuple(bundle_ids),
+            bundle_ids=tuple(candidate.publication_key for candidate in candidates),
         )
+
+    async def list_due_publications(
+        self,
+        world_id: str,
+        *,
+        storage_config: StorageConfig | None = None,
+        limit: int = 100,
+        after_publication_key: str = "",
+    ) -> tuple[ArtifactReconcileCandidate, ...]:
+        """Return a bounded page of digest-only publication references."""
+        if limit < 1:
+            raise ValueError("artifact reconciliation limit must be at least 1")
+        if after_publication_key:
+            after_publication_key = ArtifactReconcileCandidate(
+                publication_key=after_publication_key
+            ).publication_key
+        self._require_config()
+        storage, catalog = await self._catalog_for_world(world_id, storage_config)
+        del storage
+        due = await catalog.list_due_artifact_publications(
+            str(world_id),
+            limit=limit,
+            after_publication_key=after_publication_key,
+        )
+        return tuple(ArtifactReconcileCandidate(publication_key=row.publication_key) for row in due)
+
+    async def reconcile_publication(
+        self,
+        world_id: str,
+        publication_key: str,
+        *,
+        storage_config: StorageConfig | None = None,
+    ) -> ArtifactReconcileItemResult:
+        """Reconcile one exact durable publication without discovering other work."""
+        candidate = ArtifactReconcileCandidate(publication_key=publication_key)
+        config = self._require_config()
+        storage, catalog = await self._catalog_for_world(world_id, storage_config)
+        del storage
+        claimant = f"artifact-reconciler-{uuid7()}"
+        owned = False
+        publication: ArtifactPublicationRecord | None = None
+        try:
+            outcome, publication = await catalog.recover_artifact_publication(
+                str(world_id),
+                candidate.publication_key,
+                claimant,
+                lease_ms=self._lease_ms(config.lease_seconds),
+            )
+            if outcome == "obsolete":
+                return ArtifactReconcileItemResult(
+                    publication_key=candidate.publication_key,
+                    disposition=ArtifactReconcileDisposition.OBSOLETE,
+                )
+            if publication is None:
+                raise RuntimeError("artifact recovery returned no authoritative publication")
+            if outcome == "duplicate":
+                return ArtifactReconcileItemResult(
+                    publication_key=candidate.publication_key,
+                    disposition=ArtifactReconcileDisposition.INDEXED,
+                )
+            if outcome == "expired":
+                return ArtifactReconcileItemResult(
+                    publication_key=candidate.publication_key,
+                    disposition=ArtifactReconcileDisposition.EXPIRED,
+                )
+            if outcome not in {"owned", "recovered"}:
+                raise RuntimeError(f"artifact recovery returned unexpected outcome {outcome!r}")
+            owned = True
+            request = self._request_from_publication(
+                publication,
+                require_policy=publication.status == "PENDING",
+            )
+            receipt = await self._resume(request, publication, claimant, catalog)
+            disposition = (
+                ArtifactReconcileDisposition.EXPIRED
+                if receipt.status is ArtifactPublicationStatus.EXPIRED
+                else ArtifactReconcileDisposition.INDEXED
+            )
+            return ArtifactReconcileItemResult(
+                publication_key=candidate.publication_key,
+                disposition=disposition,
+            )
+        except Exception as exc:
+            if not owned:
+                logger.error(
+                    "artifact reconciliation failed before lease acquisition for %s (%s)",
+                    candidate.publication_key,
+                    type(exc).__name__,
+                )
+                raise
+            assert publication is not None
+            failure_detail = self._safe_failure_detail(exc)
+            try:
+                await catalog.fail_artifact_publication(
+                    publication.world_id,
+                    publication.publication_key,
+                    claimant,
+                    failure_detail,
+                    retry_delay_ms=self._delay_ms(config.retry_delay_seconds),
+                )
+            except Exception as record_error:
+                exc.add_note(
+                    "failed to record artifact reconciliation retry state: "
+                    f"{type(record_error).__name__}"
+                )
+                logger.error(
+                    "artifact reconciler failed to record retry state for %s after %s; "
+                    "retry-state recording also failed (%s)",
+                    publication.publication_key,
+                    type(exc).__name__,
+                    type(record_error).__name__,
+                )
+            raise
 
     def _request_from_preparation(
         self,
@@ -911,6 +980,21 @@ class ArtifactBundleService:
         catalog: ControlCatalog,
     ) -> ArtifactPublishReceipt:
         config = self._require_config()
+        outcome, authoritative = await catalog.recover_artifact_publication(
+            request.world_id,
+            publication.publication_key,
+            claimant,
+            lease_ms=self._lease_ms(config.lease_seconds),
+        )
+        if outcome == "obsolete" or authoritative is None:
+            raise RuntimeError("artifact publication disappeared before external I/O")
+        if outcome in {"duplicate", "expired"}:
+            return self._receipt(authoritative, duplicate=outcome == "duplicate")
+        publication = authoritative
+        request = self._request_from_publication(
+            publication,
+            require_policy=publication.status == "PENDING",
+        )
         # The object destination is deployment configuration rather than part
         # of the durable request. Recheck it on every cold recovery before a
         # PENDING row can upload or an UPLOADED row can reach the index.
@@ -919,20 +1003,6 @@ class ArtifactBundleService:
         records: tuple[ArtifactIndexRecord, ...]
         manifest_uri = publication.manifest_uri
         if publication.status == "PENDING":
-            if int(time.time() * 1000) > publication.retry_until_ms:
-                await catalog.expire_artifact_publication(
-                    request.world_id,
-                    publication.publication_key,
-                    claimant,
-                    "artifact publication retry window elapsed before upload",
-                )
-                expired = await catalog.get_artifact_publication(
-                    request.world_id,
-                    publication.publication_key,
-                )
-                if expired is None:
-                    raise RuntimeError("expired artifact publication disappeared from its catalog")
-                return self._receipt(expired, duplicate=False)
             async with self._lease_heartbeat(
                 catalog, request.world_id, publication.publication_key, claimant
             ):

--- a/src/archetype/app/artifacts/interfaces.py
+++ b/src/archetype/app/artifacts/interfaces.py
@@ -13,6 +13,8 @@ from daft import DataFrame
 from archetype.app.artifacts.bundle_models import (
     ArtifactBundleRequest,
     ArtifactPublishReceipt,
+    ArtifactReconcileCandidate,
+    ArtifactReconcileItemResult,
     ArtifactReconcileResult,
     PreparedArtifactBundleRequest,
 )
@@ -123,3 +125,20 @@ class iArtifactBundleService(Protocol):
         storage_config: StorageConfig | None = None,
         limit: int = 100,
     ) -> ArtifactReconcileResult: ...
+
+    async def list_due_publications(
+        self,
+        world_id: str,
+        *,
+        storage_config: StorageConfig | None = None,
+        limit: int = 100,
+        after_publication_key: str = "",
+    ) -> tuple[ArtifactReconcileCandidate, ...]: ...
+
+    async def reconcile_publication(
+        self,
+        world_id: str,
+        publication_key: str,
+        *,
+        storage_config: StorageConfig | None = None,
+    ) -> ArtifactReconcileItemResult: ...

--- a/src/archetype/app/storage/catalog.py
+++ b/src/archetype/app/storage/catalog.py
@@ -45,7 +45,9 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
+import re
 import sqlite3
 import time
 from dataclasses import dataclass
@@ -66,6 +68,82 @@ logger = logging.getLogger(__name__)
 
 _SCHEMA_VERSION = 8
 _DIGEST_DOMAIN = "archetype.catalog.v1"
+_MAX_PORTABLE_COUNTER = (1 << 53) - 1
+_MAX_ARTIFACT_LEASE_MS = 24 * 60 * 60 * 1000
+_MAX_ARTIFACT_RETRY_WINDOW_MS = 365 * 24 * 60 * 60 * 1000
+_MAX_ARTIFACT_RETRY_DELAY_MS = 365 * 24 * 60 * 60 * 1000
+_ARTIFACT_RETRY_EXPIRED_DETAIL = "artifact publication retry window elapsed before upload"
+
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+
+def _now_ms() -> int:
+    """Catalog-authoritative wall time for leases and durable scheduling."""
+
+    return time.time_ns() // 1_000_000
+
+
+def _require_sha256(value: str, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    if _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _require_bounded_text(value: str, *, field: str, max_chars: int) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    if not value.strip():
+        raise ValueError(f"{field} must not be empty")
+    if len(value) > max_chars:
+        raise ValueError(f"{field} exceeds {max_chars} characters")
+    return value
+
+
+def _require_portable_counter(value: int, *, field: str = "fence_epoch") -> int:
+    """Require an exact non-boolean fence portable through the Worker wire."""
+
+    if type(value) is not int:
+        raise TypeError(f"{field} must be an integer")
+    if value < 0 or value > _MAX_PORTABLE_COUNTER:
+        raise ValueError(f"{field} must be between 0 and {_MAX_PORTABLE_COUNTER}")
+    return value
+
+
+def _require_artifact_milliseconds(
+    value: int,
+    *,
+    field: str,
+    maximum: int,
+    allow_zero: bool = True,
+) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{field} must be an integer number of milliseconds")
+    minimum = 0 if allow_zero else 1
+    if value < minimum or value > maximum:
+        raise ValueError(f"{field} must be between {minimum} and {maximum} milliseconds")
+    return value
+
+
+def _require_artifact_lease_ms(value: int) -> int:
+    return _require_artifact_milliseconds(
+        value,
+        field="artifact lease_ms",
+        maximum=_MAX_ARTIFACT_LEASE_MS,
+        allow_zero=False,
+    )
+
+
+def _require_artifact_lease_seconds(value: float) -> float:
+    if type(value) not in {int, float} or not math.isfinite(value):
+        raise TypeError("artifact lease_seconds must be a finite number")
+    if value <= 0 or value > _MAX_ARTIFACT_LEASE_MS / 1000:
+        raise ValueError(
+            "artifact lease_seconds must be greater than zero and no greater than "
+            f"{_MAX_ARTIFACT_LEASE_MS / 1000:g}"
+        )
+    return float(value)
 
 
 def _is_unbound_legacy_indexed_claim(row: sqlite3.Row) -> bool:
@@ -382,6 +460,13 @@ class ArtifactPublicationRecord:
 
 
 @dataclass(frozen=True)
+class ArtifactPublicationCandidate:
+    """Digest-only discovery reference; exact recovery returns replay authority."""
+
+    publication_key: str
+
+
+@dataclass(frozen=True)
 class SignatureRecord:
     """Compact durable pointer to one archetype table."""
 
@@ -545,9 +630,18 @@ class ControlCatalog(Protocol):
         request_digest: str,
         request_json: str,
         claimant: str,
-        retry_until_ms: int,
-        lease_seconds: float = 900.0,
+        retry_window_ms: int,
+        retry_not_after_ms: int | None = None,
+        lease_ms: int = 900_000,
     ) -> tuple[str, ArtifactPublicationRecord]: ...
+    async def recover_artifact_publication(
+        self,
+        world_id: str,
+        publication_key: str,
+        claimant: str,
+        *,
+        lease_ms: int,
+    ) -> tuple[str, ArtifactPublicationRecord | None]: ...
     async def get_artifact_publication(
         self, world_id: str, publication_key: str
     ) -> ArtifactPublicationRecord | None: ...
@@ -581,7 +675,7 @@ class ControlCatalog(Protocol):
         claimant: str,
         error: str,
         *,
-        retry_at: float,
+        retry_delay_ms: int,
     ) -> None: ...
     async def expire_artifact_publication(
         self,
@@ -591,8 +685,12 @@ class ControlCatalog(Protocol):
         error: str,
     ) -> None: ...
     async def list_due_artifact_publications(
-        self, world_id: str, *, now: float, limit: int = 100
-    ) -> list[ArtifactPublicationRecord]: ...
+        self,
+        world_id: str,
+        *,
+        limit: int = 100,
+        after_publication_key: str = "",
+    ) -> list[ArtifactPublicationCandidate]: ...
     async def admit_commands(
         self, world_id: str, admissions: list[CommandAdmission]
     ) -> list[CommandRecord]: ...
@@ -1752,8 +1850,9 @@ class SqliteControlCatalog:
         request_digest: str,
         request_json: str,
         claimant: str,
-        retry_until_ms: int,
-        lease_seconds: float = 900.0,
+        retry_window_ms: int,
+        retry_not_after_ms: int | None = None,
+        lease_ms: int = 900_000,
     ) -> tuple[str, ArtifactPublicationRecord]:
         """Claim one bundle publication or recover its interrupted phase.
 
@@ -1761,6 +1860,19 @@ class SqliteControlCatalog:
         row contains all object metadata needed to finish indexing without
         reopening the provider checkpoint.
         """
+        claimant = _require_bounded_text(
+            claimant, field="artifact publication claimant", max_chars=1024
+        )
+        retry_window_ms = _require_artifact_milliseconds(
+            retry_window_ms,
+            field="artifact retry_window_ms",
+            maximum=_MAX_ARTIFACT_RETRY_WINDOW_MS,
+        )
+        if retry_not_after_ms is not None:
+            retry_not_after_ms = _require_portable_counter(
+                retry_not_after_ms, field="artifact retry_not_after_ms"
+            )
+        lease_ms = _require_artifact_lease_ms(lease_ms)
         publication_key = artifact_publication_key(world_id, run_id, idempotency_key)
 
         def _acquire() -> tuple[str, ArtifactPublicationRecord]:
@@ -1771,7 +1883,7 @@ class SqliteControlCatalog:
                     "SELECT * FROM artifact_publications WHERE publication_key=?",
                     (publication_key,),
                 ).fetchone()
-                now = time.time()
+                now_ms = _now_ms()
                 now_text = _utcnow()
                 if row is not None:
                     existing = _artifact_publication_from_row(row)
@@ -1780,32 +1892,32 @@ class SqliteControlCatalog:
                             f"artifact idempotency key {idempotency_key!r} was reused "
                             "with a different publication request"
                         )
-                    if existing.status == "INDEXED":
-                        return ("duplicate", existing)
-                    if existing.status == "EXPIRED":
-                        return ("expired", existing)
-                    if existing.lease_expires_at > now:
-                        raise ArtifactPublicationPendingError(
-                            f"a live lease ({existing.claimant}) holds artifact "
-                            f"publication {publication_key}; retry after it expires"
-                        )
-                    conn.execute(
-                        "UPDATE artifact_publications SET claimant=?, lease_expires_at=?, "
-                        "attempt_count=attempt_count+1, updated_at=? WHERE publication_key=?",
-                        (claimant, now + lease_seconds, now_text, publication_key),
+                    outcome, recovered = _recover_artifact_publication_row(
+                        conn,
+                        existing,
+                        claimant=claimant,
+                        lease_ms=lease_ms,
+                        now_ms=now_ms,
+                        now_text=now_text,
                     )
-                    recovered = conn.execute(
-                        "SELECT * FROM artifact_publications WHERE publication_key=?",
-                        (publication_key,),
-                    ).fetchone()
-                    return ("recovered", _artifact_publication_from_row(recovered))
+                    assert recovered is not None
+                    return outcome, recovered
+
+                retry_until_ms = now_ms + retry_window_ms
+                if retry_not_after_ms is not None:
+                    retry_until_ms = min(retry_until_ms, retry_not_after_ms)
+                initially_expired = retry_until_ms <= now_ms
+                status = "EXPIRED" if initially_expired else "PENDING"
+                lease_expires_at = 0.0 if initially_expired else (now_ms + lease_ms) / 1000
+                last_error = _ARTIFACT_RETRY_EXPIRED_DETAIL if initially_expired else ""
+                completed_at = now_text if initially_expired else None
 
                 conn.execute(
                     "INSERT INTO artifact_publications (publication_key, world_id, run_id, "
                     "attempt_id, idempotency_key, request_digest, status, request_json, "
                     "records_json, claimant, lease_expires_at, retry_until_ms, attempt_count, "
-                    "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 'PENDING', ?, '[]', "
-                    "?, ?, ?, 1, ?, ?)",
+                    "last_error, created_at, updated_at, completed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, '[]', ?, ?, ?, 1, ?, ?, ?, ?)",
                     (
                         publication_key,
                         world_id,
@@ -1813,21 +1925,64 @@ class SqliteControlCatalog:
                         attempt_id,
                         idempotency_key,
                         request_digest,
+                        status,
                         request_json,
                         claimant,
-                        now + lease_seconds,
+                        lease_expires_at,
                         retry_until_ms,
+                        last_error,
                         now_text,
                         now_text,
+                        completed_at,
                     ),
                 )
                 created = conn.execute(
                     "SELECT * FROM artifact_publications WHERE publication_key=?",
                     (publication_key,),
                 ).fetchone()
-                return ("acquired", _artifact_publication_from_row(created))
+                return (
+                    "expired" if initially_expired else "acquired",
+                    _artifact_publication_from_row(created),
+                )
 
         return await self._run(_acquire)
+
+    async def recover_artifact_publication(
+        self,
+        world_id: str,
+        publication_key: str,
+        claimant: str,
+        *,
+        lease_ms: int,
+    ) -> tuple[str, ArtifactPublicationRecord | None]:
+        """Acquire one exact durable publication without echoing source content."""
+
+        publication_key = _require_sha256(publication_key, field="publication_key")
+        claimant = _require_bounded_text(
+            claimant, field="artifact publication claimant", max_chars=1024
+        )
+        lease_ms = _require_artifact_lease_ms(lease_ms)
+
+        def _recover() -> tuple[str, ArtifactPublicationRecord | None]:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT * FROM artifact_publications WHERE publication_key=? AND world_id=?",
+                    (publication_key, world_id),
+                ).fetchone()
+                if row is None:
+                    return "obsolete", None
+                return _recover_artifact_publication_row(
+                    conn,
+                    _artifact_publication_from_row(row),
+                    claimant=claimant,
+                    lease_ms=lease_ms,
+                    now_ms=_now_ms(),
+                    now_text=_utcnow(),
+                )
+
+        return await self._run(_recover)
 
     async def renew_artifact_publication(
         self,
@@ -1838,6 +1993,8 @@ class SqliteControlCatalog:
         lease_seconds: float,
     ) -> ArtifactPublicationRecord:
         """Extend a publication lease while a long upload/index stage runs."""
+
+        lease_seconds = _require_artifact_lease_seconds(lease_seconds)
 
         def _renew() -> ArtifactPublicationRecord:
             conn = self._connect_sync()
@@ -1859,10 +2016,34 @@ class SqliteControlCatalog:
                         f"artifact publication {publication_key} was taken over by "
                         f"{existing.claimant}"
                     )
+                now_ms = _now_ms()
+                if existing.status == "PENDING" and existing.retry_until_ms <= now_ms:
+                    expired_at = _utcnow()
+                    conn.execute(
+                        "UPDATE artifact_publications SET status='EXPIRED', "
+                        "lease_expires_at=0, last_error=?, updated_at=?, completed_at=? "
+                        "WHERE publication_key=? AND status='PENDING'",
+                        (
+                            _ARTIFACT_RETRY_EXPIRED_DETAIL,
+                            expired_at,
+                            expired_at,
+                            publication_key,
+                        ),
+                    )
+                    return _artifact_publication_from_row(
+                        conn.execute(
+                            "SELECT * FROM artifact_publications WHERE publication_key=?",
+                            (publication_key,),
+                        ).fetchone()
+                    )
+                if existing.lease_expires_at <= now_ms / 1000:
+                    raise ArtifactPublicationPendingError(
+                        f"artifact publication {publication_key} lease expired before renewal"
+                    )
                 conn.execute(
                     "UPDATE artifact_publications SET lease_expires_at=?, updated_at=? "
                     "WHERE publication_key=?",
-                    (time.time() + lease_seconds, _utcnow(), publication_key),
+                    ((now_ms / 1000) + lease_seconds, _utcnow(), publication_key),
                 )
                 updated = conn.execute(
                     "SELECT * FROM artifact_publications WHERE publication_key=?",
@@ -1882,7 +2063,7 @@ class SqliteControlCatalog:
     ) -> None:
         """Persist uploaded object metadata before the Iceberg index commit."""
 
-        def _record() -> None:
+        def _record() -> bool:
             conn = self._connect_sync()
             with conn:
                 conn.execute("BEGIN IMMEDIATE")
@@ -1896,7 +2077,7 @@ class SqliteControlCatalog:
                     )
                 existing = _artifact_publication_from_row(row)
                 if existing.status == "INDEXED":
-                    return
+                    return False
                 if existing.status == "EXPIRED":
                     raise ArtifactPublicationExpiredError(
                         f"artifact publication {publication_key} has expired"
@@ -1911,18 +2092,42 @@ class SqliteControlCatalog:
                         existing.records_json == records_json
                         and existing.manifest_uri == manifest_uri
                     ):
-                        return
+                        return False
                     raise ArtifactPublicationConflictError(
                         f"artifact publication {publication_key} already recorded "
                         "different uploaded objects"
+                    )
+                now_ms = _now_ms()
+                if existing.retry_until_ms <= now_ms:
+                    expired_at = _utcnow()
+                    conn.execute(
+                        "UPDATE artifact_publications SET status='EXPIRED', "
+                        "lease_expires_at=0, last_error=?, updated_at=?, completed_at=? "
+                        "WHERE publication_key=? AND status='PENDING'",
+                        (
+                            _ARTIFACT_RETRY_EXPIRED_DETAIL,
+                            expired_at,
+                            expired_at,
+                            publication_key,
+                        ),
+                    )
+                    return True
+                if existing.lease_expires_at <= now_ms / 1000:
+                    raise ArtifactPublicationPendingError(
+                        f"artifact publication {publication_key} lease expired before uploads"
                     )
                 conn.execute(
                     "UPDATE artifact_publications SET status='UPLOADED', records_json=?, "
                     "manifest_uri=?, last_error='', updated_at=? WHERE publication_key=?",
                     (records_json, manifest_uri, _utcnow(), publication_key),
                 )
+                return False
 
-        await self._run(_record)
+        expired = await self._run(_record)
+        if expired:
+            raise ArtifactPublicationExpiredError(
+                f"artifact publication {publication_key} expired before uploads"
+            )
 
     async def complete_artifact_publication(
         self,
@@ -1971,6 +2176,10 @@ class SqliteControlCatalog:
                         f"artifact publication {publication_key} was taken over by "
                         f"{existing.claimant}"
                     )
+                if existing.lease_expires_at <= _now_ms() / 1000:
+                    raise ArtifactPublicationPendingError(
+                        f"artifact publication {publication_key} lease expired before completion"
+                    )
                 completed = _utcnow()
                 conn.execute(
                     "UPDATE artifact_publications SET status='INDEXED', "
@@ -1993,17 +2202,29 @@ class SqliteControlCatalog:
         claimant: str,
         error: str,
         *,
-        retry_at: float,
+        retry_delay_ms: int,
     ) -> None:
         """Release a failed phase for a later bounded reconciliation pass."""
+
+        claimant = _require_bounded_text(
+            claimant, field="artifact publication claimant", max_chars=1024
+        )
+        if not isinstance(error, str):
+            raise TypeError("artifact publication error must be a string")
+        if len(error) > 8000:
+            raise ValueError("artifact publication error exceeds 8000 characters")
+        retry_delay_ms = _require_artifact_milliseconds(
+            retry_delay_ms,
+            field="artifact retry_delay_ms",
+            maximum=_MAX_ARTIFACT_RETRY_DELAY_MS,
+        )
 
         def _fail() -> None:
             conn = self._connect_sync()
             with conn:
                 conn.execute("BEGIN IMMEDIATE")
                 row = conn.execute(
-                    "SELECT status, claimant FROM artifact_publications "
-                    "WHERE publication_key=? AND world_id=?",
+                    "SELECT * FROM artifact_publications WHERE publication_key=? AND world_id=?",
                     (publication_key, world_id),
                 ).fetchone()
                 if row is None or row["status"] in {"INDEXED", "EXPIRED"}:
@@ -2012,10 +2233,35 @@ class SqliteControlCatalog:
                     raise ArtifactPublicationPendingError(
                         f"artifact publication {publication_key} is no longer owned by {claimant}"
                     )
+                existing = _artifact_publication_from_row(row)
+                now_ms = _now_ms()
+                if existing.status == "PENDING" and existing.retry_until_ms <= now_ms:
+                    expired_at = _utcnow()
+                    conn.execute(
+                        "UPDATE artifact_publications SET status='EXPIRED', "
+                        "lease_expires_at=0, last_error=?, updated_at=?, completed_at=? "
+                        "WHERE publication_key=? AND status='PENDING'",
+                        (
+                            _ARTIFACT_RETRY_EXPIRED_DETAIL,
+                            expired_at,
+                            expired_at,
+                            publication_key,
+                        ),
+                    )
+                    return
+                if existing.lease_expires_at <= now_ms / 1000:
+                    raise ArtifactPublicationPendingError(
+                        f"artifact publication {publication_key} lease expired before failure"
+                    )
                 conn.execute(
                     "UPDATE artifact_publications SET last_error=?, lease_expires_at=?, "
                     "updated_at=? WHERE publication_key=?",
-                    (error[:8000], retry_at, _utcnow(), publication_key),
+                    (
+                        error,
+                        (now_ms + retry_delay_ms) / 1000,
+                        _utcnow(),
+                        publication_key,
+                    ),
                 )
 
         await self._run(_fail)
@@ -2029,13 +2275,20 @@ class SqliteControlCatalog:
     ) -> None:
         """Terminally expire a PENDING bundle after its replay window closes."""
 
+        claimant = _require_bounded_text(
+            claimant, field="artifact publication claimant", max_chars=1024
+        )
+        if not isinstance(error, str):
+            raise TypeError("artifact publication error must be a string")
+        if len(error) > 8000:
+            raise ValueError("artifact publication error exceeds 8000 characters")
+
         def _expire() -> None:
             conn = self._connect_sync()
             with conn:
                 conn.execute("BEGIN IMMEDIATE")
                 row = conn.execute(
-                    "SELECT status, claimant FROM artifact_publications "
-                    "WHERE publication_key=? AND world_id=?",
+                    "SELECT * FROM artifact_publications WHERE publication_key=? AND world_id=?",
                     (publication_key, world_id),
                 ).fetchone()
                 if row is None:
@@ -2052,11 +2305,16 @@ class SqliteControlCatalog:
                     raise ArtifactPublicationPendingError(
                         f"artifact publication {publication_key} was taken over"
                     )
+                existing = _artifact_publication_from_row(row)
+                if existing.lease_expires_at <= _now_ms() / 1000:
+                    raise ArtifactPublicationPendingError(
+                        f"artifact publication {publication_key} lease expired before expiry"
+                    )
                 completed = _utcnow()
                 conn.execute(
                     "UPDATE artifact_publications SET status='EXPIRED', last_error=?, "
                     "updated_at=?, completed_at=? WHERE publication_key=?",
-                    (error[:8000], completed, completed, publication_key),
+                    (error, completed, completed, publication_key),
                 )
 
         await self._run(_expire)
@@ -2078,20 +2336,37 @@ class SqliteControlCatalog:
         return await self._run(_get)
 
     async def list_due_artifact_publications(
-        self, world_id: str, *, now: float, limit: int = 100
-    ) -> list[ArtifactPublicationRecord]:
-        def _list() -> list[ArtifactPublicationRecord]:
+        self,
+        world_id: str,
+        *,
+        limit: int = 100,
+        after_publication_key: str = "",
+    ) -> list[ArtifactPublicationCandidate]:
+        if type(limit) is not int or limit < 1 or limit > 10_000:
+            raise ValueError("artifact publication page limit must be between 1 and 10000")
+        if after_publication_key != "":
+            after_publication_key = _require_sha256(
+                after_publication_key, field="after_publication_key"
+            )
+
+        def _list() -> list[ArtifactPublicationCandidate]:
+            now = _now_ms() / 1000
             rows = (
                 self._connect_sync()
                 .execute(
-                    "SELECT * FROM artifact_publications WHERE world_id=? "
+                    "SELECT publication_key FROM artifact_publications WHERE world_id=? "
                     "AND status IN ('PENDING', 'UPLOADED') AND lease_expires_at<=? "
-                    "ORDER BY lease_expires_at, publication_key LIMIT ?",
-                    (world_id, now, max(0, int(limit))),
+                    "AND publication_key>? ORDER BY publication_key LIMIT ?",
+                    (world_id, now, after_publication_key, limit),
                 )
                 .fetchall()
             )
-            return [_artifact_publication_from_row(row) for row in rows]
+            return [
+                ArtifactPublicationCandidate(
+                    publication_key=_require_sha256(row["publication_key"], field="publication_key")
+                )
+                for row in rows
+            ]
 
         return await self._run(_list)
 
@@ -3045,7 +3320,36 @@ def _attempt_claim_transition_replay_matches(
 
 def _artifact_publication_from_row(row: sqlite3.Row) -> ArtifactPublicationRecord:
     raw_snapshot_id = row["index_snapshot_id"]
-    status = str(row["status"])
+    status = row["status"]
+    if not isinstance(status, str) or status not in {
+        "PENDING",
+        "UPLOADED",
+        "INDEXED",
+        "EXPIRED",
+    }:
+        raise RuntimeError(f"local artifact publication has invalid status {status!r}")
+    raw_lease_expires_at = row["lease_expires_at"]
+    raw_retry_until_ms = row["retry_until_ms"]
+    raw_attempt_count = row["attempt_count"]
+    if (
+        type(raw_lease_expires_at) not in {int, float}
+        or not math.isfinite(raw_lease_expires_at)
+        or raw_lease_expires_at < 0
+        or raw_lease_expires_at > _MAX_PORTABLE_COUNTER
+    ):
+        raise RuntimeError("local artifact publication has invalid lease_expires_at")
+    if (
+        type(raw_retry_until_ms) is not int
+        or raw_retry_until_ms < 0
+        or raw_retry_until_ms > _MAX_PORTABLE_COUNTER
+    ):
+        raise RuntimeError("local artifact publication has invalid retry_until_ms")
+    if (
+        type(raw_attempt_count) is not int
+        or raw_attempt_count < 1
+        or raw_attempt_count > _MAX_PORTABLE_COUNTER
+    ):
+        raise RuntimeError("local artifact publication has invalid attempt_count")
     if type(raw_snapshot_id) is not int:
         raise RuntimeError("local artifact publication has a lossy snapshot ID")
     if status == "INDEXED":
@@ -3064,9 +3368,9 @@ def _artifact_publication_from_row(row: sqlite3.Row) -> ArtifactPublicationRecor
         request_json=row["request_json"],
         records_json=row["records_json"],
         claimant=row["claimant"],
-        lease_expires_at=float(row["lease_expires_at"]),
-        retry_until_ms=int(row["retry_until_ms"]),
-        attempt_count=int(row["attempt_count"]),
+        lease_expires_at=float(raw_lease_expires_at),
+        retry_until_ms=raw_retry_until_ms,
+        attempt_count=raw_attempt_count,
         index_snapshot_id=raw_snapshot_id,
         manifest_uri=row["manifest_uri"],
         last_error=row["last_error"],
@@ -3074,6 +3378,99 @@ def _artifact_publication_from_row(row: sqlite3.Row) -> ArtifactPublicationRecor
         updated_at=row["updated_at"],
         completed_at=row["completed_at"],
     )
+
+
+def _recover_artifact_publication_row(
+    conn: sqlite3.Connection,
+    existing: ArtifactPublicationRecord,
+    *,
+    claimant: str,
+    lease_ms: int,
+    now_ms: int,
+    now_text: str,
+) -> tuple[str, ArtifactPublicationRecord]:
+    """Apply the exact source-native recovery state machine under one write lock."""
+
+    if existing.status == "INDEXED":
+        return "duplicate", existing
+    if existing.status == "EXPIRED":
+        return "expired", existing
+    if existing.status not in {"PENDING", "UPLOADED"}:
+        raise ArtifactPublicationConflictError(
+            f"artifact publication {existing.publication_key} has invalid status {existing.status}"
+        )
+    if existing.status == "PENDING" and existing.retry_until_ms <= now_ms:
+        conn.execute(
+            "UPDATE artifact_publications SET status='EXPIRED', lease_expires_at=0, "
+            "last_error=?, updated_at=?, completed_at=? WHERE publication_key=? "
+            "AND status='PENDING'",
+            (
+                _ARTIFACT_RETRY_EXPIRED_DETAIL,
+                now_text,
+                now_text,
+                existing.publication_key,
+            ),
+        )
+        row = conn.execute(
+            "SELECT * FROM artifact_publications WHERE publication_key=?",
+            (existing.publication_key,),
+        ).fetchone()
+        assert row is not None
+        return "expired", _artifact_publication_from_row(row)
+    if existing.lease_expires_at > now_ms / 1000:
+        if existing.claimant == claimant:
+            updated = conn.execute(
+                "UPDATE artifact_publications SET lease_expires_at=?, updated_at=? "
+                "WHERE publication_key=? AND status=? AND claimant=?",
+                (
+                    (now_ms + lease_ms) / 1000,
+                    now_text,
+                    existing.publication_key,
+                    existing.status,
+                    claimant,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise ArtifactPublicationPendingError(
+                    f"artifact publication {existing.publication_key} changed before renewal"
+                )
+            row = conn.execute(
+                "SELECT * FROM artifact_publications WHERE publication_key=?",
+                (existing.publication_key,),
+            ).fetchone()
+            assert row is not None
+            return "owned", _artifact_publication_from_row(row)
+        raise ArtifactPublicationPendingError(
+            f"a live lease holds artifact publication {existing.publication_key}"
+        )
+    if existing.attempt_count >= _MAX_PORTABLE_COUNTER:
+        raise ArtifactPublicationConflictError(
+            f"artifact publication {existing.publication_key} exhausted its portable "
+            "attempt counter"
+        )
+    updated = conn.execute(
+        "UPDATE artifact_publications SET claimant=?, lease_expires_at=?, "
+        "attempt_count=attempt_count+1, updated_at=? WHERE publication_key=? "
+        "AND status=? AND lease_expires_at<=?",
+        (
+            claimant,
+            (now_ms + lease_ms) / 1000,
+            now_text,
+            existing.publication_key,
+            existing.status,
+            now_ms / 1000,
+        ),
+    )
+    if updated.rowcount != 1:
+        raise ArtifactPublicationPendingError(
+            f"artifact publication {existing.publication_key} changed before recovery"
+        )
+    row = conn.execute(
+        "SELECT * FROM artifact_publications WHERE publication_key=?",
+        (existing.publication_key,),
+    ).fetchone()
+    assert row is not None
+    return "recovered", _artifact_publication_from_row(row)
 
 
 def _command_from_row(row: sqlite3.Row) -> CommandRecord:

--- a/src/archetype/app/storage/remote_catalog.py
+++ b/src/archetype/app/storage/remote_catalog.py
@@ -20,11 +20,18 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
+from typing import cast
+from urllib.parse import urlencode
 
 import httpx
 
 from archetype.app.limits import MAX_ICEBERG_SNAPSHOT_ID
 from archetype.app.storage.catalog import (
+    _MAX_ARTIFACT_RETRY_DELAY_MS,
+    _MAX_ARTIFACT_RETRY_WINDOW_MS,
+    _MAX_PORTABLE_COUNTER,
+    ArtifactPublicationCandidate,
     ArtifactPublicationConflictError,
     ArtifactPublicationExpiredError,
     ArtifactPublicationPendingError,
@@ -44,6 +51,12 @@ from archetype.app.storage.catalog import (
     OutboxRecord,
     SignatureRecord,
     WorldRecord,
+    _require_artifact_lease_ms,
+    _require_artifact_lease_seconds,
+    _require_artifact_milliseconds,
+    _require_bounded_text,
+    _require_portable_counter,
+    _require_sha256,
     _validate_attempt_claim_transition,
     artifact_publication_key,
     claim_scope_key,
@@ -56,6 +69,8 @@ _ATTEMPT_CLAIM_PROTOCOL_VERSION = 4
 _ATTEMPT_CLAIM_CAPABILITY = "attempt_claim_execution_v2"
 _ARTIFACT_SNAPSHOT_PROTOCOL_VERSION = 3
 _ARTIFACT_SNAPSHOT_CAPABILITY = "artifact_snapshot_decimal_v1"
+_ARTIFACT_SERVER_CLOCK_PROTOCOL_VERSION = 6
+_ARTIFACT_SERVER_CLOCK_CAPABILITY = "artifact_publication_server_clock_v1"
 
 _ERROR_MAP: dict[str, type[Exception]] = {
     "attempt_claim_conflict": AttemptClaimConflictError,
@@ -123,7 +138,7 @@ class RemoteControlCatalog:
         world_id: str,
         *,
         minimum_version: int,
-        capability: str,
+        capability: str | tuple[str, ...],
         feature: str,
     ) -> None:
         """Fail closed before a versioned write reaches an older Worker."""
@@ -138,11 +153,12 @@ class RemoteControlCatalog:
             raise RuntimeError(f"remote control catalog does not support {feature}")
         capabilities = body.get("capabilities", ())
         protocol_version = body.get("catalog_protocol_version")
+        required_capabilities = (capability,) if isinstance(capability, str) else capability
         if (
             not isinstance(protocol_version, int)
             or protocol_version < minimum_version
             or not isinstance(capabilities, list)
-            or capability not in capabilities
+            or any(required not in capabilities for required in required_capabilities)
         ):
             raise RuntimeError(f"remote control catalog does not support {feature}")
 
@@ -160,6 +176,25 @@ class RemoteControlCatalog:
             minimum_version=_ARTIFACT_SNAPSHOT_PROTOCOL_VERSION,
             capability=_ARTIFACT_SNAPSHOT_CAPABILITY,
             feature="lossless artifact snapshot IDs",
+        )
+
+    async def _require_artifact_server_clock_protocol(self, world_id: str) -> None:
+        await self._require_catalog_protocol(
+            world_id,
+            minimum_version=_ARTIFACT_SERVER_CLOCK_PROTOCOL_VERSION,
+            capability=_ARTIFACT_SERVER_CLOCK_CAPABILITY,
+            feature="artifact publication server-clock v1",
+        )
+
+    async def _require_artifact_mutation_protocol(self, world_id: str) -> None:
+        await self._require_catalog_protocol(
+            world_id,
+            minimum_version=_ARTIFACT_SERVER_CLOCK_PROTOCOL_VERSION,
+            capability=(
+                _ARTIFACT_SNAPSHOT_CAPABILITY,
+                _ARTIFACT_SERVER_CLOCK_CAPABILITY,
+            ),
+            feature="lease-fenced artifact mutation v2",
         )
 
     # ── worlds ───────────────────────────────────────────────────────────────
@@ -646,28 +681,76 @@ class RemoteControlCatalog:
         request_digest: str,
         request_json: str,
         claimant: str,
-        retry_until_ms: int,
-        lease_seconds: float = 900.0,
+        retry_window_ms: int,
+        retry_not_after_ms: int | None = None,
+        lease_ms: int = 900_000,
     ) -> tuple[str, ArtifactPublicationRecord]:
+        claimant = _require_bounded_text(
+            claimant, field="artifact publication claimant", max_chars=1024
+        )
+        retry_window_ms = _require_artifact_milliseconds(
+            retry_window_ms,
+            field="artifact retry_window_ms",
+            maximum=_MAX_ARTIFACT_RETRY_WINDOW_MS,
+        )
+        if retry_not_after_ms is not None:
+            retry_not_after_ms = _require_portable_counter(
+                retry_not_after_ms, field="artifact retry_not_after_ms"
+            )
+        lease_ms = _require_artifact_lease_ms(lease_ms)
         publication_key = artifact_publication_key(world_id, run_id, idempotency_key)
-        await self._require_artifact_snapshot_protocol(world_id)
+        await self._require_artifact_server_clock_protocol(world_id)
+        payload: dict[str, object] = {
+            "publication_key": publication_key,
+            "run_id": run_id,
+            "attempt_id": attempt_id,
+            "idempotency_key": idempotency_key,
+            "request_digest": request_digest,
+            "request_json": request_json,
+            "claimant": claimant,
+            "retry_window_ms": retry_window_ms,
+            "lease_ms": lease_ms,
+        }
+        if retry_not_after_ms is not None:
+            payload["retry_not_after_ms"] = retry_not_after_ms
         response = await self._call(
             "POST",
-            f"/w/{world_id}/artifact-publications/acquire-v2",
-            {
-                "publication_key": publication_key,
-                "run_id": run_id,
-                "attempt_id": attempt_id,
-                "idempotency_key": idempotency_key,
-                "request_digest": request_digest,
-                "request_json": request_json,
-                "claimant": claimant,
-                "retry_until_ms": retry_until_ms,
-                "lease_seconds": lease_seconds,
-            },
+            f"/w/{world_id}/artifact-publications/acquire-v3",
+            payload,
         )
         body = response.json()
-        return body["outcome"], _artifact_publication_from_json(world_id, body["publication"])
+        outcome, publication = _artifact_acquisition_from_json(world_id, body)
+        if publication is None:
+            raise RuntimeError("initial artifact acquisition returned no publication")
+        if publication.publication_key != publication_key:
+            raise RuntimeError("initial artifact acquisition returned a different publication")
+        return outcome, publication
+
+    async def recover_artifact_publication(
+        self,
+        world_id: str,
+        publication_key: str,
+        claimant: str,
+        *,
+        lease_ms: int,
+    ) -> tuple[str, ArtifactPublicationRecord | None]:
+        publication_key = _require_sha256(publication_key, field="publication_key")
+        claimant = _require_bounded_text(
+            claimant, field="artifact publication claimant", max_chars=1024
+        )
+        lease_ms = _require_artifact_lease_ms(lease_ms)
+        await self._require_artifact_server_clock_protocol(world_id)
+        response = await self._call(
+            "POST",
+            f"/w/{world_id}/artifact-publications/{publication_key}/recover-v1",
+            {"claimant": claimant, "lease_ms": lease_ms},
+        )
+        outcome, publication = _artifact_acquisition_from_json(
+            world_id, response.json(), allow_obsolete=True
+        )
+        if publication is not None and publication.publication_key != publication_key:
+            raise RuntimeError("exact artifact recovery returned a different publication")
+        return outcome, publication
 
     async def renew_artifact_publication(
         self,
@@ -677,7 +760,8 @@ class RemoteControlCatalog:
         *,
         lease_seconds: float,
     ) -> ArtifactPublicationRecord:
-        await self._require_artifact_snapshot_protocol(world_id)
+        lease_seconds = _require_artifact_lease_seconds(lease_seconds)
+        await self._require_artifact_mutation_protocol(world_id)
         response = await self._call(
             "POST",
             f"/w/{world_id}/artifact-publications/{publication_key}/renew-v2",
@@ -693,7 +777,7 @@ class RemoteControlCatalog:
         records_json: str,
         manifest_uri: str,
     ) -> None:
-        await self._require_artifact_snapshot_protocol(world_id)
+        await self._require_artifact_mutation_protocol(world_id)
         await self._call(
             "POST",
             f"/w/{world_id}/artifact-publications/{publication_key}/uploads-v2",
@@ -718,7 +802,7 @@ class RemoteControlCatalog:
             or index_snapshot_id > MAX_ICEBERG_SNAPSHOT_ID
         ):
             raise ValueError("index_snapshot_id must be a positive integer no greater than 2^63-1")
-        await self._require_artifact_snapshot_protocol(world_id)
+        await self._require_artifact_mutation_protocol(world_id)
         await self._call(
             "POST",
             f"/w/{world_id}/artifact-publications/{publication_key}/complete-v2",
@@ -732,13 +816,29 @@ class RemoteControlCatalog:
         claimant: str,
         error: str,
         *,
-        retry_at: float,
+        retry_delay_ms: int,
     ) -> None:
-        await self._require_artifact_snapshot_protocol(world_id)
+        claimant = _require_bounded_text(
+            claimant, field="artifact publication claimant", max_chars=1024
+        )
+        if not isinstance(error, str):
+            raise TypeError("artifact publication error must be a string")
+        if len(error) > 8000:
+            raise ValueError("artifact publication error exceeds 8000 characters")
+        retry_delay_ms = _require_artifact_milliseconds(
+            retry_delay_ms,
+            field="artifact retry_delay_ms",
+            maximum=_MAX_ARTIFACT_RETRY_DELAY_MS,
+        )
+        await self._require_artifact_server_clock_protocol(world_id)
         await self._call(
             "POST",
-            f"/w/{world_id}/artifact-publications/{publication_key}/fail-v2",
-            {"claimant": claimant, "error": error, "retry_at": retry_at},
+            f"/w/{world_id}/artifact-publications/{publication_key}/fail-v3",
+            {
+                "claimant": claimant,
+                "error": error,
+                "retry_delay_ms": retry_delay_ms,
+            },
         )
 
     async def expire_artifact_publication(
@@ -748,7 +848,14 @@ class RemoteControlCatalog:
         claimant: str,
         error: str,
     ) -> None:
-        await self._require_artifact_snapshot_protocol(world_id)
+        claimant = _require_bounded_text(
+            claimant, field="artifact publication claimant", max_chars=1024
+        )
+        if not isinstance(error, str):
+            raise TypeError("artifact publication error must be a string")
+        if len(error) > 8000:
+            raise ValueError("artifact publication error exceeds 8000 characters")
+        await self._require_artifact_mutation_protocol(world_id)
         await self._call(
             "POST",
             f"/w/{world_id}/artifact-publications/{publication_key}/expire-v2",
@@ -768,13 +875,36 @@ class RemoteControlCatalog:
         return _artifact_publication_from_json(world_id, response.json())
 
     async def list_due_artifact_publications(
-        self, world_id: str, *, now: float, limit: int = 100
-    ) -> list[ArtifactPublicationRecord]:
+        self,
+        world_id: str,
+        *,
+        limit: int = 100,
+        after_publication_key: str = "",
+    ) -> list[ArtifactPublicationCandidate]:
+        if type(limit) is not int or limit < 1 or limit > 10_000:
+            raise ValueError("artifact publication page limit must be between 1 and 10000")
+        if after_publication_key != "":
+            after_publication_key = _require_sha256(
+                after_publication_key, field="after_publication_key"
+            )
+        await self._require_artifact_server_clock_protocol(world_id)
+        query: dict[str, str | int] = {"limit": limit}
+        if after_publication_key != "":
+            query["after_publication_key"] = after_publication_key
         response = await self._call(
             "GET",
-            f"/w/{world_id}/artifact-publications?due={now}&limit={limit}",
+            f"/w/{world_id}/artifact-publications/due-v1?{urlencode(query)}",
         )
-        return [_artifact_publication_from_json(world_id, row) for row in response.json()]
+        body = response.json()
+        if not isinstance(body, list) or len(body) > limit:
+            raise RuntimeError("remote artifact due list returned an invalid page size")
+        records = [_artifact_candidate_from_json(row) for row in body]
+        previous = after_publication_key
+        for record in records:
+            if record.publication_key <= previous:
+                raise RuntimeError("remote artifact due list is not strictly ordered")
+            previous = record.publication_key
+        return records
 
 
 def _world_from_json(row: dict) -> WorldRecord:
@@ -850,22 +980,109 @@ def _attempt_claim_from_json(world_id: str, row: dict) -> AttemptClaimRecord:
     )
 
 
+def _artifact_candidate_from_json(row: object) -> ArtifactPublicationCandidate:
+    if not isinstance(row, dict) or set(row) != {"publication_key"}:
+        raise RuntimeError("remote artifact due candidate is not digest-only")
+    candidate = cast(dict[str, object], row)
+    publication_key = candidate["publication_key"]
+    if not isinstance(publication_key, str):
+        raise RuntimeError("remote artifact due candidate has an invalid publication_key")
+    try:
+        publication_key = _require_sha256(publication_key, field="publication_key")
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("remote artifact due candidate has an invalid publication_key") from exc
+    return ArtifactPublicationCandidate(publication_key=publication_key)
+
+
+def _artifact_acquisition_from_json(
+    world_id: str,
+    body: object,
+    *,
+    allow_obsolete: bool = False,
+) -> tuple[str, ArtifactPublicationRecord | None]:
+    if not isinstance(body, dict):
+        raise RuntimeError("remote artifact acquisition returned a non-object response")
+    outcome = body.get("outcome")
+    allowed = (
+        {"owned", "recovered", "duplicate", "expired", "obsolete"}
+        if allow_obsolete
+        else {"acquired", "owned", "recovered", "duplicate", "expired"}
+    )
+    if not isinstance(outcome, str) or outcome not in allowed:
+        raise RuntimeError("remote artifact acquisition returned an invalid outcome")
+    publication = body.get("publication")
+    if outcome == "obsolete":
+        if publication is not None:
+            raise RuntimeError("obsolete artifact acquisition returned a publication")
+        return outcome, None
+    if not isinstance(publication, dict):
+        raise RuntimeError("remote artifact acquisition returned no publication")
+    record = _artifact_publication_from_json(world_id, publication)
+    expected_statuses = {
+        "acquired": {"PENDING"},
+        "owned": {"PENDING", "UPLOADED"},
+        "recovered": {"PENDING", "UPLOADED"},
+        "duplicate": {"INDEXED"},
+        "expired": {"EXPIRED"},
+    }
+    if record.status not in expected_statuses[outcome]:
+        raise RuntimeError("remote artifact acquisition outcome contradicts its status")
+    return outcome, record
+
+
 def _artifact_publication_from_json(world_id: str, row: dict) -> ArtifactPublicationRecord:
+    if not isinstance(row, dict):
+        raise RuntimeError("remote artifact publication is not an object")
+    status = row.get("status")
+    if not isinstance(status, str) or status not in {
+        "PENDING",
+        "UPLOADED",
+        "INDEXED",
+        "EXPIRED",
+    }:
+        raise RuntimeError(f"remote artifact publication has invalid status {status!r}")
+    publication_key = row.get("publication_key")
+    if not isinstance(publication_key, str):
+        raise RuntimeError("remote artifact publication has a non-string publication_key")
+    try:
+        _require_sha256(publication_key, field="publication_key")
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("remote artifact publication has an invalid publication_key") from exc
+    retry_until_ms = row.get("retry_until_ms")
+    attempt_count = row.get("attempt_count")
+    lease_expires_at = row.get("lease_expires_at")
+    if (
+        type(retry_until_ms) is not int
+        or retry_until_ms < 0
+        or retry_until_ms > _MAX_PORTABLE_COUNTER
+    ):
+        raise RuntimeError("remote artifact publication has invalid retry_until_ms")
+    if type(attempt_count) is not int or attempt_count < 1 or attempt_count > _MAX_PORTABLE_COUNTER:
+        raise RuntimeError("remote artifact publication has invalid attempt_count")
+    if isinstance(lease_expires_at, bool) or not isinstance(lease_expires_at, int | float):
+        raise RuntimeError("remote artifact publication has invalid lease_expires_at")
+    lease_expires_at_value = float(lease_expires_at)
+    if (
+        not math.isfinite(lease_expires_at_value)
+        or lease_expires_at_value < 0
+        or lease_expires_at_value > _MAX_PORTABLE_COUNTER
+    ):
+        raise RuntimeError("remote artifact publication has invalid lease_expires_at")
     index_snapshot_id = _remote_index_snapshot_id(row)
     return ArtifactPublicationRecord(
-        publication_key=row["publication_key"],
+        publication_key=publication_key,
         world_id=world_id,
         run_id=row["run_id"],
         attempt_id=row["attempt_id"],
         idempotency_key=row["idempotency_key"],
         request_digest=row["request_digest"],
-        status=row["status"],
+        status=status,
         request_json=row["request_json"],
         records_json=row.get("records_json", "[]"),
         claimant=row["claimant"],
-        lease_expires_at=float(row["lease_expires_at"]),
-        retry_until_ms=int(row["retry_until_ms"]),
-        attempt_count=int(row.get("attempt_count", 1)),
+        lease_expires_at=lease_expires_at_value,
+        retry_until_ms=retry_until_ms,
+        attempt_count=attempt_count,
         index_snapshot_id=index_snapshot_id,
         manifest_uri=row.get("manifest_uri", ""),
         last_error=row.get("last_error", ""),

--- a/tests/app/test_artifact_bundle_service.py
+++ b/tests/app/test_artifact_bundle_service.py
@@ -19,11 +19,11 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from archetype import ArchetypeRuntime, Component, _obs
-from archetype.app.artifacts import bundle_service as bundle_service_module
 from archetype.app.artifacts.bundle_models import (
     ArtifactBundleRequest,
     ArtifactCandidate,
     ArtifactPublicationStatus,
+    ArtifactReconcileDisposition,
     ArtifactStoreConfig,
     MaterializedArtifact,
 )
@@ -38,8 +38,10 @@ from archetype.app.redaction import (
     RedactionService,
     SecretQuarantineError,
 )
+from archetype.app.storage import catalog as catalog_module
 from archetype.app.storage.catalog import (
     ArtifactPublicationConflictError,
+    SqliteControlCatalog,
     artifact_publication_key,
 )
 from archetype.core.config import StorageConfig, WorldConfig
@@ -135,6 +137,62 @@ def _local_uri_path(uri: str) -> Path:
     parsed = urlparse(uri)
     assert parsed.scheme == "file"
     return Path(unquote(parsed.path))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("checkpoint_created_at_ms", True),
+        ("checkpoint_created_at_ms", 1.0),
+        ("checkpoint_expires_at_ms", "1"),
+        ("artifact_expires_at_ms", 1.5),
+        ("artifact_expires_at_ms", 1 << 53),
+    ],
+)
+async def test_artifact_request_durable_clocks_are_strict_portable_integers(tmp_path, field, value):
+    payload = {
+        "world_id": "world-1",
+        "run_id": "run-1",
+        "tick": 1,
+        "attempt_id": "attempt-1",
+        "idempotency_key": "publication-1",
+        "checkpoint_ref": "test-checkpoint://snapshot-1",
+        "checkpoint_provider": "test",
+        "artifacts": [
+            {
+                "source_ref": str(tmp_path / "result.json"),
+                "logical_path": "result.json",
+            }
+        ],
+        field: value,
+    }
+    with pytest.raises(ValueError):
+        ArtifactBundleRequest.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("lease_seconds", float("inf")),
+        ("lease_seconds", float("nan")),
+        ("lease_seconds", 86_401),
+        ("retry_delay_seconds", float("inf")),
+        ("retry_delay_seconds", float("nan")),
+        ("retry_delay_seconds", 365 * 24 * 60 * 60 + 1),
+        ("retry_window_seconds", True),
+        ("retry_window_seconds", 59),
+        ("retry_window_seconds", 365 * 24 * 60 * 60 + 1),
+    ],
+)
+async def test_artifact_store_durations_are_finite_and_bounded(tmp_path, field, value):
+    base = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    payload = {
+        "object_uri": base.object_uri,
+        "index_storage": base.index_storage,
+        field: value,
+    }
+    with pytest.raises(ValueError):
+        ArtifactStoreConfig.model_validate(payload)
 
 
 async def test_span_attributes_use_only_canonical_safe_coordinates(tmp_path):
@@ -550,7 +608,7 @@ async def test_uploaded_phase_reconciles_without_uploading_again(tmp_path, monke
             publication.publication_key,
             publication.claimant,
             "make uploaded row immediately due",
-            retry_at=0.0,
+            retry_delay_ms=0,
         )
 
         # This is a real durable corrupt row, not a list_due test double. The
@@ -564,8 +622,15 @@ async def test_uploaded_phase_reconciles_without_uploading_again(tmp_path, monke
             request_digest="corrupt-request-digest",
             request_json="{not-json",
             claimant="corrupt-seed",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
-            lease_seconds=0.0,
+            retry_window_ms=60_000,
+            lease_ms=60_000,
+        )
+        await catalog.fail_artifact_publication(
+            request.world_id,
+            corrupt.publication_key,
+            "corrupt-seed",
+            "make corrupt row immediately due",
+            retry_delay_ms=0,
         )
 
         monkeypatch.setattr(container.artifact_bundle_service, "_index_records", real_index)
@@ -593,7 +658,7 @@ async def test_uploaded_phase_reconciles_without_uploading_again(tmp_path, monke
         await container.shutdown()
 
 
-async def test_uploaded_recovery_rejects_records_from_another_request(tmp_path, monkeypatch):
+async def test_uploaded_resume_uses_and_authenticates_authoritative_records(tmp_path, monkeypatch):
     artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts").model_copy(
         update={"retry_delay_seconds": 0.0}
     )
@@ -609,7 +674,10 @@ async def test_uploaded_recovery_rejects_records_from_another_request(tmp_path, 
         )
         target = _request(world, source, idempotency_key="target-publication")
 
-        async def fail_index(_records):
+        indexed_records = []
+
+        async def fail_index(records):
+            indexed_records.append(records)
             raise RuntimeError("leave target uploaded")
 
         monkeypatch.setattr(container.artifact_bundle_service, "_index_records", fail_index)
@@ -624,6 +692,7 @@ async def test_uploaded_recovery_rejects_records_from_another_request(tmp_path, 
         )
         publication = await catalog.get_artifact_publication(target.world_id, key)
         assert publication is not None and publication.status == "UPLOADED"
+        indexed_records.clear()
         corrupt = replace(
             publication,
             records_json=json.dumps(
@@ -638,13 +707,35 @@ async def test_uploaded_recovery_rejects_records_from_another_request(tmp_path, 
             require_policy=False,
         )
 
-        with pytest.raises(ValueError, match="does not match its durable request"):
+        with pytest.raises(RuntimeError, match="leave target uploaded"):
             await container.artifact_bundle_service._resume(
                 durable_request,
                 corrupt,
                 corrupt.claimant,
                 catalog,
             )
+        expected_records = json.loads(publication.records_json)
+        assert [record.model_dump(mode="json") for record in indexed_records[0]] == expected_records
+
+        # Caller-supplied publication copies are ignored, but corruption in the
+        # authoritative row must still fail before external index I/O.
+        assert isinstance(catalog, SqliteControlCatalog)
+        connection = catalog._connect_sync()
+        with connection:
+            connection.execute(
+                "UPDATE artifact_publications SET records_json=?, manifest_uri=? "
+                "WHERE publication_key=?",
+                (corrupt.records_json, corrupt.manifest_uri, publication.publication_key),
+            )
+        indexed_records.clear()
+        with pytest.raises(ValueError, match="does not match its durable request"):
+            await container.artifact_bundle_service._resume(
+                durable_request,
+                publication,
+                publication.claimant,
+                catalog,
+            )
+        assert indexed_records == []
     finally:
         await container.shutdown()
 
@@ -1388,6 +1479,98 @@ async def test_resolver_reports_required_member_missing_from_checkpoint(tmp_path
         )
 
 
+async def test_item_scoped_reconciliation_uses_digest_only_candidates(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    source = tmp_path / "result.json"
+    source.write_text("{}")
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        request = _request(world, source, idempotency_key="item-scoped")
+        prepared = container.artifact_bundle_service.prepare(request)
+        catalog = container.storage_service.get_control_catalog(storage)
+        await catalog.acquire_artifact_publication(
+            world_id=request.world_id,
+            run_id=request.run_id,
+            attempt_id=request.attempt_id,
+            idempotency_key=request.idempotency_key,
+            request_digest=prepared.producer_digest,
+            request_json=prepared.request_json,
+            claimant="seed",
+            retry_window_ms=60_000,
+            lease_ms=60_000,
+        )
+        await catalog.fail_artifact_publication(
+            request.world_id,
+            prepared.publication_key,
+            "seed",
+            "make publication immediately due",
+            retry_delay_ms=0,
+        )
+
+        candidates = await container.artifact_bundle_service.list_due_publications(
+            request.world_id,
+            storage_config=storage,
+            limit=1,
+        )
+        assert [candidate.model_dump() for candidate in candidates] == [
+            {"publication_key": prepared.publication_key}
+        ]
+
+        indexed = await container.artifact_bundle_service.reconcile_publication(
+            request.world_id,
+            prepared.publication_key,
+            storage_config=storage,
+        )
+        assert indexed.disposition is ArtifactReconcileDisposition.INDEXED
+
+        duplicate = await container.artifact_bundle_service.reconcile_publication(
+            request.world_id,
+            prepared.publication_key,
+            storage_config=storage,
+        )
+        assert duplicate.disposition is ArtifactReconcileDisposition.INDEXED
+
+        missing_key = hashlib.sha256(b"missing-publication").hexdigest()
+        obsolete = await container.artifact_bundle_service.reconcile_publication(
+            request.world_id,
+            missing_key,
+            storage_config=storage,
+        )
+        assert obsolete.disposition is ArtifactReconcileDisposition.OBSOLETE
+    finally:
+        await container.shutdown()
+
+
+async def test_item_scoped_reconciliation_rejects_unsafe_references(tmp_path):
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+    storage = StorageConfig(uri=tmp_path / "world", namespace="world")
+    container = ServiceContainer(artifact_store_config=artifact_config)
+    try:
+        world = await container.world_service.create_world(WorldConfig(name="w"), storage)
+        with pytest.raises(ValueError, match="lowercase SHA-256"):
+            await container.artifact_bundle_service.reconcile_publication(
+                str(world.world_id),
+                "../../unsafe",
+                storage_config=storage,
+            )
+        with pytest.raises(ValueError, match="limit must be at least 1"):
+            await container.artifact_bundle_service.list_due_publications(
+                str(world.world_id),
+                storage_config=storage,
+                limit=0,
+            )
+        with pytest.raises(ValueError, match="lowercase SHA-256"):
+            await container.artifact_bundle_service.list_due_publications(
+                str(world.world_id),
+                storage_config=storage,
+                after_publication_key="../../unsafe",
+            )
+    finally:
+        await container.shutdown()
+
+
 async def test_reconcile_distinguishes_unowned_and_failure_recording_errors(
     tmp_path, monkeypatch, caplog
 ):
@@ -1408,8 +1591,8 @@ async def test_reconcile_distinguishes_unowned_and_failure_recording_errors(
             request_digest=valid.digest(),
             request_json=valid.canonical_json(),
             claimant="seed-valid",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
-            lease_seconds=0.0,
+            retry_window_ms=60_000,
+            lease_ms=60_000,
         )
         _, corrupt_row = await catalog.acquire_artifact_publication(
             world_id=valid.world_id,
@@ -1419,20 +1602,39 @@ async def test_reconcile_distinguishes_unowned_and_failure_recording_errors(
             request_digest="corrupt",
             request_json="{not-json",
             claimant="seed-corrupt",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
-            lease_seconds=0.0,
+            retry_window_ms=60_000,
+            lease_ms=60_000,
         )
-        real_acquire = catalog.acquire_artifact_publication
+        await catalog.fail_artifact_publication(
+            valid.world_id,
+            valid_row.publication_key,
+            "seed-valid",
+            "make valid row immediately due",
+            retry_delay_ms=0,
+        )
+        await catalog.fail_artifact_publication(
+            valid.world_id,
+            corrupt_row.publication_key,
+            "seed-corrupt",
+            "make corrupt row immediately due",
+            retry_delay_ms=0,
+        )
+        real_recover = catalog.recover_artifact_publication
 
-        async def selective_acquire(**kwargs):
-            if kwargs["idempotency_key"] == valid.idempotency_key:
+        async def selective_recover(world_id, publication_key, claimant, *, lease_ms):
+            if publication_key == valid_row.publication_key:
                 raise RuntimeError("acquire transport unavailable")
-            return await real_acquire(**kwargs)
+            return await real_recover(
+                world_id,
+                publication_key,
+                claimant,
+                lease_ms=lease_ms,
+            )
 
         async def fail_recording(*args, **kwargs):
             raise RuntimeError("failure catalog unavailable")
 
-        monkeypatch.setattr(catalog, "acquire_artifact_publication", selective_acquire)
+        monkeypatch.setattr(catalog, "recover_artifact_publication", selective_recover)
         monkeypatch.setattr(catalog, "fail_artifact_publication", fail_recording)
         caplog.set_level("ERROR", logger="archetype.app.artifacts.bundle_service")
 
@@ -1452,12 +1654,14 @@ async def test_reconcile_distinguishes_unowned_and_failure_recording_errors(
         assert valid_after is not None and valid_after.claimant == "seed-valid"
         assert corrupt_after is not None
         assert corrupt_after.claimant.startswith("artifact-reconciler-")
-        assert corrupt_after.last_error == ""
+        assert corrupt_after.last_error == "make corrupt row immediately due"
     finally:
         await container.shutdown()
 
 
-async def test_reconcile_expires_pending_publication_after_retry_window(tmp_path):
+async def test_reconcile_expires_pending_publication_after_retry_window(tmp_path, monkeypatch):
+    now_ms = [1_000_000]
+    monkeypatch.setattr(catalog_module, "_now_ms", lambda: now_ms[0])
     artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
     storage = StorageConfig(uri=tmp_path / "world", namespace="world")
     source = tmp_path / "result.json"
@@ -1475,9 +1679,10 @@ async def test_reconcile_expires_pending_publication_after_retry_window(tmp_path
             request_digest=request.digest(),
             request_json=request.canonical_json(),
             claimant="seed",
-            retry_until_ms=1,
-            lease_seconds=0.0,
+            retry_window_ms=100,
+            lease_ms=1,
         )
+        now_ms[0] += 101
         result = await container.artifact_bundle_service.reconcile(
             request.world_id, storage_config=storage
         )
@@ -1491,13 +1696,8 @@ async def test_reconcile_expires_pending_publication_after_retry_window(tmp_path
 
 
 async def test_reconcile_counts_expiry_crossing_inside_resume(tmp_path, monkeypatch):
-    class _Clock:
-        def __init__(self, start: float) -> None:
-            self.values = iter((start + 1.0, start + 1.0, start + 200.0))
-
-        def time(self) -> float:
-            return next(self.values)
-
+    now_ms = [2_000_000]
+    monkeypatch.setattr(catalog_module, "_now_ms", lambda: now_ms[0])
     artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
     storage = StorageConfig(uri=tmp_path / "world", namespace="world")
     source = tmp_path / "result.json"
@@ -1508,7 +1708,6 @@ async def test_reconcile_counts_expiry_crossing_inside_resume(tmp_path, monkeypa
         request = _request(world, source, idempotency_key="expires-inside-resume")
         prepared = container.artifact_bundle_service.prepare(request)
         catalog = container.storage_service.get_control_catalog(storage)
-        started_at = time.time()
         await catalog.acquire_artifact_publication(
             world_id=request.world_id,
             run_id=request.run_id,
@@ -1517,10 +1716,35 @@ async def test_reconcile_counts_expiry_crossing_inside_resume(tmp_path, monkeypa
             request_digest=prepared.producer_digest,
             request_json=prepared.request_json,
             claimant="seed",
-            retry_until_ms=int((started_at + 150.0) * 1000),
-            lease_seconds=0.0,
+            retry_window_ms=150,
+            lease_ms=1,
         )
-        monkeypatch.setattr(bundle_service_module, "time", _Clock(started_at))
+        now_ms[0] += 2
+        real_recover = catalog.recover_artifact_publication
+        recover_calls = 0
+
+        async def cross_deadline(world_id, publication_key, claimant, *, lease_ms):
+            nonlocal recover_calls
+            result = await real_recover(
+                world_id,
+                publication_key,
+                claimant,
+                lease_ms=lease_ms,
+            )
+            recover_calls += 1
+            if recover_calls == 1:
+                now_ms[0] += 200
+            return result
+
+        upload_calls = 0
+
+        async def forbidden_upload(*_args, **_kwargs):
+            nonlocal upload_calls
+            upload_calls += 1
+            raise AssertionError("expired publication reached upload")
+
+        monkeypatch.setattr(catalog, "recover_artifact_publication", cross_deadline)
+        monkeypatch.setattr(container.artifact_bundle_service, "_upload_bundle", forbidden_upload)
 
         result = await container.artifact_bundle_service.reconcile(
             request.world_id,
@@ -1531,6 +1755,8 @@ async def test_reconcile_counts_expiry_crossing_inside_resume(tmp_path, monkeypa
         assert result.expired == 1
         assert result.indexed == 0
         assert result.failed == 0
+        assert recover_calls == 2
+        assert upload_calls == 0
         publication = await catalog.get_artifact_publication(
             request.world_id,
             prepared.publication_key,
@@ -1559,7 +1785,7 @@ async def test_duplicate_expired_publication_returns_typed_receipt(tmp_path):
             request_digest=prepared.producer_digest,
             request_json=prepared.request_json,
             claimant="seed",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
+            retry_window_ms=60_000,
         )
         await catalog.expire_artifact_publication(
             request.world_id,
@@ -1584,8 +1810,12 @@ async def test_duplicate_expired_publication_returns_typed_receipt(tmp_path):
         await container.shutdown()
 
 
-async def test_expiry_during_resume_returns_typed_receipt(tmp_path):
-    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts")
+async def test_expiry_during_resume_returns_typed_receipt(tmp_path, monkeypatch):
+    now_ms = [3_000_000]
+    monkeypatch.setattr(catalog_module, "_now_ms", lambda: now_ms[0])
+    artifact_config = ArtifactStoreConfig.local(tmp_path / "artifacts").model_copy(
+        update={"retry_window_seconds": 60}
+    )
     storage = StorageConfig(uri=tmp_path / "world", namespace="world")
     source = tmp_path / "result.json"
     source.write_text("{}")
@@ -1595,17 +1825,22 @@ async def test_expiry_during_resume_returns_typed_receipt(tmp_path):
         request = _request(world, source, idempotency_key="expires-during-resume")
         prepared = container.artifact_bundle_service.prepare(request)
         catalog = container.storage_service.get_control_catalog(storage)
-        await catalog.acquire_artifact_publication(
-            world_id=request.world_id,
-            run_id=request.run_id,
-            attempt_id=request.attempt_id,
-            idempotency_key=request.idempotency_key,
-            request_digest=prepared.producer_digest,
-            request_json=prepared.request_json,
-            claimant="seed",
-            retry_until_ms=1,
-            lease_seconds=0.0,
-        )
+        real_acquire = catalog.acquire_artifact_publication
+
+        async def cross_deadline_after_acquire(**kwargs):
+            result = await real_acquire(**kwargs)
+            now_ms[0] += 60_001
+            return result
+
+        upload_calls = 0
+
+        async def forbidden_upload(*_args, **_kwargs):
+            nonlocal upload_calls
+            upload_calls += 1
+            raise AssertionError("expired publication reached upload")
+
+        monkeypatch.setattr(catalog, "acquire_artifact_publication", cross_deadline_after_acquire)
+        monkeypatch.setattr(container.artifact_bundle_service, "_upload_bundle", forbidden_upload)
 
         receipt = await container.artifact_bundle_service.publish_prepared(
             prepared,
@@ -1614,6 +1849,7 @@ async def test_expiry_during_resume_returns_typed_receipt(tmp_path):
 
         assert receipt.status is ArtifactPublicationStatus.EXPIRED
         assert not receipt.duplicate
+        assert upload_calls == 0
         expired = await catalog.get_artifact_publication(
             request.world_id,
             prepared.publication_key,
@@ -1641,7 +1877,7 @@ async def test_durable_request_identity_and_digest_are_authenticated(tmp_path):
             request_digest=request.digest(),
             request_json=request.canonical_json(),
             claimant="seed",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
+            retry_window_ms=60_000,
         )
         with pytest.raises(ValueError, match="identity does not match"):
             container.artifact_bundle_service._request_from_publication(
@@ -1838,8 +2074,15 @@ async def test_reconcile_rechecks_changed_secret_bearing_object_root_before_io(t
             request_digest=prepared.producer_digest,
             request_json=prepared.request_json,
             claimant="seed-before-config-drift",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
-            lease_seconds=0.0,
+            retry_window_ms=60_000,
+            lease_ms=60_000,
+        )
+        await catalog.fail_artifact_publication(
+            request.world_id,
+            publication.publication_key,
+            "seed-before-config-drift",
+            "make publication immediately due",
+            retry_delay_ms=0,
         )
         assert outcome == "acquired" and publication.status == "PENDING"
         world_id = request.world_id

--- a/tests/app/test_artifact_publication_catalog.py
+++ b/tests/app/test_artifact_publication_catalog.py
@@ -6,12 +6,13 @@
 import asyncio
 import json
 import threading
-import time
 
 import pytest
 
+from archetype.app.storage import catalog as catalog_module
 from archetype.app.storage.catalog import (
     ArtifactPublicationConflictError,
+    ArtifactPublicationExpiredError,
     ArtifactPublicationPendingError,
     SqliteControlCatalog,
 )
@@ -22,17 +23,24 @@ pytestmark = [
 ]
 
 
-async def _acquire(catalog, *, claimant="owner-1", digest="digest-1", lease=60.0):
+async def _acquire(
+    catalog,
+    *,
+    claimant="owner-1",
+    digest="digest-1",
+    lease_ms=60_000,
+    idempotency_key="bundle-1",
+):
     return await catalog.acquire_artifact_publication(
         world_id="world-1",
         run_id="run-1",
         attempt_id="attempt-1",
-        idempotency_key="bundle-1",
+        idempotency_key=idempotency_key,
         request_digest=digest,
         request_json=json.dumps({"request": 1}),
         claimant=claimant,
-        retry_until_ms=int(time.time() * 1000) + 60_000,
-        lease_seconds=lease,
+        retry_window_ms=60_000,
+        lease_ms=lease_ms,
     )
 
 
@@ -81,7 +89,7 @@ async def test_publication_records_request_before_io_and_cas_transitions(tmp_pat
 async def test_failed_phase_is_due_and_recovered_without_losing_upload_metadata(tmp_path):
     catalog = SqliteControlCatalog(tmp_path / "catalog.db")
     try:
-        _, publication = await _acquire(catalog, lease=60.0)
+        _, publication = await _acquire(catalog, lease_ms=60_000)
         await catalog.record_artifact_uploads(
             "world-1",
             publication.publication_key,
@@ -94,12 +102,12 @@ async def test_failed_phase_is_due_and_recovered_without_losing_upload_metadata(
             publication.publication_key,
             "owner-1",
             "index unavailable",
-            retry_at=0.0,
+            retry_delay_ms=0,
         )
 
-        due = await catalog.list_due_artifact_publications("world-1", now=time.time(), limit=10)
+        due = await catalog.list_due_artifact_publications("world-1", limit=10)
         assert [row.publication_key for row in due] == [publication.publication_key]
-        assert due[0].status == "UPLOADED"
+        assert vars(due[0]) == {"publication_key": publication.publication_key}
 
         outcome, recovered = await _acquire(catalog, claimant="reconciler")
         assert outcome == "recovered"
@@ -128,7 +136,7 @@ async def test_fail_holds_write_lock_until_claimant_check_and_update_finish(tmp_
 
         def execute(self, sql, parameters=()):
             cursor = self._conn.execute(sql, parameters)
-            if "SELECT status, claimant FROM artifact_publications" in sql:
+            if "SELECT * FROM artifact_publications" in sql:
                 self._selected.set()
                 if not self._release.wait(timeout=2.0):
                     raise AssertionError("timed out waiting to release failure transaction")
@@ -143,7 +151,7 @@ async def test_fail_holds_write_lock_until_claimant_check_and_update_finish(tmp_
     release = threading.Event()
     selected = threading.Event()
     try:
-        _, publication = await _acquire(failing_catalog, lease=0.0)
+        _, publication = await _acquire(failing_catalog, lease_ms=60_000)
         failing_catalog._conn = PauseAfterClaimantRead(  # type: ignore[assignment]
             failing_catalog._connect_sync(), selected, release
         )
@@ -154,7 +162,7 @@ async def test_fail_holds_write_lock_until_claimant_check_and_update_finish(tmp_
                 publication.publication_key,
                 "owner-1",
                 "upload failed",
-                retry_at=0.0,
+                retry_delay_ms=0,
             )
         )
         assert await asyncio.to_thread(selected.wait, 1.0)
@@ -174,7 +182,7 @@ async def test_fail_holds_write_lock_until_claimant_check_and_update_finish(tmp_
         assert takeover_was_blocked
         assert outcome == "recovered"
         assert replacement.claimant == "owner-2"
-        assert replacement.lease_expires_at > time.time()
+        assert replacement.lease_expires_at > catalog_module._now_ms() / 1000
     finally:
         release.set()
         await failing_catalog.close()
@@ -192,5 +200,269 @@ async def test_pending_publication_can_expire_but_uploaded_publication_cannot(tm
         assert outcome == "expired"
         assert expired.status == "EXPIRED"
         assert expired.last_error == "checkpoint expired"
+    finally:
+        await catalog.close()
+
+
+async def test_due_publication_pages_advance_lexicographically_past_sparse_work(tmp_path):
+    catalog = SqliteControlCatalog(tmp_path / "catalog.db")
+    try:
+        publications = []
+        for index in range(3):
+            _, publication = await _acquire(
+                catalog,
+                claimant=f"owner-{index}",
+                lease_ms=60_000,
+                idempotency_key=f"bundle-{index}",
+            )
+            await catalog.fail_artifact_publication(
+                "world-1",
+                publication.publication_key,
+                f"owner-{index}",
+                "make publication immediately due",
+                retry_delay_ms=0,
+            )
+            publications.append(publication)
+        expected_keys = sorted(publication.publication_key for publication in publications)
+        first = await catalog.list_due_artifact_publications("world-1", limit=2)
+        second = await catalog.list_due_artifact_publications(
+            "world-1",
+            limit=2,
+            after_publication_key=first[-1].publication_key,
+        )
+
+        assert [publication.publication_key for publication in first] == expected_keys[:2]
+        assert [publication.publication_key for publication in second] == expected_keys[2:]
+        with pytest.raises(ValueError, match="lowercase SHA-256"):
+            await catalog.list_due_artifact_publications(
+                "world-1",
+                after_publication_key="raw-publication-id",
+            )
+    finally:
+        await catalog.close()
+
+
+async def test_exact_recovery_uses_catalog_clock_and_preserves_uploaded_authority(
+    tmp_path, monkeypatch
+):
+    now_ms = [1_000_000]
+    monkeypatch.setattr(catalog_module, "_now_ms", lambda: now_ms[0])
+    catalog = SqliteControlCatalog(tmp_path / "catalog.db")
+    try:
+        outcome, missing = await catalog.recover_artifact_publication(
+            "world-1", "f" * 64, "reconciler", lease_ms=1_000
+        )
+        assert outcome == "obsolete" and missing is None
+
+        _, publication = await _acquire(catalog, lease_ms=1_000)
+        original_lease = publication.lease_expires_at
+        now_ms[0] += 100
+        outcome, owned = await catalog.recover_artifact_publication(
+            "world-1", publication.publication_key, "owner-1", lease_ms=2_000
+        )
+        assert outcome == "owned" and owned is not None
+        assert owned.attempt_count == 1
+        assert owned.lease_expires_at == (now_ms[0] + 2_000) / 1000
+        assert owned.lease_expires_at > original_lease
+        with pytest.raises(ArtifactPublicationPendingError):
+            await catalog.recover_artifact_publication(
+                "world-1", publication.publication_key, "other", lease_ms=1_000
+            )
+
+        now_ms[0] += 2_001
+        outcome, recovered = await catalog.recover_artifact_publication(
+            "world-1", publication.publication_key, "other", lease_ms=1_000
+        )
+        assert outcome == "recovered" and recovered is not None
+        assert recovered.attempt_count == 2
+
+        _, deadline = await catalog.acquire_artifact_publication(
+            world_id="world-1",
+            run_id="run-1",
+            attempt_id="attempt-deadline",
+            idempotency_key="deadline-before-live-owner",
+            request_digest="digest-deadline",
+            request_json="{}",
+            claimant="deadline-owner",
+            retry_window_ms=100,
+            lease_ms=1_000,
+        )
+        now_ms[0] += 101
+        outcome, expired = await catalog.recover_artifact_publication(
+            "world-1", deadline.publication_key, "different-owner", lease_ms=1_000
+        )
+        assert outcome == "expired" and expired is not None
+        assert expired.status == "EXPIRED"
+
+        _, uploaded = await catalog.acquire_artifact_publication(
+            world_id="world-1",
+            run_id="run-1",
+            attempt_id="attempt-uploaded",
+            idempotency_key="uploaded-outlives-deadline",
+            request_digest="digest-uploaded",
+            request_json="{}",
+            claimant="uploader",
+            retry_window_ms=100,
+            lease_ms=1_000,
+        )
+        await catalog.record_artifact_uploads(
+            "world-1", uploaded.publication_key, "uploader", "[]", "file:///manifest"
+        )
+        now_ms[0] += 1_001
+        outcome, uploaded_recovery = await catalog.recover_artifact_publication(
+            "world-1", uploaded.publication_key, "indexer", lease_ms=1_000
+        )
+        assert outcome == "recovered" and uploaded_recovery is not None
+        assert uploaded_recovery.status == "UPLOADED"
+        await catalog.complete_artifact_publication(
+            "world-1", uploaded.publication_key, "indexer", 42
+        )
+        outcome, duplicate = await catalog.recover_artifact_publication(
+            "world-1", uploaded.publication_key, "later", lease_ms=1_000
+        )
+        assert outcome == "duplicate" and duplicate is not None
+        assert duplicate.status == "INDEXED"
+    finally:
+        await catalog.close()
+
+
+async def test_source_mutations_require_a_live_catalog_lease(tmp_path, monkeypatch):
+    now_ms = [2_000_000]
+    monkeypatch.setattr(catalog_module, "_now_ms", lambda: now_ms[0])
+    catalog = SqliteControlCatalog(tmp_path / "catalog.db")
+    try:
+        _, pending = await _acquire(catalog, lease_ms=100)
+        now_ms[0] += 101
+        with pytest.raises(ArtifactPublicationPendingError, match="lease expired"):
+            await catalog.renew_artifact_publication(
+                "world-1", pending.publication_key, "owner-1", lease_seconds=1.0
+            )
+        with pytest.raises(ArtifactPublicationPendingError, match="lease expired"):
+            await catalog.record_artifact_uploads(
+                "world-1", pending.publication_key, "owner-1", "[]", "file:///manifest"
+            )
+        with pytest.raises(ArtifactPublicationPendingError, match="lease expired"):
+            await catalog.expire_artifact_publication(
+                "world-1", pending.publication_key, "owner-1", "manual expiry"
+            )
+        with pytest.raises(ArtifactPublicationPendingError, match="lease expired"):
+            await catalog.fail_artifact_publication(
+                "world-1",
+                pending.publication_key,
+                "owner-1",
+                "late failure",
+                retry_delay_ms=0,
+            )
+
+        _, uploaded = await _acquire(
+            catalog,
+            lease_ms=100,
+            idempotency_key="uploaded-stale-completion",
+        )
+        await catalog.record_artifact_uploads(
+            "world-1", uploaded.publication_key, "owner-1", "[]", "file:///manifest"
+        )
+        now_ms[0] += 101
+        with pytest.raises(ArtifactPublicationPendingError, match="lease expired"):
+            await catalog.complete_artifact_publication(
+                "world-1", uploaded.publication_key, "owner-1", 42
+            )
+    finally:
+        await catalog.close()
+
+
+async def test_pending_upload_crossing_retry_deadline_commits_expiry(tmp_path, monkeypatch):
+    now_ms = [3_000_000]
+    monkeypatch.setattr(catalog_module, "_now_ms", lambda: now_ms[0])
+    catalog = SqliteControlCatalog(tmp_path / "catalog.db")
+    try:
+        _, publication = await catalog.acquire_artifact_publication(
+            world_id="world-1",
+            run_id="run-1",
+            attempt_id="attempt-1",
+            idempotency_key="deadline-upload",
+            request_digest="digest-1",
+            request_json="{}",
+            claimant="owner-1",
+            retry_window_ms=50,
+            lease_ms=1_000,
+        )
+        now_ms[0] += 51
+        with pytest.raises(ArtifactPublicationExpiredError):
+            await catalog.record_artifact_uploads(
+                "world-1", publication.publication_key, "owner-1", "[]", "file:///manifest"
+            )
+        expired = await catalog.get_artifact_publication("world-1", publication.publication_key)
+        assert expired is not None and expired.status == "EXPIRED"
+    finally:
+        await catalog.close()
+
+
+@pytest.mark.parametrize("lease_ms", [0, True, 1.0, "1"])
+async def test_artifact_lease_duration_is_strictly_positive(tmp_path, lease_ms):
+    catalog = SqliteControlCatalog(tmp_path / "catalog.db")
+    try:
+        with pytest.raises((TypeError, ValueError)):
+            await _acquire(catalog, lease_ms=lease_ms)
+        with pytest.raises((TypeError, ValueError)):
+            await catalog.recover_artifact_publication(
+                "world-1", "f" * 64, "owner", lease_ms=lease_ms
+            )
+    finally:
+        await catalog.close()
+
+
+@pytest.mark.parametrize("lease_seconds", [True, 0, -1, float("inf"), float("nan"), 86_401])
+async def test_artifact_renewal_duration_is_finite_and_bounded(tmp_path, lease_seconds):
+    catalog = SqliteControlCatalog(tmp_path / "catalog.db")
+    try:
+        with pytest.raises((TypeError, ValueError)):
+            await catalog.renew_artifact_publication(
+                "world-1", "f" * 64, "owner", lease_seconds=lease_seconds
+            )
+    finally:
+        await catalog.close()
+
+
+@pytest.mark.parametrize(
+    ("field", "statement", "value", "message"),
+    [
+        (
+            "status",
+            "UPDATE artifact_publications SET status=? WHERE publication_key=?",
+            "pending",
+            "invalid status",
+        ),
+        (
+            "retry",
+            "UPDATE artifact_publications SET retry_until_ms=? WHERE publication_key=?",
+            1.5,
+            "invalid retry_until_ms",
+        ),
+        (
+            "attempt",
+            "UPDATE artifact_publications SET attempt_count=? WHERE publication_key=?",
+            1.5,
+            "invalid attempt_count",
+        ),
+        (
+            "lease",
+            "UPDATE artifact_publications SET lease_expires_at=? WHERE publication_key=?",
+            "not-a-clock",
+            "invalid lease_expires_at",
+        ),
+    ],
+)
+async def test_local_artifact_rows_reject_corrupt_durable_scalars(
+    tmp_path, field, statement, value, message
+):
+    catalog = SqliteControlCatalog(tmp_path / f"catalog-{field}.db")
+    try:
+        _, publication = await _acquire(catalog)
+        connection = catalog._connect_sync()
+        with connection:
+            connection.execute(statement, (value, publication.publication_key))
+        with pytest.raises(RuntimeError, match=message):
+            await catalog.get_artifact_publication("world-1", publication.publication_key)
     finally:
         await catalog.close()

--- a/tests/app/test_indexed_finalization_crash_oracle.py
+++ b/tests/app/test_indexed_finalization_crash_oracle.py
@@ -47,6 +47,8 @@ _FIRST_TICK = 41
 _RECOVERY_TICK = 97
 _REPLAY_TICK = 113
 _ATTEMPT_LEASE_SECONDS = 1.0
+_RECOVERY_ATTEMPT_LEASE_SECONDS = 10.0
+_ARTIFACT_LEASE_SECONDS = 1.0
 _CAPABILITIES = ProviderExecutionCapabilities(
     provider="crash-oracle",
     request_fingerprint="crash-oracle-provider-v1",
@@ -442,7 +444,7 @@ async def test_indexed_finalization_cold_restart_crash_oracle(
     boundary: str,
 ) -> None:
     artifact_config = ArtifactStoreConfig.local(tmp_path / "artifact-store").model_copy(
-        update={"lease_seconds": 0.05, "retry_delay_seconds": 0.0}
+        update={"lease_seconds": _ARTIFACT_LEASE_SECONDS, "retry_delay_seconds": 0.0}
     )
     storage = StorageConfig(
         uri=tmp_path / "non-default-world-store",
@@ -588,7 +590,7 @@ async def test_indexed_finalization_cold_restart_crash_oracle(
             tick=_RECOVERY_TICK,
             claimant=f"recovery-{boundary}",
             runner=recovery_runner,
-            lease_seconds=1.0,
+            lease_seconds=_RECOVERY_ATTEMPT_LEASE_SECONDS,
         )
 
         assert completed is not None

--- a/tests/app/test_mission_attempt_claims.py
+++ b/tests/app/test_mission_attempt_claims.py
@@ -194,8 +194,8 @@ async def _advance_artifact_publication(
             request_digest=projection.producer_digest,
             request_json=projection.request_json,
             claimant=claimant,
-            retry_until_ms=int(time.time() * 1000) + 60_000,
-            lease_seconds=60,
+            retry_window_ms=60_000,
+            lease_ms=60_000,
         )
     assert publication.publication_key == projection.publication_key
 
@@ -1747,8 +1747,8 @@ async def test_actual_expired_artifact_publication_cold_settles_and_replays(
             request_digest=projection.producer_digest,
             request_json=projection.request_json,
             claimant="expiry-seed",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
-            lease_seconds=1,
+            retry_window_ms=60_000,
+            lease_ms=1_000,
         )
         assert artifact_outcome == "acquired"
         assert artifact_claim.status == "PENDING"

--- a/tests/app/test_remote_catalog_client.py
+++ b/tests/app/test_remote_catalog_client.py
@@ -14,12 +14,15 @@ from archetype.app.storage.catalog import (
     AttemptClaimConflictError,
     AttemptClaimStaleError,
     CommandAdmission,
+    artifact_publication_key,
 )
 from archetype.app.storage.remote_catalog import RemoteControlCatalog
 from archetype.app.storage.service import StorageService
 from archetype.core.config import StorageConfig
 
 pytestmark = pytest.mark.asyncio
+
+_ARTIFACT_KEY = artifact_publication_key("world-1", "run-1", "bundle-1")
 
 
 async def _catalog_with(
@@ -53,8 +56,11 @@ def _artifact_protocol_response() -> httpx.Response:
         200,
         json={
             "status": "active",
-            "catalog_protocol_version": 3,
-            "capabilities": ["artifact_snapshot_decimal_v1"],
+            "catalog_protocol_version": 6,
+            "capabilities": [
+                "artifact_snapshot_decimal_v1",
+                "artifact_publication_server_clock_v1",
+            ],
         },
     )
 
@@ -184,7 +190,7 @@ def _outbox_row():
 
 def _artifact_publication_row(**overrides):
     row = {
-        "publication_key": "publication-1",
+        "publication_key": _ARTIFACT_KEY,
         "run_id": "run-1",
         "attempt_id": "attempt-1",
         "idempotency_key": "bundle-1",
@@ -216,7 +222,7 @@ async def _acquire_test_artifact(catalog: RemoteControlCatalog) -> None:
         request_digest="digest-1",
         request_json="{}",
         claimant="owner-1",
-        retry_until_ms=60_000,
+        retry_window_ms=60_000,
     )
 
 
@@ -912,7 +918,8 @@ async def test_artifact_publication_transport_is_typed_and_scoped():
                 200,
                 json=_artifact_publication_row(status="INDEXED", index_snapshot_id="42"),
             ),
-            httpx.Response(200, json=[_artifact_publication_row(status="UPLOADED")]),
+            _artifact_protocol_response(),
+            httpx.Response(200, json=[{"publication_key": _ARTIFACT_KEY}]),
         ],
         requests,
     )
@@ -925,8 +932,8 @@ async def test_artifact_publication_transport_is_typed_and_scoped():
             request_digest="digest-1",
             request_json="{}",
             claimant="owner-1",
-            retry_until_ms=60_000,
-            lease_seconds=15.0,
+            retry_window_ms=60_000,
+            lease_ms=15_000,
         )
         renewed = await catalog.renew_artifact_publication(
             "world-1", publication.publication_key, "owner-1", lease_seconds=60.0
@@ -938,39 +945,195 @@ async def test_artifact_publication_transport_is_typed_and_scoped():
             "world-1", publication.publication_key, "owner-1", 42
         )
         await catalog.fail_artifact_publication(
-            "world-1", publication.publication_key, "owner-1", "retry", retry_at=3.0
+            "world-1",
+            publication.publication_key,
+            "owner-1",
+            "retry",
+            retry_delay_ms=3_000,
         )
         await catalog.expire_artifact_publication(
             "world-1", publication.publication_key, "owner-1", "expired"
         )
         missing = await catalog.get_artifact_publication("world-1", "missing")
         indexed = await catalog.get_artifact_publication("world-1", publication.publication_key)
-        due = await catalog.list_due_artifact_publications("world-1", now=5.0, limit=7)
+        due = await catalog.list_due_artifact_publications(
+            "world-1",
+            limit=7,
+            after_publication_key="1" * 64,
+        )
 
         assert outcome == "acquired" and publication.world_id == "world-1"
         assert renewed.lease_expires_at == 90.0
         assert missing is None
         assert indexed is not None and indexed.status == "INDEXED"
-        assert [record.status for record in due] == ["UPLOADED"]
+        assert [record.publication_key for record in due] == [_ARTIFACT_KEY]
         assert [request.url.path for request in requests] == [
             "/ns/test/w/world-1/status",
-            "/ns/test/w/world-1/artifact-publications/acquire-v2",
+            "/ns/test/w/world-1/artifact-publications/acquire-v3",
             "/ns/test/w/world-1/status",
-            "/ns/test/w/world-1/artifact-publications/publication-1/renew-v2",
+            f"/ns/test/w/world-1/artifact-publications/{_ARTIFACT_KEY}/renew-v2",
             "/ns/test/w/world-1/status",
-            "/ns/test/w/world-1/artifact-publications/publication-1/uploads-v2",
+            f"/ns/test/w/world-1/artifact-publications/{_ARTIFACT_KEY}/uploads-v2",
             "/ns/test/w/world-1/status",
-            "/ns/test/w/world-1/artifact-publications/publication-1/complete-v2",
+            f"/ns/test/w/world-1/artifact-publications/{_ARTIFACT_KEY}/complete-v2",
             "/ns/test/w/world-1/status",
-            "/ns/test/w/world-1/artifact-publications/publication-1/fail-v2",
+            f"/ns/test/w/world-1/artifact-publications/{_ARTIFACT_KEY}/fail-v3",
             "/ns/test/w/world-1/status",
-            "/ns/test/w/world-1/artifact-publications/publication-1/expire-v2",
+            f"/ns/test/w/world-1/artifact-publications/{_ARTIFACT_KEY}/expire-v2",
             "/ns/test/w/world-1/artifact-publications/missing",
-            "/ns/test/w/world-1/artifact-publications/publication-1",
-            "/ns/test/w/world-1/artifact-publications",
+            f"/ns/test/w/world-1/artifact-publications/{_ARTIFACT_KEY}",
+            "/ns/test/w/world-1/status",
+            "/ns/test/w/world-1/artifact-publications/due-v1",
         ]
-        assert dict(requests[-1].url.params) == {"due": "5.0", "limit": "7"}
+        assert dict(requests[-1].url.params) == {
+            "limit": "7",
+            "after_publication_key": "1" * 64,
+        }
         assert json.loads(requests[7].content)["index_snapshot_id"] == "42"
+    finally:
+        await catalog.close()
+
+
+async def test_exact_artifact_recovery_sends_only_claimant_and_lease_duration():
+    requests: list[httpx.Request] = []
+    catalog = await _catalog_with(
+        [
+            _artifact_protocol_response(),
+            httpx.Response(
+                200,
+                json={
+                    "outcome": "owned",
+                    "publication": _artifact_publication_row(),
+                },
+            ),
+        ],
+        requests,
+    )
+    try:
+        outcome, publication = await catalog.recover_artifact_publication(
+            "world-1", _ARTIFACT_KEY, "owner-1", lease_ms=15_000
+        )
+        assert outcome == "owned" and publication is not None
+        assert [request.url.path for request in requests] == [
+            "/ns/test/w/world-1/status",
+            f"/ns/test/w/world-1/artifact-publications/{_ARTIFACT_KEY}/recover-v1",
+        ]
+        assert json.loads(requests[-1].content) == {
+            "claimant": "owner-1",
+            "lease_ms": 15_000,
+        }
+    finally:
+        await catalog.close()
+
+
+async def test_exact_artifact_recovery_rejects_a_different_response_key():
+    catalog = await _catalog_with(
+        [
+            _artifact_protocol_response(),
+            httpx.Response(
+                200,
+                json={
+                    "outcome": "owned",
+                    "publication": _artifact_publication_row(publication_key="b" * 64),
+                },
+            ),
+        ]
+    )
+    try:
+        with pytest.raises(RuntimeError, match="different publication"):
+            await catalog.recover_artifact_publication(
+                "world-1", _ARTIFACT_KEY, "owner-1", lease_ms=15_000
+            )
+    finally:
+        await catalog.close()
+
+
+async def test_remote_due_discovery_rejects_full_replay_rows():
+    catalog = await _catalog_with(
+        [
+            _artifact_protocol_response(),
+            httpx.Response(200, json=[_artifact_publication_row()]),
+        ]
+    )
+    try:
+        with pytest.raises(RuntimeError, match="digest-only"):
+            await catalog.list_due_artifact_publications("world-1")
+    finally:
+        await catalog.close()
+
+
+@pytest.mark.parametrize(
+    ("outcome", "status"),
+    [
+        ("owned", "INDEXED"),
+        ("recovered", "EXPIRED"),
+        ("duplicate", "PENDING"),
+        ("expired", "UPLOADED"),
+    ],
+)
+async def test_remote_exact_recovery_rejects_contradictory_outcome_status(outcome, status):
+    catalog = await _catalog_with(
+        [
+            _artifact_protocol_response(),
+            httpx.Response(
+                200,
+                json={
+                    "outcome": outcome,
+                    "publication": _artifact_publication_row(
+                        status=status,
+                        index_snapshot_id="1" if status == "INDEXED" else "0",
+                    ),
+                },
+            ),
+        ]
+    )
+    try:
+        with pytest.raises(RuntimeError, match="contradicts"):
+            await catalog.recover_artifact_publication(
+                "world-1", _ARTIFACT_KEY, "owner-1", lease_ms=15_000
+            )
+    finally:
+        await catalog.close()
+
+
+async def test_remote_artifact_decoder_requires_attempt_count():
+    row = _artifact_publication_row()
+    del row["attempt_count"]
+    catalog = await _catalog_with([httpx.Response(200, json=row)])
+    try:
+        with pytest.raises(RuntimeError, match="attempt_count"):
+            await catalog.get_artifact_publication("world-1", _ARTIFACT_KEY)
+    finally:
+        await catalog.close()
+
+
+@pytest.mark.parametrize("lease_ms", [0, True, 1.0, "1"])
+async def test_remote_artifact_lease_duration_is_strictly_positive(lease_ms):
+    requests: list[httpx.Request] = []
+    catalog = await _catalog_with([], requests)
+    try:
+        with pytest.raises((TypeError, ValueError)):
+            await catalog.recover_artifact_publication(
+                "world-1", _ARTIFACT_KEY, "owner-1", lease_ms=lease_ms
+            )
+        assert requests == []
+    finally:
+        await catalog.close()
+
+
+@pytest.mark.parametrize("lease_seconds", [True, 0, -1, float("inf"), float("nan"), 86_401])
+async def test_remote_artifact_renewal_duration_is_finite_and_bounded(lease_seconds):
+    requests: list[httpx.Request] = []
+    catalog = await _catalog_with([], requests)
+    try:
+        with pytest.raises((TypeError, ValueError)):
+            await catalog.renew_artifact_publication(
+                "world-1",
+                _ARTIFACT_KEY,
+                "owner-1",
+                lease_seconds=lease_seconds,
+            )
+        assert requests == []
     finally:
         await catalog.close()
 
@@ -1001,14 +1164,14 @@ async def test_artifact_acquire_missing_capability_fails_before_mutation():
         requests,
     )
     try:
-        with pytest.raises(RuntimeError, match="lossless artifact snapshot IDs"):
+        with pytest.raises(RuntimeError, match="artifact publication server-clock v1"):
             await _acquire_test_artifact(catalog)
         assert [request.url.path for request in requests] == ["/ns/test/w/world-1/status"]
     finally:
         await catalog.close()
 
 
-async def test_artifact_acquire_v2_route_404_fails_closed_after_probe():
+async def test_artifact_acquire_v3_route_404_fails_closed_after_probe():
     requests: list[httpx.Request] = []
     catalog = await _catalog_with(
         [_artifact_protocol_response(), httpx.Response(404, json={"error": "bad_route"})],
@@ -1019,7 +1182,7 @@ async def test_artifact_acquire_v2_route_404_fails_closed_after_probe():
             await _acquire_test_artifact(catalog)
         assert [request.url.path for request in requests] == [
             "/ns/test/w/world-1/status",
-            "/ns/test/w/world-1/artifact-publications/acquire-v2",
+            "/ns/test/w/world-1/artifact-publications/acquire-v3",
         ]
     finally:
         await catalog.close()
@@ -1044,7 +1207,7 @@ async def test_artifact_publication_completion_rejects_nonpositive_noninteger_sn
         await catalog.close()
 
 
-async def test_artifact_snapshot_protocol_missing_capability_fails_before_write():
+async def test_artifact_mutation_protocol_missing_capability_fails_before_write():
     requests: list[httpx.Request] = []
     catalog = await _catalog_with(
         [
@@ -1060,14 +1223,14 @@ async def test_artifact_snapshot_protocol_missing_capability_fails_before_write(
         requests,
     )
     try:
-        with pytest.raises(RuntimeError, match="lossless artifact snapshot IDs"):
+        with pytest.raises(RuntimeError, match="lease-fenced artifact mutation v2"):
             await catalog.complete_artifact_publication("world-1", "publication-1", "owner-1", 42)
         assert [request.url.path for request in requests] == ["/ns/test/w/world-1/status"]
     finally:
         await catalog.close()
 
 
-async def test_artifact_snapshot_v2_route_404_fails_closed_after_probe():
+async def test_artifact_mutation_v2_route_404_fails_closed_after_probe():
     requests: list[httpx.Request] = []
     catalog = await _catalog_with(
         [
@@ -1075,8 +1238,11 @@ async def test_artifact_snapshot_v2_route_404_fails_closed_after_probe():
                 200,
                 json={
                     "status": "active",
-                    "catalog_protocol_version": 3,
-                    "capabilities": ["artifact_snapshot_decimal_v1"],
+                    "catalog_protocol_version": 6,
+                    "capabilities": [
+                        "artifact_snapshot_decimal_v1",
+                        "artifact_publication_server_clock_v1",
+                    ],
                 },
             ),
             httpx.Response(404, json={"error": "bad_route"}),

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -2318,8 +2318,8 @@ async def test_artifact_source_mutations_require_live_lease_parity(tmp_path, wor
 
 async def test_artifact_publication_key_unicode_parity(tmp_path, worker_url):
     world_id = "wörld-🚀"
-    run_id = "rün-雪"
-    idempotency_key = "bundlé-🧪"
+    run_id = "rün-\x7f-雪"
+    idempotency_key = "bundlé-\x7f-🧪"
     expected = artifact_publication_key(world_id, run_id, idempotency_key)
     for catalog in await _both(tmp_path, worker_url):
         try:
@@ -2408,6 +2408,8 @@ async def test_worker_artifact_key_hashes_before_clock_and_due_is_digest_only():
     assert "SELECT publication_key FROM artifact_publications" in source
     assert "function artifactPublicationAuthorityError(" in source
     assert source.count("artifactPublicationAuthorityError(row,") >= 3
+    assert source.count('(route.length === 1 && method === "GET")') == 1
+    assert "SELECT * FROM artifact_publications WHERE status IN" not in source
 
 
 async def test_worker_rejects_invalid_snapshot_before_indexed_replay(worker_url):

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -29,6 +29,7 @@ import pytest
 
 from archetype.app.storage.catalog import (
     ArtifactPublicationConflictError,
+    ArtifactPublicationExpiredError,
     ArtifactPublicationPendingError,
     AttemptClaimConflictError,
     AttemptClaimPendingError,
@@ -41,6 +42,7 @@ from archetype.app.storage.catalog import (
     SignatureRecord,
     SqliteControlCatalog,
     WorldRecord,
+    artifact_publication_key,
 )
 from archetype.core.interfaces import StaleWriterError
 
@@ -1930,9 +1932,8 @@ async def test_mission_attempt_expired_lease_rejects_every_mutation_parity(
 
 async def test_artifact_publication_lifecycle_parity(tmp_path, worker_url):
     request_json = '{"world_id":"w1","run_id":"r1"}'
-    retry_until_ms = int(time.time() * 1000) + 60_000
     for catalog in await _both(tmp_path, worker_url):
-        missing = "missing-publication"
+        missing = "f" * 64
         for invalid_snapshot in (True, 1.5, "1", 0, -1, 1 << 63):
             with pytest.raises(ValueError, match="positive integer"):
                 await catalog.complete_artifact_publication(
@@ -1950,7 +1951,7 @@ async def test_artifact_publication_lifecycle_parity(tmp_path, worker_url):
             await catalog.expire_artifact_publication("w1", missing, "nobody", "expired")
         # Failure release is deliberately idempotent for a missing row.
         await catalog.fail_artifact_publication(
-            "w1", missing, "nobody", "nothing to release", retry_at=0.0
+            "w1", missing, "nobody", "nothing to release", retry_delay_ms=0
         )
 
         outcome, publication = await catalog.acquire_artifact_publication(
@@ -1961,8 +1962,8 @@ async def test_artifact_publication_lifecycle_parity(tmp_path, worker_url):
             request_digest="digest-1",
             request_json=request_json,
             claimant="owner-1",
-            retry_until_ms=retry_until_ms,
-            lease_seconds=30.0,
+            retry_window_ms=60_000,
+            lease_ms=30_000,
         )
         assert outcome == "acquired" and publication.status == "PENDING"
 
@@ -1975,7 +1976,7 @@ async def test_artifact_publication_lifecycle_parity(tmp_path, worker_url):
                 request_digest="digest-1",
                 request_json=request_json,
                 claimant="owner-2",
-                retry_until_ms=retry_until_ms,
+                retry_window_ms=60_000,
             )
         with pytest.raises(ArtifactPublicationConflictError):
             await catalog.acquire_artifact_publication(
@@ -1986,7 +1987,7 @@ async def test_artifact_publication_lifecycle_parity(tmp_path, worker_url):
                 request_digest="different",
                 request_json=request_json,
                 claimant="owner-2",
-                retry_until_ms=retry_until_ms,
+                retry_window_ms=60_000,
             )
 
         await catalog.record_artifact_uploads(
@@ -2001,21 +2002,18 @@ async def test_artifact_publication_lifecycle_parity(tmp_path, worker_url):
             publication.publication_key,
             "owner-1",
             "index unavailable",
-            retry_at=0.0,
+            retry_delay_ms=0,
         )
-        due = await catalog.list_due_artifact_publications("w1", now=time.time(), limit=10)
-        assert len(due) == 1 and due[0].status == "UPLOADED"
+        due = await catalog.list_due_artifact_publications("w1", limit=10)
+        assert [candidate.publication_key for candidate in due] == [publication.publication_key]
 
-        outcome, recovered = await catalog.acquire_artifact_publication(
-            world_id="w1",
-            run_id="r1",
-            attempt_id="a1",
-            idempotency_key="bundle-1",
-            request_digest="digest-1",
-            request_json=request_json,
-            claimant="reconciler",
-            retry_until_ms=retry_until_ms,
+        outcome, recovered = await catalog.recover_artifact_publication(
+            "w1",
+            publication.publication_key,
+            "reconciler",
+            lease_ms=900_000,
         )
+        assert recovered is not None
         assert outcome == "recovered" and recovered.attempt_count == 2
         renewed = await catalog.renew_artifact_publication(
             "w1",
@@ -2043,11 +2041,354 @@ async def test_artifact_publication_lifecycle_parity(tmp_path, worker_url):
             request_digest="digest-1",
             request_json=request_json,
             claimant="later",
-            retry_until_ms=retry_until_ms,
+            retry_window_ms=60_000,
         )
         assert outcome == "duplicate"
         assert duplicate.index_snapshot_id == snapshot_id
         await catalog.close()
+
+
+async def test_due_artifact_publication_cursor_parity(tmp_path, worker_url):
+    for catalog in await _both(tmp_path, worker_url):
+        try:
+            publications = []
+            for index in range(3):
+                _, publication = await catalog.acquire_artifact_publication(
+                    world_id="w-cursor",
+                    run_id="r-cursor",
+                    attempt_id=f"a-{index}",
+                    idempotency_key=f"bundle-{index}",
+                    request_digest=f"digest-{index}",
+                    request_json="{}",
+                    claimant=f"owner-{index}",
+                    retry_window_ms=60_000,
+                    lease_ms=60_000,
+                )
+                await catalog.fail_artifact_publication(
+                    "w-cursor",
+                    publication.publication_key,
+                    f"owner-{index}",
+                    "make publication immediately due",
+                    retry_delay_ms=0,
+                )
+                publications.append(publication)
+
+            expected_keys = sorted(row.publication_key for row in publications)
+            first = await catalog.list_due_artifact_publications("w-cursor", limit=2)
+            second = await catalog.list_due_artifact_publications(
+                "w-cursor",
+                limit=2,
+                after_publication_key=first[-1].publication_key,
+            )
+            assert [row.publication_key for row in first] == expected_keys[:2]
+            assert [row.publication_key for row in second] == expected_keys[2:]
+            with pytest.raises(ValueError, match="lowercase SHA-256"):
+                await catalog.list_due_artifact_publications(
+                    "w-cursor",
+                    after_publication_key="raw-publication-id",
+                )
+        finally:
+            await catalog.close()
+
+
+async def test_exact_artifact_recovery_state_machine_parity(tmp_path, worker_url):
+    for catalog in await _both(tmp_path, worker_url):
+        try:
+            outcome, missing = await catalog.recover_artifact_publication(
+                "w-exact", "f" * 64, "worker", lease_ms=100
+            )
+            assert outcome == "obsolete" and missing is None
+
+            _, publication = await catalog.acquire_artifact_publication(
+                world_id="w-exact",
+                run_id="r-exact",
+                attempt_id="a-owned",
+                idempotency_key="same-owner",
+                request_digest="digest-owned",
+                request_json="{}",
+                claimant="owner",
+                retry_window_ms=10_000,
+                lease_ms=10_000,
+            )
+            outcome, owned = await catalog.recover_artifact_publication(
+                "w-exact", publication.publication_key, "owner", lease_ms=10_000
+            )
+            assert outcome == "owned" and owned is not None
+            assert owned.attempt_count == 1
+            # The remote catalog clock is millisecond-granular. Acquisition
+            # and same-owner recovery can therefore observe the same catalog
+            # millisecond and produce an equal (never regressed) expiry.
+            # The deterministic clock test in test_artifact_publication_catalog
+            # advances time explicitly and proves that renewal extends from a
+            # later catalog instant.
+            assert owned.lease_expires_at >= publication.lease_expires_at
+            with pytest.raises(ArtifactPublicationPendingError):
+                await catalog.recover_artifact_publication(
+                    "w-exact", publication.publication_key, "other", lease_ms=100
+                )
+            await catalog.fail_artifact_publication(
+                "w-exact",
+                publication.publication_key,
+                "owner",
+                "release owned lease",
+                retry_delay_ms=0,
+            )
+            outcome, recovered = await catalog.recover_artifact_publication(
+                "w-exact", publication.publication_key, "other", lease_ms=500
+            )
+            assert outcome == "recovered" and recovered is not None
+            assert recovered.attempt_count == 2
+
+            _, deadline = await catalog.acquire_artifact_publication(
+                world_id="w-exact",
+                run_id="r-exact",
+                attempt_id="a-deadline",
+                idempotency_key="deadline-before-live-owner",
+                request_digest="digest-deadline",
+                request_json="{}",
+                claimant="deadline-owner",
+                retry_window_ms=25,
+                lease_ms=1_000,
+            )
+            await asyncio.sleep(0.05)
+            outcome, expired = await catalog.recover_artifact_publication(
+                "w-exact", deadline.publication_key, "different-owner", lease_ms=100
+            )
+            assert outcome == "expired" and expired is not None
+            assert expired.status == "EXPIRED"
+
+            _, uploaded = await catalog.acquire_artifact_publication(
+                world_id="w-exact",
+                run_id="r-exact",
+                attempt_id="a-uploaded",
+                idempotency_key="uploaded-past-deadline",
+                request_digest="digest-uploaded",
+                request_json="{}",
+                claimant="uploader",
+                retry_window_ms=50,
+                lease_ms=500,
+            )
+            await catalog.record_artifact_uploads(
+                "w-exact", uploaded.publication_key, "uploader", "[]", "file:///manifest"
+            )
+            await catalog.fail_artifact_publication(
+                "w-exact",
+                uploaded.publication_key,
+                "uploader",
+                "release uploaded lease",
+                retry_delay_ms=0,
+            )
+            await asyncio.sleep(0.06)
+            outcome, uploaded_recovery = await catalog.recover_artifact_publication(
+                "w-exact", uploaded.publication_key, "indexer", lease_ms=500
+            )
+            assert outcome == "recovered" and uploaded_recovery is not None
+            assert uploaded_recovery.status == "UPLOADED"
+            await catalog.complete_artifact_publication(
+                "w-exact", uploaded.publication_key, "indexer", 42
+            )
+            outcome, duplicate = await catalog.recover_artifact_publication(
+                "w-exact", uploaded.publication_key, "later", lease_ms=100
+            )
+            assert outcome == "duplicate" and duplicate is not None
+
+            _, explicitly_expired = await catalog.acquire_artifact_publication(
+                world_id="w-exact",
+                run_id="r-exact",
+                attempt_id="a-explicit",
+                idempotency_key="explicit-expiry",
+                request_digest="digest-explicit",
+                request_json="{}",
+                claimant="expirer",
+                retry_window_ms=10_000,
+                lease_ms=500,
+            )
+            await catalog.expire_artifact_publication(
+                "w-exact", explicitly_expired.publication_key, "expirer", "manual"
+            )
+            outcome, terminal = await catalog.recover_artifact_publication(
+                "w-exact", explicitly_expired.publication_key, "later", lease_ms=100
+            )
+            assert outcome == "expired" and terminal is not None
+        finally:
+            await catalog.close()
+
+
+async def test_artifact_source_mutations_require_live_lease_parity(tmp_path, worker_url):
+    for catalog in await _both(tmp_path, worker_url):
+        try:
+            _, pending = await catalog.acquire_artifact_publication(
+                world_id="w-source-fence",
+                run_id="r1",
+                attempt_id="a-pending",
+                idempotency_key="stale-pending",
+                request_digest="digest-pending",
+                request_json="{}",
+                claimant="owner",
+                retry_window_ms=10_000,
+                lease_ms=40,
+            )
+            await asyncio.sleep(0.07)
+            with pytest.raises(ArtifactPublicationPendingError):
+                await catalog.renew_artifact_publication(
+                    "w-source-fence",
+                    pending.publication_key,
+                    "owner",
+                    lease_seconds=1.0,
+                )
+            with pytest.raises(ArtifactPublicationPendingError):
+                await catalog.record_artifact_uploads(
+                    "w-source-fence", pending.publication_key, "owner", "[]", "file:///m"
+                )
+            with pytest.raises(ArtifactPublicationPendingError):
+                await catalog.fail_artifact_publication(
+                    "w-source-fence",
+                    pending.publication_key,
+                    "owner",
+                    "late",
+                    retry_delay_ms=0,
+                )
+            with pytest.raises(ArtifactPublicationPendingError):
+                await catalog.expire_artifact_publication(
+                    "w-source-fence", pending.publication_key, "owner", "late"
+                )
+
+            _, uploaded = await catalog.acquire_artifact_publication(
+                world_id="w-source-fence",
+                run_id="r1",
+                attempt_id="a-uploaded",
+                idempotency_key="stale-complete",
+                request_digest="digest-uploaded",
+                request_json="{}",
+                claimant="owner",
+                retry_window_ms=10_000,
+                lease_ms=40,
+            )
+            await catalog.record_artifact_uploads(
+                "w-source-fence", uploaded.publication_key, "owner", "[]", "file:///m"
+            )
+            await asyncio.sleep(0.07)
+            with pytest.raises(ArtifactPublicationPendingError):
+                await catalog.complete_artifact_publication(
+                    "w-source-fence", uploaded.publication_key, "owner", 42
+                )
+
+            _, deadline = await catalog.acquire_artifact_publication(
+                world_id="w-source-fence",
+                run_id="r1",
+                attempt_id="a-deadline",
+                idempotency_key="deadline-upload",
+                request_digest="digest-deadline",
+                request_json="{}",
+                claimant="owner",
+                retry_window_ms=25,
+                lease_ms=500,
+            )
+            await asyncio.sleep(0.05)
+            with pytest.raises(ArtifactPublicationExpiredError):
+                await catalog.record_artifact_uploads(
+                    "w-source-fence", deadline.publication_key, "owner", "[]", "file:///m"
+                )
+            expired = await catalog.get_artifact_publication(
+                "w-source-fence", deadline.publication_key
+            )
+            assert expired is not None and expired.status == "EXPIRED"
+        finally:
+            await catalog.close()
+
+
+async def test_artifact_publication_key_unicode_parity(tmp_path, worker_url):
+    world_id = "wörld-🚀"
+    run_id = "rün-雪"
+    idempotency_key = "bundlé-🧪"
+    expected = artifact_publication_key(world_id, run_id, idempotency_key)
+    for catalog in await _both(tmp_path, worker_url):
+        try:
+            outcome, publication = await catalog.acquire_artifact_publication(
+                world_id=world_id,
+                run_id=run_id,
+                attempt_id="attempt-unicode",
+                idempotency_key=idempotency_key,
+                request_digest="digest-unicode",
+                request_json="{}",
+                claimant="owner",
+                retry_window_ms=10_000,
+                lease_ms=500,
+            )
+            assert outcome == "acquired"
+            assert publication.publication_key == expected
+        finally:
+            await catalog.close()
+
+
+async def test_worker_rejects_open_or_lossy_artifact_mutation_bodies(worker_url):
+    catalog = _remote(worker_url)
+    try:
+        _, publication = await catalog.acquire_artifact_publication(
+            world_id="w-mutation-wire",
+            run_id="r1",
+            attempt_id="a1",
+            idempotency_key="mutation-wire",
+            request_digest="digest",
+            request_json="{}",
+            claimant="owner",
+            retry_window_ms=10_000,
+            lease_ms=1_000,
+        )
+        base = (
+            f"{catalog._base}/w/w-mutation-wire/artifact-publications/{publication.publication_key}"
+        )
+        invalid_renewals = [
+            await catalog._client.post(
+                f"{base}/renew-v2",
+                json={"claimant": "owner", "lease_seconds": value},
+            )
+            for value in ("1", True, 0, -1, 86_401)
+        ]
+        open_renewal = await catalog._client.post(
+            f"{base}/renew-v2",
+            json={"claimant": "owner", "lease_seconds": 1, "now": time.time()},
+        )
+        open_upload = await catalog._client.post(
+            f"{base}/uploads-v2",
+            json={
+                "claimant": "owner",
+                "records_json": "[]",
+                "manifest_uri": "file:///m",
+                "request_json": "{}",
+            },
+        )
+        open_completion = await catalog._client.post(
+            f"{base}/complete-v2",
+            json={"claimant": "owner", "index_snapshot_id": "1", "retry_at": 0},
+        )
+        open_expiry = await catalog._client.post(
+            f"{base}/expire-v2",
+            json={"claimant": "owner", "error": "manual", "operator": True},
+        )
+
+        assert all(response.status_code == 400 for response in invalid_renewals)
+        assert open_renewal.status_code == 400
+        assert open_upload.status_code == 400
+        assert open_completion.status_code == 400
+        assert open_expiry.status_code == 400
+    finally:
+        await catalog.close()
+
+
+async def test_worker_artifact_key_hashes_before_clock_and_due_is_digest_only():
+    source = (WORKER_DIR / "src" / "index.ts").read_text()
+    start = source.index('route[1] === "acquire-v3"')
+    end = source.index('route[1] === "due-v1"', start)
+    acquire_block = source[start:end]
+    hash_position = acquire_block.index("await artifactPublicationKey")
+    clock_position = acquire_block.index("Date.now()", hash_position)
+
+    assert hash_position < clock_position
+    assert "await " not in acquire_block[clock_position:]
+    assert "SELECT publication_key FROM artifact_publications" in source
+    assert "function artifactPublicationAuthorityError(" in source
+    assert source.count("artifactPublicationAuthorityError(row,") >= 3
 
 
 async def test_worker_rejects_invalid_snapshot_before_indexed_replay(worker_url):
@@ -2061,7 +2402,7 @@ async def test_worker_rejects_invalid_snapshot_before_indexed_replay(worker_url)
             request_digest="digest-snapshot-wire",
             request_json="{}",
             claimant="snapshot-worker",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
+            retry_window_ms=60_000,
         )
         await catalog.record_artifact_uploads(
             publication.world_id,
@@ -2123,7 +2464,7 @@ async def test_worker_rejects_invalid_snapshot_before_indexed_replay(worker_url)
             request_digest="digest-snapshot-wire-legacy",
             request_json="{}",
             claimant="snapshot-worker",
-            retry_until_ms=int(time.time() * 1000) + 60_000,
+            retry_window_ms=60_000,
         )
         await catalog.record_artifact_uploads(
             legacy.world_id,

--- a/tests/app/test_remote_catalog_parity.py
+++ b/tests/app/test_remote_catalog_parity.py
@@ -437,6 +437,25 @@ async def test_world_registration_parity(tmp_path, worker_url):
         await catalog.close()
 
 
+async def test_world_unicode_identity_parity(tmp_path, worker_url):
+    world_id = "wörld-🚀"
+    for catalog in await _both(tmp_path, worker_url):
+        try:
+            await catalog.register_world(_world(world_id))
+            assert (await catalog.get_world(world_id)).world_id == world_id
+
+            await catalog.set_world_status(world_id, "destroyed")
+            await catalog.set_world_run(world_id, "rün-雪")
+
+            record = await catalog.get_world(world_id)
+            assert record is not None
+            assert record.status == "destroyed"
+            assert record.run_id == "rün-雪"
+            assert [world.world_id for world in await catalog.list_worlds()] == [world_id]
+        finally:
+            await catalog.close()
+
+
 async def test_signature_registration_parity(tmp_path, worker_url):
     rec = SignatureRecord(
         table_id="t1", component_names=("A", "B"), schema_json='{"fields":[]}', fingerprint="f1"

--- a/tests/scripts/test_check_observability.py
+++ b/tests/scripts/test_check_observability.py
@@ -1787,5 +1787,5 @@ def test_repository_observability_policy_passes_for_all_protocol_operations() ->
     )
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert "259 operations" in completed.stdout
+    assert "262 operations" in completed.stdout
     assert "Observability audit passed" in completed.stdout

--- a/tests/scripts/test_check_pre_durability_redaction.py
+++ b/tests/scripts/test_check_pre_durability_redaction.py
@@ -36,6 +36,9 @@ class ArtifactBundleService:
         self.fail_artifact_publication()
 
     async def reconcile(self):
+        await self.reconcile_publication()
+
+    async def reconcile_publication(self):
         self._safe_failure_detail()
         self.fail_artifact_publication()
 
@@ -87,6 +90,9 @@ class ArtifactBundleService:
         self._safe_failure_detail()
 
     async def reconcile(self):
+        await self.reconcile_publication()
+
+    async def reconcile_publication(self):
         self.fail_artifact_publication()
 
     async def _resume(self):
@@ -107,7 +113,7 @@ class ArtifactBundleService:
     )
     assert checker.audit_path(source) == [
         "publish_prepared must call _safe_failure_detail() before fail_artifact_publication()",
-        "reconcile must call _safe_failure_detail()",
+        "reconcile_publication must call _safe_failure_detail()",
     ]
 
 


### PR DESCRIPTION
## What changed

- makes artifact-publication acquisition, retry-window expiry, due discovery, exact reacquisition, and source mutations use catalog-authoritative time;
- adds digest-only due paging and strict portable decoding across SQLite and the remote Durable Object catalog;
- fences upload, completion, failure, expiry, and renewal writes behind a live publication lease;
- keeps the local and remote implementations, Worker routes, contracts, observability registry, redaction audit, docs, and capability eval in one reviewable slice.

## Why

The fleet reconciler in #503 cannot safely claim publication work if callers provide the clock or if a stale owner can mutate the publication after lease expiry. The previous artifact API also returned full publication records during discovery, coupling fleet scans to durable payload materialization.

This PR establishes the artifact-reconciliation substrate only. Fenced fleet sweep authority and the bounded recovery service remain on the following stacked branches; this PR does not close #503.

## Impact

- existing legacy clock-bearing remote routes now fail closed with an upgrade-required response;
- publication discovery returns ordered content-addressed identities, then exact reacquisition resolves authoritative state;
- indexed finalization remains the mission gate, with stricter retry and lease evidence.

## Validation

- `uv run pytest -q tests/app/test_artifact_bundle_service.py tests/app/test_artifact_publication_catalog.py tests/app/test_remote_catalog_client.py tests/app/test_remote_catalog_parity.py tests/app/test_mission_attempt_claims.py tests/scripts/test_check_pre_durability_redaction.py` — 257 passed
- `make static`
- `make eval-capability` — 10/10 capability tasks passed

Part of #503.
