### PR TITLE
feat(artifacts): publish a portable sanitized full-worktree archive

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -395,10 +395,11 @@ Claim contract v9 adds `worktree_archive_ref` to that required evidence. Durable
 v7 and v8 rows retain their versioned replay contract: a missing archive
 reference projects as empty evidence instead of making an already-recorded
 attempt unreadable, while all new writes still require the field.
-For a direct non-finalizing outcome, the official execution service first uses
-strict current-write `MissionService.apply_attempt`; its authoritative
-`AttemptStatus` is the status stored by direct settlement and must agree with
-the outcome's provider semantics. A finalized `INDEXED` or `EXPIRED` outcome
+For a direct non-finalizing outcome, the official execution service assesses
+and projects through the authenticated claim contract before settlement;
+public callers of `MissionService.apply_attempt` still use strict current-write
+semantics. The authoritative `AttemptStatus` stored by direct settlement must
+agree with the outcome's provider semantics. A finalized `INDEXED` or `EXPIRED` outcome
 uses the claim-bound order instead: authenticate the terminal durable row,
 construct and seal the prepared settlement, settle `finalizing -> settled`,
 reread and authenticate the winning row through `require_settled`, and only

--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -379,7 +379,7 @@ the read boundary also normalizes any such row overmarked by an early
 phase-agnostic v8 backfill. Projection still requires the narrow accepted
 `published` or `indexed` legacy shape with no staged or finalized artifact
 authority. A qualifying replay exposes
-`Finalization.legacy_unbound=true` in the world row; current v8 writes always
+`Finalization.legacy_unbound=true` in the world row; current v9 writes always
 expose `false`. This is a compatibility classification, not synthesized
 artifact provenance: the canonical legacy outcome remains byte-for-byte
 unchanged. Migration-proven v7 rows remain exclusively legacy even if their
@@ -391,6 +391,10 @@ Terminal settlement accepts only a complete replayable sandbox outcome bound
 to the claimed attempt, idempotency key, attempt index, and normalized sandbox
 request. It validates provider status and `accepted`, validator and result
 shape, checkpoint coherence, finalization phase, and accepted commit evidence.
+Claim contract v9 adds `worktree_archive_ref` to that required evidence. Durable
+v7 and v8 rows retain their versioned replay contract: a missing archive
+reference projects as empty evidence instead of making an already-recorded
+attempt unreadable, while all new writes still require the field.
 For a direct non-finalizing outcome, the official execution service first uses
 strict current-write `MissionService.apply_attempt`; its authoritative
 `AttemptStatus` is the status stored by direct settlement and must agree with

--- a/docs/guide/artifact-finalization.md
+++ b/docs/guide/artifact-finalization.md
@@ -22,6 +22,13 @@ snapshot as bytes at all. The artifact index stores a
 reference, its provider, and its expiration. Portable files are uploaded as
 ordinary objects and carry hashes, sizes, and MIME types.
 
+One portable object is the sanitized full-worktree archive at
+`recovery/full-worktree.tar` (`kind=worktree_archive`). It is distinct from
+the provider checkpoint, sanitized Git bundle, binary patch, declared result
+files, and generated bundle manifest; each retains its own artifact identity,
+object URI, hash, and lifecycle row. Provider checkpoint expiry or deletion
+therefore cannot erase the indexed worktree archive.
+
 Telemetry is operational evidence, not the state authority. Losing a trace
 must not make an otherwise indexed bundle disappear; losing the control record
 or artifact index is a durability failure.
@@ -189,6 +196,50 @@ back to the logical filename's registered MIME type. Upload uses
 `daft.functions.upload`; R2 is supplied through Daft's S3-compatible
 `IOConfig`. Credentials remain in that process-local configuration and are
 never serialized into requests, control rows, manifests, or the index.
+
+### Portable full-worktree archive
+
+The archive format is `archetype-worktree-tar-v1`: an uncompressed POSIX PAX
+tar with normalized `uid`, `gid`, owner/group names, and `mtime`. Members are
+ordered by portable path; modes are retained; links and special members are
+forbidden. Identical approved repository state, Git identities, exclusions,
+and redaction policy therefore produce identical bytes.
+
+`archive-manifest.json` has `schema_version=1` and records:
+
+- baseline and end-state `HEAD` identities plus the archive-format identity;
+- every approved path, type, mode, byte size, and SHA-256 hash;
+- every policy exclusion with path, observed type, and reason; and
+- the bound redaction policy plus aggregate and per-file safe receipts.
+
+The `worktree/` subtree captures tracked, untracked, ignored, rejected, and
+uncommitted repository files, including policy-allowed `.context` content.
+Raw `.git` internals are excluded. `recovery/` instead contains the separately
+generated status, binary patch, and sanitized Git bundle needed to reconstruct
+Git state. Credential paths, auth material, caches, provider internals, and
+archive staging are excluded by construction and recorded. A symbolic link,
+hard link, device, FIFO, socket, path escape, or unreadable/incomplete file
+fails the capture rather than being represented ambiguously.
+
+Capture inventories the tree before and after copying. Every regular file is
+opened without following links, its device/inode/size/time identity is checked
+against the inventory, and that same handle supplies the staged bytes. A
+change before, during, or after a read fails the attempt's evidence capture.
+The raw provider-side tar is not durable evidence. During artifact publication
+the application validates its manifest and exact member set, sanitizes every
+regular member through `iRedactionService`, rebuilds the deterministic tar,
+binds the active policy and safe receipts into the manifest, and only then
+hashes and uploads it. Text findings are rewritten; credential paths, opaque
+secret-bearing bytes, nested containers, invalid metadata, and incomplete
+inspection quarantine before object or index visibility.
+
+Restore requires a clean directory and optionally the expected indexed object
+hash. It validates the complete tar and manifest before writing, rejects any
+undeclared, missing, linked, special, oversized, escaped, or hash-mismatched
+member, and creates every output beneath no-follow directory handles. It then
+rehashes the reconstructed bytes. This round-trip is the executable proof that
+the approved tree and recovery material remain usable without the provider
+snapshot.
 
 ## 4. Pre-durability secret redaction
 

--- a/docs/guide/artifact-finalization.md
+++ b/docs/guide/artifact-finalization.md
@@ -417,6 +417,9 @@ Non-indexed v7 claims remain ordinary historical replays. A narrowly valid
 legacy replay exposes `Finalization.legacy_unbound=true` while preserving its
 canonical outcome unchanged. That flag is an explicit compatibility
 classification, not a claim that historical artifact provenance was recovered.
+Claim contract v9 requires `worktree_archive_ref` on new replayable outcomes.
+Previously durable v7/v8 outcomes remain readable under their original field
+set and project an empty archive reference when none was recorded.
 
 The Iceberg append is the query visibility point. If a process dies after the
 append but before marking the control row `INDEXED`, a retry reads and verifies

--- a/docs/guide/artifact-finalization.md
+++ b/docs/guide/artifact-finalization.md
@@ -419,7 +419,10 @@ canonical outcome unchanged. That flag is an explicit compatibility
 classification, not a claim that historical artifact provenance was recovered.
 Claim contract v9 requires `worktree_archive_ref` on new replayable outcomes.
 Previously durable v7/v8 outcomes remain readable under their original field
-set and project an empty archive reference when none was recorded.
+set and project an empty archive reference when none was recorded. If a
+nonterminal v7/v8 claim reconciles into indexed finalization, its authenticated
+contract version also makes the archive bundle candidate optional; current v9
+claims still require that candidate before staging.
 
 The Iceberg append is the query visibility point. If a process dies after the
 append but before marking the control row `INDEXED`, a retry reads and verifies

--- a/docs/guide/sandbox-execution.md
+++ b/docs/guide/sandbox-execution.md
@@ -71,7 +71,8 @@ admission boundary for the execution phase, not a seventh attempt phase.
    worktree on top of the trusted baseline. The outer gate supplies the commit
    identity and message.
 4. **Evidence** — capture the attempt manifest, agent trace, validator details,
-   Git status, binary patch, Git bundle source, filesystem manifests and diff,
+   Git status, binary patch, Git bundle source, deterministic full-worktree
+   archive, filesystem manifests and diff,
    live-event paths, and `.context` when present. These sources remain
    non-durable until the redaction gate accepts them.
 5. **Checkpoint** — after evidence exists, request a provider checkpoint. A

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -125,9 +125,10 @@ its drain and quota-reset callables.
 `iCommandScheduler` exposes the current combined scheduling/dispatch port over
 the control catalog. Tick publication performs terminal applied settlement.
 `iArtifactService` and `iEvaluationService` expose separate claim-backed
-workflows. `iArtifactBundleService` owns full attempt-bundle publication and
-reconciliation while provider checkpoints remain recovery objects. It consumes
-`iRedactionService` before its control, object, manifest, and index durability
+workflows. `iArtifactBundleService` owns full attempt-bundle publication,
+including the validated and sanitized `archetype-worktree-tar-v1` recovery
+object, and reconciliation while provider checkpoints remain recovery objects.
+It consumes `iRedactionService` before its control, object, manifest, and index durability
 boundaries. Future live-event, OTel, and proxy exporters consume that same port;
 they do not fork scanner policy.
 `iAuditLog` is a projection/read port, not the authority for command outcome.

--- a/docs/guide/service-protocols.md
+++ b/docs/guide/service-protocols.md
@@ -204,7 +204,11 @@ and awaits both local tasks. This cleanup makes no claim that a remote provider
 operation was terminated; that remains adapter-specific or reconciled from
 `possibly_submitted`. After successful runner completion, the service renews
 the claim once more before it validates evidence through the claim service's
-pre-durability redaction boundary. When policy requires `indexed`, it asks
+pre-durability redaction boundary. Outcome assessment and the private
+pre-settlement row projection both use the authenticated claim contract, so a
+reconciled pre-v9 provider response remains readable without weakening the
+current-write `iMissionService.apply_attempt` contract. When policy requires
+`indexed`, it asks
 `iMissionArtifactFinalizer.prepare` for an exact request without external I/O,
 atomically stages that request and sanitized outcome on the claim, then calls
 `publish` only with the reconstructed staged projection. Accepted and rejected

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -39,7 +39,8 @@ machine authority; this page is its review surface.
 | `missions.transition.evidence_gated` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 2. Typed mission/task/attempt transition graph | pytest: 2; static: 1; eval: 1 | `pr`, `main`, `release` |
 | `missions.attempt.claim_fenced` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 5. Durable pre-execution claim and recovery | pytest: 6; static: 1; eval: 1 | `pr`, `main`, `release` |
 | `missions.attempt.indexed_finalization` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 5. Durable pre-execution claim and recovery | pytest: 9; static: 2; eval: 1 | `pr`, `main`, `release` |
-| `security.redaction.pre_durability` | `redaction` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — 4. Pre-durability secret redaction | pytest: 12; static: 2; eval: 1 | `pr`, `main`, `release` |
+| `artifacts.worktree_archive.portable` | `artifacts` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — Portable full-worktree archive | pytest: 3; static: 2; eval: 1 | `pr`, `main`, `release` |
+| `security.redaction.pre_durability` | `redaction` | high | [docs/guide/artifact-finalization.md](../guide/artifact-finalization.md) — 4. Pre-durability secret redaction | pytest: 13; static: 2; eval: 1 | `pr`, `main`, `release` |
 
 Profile membership states where a contract must be enforced. Eval suite
 blocking/advisory policy is defined separately in `quality/eval_profiles.toml`;

--- a/evals/suites/capability/agent_missions.py
+++ b/evals/suites/capability/agent_missions.py
@@ -107,6 +107,7 @@ def _outcome(
         "git_status_ref": "fake://status",
         "git_patch_ref": "fake://patch",
         "git_bundle_ref": "fake://bundle",
+        "worktree_archive_ref": "fake://full-worktree",
         "context_ref": "fake://context",
         "friction": [],
         "sha": "abc123" if accepted else "",

--- a/evals/suites/capability/indexed_finalization.py
+++ b/evals/suites/capability/indexed_finalization.py
@@ -321,6 +321,7 @@ def _accepted_outcome(request: MissionAttemptRequest) -> dict[str, Any]:
         "git_status_ref": "eval://recovery/git-status.txt",
         "git_patch_ref": "eval://recovery/worktree.patch",
         "git_bundle_ref": "eval://recovery/repository.bundle",
+        "worktree_archive_ref": "eval://recovery/full-worktree.tar",
         "context_ref": "eval://context",
         "friction": [],
         "sha": "e" * 40,

--- a/evals/suites/capability/mission_attempt_claims.py
+++ b/evals/suites/capability/mission_attempt_claims.py
@@ -119,6 +119,7 @@ async def _task_mission_attempt_claim_recovery() -> list[GraderResult]:
         "git_status_ref": "eval://git-status",
         "git_patch_ref": "eval://git-patch",
         "git_bundle_ref": "eval://git-bundle",
+        "worktree_archive_ref": "eval://full-worktree",
         "context_ref": "eval://context",
         "friction": [],
         "sha": "",

--- a/evals/suites/capability/redaction.py
+++ b/evals/suites/capability/redaction.py
@@ -5,6 +5,14 @@
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
+from archetype.app.artifacts.worktree_archive import (
+    capture_worktree_archive,
+    restore_worktree_archive,
+    sanitize_worktree_archive,
+)
 from archetype.app.redaction import RedactionService, SecretQuarantineError
 from evals.graders import state_check
 from evals.harness import EvalHarness
@@ -34,6 +42,70 @@ def task_pre_durability_redaction() -> list[GraderResult]:
         else:
             metadata_fails_closed = False
 
+    with tempfile.TemporaryDirectory(prefix="archetype-archive-eval-") as temporary_value:
+        temporary = Path(temporary_value)
+        worktree = temporary / "worktree"
+        worktree.mkdir()
+        corpus = "\n".join(case.payload for case in SECRET_LEAK_CORPUS)
+        (worktree / "tracked.txt").write_text(corpus)
+        (worktree / "ignored.log").write_text("ignored but portable\n")
+        (worktree / ".context").mkdir()
+        (worktree / ".context" / "review.md").write_text("portable context\n")
+        (worktree / ".env").write_text(SECRET_LEAK_CORPUS[0].payload)
+        recovery = temporary / "recovery"
+        recovery.mkdir()
+        recovery_files = {}
+        for name in ("git-status.txt", "worktree.patch", "repository.bundle"):
+            path = recovery / name
+            path.write_text(f"safe {name}\n")
+            recovery_files[name] = path
+        raw = temporary / "raw.tar"
+        capture_worktree_archive(
+            worktree,
+            raw,
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+            recovery_files=recovery_files,
+        )
+        approved = temporary / "approved.tar"
+        archive_receipt = sanitize_worktree_archive(
+            raw,
+            approved,
+            logical_path="recovery/full-worktree.tar",
+            redaction_service=service,
+        ).receipt
+        restored = temporary / "restored"
+        archive_manifest = restore_worktree_archive(approved, restored)
+        restored_corpus = (restored / "worktree/tracked.txt").read_text()
+        ignored_and_context_restored = (restored / "worktree/ignored.log").is_file() and (
+            restored / "worktree/.context/review.md"
+        ).is_file()
+        credential_path_excluded = not (restored / "worktree/.env").exists() and any(
+            item["path"] == ".env" and item["reason"] == "credential-path"
+            for item in archive_manifest["exclusions"]
+        )
+
+        opaque = temporary / "opaque"
+        opaque.mkdir()
+        (opaque / "secret.bin").write_bytes(b"\x00" + SECRET_LEAK_CORPUS[0].payload.encode())
+        opaque_raw = temporary / "opaque-raw.tar"
+        capture_worktree_archive(
+            opaque,
+            opaque_raw,
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+        )
+        opaque_quarantined = False
+        try:
+            sanitize_worktree_archive(
+                opaque_raw,
+                temporary / "opaque-approved.tar",
+                logical_path="recovery/full-worktree.tar",
+                redaction_service=service,
+            )
+        except SecretQuarantineError:
+            opaque_quarantined = True
+
     return [
         state_check(
             {
@@ -53,6 +125,11 @@ def task_pre_durability_redaction() -> list[GraderResult]:
                 "policy_identity_is_versioned": service.policy_id.startswith(
                     "archetype-secret-redaction-v1:"
                 ),
+                "worktree_archive_redacts_complete_corpus": archive_receipt.status == "redacted"
+                and all(case.payload not in restored_corpus for case in SECRET_LEAK_CORPUS),
+                "worktree_archive_keeps_ignored_and_context": ignored_and_context_restored,
+                "worktree_archive_excludes_credential_paths": credential_path_excluded,
+                "worktree_archive_quarantines_opaque_secret": opaque_quarantined,
             },
             name="pre_durability_secret_redaction",
         )
@@ -66,6 +143,6 @@ def register(harness: EvalHarness) -> None:
         fn=task_pre_durability_redaction,
         desc=(
             "Shared scanner redacts provider/cloud credentials, preserves safe placeholders, "
-            "and fails metadata closed without echoing secrets"
+            "fails metadata closed, and sanitizes portable full-worktree archives"
         ),
     )

--- a/evals/suites/capability/sandbox_kernel.py
+++ b/evals/suites/capability/sandbox_kernel.py
@@ -232,6 +232,9 @@ async def _task_sandbox_kernel_phase_contract() -> list[GraderResult]:
                 "nonzero_agent_retained": first["agent_returncode"] == 7,
                 "checkpoint_qualified": first["finalization_phase"] == "checkpointed",
                 "artifact_declared": first["git_bundle_ref"].startswith("eval-checkpoint://one#"),
+                "worktree_archive_declared": first["worktree_archive_ref"].startswith(
+                    "eval-checkpoint://one#"
+                ),
                 "correlated": first["correlation"]["world_id"] == "eval-world",
                 "sandbox_receipt_replayed": second == first and client.agent_calls == 1,
             },

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -140,36 +140,36 @@ reason = "same grading-boundary site as the collect above: per-entity terminal r
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1321
+line = 1330
 method = "to_pylist"
 reason = "Artifact-manifest boundary: the caller-declared, size-bounded file set has already been hashed and MIME-classified by native Daft expressions; scalar metadata must enter Python to construct validated immutable index records and the canonical bundle manifest."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1373
+line = 1382
 method = "to_pylist"
 reason = "Object-store completion boundary: each caller-declared, size-bounded upload has executed through Daft and its returned object URI must enter Python to construct the portable manifest and deterministic artifact-index rows."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1386
+line = 1395
 method = "to_pylist"
 reason = "Single-object upload boundary: one generated bundle-manifest byte value is uploaded through Daft and its sole destination URI must enter the durable publication receipt and control-catalog record."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1440
+line = 1449
 method = "to_pylist"
 reason = "Existing-object metadata authorization boundary: only paths and sizes beneath one deterministic content-addressed destination enter Python so each candidate URI can pass shared redaction policy and exact-size eligibility before any remote byte read."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1473
+line = 1482
 method = "to_pylist"
 reason = "Existing-object byte-integrity boundary: one size-eligible, metadata-approved remote candidate is read through Daft and its bytes enter Python solely to verify exact size and SHA-256 before durable reuse."
 
 [[entries]]
 path = "src/archetype/app/artifacts/bundle_service.py"
-line = 1489
+line = 1498
 method = "to_pylist"
 reason = "Bundle-index idempotency boundary: the Iceberg query is filtered to one deterministic bundle and its bounded artifact rows must enter Python for exact conflict detection and missing-row selection before an append."

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -324,9 +324,19 @@ allowed_interfaces = [
 ]
 allowed_app = [
   "archetype.app.artifacts.bundle_models",
+  "archetype.app.artifacts.worktree_archive",
   "archetype.app.limits",
   "archetype.app.redaction.models",
   "archetype.app.storage.catalog",
+]
+
+[[module_rule]]
+module = "archetype.app.artifacts.worktree_archive"
+allowed_interfaces = [
+  "archetype.app.redaction.interfaces.iRedactionService",
+]
+allowed_app = [
+  "archetype.app.redaction.models",
 ]
 
 [[module_rule]]

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -478,6 +478,25 @@ benchmarks = []
 profiles = ["pr", "main", "release"]
 
 [[contract]]
+id = "artifacts.worktree_archive.portable"
+source = "docs/guide/artifact-finalization.md"
+section = "Portable full-worktree archive"
+owner = "artifacts"
+risk = "high"
+pytest = [
+  "tests/app/test_worktree_archive.py",
+  "tests/app/test_mission_artifact_finalizer.py",
+  "tests/app/test_indexed_finalization_crash_oracle.py",
+]
+static = [
+  "scripts/check_architecture.py",
+  "scripts/check_pre_durability_redaction.py",
+]
+evals = ["security.pre_durability_redaction"]
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
 id = "security.redaction.pre_durability"
 source = "docs/guide/artifact-finalization.md"
 section = "4. Pre-durability secret redaction"
@@ -486,6 +505,7 @@ risk = "high"
 pytest = [
   "tests/app/test_redaction_service.py",
   "tests/app/test_artifact_bundle_service.py",
+  "tests/app/test_worktree_archive.py",
   "tests/app/test_mission_attempt_claims.py::test_secret_bearing_request_is_quarantined_before_claim_commit",
   "tests/app/test_mission_attempt_claims.py::test_secret_bearing_provider_capability_is_quarantined_before_claim_commit",
   "tests/app/test_mission_attempt_claims.py::test_secret_bearing_provider_identity_is_quarantined_before_ack_commit",

--- a/quality/observability/missions.toml
+++ b/quality/observability/missions.toml
@@ -6,6 +6,7 @@ family = "missions"
 operations = [
   "interfaces.iMissionService.prepare_attempt",
   "interfaces.iMissionService.apply_attempt",
+  "interfaces._iMissionExecutionProjection._apply_claimed_attempt",
   "interfaces._iMissionExecutionProjection._apply_settled_attempt",
   "interfaces.iMissionAttemptClaimService.acquire",
   "interfaces.iMissionAttemptClaimService.decide_recovery",
@@ -19,6 +20,7 @@ operations = [
   "interfaces.iMissionAttemptClaimService.require_settled",
   "interfaces.iMissionAttemptClaimService.list_due",
   "interfaces.iMissionAttemptClaimService.prepare_durable_outcome",
+  "interfaces.iMissionAttemptClaimService.assess_outcome",
   "interfaces.iMissionAttemptClaimService.settled_outcome",
   "interfaces.iMissionAttemptClaimService.staged_artifact_projection",
   "interfaces.iMissionAttemptClaimService.prepare_artifact_finalization_outcome",

--- a/src/archetype/app/application/mission_artifacts.py
+++ b/src/archetype/app/application/mission_artifacts.py
@@ -12,6 +12,7 @@ from archetype.app.artifacts.bundle_models import PreparedArtifactBundleRequest
 from archetype.app.artifacts.interfaces import iArtifactBundleService
 from archetype.app.missions.interfaces import iMissionArtifactFinalizer
 from archetype.app.missions.models import (
+    WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     AttemptArtifactExpiration,
     AttemptArtifactProjection,
     AttemptArtifactPublication,
@@ -88,6 +89,7 @@ class MissionArtifactFinalizer(iMissionArtifactFinalizer):
         outcome: Mapping[str, Any],
         *,
         redaction_policy_id: str,
+        claim_contract_version: int = WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     ) -> AttemptArtifactProjection:
         """Return a deterministic, scanned projection without publication I/O."""
 
@@ -95,6 +97,7 @@ class MissionArtifactFinalizer(iMissionArtifactFinalizer):
             request,
             outcome,
             redaction_policy_id=redaction_policy_id,
+            claim_contract_version=claim_contract_version,
         )
         prepared = self._artifact_bundles.prepare(bundle_request)
         if prepared.redaction_policy_id != redaction_policy_id:
@@ -175,7 +178,13 @@ class MissionArtifactFinalizer(iMissionArtifactFinalizer):
         outcome: Mapping[str, Any],
         *,
         redaction_policy_id: str,
+        claim_contract_version: int,
     ) -> ArtifactBundleRequest:
+        if (
+            type(claim_contract_version) is not int
+            or not 1 <= claim_contract_version <= WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION
+        ):
+            raise ValueError("mission artifact preparation requires a supported claim contract")
         if str(outcome.get("attempt_id", "")) != request.attempt_id:
             raise ValueError("artifact outcome does not match the mission attempt_id")
         if str(outcome.get("idempotency_key", "")) != request.idempotency_key:
@@ -201,9 +210,13 @@ class MissionArtifactFinalizer(iMissionArtifactFinalizer):
 
         artifacts: list[ArtifactCandidate] = []
         for field, logical_path, kind, recursive, required in _MISSION_ARTIFACT_CANDIDATES:
+            candidate_required = required and not (
+                field == "worktree_archive_ref"
+                and claim_contract_version < WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION
+            )
             source_ref = str(outcome.get(field) or "")
             if not source_ref:
-                if required:
+                if candidate_required:
                     raise ValueError(f"mission artifact outcome requires {field}")
                 continue
             artifacts.append(
@@ -212,7 +225,7 @@ class MissionArtifactFinalizer(iMissionArtifactFinalizer):
                     logical_path=logical_path,
                     kind=kind,
                     recursive=recursive,
-                    required=required,
+                    required=candidate_required,
                 )
             )
 

--- a/src/archetype/app/application/mission_artifacts.py
+++ b/src/archetype/app/application/mission_artifacts.py
@@ -59,6 +59,13 @@ _MISSION_ARTIFACT_CANDIDATES = (
     ("git_status_ref", "recovery/git-status.txt", "git_status", False, True),
     ("git_patch_ref", "recovery/worktree.patch", "git_patch", False, True),
     ("git_bundle_ref", "recovery/repository.bundle", "git_bundle", False, True),
+    (
+        "worktree_archive_ref",
+        "recovery/full-worktree.tar",
+        "worktree_archive",
+        False,
+        True,
+    ),
     ("context_ref", "context", "context", True, False),
 )
 

--- a/src/archetype/app/artifacts/bundle_service.py
+++ b/src/archetype/app/artifacts/bundle_service.py
@@ -57,6 +57,17 @@ from archetype.artifacts.bundles import (
     MaterializedArtifact,
     _canonical_json,
 )
+from archetype.app.artifacts.worktree_archive import sanitize_worktree_archive
+from archetype.app.limits import MAX_ICEBERG_SNAPSHOT_ID
+from archetype.app.redaction.interfaces import iRedactionService
+from archetype.app.redaction.models import RedactionReceipt
+from archetype.app.storage.catalog import (
+    ArtifactPublicationExpiredError,
+    ArtifactPublicationRecord,
+    artifact_publication_key,
+)
+from archetype.app.storage.interfaces import iStorageService
+from archetype.app.world.interfaces import iWorldService
 from archetype.core.config import StorageConfig
 
 if TYPE_CHECKING:
@@ -1258,11 +1269,19 @@ class ArtifactBundleService:
         sanitized: list[MaterializedArtifact] = []
         receipts: list[RedactionReceipt] = []
         for index, value in enumerate(values):
-            result = self._redaction_service.sanitize_file(
-                value.path,
-                destination / f"{index:08d}",
-                logical_path=value.logical_path,
-            )
+            if value.kind == "worktree_archive":
+                result = sanitize_worktree_archive(
+                    value.path,
+                    destination / f"{index:08d}",
+                    logical_path=value.logical_path,
+                    redaction_service=self._redaction_service,
+                )
+            else:
+                result = self._redaction_service.sanitize_file(
+                    value.path,
+                    destination / f"{index:08d}",
+                    logical_path=value.logical_path,
+                )
             sanitized.append(
                 MaterializedArtifact(
                     path=result.path,

--- a/src/archetype/app/artifacts/bundle_service.py
+++ b/src/archetype/app/artifacts/bundle_service.py
@@ -31,6 +31,7 @@ from uuid_utils import uuid7
 
 from archetype import _obs
 from archetype.app.artifacts.bundle_models import PreparedArtifactBundleRequest
+from archetype.app.artifacts.worktree_archive import sanitize_worktree_archive
 from archetype.app.limits import MAX_ICEBERG_SNAPSHOT_ID
 from archetype.app.redaction.interfaces import iRedactionService
 from archetype.app.redaction.models import RedactionReceipt
@@ -57,17 +58,6 @@ from archetype.artifacts.bundles import (
     MaterializedArtifact,
     _canonical_json,
 )
-from archetype.app.artifacts.worktree_archive import sanitize_worktree_archive
-from archetype.app.limits import MAX_ICEBERG_SNAPSHOT_ID
-from archetype.app.redaction.interfaces import iRedactionService
-from archetype.app.redaction.models import RedactionReceipt
-from archetype.app.storage.catalog import (
-    ArtifactPublicationExpiredError,
-    ArtifactPublicationRecord,
-    artifact_publication_key,
-)
-from archetype.app.storage.interfaces import iStorageService
-from archetype.app.world.interfaces import iWorldService
 from archetype.core.config import StorageConfig
 
 if TYPE_CHECKING:

--- a/src/archetype/app/artifacts/worktree_archive.py
+++ b/src/archetype/app/artifacts/worktree_archive.py
@@ -1,0 +1,842 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic, sanitized, and independently restorable worktree archives."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import IO, Any
+
+from archetype.app.redaction.interfaces import iRedactionService
+from archetype.app.redaction.models import (
+    RedactedFile,
+    RedactionReceipt,
+    SecretQuarantineError,
+)
+
+WORKTREE_ARCHIVE_FORMAT = "archetype-worktree-tar-v1"
+WORKTREE_ARCHIVE_MANIFEST_PATH = "archive-manifest.json"
+WORKTREE_ARCHIVE_SCHEMA_VERSION = 1
+
+_MAX_ARCHIVE_MEMBERS = 10_000
+_MAX_ARCHIVE_MEMBER_BYTES = 1 << 30
+_MAX_ARCHIVE_EXPANDED_BYTES = 4 << 30
+_COPY_CHUNK_BYTES = 1 << 20
+_CACHE_NAMES = frozenset(
+    {
+        ".cache",
+        ".mypy_cache",
+        ".nox",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+        "venv",
+    }
+)
+_CREDENTIAL_BASENAMES = frozenset(
+    {
+        ".env",
+        ".env.development",
+        ".env.local",
+        ".env.production",
+        ".git-credentials",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+        "id_rsa",
+    }
+)
+_CREDENTIAL_SUFFIXES = (
+    (".codex", "auth.json"),
+    (".claude", ".credentials.json"),
+    (".config", "opencode", "auth.json"),
+    (".local", "share", "opencode", "auth.json"),
+    (".aws", "credentials"),
+    (".config", "gcloud", "application_default_credentials.json"),
+    (".config", "gcloud", "credentials.db"),
+    (".config", "gcloud", "access_tokens.db"),
+    (".config", "gh", "hosts.yml"),
+    (".docker", "config.json"),
+    (".kube", "config"),
+    (".azure", "accesstokens.json"),
+    (".cache", "huggingface", "token"),
+    (".huggingface", "token"),
+)
+
+
+class WorktreeArchiveError(ValueError):
+    """A worktree cannot be captured or restored without ambiguity."""
+
+
+@dataclass(frozen=True)
+class WorktreeArchiveResult:
+    """One locally materialized archive and its authenticated manifest."""
+
+    path: Path
+    content_hash: str
+    size_bytes: int
+    manifest: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _InventoryEntry:
+    path: str
+    type: str
+    mode: int
+    size: int
+    device: int
+    inode: int
+    mtime_ns: int
+    ctime_ns: int
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(_COPY_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _portable_path(value: str) -> str:
+    normalized = value.replace("\\", "/").strip("/")
+    path = PurePosixPath(normalized)
+    if (
+        not normalized
+        or path.is_absolute()
+        or ".." in path.parts
+        or any(part in {"", "."} for part in path.parts)
+    ):
+        raise WorktreeArchiveError("worktree archive contains an unsafe path")
+    return path.as_posix()
+
+
+def _is_credential_path(parts: tuple[str, ...]) -> bool:
+    lower = tuple(part.lower() for part in parts)
+    return bool(lower and lower[-1] in _CREDENTIAL_BASENAMES) or any(
+        len(lower) >= len(suffix) and lower[-len(suffix) :] == suffix
+        for suffix in _CREDENTIAL_SUFFIXES
+    )
+
+
+def _exclusion_reason(parts: tuple[str, ...], *, is_dir: bool) -> str | None:
+    if parts and parts[0] == ".git":
+        return "git-internals"
+    if parts and parts[0] == ".archetype-agent":
+        return "provider-internals"
+    if _is_credential_path(parts):
+        return "credential-path"
+    if is_dir and parts and parts[-1] in _CACHE_NAMES:
+        return "cache"
+    return None
+
+
+def _inventory(root: Path) -> tuple[dict[str, _InventoryEntry], list[dict[str, str]]]:
+    entries: dict[str, _InventoryEntry] = {}
+    exclusions: list[dict[str, str]] = []
+    seen_inodes: set[tuple[int, int]] = set()
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    root_descriptor = os.open(root, flags)
+    root_device = os.fstat(root_descriptor).st_dev
+    stack: list[tuple[int, tuple[str, ...]]] = [(root_descriptor, ())]
+    try:
+        while stack:
+            descriptor, prefix = stack.pop()
+            try:
+                children = sorted(os.scandir(descriptor), key=lambda item: item.name, reverse=True)
+            except OSError as exc:
+                os.close(descriptor)
+                raise WorktreeArchiveError("worktree directory changed during inventory") from exc
+            try:
+                for child in children:
+                    parts = (*prefix, child.name)
+                    relative = PurePosixPath(*parts).as_posix()
+                    try:
+                        info = child.stat(follow_symlinks=False)
+                    except OSError as exc:
+                        raise WorktreeArchiveError(
+                            "worktree entry changed during inventory"
+                        ) from exc
+                    is_dir = stat.S_ISDIR(info.st_mode)
+                    is_file = stat.S_ISREG(info.st_mode)
+                    if stat.S_ISLNK(info.st_mode):
+                        raise WorktreeArchiveError("worktree archive rejects symbolic links")
+                    if not is_dir and not is_file:
+                        raise WorktreeArchiveError("worktree archive rejects special files")
+                    reason = _exclusion_reason(parts, is_dir=is_dir)
+                    if reason is not None:
+                        exclusions.append(
+                            {
+                                "path": relative,
+                                "type": "directory" if is_dir else "file",
+                                "reason": reason,
+                            }
+                        )
+                        continue
+                    if info.st_dev != root_device:
+                        raise WorktreeArchiveError("worktree archive rejects nested filesystems")
+                    if is_dir:
+                        kind = "directory"
+                        size = 0
+                        try:
+                            child_descriptor = os.open(child.name, flags, dir_fd=descriptor)
+                        except OSError as exc:
+                            raise WorktreeArchiveError(
+                                "worktree directory changed during inventory"
+                            ) from exc
+                        opened = os.fstat(child_descriptor)
+                        if (
+                            not stat.S_ISDIR(opened.st_mode)
+                            or opened.st_dev != info.st_dev
+                            or opened.st_ino != info.st_ino
+                        ):
+                            os.close(child_descriptor)
+                            raise WorktreeArchiveError(
+                                "worktree directory changed during inventory"
+                            )
+                        stack.append((child_descriptor, parts))
+                    elif is_file:
+                        if info.st_nlink != 1 or (info.st_dev, info.st_ino) in seen_inodes:
+                            raise WorktreeArchiveError("worktree archive rejects hard-linked files")
+                        seen_inodes.add((info.st_dev, info.st_ino))
+                        kind = "file"
+                        size = info.st_size
+                    entries[relative] = _InventoryEntry(
+                        path=relative,
+                        type=kind,
+                        mode=stat.S_IMODE(info.st_mode),
+                        size=size,
+                        device=info.st_dev,
+                        inode=info.st_ino,
+                        mtime_ns=info.st_mtime_ns,
+                        ctime_ns=info.st_ctime_ns,
+                    )
+            finally:
+                os.close(descriptor)
+    finally:
+        for descriptor, _ in stack:
+            os.close(descriptor)
+    exclusions.sort(key=lambda item: (item["path"], item["reason"]))
+    return entries, exclusions
+
+
+def _copy_stable_file(source: Path, destination: Path, expected: _InventoryEntry) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(source, flags)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise WorktreeArchiveError("worktree file became a symbolic link") from None
+        raise WorktreeArchiveError("worktree file could not be opened completely") from exc
+    try:
+        opened = os.fstat(descriptor)
+        identity = (
+            opened.st_dev,
+            opened.st_ino,
+            opened.st_size,
+            opened.st_mtime_ns,
+            opened.st_ctime_ns,
+        )
+        expected_identity = (
+            expected.device,
+            expected.inode,
+            expected.size,
+            expected.mtime_ns,
+            expected.ctime_ns,
+        )
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or identity != expected_identity
+        ):
+            raise WorktreeArchiveError("worktree file changed before its stable read")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with (
+            os.fdopen(descriptor, "rb", closefd=False) as reader,
+            destination.open("xb") as writer,
+        ):
+            shutil.copyfileobj(reader, writer, length=_COPY_CHUNK_BYTES)
+        finished = os.fstat(descriptor)
+        final_identity = (
+            finished.st_dev,
+            finished.st_ino,
+            finished.st_size,
+            finished.st_mtime_ns,
+            finished.st_ctime_ns,
+        )
+        if final_identity != identity or destination.stat().st_size != expected.size:
+            raise WorktreeArchiveError("worktree file changed during its stable read")
+    finally:
+        os.close(descriptor)
+
+
+def _tar_info(name: str, *, mode: int, size: int = 0, directory: bool = False) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name)
+    info.mode = mode
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    info.mtime = 0
+    info.size = size
+    info.type = tarfile.DIRTYPE if directory else tarfile.REGTYPE
+    return info
+
+
+def _write_archive(
+    destination: Path,
+    manifest: dict[str, Any],
+    files_root: Path,
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f"{destination.name}.writing")
+    temporary.unlink(missing_ok=True)
+    manifest_bytes = _canonical_json(manifest).encode()
+    with tarfile.open(temporary, mode="w", format=tarfile.PAX_FORMAT) as archive:
+        archive.addfile(
+            _tar_info(
+                WORKTREE_ARCHIVE_MANIFEST_PATH,
+                mode=0o644,
+                size=len(manifest_bytes),
+            ),
+            fileobj=_BytesReader(manifest_bytes),
+        )
+        for entry in manifest["entries"]:
+            name = str(entry["path"])
+            if entry["type"] == "directory":
+                archive.addfile(_tar_info(name, mode=int(entry["mode"]), directory=True))
+                continue
+            path = files_root / PurePosixPath(name)
+            with path.open("rb") as stream:
+                archive.addfile(
+                    _tar_info(name, mode=int(entry["mode"]), size=int(entry["size_bytes"])),
+                    fileobj=stream,
+                )
+    os.replace(temporary, destination)
+
+
+class _BytesReader(IO[bytes]):
+    """Tiny seek-free reader accepted by ``TarFile.addfile``."""
+
+    def __init__(self, value: bytes) -> None:
+        self._value = value
+        self._offset = 0
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self._value) - self._offset
+        value = self._value[self._offset : self._offset + size]
+        self._offset += len(value)
+        return value
+
+
+def _entry_payload(path: str, kind: str, mode: int, file_path: Path | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"path": path, "type": kind, "mode": mode}
+    if kind == "file":
+        assert file_path is not None
+        payload.update(
+            {
+                "size_bytes": file_path.stat().st_size,
+                "sha256": _sha256_file(file_path),
+            }
+        )
+    else:
+        payload.update({"size_bytes": 0, "sha256": ""})
+    return payload
+
+
+def capture_worktree_archive(
+    worktree: str | Path,
+    destination: str | Path,
+    *,
+    baseline_sha: str,
+    head_sha: str,
+    recovery_files: Mapping[str, str | Path] | None = None,
+) -> WorktreeArchiveResult:
+    """Capture tracked, untracked, ignored, context, and recovery state.
+
+    The source is inventoried twice. Every regular file is copied from a stable,
+    no-follow handle and the archive is built only from those controlled copies.
+    """
+
+    root = Path(worktree).resolve(strict=True)
+    if not root.is_dir():
+        raise NotADirectoryError(root)
+    output = Path(destination)
+    try:
+        output_relative = output.resolve(strict=False).relative_to(root)
+    except ValueError:
+        output_relative = None
+    if output_relative is not None and (
+        not output_relative.parts or output_relative.parts[0] != ".archetype-agent"
+    ):
+        raise WorktreeArchiveError(
+            "worktree archive output must be outside the worktree or provider staging"
+        )
+    initial, exclusions = _inventory(root)
+    with tempfile.TemporaryDirectory(prefix="archetype-worktree-") as temporary_value:
+        staged = Path(temporary_value)
+        for entry in sorted(initial.values(), key=lambda item: item.path):
+            archive_path = f"worktree/{entry.path}"
+            target = staged / PurePosixPath(archive_path)
+            if entry.type == "directory":
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            _copy_stable_file(root / PurePosixPath(entry.path), target, entry)
+
+        recovery_entries: list[dict[str, Any]] = []
+        for raw_name, raw_source in sorted((recovery_files or {}).items()):
+            name = _portable_path(raw_name)
+            source = Path(raw_source)
+            info = source.lstat()
+            if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+                raise WorktreeArchiveError("Git recovery material must be a regular file")
+            expected = _InventoryEntry(
+                path=name,
+                type="file",
+                mode=stat.S_IMODE(info.st_mode),
+                size=info.st_size,
+                device=info.st_dev,
+                inode=info.st_ino,
+                mtime_ns=info.st_mtime_ns,
+                ctime_ns=info.st_ctime_ns,
+            )
+            archive_path = f"recovery/{name}"
+            target = staged / PurePosixPath(archive_path)
+            _copy_stable_file(source, target, expected)
+            recovery_entries.append(_entry_payload(archive_path, "file", expected.mode, target))
+
+        final, final_exclusions = _inventory(root)
+        if final != initial or final_exclusions != exclusions:
+            raise WorktreeArchiveError("worktree changed while the archive was captured")
+
+        entries = [
+            _entry_payload(
+                f"worktree/{entry.path}",
+                entry.type,
+                entry.mode,
+                staged / "worktree" / PurePosixPath(entry.path) if entry.type == "file" else None,
+            )
+            for entry in sorted(initial.values(), key=lambda item: item.path)
+        ]
+        entries.extend(recovery_entries)
+        entries.sort(key=lambda item: str(item["path"]))
+        manifest: dict[str, Any] = {
+            "schema_version": WORKTREE_ARCHIVE_SCHEMA_VERSION,
+            "archive_format": WORKTREE_ARCHIVE_FORMAT,
+            "baseline_sha": baseline_sha,
+            "head_sha": head_sha,
+            "redaction_policy_id": "",
+            "entries": entries,
+            "exclusions": exclusions,
+            "redaction": {
+                "status": "unscanned",
+                "files_scanned": 0,
+                "bytes_scanned": 0,
+                "redaction_count": 0,
+                "rule_ids": [],
+                "files": [],
+            },
+        }
+        _validate_manifest_header(manifest)
+        _write_archive(output, manifest, staged)
+    return WorktreeArchiveResult(
+        path=output,
+        content_hash=_sha256_file(output),
+        size_bytes=output.stat().st_size,
+        manifest=manifest,
+    )
+
+
+def _extract_validated_archive(
+    source: Path,
+    destination: Path,
+    *,
+    require_sanitized: bool = False,
+) -> dict[str, Any]:
+    destination.mkdir(parents=True, exist_ok=True)
+    members_seen: set[str] = set()
+    expanded = 0
+    manifest: dict[str, Any] | None = None
+    try:
+        with tarfile.open(source, mode="r:") as archive:
+            members = archive.getmembers()
+            if len(members) > _MAX_ARCHIVE_MEMBERS + 1:
+                raise WorktreeArchiveError("worktree archive exceeds its member bound")
+            manifest_members = [
+                member for member in members if member.name == WORKTREE_ARCHIVE_MANIFEST_PATH
+            ]
+            if len(manifest_members) != 1 or not manifest_members[0].isfile():
+                raise WorktreeArchiveError("worktree archive requires one regular manifest")
+            if manifest_members[0].size > _MAX_ARCHIVE_MEMBER_BYTES:
+                raise WorktreeArchiveError("worktree archive manifest exceeds its byte bound")
+            manifest_stream = archive.extractfile(manifest_members[0])
+            if manifest_stream is None:
+                raise WorktreeArchiveError("worktree archive manifest is unreadable")
+            with manifest_stream:
+                manifest_value = json.load(manifest_stream)
+            if not isinstance(manifest_value, dict):
+                raise WorktreeArchiveError("worktree archive manifest must be an object")
+            manifest = manifest_value
+            _validate_manifest_header(manifest, require_sanitized=require_sanitized)
+            expected = {str(entry["path"]): entry for entry in manifest["entries"]}
+            if len(expected) != len(manifest["entries"]):
+                raise WorktreeArchiveError("worktree archive manifest paths must be unique")
+            for member in members:
+                if member.name == WORKTREE_ARCHIVE_MANIFEST_PATH:
+                    continue
+                name = _portable_path(member.name)
+                if name in members_seen or name not in expected:
+                    raise WorktreeArchiveError("worktree archive members do not match its manifest")
+                members_seen.add(name)
+                entry = expected[name]
+                if member.isdir():
+                    if entry["type"] != "directory" or member.size != 0:
+                        raise WorktreeArchiveError("worktree archive directory metadata is invalid")
+                    (destination / PurePosixPath(name)).mkdir(parents=True, exist_ok=True)
+                    continue
+                if not member.isfile() or entry["type"] != "file":
+                    raise WorktreeArchiveError("worktree archive rejects links and special members")
+                declared_size = int(entry["size_bytes"])
+                if member.size != declared_size or member.size > _MAX_ARCHIVE_MEMBER_BYTES:
+                    raise WorktreeArchiveError("worktree archive member size is invalid")
+                expanded += member.size
+                if expanded > _MAX_ARCHIVE_EXPANDED_BYTES:
+                    raise WorktreeArchiveError("worktree archive exceeds its expanded-byte bound")
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise WorktreeArchiveError("worktree archive member is unreadable")
+                output = destination / PurePosixPath(name)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                digest = hashlib.sha256()
+                written = 0
+                with stream, output.open("xb") as target:
+                    while chunk := stream.read(_COPY_CHUNK_BYTES):
+                        written += len(chunk)
+                        if written > declared_size:
+                            raise WorktreeArchiveError("worktree archive member exceeded its size")
+                        digest.update(chunk)
+                        target.write(chunk)
+                if written != declared_size or digest.hexdigest() != entry["sha256"]:
+                    raise WorktreeArchiveError("worktree archive member failed content validation")
+            if members_seen != set(expected):
+                raise WorktreeArchiveError("worktree archive is missing manifest members")
+    except WorktreeArchiveError:
+        raise
+    except (
+        tarfile.TarError,
+        EOFError,
+        OSError,
+        ValueError,
+        TypeError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise WorktreeArchiveError("worktree archive is incomplete or unreadable") from exc
+    assert manifest is not None
+    return manifest
+
+
+def _validate_manifest_header(
+    manifest: dict[str, Any],
+    *,
+    require_sanitized: bool = False,
+) -> None:
+    if manifest.get("schema_version") != WORKTREE_ARCHIVE_SCHEMA_VERSION:
+        raise WorktreeArchiveError("unsupported worktree archive manifest schema")
+    if manifest.get("archive_format") != WORKTREE_ARCHIVE_FORMAT:
+        raise WorktreeArchiveError("unsupported worktree archive format")
+    if not isinstance(manifest.get("baseline_sha"), str) or not isinstance(
+        manifest.get("head_sha"), str
+    ):
+        raise WorktreeArchiveError("worktree archive Git identities are invalid")
+    entries = manifest.get("entries")
+    exclusions = manifest.get("exclusions")
+    redaction = manifest.get("redaction")
+    if (
+        not isinstance(entries, list)
+        or not isinstance(exclusions, list)
+        or not isinstance(redaction, dict)
+    ):
+        raise WorktreeArchiveError("worktree archive manifest collections are invalid")
+    policy_id = manifest.get("redaction_policy_id")
+    if not isinstance(policy_id, str):
+        raise WorktreeArchiveError("worktree archive redaction policy is invalid")
+    if require_sanitized and (
+        not policy_id.strip() or redaction.get("status") not in {"clean", "redacted"}
+    ):
+        raise WorktreeArchiveError("worktree archive is not redaction-approved")
+    for identity in (manifest["baseline_sha"], manifest["head_sha"]):
+        if len(identity) not in {40, 64} or any(
+            char not in "0123456789abcdef" for char in identity
+        ):
+            raise WorktreeArchiveError("worktree archive Git identities are invalid")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise WorktreeArchiveError("worktree archive entry is invalid")
+        entry["path"] = _portable_path(str(entry.get("path", "")))
+        if entry.get("type") not in {"file", "directory"}:
+            raise WorktreeArchiveError("worktree archive entry type is invalid")
+        mode = entry.get("mode")
+        size = entry.get("size_bytes")
+        digest = entry.get("sha256")
+        if type(mode) is not int or not 0 <= mode <= 0o7777:
+            raise WorktreeArchiveError("worktree archive entry mode is invalid")
+        if type(size) is not int or size < 0:
+            raise WorktreeArchiveError("worktree archive entry size is invalid")
+        if entry["type"] == "directory" and (size != 0 or digest != ""):
+            raise WorktreeArchiveError("worktree archive directory integrity is invalid")
+        if entry["type"] == "file" and (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(char not in "0123456789abcdef" for char in digest)
+        ):
+            raise WorktreeArchiveError("worktree archive file digest is invalid")
+
+
+def sanitize_worktree_archive(
+    source: Path,
+    destination: Path,
+    *,
+    logical_path: str,
+    redaction_service: iRedactionService,
+) -> RedactedFile:
+    """Rebuild one raw capture from per-member approved bytes.
+
+    Text members are deterministically redacted. Credential paths, secrets in
+    opaque bytes, nested containers, links, special members, and malformed
+    manifests quarantine the publication before hashing or upload.
+    """
+
+    redaction_service.assert_safe_metadata(logical_path, field="artifact.logical_path")
+    redaction_service.assert_safe_metadata(source.as_posix(), field="artifact.source_path")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="archetype-worktree-sanitize-") as temporary_value:
+        temporary = Path(temporary_value)
+        raw = temporary / "raw.tar"
+        source_info = source.lstat()
+        expected = _InventoryEntry(
+            path=logical_path,
+            type="file",
+            mode=stat.S_IMODE(source_info.st_mode),
+            size=source_info.st_size,
+            device=source_info.st_dev,
+            inode=source_info.st_ino,
+            mtime_ns=source_info.st_mtime_ns,
+            ctime_ns=source_info.st_ctime_ns,
+        )
+        if not stat.S_ISREG(source_info.st_mode) or source_info.st_nlink != 1:
+            raise SecretQuarantineError(logical_path, ("unsupported-source-file",))
+        try:
+            _copy_stable_file(source, raw, expected)
+        except WorktreeArchiveError as exc:
+            raise SecretQuarantineError(logical_path, ("source-file-race",)) from exc
+
+        extracted = temporary / "extracted"
+        try:
+            manifest = _extract_validated_archive(raw, extracted)
+        except WorktreeArchiveError as exc:
+            raise SecretQuarantineError(logical_path, ("worktree-archive-invalid",)) from exc
+        redaction_service.assert_safe_metadata(
+            _canonical_json(manifest),
+            field="artifact.worktree_archive_manifest",
+        )
+        approved = temporary / "approved"
+        receipts: list[tuple[str, RedactionReceipt]] = []
+        sanitized_entries: list[dict[str, Any]] = []
+        for entry in manifest["entries"]:
+            name = str(entry["path"])
+            if entry["type"] == "directory":
+                (approved / PurePosixPath(name)).mkdir(parents=True, exist_ok=True)
+                sanitized_entries.append(dict(entry))
+                continue
+            source_member = extracted / PurePosixPath(name)
+            if tarfile.is_tarfile(source_member) or zipfile.is_zipfile(source_member):
+                raise SecretQuarantineError(logical_path, ("nested-archive-unsupported",))
+            result = redaction_service.sanitize_file(
+                source_member,
+                approved / PurePosixPath(name),
+                logical_path=name,
+            )
+            receipts.append((name, result.receipt))
+            sanitized_entries.append(_entry_payload(name, "file", int(entry["mode"]), result.path))
+        sanitized_entries.sort(key=lambda item: str(item["path"]))
+        redacted = [receipt for _, receipt in receipts if receipt.status == "redacted"]
+        manifest["entries"] = sanitized_entries
+        manifest["redaction_policy_id"] = redaction_service.policy_id
+        manifest["redaction"] = {
+            "status": "redacted" if redacted else "clean",
+            "files_scanned": len(receipts),
+            "bytes_scanned": sum(receipt.scanned_bytes for _, receipt in receipts),
+            "redaction_count": sum(receipt.redaction_count for _, receipt in receipts),
+            "rule_ids": sorted({rule for _, receipt in receipts for rule in receipt.rule_ids}),
+            "files": [
+                {"path": name, **receipt.model_dump(mode="json")} for name, receipt in receipts
+            ],
+        }
+        redaction_service.assert_safe_metadata(
+            _canonical_json(manifest),
+            field="artifact.worktree_archive_manifest",
+        )
+        _write_archive(destination, manifest, approved)
+        with tempfile.TemporaryDirectory(prefix="archetype-worktree-verify-") as verify_value:
+            _extract_validated_archive(
+                destination,
+                Path(verify_value),
+                require_sanitized=True,
+            )
+    rule_ids = tuple(sorted({rule for _, receipt in receipts for rule in receipt.rule_ids}))
+    redaction_count = sum(receipt.redaction_count for _, receipt in receipts)
+    return RedactedFile(
+        path=destination,
+        receipt=RedactionReceipt(
+            policy_id=redaction_service.policy_id,
+            scope=f"artifact:{logical_path}",
+            status="redacted" if redaction_count else "clean",
+            scanned_bytes=sum(receipt.scanned_bytes for _, receipt in receipts),
+            redaction_count=redaction_count,
+            rule_ids=rule_ids,
+        ),
+    )
+
+
+def _open_directory(parent_fd: int, name: str, *, create: bool) -> int:
+    if create:
+        try:
+            os.mkdir(name, mode=0o700, dir_fd=parent_fd)
+        except FileExistsError:
+            pass
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    return os.open(name, flags, dir_fd=parent_fd)
+
+
+def _parent_fd(root_fd: int, parts: tuple[str, ...]) -> int:
+    current = os.dup(root_fd)
+    try:
+        for part in parts:
+            child = _open_directory(current, part, create=True)
+            os.close(current)
+            current = child
+        return current
+    except BaseException:
+        os.close(current)
+        raise
+
+
+def restore_worktree_archive(
+    source: str | Path,
+    destination: str | Path,
+    *,
+    expected_content_hash: str | None = None,
+) -> dict[str, Any]:
+    """Validate and restore an archive beneath a clean, no-follow directory."""
+
+    archive_path = Path(source)
+    content_hash = _sha256_file(archive_path)
+    if expected_content_hash is not None and content_hash != expected_content_hash:
+        raise WorktreeArchiveError("worktree archive content hash does not match")
+    target = Path(destination)
+    target.mkdir(parents=True, exist_ok=True)
+    if any(target.iterdir()):
+        raise WorktreeArchiveError("worktree archive restore requires a clean directory")
+    with tempfile.TemporaryDirectory(prefix="archetype-worktree-restore-") as temporary_value:
+        staged = Path(temporary_value)
+        manifest = _extract_validated_archive(
+            archive_path,
+            staged,
+            require_sanitized=True,
+        )
+        root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        root_fd = os.open(target, root_flags)
+        try:
+            directory_modes: list[tuple[tuple[str, ...], int]] = []
+            for entry in sorted(
+                manifest["entries"],
+                key=lambda value: (str(value["path"]).count("/"), str(value["path"])),
+            ):
+                parts = tuple(PurePosixPath(str(entry["path"])).parts)
+                parent = _parent_fd(root_fd, parts[:-1])
+                try:
+                    if entry["type"] == "directory":
+                        child = _open_directory(parent, parts[-1], create=True)
+                        os.close(child)
+                        directory_modes.append((parts, int(entry["mode"])))
+                        continue
+                    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+                    descriptor = os.open(parts[-1], flags, mode=0o600, dir_fd=parent)
+                    try:
+                        digest = hashlib.sha256()
+                        written = 0
+                        with (
+                            (staged / PurePosixPath(*parts)).open("rb") as reader,
+                            os.fdopen(descriptor, "wb", closefd=False) as writer,
+                        ):
+                            while chunk := reader.read(_COPY_CHUNK_BYTES):
+                                digest.update(chunk)
+                                written += len(chunk)
+                                writer.write(chunk)
+                        if written != entry["size_bytes"] or digest.hexdigest() != entry["sha256"]:
+                            raise WorktreeArchiveError("restored worktree bytes failed validation")
+                        os.fchmod(descriptor, int(entry["mode"]))
+                    finally:
+                        os.close(descriptor)
+                finally:
+                    os.close(parent)
+            for parts, mode in sorted(
+                directory_modes,
+                key=lambda value: len(value[0]),
+                reverse=True,
+            ):
+                parent = _parent_fd(root_fd, parts[:-1])
+                try:
+                    child = _open_directory(parent, parts[-1], create=False)
+                    try:
+                        os.fchmod(child, mode)
+                    finally:
+                        os.close(child)
+                finally:
+                    os.close(parent)
+        finally:
+            os.close(root_fd)
+    return manifest
+
+
+__all__ = [
+    "WORKTREE_ARCHIVE_FORMAT",
+    "WORKTREE_ARCHIVE_MANIFEST_PATH",
+    "WORKTREE_ARCHIVE_SCHEMA_VERSION",
+    "WorktreeArchiveError",
+    "WorktreeArchiveResult",
+    "capture_worktree_archive",
+    "restore_worktree_archive",
+    "sanitize_worktree_archive",
+]

--- a/src/archetype/app/artifacts/worktree_archive.py
+++ b/src/archetype/app/artifacts/worktree_archive.py
@@ -129,7 +129,9 @@ def _sha256_file(path: Path) -> str:
 
 
 def _portable_path(value: str) -> str:
-    normalized = value.replace("\\", "/").strip("/")
+    if "\\" in value:
+        raise WorktreeArchiveError("worktree archive contains an unsafe path")
+    normalized = value.strip("/")
     path = PurePosixPath(normalized)
     if (
         not normalized
@@ -180,7 +182,7 @@ def _inventory(root: Path) -> tuple[dict[str, _InventoryEntry], list[dict[str, s
             try:
                 for child in children:
                     parts = (*prefix, child.name)
-                    relative = PurePosixPath(*parts).as_posix()
+                    relative = _portable_path(PurePosixPath(*parts).as_posix())
                     try:
                         info = child.stat(follow_symlinks=False)
                     except OSError as exc:
@@ -623,6 +625,24 @@ def _validate_manifest_header(
             raise WorktreeArchiveError("worktree archive file digest is invalid")
 
 
+def _import_policy_violation(entry: Mapping[str, Any]) -> str | None:
+    """Re-apply capture policy to untrusted raw-archive member names."""
+
+    parts = PurePosixPath(str(entry["path"])).parts
+    if len(parts) < 2 or parts[0] not in {"worktree", "recovery"}:
+        return "unexpected-namespace"
+    relative = tuple(parts[1:])
+    is_dir = entry["type"] == "directory"
+    reason = _exclusion_reason(relative, is_dir=is_dir)
+    if reason is not None:
+        return reason
+    for length in range(1, len(relative)):
+        reason = _exclusion_reason(relative[:length], is_dir=True)
+        if reason is not None:
+            return reason
+    return None
+
+
 def sanitize_worktree_archive(
     source: Path,
     destination: Path,
@@ -675,6 +695,12 @@ def sanitize_worktree_archive(
         sanitized_entries: list[dict[str, Any]] = []
         for entry in manifest["entries"]:
             name = str(entry["path"])
+            violation = _import_policy_violation(entry)
+            if violation is not None:
+                raise SecretQuarantineError(
+                    logical_path,
+                    (f"worktree-archive-policy-{violation}",),
+                )
             if entry["type"] == "directory":
                 (approved / PurePosixPath(name)).mkdir(parents=True, exist_ok=True)
                 sanitized_entries.append(dict(entry))

--- a/src/archetype/app/missions/claim_service.py
+++ b/src/archetype/app/missions/claim_service.py
@@ -34,8 +34,11 @@ from archetype.app.missions.models import (
     normalize_attempt_validators,
 )
 from archetype.app.missions.outcomes import (
+    WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
+    MissionAttemptAssessment,
     assess_attempt_outcome,
     assess_legacy_unbound_settled_outcome,
+    assess_pre_worktree_archive_outcome,
 )
 from archetype.app.missions.transitions import (
     AttemptClaimAcquireOutcome,
@@ -66,7 +69,8 @@ from archetype.missions.transitions import (
 )
 
 _CLAIM_DOMAIN = "archetype.mission-attempt-claim.v1"
-_CURRENT_CLAIM_CONTRACT_VERSION = 8
+_CURRENT_CLAIM_CONTRACT_VERSION = WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION
+_PRE_WORKTREE_ARCHIVE_CLAIM_CONTRACT_VERSION = 8
 _LEGACY_CLAIM_CONTRACT_VERSION = 7
 _ARTIFACT_PUBLICATION_EXPIRED = "artifact_publication_expired"
 _MAX_LAST_ERROR_CHARS = 4096
@@ -360,7 +364,7 @@ class MissionAttemptClaimService:
         self._require_active_policy(current)
         durable_outcome = self._coerce_durable_outcome(current, outcome)
         request = self.recover_request(current)
-        assessment = assess_attempt_outcome(request, durable_outcome.value)
+        assessment = self._assess_claim_outcome(current, durable_outcome.value)
         if request.required_finalization_phase is not FinalizationPhase.INDEXED:
             raise ValueError("artifact finalization may only be staged for an indexed gate")
         if assessment.provider_status not in {
@@ -714,7 +718,7 @@ class MissionAttemptClaimService:
         self._require_active_policy(claim)
         self._validate_outcome(
             claim,
-            settlement=assess_attempt_outcome(self.recover_request(claim), outcome).attempt_status,
+            settlement=self._assess_claim_outcome(claim, outcome).attempt_status,
             outcome=outcome,
         )
         canonical = json.loads(self._json(outcome))
@@ -727,9 +731,7 @@ class MissionAttemptClaimService:
         )
         self._validate_outcome(
             claim,
-            settlement=assess_attempt_outcome(
-                self.recover_request(claim), redacted.value
-            ).attempt_status,
+            settlement=self._assess_claim_outcome(claim, redacted.value).attempt_status,
             outcome=redacted.value,
         )
         return redacted
@@ -864,7 +866,7 @@ class MissionAttemptClaimService:
         )
         finalized = self._rescan_enriched_outcome(claim, value)
         self._assert_safe_outcome_identity(finalized.value)
-        assessment = assess_attempt_outcome(self.recover_request(claim), finalized.value)
+        assessment = self._assess_claim_outcome(claim, finalized.value)
         self._validate_outcome(
             claim,
             settlement=assessment.attempt_status,
@@ -929,7 +931,7 @@ class MissionAttemptClaimService:
         value["finalization_error"] = _ARTIFACT_PUBLICATION_EXPIRED
         self._assert_safe_outcome_identity(value)
         rescanned = self._rescan_enriched_outcome(claim, value)
-        assessment = assess_attempt_outcome(self.recover_request(claim), rescanned.value)
+        assessment = self._assess_claim_outcome(claim, rescanned.value)
         if assessment.attempt_status not in {
             AttemptStatus.INCOMPLETE,
             AttemptStatus.REJECTED,
@@ -1162,7 +1164,7 @@ class MissionAttemptClaimService:
         )
         if defensive.value != outcome.value:
             raise ValueError("prepared attempt outcome is not safe for durability")
-        assessment = assess_attempt_outcome(self.recover_request(claim), outcome.value)
+        assessment = self._assess_claim_outcome(claim, outcome.value)
         self._validate_outcome(
             claim,
             settlement=assessment.attempt_status,
@@ -1398,6 +1400,8 @@ class MissionAttemptClaimService:
         if contract_version == _LEGACY_CLAIM_CONTRACT_VERSION:
             expected_value.pop("claim_contract_version")
             expected_value.pop("observation_tick")
+        else:
+            expected_value["claim_contract_version"] = contract_version
         if cls._json(expected_value) != request_json:
             raise ValueError("persisted attempt claim request is not canonical")
         expected_fingerprint = mission_attempt_request_fingerprint(
@@ -1543,6 +1547,7 @@ class MissionAttemptClaimService:
             raise ValueError("persisted attempt claim has an invalid contract version") from exc
         if version not in {
             _LEGACY_CLAIM_CONTRACT_VERSION,
+            _PRE_WORKTREE_ARCHIVE_CLAIM_CONTRACT_VERSION,
             _CURRENT_CLAIM_CONTRACT_VERSION,
         }:
             raise ValueError("persisted attempt claim has an unsupported contract version")
@@ -1598,6 +1603,17 @@ class MissionAttemptClaimService:
             raise ValueError("mission attempt request fingerprint is invalid")
 
     @classmethod
+    def _assess_claim_outcome(
+        cls,
+        claim: AttemptClaim,
+        outcome: Mapping[str, Any],
+    ) -> MissionAttemptAssessment:
+        request = cls.recover_request(claim)
+        if claim.contract_version < _CURRENT_CLAIM_CONTRACT_VERSION:
+            return assess_pre_worktree_archive_outcome(request, outcome)
+        return assess_attempt_outcome(request, outcome)
+
+    @classmethod
     def _validate_outcome(
         cls,
         claim: AttemptClaim,
@@ -1605,7 +1621,7 @@ class MissionAttemptClaimService:
         settlement: AttemptStatus,
         outcome: Mapping[str, Any],
     ) -> None:
-        assessment = assess_attempt_outcome(cls.recover_request(claim), outcome)
+        assessment = cls._assess_claim_outcome(claim, outcome)
         if settlement is not assessment.attempt_status:
             raise ValueError(
                 "attempt settlement status disagrees with its authoritative mission outcome"
@@ -1821,6 +1837,8 @@ class MissionAttemptClaimService:
                 # never be reinterpreted under the current indexed contract.
                 assessment = assess_legacy_unbound_settled_outcome(request, outcome)
                 legacy_unbound = True
+            elif contract_version < _CURRENT_CLAIM_CONTRACT_VERSION:
+                assessment = assess_pre_worktree_archive_outcome(request, outcome)
             else:
                 assessment = assess_attempt_outcome(request, outcome)
             if (

--- a/src/archetype/app/missions/claim_service.py
+++ b/src/archetype/app/missions/claim_service.py
@@ -364,7 +364,7 @@ class MissionAttemptClaimService:
         self._require_active_policy(current)
         durable_outcome = self._coerce_durable_outcome(current, outcome)
         request = self.recover_request(current)
-        assessment = self._assess_claim_outcome(current, durable_outcome.value)
+        assessment = self.assess_outcome(current, durable_outcome.value)
         if request.required_finalization_phase is not FinalizationPhase.INDEXED:
             raise ValueError("artifact finalization may only be staged for an indexed gate")
         if assessment.provider_status not in {
@@ -718,7 +718,7 @@ class MissionAttemptClaimService:
         self._require_active_policy(claim)
         self._validate_outcome(
             claim,
-            settlement=self._assess_claim_outcome(claim, outcome).attempt_status,
+            settlement=self.assess_outcome(claim, outcome).attempt_status,
             outcome=outcome,
         )
         canonical = json.loads(self._json(outcome))
@@ -731,7 +731,7 @@ class MissionAttemptClaimService:
         )
         self._validate_outcome(
             claim,
-            settlement=self._assess_claim_outcome(claim, redacted.value).attempt_status,
+            settlement=self.assess_outcome(claim, redacted.value).attempt_status,
             outcome=redacted.value,
         )
         return redacted
@@ -866,7 +866,7 @@ class MissionAttemptClaimService:
         )
         finalized = self._rescan_enriched_outcome(claim, value)
         self._assert_safe_outcome_identity(finalized.value)
-        assessment = self._assess_claim_outcome(claim, finalized.value)
+        assessment = self.assess_outcome(claim, finalized.value)
         self._validate_outcome(
             claim,
             settlement=assessment.attempt_status,
@@ -931,7 +931,7 @@ class MissionAttemptClaimService:
         value["finalization_error"] = _ARTIFACT_PUBLICATION_EXPIRED
         self._assert_safe_outcome_identity(value)
         rescanned = self._rescan_enriched_outcome(claim, value)
-        assessment = self._assess_claim_outcome(claim, rescanned.value)
+        assessment = self.assess_outcome(claim, rescanned.value)
         if assessment.attempt_status not in {
             AttemptStatus.INCOMPLETE,
             AttemptStatus.REJECTED,
@@ -1164,7 +1164,7 @@ class MissionAttemptClaimService:
         )
         if defensive.value != outcome.value:
             raise ValueError("prepared attempt outcome is not safe for durability")
-        assessment = self._assess_claim_outcome(claim, outcome.value)
+        assessment = self.assess_outcome(claim, outcome.value)
         self._validate_outcome(
             claim,
             settlement=assessment.attempt_status,
@@ -1603,7 +1603,7 @@ class MissionAttemptClaimService:
             raise ValueError("mission attempt request fingerprint is invalid")
 
     @classmethod
-    def _assess_claim_outcome(
+    def assess_outcome(
         cls,
         claim: AttemptClaim,
         outcome: Mapping[str, Any],
@@ -1621,7 +1621,7 @@ class MissionAttemptClaimService:
         settlement: AttemptStatus,
         outcome: Mapping[str, Any],
     ) -> None:
-        assessment = cls._assess_claim_outcome(claim, outcome)
+        assessment = cls.assess_outcome(claim, outcome)
         if settlement is not assessment.attempt_status:
             raise ValueError(
                 "attempt settlement status disagrees with its authoritative mission outcome"

--- a/src/archetype/app/missions/claim_service.py
+++ b/src/archetype/app/missions/claim_service.py
@@ -107,6 +107,7 @@ _OUTCOME_IDENTITY_FIELDS = (
     "git_status_ref",
     "git_patch_ref",
     "git_bundle_ref",
+    "worktree_archive_ref",
     "context_ref",
     "sha",
     "artifact_publication_key",

--- a/src/archetype/app/missions/claim_service.py
+++ b/src/archetype/app/missions/claim_service.py
@@ -18,6 +18,7 @@ from pydantic import JsonValue
 
 from archetype.app.limits import MAX_ICEBERG_SNAPSHOT_ID
 from archetype.app.missions.models import (
+    WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     AttemptArtifactExpiration,
     AttemptArtifactProjection,
     AttemptArtifactPublication,
@@ -34,7 +35,6 @@ from archetype.app.missions.models import (
     normalize_attempt_validators,
 )
 from archetype.app.missions.outcomes import (
-    WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     MissionAttemptAssessment,
     assess_attempt_outcome,
     assess_legacy_unbound_settled_outcome,

--- a/src/archetype/app/missions/execution_service.py
+++ b/src/archetype/app/missions/execution_service.py
@@ -210,6 +210,7 @@ class MissionAttemptExecutionService:
                 request,
                 sanitized_outcome,
                 redaction_policy_id=active_claim.redaction_policy_id,
+                claim_contract_version=active_claim.contract_version,
             )
             active_claim = await self._claims.stage_finalization(
                 active_claim,

--- a/src/archetype/app/missions/execution_service.py
+++ b/src/archetype/app/missions/execution_service.py
@@ -25,7 +25,6 @@ from archetype.app.missions.models import (
     MissionAttemptExecution,
     MissionAttemptRequest,
 )
-from archetype.app.missions.outcomes import assess_attempt_outcome
 from archetype.app.missions.transitions import (
     AttemptClaimStatus,
     AttemptRecoveryAction,
@@ -189,7 +188,7 @@ class MissionAttemptExecutionService:
             )
         durable_outcome = self._claims.prepare_durable_outcome(active_claim, outcome)
         sanitized_outcome = dict(durable_outcome.value)
-        assessment = assess_attempt_outcome(request, sanitized_outcome)
+        assessment = self._claims.assess_outcome(active_claim, sanitized_outcome)
         if (
             request.required_finalization_phase is FinalizationPhase.INDEXED
             and assessment.provider_status in {AttemptStatus.ACCEPTED, AttemptStatus.REJECTED}
@@ -226,7 +225,12 @@ class MissionAttemptExecutionService:
                 lease_seconds=lease_seconds,
                 replayed=False,
             )
-        updated = self._missions.apply_attempt(row, request, sanitized_outcome)
+        updated = self._missions._apply_claimed_attempt(
+            row,
+            request,
+            sanitized_outcome,
+            active_claim,
+        )
         settled = await self._claims.settle(
             active_claim,
             attempt_status=AttemptStatus(str(updated["attempt__status"])),

--- a/src/archetype/app/missions/interfaces.py
+++ b/src/archetype/app/missions/interfaces.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
 
 from archetype.app.missions.models import (
+    WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     AttemptArtifactProjection,
     AttemptArtifactPublication,
     AttemptClaim,
@@ -185,6 +186,7 @@ class iMissionArtifactFinalizer(Protocol):
         outcome: Mapping[str, Any],
         *,
         redaction_policy_id: str,
+        claim_contract_version: int = WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     ) -> AttemptArtifactProjection: ...
 
     async def publish(

--- a/src/archetype/app/missions/interfaces.py
+++ b/src/archetype/app/missions/interfaces.py
@@ -21,6 +21,7 @@ from archetype.app.missions.models import (
     PreparedFinalizationSettlement,
     ProviderExecutionCapabilities,
 )
+from archetype.app.missions.outcomes import MissionAttemptAssessment
 from archetype.app.redaction.models import RedactedRecord
 from archetype.missions.transitions import AttemptStatus
 
@@ -44,6 +45,14 @@ class iMissionService(Protocol):
 @runtime_checkable
 class _iMissionExecutionProjection(iMissionService, Protocol):
     """Family-private row transformer reached only after durable authentication."""
+
+    def _apply_claimed_attempt(
+        self,
+        row: Mapping[str, Any],
+        request: MissionAttemptRequest,
+        outcome: Mapping[str, Any],
+        claim: AttemptClaim,
+    ) -> dict[str, Any]: ...
 
     def _apply_settled_attempt(
         self,
@@ -136,6 +145,12 @@ class iMissionAttemptClaimService(Protocol):
         claim: AttemptClaim,
         outcome: Mapping[str, Any],
     ) -> RedactedRecord: ...
+
+    def assess_outcome(
+        self,
+        claim: AttemptClaim,
+        outcome: Mapping[str, Any],
+    ) -> MissionAttemptAssessment: ...
 
     def settled_outcome(self, claim: AttemptClaim) -> Any: ...
 

--- a/src/archetype/app/missions/models.py
+++ b/src/archetype/app/missions/models.py
@@ -27,6 +27,7 @@ from archetype.missions.transitions import (
 )
 
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
+WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION = 9
 
 
 @dataclass(frozen=True)

--- a/src/archetype/app/missions/models.py
+++ b/src/archetype/app/missions/models.py
@@ -382,7 +382,7 @@ class AttemptClaim:
     acknowledged_at: str | None
     finalizing_at: str | None
     settled_at: str | None
-    contract_version: int = 8
+    contract_version: int = 9
     legacy_unbound_eligible: bool = False
     legacy_unbound: bool = False
 

--- a/src/archetype/app/missions/outcomes.py
+++ b/src/archetype/app/missions/outcomes.py
@@ -11,10 +11,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from archetype.app.limits import MAX_ICEBERG_SNAPSHOT_ID
-from archetype.app.missions.models import (
-    MissionAttemptRequest,
-    attempt_invocation_fingerprint,
-)
+from archetype.app.missions.models import MissionAttemptRequest, attempt_invocation_fingerprint
 from archetype.missions.transitions import (
     AttemptStatus,
     CheckpointStatus,
@@ -22,7 +19,6 @@ from archetype.missions.transitions import (
 )
 
 REPOSITORY_CHANGE_GATE_NAME = "git_tree_change"
-WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION = 9
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
 REPLAY_REQUIRED_OUTCOME_FIELDS = frozenset(
     {

--- a/src/archetype/app/missions/outcomes.py
+++ b/src/archetype/app/missions/outcomes.py
@@ -52,6 +52,7 @@ REPLAY_REQUIRED_OUTCOME_FIELDS = frozenset(
         "git_status_ref",
         "git_patch_ref",
         "git_bundle_ref",
+        "worktree_archive_ref",
         "context_ref",
         "sha",
         "message",

--- a/src/archetype/app/missions/outcomes.py
+++ b/src/archetype/app/missions/outcomes.py
@@ -22,6 +22,7 @@ from archetype.missions.transitions import (
 )
 
 REPOSITORY_CHANGE_GATE_NAME = "git_tree_change"
+WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION = 9
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
 REPLAY_REQUIRED_OUTCOME_FIELDS = frozenset(
     {
@@ -59,6 +60,9 @@ REPLAY_REQUIRED_OUTCOME_FIELDS = frozenset(
         "pushed",
     }
 )
+_PRE_WORKTREE_ARCHIVE_REQUIRED_OUTCOME_FIELDS = REPLAY_REQUIRED_OUTCOME_FIELDS - {
+    "worktree_archive_ref"
+}
 
 
 @dataclass(frozen=True)
@@ -138,10 +142,11 @@ def _assess_attempt_outcome(
     outcome: Mapping[str, Any],
     *,
     legacy_unbound: bool,
+    required_fields: frozenset[str],
 ) -> MissionAttemptAssessment:
     """Validate one outcome under either current or terminal-legacy semantics."""
 
-    missing = sorted(REPLAY_REQUIRED_OUTCOME_FIELDS - outcome.keys())
+    missing = sorted(required_fields - outcome.keys())
     if missing:
         raise ValueError("attempt outcome is not replayable; missing fields: " + ", ".join(missing))
     if str(outcome["attempt_id"]) != request.attempt_id:
@@ -324,7 +329,26 @@ def assess_attempt_outcome(
 ) -> MissionAttemptAssessment:
     """Validate a replayable outcome under the current write authority."""
 
-    return _assess_attempt_outcome(request, outcome, legacy_unbound=False)
+    return _assess_attempt_outcome(
+        request,
+        outcome,
+        legacy_unbound=False,
+        required_fields=REPLAY_REQUIRED_OUTCOME_FIELDS,
+    )
+
+
+def assess_pre_worktree_archive_outcome(
+    request: MissionAttemptRequest,
+    outcome: Mapping[str, Any],
+) -> MissionAttemptAssessment:
+    """Read durable v7/v8 evidence written before full-worktree capture."""
+
+    return _assess_attempt_outcome(
+        request,
+        outcome,
+        legacy_unbound=False,
+        required_fields=_PRE_WORKTREE_ARCHIVE_REQUIRED_OUTCOME_FIELDS,
+    )
 
 
 def assess_legacy_unbound_settled_outcome(
@@ -350,7 +374,12 @@ def assess_legacy_unbound_settled_outcome(
 
     # v7 accepted arbitrary extra keys. Authority-shaped names in its terminal
     # bytes are inert compatibility data, never current artifact provenance.
-    assessment = _assess_attempt_outcome(request, outcome, legacy_unbound=True)
+    assessment = _assess_attempt_outcome(
+        request,
+        outcome,
+        legacy_unbound=True,
+        required_fields=_PRE_WORKTREE_ARCHIVE_REQUIRED_OUTCOME_FIELDS,
+    )
     if assessment.attempt_status is not AttemptStatus.ACCEPTED:
         raise ValueError("legacy unbound finalization is not an accepted terminal outcome")
     return assessment

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -387,6 +387,7 @@ class MissionService:
                 "evidence__git_status_ref": str(outcome["git_status_ref"]),
                 "evidence__git_patch_ref": str(outcome["git_patch_ref"]),
                 "evidence__git_bundle_ref": str(outcome["git_bundle_ref"]),
+                "evidence__worktree_archive_ref": str(outcome["worktree_archive_ref"]),
                 "evidence__context_ref": str(outcome["context_ref"]),
                 "frictionlog__entries_json": self._json(prior_friction),
             }

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -12,13 +12,13 @@ from typing import Any
 
 from archetype.app.limits import MAX_ICEBERG_SNAPSHOT_ID
 from archetype.app.missions.models import (
+    WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     AttemptClaim,
     MissionAttemptRequest,
     mission_attempt_request_fingerprint,
     normalize_attempt_validators,
 )
 from archetype.app.missions.outcomes import (
-    WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     assess_attempt_outcome,
     assess_legacy_unbound_settled_outcome,
     assess_pre_worktree_archive_outcome,

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -18,8 +18,10 @@ from archetype.app.missions.models import (
     normalize_attempt_validators,
 )
 from archetype.app.missions.outcomes import (
+    WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION,
     assess_attempt_outcome,
     assess_legacy_unbound_settled_outcome,
+    assess_pre_worktree_archive_outcome,
 )
 from archetype.app.missions.transitions import AttemptClaimStatus
 from archetype.missions.transitions import (
@@ -190,6 +192,7 @@ class MissionService:
             request,
             outcome,
             legacy_unbound=False,
+            pre_worktree_archive=False,
             expected_status=None,
         )
 
@@ -238,6 +241,9 @@ class MissionService:
             request,
             outcome,
             legacy_unbound=claim.legacy_unbound,
+            pre_worktree_archive=(
+                claim.contract_version < WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION
+            ),
             expected_status=settlement,
         )
 
@@ -248,6 +254,7 @@ class MissionService:
         outcome: Mapping[str, Any],
         *,
         legacy_unbound: bool,
+        pre_worktree_archive: bool,
         expected_status: AttemptStatus | None,
     ) -> dict[str, Any]:
         source = self._state(row)
@@ -272,11 +279,12 @@ class MissionService:
         if required_phase is not request.required_finalization_phase:
             raise ValueError("mission finalization gate changed after this attempt was prepared")
 
-        assessment = (
-            assess_legacy_unbound_settled_outcome(request, outcome)
-            if legacy_unbound
-            else assess_attempt_outcome(request, outcome)
-        )
+        if legacy_unbound:
+            assessment = assess_legacy_unbound_settled_outcome(request, outcome)
+        elif pre_worktree_archive:
+            assessment = assess_pre_worktree_archive_outcome(request, outcome)
+        else:
+            assessment = assess_attempt_outcome(request, outcome)
         if expected_status is not None and assessment.attempt_status is not expected_status:
             raise ValueError("settled outcome disagrees with its terminal claim status")
 
@@ -387,7 +395,7 @@ class MissionService:
                 "evidence__git_status_ref": str(outcome["git_status_ref"]),
                 "evidence__git_patch_ref": str(outcome["git_patch_ref"]),
                 "evidence__git_bundle_ref": str(outcome["git_bundle_ref"]),
-                "evidence__worktree_archive_ref": str(outcome["worktree_archive_ref"]),
+                "evidence__worktree_archive_ref": str(outcome.get("worktree_archive_ref", "")),
                 "evidence__context_ref": str(outcome["context_ref"]),
                 "frictionlog__entries_json": self._json(prior_friction),
             }

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -247,6 +247,38 @@ class MissionService:
             expected_status=settlement,
         )
 
+    def _apply_claimed_attempt(
+        self,
+        row: Mapping[str, Any],
+        request: MissionAttemptRequest,
+        outcome: Mapping[str, Any],
+        claim: AttemptClaim,
+    ) -> dict[str, Any]:
+        """Project sanitized evidence under its authenticated claim contract."""
+
+        if claim.status not in {
+            AttemptClaimStatus.POSSIBLY_SUBMITTED,
+            AttemptClaimStatus.PROVIDER_ACKNOWLEDGED,
+        }:
+            raise ValueError("claimed mission projection requires an active attempt claim")
+        if (
+            claim.attempt_id != request.attempt_id
+            or claim.idempotency_key != request.idempotency_key
+            or claim.mission_id != request.mission_id
+            or claim.task_id != request.task_id
+        ):
+            raise ValueError("active attempt claim does not match its mission request")
+        return self._apply_attempt(
+            row,
+            request,
+            outcome,
+            legacy_unbound=False,
+            pre_worktree_archive=(
+                claim.contract_version < WORKTREE_ARCHIVE_OUTCOME_CONTRACT_VERSION
+            ),
+            expected_status=None,
+        )
+
     def _apply_attempt(
         self,
         row: Mapping[str, Any],

--- a/src/archetype/app/sandboxes/common.py
+++ b/src/archetype/app/sandboxes/common.py
@@ -163,6 +163,226 @@ with open(output, "w", encoding="utf-8") as file:
         )
 """
 
+_WORKTREE_ARCHIVE_SCRIPT = r"""
+import errno
+import hashlib
+import json
+import os
+import shutil
+import stat
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+root = Path(sys.argv[1]).resolve(strict=True)
+output = Path(sys.argv[2])
+baseline_sha, head_sha = sys.argv[3:5]
+recovery = {
+    "git-status.txt": Path(sys.argv[5]),
+    "worktree.patch": Path(sys.argv[6]),
+    "repository.bundle": Path(sys.argv[7]),
+}
+caches = {
+    ".cache", ".mypy_cache", ".nox", ".pytest_cache", ".ruff_cache", ".tox",
+    ".venv", "__pycache__", "build", "dist", "node_modules", "venv",
+}
+credential_names = {
+    ".env", ".env.development", ".env.local", ".env.production", ".git-credentials",
+    ".netrc", ".npmrc", ".pypirc", "id_dsa", "id_ecdsa", "id_ed25519", "id_rsa",
+}
+credential_suffixes = (
+    (".codex", "auth.json"), (".claude", ".credentials.json"),
+    (".config", "opencode", "auth.json"),
+    (".local", "share", "opencode", "auth.json"), (".aws", "credentials"),
+    (".config", "gcloud", "application_default_credentials.json"),
+    (".config", "gcloud", "credentials.db"),
+    (".config", "gcloud", "access_tokens.db"), (".config", "gh", "hosts.yml"),
+    (".docker", "config.json"), (".kube", "config"),
+    (".azure", "accesstokens.json"), (".cache", "huggingface", "token"),
+    (".huggingface", "token"),
+)
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def reason(parts, is_dir):
+    lower = tuple(part.lower() for part in parts)
+    if parts and parts[0] == ".git":
+        return "git-internals"
+    if parts and parts[0] == ".archetype-agent":
+        return "provider-internals"
+    if (lower and lower[-1] in credential_names) or any(
+        len(lower) >= len(suffix) and lower[-len(suffix):] == suffix
+        for suffix in credential_suffixes
+    ):
+        return "credential-path"
+    if is_dir and parts and parts[-1] in caches:
+        return "cache"
+    return None
+
+
+def inventory():
+    values = {}
+    excluded = []
+    inodes = set()
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    root_descriptor = os.open(root, flags)
+    root_device = os.fstat(root_descriptor).st_dev
+    stack = [(root_descriptor, ())]
+    try:
+        while stack:
+            descriptor, prefix = stack.pop()
+            try:
+                children = sorted(os.scandir(descriptor), key=lambda item: item.name, reverse=True)
+            except BaseException:
+                os.close(descriptor)
+                raise
+            try:
+                for child in children:
+                    parts = (*prefix, child.name)
+                    path = PurePosixPath(*parts).as_posix()
+                    info = child.stat(follow_symlinks=False)
+                    is_dir = stat.S_ISDIR(info.st_mode)
+                    is_file = stat.S_ISREG(info.st_mode)
+                    if stat.S_ISLNK(info.st_mode):
+                        raise RuntimeError("worktree archive rejects symbolic links")
+                    if not is_dir and not is_file:
+                        raise RuntimeError("worktree archive rejects special files")
+                    why = reason(parts, is_dir)
+                    if why:
+                        excluded.append({"path": path, "type": "directory" if is_dir else "file", "reason": why})
+                        continue
+                    if info.st_dev != root_device:
+                        raise RuntimeError("worktree archive rejects nested filesystems")
+                    if is_dir:
+                        kind, size = "directory", 0
+                        child_descriptor = os.open(child.name, flags, dir_fd=descriptor)
+                        opened = os.fstat(child_descriptor)
+                        if not stat.S_ISDIR(opened.st_mode) or opened.st_dev != info.st_dev or opened.st_ino != info.st_ino:
+                            os.close(child_descriptor)
+                            raise RuntimeError("worktree directory changed during inventory")
+                        stack.append((child_descriptor, parts))
+                    elif is_file:
+                        if info.st_nlink != 1 or (info.st_dev, info.st_ino) in inodes:
+                            raise RuntimeError("worktree archive rejects hard-linked files")
+                        inodes.add((info.st_dev, info.st_ino))
+                        kind, size = "file", info.st_size
+                    values[path] = (
+                        kind, stat.S_IMODE(info.st_mode), size, info.st_dev, info.st_ino,
+                        info.st_mtime_ns, info.st_ctime_ns,
+                    )
+            finally:
+                os.close(descriptor)
+    finally:
+        for descriptor, _ in stack:
+            os.close(descriptor)
+    return values, sorted(excluded, key=lambda item: (item["path"], item["reason"]))
+
+
+def copy_stable(source, destination, expected):
+    flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(source, flags)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise RuntimeError("worktree file became a symbolic link") from None
+        raise
+    try:
+        opened = os.fstat(descriptor)
+        identity = (opened.st_size, opened.st_dev, opened.st_ino, opened.st_mtime_ns, opened.st_ctime_ns)
+        wanted = (expected[2], expected[3], expected[4], expected[5], expected[6])
+        if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1 or identity != wanted:
+            raise RuntimeError("worktree file changed before its stable read")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with os.fdopen(descriptor, "rb", closefd=False) as reader, destination.open("xb") as writer:
+            shutil.copyfileobj(reader, writer, length=1024 * 1024)
+        finished = os.fstat(descriptor)
+        final = (finished.st_size, finished.st_dev, finished.st_ino, finished.st_mtime_ns, finished.st_ctime_ns)
+        if final != identity or destination.stat().st_size != expected[2]:
+            raise RuntimeError("worktree file changed during its stable read")
+    finally:
+        os.close(descriptor)
+
+
+def file_entry(path, mode, source):
+    digest = hashlib.sha256()
+    with source.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "path": path, "type": "file", "mode": mode,
+        "size_bytes": source.stat().st_size, "sha256": digest.hexdigest(),
+    }
+
+
+def tar_info(name, mode, size=0, directory=False):
+    info = tarfile.TarInfo(name)
+    info.mode, info.uid, info.gid, info.uname, info.gname, info.mtime = mode, 0, 0, "", "", 0
+    info.size = size
+    info.type = tarfile.DIRTYPE if directory else tarfile.REGTYPE
+    return info
+
+
+initial, exclusions = inventory()
+with tempfile.TemporaryDirectory(prefix="archetype-worktree-") as temporary:
+    staged = Path(temporary)
+    entries = []
+    for path, value in sorted(initial.items()):
+        kind, mode = value[:2]
+        archive_path = f"worktree/{path}"
+        target = staged / PurePosixPath(archive_path)
+        if kind == "directory":
+            target.mkdir(parents=True, exist_ok=True)
+            entries.append({"path": archive_path, "type": kind, "mode": mode, "size_bytes": 0, "sha256": ""})
+        else:
+            copy_stable(root / PurePosixPath(path), target, value)
+            entries.append(file_entry(archive_path, mode, target))
+    for name, source in sorted(recovery.items()):
+        info = source.lstat()
+        expected = (
+            "file", stat.S_IMODE(info.st_mode), info.st_size, info.st_dev, info.st_ino,
+            info.st_mtime_ns, info.st_ctime_ns,
+        )
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise RuntimeError("Git recovery material must be a regular file")
+        archive_path = f"recovery/{name}"
+        target = staged / archive_path
+        copy_stable(source, target, expected)
+        entries.append(file_entry(archive_path, expected[1], target))
+    if inventory() != (initial, exclusions):
+        raise RuntimeError("worktree changed while the archive was captured")
+    entries.sort(key=lambda item: item["path"])
+    manifest = {
+        "schema_version": 1,
+        "archive_format": "archetype-worktree-tar-v1",
+        "baseline_sha": baseline_sha,
+        "head_sha": head_sha,
+        "redaction_policy_id": "",
+        "entries": entries,
+        "exclusions": exclusions,
+        "redaction": {
+            "status": "unscanned", "files_scanned": 0, "bytes_scanned": 0,
+            "redaction_count": 0, "rule_ids": [], "files": [],
+        },
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    writing = output.with_name(output.name + ".writing")
+    writing.unlink(missing_ok=True)
+    manifest_bytes = canonical(manifest)
+    with tarfile.open(writing, "w", format=tarfile.PAX_FORMAT) as archive:
+        archive.addfile(tar_info("archive-manifest.json", 0o644, len(manifest_bytes)), __import__("io").BytesIO(manifest_bytes))
+        for entry in entries:
+            if entry["type"] == "directory":
+                archive.addfile(tar_info(entry["path"], entry["mode"], directory=True))
+            else:
+                with (staged / PurePosixPath(entry["path"])).open("rb") as stream:
+                    archive.addfile(tar_info(entry["path"], entry["mode"], entry["size_bytes"]), stream)
+    os.replace(writing, output)
+"""
+
 
 @dataclass
 class CodingAgentSandboxClient[SandboxSpecT: CodingAgentSandboxSpec](ABC):
@@ -620,6 +840,11 @@ class CodingAgentSandboxClient[SandboxSpecT: CodingAgentSandboxSpec](ABC):
     ) -> EvidenceCapture:
         await self._emit_live_event("evidence_capture_started")
         git_recovery = await self._capture_git_recovery(prepared.attempt_id, prepared.baseline_sha)
+        worktree_archive_path = await self._capture_worktree_archive(
+            prepared.attempt_id,
+            prepared.baseline_sha,
+            git_recovery,
+        )
         context_path = f"{self.spec.workspace}/.context"
         context_exists = await self._exec("test", "-d", context_path, timeout=30)
         if context_exists.returncode != 0:
@@ -643,6 +868,7 @@ class CodingAgentSandboxClient[SandboxSpecT: CodingAgentSandboxSpec](ABC):
             git_status_path=git_recovery["status"],
             git_patch_path=git_recovery["patch"],
             git_bundle_path=git_recovery["bundle"],
+            worktree_archive_path=worktree_archive_path,
             context_path=context_path,
         )
         attempt_manifest = {
@@ -674,6 +900,7 @@ class CodingAgentSandboxClient[SandboxSpecT: CodingAgentSandboxSpec](ABC):
                 "git_status": evidence.git_status_path,
                 "git_patch": evidence.git_patch_path,
                 "git_bundle": evidence.git_bundle_path,
+                "worktree_archive": evidence.worktree_archive_path,
                 "context_directory": evidence.context_path,
             },
         }
@@ -683,6 +910,7 @@ class CodingAgentSandboxClient[SandboxSpecT: CodingAgentSandboxSpec](ABC):
             attempt_manifest_path=attempt_manifest_path,
             filesystem_diff_path=filesystem_diff_path,
             git_bundle_path=evidence.git_bundle_path,
+            worktree_archive_path=evidence.worktree_archive_path,
         )
         return evidence
 
@@ -899,6 +1127,9 @@ class CodingAgentSandboxClient[SandboxSpecT: CodingAgentSandboxSpec](ABC):
             "git_status_ref": self._artifact_ref(checkpoint.ref, evidence.git_status_path),
             "git_patch_ref": self._artifact_ref(checkpoint.ref, evidence.git_patch_path),
             "git_bundle_ref": self._artifact_ref(checkpoint.ref, evidence.git_bundle_path),
+            "worktree_archive_ref": self._artifact_ref(
+                checkpoint.ref, evidence.worktree_archive_path
+            ),
             "context_ref": self._artifact_ref(checkpoint.ref, evidence.context_path),
         }
         return ArtifactHandoff(
@@ -1174,6 +1405,31 @@ class CodingAgentSandboxClient[SandboxSpecT: CodingAgentSandboxSpec](ABC):
         await self._write_text(patch_path, patch.stdout)
         await self._git("bundle", "create", bundle_path, "--all")
         return {"status": status_path, "patch": patch_path, "bundle": bundle_path}
+
+    async def _capture_worktree_archive(
+        self,
+        attempt_id: str,
+        baseline: str,
+        git_recovery: Mapping[str, str],
+    ) -> str:
+        directory = f"{self.spec.workspace}/.archetype-agent/recovery"
+        archive_path = f"{directory}/{attempt_id}-worktree.tar"
+        head = (await self._git("rev-parse", "HEAD")).stdout.strip()
+        result = await self._exec(
+            "python3",
+            "-c",
+            _WORKTREE_ARCHIVE_SCRIPT,
+            self.spec.workspace,
+            archive_path,
+            baseline,
+            head,
+            git_recovery["status"],
+            git_recovery["patch"],
+            git_recovery["bundle"],
+            timeout=self.spec.snapshot_timeout_seconds,
+        )
+        self._raise_for_result(result, "portable worktree archive")
+        return archive_path
 
     async def _ensure_start_manifest(self) -> str:
         if not self.spec.capture_filesystem_manifests:

--- a/src/archetype/app/sandboxes/models.py
+++ b/src/archetype/app/sandboxes/models.py
@@ -173,6 +173,7 @@ class EvidenceCapture:
     git_status_path: str
     git_patch_path: str
     git_bundle_path: str
+    worktree_archive_path: str
     context_path: str
 
 

--- a/src/archetype/missions/components.py
+++ b/src/archetype/missions/components.py
@@ -233,6 +233,7 @@ class Evidence(Component):
     git_status_ref: str = ""
     git_patch_ref: str = ""
     git_bundle_ref: str = ""
+    worktree_archive_ref: str = ""
     context_ref: str = ""
 
 

--- a/tests/app/test_indexed_finalization_crash_oracle.py
+++ b/tests/app/test_indexed_finalization_crash_oracle.py
@@ -19,6 +19,7 @@ import pytest
 
 from archetype.app.artifacts.bundle_models import PreparedArtifactBundleRequest
 from archetype.app.artifacts.bundle_service import _ARTIFACT_INDEX_TABLE
+from archetype.app.artifacts.worktree_archive import capture_worktree_archive
 from archetype.app.container import ServiceContainer
 from archetype.app.missions import (
     AttemptClaimAcquireOutcome,
@@ -158,9 +159,26 @@ def _source_evidence(root: Path) -> dict[str, str]:
         "git_status_ref": root / "git-status.txt",
         "git_patch_ref": root / "worktree.patch",
         "git_bundle_ref": root / "repository.bundle",
+        "worktree_archive_ref": root / "full-worktree.tar",
     }
     for field, path in files.items():
+        if field == "worktree_archive_ref":
+            continue
         path.write_text(f"durable local evidence for {field}\n")
+    worktree = root / "worktree"
+    worktree.mkdir()
+    (worktree / "tracked.py").write_text("print('recoverable')\n")
+    capture_worktree_archive(
+        worktree,
+        files["worktree_archive_ref"],
+        baseline_sha="a" * 40,
+        head_sha="b" * 40,
+        recovery_files={
+            "git-status.txt": files["git_status_ref"],
+            "worktree.patch": files["git_patch_ref"],
+            "repository.bundle": files["git_bundle_ref"],
+        },
+    )
     traces = root / "traces"
     traces.mkdir()
     (traces / "0001.jsonl").write_text('{"event":"first"}\n')

--- a/tests/app/test_mission_artifact_finalizer.py
+++ b/tests/app/test_mission_artifact_finalizer.py
@@ -122,6 +122,7 @@ def _outcome() -> dict[str, object]:
         "git_status_ref": "modal-image://checkpoint-1#/git/status.txt",
         "git_patch_ref": "modal-image://checkpoint-1#/git/worktree.patch",
         "git_bundle_ref": "modal-image://checkpoint-1#/git/repository.bundle",
+        "worktree_archive_ref": "modal-image://checkpoint-1#/git/full-worktree.tar",
         "context_ref": "modal-image://checkpoint-1#/.context",
     }
 
@@ -176,11 +177,14 @@ def test_mission_projection_is_deterministic_and_maps_every_evidence_family(tmp_
         "recovery/git-status.txt",
         "recovery/worktree.patch",
         "recovery/repository.bundle",
+        "recovery/full-worktree.tar",
         "context",
     }
     assert by_path["attempt/traces"].recursive
     assert not by_path["attempt/traces"].required
     assert by_path["context"].recursive
+    assert by_path["recovery/full-worktree.tar"].kind == "worktree_archive"
+    assert by_path["recovery/full-worktree.tar"].required
     assert not by_path["attempt/live-events.jsonl"].required
 
 
@@ -330,12 +334,13 @@ async def test_mission_finalizer_returns_exact_indexed_evidence(tmp_path):
     assert publication.index_snapshot_id == 42
 
 
-def test_mission_projection_rejects_missing_required_recovery_reference(tmp_path):
+@pytest.mark.parametrize("field", ["git_bundle_ref", "worktree_archive_ref"])
+def test_mission_projection_rejects_missing_required_recovery_reference(tmp_path, field):
     finalizer, _bundles, policy_id = _finalizer(tmp_path)
     outcome = _outcome()
-    outcome["git_bundle_ref"] = ""
+    outcome[field] = ""
 
-    with pytest.raises(ValueError, match="requires git_bundle_ref"):
+    with pytest.raises(ValueError, match=f"requires {field}"):
         finalizer.prepare(
             _request(),
             outcome,

--- a/tests/app/test_mission_artifact_finalizer.py
+++ b/tests/app/test_mission_artifact_finalizer.py
@@ -348,6 +348,24 @@ def test_mission_projection_rejects_missing_required_recovery_reference(tmp_path
         )
 
 
+def test_pre_v9_mission_projection_allows_missing_worktree_archive(tmp_path):
+    finalizer, _bundles, policy_id = _finalizer(tmp_path)
+    outcome = _outcome()
+    assert outcome.pop("worktree_archive_ref")
+
+    projection = finalizer.prepare(
+        _request(),
+        outcome,
+        redaction_policy_id=policy_id,
+        claim_contract_version=8,
+    )
+
+    request = ArtifactBundleRequest.model_validate_json(projection.request_json)
+    by_path = {candidate.logical_path: candidate for candidate in request.artifacts}
+    assert "recovery/full-worktree.tar" not in by_path
+    assert by_path["recovery/repository.bundle"].required is True
+
+
 @pytest.mark.asyncio
 async def test_container_wires_the_authoritative_mission_artifact_adapter(tmp_path):
     container = ServiceContainer(

--- a/tests/app/test_mission_attempt_claims.py
+++ b/tests/app/test_mission_attempt_claims.py
@@ -335,7 +335,7 @@ async def _seed_unbound_settled_claim(
     legacy_request_json = ""
     if as_v7:
         legacy_request = json.loads(acknowledged.request_json)
-        assert legacy_request.pop("claim_contract_version") == 8
+        assert legacy_request.pop("claim_contract_version") == 9
         assert legacy_request.pop("observation_tick") == request.observation_tick
         legacy_request_json = service._json(legacy_request)
         request_receipt = redaction.redact_record(
@@ -391,7 +391,7 @@ def _strip_claim_contract_marker(path: Any) -> None:
     ).fetchone()
     assert row is not None
     request_json = json.loads(row["request_json"])
-    assert request_json.pop("claim_contract_version") == 8
+    assert request_json.pop("claim_contract_version") == 9
     assert request_json.pop("observation_tick") == 11
     evidence = json.loads(row["redaction_evidence_json"])
     receipt = (
@@ -403,6 +403,38 @@ def _strip_claim_contract_marker(path: Any) -> None:
         .receipt
     )
     evidence["request"] = receipt.model_dump(mode="json")
+    connection.execute(
+        "UPDATE mission_attempt_claims SET request_json=?, redaction_evidence_json=?",
+        (
+            json.dumps(request_json, sort_keys=True, separators=(",", ":")),
+            json.dumps(evidence, sort_keys=True, separators=(",", ":")),
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+
+def _set_claim_contract_version(path: Any, version: int) -> None:
+    """Rewrite only the authenticated request marker for a compatibility fixture."""
+
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    row = connection.execute(
+        "SELECT request_json, redaction_evidence_json FROM mission_attempt_claims"
+    ).fetchone()
+    assert row is not None
+    request_json = json.loads(row["request_json"])
+    assert request_json["claim_contract_version"] == 9
+    request_json["claim_contract_version"] = version
+    evidence = json.loads(row["redaction_evidence_json"])
+    evidence["request"] = (
+        RedactionService()
+        .redact_record(
+            request_json,
+            scope="mission-attempt-request",
+        )
+        .receipt.model_dump(mode="json")
+    )
     connection.execute(
         "UPDATE mission_attempt_claims SET request_json=?, redaction_evidence_json=?",
         (
@@ -1876,6 +1908,86 @@ async def test_cold_replay_after_indexed_settlement_applies_without_runner_or_fi
     await cold_catalog.close()
 
 
+async def test_v8_settled_claim_without_worktree_archive_cold_replays(
+    tmp_path,
+) -> None:
+    path = tmp_path / "v8-settled-before-worktree-archive.db"
+    request, stored_outcome = await _seed_unbound_settled_claim(
+        path,
+        phase=FinalizationPhase.CHECKPOINTED,
+        required_phase=FinalizationPhase.CHECKPOINTED,
+        as_v7=False,
+    )
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    row = connection.execute(
+        "SELECT request_json, outcome_json, redaction_evidence_json FROM mission_attempt_claims"
+    ).fetchone()
+    assert row is not None
+    request_json = json.loads(row["request_json"])
+    assert request_json["claim_contract_version"] == 9
+    request_json["claim_contract_version"] = 8
+    outcome = json.loads(row["outcome_json"])
+    assert outcome.pop("worktree_archive_ref") == "fake://full-worktree"
+    redaction = RedactionService()
+    evidence = json.loads(row["redaction_evidence_json"])
+    evidence["request"] = redaction.redact_record(
+        request_json,
+        scope="mission-attempt-request",
+    ).receipt.model_dump(mode="json")
+    evidence["outcome"] = redaction.redact_record(
+        outcome,
+        scope="mission-attempt-outcome",
+    ).receipt.model_dump(mode="json")
+    canonical_request = json.dumps(request_json, sort_keys=True, separators=(",", ":"))
+    canonical_outcome = json.dumps(outcome, sort_keys=True, separators=(",", ":"))
+    connection.execute(
+        "UPDATE mission_attempt_claims SET request_json=?, outcome_json=?, "
+        "outcome_digest=?, redaction_evidence_json=?",
+        (
+            canonical_request,
+            canonical_outcome,
+            hashlib.sha256(canonical_outcome.encode()).hexdigest(),
+            json.dumps(evidence, sort_keys=True, separators=(",", ":")),
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    catalog = SqliteControlCatalog(path)
+    service = _claim_service(catalog)
+    claim_key = service.claim_key(
+        world_id="world-1",
+        mission_id=request.mission_id,
+        task_id=request.task_id,
+        attempt_id=request.attempt_id,
+    )
+    projected = await service.get("world-1", claim_key)
+    assert projected is not None
+    assert projected.contract_version == 8
+    assert projected.legacy_unbound is False
+    assert service.settled_outcome(projected) == outcome
+    assert stored_outcome["worktree_archive_ref"] == "fake://full-worktree"
+
+    runner = _NoRunRunner()
+    replay = await MissionAttemptExecutionService(service, MissionService()).run(
+        _row(),
+        tick=100,
+        claimant="cold-v8-worker",
+        runner=runner,
+    )
+
+    assert replay is not None
+    assert replay.acquisition.outcome is AttemptClaimAcquireOutcome.DUPLICATE
+    assert replay.decision.action is AttemptRecoveryAction.SETTLED
+    assert replay.replayed is True
+    assert "worktree_archive_ref" not in replay.outcome
+    assert replay.updated_row["evidence__worktree_archive_ref"] == ""
+    assert replay.updated_row["finalization__legacy_unbound"] is False
+    assert runner.run_calls == 0
+    await catalog.close()
+
+
 @pytest.mark.parametrize(
     "phase",
     [FinalizationPhase.PUBLISHED, FinalizationPhase.INDEXED],
@@ -2122,6 +2234,7 @@ async def test_v8_authority_named_extras_without_staged_claim_fail_closed(
         as_v7=False,
         authority_extras=True,
     )
+    _set_claim_contract_version(path, 8)
     assert stored_outcome["finalization_bundle_id"] == "b" * 64
     catalog = SqliteControlCatalog(path)
     service = _claim_service(catalog)
@@ -2158,9 +2271,9 @@ async def test_claim_is_durable_before_submission_is_armed(tmp_path) -> None:
     assert acquired.outcome is AttemptClaimAcquireOutcome.ACQUIRED
     assert acquired.claim.status is AttemptClaimStatus.CLAIMED
     assert acquired.claim.fence_epoch == 1
-    assert acquired.claim.contract_version == 8
+    assert acquired.claim.contract_version == 9
     assert acquired.claim.legacy_unbound_eligible is False
-    assert json.loads(acquired.claim.request_json)["claim_contract_version"] == 8
+    assert json.loads(acquired.claim.request_json)["claim_contract_version"] == 9
     assert acquired.claim.possibly_submitted_at is None
 
     cold_catalog = SqliteControlCatalog(path)

--- a/tests/app/test_mission_attempt_claims.py
+++ b/tests/app/test_mission_attempt_claims.py
@@ -639,6 +639,7 @@ def _outcome(
         "git_status_ref": "fake://git-status",
         "git_patch_ref": "fake://git-patch",
         "git_bundle_ref": "fake://git-bundle",
+        "worktree_archive_ref": "fake://full-worktree",
         "context_ref": "fake://context",
         "friction": [],
         "sha": "abc123" if status is AttemptStatus.ACCEPTED else "",

--- a/tests/app/test_mission_attempt_claims.py
+++ b/tests/app/test_mission_attempt_claims.py
@@ -558,6 +558,20 @@ class _IndexedRunner:
         )
 
 
+class _CachedOutcomeRunner:
+    def __init__(self, outcome: dict[str, Any]) -> None:
+        self.outcome = outcome
+        self.run_calls = 0
+
+    @property
+    def provider_execution_capabilities(self) -> ProviderExecutionCapabilities:
+        return _capabilities()
+
+    async def run_attempt(self, **_: Any) -> dict[str, Any]:
+        self.run_calls += 1
+        return dict(self.outcome)
+
+
 class _StageObservingFinalizer:
     def __init__(
         self,
@@ -1986,6 +2000,59 @@ async def test_v8_settled_claim_without_worktree_archive_cold_replays(
     assert replay.updated_row["finalization__legacy_unbound"] is False
     assert runner.run_calls == 0
     await catalog.close()
+
+
+async def test_v8_acknowledged_claim_reconciles_cached_outcome_without_worktree_archive(
+    tmp_path,
+) -> None:
+    path = tmp_path / "v8-acknowledged-before-worktree-archive.db"
+    first_catalog = SqliteControlCatalog(path)
+    first = _claim_service(first_catalog)
+    request = _request()
+    acquired = await first.acquire(
+        request,
+        _capabilities(),
+        claimant="v8-worker",
+        lease_seconds=0.05,
+    )
+    decision = await first.decide_recovery(acquired.claim, lease_seconds=0.05)
+    consumed = await first.consume_execution(decision.authorization)
+    acknowledged = await first.acknowledge_provider(
+        consumed,
+        provider_session_id="session-v8",
+        provider_request_id="request-v8",
+    )
+    assert acknowledged.status is AttemptClaimStatus.PROVIDER_ACKNOWLEDGED
+    _set_claim_contract_version(path, 8)
+    await first_catalog.close()
+    await asyncio.sleep(0.06)
+
+    cached_outcome = _outcome(
+        request=request,
+        status=AttemptStatus.ACCEPTED,
+        agent_session_id="session-v8",
+    )
+    assert cached_outcome.pop("worktree_archive_ref") == "fake://full-worktree"
+    cold_catalog = SqliteControlCatalog(path)
+    cold = _claim_service(cold_catalog)
+    runner = _CachedOutcomeRunner(cached_outcome)
+    execution = await MissionAttemptExecutionService(cold, MissionService()).run(
+        _row(),
+        tick=100,
+        claimant="v8-recovery-worker",
+        runner=runner,
+        lease_seconds=1,
+    )
+
+    assert execution is not None
+    assert execution.acquisition.outcome is AttemptClaimAcquireOutcome.RECOVERED
+    assert execution.decision.action is AttemptRecoveryAction.RECONCILE
+    assert execution.claim.status is AttemptClaimStatus.SETTLED
+    assert execution.claim.contract_version == 8
+    assert "worktree_archive_ref" not in execution.outcome
+    assert execution.updated_row["evidence__worktree_archive_ref"] == ""
+    assert runner.run_calls == 1
+    await cold_catalog.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/app/test_mission_attempt_claims.py
+++ b/tests/app/test_mission_attempt_claims.py
@@ -578,10 +578,13 @@ class _StageObservingFinalizer:
         service: MissionAttemptClaimService,
         catalog: Any,
         request: Any,
+        *,
+        expected_contract_version: int = 9,
     ) -> None:
         self.service = service
         self.catalog = catalog
         self.request = request
+        self.expected_contract_version = expected_contract_version
         self.prepare_calls = 0
         self.publish_calls = 0
         self.observed_status: AttemptClaimStatus | None = None
@@ -592,11 +595,13 @@ class _StageObservingFinalizer:
         outcome: Any,
         *,
         redaction_policy_id: str,
+        claim_contract_version: int,
     ) -> AttemptArtifactProjection:
         self.prepare_calls += 1
         assert request == self.request
         assert outcome["finalization_phase"] == "checkpointed"
         assert request.observation_tick == self.request.observation_tick
+        assert claim_contract_version == self.expected_contract_version
         return _artifact_projection(request, redaction_policy_id)
 
     async def publish(
@@ -2052,6 +2057,72 @@ async def test_v8_acknowledged_claim_reconciles_cached_outcome_without_worktree_
     assert "worktree_archive_ref" not in execution.outcome
     assert execution.updated_row["evidence__worktree_archive_ref"] == ""
     assert runner.run_calls == 1
+    await cold_catalog.close()
+
+
+async def test_v8_acknowledged_indexed_claim_finalizes_cached_outcome_without_archive(
+    tmp_path,
+) -> None:
+    path = tmp_path / "v8-indexed-before-worktree-archive.db"
+    first_catalog = SqliteControlCatalog(path)
+    first = _claim_service(first_catalog)
+    request = _indexed_request()
+    acquired = await first.acquire(
+        request,
+        _capabilities(),
+        claimant="v8-indexed-worker",
+        lease_seconds=0.05,
+    )
+    decision = await first.decide_recovery(acquired.claim, lease_seconds=0.05)
+    consumed = await first.consume_execution(decision.authorization)
+    acknowledged = await first.acknowledge_provider(
+        consumed,
+        provider_session_id="session-indexed",
+        provider_request_id="request-indexed",
+    )
+    assert acknowledged.status is AttemptClaimStatus.PROVIDER_ACKNOWLEDGED
+    _set_claim_contract_version(path, 8)
+    await first_catalog.close()
+    await asyncio.sleep(0.06)
+
+    cached_outcome = _outcome(
+        request=request,
+        status=AttemptStatus.ACCEPTED,
+        agent_session_id="session-indexed",
+    )
+    assert cached_outcome.pop("worktree_archive_ref") == "fake://full-worktree"
+    cold_catalog = SqliteControlCatalog(path)
+    cold = _claim_service(cold_catalog)
+    runner = _CachedOutcomeRunner(cached_outcome)
+    finalizer = _StageObservingFinalizer(
+        cold,
+        cold_catalog,
+        request,
+        expected_contract_version=8,
+    )
+    execution = await MissionAttemptExecutionService(
+        cold,
+        MissionService(),
+        finalizer,
+    ).run(
+        _indexed_row(),
+        tick=100,
+        claimant="v8-indexed-recovery-worker",
+        runner=runner,
+        lease_seconds=1,
+    )
+
+    assert execution is not None
+    assert execution.acquisition.outcome is AttemptClaimAcquireOutcome.RECOVERED
+    assert execution.decision.action is AttemptRecoveryAction.RECONCILE
+    assert execution.claim.status is AttemptClaimStatus.SETTLED
+    assert execution.claim.contract_version == 8
+    assert execution.outcome["finalization_phase"] == FinalizationPhase.INDEXED.value
+    assert "worktree_archive_ref" not in execution.outcome
+    assert execution.updated_row["evidence__worktree_archive_ref"] == ""
+    assert runner.run_calls == 1
+    assert finalizer.prepare_calls == 1
+    assert finalizer.publish_calls == 1
     await cold_catalog.close()
 
 

--- a/tests/app/test_mission_transition_authority.py
+++ b/tests/app/test_mission_transition_authority.py
@@ -120,6 +120,7 @@ def _outcome(
         "git_status_ref": "fake://status",
         "git_patch_ref": "fake://patch",
         "git_bundle_ref": "fake://bundle",
+        "worktree_archive_ref": "fake://full-worktree",
         "context_ref": "fake://context",
         "friction": [{"kind": "note", "message": "fixture"}],
         "sha": "abc123" if accepted else "",

--- a/tests/app/test_sandbox_kernel.py
+++ b/tests/app/test_sandbox_kernel.py
@@ -417,6 +417,7 @@ async def test_attempt_runs_six_phases_and_returns_checkpoint_qualified_handoff(
         "step_index": 0,
     }
     assert outcome["git_bundle_ref"].startswith("fake-checkpoint://checkpoint-1#")
+    assert outcome["worktree_archive_ref"].startswith("fake-checkpoint://checkpoint-1#")
     assert outcome["live_events_ref"].startswith("fake-sandbox://sandbox-1/")
     assert any(path.endswith(".json") for path in client.files)
     initial_mkdir = next(call[0] for call in client.commands if call[0][:2] == ("mkdir", "-p"))
@@ -722,6 +723,7 @@ async def test_checkpoint_failure_is_evidence_not_lost_attempt() -> None:
     assert outcome["finalization_phase"] == "captured"
     assert "snapshot unavailable" in outcome["finalization_error"]
     assert outcome["git_bundle_ref"].startswith("fake-sandbox://sandbox-1/")
+    assert outcome["worktree_archive_ref"].startswith("fake-sandbox://sandbox-1/")
     assert outcome["friction"][-1]["finding"] == "Provider checkpoint failed"
 
 

--- a/tests/app/test_worktree_archive.py
+++ b/tests/app/test_worktree_archive.py
@@ -1,0 +1,270 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import stat
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from archetype.app.artifacts.worktree_archive import (
+    WORKTREE_ARCHIVE_FORMAT,
+    WorktreeArchiveError,
+    capture_worktree_archive,
+    restore_worktree_archive,
+    sanitize_worktree_archive,
+)
+from archetype.app.redaction import RedactionService, SecretQuarantineError
+
+pytestmark = pytest.mark.contract("artifacts.worktree_archive.portable")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, dict[str, Path]]:
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    (worktree / ".git").mkdir()
+    (worktree / ".git" / "config").write_text("provider internals")
+    (worktree / ".gitignore").write_text("ignored.log\n")
+    (worktree / "tracked.py").write_text("print('tracked')\n")
+    (worktree / "untracked.txt").write_text("untracked\n")
+    (worktree / "ignored.log").write_text("ignored but recoverable\n")
+    (worktree / ".context").mkdir()
+    (worktree / ".context" / "notes.md").write_text("review notes\n")
+    (worktree / "locked").mkdir()
+    (worktree / "locked" / "inside.txt").write_text("mode preserved\n")
+    (worktree / "locked").chmod(0o555)
+    recovery = tmp_path / "recovery"
+    recovery.mkdir()
+    files = {
+        "git-status.txt": recovery / "status.txt",
+        "worktree.patch": recovery / "worktree.patch",
+        "repository.bundle": recovery / "repository.bundle",
+    }
+    for name, path in files.items():
+        path.write_text(f"{name}\n")
+    return worktree, files
+
+
+def test_worktree_archive_is_deterministic_sanitized_and_restorable(tmp_path: Path) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    raw_a = tmp_path / "raw-a.tar"
+    raw_b = tmp_path / "raw-b.tar"
+    capture_worktree_archive(
+        worktree,
+        raw_a,
+        baseline_sha="a" * 40,
+        head_sha="b" * 40,
+        recovery_files=recovery,
+    )
+    capture_worktree_archive(
+        worktree,
+        raw_b,
+        baseline_sha="a" * 40,
+        head_sha="b" * 40,
+        recovery_files=recovery,
+    )
+    assert raw_a.read_bytes() == raw_b.read_bytes()
+
+    redaction = RedactionService()
+    sanitized = tmp_path / "sanitized.tar"
+    result = sanitize_worktree_archive(
+        raw_a,
+        sanitized,
+        logical_path="recovery/worktree.tar",
+        redaction_service=redaction,
+    )
+    restored = tmp_path / "restored"
+    manifest = restore_worktree_archive(
+        sanitized,
+        restored,
+        expected_content_hash=_sha256(sanitized),
+    )
+
+    assert result.receipt.status == "clean"
+    assert manifest["archive_format"] == WORKTREE_ARCHIVE_FORMAT
+    assert manifest["redaction_policy_id"] == redaction.policy_id
+    assert manifest["baseline_sha"] == "a" * 40
+    assert manifest["head_sha"] == "b" * 40
+    assert (restored / "worktree/tracked.py").read_text() == "print('tracked')\n"
+    assert (restored / "worktree/untracked.txt").read_text() == "untracked\n"
+    assert (restored / "worktree/ignored.log").read_text() == "ignored but recoverable\n"
+    assert (restored / "worktree/.context/notes.md").read_text() == "review notes\n"
+    assert (restored / "worktree/locked/inside.txt").read_text() == "mode preserved\n"
+    assert stat.S_IMODE((restored / "worktree/locked").stat().st_mode) == 0o555
+    assert (restored / "recovery/repository.bundle").read_text() == "repository.bundle\n"
+    assert not (restored / "worktree/.git").exists()
+    assert {item["reason"] for item in manifest["exclusions"]} >= {"git-internals"}
+
+
+def test_worktree_archive_redacts_text_and_excludes_credentials(tmp_path: Path) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    secret = "sk-proj-" + "x" * 30
+    (worktree / "normal.txt").write_text(f"api_key={secret}\n")
+    (worktree / ".env").write_text(f"TOKEN={secret}\n")
+    raw = tmp_path / "raw.tar"
+    capture_worktree_archive(
+        worktree,
+        raw,
+        baseline_sha="a" * 40,
+        head_sha="b" * 40,
+        recovery_files=recovery,
+    )
+    sanitized = tmp_path / "sanitized.tar"
+    result = sanitize_worktree_archive(
+        raw,
+        sanitized,
+        logical_path="recovery/worktree.tar",
+        redaction_service=RedactionService(),
+    )
+    restored = tmp_path / "restored"
+    manifest = restore_worktree_archive(sanitized, restored)
+
+    assert result.receipt.status == "redacted"
+    assert secret not in (restored / "worktree/normal.txt").read_text()
+    assert "<redacted:" in (restored / "worktree/normal.txt").read_text()
+    assert not (restored / "worktree/.env").exists()
+    assert {item["path"]: item["reason"] for item in manifest["exclusions"]}[".env"] == (
+        "credential-path"
+    )
+
+
+@pytest.mark.parametrize("unsafe", ["symlink", "hardlink"])
+def test_worktree_archive_rejects_link_ambiguity(tmp_path: Path, unsafe: str) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    target = worktree / "tracked.py"
+    if unsafe == "symlink":
+        (worktree / "unsafe").symlink_to(target)
+    else:
+        os.link(target, worktree / "unsafe")
+    with pytest.raises(WorktreeArchiveError, match="links|linked"):
+        capture_worktree_archive(
+            worktree,
+            tmp_path / "raw.tar",
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+            recovery_files=recovery,
+        )
+
+
+def test_worktree_archive_rejects_special_files(tmp_path: Path) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    os.mkfifo(worktree / "named-pipe")
+    with pytest.raises(WorktreeArchiveError, match="special files"):
+        capture_worktree_archive(
+            worktree,
+            tmp_path / "raw.tar",
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+            recovery_files=recovery,
+        )
+
+
+def test_worktree_archive_rejects_path_race(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    from archetype.app.artifacts import worktree_archive as archive_module
+
+    real_copy = archive_module._copy_stable_file
+    raced = False
+
+    def mutate_then_copy(source: Path, destination: Path, expected: object) -> None:
+        nonlocal raced
+        if not raced and source.name == "tracked.py":
+            raced = True
+            source.write_text("changed after inventory\n")
+        real_copy(source, destination, expected)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(archive_module, "_copy_stable_file", mutate_then_copy)
+    with pytest.raises(WorktreeArchiveError, match="changed"):
+        capture_worktree_archive(
+            worktree,
+            tmp_path / "raw.tar",
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+            recovery_files=recovery,
+        )
+
+
+def test_worktree_archive_rejects_output_inside_approved_tree(tmp_path: Path) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    with pytest.raises(WorktreeArchiveError, match="output must be outside"):
+        capture_worktree_archive(
+            worktree,
+            worktree / "archive.tar",
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+            recovery_files=recovery,
+        )
+
+
+def test_worktree_archive_restore_rejects_unsafe_member(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.tar"
+    manifest = json.dumps(
+        {
+            "archive_format": "archetype-worktree-tar-v1",
+            "baseline_sha": "a" * 40,
+            "entries": [],
+            "exclusions": [],
+            "head_sha": "b" * 40,
+            "redaction": {"status": "clean"},
+            "redaction_policy_id": "test-policy",
+            "schema_version": 1,
+        },
+        sort_keys=True,
+    ).encode()
+    with tarfile.open(archive, "w") as output:
+        info = tarfile.TarInfo("archive-manifest.json")
+        info.size = len(manifest)
+        output.addfile(info, io.BytesIO(manifest))
+        info = tarfile.TarInfo("../escape")
+        info.size = 1
+        output.addfile(info, io.BytesIO(b"x"))
+    with pytest.raises(WorktreeArchiveError, match="members|unsafe"):
+        restore_worktree_archive(archive, tmp_path / "restore")
+
+
+def test_worktree_archive_restore_rejects_raw_unapproved_capture(tmp_path: Path) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    raw = tmp_path / "raw.tar"
+    capture_worktree_archive(
+        worktree,
+        raw,
+        baseline_sha="a" * 40,
+        head_sha="b" * 40,
+        recovery_files=recovery,
+    )
+    with pytest.raises(WorktreeArchiveError, match="not redaction-approved"):
+        restore_worktree_archive(raw, tmp_path / "restore")
+
+
+def test_worktree_archive_quarantines_nested_container(tmp_path: Path) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    nested = worktree / "nested.tar"
+    with tarfile.open(nested, "w"):
+        pass
+    raw = tmp_path / "raw.tar"
+    capture_worktree_archive(
+        worktree,
+        raw,
+        baseline_sha="a" * 40,
+        head_sha="b" * 40,
+        recovery_files=recovery,
+    )
+    with pytest.raises(SecretQuarantineError, match="nested-archive-unsupported"):
+        sanitize_worktree_archive(
+            raw,
+            tmp_path / "sanitized.tar",
+            logical_path="recovery/worktree.tar",
+            redaction_service=RedactionService(),
+        )

--- a/tests/app/test_worktree_archive.py
+++ b/tests/app/test_worktree_archive.py
@@ -29,6 +29,58 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _valid_manifest(*, entries: list[object] | None = None) -> dict[str, object]:
+    return {
+        "archive_format": WORKTREE_ARCHIVE_FORMAT,
+        "baseline_sha": "a" * 40,
+        "entries": [] if entries is None else entries,
+        "exclusions": [],
+        "head_sha": "b" * 40,
+        "redaction": {"status": "clean"},
+        "redaction_policy_id": "test-policy",
+        "schema_version": 1,
+    }
+
+
+def _file_entry(
+    path: str = "worktree/file.txt",
+    *,
+    size: int = 0,
+    digest: str | None = None,
+) -> dict[str, object]:
+    return {
+        "path": path,
+        "type": "file",
+        "mode": 0o600,
+        "size_bytes": size,
+        "sha256": hashlib.sha256(b"").hexdigest() if digest is None else digest,
+    }
+
+
+def _directory_entry(path: str = "worktree/directory") -> dict[str, object]:
+    return {
+        "path": path,
+        "type": "directory",
+        "mode": 0o700,
+        "size_bytes": 0,
+        "sha256": "",
+    }
+
+
+def _write_manifest_archive(
+    path: Path,
+    manifest: object,
+    *members: tuple[tarfile.TarInfo, bytes | None],
+) -> None:
+    payload = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(path, "w") as output:
+        info = tarfile.TarInfo("archive-manifest.json")
+        info.size = len(payload)
+        output.addfile(info, io.BytesIO(payload))
+        for member, content in members:
+            output.addfile(member, None if content is None else io.BytesIO(content))
+
+
 def _fixture(tmp_path: Path) -> tuple[Path, dict[str, Path]]:
     worktree = tmp_path / "repo"
     worktree.mkdir()
@@ -268,3 +320,250 @@ def test_worktree_archive_quarantines_nested_container(tmp_path: Path) -> None:
             logical_path="recovery/worktree.tar",
             redaction_service=RedactionService(),
         )
+
+
+def test_worktree_archive_records_provider_and_cache_exclusions(tmp_path: Path) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    (worktree / ".archetype-agent").mkdir()
+    (worktree / ".archetype-agent" / "private.txt").write_text("provider state\n")
+    (worktree / "__pycache__").mkdir()
+    (worktree / "__pycache__" / "cached.pyc").write_bytes(b"cache")
+
+    result = capture_worktree_archive(
+        worktree,
+        tmp_path / "raw.tar",
+        baseline_sha="a" * 40,
+        head_sha="b" * 40,
+        recovery_files=recovery,
+    )
+
+    assert {item["reason"] for item in result.manifest["exclusions"]} >= {
+        "provider-internals",
+        "cache",
+    }
+
+
+def test_worktree_archive_requires_a_directory_source(tmp_path: Path) -> None:
+    source = tmp_path / "not-a-directory"
+    source.write_text("plain file\n")
+
+    with pytest.raises(NotADirectoryError):
+        capture_worktree_archive(
+            source,
+            tmp_path / "raw.tar",
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+        )
+
+
+def test_worktree_archive_rejects_linked_recovery_material(tmp_path: Path) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    linked = tmp_path / "linked-status"
+    linked.symlink_to(recovery["git-status.txt"])
+
+    with pytest.raises(WorktreeArchiveError, match="regular file"):
+        capture_worktree_archive(
+            worktree,
+            tmp_path / "raw.tar",
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+            recovery_files={"git-status.txt": linked},
+        )
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("schema", "schema"),
+        ("format", "format"),
+        ("identity-type", "Git identities"),
+        ("collections", "collections"),
+        ("policy", "policy"),
+        ("identity-value", "Git identities"),
+        ("entry", "entry is invalid"),
+        ("entry-type", "entry type"),
+        ("mode", "entry mode"),
+        ("size", "entry size"),
+        ("directory-integrity", "directory integrity"),
+        ("digest", "file digest"),
+    ],
+)
+def test_worktree_archive_rejects_invalid_manifest_headers(
+    tmp_path: Path,
+    case: str,
+    message: str,
+) -> None:
+    manifest = _valid_manifest()
+    if case == "schema":
+        manifest["schema_version"] = 2
+    elif case == "format":
+        manifest["archive_format"] = "unknown"
+    elif case == "identity-type":
+        manifest["baseline_sha"] = None
+    elif case == "collections":
+        manifest["exclusions"] = None
+    elif case == "policy":
+        manifest["redaction_policy_id"] = None
+    elif case == "identity-value":
+        manifest["head_sha"] = "not-a-sha"
+    elif case == "entry":
+        manifest["entries"] = [None]
+    else:
+        entry = _file_entry()
+        manifest["entries"] = [entry]
+        if case == "entry-type":
+            entry["type"] = "link"
+        elif case == "mode":
+            entry["mode"] = None
+        elif case == "size":
+            entry["size_bytes"] = -1
+        elif case == "directory-integrity":
+            entry.update(type="directory", size_bytes=1, sha256="")
+        elif case == "digest":
+            entry["sha256"] = "invalid"
+    archive = tmp_path / f"{case}.tar"
+    _write_manifest_archive(archive, manifest)
+
+    with pytest.raises(WorktreeArchiveError, match=message):
+        restore_worktree_archive(archive, tmp_path / f"restore-{case}")
+
+
+def test_worktree_archive_rejects_non_object_manifest(tmp_path: Path) -> None:
+    archive = tmp_path / "non-object.tar"
+    _write_manifest_archive(archive, [])
+
+    with pytest.raises(WorktreeArchiveError, match="manifest must be an object"):
+        restore_worktree_archive(archive, tmp_path / "restore")
+
+
+def test_worktree_archive_rejects_duplicate_manifest_paths(tmp_path: Path) -> None:
+    archive = tmp_path / "duplicate.tar"
+    entry = _directory_entry()
+    _write_manifest_archive(archive, _valid_manifest(entries=[entry, dict(entry)]))
+
+    with pytest.raises(WorktreeArchiveError, match="paths must be unique"):
+        restore_worktree_archive(archive, tmp_path / "restore")
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("unexpected", "members do not match"),
+        ("directory-metadata", "directory metadata"),
+        ("link", "rejects links"),
+        ("size", "member size"),
+        ("digest", "content validation"),
+        ("missing", "missing manifest members"),
+    ],
+)
+def test_worktree_archive_rejects_tampered_members(
+    tmp_path: Path,
+    case: str,
+    message: str,
+) -> None:
+    archive = tmp_path / f"tampered-{case}.tar"
+    member = tarfile.TarInfo("worktree/file.txt")
+    content: bytes | None = b""
+    if case == "unexpected":
+        manifest = _valid_manifest()
+    elif case == "directory-metadata":
+        manifest = _valid_manifest(entries=[_file_entry()])
+        member.type = tarfile.DIRTYPE
+        content = None
+    elif case == "link":
+        manifest = _valid_manifest(entries=[_file_entry()])
+        member.type = tarfile.SYMTYPE
+        member.linkname = "target"
+        content = None
+    elif case == "size":
+        manifest = _valid_manifest(entries=[_file_entry()])
+        member.size = 1
+        content = b"x"
+    elif case == "digest":
+        manifest = _valid_manifest(entries=[_file_entry(size=1, digest="0" * 64)])
+        member.size = 1
+        content = b"x"
+    else:
+        manifest = _valid_manifest(entries=[_directory_entry()])
+        _write_manifest_archive(archive, manifest)
+        with pytest.raises(WorktreeArchiveError, match=message):
+            restore_worktree_archive(archive, tmp_path / f"restore-{case}")
+        return
+    _write_manifest_archive(archive, manifest, (member, content))
+
+    with pytest.raises(WorktreeArchiveError, match=message):
+        restore_worktree_archive(archive, tmp_path / f"restore-{case}")
+
+
+def test_worktree_archive_rejects_unreadable_tar(tmp_path: Path) -> None:
+    archive = tmp_path / "unreadable.tar"
+    archive.write_bytes(b"not a tar archive")
+
+    with pytest.raises(WorktreeArchiveError, match="incomplete or unreadable"):
+        restore_worktree_archive(archive, tmp_path / "restore")
+
+
+def test_worktree_archive_sanitizer_quarantines_unsupported_source(tmp_path: Path) -> None:
+    source = tmp_path / "source-directory"
+    source.mkdir()
+
+    with pytest.raises(SecretQuarantineError, match="unsupported-source-file"):
+        sanitize_worktree_archive(
+            source,
+            tmp_path / "sanitized.tar",
+            logical_path="recovery/worktree.tar",
+            redaction_service=RedactionService(),
+        )
+
+
+def test_worktree_archive_sanitizer_quarantines_source_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from archetype.app.artifacts import worktree_archive as archive_module
+
+    source = tmp_path / "raw.tar"
+    source.write_bytes(b"raw")
+
+    def fail_copy(source: Path, destination: Path, expected: object) -> None:
+        raise WorktreeArchiveError("changed")
+
+    monkeypatch.setattr(archive_module, "_copy_stable_file", fail_copy)
+    with pytest.raises(SecretQuarantineError, match="source-file-race"):
+        sanitize_worktree_archive(
+            source,
+            tmp_path / "sanitized.tar",
+            logical_path="recovery/worktree.tar",
+            redaction_service=RedactionService(),
+        )
+
+
+def test_worktree_archive_sanitizer_quarantines_invalid_archive(tmp_path: Path) -> None:
+    source = tmp_path / "raw.tar"
+    source.write_bytes(b"not a tar archive")
+
+    with pytest.raises(SecretQuarantineError, match="worktree-archive-invalid"):
+        sanitize_worktree_archive(
+            source,
+            tmp_path / "sanitized.tar",
+            logical_path="recovery/worktree.tar",
+            redaction_service=RedactionService(),
+        )
+
+
+def test_worktree_archive_restore_checks_indexed_hash_and_clean_target(tmp_path: Path) -> None:
+    archive = tmp_path / "raw.tar"
+    archive.write_bytes(b"archive bytes")
+
+    with pytest.raises(WorktreeArchiveError, match="content hash"):
+        restore_worktree_archive(
+            archive,
+            tmp_path / "hash-restore",
+            expected_content_hash="0" * 64,
+        )
+
+    dirty = tmp_path / "dirty-restore"
+    dirty.mkdir()
+    (dirty / "existing.txt").write_text("existing\n")
+    with pytest.raises(WorktreeArchiveError, match="clean directory"):
+        restore_worktree_archive(archive, dirty)

--- a/tests/app/test_worktree_archive.py
+++ b/tests/app/test_worktree_archive.py
@@ -221,6 +221,22 @@ def test_worktree_archive_rejects_special_files(tmp_path: Path) -> None:
         )
 
 
+def test_worktree_archive_rejects_backslash_filename_instead_of_rewriting_it(
+    tmp_path: Path,
+) -> None:
+    worktree, recovery = _fixture(tmp_path)
+    (worktree / "folder\\file.txt").write_text("must remain one path component\n")
+
+    with pytest.raises(WorktreeArchiveError, match="unsafe path"):
+        capture_worktree_archive(
+            worktree,
+            tmp_path / "raw.tar",
+            baseline_sha="a" * 40,
+            head_sha="b" * 40,
+            recovery_files=recovery,
+        )
+
+
 def test_worktree_archive_rejects_path_race(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -549,6 +565,47 @@ def test_worktree_archive_sanitizer_quarantines_invalid_archive(tmp_path: Path) 
             logical_path="recovery/worktree.tar",
             redaction_service=RedactionService(),
         )
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "outside/file.txt",
+        "worktree/.git/config",
+        "worktree/.archetype-agent/provider-state.json",
+        "worktree/__pycache__/cached.pyc",
+        "worktree/.env",
+    ],
+)
+def test_worktree_archive_sanitizer_reapplies_capture_policy(
+    tmp_path: Path,
+    member_name: str,
+) -> None:
+    content = b"tampered raw capture\n"
+    member = tarfile.TarInfo(member_name)
+    member.size = len(content)
+    source = tmp_path / "raw.tar"
+    manifest = _valid_manifest(
+        entries=[
+            _file_entry(
+                member_name,
+                size=len(content),
+                digest=hashlib.sha256(content).hexdigest(),
+            )
+        ]
+    )
+    _write_manifest_archive(source, manifest, (member, content))
+    destination = tmp_path / "sanitized.tar"
+
+    with pytest.raises(SecretQuarantineError, match="worktree-archive-policy"):
+        sanitize_worktree_archive(
+            source,
+            destination,
+            logical_path="recovery/worktree.tar",
+            redaction_service=RedactionService(),
+        )
+
+    assert not destination.exists()
 
 
 def test_worktree_archive_restore_checks_indexed_hash_and_clean_target(tmp_path: Path) -> None:

--- a/tests/missions/test_domain_contracts.py
+++ b/tests/missions/test_domain_contracts.py
@@ -66,8 +66,8 @@ _COMPONENT_SCHEMA_FINGERPRINTS = {
         "256c0114555bcca6946672dc6f13d53e40a269725973be48bfe0d34af8913db9",
     ),
     "Evidence": (
-        "28f43c8dfce6be622bb3c4ba5cd1290a2e37b0d0e14f69612b9f02c4c4440b6a",
-        "927a2cacf9b114d191d398b5bea0f2ed4359e3266e374cc0d879d8b456cffdb2",
+        "fb83ecc02c9eac7b6a28a5ca154d67ebc162c35f98af6e43aa60a5255f6b514b",
+        "0f77b643f5e3f34b9998ce03ee0fe605d823a36c5941fe0e80d231ae6830d4c3",
     ),
     "FrictionLog": (
         "5f4e6c3260ff26412db2c2b3161e705e0e8e9f36293b4790c27132c41d8395d6",

--- a/tests/scripts/test_check_observability.py
+++ b/tests/scripts/test_check_observability.py
@@ -1787,5 +1787,5 @@ def test_repository_observability_policy_passes_for_all_protocol_operations() ->
     )
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert "264 operations" in completed.stdout
+    assert "261 operations" in completed.stdout
     assert "Observability audit passed" in completed.stdout

--- a/tests/scripts/test_check_observability.py
+++ b/tests/scripts/test_check_observability.py
@@ -1787,5 +1787,5 @@ def test_repository_observability_policy_passes_for_all_protocol_operations() ->
     )
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert "259 operations" in completed.stdout
+    assert "264 operations" in completed.stdout
     assert "Observability audit passed" in completed.stdout


### PR DESCRIPTION
Closes #505

## Summary

- capture the complete sandbox worktree, including ignored, untracked, and `.context` state, in a deterministic portable archive
- preserve Git recovery material while excluding repository internals, provider state, caches, credentials, links, special files, nested filesystems, and unsafe path races
- sanitize and rebuild the archive through the shared redaction service before publication, with manifest hashes, exclusions, quarantine receipts, and an approved restoration path
- publish the archive as required mission evidence at `recovery/full-worktree.tar`
- retain replay compatibility for durable v7/v8 attempt outcomes while making the archive reference mandatory for current v9 claims

## Trust-boundary hardening

- the sanitizer independently enforces the `worktree/` and `recovery/` namespaces plus every capture exclusion, including excluded ancestor directories
- portable path validation rejects backslashes instead of rewriting legal POSIX filenames into different restored paths
- pre-existing durable outcomes without `worktree_archive_ref` remain readable and project an empty reference; new writes still fail closed when the field is absent
- v8 claims interrupted after provider acknowledgement can reconcile their pre-deploy cached outcome through claim-version-aware assessment, projection, and indexed artifact preparation

## Why

Provider checkpoints can expire, while the existing patch, Git bundle, and declared-output evidence do not preserve the full final worktree. That left ignored files, untracked files, and `.context` state without a portable, independently restorable recovery artifact.

## Impact

Successful mission finalization now requires a sanitized full-worktree archive. Restore verifies approval, the indexed artifact hash, exact member inventory, and per-file content hashes before writing into a clean destination.

## Validation

- local full suite: 2,006 passed, 1 skipped; the sole initial failure was the updated observability operation-count snapshot, whose focused rerun passed
- post-rebase mission claim, artifact-finalization, transition, and service-protocol contracts: 151 passed after the final review fix
- post-rebase `make static` and `git diff --check` passed
- prior exact-head Quality matrix: Python 3.12 and 3.13 passed with 86.4% total coverage
- evals: regression 15/15, spec 8/8, idempotency 23/23, capability 10/10
- static, type, lock, architecture, redaction, contract, traceability, docs, examples, R2, package smoke, and CodeQL gates passed on the prior reviewed head
- Codecov patch: 91.68% (passing)
- all four actionable review threads replied to and resolved with regressions
- exact-head GitHub gates: pending for `40caf233`
