### PR TITLE
fix(observability): isolate Daft native OTLP providers

### DIFF
--- a/docs/guide/api-layer.md
+++ b/docs/guide/api-layer.md
@@ -26,7 +26,11 @@ Imports and `create_app()` perform no logging or telemetry setup. Each worker
 configures its host from the lifespan path, which keeps reload and multi-worker
 startup explicit and idempotent. The factory does not automatically invoke
 Logfire FastAPI instrumentation; optional Logfire or OTLP export is selected
-through the vendor-neutral host adapter.
+through the vendor-neutral host adapter. The package bootstrap does route
+generic OTLP environment configuration away from Daft's independent native
+log/trace providers before route imports; that isolation installs no provider
+and remains effective for later workers that inherit the server host's
+environment.
 
 All worlds live in the server event loop. CLI invocations and remote clients talk to that process over HTTP.
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -142,6 +142,17 @@ runtime/server startup:
   export. Foreign fields, links, trace state, and status descriptions are
   discarded.
 
+Archetype-owned HTTP exporters suppress dependency exception tracebacks and
+collector response bodies, replacing a failed export with one fixed diagnostic.
+OTLP endpoint URLs are routing configuration, not a credential transport: only
+absolute `http` or `https` URLs without user information, a query, or a fragment
+are accepted. Authentication belongs in the operator-owned OTLP header settings.
+Rejected endpoint values are removed and are never copied into a diagnostic.
+Endpoint hosts and paths remain non-secret routing data; a host that enables
+root-level HTTP dependency debug logs may observe them. Valid standard sampling
+configuration remains host-owned; malformed SDK configuration is prevented from
+echoing its raw value while the dependency falls back to its documented default.
+
 Daft 0.7.19 owns separate Rust providers initialized when its compiled module
 is imported. Standard generic OTLP environment variables are broadcast
 configuration, not evidence that those dependency providers passed
@@ -164,11 +175,17 @@ requested, arbitrary `OTEL_RESOURCE_ATTRIBUTES` and `OTEL_SERVICE_NAME` values
 are removed before Daft import; Daft uses its fixed default service identity.
 Daft metrics are enabled only for versions named in the fresh-process
 compatibility matrix (currently exactly 0.7.19), and accept only `grpc` or
-`http/protobuf`; an unvalidated version, empty/malformed endpoint, or another
-protocol is ignored so telemetry configuration cannot make application import
-fail. The next explicit host configuration emits a fixed diagnostic without
-the rejected value. Transport headers remain operator-owned exporter
-configuration and are never copied into Archetype signal attributes.
+`http/protobuf`, spelled exactly as Daft parses them; an unvalidated version,
+empty/malformed endpoint, or another protocol is removed so telemetry
+configuration cannot make application import fail. The next explicit host
+configuration emits a fixed diagnostic without the rejected value. Transport
+headers remain operator-owned exporter configuration and are never copied into
+Archetype signal attributes. Native Daft metrics are uncompressed because the
+0.7.19 wheel does not compile the Rust compression features: generic and
+metrics-specific compression settings are removed whenever that endpoint is
+enabled. A configured export interval must be a positive unsigned 64-bit
+millisecond value; zero and malformed values are removed before they can create
+an invalid or busy-spinning native reader.
 
 This bootstrap installs no provider and preserves lazy package imports. It can
 protect only an Archetype-owned host: importing Daft first under a generic,

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -142,6 +142,46 @@ runtime/server startup:
   export. Foreign fields, links, trace state, and status descriptions are
   discarded.
 
+Daft 0.7.19 owns separate Rust providers initialized when its compiled module
+is imported. Standard generic OTLP environment variables are broadcast
+configuration, not evidence that those dependency providers passed
+Archetype's safe-signal boundary. Before any Archetype submodule can import
+Daft, the package host therefore applies this signal-routing contract:
+
+| Host setting | Owner and behavior |
+|---|---|
+| `ARCHETYPE_OTLP_TRACES_ENDPOINT` | Full HTTP/protobuf traces endpoint consumed only by Archetype's filtered exporter. This is the preferred explicit setting. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Compatibility input consumed once, converted to its `/v1/traces` endpoint, and removed from the process and inherited worker environment. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Compatibility input consumed as Archetype's full traces endpoint and then removed. |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | The only supported Daft-native opt-in. It exports physical engine metrics directly through Daft and is never re-emitted as Archetype metrics. |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` or `DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT` | Unsupported content-bearing dependency routes; removed before Daft initialization. |
+
+The consumed generic/log/trace variables are not restored: a later local,
+spawned, or distributed Daft worker that inherits this host environment must
+not recreate the unsafe providers. Externally managed workers require the same
+endpoint policy in their own launch environment. When native metrics are
+requested, arbitrary `OTEL_RESOURCE_ATTRIBUTES` and `OTEL_SERVICE_NAME` values
+are removed before Daft import; Daft uses its fixed default service identity.
+Daft metrics are enabled only for versions named in the fresh-process
+compatibility matrix (currently exactly 0.7.19), and accept only `grpc` or
+`http/protobuf`; an unvalidated version, empty/malformed endpoint, or another
+protocol is ignored so telemetry configuration cannot make application import
+fail. The next explicit host configuration emits a fixed diagnostic without
+the rejected value. Transport headers remain operator-owned exporter
+configuration and are never copied into Archetype signal attributes.
+
+This bootstrap installs no provider and preserves lazy package imports. It can
+protect only an Archetype-owned host: importing Daft first under a generic,
+logs, or traces endpoint initializes native providers before Archetype code can
+run, and Daft 0.7.19 exposes no shutdown or reconfiguration API for them. Such
+hosts must install an external provider before importing Archetype or use the
+Archetype-specific traces endpoint, and must expose only the metrics-specific
+endpoint to Daft. A fixed diagnostic reports a detectable late ordering, but
+only when the explicit host adapter next runs; telemetry never aborts or changes
+application work. Endpoint settings are process-start configuration: mutating
+standard OTLP endpoint variables after the first Archetype import and then
+importing Daft directly is unsupported.
+
 The SDK bundled for the explicit debug-console host path is not permission for
 family imports. Optional OTLP and Logfire integrations remain host concerns.
 `RunConfig.debug` controls execution diagnostics and is not a telemetry-export
@@ -298,10 +338,10 @@ explicitly separate or use only a safe, evidence-backed correlation mechanism;
 the system never fabricates ancestry.
 
 Generic process-wide OTLP configuration is not sufficient authorization to
-export dependency-owned telemetry. #537 owns a safe, host-controlled Daft
-integration that prevents native logs, exception text, tracebacks, UDF
-arguments, payloads, or secrets from bypassing Archetype's signal policy. #444
-preserves typed processor failures at the logical boundary. With those
-prerequisites, #519 replaces the legacy world phases with the truthful tick and
-commit envelope described here while consuming, rather than duplicating,
-Daft's physical execution telemetry.
+export dependency-owned telemetry. The host routing in section 5 prevents
+native logs, exception text, tracebacks, UDF arguments, payloads, or secrets
+from bypassing Archetype's signal policy while preserving explicit Daft
+metrics. #444 preserves typed processor failures at the logical boundary. With
+those prerequisites, #519 replaces the legacy world phases with the truthful
+tick and commit envelope described here while consuming, rather than
+duplicating, Daft's physical execution telemetry.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -73,7 +73,7 @@ The current canonical span vocabulary is:
 - the existing bounded `world.query` and `world.update` scopes, without an
   execution-attribution claim; and
 - the legacy `world.materialize` and `world.execute` phases listed in section 7
-  pending measured attribution.
+  pending replacement by the logical/physical ownership model in #519.
 
 Gateway source uses only the canonical `gateway.*` names. The former
 `gate.create_world` and `gate.get_world_info` spellings are neither accepted
@@ -195,7 +195,7 @@ signal boundary.
 | Gateway | Child spans for the three currently decorated operations; #515 owns a coherent ingress-root design | RBAC decision, typed application result, and access-audit evidence |
 | RuntimeApplication | No direct signal yet; lower owning family remains visible | Typed family result/exception |
 | Commands | No direct signal yet | Durable command ledger and settlement |
-| World lifecycle, mutation, simulation | Existing query/update scopes without execution-attribution claims; materialize/execute names are legacy pending #518/#519 | Tick manifest, world record, and typed result/exception |
+| World lifecycle, mutation, simulation | Existing query/update scopes without execution-attribution claims; materialize/execute names are legacy planning scopes pending #519 | Tick manifest, world record, and typed result/exception |
 | Storage and query | No direct signal yet | Store/catalog state and returned frame |
 | Redaction | No direct signal; safe rule IDs may be carried by approved callers | Redaction receipt or quarantine exception |
 | Artifacts | Child spans for publish, upload, and index | Publication row, object/index state, and publish receipt |
@@ -261,15 +261,47 @@ cannot prove, including values smuggled under an approved key and telemetry
 used as application authority. Focused behavior contracts still prove typed
 failure identity, retry behavior, and durable evidence.
 
-## 7. Lazy execution honesty
+## 7. Lazy planning and execution ownership
 
 `world.materialize` and `world.execute` are retained legacy names, not claims
 that Daft work was materialized or executed inside those spans. Processor
-methods commonly build lazy expressions whose work runs at a later terminal
-boundary. Telemetry must not add `.collect()`, `.to_pylist()`, or any other
-materialization to manufacture a duration.
+methods build a lazy DataFrame plan. Building that plan is normally cheap and
+does not perform the physical work it describes; the same plan may execute
+later at a terminal boundary or in a distributed execution environment.
+Telemetry must not add any materialization or execution boundary to manufacture
+a duration.
 
-Issue #518 must characterize Daft execution attribution and worker context with the
-locked version and supported runner. #519 then replaces or redefines these
-world phases from that evidence. Until then, no processor planning duration may
-be described as processor execution duration.
+Archetype and Daft therefore own different parts of the trace:
+
+- Archetype owns the logical and durable workflow envelope: tick attempt,
+  mutation composition, terminal invocation, persistence, visibility
+  publication, command settlement, and typed outcome.
+- Daft owns physical execution telemetry for plans, stages, operators, tasks,
+  UDF execution, workers, and engine resource use through its native OTel
+  surface.
+- The process host owns the explicit bridge between those surfaces, including
+  provider and exporter configuration, signal selection, safe routing, and
+  whatever correlation the locked Daft version and runner can truthfully
+  preserve.
+
+An Archetype span may measure the wall-clock workflow phase that invokes an
+already-owned terminal boundary. It must not infer physical processor, stage,
+or worker execution from Python planning calls. Engine-level attribution comes
+from Daft or remains unavailable.
+
+The #518 characterization established that processor calls and physical plan
+nodes are not one-to-one and that application OTel context does not reliably
+propagate into Daft workers. A unified parent-child trace is therefore not a
+contract unless a focused integration test proves it for the locked Daft
+version and supported runner. Otherwise Archetype and Daft telemetry remain
+explicitly separate or use only a safe, evidence-backed correlation mechanism;
+the system never fabricates ancestry.
+
+Generic process-wide OTLP configuration is not sufficient authorization to
+export dependency-owned telemetry. #537 owns a safe, host-controlled Daft
+integration that prevents native logs, exception text, tracebacks, UDF
+arguments, payloads, or secrets from bypassing Archetype's signal policy. #444
+preserves typed processor failures at the logical boundary. With those
+prerequisites, #519 replaces the legacy world phases with the truthful tick and
+commit envelope described here while consuming, rather than duplicating,
+Daft's physical execution telemetry.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -162,22 +162,29 @@ Daft, the package host therefore applies this signal-routing contract:
 | Host setting | Owner and behavior |
 |---|---|
 | `ARCHETYPE_OTLP_TRACES_ENDPOINT` | Full HTTP/protobuf traces endpoint consumed only by Archetype's filtered exporter. This is the preferred explicit setting. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Compatibility input consumed once, converted to its `/v1/traces` endpoint, and removed from the process and inherited worker environment. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Compatibility input converted to its `/v1/traces` endpoint and removed from the process and inherited worker environment. |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Compatibility input consumed as Archetype's full traces endpoint and then removed. |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | The only supported Daft-native opt-in. It exports physical engine metrics directly through Daft and is never re-emitted as Archetype metrics. |
+| `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` | Metrics-specific compatibility input. When native metrics are enabled, it takes precedence over the generic protocol and is copied to the generic setting consumed by the pinned Daft version. |
 | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` or `DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT` | Unsupported content-bearing dependency routes; removed before Daft initialization. |
 
 The consumed generic/log/trace variables are not restored: a later local,
 spawned, or distributed Daft worker that inherits this host environment must
 not recreate the unsafe providers. Externally managed workers require the same
-endpoint policy in their own launch environment. When native metrics are
-requested, arbitrary `OTEL_RESOURCE_ATTRIBUTES` and `OTEL_SERVICE_NAME` values
+endpoint policy in their own launch environment. The host remembers the private
+trace endpoint value it last routed: a standard endpoint supplied at a later
+explicit host check replaces that retained value, while a changed private
+endpoint remains an explicit override. When native metrics are requested,
+arbitrary `OTEL_RESOURCE_ATTRIBUTES` and `OTEL_SERVICE_NAME` values
 are removed before Daft import; Daft uses its fixed default service identity.
 Daft metrics are enabled only for versions named in the fresh-process
 compatibility matrix (currently exactly 0.7.19), and accept only `grpc` or
-`http/protobuf`, spelled exactly as Daft parses them; an unvalidated version,
-empty/malformed endpoint, or another protocol is removed so telemetry
-configuration cannot make application import fail. The next explicit host
+`http/protobuf`, spelled exactly as Daft parses them. The metrics-specific
+protocol takes precedence over the generic protocol. Daft 0.7.19 reads only
+the generic variable, so the host copies a valid metrics-specific value there
+before import. An unvalidated version, empty/malformed endpoint, or another
+effective protocol is removed so telemetry configuration cannot make
+application import fail. The next explicit host
 configuration emits a fixed diagnostic without the rejected value. Transport
 headers remain operator-owned exporter configuration and are never copied into
 Archetype signal attributes. Native Daft metrics are uncompressed because the

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -204,6 +204,15 @@ failure handling, and metric cardinality follow the normative
 [Observability contract](observability.md); telemetry never changes a runtime
 result or exception.
 
+`ARCHETYPE_OTLP_TRACES_ENDPOINT` is the explicit endpoint for Archetype's
+filtered HTTP/protobuf traces. Standard generic or trace-specific OTLP
+endpoints are accepted as compatibility inputs, consumed before Daft import,
+and kept out of child environments. Only
+`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` opts Daft into native physical-execution
+telemetry; Daft logs and traces are not enabled by an Archetype host. See the
+process-host endpoint matrix in the observability contract before combining
+Archetype with an externally configured OTel process.
+
 ### R14 — Public callables do not accept raw services
 
 Supported callables may accept `ArchetypeRuntime`, handles, configuration,

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -207,9 +207,12 @@ result or exception.
 `ARCHETYPE_OTLP_TRACES_ENDPOINT` is the explicit endpoint for Archetype's
 filtered HTTP/protobuf traces. Standard generic or trace-specific OTLP
 endpoints are accepted as compatibility inputs, consumed before Daft import,
-and kept out of child environments. Only
+and kept out of child environments. Trace endpoint URLs must be absolute
+`http` or `https` URLs without credentials, queries, or fragments; configure
+collector authentication through OTLP headers. Only
 `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` opts Daft into native physical-execution
-telemetry; Daft logs and traces are not enabled by an Archetype host. See the
+telemetry; that native path is uncompressed, and any configured export interval
+must be positive. Daft logs and traces are not enabled by an Archetype host. See the
 process-host endpoint matrix in the observability contract before combining
 Archetype with an externally configured OTel process.
 

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -7,7 +7,7 @@ machine authority; this page is its review surface.
 
 | Contract | Owner | Risk | Normative source | Executable evidence | Profiles |
 | --- | --- | --- | --- | --- | --- |
-| `observability.signals.safe` | `observability` | high | [docs/guide/observability.md](../guide/observability.md) — 1. Safe signal contract | pytest: 2 | `pr`, `main`, `release` |
+| `observability.signals.safe` | `observability` | high | [docs/guide/observability.md](../guide/observability.md) — 1. Safe signal contract | pytest: 4 | `pr`, `main`, `release` |
 | `observability.logging.correlated` | `observability` | medium | [docs/guide/observability.md](../guide/observability.md) — 5. Process-host ownership | pytest: 2 | `pr`, `main`, `release` |
 | `observability.repository.enforced` | `observability` | high | [docs/guide/observability.md](../guide/observability.md) — 6. Family dispositions | pytest: 2; static: 1 | `pr`, `main`, `release` |
 | `missions.environment.pinned` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 5. Sandbox and validator protocol | pytest: 3; static: 1 | `pr`, `main`, `release` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,8 @@ dev = [
     # explicit host adapter; the published base package remains vendor-neutral.
     "logfire[fastapi]>=4.32.0",
     "python-dotenv>=1.2.2",
+    "grpcio>=1.60",
+    "opentelemetry-proto>=1.20",
 ]
 
 # Mutation testing. Scoped narrowly: mutmut runs each mutation as a full

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -40,6 +40,7 @@ forbidden_outward = [
 ]
 reserved_infrastructure = [
   "archetype._api",
+  "archetype._dependency_telemetry",
   "archetype._logging",
   "archetype._obs",
   "archetype._storage_uri",

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -6,7 +6,11 @@ source = "docs/guide/observability.md"
 section = "1. Safe signal contract"
 owner = "observability"
 risk = "high"
-pytest = ["tests/app/test_obs.py", "tests/app/test_obs_process.py"]
+pytest = [
+    "tests/app/test_obs.py",
+    "tests/app/test_obs_process.py",
+    "tests/app/test_daft_telemetry_process.py",
+]
 static = []
 evals = []
 benchmarks = []

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -7,6 +7,7 @@ section = "1. Safe signal contract"
 owner = "observability"
 risk = "high"
 pytest = [
+    "tests/app/test_dependency_telemetry.py",
     "tests/app/test_obs.py",
     "tests/app/test_obs_process.py",
     "tests/app/test_daft_telemetry_process.py",

--- a/quality/observability/hosts.toml
+++ b/quality/observability/hosts.toml
@@ -35,6 +35,24 @@ evidence = [
 rationale = "This is the sole approved shipped non-CLI console export boundary and emits only sanitized spans."
 
 [[host_callable]]
+qualified_scope = "archetype._obs._DependencyExporterLogGuard.__init__"
+capabilities = ["logging_configuration"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_obs_process.py",
+]
+rationale = "This private process-host guard suppresses dependency exporter records whose exception or response content can include operator endpoint details."
+
+[[host_callable]]
+qualified_scope = "archetype._obs._DependencyExporterLogGuard._finish_if_ready"
+capabilities = ["logging_configuration"]
+evidence = [
+  "docs/guide/observability.md",
+  "tests/app/test_obs_process.py",
+]
+rationale = "This private process-host guard removes only the exact dependency filters that its constructor installed, after every active exporter call has returned."
+
+[[host_callable]]
 qualified_scope = "archetype._logging._ArchetypeHandler.__init__"
 capabilities = ["logging_configuration"]
 evidence = [

--- a/scripts/check_observability.py
+++ b/scripts/check_observability.py
@@ -620,7 +620,7 @@ def _host_scope_allowed(scope: str, capability: str) -> bool:
     if capability == "provider_configuration":
         return scope.startswith("archetype._obs.")
     if capability == "logging_configuration":
-        return scope.startswith("archetype._logging.")
+        return scope.startswith(("archetype._logging.", "archetype._obs."))
     if capability == "console_export":
         return scope.startswith("archetype._obs.")
     if capability == "invoke_configuration":

--- a/scripts/check_observability.py
+++ b/scripts/check_observability.py
@@ -1631,11 +1631,10 @@ class _SourceAnalyzer(ast.NodeVisitor):
             "logging.config.stopListening",
         }:
             return "logging_configuration"
-        receiver = (
-            _resolved_name(node.func.value, self.bindings)
-            if isinstance(node.func, ast.Attribute)
-            else ""
-        )
+        receiver_node = node.func.value if isinstance(node.func, ast.Attribute) else None
+        receiver = _resolved_name(receiver_node, self.bindings)
+        if not receiver and isinstance(receiver_node, ast.Call):
+            receiver = _assignment_binding(receiver_node, self.bindings)
         if tail in {
             "addFilter",
             "removeFilter",

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -30,6 +30,10 @@ import os
 from importlib import import_module
 from typing import Any
 
+from archetype._dependency_telemetry import (
+    prepare_dependency_telemetry as _prepare_dependency_telemetry,
+)
+
 # Daft phones home to Scarf (daft.gateway.scarf.sh + osstelemetry.io) at import
 # and per-runner, via a *blocking* urllib.urlopen. Archetype runs Daft on every
 # world.step, so on a slow or firewalled network that telemetry adds seconds of
@@ -37,6 +41,11 @@ from typing import Any
 # 1.6s with it off) and taxes every real run. Opt out before Daft is imported;
 # `setdefault` honors an explicit `DO_NOT_TRACK=0` if a user wants telemetry on.
 os.environ.setdefault("DO_NOT_TRACK", "1")
+
+# Daft initializes independent native OTLP providers inside its compiled module
+# import.  Route process-host configuration before any lazy public export can
+# import Daft, and keep unsafe broadcast endpoints out of spawned workers.
+_prepare_dependency_telemetry()
 
 __version__ = "0.4.1"
 
@@ -259,6 +268,7 @@ def __getattr__(name: str) -> Any:
     the entire world at `import archetype` time so small utilities can run in
     minimal environments.
     """
+    _prepare_dependency_telemetry()
     if name in _SYNC_TIER_DEPRECATED:
         import warnings
 

--- a/src/archetype/_dependency_telemetry.py
+++ b/src/archetype/_dependency_telemetry.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process-host isolation for dependency-owned native telemetry.
+
+Daft 0.7.19 snapshots the standard OTLP environment when its compiled module
+is imported.  A generic endpoint enables Daft logs, metrics, and traces; its
+UDF error log can contain exception text, tracebacks, and argument values.
+Archetype therefore consumes content-bearing endpoint configuration before
+any Archetype submodule can import Daft.  Only the explicit metrics endpoint
+remains visible to Daft and to child workers.
+
+This module configures no provider and emits no signal.  It only routes process
+host configuration to the provider that owns the corresponding safe schema.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from importlib.metadata import version
+from ipaddress import ip_address
+from threading import RLock
+from urllib.parse import urlsplit, urlunsplit
+
+_ARCHETYPE_TRACES_ENDPOINT = "ARCHETYPE_OTLP_TRACES_ENDPOINT"
+_GENERIC_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"
+_TRACES_ENDPOINT = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+_LOGS_ENDPOINT = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
+_METRICS_ENDPOINT = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+_DEPRECATED_DAFT_ENDPOINT = "DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT"
+_PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL"
+_RESOURCE_CONFIGURATION = ("OTEL_RESOURCE_ATTRIBUTES", "OTEL_SERVICE_NAME")
+_CONTENT_BEARING_ENDPOINTS = (
+    _GENERIC_ENDPOINT,
+    _LOGS_ENDPOINT,
+    _TRACES_ENDPOINT,
+    _DEPRECATED_DAFT_ENDPOINT,
+)
+
+_LATE_DAFT_DIAGNOSTIC = (
+    "Daft native telemetry initialized before Archetype's host isolation boundary; "
+    "dependency signal export may be unsafe."
+)
+_METRICS_DISABLED_DIAGNOSTIC = "Unsupported Daft metrics telemetry configuration was disabled."
+_UNVALIDATED_DAFT_DIAGNOSTIC = (
+    "Daft native metrics were disabled for an unvalidated dependency version."
+)
+_TRACES_DISABLED_DIAGNOSTIC = "Malformed generic OTLP trace configuration was disabled."
+
+_lock = RLock()
+_pending_diagnostics: set[str] = set()
+
+_ENDPOINT_RE = re.compile(r"[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]{1,2048}")
+_HOST_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?")
+_INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_VALIDATED_DAFT_NATIVE_OTEL_VERSIONS = frozenset({"0.7.19"})
+
+
+def _generic_traces_endpoint(endpoint: str) -> str | None:
+    try:
+        parsed = urlsplit(endpoint)
+    except (TypeError, ValueError):
+        return None
+    path = parsed.path + ("v1/traces" if parsed.path.endswith("/") else "/v1/traces")
+    return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment))
+
+
+def _daft_native_metrics_are_validated() -> bool:
+    try:
+        installed_version = version("daft")
+    except BaseException:
+        return False
+    return installed_version in _VALIDATED_DAFT_NATIVE_OTEL_VERSIONS
+
+
+def _valid_metrics_endpoint(endpoint: str) -> bool:
+    if (
+        _ENDPOINT_RE.fullmatch(endpoint) is None
+        or _INVALID_PERCENT_ESCAPE_RE.search(endpoint) is not None
+    ):
+        return False
+    try:
+        parsed = urlsplit(endpoint)
+        parsed_port = parsed.port
+    except (TypeError, ValueError):
+        return False
+    hostname = parsed.hostname
+    if (
+        parsed.scheme not in {"http", "https"}
+        or hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or not (parsed_port is None or 0 < parsed_port <= 65535)
+    ):
+        return False
+    if ":" not in hostname:
+        return _HOST_RE.fullmatch(hostname) is not None
+    try:
+        ip_address(hostname)
+    except ValueError:
+        return False
+    return True
+
+
+def prepare_dependency_telemetry() -> None:
+    """Keep content-bearing OTLP configuration out of Daft and its workers.
+
+    The operation is idempotent and deliberately does not import Daft.  It is
+    safe to repeat at explicit host configuration points so endpoint values set
+    after package import are consumed before later Archetype imports.
+    """
+    try:
+        with _lock:
+            unsafe_present = any(name in os.environ for name in _CONTENT_BEARING_ENDPOINTS)
+            daft_already_loaded = "daft.daft" in sys.modules
+
+            generic_endpoint = os.environ.get(_GENERIC_ENDPOINT)
+            traces_endpoint = os.environ.get(_TRACES_ENDPOINT)
+            if not os.environ.get(_ARCHETYPE_TRACES_ENDPOINT):
+                if traces_endpoint:
+                    os.environ[_ARCHETYPE_TRACES_ENDPOINT] = traces_endpoint
+                elif generic_endpoint:
+                    isolated_endpoint = _generic_traces_endpoint(generic_endpoint)
+                    if isolated_endpoint is None:
+                        _pending_diagnostics.add(_TRACES_DISABLED_DIAGNOSTIC)
+                    else:
+                        os.environ[_ARCHETYPE_TRACES_ENDPOINT] = isolated_endpoint
+
+            for name in _CONTENT_BEARING_ENDPOINTS:
+                os.environ.pop(name, None)
+
+            metrics_endpoint = os.environ.get(_METRICS_ENDPOINT)
+            dependency_telemetry_requested = unsafe_present or metrics_endpoint is not None
+            if dependency_telemetry_requested:
+                for name in _RESOURCE_CONFIGURATION:
+                    os.environ.pop(name, None)
+
+            protocol = os.environ.get(_PROTOCOL, "grpc").strip().lower()
+            if metrics_endpoint is not None:
+                if not _daft_native_metrics_are_validated():
+                    os.environ.pop(_METRICS_ENDPOINT, None)
+                    _pending_diagnostics.add(_UNVALIDATED_DAFT_DIAGNOSTIC)
+                elif not _valid_metrics_endpoint(metrics_endpoint) or protocol not in {
+                    "grpc",
+                    "http/protobuf",
+                }:
+                    os.environ.pop(_METRICS_ENDPOINT, None)
+                    _pending_diagnostics.add(_METRICS_DISABLED_DIAGNOSTIC)
+
+            if unsafe_present and daft_already_loaded:
+                _pending_diagnostics.add(_LATE_DAFT_DIAGNOSTIC)
+    except BaseException:
+        # Process-host telemetry is advisory.  Even a hostile environment
+        # mapping must not become application control flow.
+        return
+
+
+def archetype_traces_endpoint() -> str | None:
+    """Return the isolated endpoint for Archetype's filtered trace exporter."""
+    prepare_dependency_telemetry()
+    try:
+        return os.environ.get(_ARCHETYPE_TRACES_ENDPOINT) or None
+    except BaseException:
+        return None
+
+
+def take_diagnostics() -> tuple[str, ...]:
+    """Return each fixed host diagnostic once, without configuration values."""
+    try:
+        with _lock:
+            diagnostics = tuple(sorted(_pending_diagnostics))
+            _pending_diagnostics.clear()
+            return diagnostics
+    except BaseException:
+        return ()

--- a/src/archetype/_dependency_telemetry.py
+++ b/src/archetype/_dependency_telemetry.py
@@ -42,6 +42,7 @@ _LOGS_ENDPOINT = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
 _METRICS_ENDPOINT = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
 _DEPRECATED_DAFT_ENDPOINT = "DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT"
 _PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL"
+_METRICS_PROTOCOL = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
 _GENERIC_COMPRESSION = "OTEL_EXPORTER_OTLP_COMPRESSION"
 _METRICS_COMPRESSION = "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION"
 _METRICS_INTERVAL = "OTEL_METRIC_EXPORT_INTERVAL"
@@ -71,6 +72,7 @@ _TRACES_DISABLED_DIAGNOSTIC = "Unsupported Archetype OTLP trace configuration wa
 
 _lock = RLock()
 _pending_diagnostics: set[str] = set()
+_last_routed_traces_endpoint: str | None = None
 
 _ENDPOINT_RE = re.compile(r"[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]{1,2048}")
 _HOST_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?")
@@ -157,6 +159,7 @@ def prepare_dependency_telemetry() -> None:
     safe to repeat at explicit host configuration points so endpoint values set
     after package import are consumed before later Archetype imports.
     """
+    global _last_routed_traces_endpoint
     try:
         with _lock:
             unsafe_present = any(name in os.environ for name in _CONTENT_BEARING_ENDPOINTS)
@@ -165,13 +168,17 @@ def prepare_dependency_telemetry() -> None:
             private_endpoint_present = _ARCHETYPE_TRACES_ENDPOINT in os.environ
             generic_endpoint_present = _GENERIC_ENDPOINT in os.environ
             traces_endpoint_present = _TRACES_ENDPOINT in os.environ
+            private_endpoint = os.environ.get(_ARCHETYPE_TRACES_ENDPOINT)
             generic_endpoint = os.environ.get(_GENERIC_ENDPOINT)
             traces_endpoint = os.environ.get(_TRACES_ENDPOINT)
             trace_configuration_present = (
                 private_endpoint_present or generic_endpoint_present or traces_endpoint_present
             )
-            candidate_endpoint = os.environ.get(_ARCHETYPE_TRACES_ENDPOINT)
-            if not private_endpoint_present:
+            candidate_endpoint = private_endpoint
+            private_endpoint_changed = (
+                private_endpoint_present and private_endpoint != _last_routed_traces_endpoint
+            )
+            if not private_endpoint_changed:
                 if traces_endpoint_present:
                     candidate_endpoint = traces_endpoint
                 elif generic_endpoint_present:
@@ -180,9 +187,13 @@ def prepare_dependency_telemetry() -> None:
             if trace_configuration_present:
                 if candidate_endpoint and _valid_otlp_endpoint(candidate_endpoint):
                     os.environ[_ARCHETYPE_TRACES_ENDPOINT] = candidate_endpoint
+                    _last_routed_traces_endpoint = candidate_endpoint
                 else:
                     os.environ.pop(_ARCHETYPE_TRACES_ENDPOINT, None)
+                    _last_routed_traces_endpoint = None
                     _pending_diagnostics.add(_TRACES_DISABLED_DIAGNOSTIC)
+            else:
+                _last_routed_traces_endpoint = None
 
             for name in _CONTENT_BEARING_ENDPOINTS:
                 os.environ.pop(name, None)
@@ -213,7 +224,12 @@ def prepare_dependency_telemetry() -> None:
                 for name in _RESOURCE_CONFIGURATION:
                     os.environ.pop(name, None)
 
-            protocol = os.environ.get(_PROTOCOL, "grpc")
+            metrics_specific_protocol = os.environ.get(_METRICS_PROTOCOL)
+            protocol = (
+                metrics_specific_protocol
+                if metrics_specific_protocol is not None
+                else os.environ.get(_PROTOCOL, "grpc")
+            )
             if metrics_endpoint is not None:
                 if not _daft_native_metrics_are_validated():
                     os.environ.pop(_METRICS_ENDPOINT, None)
@@ -226,6 +242,11 @@ def prepare_dependency_telemetry() -> None:
                     os.environ.pop(_METRICS_ENDPOINT, None)
                     _pending_diagnostics.add(_METRICS_DISABLED_DIAGNOSTIC)
                     metrics_rejected = True
+                elif metrics_specific_protocol is not None:
+                    # Daft 0.7.19 reads only the generic protocol variable.
+                    # Translate the standard signal-specific precedence into
+                    # the exact value its pinned native provider consumes.
+                    os.environ[_PROTOCOL] = metrics_specific_protocol
 
             if unsafe_present and daft_already_loaded:
                 _pending_diagnostics.add(_LATE_DAFT_DIAGNOSTIC)

--- a/src/archetype/_dependency_telemetry.py
+++ b/src/archetype/_dependency_telemetry.py
@@ -103,6 +103,8 @@ def _valid_metrics_endpoint(endpoint: str) -> bool:
         or hostname is None
         or parsed.username is not None
         or parsed.password is not None
+        or parsed.netloc.endswith(":")
+        or bool(parsed.fragment)
         or not (parsed_port is None or 0 < parsed_port <= 65535)
     ):
         return False

--- a/src/archetype/_dependency_telemetry.py
+++ b/src/archetype/_dependency_telemetry.py
@@ -42,6 +42,9 @@ _LOGS_ENDPOINT = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
 _METRICS_ENDPOINT = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
 _DEPRECATED_DAFT_ENDPOINT = "DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT"
 _PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL"
+_GENERIC_COMPRESSION = "OTEL_EXPORTER_OTLP_COMPRESSION"
+_METRICS_COMPRESSION = "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION"
+_METRICS_INTERVAL = "OTEL_METRIC_EXPORT_INTERVAL"
 _RESOURCE_CONFIGURATION = ("OTEL_RESOURCE_ATTRIBUTES", "OTEL_SERVICE_NAME")
 _CONTENT_BEARING_ENDPOINTS = (
     _GENERIC_ENDPOINT,
@@ -54,11 +57,17 @@ _LATE_DAFT_DIAGNOSTIC = (
     "Daft native telemetry initialized before Archetype's host isolation boundary; "
     "dependency signal export may be unsafe."
 )
-_METRICS_DISABLED_DIAGNOSTIC = "Unsupported Daft metrics telemetry configuration was disabled."
+_METRICS_DISABLED_DIAGNOSTIC = "Unsupported Daft metrics telemetry configuration was removed."
 _UNVALIDATED_DAFT_DIAGNOSTIC = (
-    "Daft native metrics were disabled for an unvalidated dependency version."
+    "Daft native metrics configuration was removed for an unvalidated dependency version."
 )
-_TRACES_DISABLED_DIAGNOSTIC = "Malformed generic OTLP trace configuration was disabled."
+_LATE_METRICS_DIAGNOSTIC = (
+    "Rejected Daft metrics configuration may already have initialized a dependency "
+    "provider before Archetype isolation."
+)
+_METRICS_COMPRESSION_DIAGNOSTIC = "Unsupported Daft metrics compression configuration was removed."
+_METRICS_INTERVAL_DIAGNOSTIC = "Unsupported Daft metrics export interval configuration was removed."
+_TRACES_DISABLED_DIAGNOSTIC = "Unsupported Archetype OTLP trace configuration was removed."
 
 _lock = RLock()
 _pending_diagnostics: set[str] = set()
@@ -70,12 +79,15 @@ _VALIDATED_DAFT_NATIVE_OTEL_VERSIONS = frozenset({"0.7.19"})
 
 
 def _generic_traces_endpoint(endpoint: str) -> str | None:
+    if not _valid_otlp_endpoint(endpoint):
+        return None
     try:
         parsed = urlsplit(endpoint)
     except (TypeError, ValueError):
         return None
     path = parsed.path + ("v1/traces" if parsed.path.endswith("/") else "/v1/traces")
-    return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment))
+    isolated = urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+    return isolated if _valid_otlp_endpoint(isolated) else None
 
 
 def _daft_native_metrics_are_validated() -> bool:
@@ -86,10 +98,13 @@ def _daft_native_metrics_are_validated() -> bool:
     return installed_version in _VALIDATED_DAFT_NATIVE_OTEL_VERSIONS
 
 
-def _valid_metrics_endpoint(endpoint: str) -> bool:
+def _valid_otlp_endpoint(endpoint: str) -> bool:
     if (
-        _ENDPOINT_RE.fullmatch(endpoint) is None
+        type(endpoint) is not str
+        or _ENDPOINT_RE.fullmatch(endpoint) is None
         or _INVALID_PERCENT_ESCAPE_RE.search(endpoint) is not None
+        or "?" in endpoint
+        or "#" in endpoint
     ):
         return False
     try:
@@ -104,7 +119,6 @@ def _valid_metrics_endpoint(endpoint: str) -> bool:
         or parsed.username is not None
         or parsed.password is not None
         or parsed.netloc.endswith(":")
-        or bool(parsed.fragment)
         or not (parsed_port is None or 0 < parsed_port <= 65535)
     ):
         return False
@@ -115,6 +129,25 @@ def _valid_metrics_endpoint(endpoint: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _valid_metrics_endpoint(endpoint: str) -> bool:
+    return _valid_otlp_endpoint(endpoint)
+
+
+def _valid_metrics_interval(interval: str) -> bool:
+    if (
+        type(interval) is not str
+        or len(interval) > 20
+        or not interval.isascii()
+        or not interval.isdigit()
+    ):
+        return False
+    try:
+        parsed = int(interval)
+    except (TypeError, ValueError):
+        return False
+    return 0 < parsed <= (2**64 - 1)
 
 
 def prepare_dependency_telemetry() -> None:
@@ -129,41 +162,75 @@ def prepare_dependency_telemetry() -> None:
             unsafe_present = any(name in os.environ for name in _CONTENT_BEARING_ENDPOINTS)
             daft_already_loaded = "daft.daft" in sys.modules
 
+            private_endpoint_present = _ARCHETYPE_TRACES_ENDPOINT in os.environ
+            generic_endpoint_present = _GENERIC_ENDPOINT in os.environ
+            traces_endpoint_present = _TRACES_ENDPOINT in os.environ
             generic_endpoint = os.environ.get(_GENERIC_ENDPOINT)
             traces_endpoint = os.environ.get(_TRACES_ENDPOINT)
-            if not os.environ.get(_ARCHETYPE_TRACES_ENDPOINT):
-                if traces_endpoint:
-                    os.environ[_ARCHETYPE_TRACES_ENDPOINT] = traces_endpoint
-                elif generic_endpoint:
-                    isolated_endpoint = _generic_traces_endpoint(generic_endpoint)
-                    if isolated_endpoint is None:
-                        _pending_diagnostics.add(_TRACES_DISABLED_DIAGNOSTIC)
-                    else:
-                        os.environ[_ARCHETYPE_TRACES_ENDPOINT] = isolated_endpoint
+            trace_configuration_present = (
+                private_endpoint_present or generic_endpoint_present or traces_endpoint_present
+            )
+            candidate_endpoint = os.environ.get(_ARCHETYPE_TRACES_ENDPOINT)
+            if not private_endpoint_present:
+                if traces_endpoint_present:
+                    candidate_endpoint = traces_endpoint
+                elif generic_endpoint_present:
+                    candidate_endpoint = _generic_traces_endpoint(generic_endpoint or "")
+
+            if trace_configuration_present:
+                if candidate_endpoint and _valid_otlp_endpoint(candidate_endpoint):
+                    os.environ[_ARCHETYPE_TRACES_ENDPOINT] = candidate_endpoint
+                else:
+                    os.environ.pop(_ARCHETYPE_TRACES_ENDPOINT, None)
+                    _pending_diagnostics.add(_TRACES_DISABLED_DIAGNOSTIC)
 
             for name in _CONTENT_BEARING_ENDPOINTS:
                 os.environ.pop(name, None)
 
             metrics_endpoint = os.environ.get(_METRICS_ENDPOINT)
-            dependency_telemetry_requested = unsafe_present or metrics_endpoint is not None
+            metrics_compression_present = metrics_endpoint is not None and (
+                _METRICS_COMPRESSION in os.environ or _GENERIC_COMPRESSION in os.environ
+            )
+            metrics_rejected = metrics_compression_present
+            if metrics_endpoint is not None:
+                os.environ.pop(_METRICS_COMPRESSION, None)
+                os.environ.pop(_GENERIC_COMPRESSION, None)
+            if metrics_compression_present:
+                _pending_diagnostics.add(_METRICS_COMPRESSION_DIAGNOSTIC)
+            metrics_interval = os.environ.get(_METRICS_INTERVAL)
+            if (
+                metrics_endpoint is not None
+                and metrics_interval is not None
+                and not _valid_metrics_interval(metrics_interval)
+            ):
+                os.environ.pop(_METRICS_INTERVAL, None)
+                _pending_diagnostics.add(_METRICS_INTERVAL_DIAGNOSTIC)
+                metrics_rejected = True
+            dependency_telemetry_requested = (
+                trace_configuration_present or unsafe_present or metrics_endpoint is not None
+            )
             if dependency_telemetry_requested:
                 for name in _RESOURCE_CONFIGURATION:
                     os.environ.pop(name, None)
 
-            protocol = os.environ.get(_PROTOCOL, "grpc").strip().lower()
+            protocol = os.environ.get(_PROTOCOL, "grpc")
             if metrics_endpoint is not None:
                 if not _daft_native_metrics_are_validated():
                     os.environ.pop(_METRICS_ENDPOINT, None)
                     _pending_diagnostics.add(_UNVALIDATED_DAFT_DIAGNOSTIC)
+                    metrics_rejected = True
                 elif not _valid_metrics_endpoint(metrics_endpoint) or protocol not in {
                     "grpc",
                     "http/protobuf",
                 }:
                     os.environ.pop(_METRICS_ENDPOINT, None)
                     _pending_diagnostics.add(_METRICS_DISABLED_DIAGNOSTIC)
+                    metrics_rejected = True
 
             if unsafe_present and daft_already_loaded:
                 _pending_diagnostics.add(_LATE_DAFT_DIAGNOSTIC)
+            if metrics_rejected and daft_already_loaded:
+                _pending_diagnostics.add(_LATE_METRICS_DIAGNOSTIC)
     except BaseException:
         # Process-host telemetry is advisory.  Even a hostile environment
         # mapping must not become application control flow.

--- a/src/archetype/_obs.py
+++ b/src/archetype/_obs.py
@@ -580,6 +580,13 @@ def record_outcome(outcome: Outcome, *, operation: str | None = None) -> None:
 _configuration_lock = Lock()
 _configured = False
 _owned_tracer_provider: object | None = None
+_OTLP_EXPORT_LOGGERS = ("opentelemetry.exporter.otlp.proto.http.trace_exporter",)
+_OWNED_PROVIDER_CONSTRUCTION_LOGGERS = (
+    "opentelemetry.sdk.trace.export",
+    "opentelemetry.sdk.trace.sampling",
+    "opentelemetry.util.re",
+)
+_OTLP_EXPORT_FAILED_DIAGNOSTIC = "OTLP trace export failed; telemetry was dropped."
 
 
 def _warn_fixed(message: str) -> None:
@@ -594,6 +601,145 @@ def _safe_shutdown(provider: Any) -> None:
         provider.shutdown()
     except BaseException:
         pass
+
+
+class _DropDependencyExporterLogs(logging.Filter):
+    """Suppress dependency messages that may contain endpoints or response bodies."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return False
+
+
+class _DependencyExporterLogGuard:
+    """Own the temporary dependency-logger filter for one host exporter."""
+
+    def __init__(self, logger_names: tuple[str, ...]) -> None:
+        self._logger_names = logger_names
+        self._filter = _DropDependencyExporterLogs()
+        self._lock = Lock()
+        self._active_calls = 0
+        self._closing = False
+        self._closed = False
+        added: list[str] = []
+        try:
+            for logger_name in self._logger_names:
+                logging.getLogger(logger_name).addFilter(self._filter)
+                added.append(logger_name)
+        except BaseException:
+            for logger_name in added:
+                try:
+                    logging.getLogger(logger_name).removeFilter(self._filter)
+                except BaseException:
+                    pass
+            raise
+
+    def enter(self) -> bool:
+        with self._lock:
+            if self._closing or self._closed:
+                return False
+            self._active_calls += 1
+            return True
+
+    def leave(self) -> None:
+        with self._lock:
+            if self._active_calls > 0:
+                self._active_calls -= 1
+        self._finish_if_ready()
+
+    def close(self) -> None:
+        with self._lock:
+            self._closing = True
+        self._finish_if_ready()
+
+    def _finish_if_ready(self) -> None:
+        with self._lock:
+            if self._closed or not self._closing or self._active_calls > 0:
+                return
+            self._closed = True
+        for logger_name in self._logger_names:
+            try:
+                logging.getLogger(logger_name).removeFilter(self._filter)
+            except BaseException:
+                pass
+
+
+def _safe_otlp_http_exporter(exporter_type: Any, *, endpoint: str) -> Any:
+    """Wrap the HTTP exporter so dependency failures remain fixed and content-free."""
+    from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+    log_guard = _DependencyExporterLogGuard(_OTLP_EXPORT_LOGGERS)
+    try:
+        delegate = exporter_type(endpoint=endpoint)
+    except BaseException:
+        log_guard.close()
+        raise
+
+    class _SafeOTLPHTTPExporter(SpanExporter):
+        def __init__(self) -> None:
+            self._failure_lock = Lock()
+            self._failure_reported = False
+            self._shutdown = False
+
+        def _report_failure(self) -> None:
+            with self._failure_lock:
+                if self._failure_reported:
+                    return
+                self._failure_reported = True
+            _warn_fixed(_OTLP_EXPORT_FAILED_DIAGNOSTIC)
+
+        def export(self, spans: Any) -> SpanExportResult:
+            with self._failure_lock:
+                if self._shutdown:
+                    return SpanExportResult.FAILURE
+            if not log_guard.enter():
+                return SpanExportResult.FAILURE
+            try:
+                try:
+                    outcome = delegate.export(spans)
+                except BaseException:
+                    self._report_failure()
+                    return SpanExportResult.FAILURE
+                if outcome is not SpanExportResult.SUCCESS:
+                    self._report_failure()
+                    return SpanExportResult.FAILURE
+                return SpanExportResult.SUCCESS
+            except BaseException:
+                self._report_failure()
+                return SpanExportResult.FAILURE
+            finally:
+                log_guard.leave()
+
+        def force_flush(self, timeout_millis: int = 30_000) -> bool:
+            with self._failure_lock:
+                if self._shutdown:
+                    return False
+            if not log_guard.enter():
+                return False
+            try:
+                try:
+                    return bool(delegate.force_flush(timeout_millis))
+                except BaseException:
+                    self._report_failure()
+                    return False
+            except BaseException:
+                self._report_failure()
+                return False
+            finally:
+                log_guard.leave()
+
+        def shutdown(self) -> None:
+            with self._failure_lock:
+                if self._shutdown:
+                    return
+                self._shutdown = True
+            try:
+                delegate.shutdown()
+            except BaseException:
+                self._report_failure()
+            finally:
+                log_guard.close()
+
+    return _SafeOTLPHTTPExporter()
 
 
 def _logfire_provider_state(instance: Any) -> tuple[object | None, bool, bool]:
@@ -732,6 +878,9 @@ def configure_tracing(*, service_name: str, debug_console: bool = False) -> None
 
         if otlp_endpoint:
             candidate: object | None = None
+            unattached_exporter: object | None = None
+            unattached_processor: object | None = None
+            construction_log_guard: _DependencyExporterLogGuard | None = None
             try:
                 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
                     OTLPSpanExporter,
@@ -740,18 +889,37 @@ def configure_tracing(*, service_name: str, debug_console: bool = False) -> None
                 from opentelemetry.sdk.trace import TracerProvider
                 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-                candidate = TracerProvider(resource=Resource({"service.name": safe_service_name}))
-                processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint))
-                candidate.add_span_processor(
-                    _filtered_processor(processor, service_name=safe_service_name)
+                construction_log_guard = _DependencyExporterLogGuard(
+                    _OWNED_PROVIDER_CONSTRUCTION_LOGGERS
                 )
+                candidate = TracerProvider(resource=Resource({"service.name": safe_service_name}))
+                unattached_exporter = _safe_otlp_http_exporter(
+                    OTLPSpanExporter,
+                    endpoint=otlp_endpoint,
+                )
+                unattached_processor = BatchSpanProcessor(unattached_exporter)
+                unattached_exporter = None
+                filtered_processor = _filtered_processor(
+                    unattached_processor,
+                    service_name=safe_service_name,
+                )
+                candidate.add_span_processor(filtered_processor)
+                unattached_processor = None
                 if debug_console:
                     candidate.add_span_processor(_console_processor(service_name=safe_service_name))
             except ImportError:
+                if unattached_processor is not None:
+                    _safe_shutdown(unattached_processor)
+                if unattached_exporter is not None:
+                    _safe_shutdown(unattached_exporter)
                 if candidate is not None:
                     _safe_shutdown(candidate)
                 _warn_fixed("OTLP telemetry was requested but its optional adapter is unavailable.")
             except BaseException:
+                if unattached_processor is not None:
+                    _safe_shutdown(unattached_processor)
+                if unattached_exporter is not None:
+                    _safe_shutdown(unattached_exporter)
                 if candidate is not None:
                     _safe_shutdown(candidate)
                 _warn_fixed("OTLP telemetry initialization failed; tracing remains retryable.")
@@ -759,13 +927,20 @@ def configure_tracing(*, service_name: str, debug_console: bool = False) -> None
                 if _install_candidate(candidate):
                     _configured = True
                     return
+            finally:
+                if construction_log_guard is not None:
+                    construction_log_guard.close()
 
         if debug_console:
             candidate = None
+            construction_log_guard = None
             try:
                 from opentelemetry.sdk.resources import Resource
                 from opentelemetry.sdk.trace import TracerProvider
 
+                construction_log_guard = _DependencyExporterLogGuard(
+                    _OWNED_PROVIDER_CONSTRUCTION_LOGGERS
+                )
                 candidate = TracerProvider(resource=Resource({"service.name": safe_service_name}))
                 candidate.add_span_processor(_console_processor(service_name=safe_service_name))
             except BaseException:
@@ -775,6 +950,9 @@ def configure_tracing(*, service_name: str, debug_console: bool = False) -> None
             else:
                 if _install_candidate(candidate):
                     _configured = True
+            finally:
+                if construction_log_guard is not None:
+                    construction_log_guard.close()
 
 
 def _safe_span_context(value: object) -> Any | None:

--- a/src/archetype/_obs.py
+++ b/src/archetype/_obs.py
@@ -44,6 +44,8 @@ from uuid import UUID
 from opentelemetry import metrics, trace
 from opentelemetry.trace import Status, StatusCode
 
+from archetype._dependency_telemetry import archetype_traces_endpoint, take_diagnostics
+
 logger = logging.getLogger(__name__)
 
 SIGNAL_SCHEMA_VERSION: Final = 1
@@ -684,6 +686,10 @@ def configure_tracing(*, service_name: str, debug_console: bool = False) -> None
         else "archetype"
     )
 
+    otlp_endpoint = archetype_traces_endpoint()
+    for diagnostic in take_diagnostics():
+        _warn_fixed(diagnostic)
+
     with _configuration_lock:
         if _configured:
             return
@@ -724,9 +730,6 @@ def configure_tracing(*, service_name: str, debug_console: bool = False) -> None
                     _configured = True
                     return
 
-        otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or os.environ.get(
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
-        )
         if otlp_endpoint:
             candidate: object | None = None
             try:
@@ -738,7 +741,7 @@ def configure_tracing(*, service_name: str, debug_console: bool = False) -> None
                 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
                 candidate = TracerProvider(resource=Resource({"service.name": safe_service_name}))
-                processor = BatchSpanProcessor(OTLPSpanExporter())
+                processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint))
                 candidate.add_span_processor(
                     _filtered_processor(processor, service_name=safe_service_name)
                 )

--- a/tests/app/test_daft_telemetry_process.py
+++ b/tests/app/test_daft_telemetry_process.py
@@ -525,11 +525,12 @@ def test_generic_archetype_traces_and_explicit_daft_metrics_stay_separate() -> N
     assert _PAYLOAD_CANARY not in exported_metrics
 
 
-def test_metrics_specific_http_protobuf_transport_is_supported() -> None:
+def test_signal_specific_metrics_protocol_is_translated_for_daft() -> None:
     with _metrics_http_receiver() as (endpoint, captured):
         completed = _run_daft_failure(
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=endpoint,
-            OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf",
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+            OTEL_EXPORTER_OTLP_METRICS_PROTOCOL="http/protobuf",
             OTEL_METRIC_EXPORT_INTERVAL="10",
             OTEL_RESOURCE_ATTRIBUTES="unsafe.label=resource-canary",
         )

--- a/tests/app/test_daft_telemetry_process.py
+++ b/tests/app/test_daft_telemetry_process.py
@@ -1,0 +1,507 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fresh-process contracts for Daft's dependency-owned OTLP providers."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Protocol, cast
+
+import grpc
+import pytest
+from opentelemetry.proto.collector.logs.v1 import logs_service_pb2, logs_service_pb2_grpc
+from opentelemetry.proto.collector.metrics.v1 import (
+    metrics_service_pb2,
+    metrics_service_pb2_grpc,
+)
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2, trace_service_pb2_grpc
+
+pytestmark = [
+    pytest.mark.contract("observability.signals.safe"),
+    pytest.mark.integration,
+    pytest.mark.process,
+]
+
+ROOT = Path(__file__).resolve().parents[2]
+_EXCEPTION_CANARY = b"exception-canary"
+_ARGUMENT_CANARY = b"argument-canary"
+_PROMPT_CANARY = b"prompt-canary"
+_PAYLOAD_CANARY = b"payload-canary"
+_RESOURCE_CANARY = b"resource-canary"
+
+
+class _SerializableRequest(Protocol):
+    def SerializeToString(self) -> bytes: ...  # noqa: N802
+
+
+@dataclass
+class _CapturedOTLP:
+    """Thread-safe serialized requests received from Daft's native exporters."""
+
+    log_requests: list[bytes] = field(default_factory=list)
+    metric_requests: list[bytes] = field(default_factory=list)
+    trace_requests: list[bytes] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def append_log(self, request: _SerializableRequest) -> None:
+        with self.lock:
+            self.log_requests.append(request.SerializeToString())
+
+    def append_metrics(self, request: _SerializableRequest) -> None:
+        with self.lock:
+            self.metric_requests.append(request.SerializeToString())
+
+    def append_trace(self, request: _SerializableRequest) -> None:
+        with self.lock:
+            self.trace_requests.append(request.SerializeToString())
+
+
+class _LogsReceiver(logs_service_pb2_grpc.LogsServiceServicer):
+    def __init__(self, captured: _CapturedOTLP) -> None:
+        self._captured = captured
+
+    def Export(  # noqa: N802
+        self, request: _SerializableRequest, context: grpc.ServicerContext
+    ) -> object:
+        self._captured.append_log(request)
+        return logs_service_pb2.ExportLogsServiceResponse()
+
+
+class _MetricsReceiver(metrics_service_pb2_grpc.MetricsServiceServicer):
+    def __init__(self, captured: _CapturedOTLP) -> None:
+        self._captured = captured
+
+    def Export(  # noqa: N802
+        self, request: _SerializableRequest, context: grpc.ServicerContext
+    ) -> object:
+        self._captured.append_metrics(request)
+        return metrics_service_pb2.ExportMetricsServiceResponse()
+
+
+class _TraceReceiver(trace_service_pb2_grpc.TraceServiceServicer):
+    def __init__(self, captured: _CapturedOTLP) -> None:
+        self._captured = captured
+
+    def Export(  # noqa: N802
+        self, request: _SerializableRequest, context: grpc.ServicerContext
+    ) -> object:
+        self._captured.append_trace(request)
+        return trace_service_pb2.ExportTraceServiceResponse()
+
+
+class _MetricsHTTPServer(ThreadingHTTPServer):
+    captured: _CapturedOTLP
+
+
+class _MetricsHTTPHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        server = cast(_MetricsHTTPServer, self.server)
+        server.captured.append_metrics(
+            metrics_service_pb2.ExportMetricsServiceRequest.FromString(body)
+        )
+        response = metrics_service_pb2.ExportMetricsServiceResponse().SerializeToString()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-protobuf")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+
+@contextmanager
+def _otlp_receiver() -> Iterator[tuple[str, _CapturedOTLP]]:
+    captured = _CapturedOTLP()
+    executor = ThreadPoolExecutor(max_workers=3)
+    server = grpc.server(executor)
+    logs_service_pb2_grpc.add_LogsServiceServicer_to_server(_LogsReceiver(captured), server)
+    metrics_service_pb2_grpc.add_MetricsServiceServicer_to_server(
+        _MetricsReceiver(captured), server
+    )
+    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(_TraceReceiver(captured), server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    assert port > 0
+    server.start()
+    try:
+        yield f"http://127.0.0.1:{port}", captured
+    finally:
+        server.stop(grace=0).wait(timeout=5)
+        executor.shutdown(wait=True)
+
+
+@contextmanager
+def _metrics_http_receiver() -> Iterator[tuple[str, _CapturedOTLP]]:
+    captured = _CapturedOTLP()
+    server = _MetricsHTTPServer(("127.0.0.1", 0), _MetricsHTTPHandler)
+    server.captured = captured
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}/v1/metrics", captured
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _child_environment(**values: str) -> dict[str, str]:
+    env = os.environ.copy()
+    for key in tuple(env):
+        if key.startswith(("ARCHETYPE_", "DAFT_DEV_OTEL_", "LOGFIRE_", "OTEL_")):
+            env.pop(key)
+    env.update(values)
+    env["DO_NOT_TRACK"] = "1"
+    source = str(ROOT / "src")
+    env["PYTHONPATH"] = source + os.pathsep + env.get("PYTHONPATH", "")
+    return env
+
+
+def _run_daft_failure(**env_values: str) -> subprocess.CompletedProcess[str]:
+    source = """
+        import json
+        import logging
+        import os
+
+        logging.disable(logging.CRITICAL)
+        late_generic_endpoint = os.environ.pop("TEST_LATE_OTLP_ENDPOINT", None)
+
+        # Importing Archetype establishes the dependency telemetry boundary
+        # before Daft's compiled extension initializes its native providers.
+        import archetype  # noqa: F401
+        if late_generic_endpoint:
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = late_generic_endpoint
+            from archetype import ArchetypeRuntime  # noqa: F401
+        import daft
+        from daft import DataType, col
+
+        @daft.func(return_dtype=DataType.int64(), on_error="log", use_process=False)
+        def fail(secret: str) -> int:
+            raise RuntimeError(f"exception-canary:{secret}")
+
+        out = daft.from_pydict({
+            "secret": ["argument-canary:prompt-canary:payload-canary"]
+        }).with_column(
+            "out", fail(col("secret"))
+        ).collect()
+        print(json.dumps({
+            "daft_version": daft.__version__,
+            "archetype_trace_endpoint_preserved": bool(
+                os.environ.get("ARCHETYPE_OTLP_TRACES_ENDPOINT")
+            ),
+            "generic_endpoint_present": "OTEL_EXPORTER_OTLP_ENDPOINT" in os.environ,
+            "resource_attributes_present": "OTEL_RESOURCE_ATTRIBUTES" in os.environ,
+            "out": out.to_pydict()["out"],
+        }, sort_keys=True))
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_child_environment(**env_values),
+        timeout=30,
+    )
+
+
+def _run_inherited_daft_failure(**env_values: str) -> subprocess.CompletedProcess[str]:
+    source = """
+        import json
+        import os
+        import subprocess
+        import sys
+        import textwrap
+
+        import archetype  # noqa: F401
+
+        child_source = '''
+            import json
+            import os
+
+            import daft
+            from daft import DataType, col
+
+            @daft.func(return_dtype=DataType.int64(), on_error="log", use_process=False)
+            def fail(secret: str) -> int:
+                raise RuntimeError(f"exception-canary:{secret}")
+
+            out = daft.from_pydict({
+                "secret": ["argument-canary:prompt-canary:payload-canary"]
+            }).with_column(
+                "out", fail(col("secret"))
+            ).collect()
+            print(json.dumps({
+                "generic_endpoint_present": (
+                    "OTEL_EXPORTER_OTLP_ENDPOINT" in os.environ
+                ),
+                "out": out.to_pydict()["out"],
+            }, sort_keys=True))
+        '''
+        child = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(child_source)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=os.environ.copy(),
+            timeout=30,
+        )
+        assert child.returncode == 0, child.stderr
+        print(json.dumps({
+            "archetype_trace_endpoint_preserved": bool(
+                os.environ.get("ARCHETYPE_OTLP_TRACES_ENDPOINT")
+            ),
+            "child": json.loads(child.stdout.strip().splitlines()[-1]),
+            "generic_endpoint_present": "OTEL_EXPORTER_OTLP_ENDPOINT" in os.environ,
+        }, sort_keys=True))
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_child_environment(**env_values),
+        timeout=40,
+    )
+
+
+def _result(completed: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_generic_otlp_cannot_export_daft_udf_error_content() -> None:
+    with _otlp_receiver() as (endpoint, captured):
+        completed = _run_daft_failure(
+            DAFT_LOG="off",
+            OTEL_EXPORTER_OTLP_ENDPOINT=endpoint,
+            OTEL_LOGS_EXPORTER="none",
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+            OTEL_RESOURCE_ATTRIBUTES="unsafe.label=resource-canary",
+            OTEL_SDK_DISABLED="true",
+            OTEL_TRACES_EXPORTER="none",
+        )
+
+    assert _result(completed) == {
+        "archetype_trace_endpoint_preserved": True,
+        "daft_version": "0.7.19",
+        "generic_endpoint_present": False,
+        "out": [None],
+        "resource_attributes_present": False,
+    }
+    exported_requests = b"".join(
+        captured.log_requests + captured.metric_requests + captured.trace_requests
+    )
+    assert captured.log_requests == []
+    assert captured.metric_requests == []
+    assert captured.trace_requests == []
+    assert _EXCEPTION_CANARY not in exported_requests
+    assert _ARGUMENT_CANARY not in exported_requests
+    assert _PROMPT_CANARY not in exported_requests
+    assert _PAYLOAD_CANARY not in exported_requests
+    assert b"traceback" not in exported_requests
+    assert b"udf_args" not in exported_requests
+
+
+@pytest.mark.parametrize(
+    ("endpoint_variable", "archetype_trace_endpoint_preserved"),
+    [
+        ("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", False),
+        ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", True),
+        ("DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT", False),
+    ],
+)
+def test_dependency_log_and_trace_endpoints_are_not_visible_to_daft(
+    endpoint_variable: str, archetype_trace_endpoint_preserved: bool
+) -> None:
+    with _otlp_receiver() as (endpoint, captured):
+        completed = _run_daft_failure(
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+            **{endpoint_variable: endpoint},
+        )
+
+    result = _result(completed)
+    assert result["archetype_trace_endpoint_preserved"] is (archetype_trace_endpoint_preserved)
+    assert result["out"] == [None]
+    assert captured.log_requests == []
+    assert captured.metric_requests == []
+    assert captured.trace_requests == []
+
+
+def test_metrics_specific_endpoint_is_explicit_daft_opt_in_without_logs() -> None:
+    with _otlp_receiver() as (endpoint, captured):
+        completed = _run_daft_failure(
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=endpoint,
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+            OTEL_METRIC_EXPORT_INTERVAL="10",
+            OTEL_RESOURCE_ATTRIBUTES="unsafe.label=resource-canary",
+        )
+
+    assert _result(completed) == {
+        "archetype_trace_endpoint_preserved": False,
+        "daft_version": "0.7.19",
+        "generic_endpoint_present": False,
+        "out": [None],
+        "resource_attributes_present": False,
+    }
+    assert captured.metric_requests
+    assert captured.log_requests == []
+    assert captured.trace_requests == []
+    exported_metrics = b"".join(captured.metric_requests)
+    assert _EXCEPTION_CANARY not in exported_metrics
+    assert _ARGUMENT_CANARY not in exported_metrics
+    assert _PROMPT_CANARY not in exported_metrics
+    assert _PAYLOAD_CANARY not in exported_metrics
+    assert _RESOURCE_CANARY not in exported_metrics
+
+
+def test_generic_archetype_traces_and_explicit_daft_metrics_stay_separate() -> None:
+    with _otlp_receiver() as (endpoint, captured):
+        completed = _run_daft_failure(
+            OTEL_EXPORTER_OTLP_ENDPOINT=endpoint,
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=endpoint,
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+            OTEL_METRIC_EXPORT_INTERVAL="10",
+        )
+
+    result = _result(completed)
+    assert result["archetype_trace_endpoint_preserved"] is True
+    assert result["generic_endpoint_present"] is False
+    assert result["out"] == [None]
+    assert captured.metric_requests
+    assert captured.log_requests == []
+    assert captured.trace_requests == []
+    exported_metrics = b"".join(captured.metric_requests)
+    assert _EXCEPTION_CANARY not in exported_metrics
+    assert _ARGUMENT_CANARY not in exported_metrics
+    assert _PROMPT_CANARY not in exported_metrics
+    assert _PAYLOAD_CANARY not in exported_metrics
+
+
+def test_metrics_specific_http_protobuf_transport_is_supported() -> None:
+    with _metrics_http_receiver() as (endpoint, captured):
+        completed = _run_daft_failure(
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=endpoint,
+            OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf",
+            OTEL_METRIC_EXPORT_INTERVAL="10",
+            OTEL_RESOURCE_ATTRIBUTES="unsafe.label=resource-canary",
+        )
+
+    assert _result(completed)["out"] == [None]
+    assert captured.metric_requests
+    exported_metrics = b"".join(captured.metric_requests)
+    assert _EXCEPTION_CANARY not in exported_metrics
+    assert _ARGUMENT_CANARY not in exported_metrics
+    assert _PROMPT_CANARY not in exported_metrics
+    assert _PAYLOAD_CANARY not in exported_metrics
+    assert _RESOURCE_CANARY not in exported_metrics
+
+
+def test_generic_otlp_is_not_restored_for_inherited_daft_workers() -> None:
+    with _otlp_receiver() as (endpoint, captured):
+        completed = _run_inherited_daft_failure(
+            OTEL_EXPORTER_OTLP_ENDPOINT=endpoint,
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+        )
+
+    assert _result(completed) == {
+        "archetype_trace_endpoint_preserved": True,
+        "child": {"generic_endpoint_present": False, "out": [None]},
+        "generic_endpoint_present": False,
+    }
+    assert captured.log_requests == []
+    assert captured.metric_requests == []
+    assert captured.trace_requests == []
+
+
+def test_lazy_runtime_export_rechecks_late_host_configuration_before_daft() -> None:
+    with _otlp_receiver() as (endpoint, captured):
+        completed = _run_daft_failure(TEST_LATE_OTLP_ENDPOINT=endpoint)
+
+    result = _result(completed)
+    assert result["archetype_trace_endpoint_preserved"] is True
+    assert result["generic_endpoint_present"] is False
+    assert result["out"] == [None]
+    assert captured.log_requests == []
+    assert captured.metric_requests == []
+    assert captured.trace_requests == []
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "protocol"),
+    [
+        ("http://127.0.0.1:1", "http/json"),
+        ("http://bad host:4317", "grpc"),
+        ("http://%zz:4317", "grpc"),
+        ("http://127.0.0.1:4317/a path", "grpc"),
+    ],
+)
+def test_unsupported_metrics_configuration_cannot_change_result(
+    endpoint: str, protocol: str
+) -> None:
+    baseline = _result(_run_daft_failure())
+    unsupported = _result(
+        _run_daft_failure(
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=endpoint,
+            OTEL_EXPORTER_OTLP_PROTOCOL=protocol,
+        )
+    )
+
+    assert unsupported["out"] == baseline["out"]
+    assert unsupported["daft_version"] == baseline["daft_version"] == "0.7.19"
+
+
+def test_malformed_generic_endpoint_cannot_reach_daft_initialization() -> None:
+    baseline = _result(_run_daft_failure())
+    malformed = _result(
+        _run_daft_failure(
+            OTEL_EXPORTER_OTLP_ENDPOINT="http://[endpoint-canary",
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+        )
+    )
+
+    assert malformed["archetype_trace_endpoint_preserved"] is False
+    assert malformed["generic_endpoint_present"] is False
+    assert malformed["out"] == baseline["out"]
+    assert malformed["daft_version"] == baseline["daft_version"] == "0.7.19"
+
+
+def test_disabled_and_unreachable_otlp_preserve_daft_result() -> None:
+    disabled = _result(_run_daft_failure())
+    unreachable_generic = _result(
+        _run_daft_failure(
+            OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:1",
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+        )
+    )
+    unreachable_metrics = _result(
+        _run_daft_failure(
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="http://127.0.0.1:1",
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+            OTEL_EXPORTER_OTLP_TIMEOUT="0.1",
+        )
+    )
+
+    assert disabled["out"] == [None]
+    assert unreachable_generic["out"] == disabled["out"]
+    assert unreachable_metrics["out"] == disabled["out"]
+    assert (
+        unreachable_generic["daft_version"]
+        == unreachable_metrics["daft_version"]
+        == disabled["daft_version"]
+        == "0.7.19"
+    )

--- a/tests/app/test_daft_telemetry_process.py
+++ b/tests/app/test_daft_telemetry_process.py
@@ -101,19 +101,28 @@ class _TraceReceiver(trace_service_pb2_grpc.TraceServiceServicer):
         return trace_service_pb2.ExportTraceServiceResponse()
 
 
-class _MetricsHTTPServer(ThreadingHTTPServer):
+class _OTLPHTTPServer(ThreadingHTTPServer):
     captured: _CapturedOTLP
 
 
-class _MetricsHTTPHandler(BaseHTTPRequestHandler):
+class _OTLPHTTPHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         length = int(self.headers.get("Content-Length", "0"))
         body = self.rfile.read(length)
-        server = cast(_MetricsHTTPServer, self.server)
-        server.captured.append_metrics(
-            metrics_service_pb2.ExportMetricsServiceRequest.FromString(body)
-        )
-        response = metrics_service_pb2.ExportMetricsServiceResponse().SerializeToString()
+        server = cast(_OTLPHTTPServer, self.server)
+        if self.path == "/v1/metrics":
+            server.captured.append_metrics(
+                metrics_service_pb2.ExportMetricsServiceRequest.FromString(body)
+            )
+            response = metrics_service_pb2.ExportMetricsServiceResponse().SerializeToString()
+        elif self.path == "/v1/traces":
+            server.captured.append_trace(
+                trace_service_pb2.ExportTraceServiceRequest.FromString(body)
+            )
+            response = trace_service_pb2.ExportTraceServiceResponse().SerializeToString()
+        else:
+            self.send_error(404)
+            return
         self.send_response(200)
         self.send_header("Content-Type", "application/x-protobuf")
         self.send_header("Content-Length", str(len(response)))
@@ -147,13 +156,29 @@ def _otlp_receiver() -> Iterator[tuple[str, _CapturedOTLP]]:
 @contextmanager
 def _metrics_http_receiver() -> Iterator[tuple[str, _CapturedOTLP]]:
     captured = _CapturedOTLP()
-    server = _MetricsHTTPServer(("127.0.0.1", 0), _MetricsHTTPHandler)
+    server = _OTLPHTTPServer(("127.0.0.1", 0), _OTLPHTTPHandler)
     server.captured = captured
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
         host, port = server.server_address
         yield f"http://{host}:{port}/v1/metrics", captured
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@contextmanager
+def _otlp_http_receiver() -> Iterator[tuple[str, _CapturedOTLP]]:
+    captured = _CapturedOTLP()
+    server = _OTLPHTTPServer(("127.0.0.1", 0), _OTLPHTTPHandler)
+    server.captured = captured
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}", captured
     finally:
         server.shutdown()
         server.server_close()
@@ -180,10 +205,20 @@ def _run_daft_failure(**env_values: str) -> subprocess.CompletedProcess[str]:
 
         logging.disable(logging.CRITICAL)
         late_generic_endpoint = os.environ.pop("TEST_LATE_OTLP_ENDPOINT", None)
+        emit_archetype_trace = os.environ.pop("TEST_EMIT_ARCHETYPE_TRACE", None) == "1"
 
         # Importing Archetype establishes the dependency telemetry boundary
         # before Daft's compiled extension initializes its native providers.
         import archetype  # noqa: F401
+        if emit_archetype_trace:
+            from archetype import _obs
+
+            _obs.configure_tracing(service_name="archetype-test")
+            with _obs.span(
+                "artifact.publish",
+                operation="artifact.publish",
+            ):
+                pass
         if late_generic_endpoint:
             os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = late_generic_endpoint
             from archetype import ArchetypeRuntime  # noqa: F401
@@ -199,6 +234,12 @@ def _run_daft_failure(**env_values: str) -> subprocess.CompletedProcess[str]:
         }).with_column(
             "out", fail(col("secret"))
         ).collect()
+        if emit_archetype_trace:
+            from opentelemetry import trace
+
+            provider = trace.get_tracer_provider()
+            provider.force_flush(timeout_millis=5_000)
+            provider.shutdown()
         print(json.dumps({
             "daft_version": daft.__version__,
             "archetype_trace_endpoint_preserved": bool(
@@ -282,6 +323,40 @@ def _run_inherited_daft_failure(**env_values: str) -> subprocess.CompletedProces
 def _result(completed: subprocess.CompletedProcess[str]) -> dict[str, object]:
     assert completed.returncode == 0, completed.stderr
     return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def _run_daft_import(**env_values: str) -> subprocess.CompletedProcess[str]:
+    source = """
+        import json
+        import os
+
+        import archetype  # noqa: F401
+        import daft
+
+        print(json.dumps({
+            "daft_version": daft.__version__,
+            "generic_compression_present": (
+                "OTEL_EXPORTER_OTLP_COMPRESSION" in os.environ
+            ),
+            "metrics_compression_present": (
+                "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION" in os.environ
+            ),
+            "metrics_endpoint_present": (
+                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" in os.environ
+            ),
+            "metrics_interval_present": (
+                "OTEL_METRIC_EXPORT_INTERVAL" in os.environ
+            ),
+        }, sort_keys=True))
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_child_environment(**env_values),
+        timeout=30,
+    )
 
 
 def test_generic_otlp_cannot_export_daft_udf_error_content() -> None:
@@ -369,13 +444,65 @@ def test_metrics_specific_endpoint_is_explicit_daft_opt_in_without_logs() -> Non
     assert _RESOURCE_CANARY not in exported_metrics
 
 
+@pytest.mark.parametrize("protocol", ["grpc", "http/protobuf"])
+@pytest.mark.parametrize(
+    ("compression_variable", "compression_value"),
+    [
+        ("OTEL_EXPORTER_OTLP_COMPRESSION", "invalid-compression-canary"),
+        ("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip"),
+        ("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION", "invalid-compression-canary"),
+        ("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION", "gzip"),
+    ],
+)
+def test_native_metrics_compression_cannot_make_daft_import_fail(
+    protocol: str,
+    compression_variable: str,
+    compression_value: str,
+) -> None:
+    endpoint = "http://127.0.0.1:1"
+    if protocol == "http/protobuf":
+        endpoint += "/v1/metrics"
+    completed = _run_daft_import(
+        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=endpoint,
+        OTEL_EXPORTER_OTLP_PROTOCOL=protocol,
+        **{compression_variable: compression_value},
+    )
+
+    assert _result(completed) == {
+        "daft_version": "0.7.19",
+        "generic_compression_present": False,
+        "metrics_compression_present": False,
+        "metrics_endpoint_present": True,
+        "metrics_interval_present": False,
+    }
+    assert "invalid-compression-canary" not in completed.stderr
+
+
+@pytest.mark.parametrize("protocol", ["grpc", "http/protobuf"])
+def test_zero_metrics_interval_cannot_busy_spin_native_reader(protocol: str) -> None:
+    endpoint = "http://127.0.0.1:1"
+    if protocol == "http/protobuf":
+        endpoint += "/v1/metrics"
+    completed = _run_daft_import(
+        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=endpoint,
+        OTEL_EXPORTER_OTLP_PROTOCOL=protocol,
+        OTEL_METRIC_EXPORT_INTERVAL="0",
+    )
+
+    result = _result(completed)
+    assert result["daft_version"] == "0.7.19"
+    assert result["metrics_endpoint_present"] is True
+    assert result["metrics_interval_present"] is False
+
+
 def test_generic_archetype_traces_and_explicit_daft_metrics_stay_separate() -> None:
-    with _otlp_receiver() as (endpoint, captured):
+    with _otlp_http_receiver() as (endpoint, captured):
         completed = _run_daft_failure(
             OTEL_EXPORTER_OTLP_ENDPOINT=endpoint,
-            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=endpoint,
-            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=f"{endpoint}/v1/metrics",
+            OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf",
             OTEL_METRIC_EXPORT_INTERVAL="10",
+            TEST_EMIT_ARCHETYPE_TRACE="1",
         )
 
     result = _result(completed)
@@ -384,7 +511,13 @@ def test_generic_archetype_traces_and_explicit_daft_metrics_stay_separate() -> N
     assert result["out"] == [None]
     assert captured.metric_requests
     assert captured.log_requests == []
-    assert captured.trace_requests == []
+    assert captured.trace_requests
+    exported_traces = b"".join(captured.trace_requests)
+    assert b"artifact.publish" in exported_traces
+    assert _EXCEPTION_CANARY not in exported_traces
+    assert _ARGUMENT_CANARY not in exported_traces
+    assert _PROMPT_CANARY not in exported_traces
+    assert _PAYLOAD_CANARY not in exported_traces
     exported_metrics = b"".join(captured.metric_requests)
     assert _EXCEPTION_CANARY not in exported_metrics
     assert _ARGUMENT_CANARY not in exported_metrics

--- a/tests/app/test_dependency_telemetry.py
+++ b/tests/app/test_dependency_telemetry.py
@@ -25,6 +25,7 @@ _ENVIRONMENT_KEYS = (
     "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
     "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION",
     "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
     "OTEL_EXPORTER_OTLP_PROTOCOL",
     "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
     "OTEL_RESOURCE_ATTRIBUTES",
@@ -38,6 +39,7 @@ def _isolated_host_environment(monkeypatch: pytest.MonkeyPatch) -> Iterator[None
     for name in _ENVIRONMENT_KEYS:
         monkeypatch.delenv(name, raising=False)
     _dependency_telemetry._pending_diagnostics.clear()
+    monkeypatch.setattr(_dependency_telemetry, "_last_routed_traces_endpoint", None)
     monkeypatch.setattr(_dependency_telemetry, "sys", SimpleNamespace(modules={}))
     yield
     _dependency_telemetry._pending_diagnostics.clear()
@@ -261,6 +263,73 @@ def test_trace_specific_endpoint_has_precedence_over_generic(
 
 
 @pytest.mark.parametrize(
+    ("source_variable", "first_value", "second_value", "first_expected", "second_expected"),
+    [
+        (
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "https://first.example/otlp",
+            "https://second.example/otlp",
+            "https://first.example/otlp/v1/traces",
+            "https://second.example/otlp/v1/traces",
+        ),
+        (
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "https://first.example/v1/traces",
+            "https://second.example/v1/traces",
+            "https://first.example/v1/traces",
+            "https://second.example/v1/traces",
+        ),
+    ],
+)
+def test_repeated_prepare_consumes_later_standard_trace_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    source_variable: str,
+    first_value: str,
+    second_value: str,
+    first_expected: str,
+    second_expected: str,
+) -> None:
+    monkeypatch.setenv(source_variable, first_value)
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] == first_expected
+    assert source_variable not in _dependency_telemetry.os.environ
+
+    monkeypatch.setenv(source_variable, second_value)
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] == second_expected
+    assert source_variable not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == ()
+
+
+def test_changed_private_trace_endpoint_wins_over_later_standard_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://first.example/otlp")
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    monkeypatch.setenv(
+        "ARCHETYPE_OTLP_TRACES_ENDPOINT",
+        "https://private.example/v1/traces",
+    )
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "https://later.example/v1/traces",
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] == (
+        "https://private.example/v1/traces"
+    )
+    assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == ()
+
+
+@pytest.mark.parametrize(
     "variable",
     [
         "ARCHETYPE_OTLP_TRACES_ENDPOINT",
@@ -331,6 +400,61 @@ def test_noncanonical_metrics_protocol_is_rejected(
 ) -> None:
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example:4317")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", protocol)
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: True,
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Unsupported Daft metrics telemetry configuration was removed.",
+    )
+
+
+@pytest.mark.parametrize(
+    ("generic_protocol", "metrics_protocol"),
+    [
+        ("grpc", "http/protobuf"),
+        ("http/json", "grpc"),
+    ],
+)
+def test_signal_specific_metrics_protocol_is_validated_and_translated_for_daft(
+    monkeypatch: pytest.MonkeyPatch,
+    generic_protocol: str,
+    metrics_protocol: str,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", generic_protocol)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", metrics_protocol)
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: True,
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] == (
+        "http://metrics.example:4317"
+    )
+    assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] == metrics_protocol
+    assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] == (
+        metrics_protocol
+    )
+    assert _dependency_telemetry.take_diagnostics() == ()
+
+
+@pytest.mark.parametrize("metrics_protocol", ["http/json", "GRPC", " HTTP/PROTOBUF "])
+def test_unsupported_signal_specific_metrics_protocol_rejects_native_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    metrics_protocol: str,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", metrics_protocol)
     monkeypatch.setattr(
         _dependency_telemetry,
         "_daft_native_metrics_are_validated",

--- a/tests/app/test_dependency_telemetry.py
+++ b/tests/app/test_dependency_telemetry.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused contracts for dependency-owned telemetry configuration routing."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+
+from archetype import _dependency_telemetry
+
+pytestmark = [
+    pytest.mark.contract("observability.signals.safe"),
+    pytest.mark.unit,
+]
+
+_ENVIRONMENT_KEYS = (
+    "ARCHETYPE_OTLP_TRACES_ENDPOINT",
+    "DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_RESOURCE_ATTRIBUTES",
+    "OTEL_SERVICE_NAME",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_host_environment(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    for name in _ENVIRONMENT_KEYS:
+        monkeypatch.delenv(name, raising=False)
+    _dependency_telemetry._pending_diagnostics.clear()
+    monkeypatch.setattr(_dependency_telemetry, "sys", SimpleNamespace(modules={}))
+    yield
+    _dependency_telemetry._pending_diagnostics.clear()
+    # The subject mutates ``os.environ`` directly, so remove values it created
+    # before monkeypatch restores the process's original environment.
+    for name in _ENVIRONMENT_KEYS:
+        _dependency_telemetry.os.environ.pop(name, None)
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ("https://collector.example", "https://collector.example/v1/traces"),
+        (
+            "https://collector.example/otlp/?tenant=a#fragment",
+            "https://collector.example/otlp/v1/traces?tenant=a#fragment",
+        ),
+        ("http://[malformed", None),
+    ],
+)
+def test_generic_endpoint_conversion_updates_only_the_url_path(
+    endpoint: str, expected: str | None
+) -> None:
+    assert _dependency_telemetry._generic_traces_endpoint(endpoint) == expected
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://localhost:4317",
+        "https://127.0.0.1/v1/metrics",
+        "http://[::1]:4317",
+        "https://collector.example/metrics%20path",
+    ],
+)
+def test_valid_metrics_endpoints_are_accepted(endpoint: str) -> None:
+    assert _dependency_telemetry._valid_metrics_endpoint(endpoint) is True
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "",
+        "ftp://collector.example",
+        "http://bad host:4317",
+        "http://%zz:4317",
+        "http://user@collector.example:4317",
+        "http://collector.example:",
+        "http://collector.example:99999",
+        "http://[invalid]:4317",
+        "http://collector.example/path#fragment",
+    ],
+)
+def test_invalid_metrics_endpoints_are_rejected(endpoint: str) -> None:
+    assert _dependency_telemetry._valid_metrics_endpoint(endpoint) is False
+
+
+def test_native_metrics_require_an_explicitly_validated_daft_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_dependency_telemetry, "version", lambda distribution: "0.7.19")
+    assert _dependency_telemetry._daft_native_metrics_are_validated() is True
+
+    monkeypatch.setattr(_dependency_telemetry, "version", lambda distribution: "0.7.20")
+    assert _dependency_telemetry._daft_native_metrics_are_validated() is False
+
+    def unavailable(distribution: str) -> str:
+        raise RuntimeError("version-canary")
+
+    monkeypatch.setattr(_dependency_telemetry, "version", unavailable)
+    assert _dependency_telemetry._daft_native_metrics_are_validated() is False
+
+
+def test_generic_traces_and_validated_metrics_are_routed_to_separate_owners(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "https://collector.example/otlp?tenant=a",
+    )
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://logs.example")
+    monkeypatch.setenv("DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT", "https://old.example")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "unsafe.label=resource-canary")
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "service-canary")
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: True,
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] == (
+        "https://collector.example/otlp/v1/traces?tenant=a"
+    )
+    assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] == (
+        "http://metrics.example"
+    )
+    for name in (
+        "DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_RESOURCE_ATTRIBUTES",
+        "OTEL_SERVICE_NAME",
+    ):
+        assert name not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == ()
+
+
+def test_trace_specific_endpoint_has_precedence_over_generic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://generic.example")
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "https://traces.example/custom",
+    )
+
+    assert _dependency_telemetry.archetype_traces_endpoint() == ("https://traces.example/custom")
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" not in _dependency_telemetry.os.environ
+
+
+def test_malformed_endpoints_are_removed_with_fixed_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://[trace-canary")
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "http://metrics-canary invalid:4317",
+    )
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: True,
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Malformed generic OTLP trace configuration was disabled.",
+        "Unsupported Daft metrics telemetry configuration was disabled.",
+    )
+
+
+def test_unvalidated_version_removes_metrics_with_a_fixed_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example:4317")
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: False,
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Daft native metrics were disabled for an unvalidated dependency version.",
+    )
+
+
+def test_late_daft_initialization_is_detected_without_restoring_generic_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example")
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "sys",
+        SimpleNamespace(modules={"daft.daft": object()}),
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Daft native telemetry initialized before Archetype's host isolation boundary; "
+        "dependency signal export may be unsafe.",
+    )

--- a/tests/app/test_dependency_telemetry.py
+++ b/tests/app/test_dependency_telemetry.py
@@ -21,12 +21,15 @@ _ENVIRONMENT_KEYS = (
     "ARCHETYPE_OTLP_TRACES_ENDPOINT",
     "DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT",
     "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_COMPRESSION",
     "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION",
     "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
     "OTEL_EXPORTER_OTLP_PROTOCOL",
     "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
     "OTEL_RESOURCE_ATTRIBUTES",
     "OTEL_SERVICE_NAME",
+    "OTEL_METRIC_EXPORT_INTERVAL",
 )
 
 
@@ -49,9 +52,11 @@ def _isolated_host_environment(monkeypatch: pytest.MonkeyPatch) -> Iterator[None
     [
         ("https://collector.example", "https://collector.example/v1/traces"),
         (
-            "https://collector.example/otlp/?tenant=a#fragment",
-            "https://collector.example/otlp/v1/traces?tenant=a#fragment",
+            "https://collector.example/otlp/",
+            "https://collector.example/otlp/v1/traces",
         ),
+        ("https://collector.example/otlp?tenant=secret-canary", None),
+        ("https://collector.example/otlp#secret-canary", None),
         ("http://[malformed", None),
     ],
 )
@@ -74,6 +79,19 @@ def test_valid_metrics_endpoints_are_accepted(endpoint: str) -> None:
     assert _dependency_telemetry._valid_metrics_endpoint(endpoint) is True
 
 
+@pytest.mark.parametrize("interval", ["1", "10", "500", str(2**64 - 1)])
+def test_positive_u64_metrics_intervals_are_accepted(interval: str) -> None:
+    assert _dependency_telemetry._valid_metrics_interval(interval) is True
+
+
+@pytest.mark.parametrize(
+    "interval",
+    ["", "0", "-1", "1.0", "invalid", str(2**64), "9" * 4_301],
+)
+def test_nonpositive_or_malformed_metrics_intervals_are_rejected(interval: str) -> None:
+    assert _dependency_telemetry._valid_metrics_interval(interval) is False
+
+
 @pytest.mark.parametrize(
     "endpoint",
     [
@@ -86,6 +104,7 @@ def test_valid_metrics_endpoints_are_accepted(endpoint: str) -> None:
         "http://collector.example:99999",
         "http://[invalid]:4317",
         "http://collector.example/path#fragment",
+        "http://collector.example/path?token=secret-canary",
     ],
 )
 def test_invalid_metrics_endpoints_are_rejected(endpoint: str) -> None:
@@ -113,7 +132,7 @@ def test_generic_traces_and_validated_metrics_are_routed_to_separate_owners(
 ) -> None:
     monkeypatch.setenv(
         "OTEL_EXPORTER_OTLP_ENDPOINT",
-        "https://collector.example/otlp?tenant=a",
+        "https://collector.example/otlp",
     )
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://logs.example")
     monkeypatch.setenv("DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT", "https://old.example")
@@ -130,7 +149,7 @@ def test_generic_traces_and_validated_metrics_are_routed_to_separate_owners(
     _dependency_telemetry.prepare_dependency_telemetry()
 
     assert _dependency_telemetry.os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] == (
-        "https://collector.example/otlp/v1/traces?tenant=a"
+        "https://collector.example/otlp/v1/traces"
     )
     assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] == (
         "http://metrics.example"
@@ -147,6 +166,86 @@ def test_generic_traces_and_validated_metrics_are_routed_to_separate_owners(
     assert _dependency_telemetry.take_diagnostics() == ()
 
 
+@pytest.mark.parametrize(
+    ("variable", "value"),
+    [
+        ("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip"),
+        ("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION", "invalid-canary"),
+    ],
+)
+def test_native_metrics_compression_is_removed_while_endpoint_remains_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    variable: str,
+    value: str,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example:4317")
+    monkeypatch.setenv(variable, value)
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: True,
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] == (
+        "http://metrics.example:4317"
+    )
+    assert "OTEL_EXPORTER_OTLP_COMPRESSION" not in _dependency_telemetry.os.environ
+    assert "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Unsupported Daft metrics compression configuration was removed.",
+    )
+
+
+def test_generic_trace_compression_remains_when_native_metrics_are_not_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.example")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip")
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_COMPRESSION"] == "gzip"
+    assert _dependency_telemetry.take_diagnostics() == ()
+
+
+@pytest.mark.parametrize("interval", ["0", "-1", "invalid", str(2**64)])
+def test_unsafe_metrics_interval_is_removed_with_fixed_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+    interval: str,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example:4317")
+    monkeypatch.setenv("OTEL_METRIC_EXPORT_INTERVAL", interval)
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: True,
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert "OTEL_METRIC_EXPORT_INTERVAL" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Unsupported Daft metrics export interval configuration was removed.",
+    )
+
+
+def test_native_metrics_controls_are_untouched_without_a_metrics_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION", "gzip")
+    monkeypatch.setenv("OTEL_METRIC_EXPORT_INTERVAL", "0")
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_COMPRESSION"] == "gzip"
+    assert _dependency_telemetry.os.environ["OTEL_EXPORTER_OTLP_METRICS_COMPRESSION"] == "gzip"
+    assert _dependency_telemetry.os.environ["OTEL_METRIC_EXPORT_INTERVAL"] == "0"
+    assert _dependency_telemetry.take_diagnostics() == ()
+
+
 def test_trace_specific_endpoint_has_precedence_over_generic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -159,6 +258,28 @@ def test_trace_specific_endpoint_has_precedence_over_generic(
     assert _dependency_telemetry.archetype_traces_endpoint() == ("https://traces.example/custom")
     assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in _dependency_telemetry.os.environ
     assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" not in _dependency_telemetry.os.environ
+
+
+@pytest.mark.parametrize(
+    "variable",
+    [
+        "ARCHETYPE_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    ],
+)
+def test_secret_bearing_trace_endpoint_is_removed_without_echoing_value(
+    monkeypatch: pytest.MonkeyPatch,
+    variable: str,
+) -> None:
+    monkeypatch.setenv(variable, "https://collector.example/path?token=secret-canary")
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert "ARCHETYPE_OTLP_TRACES_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Unsupported Archetype OTLP trace configuration was removed.",
+    )
 
 
 def test_malformed_endpoints_are_removed_with_fixed_diagnostics(
@@ -180,8 +301,8 @@ def test_malformed_endpoints_are_removed_with_fixed_diagnostics(
     assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in _dependency_telemetry.os.environ
     assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in _dependency_telemetry.os.environ
     assert _dependency_telemetry.take_diagnostics() == (
-        "Malformed generic OTLP trace configuration was disabled.",
-        "Unsupported Daft metrics telemetry configuration was disabled.",
+        "Unsupported Archetype OTLP trace configuration was removed.",
+        "Unsupported Daft metrics telemetry configuration was removed.",
     )
 
 
@@ -199,7 +320,52 @@ def test_unvalidated_version_removes_metrics_with_a_fixed_diagnostic(
 
     assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in _dependency_telemetry.os.environ
     assert _dependency_telemetry.take_diagnostics() == (
-        "Daft native metrics were disabled for an unvalidated dependency version.",
+        "Daft native metrics configuration was removed for an unvalidated dependency version.",
+    )
+
+
+@pytest.mark.parametrize("protocol", ["GRPC", " HTTP/PROTOBUF ", "http/json"])
+def test_noncanonical_metrics_protocol_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    protocol: str,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", protocol)
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: True,
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in _dependency_telemetry.os.environ
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Unsupported Daft metrics telemetry configuration was removed.",
+    )
+
+
+def test_rejected_metrics_after_daft_load_reports_unverified_provider_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics.example:4317")
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "_daft_native_metrics_are_validated",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        _dependency_telemetry,
+        "sys",
+        SimpleNamespace(modules={"daft.daft": object()}),
+    )
+
+    _dependency_telemetry.prepare_dependency_telemetry()
+
+    assert _dependency_telemetry.take_diagnostics() == (
+        "Daft native metrics configuration was removed for an unvalidated dependency version.",
+        "Rejected Daft metrics configuration may already have initialized a dependency "
+        "provider before Archetype isolation.",
     )
 
 

--- a/tests/app/test_logging_process.py
+++ b/tests/app/test_logging_process.py
@@ -21,7 +21,7 @@ pytestmark = [
 def _run(source: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     for key in tuple(env):
-        if key.startswith(("LOGFIRE_", "OTEL_")) or key == "ARCHETYPE_LOG":
+        if key.startswith(("ARCHETYPE_OTLP_", "LOGFIRE_", "OTEL_")) or key == ("ARCHETYPE_LOG"):
             env.pop(key)
     return subprocess.run(
         [sys.executable, "-c", textwrap.dedent(source)],

--- a/tests/app/test_obs.py
+++ b/tests/app/test_obs.py
@@ -11,6 +11,8 @@ global provider, so no test poisons the process-wide OTel state.
 
 import asyncio
 import inspect
+import logging
+import threading
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any, cast
@@ -19,7 +21,7 @@ import pytest
 from opentelemetry import context, trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind, Status, StatusCode
 from uuid_utils import uuid7
@@ -38,6 +40,103 @@ def _capture(monkeypatch) -> InMemorySpanExporter:
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     monkeypatch.setattr(_obs, "_tracer", provider.get_tracer("archetype"))
     return exporter
+
+
+def test_safe_otlp_exporter_suppresses_dependency_content_and_cleans_up_filter(caplog):
+    dependency_loggers = tuple(logging.getLogger(name) for name in _obs._OTLP_EXPORT_LOGGERS)
+    original_filters = {
+        dependency_logger: tuple(dependency_logger.filters)
+        for dependency_logger in dependency_loggers
+    }
+
+    class FailingExporter:
+        instance = None
+
+        def __init__(self, *, endpoint):
+            self.endpoint = endpoint
+            self.shutdown_calls = 0
+            type(self).instance = self
+
+        def export(self, spans):
+            dependency_loggers[0].error("collector-response-body-canary")
+            raise RuntimeError("exporter-exception-canary")
+
+        def force_flush(self, timeout_millis):
+            raise RuntimeError("flush-exception-canary")
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+            raise RuntimeError("shutdown-exception-canary")
+
+    caplog.set_level(logging.WARNING)
+    exporter = _obs._safe_otlp_http_exporter(
+        FailingExporter,
+        endpoint="http://collector.invalid/v1/traces",
+    )
+    for dependency_logger in dependency_loggers:
+        assert len(dependency_logger.filters) == len(original_filters[dependency_logger]) + 1
+
+    assert exporter.export(()) is SpanExportResult.FAILURE
+    assert exporter.force_flush() is False
+    exporter.shutdown()
+    exporter.shutdown()
+
+    for dependency_logger in dependency_loggers:
+        assert tuple(dependency_logger.filters) == original_filters[dependency_logger]
+    assert FailingExporter.instance is not None
+    assert FailingExporter.instance.shutdown_calls == 1
+    assert [record.getMessage() for record in caplog.records] == [
+        "OTLP trace export failed; telemetry was dropped.",
+    ]
+    assert "canary" not in caplog.text
+
+
+def test_safe_otlp_exporter_keeps_filter_until_active_export_returns(caplog):
+    dependency_logger = logging.getLogger(_obs._OTLP_EXPORT_LOGGERS[0])
+    original_filters = tuple(dependency_logger.filters)
+    started = threading.Event()
+    release = threading.Event()
+    outcomes = []
+
+    class BlockingExporter:
+        def __init__(self, *, endpoint):
+            pass
+
+        def export(self, spans):
+            started.set()
+            assert release.wait(timeout=5)
+            dependency_logger.error("late-response-body-canary")
+            return SpanExportResult.FAILURE
+
+        def force_flush(self, timeout_millis):
+            return True
+
+        def shutdown(self):
+            return None
+
+    caplog.set_level(logging.WARNING)
+    exporter = _obs._safe_otlp_http_exporter(
+        BlockingExporter,
+        endpoint="http://collector.invalid/v1/traces",
+    )
+    worker = threading.Thread(target=lambda: outcomes.append(exporter.export(())))
+    worker.start()
+    assert started.wait(timeout=5)
+    try:
+        exporter.shutdown()
+        assert len(dependency_logger.filters) == len(original_filters) + 1
+    finally:
+        release.set()
+        worker.join(timeout=5)
+        exporter.shutdown()
+
+    assert not worker.is_alive()
+    assert outcomes == [SpanExportResult.FAILURE]
+    assert tuple(dependency_logger.filters) == original_filters
+    assert "late-response-body-canary" not in caplog.text
+    assert [record.getMessage() for record in caplog.records] == [
+        "OTLP trace export failed; telemetry was dropped.",
+    ]
 
 
 def test_instrument_is_a_noop_without_any_provider():

--- a/tests/app/test_obs.py
+++ b/tests/app/test_obs.py
@@ -21,7 +21,7 @@ import pytest
 from opentelemetry import context, trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind, Status, StatusCode
 from uuid_utils import uuid7
@@ -136,6 +136,145 @@ def test_safe_otlp_exporter_keeps_filter_until_active_export_returns(caplog):
     assert "late-response-body-canary" not in caplog.text
     assert [record.getMessage() for record in caplog.records] == [
         "OTLP trace export failed; telemetry was dropped.",
+    ]
+
+
+def test_safe_otlp_exporter_success_closed_state_and_constructor_cleanup():
+    dependency_logger = logging.getLogger(_obs._OTLP_EXPORT_LOGGERS[0])
+    original_filters = tuple(dependency_logger.filters)
+
+    class SuccessfulExporter:
+        instance = None
+
+        def __init__(self, *, endpoint):
+            self.shutdown_calls = 0
+            type(self).instance = self
+
+        def export(self, spans):
+            return SpanExportResult.SUCCESS
+
+        def force_flush(self, timeout_millis):
+            return True
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    exporter = _obs._safe_otlp_http_exporter(
+        SuccessfulExporter,
+        endpoint="http://collector.invalid/v1/traces",
+    )
+
+    assert exporter.export(()) is SpanExportResult.SUCCESS
+    assert exporter.force_flush() is True
+    exporter.shutdown()
+    assert exporter.export(()) is SpanExportResult.FAILURE
+    assert exporter.force_flush() is False
+    assert SuccessfulExporter.instance is not None
+    assert SuccessfulExporter.instance.shutdown_calls == 1
+    assert tuple(dependency_logger.filters) == original_filters
+
+    class ConstructorFailure:
+        def __init__(self, *, endpoint):
+            raise RuntimeError("constructor failure")
+
+    with pytest.raises(RuntimeError, match="constructor failure"):
+        _obs._safe_otlp_http_exporter(
+            ConstructorFailure,
+            endpoint="http://collector.invalid/v1/traces",
+        )
+    assert tuple(dependency_logger.filters) == original_filters
+
+
+def test_configure_tracing_cleans_rejected_otlp_and_console_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from opentelemetry.exporter.otlp.proto.http import trace_exporter
+
+    class TrackingExporter(SpanExporter):
+        instances = []
+
+        def __init__(self, *, endpoint):
+            self.shutdown_calls = 0
+            type(self).instances.append(self)
+
+        def export(self, spans):
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    candidates = []
+
+    def reject(candidate):
+        candidates.append(candidate)
+        candidate.shutdown()
+        return False
+
+    monkeypatch.setattr(_obs, "_configured", False)
+    monkeypatch.setattr(
+        _obs,
+        "archetype_traces_endpoint",
+        lambda: "http://collector.invalid/v1/traces",
+    )
+    monkeypatch.setattr(_obs, "take_diagnostics", lambda: ("Fixed host diagnostic.",))
+    monkeypatch.setattr(_obs.trace, "get_tracer_provider", trace.ProxyTracerProvider)
+    monkeypatch.setattr(_obs, "_install_candidate", reject)
+    monkeypatch.setattr(trace_exporter, "OTLPSpanExporter", TrackingExporter)
+    caplog.set_level(logging.WARNING)
+
+    _obs.configure_tracing(service_name="archetype-test", debug_console=True)
+
+    assert _obs._configured is False
+    assert len(candidates) == 2
+    assert len(TrackingExporter.instances) == 1
+    assert TrackingExporter.instances[0].shutdown_calls == 1
+    assert "Fixed host diagnostic." in [record.getMessage() for record in caplog.records]
+
+
+def test_configure_tracing_shuts_down_exporter_when_processor_construction_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from opentelemetry.exporter.otlp.proto.http import trace_exporter
+    from opentelemetry.sdk.trace import export as trace_export
+
+    class TrackingExporter(SpanExporter):
+        instance = None
+
+        def __init__(self, *, endpoint):
+            self.shutdown_calls = 0
+            type(self).instance = self
+
+        def export(self, spans):
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    class FailingProcessor:
+        def __init__(self, exporter):
+            raise RuntimeError("processor construction failure")
+
+    monkeypatch.setattr(_obs, "_configured", False)
+    monkeypatch.setattr(
+        _obs,
+        "archetype_traces_endpoint",
+        lambda: "http://collector.invalid/v1/traces",
+    )
+    monkeypatch.setattr(_obs, "take_diagnostics", lambda: ())
+    monkeypatch.setattr(_obs.trace, "get_tracer_provider", trace.ProxyTracerProvider)
+    monkeypatch.setattr(trace_exporter, "OTLPSpanExporter", TrackingExporter)
+    monkeypatch.setattr(trace_export, "BatchSpanProcessor", FailingProcessor)
+    caplog.set_level(logging.WARNING)
+
+    _obs.configure_tracing(service_name="archetype-test")
+
+    assert _obs._configured is False
+    assert TrackingExporter.instance is not None
+    assert TrackingExporter.instance.shutdown_calls == 1
+    assert "OTLP telemetry initialization failed; tracing remains retryable." in [
+        record.getMessage() for record in caplog.records
     ]
 
 

--- a/tests/app/test_obs_process.py
+++ b/tests/app/test_obs_process.py
@@ -79,7 +79,8 @@ def test_otlp_configuration_installs_a_sanitizing_owned_provider() -> None:
         class CapturingExporter(SpanExporter):
             instances = []
 
-            def __init__(self):
+            def __init__(self, *, endpoint):
+                self.endpoint = endpoint
                 self.spans = []
                 self.shutdown_calls = 0
                 self.instances.append(self)
@@ -92,7 +93,9 @@ def test_otlp_configuration_installs_a_sanitizing_owned_provider() -> None:
                 self.shutdown_calls += 1
 
         trace_exporter.OTLPSpanExporter = CapturingExporter
-        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://collector.invalid/v1/traces"
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = (
+            "https://collector.invalid/otlp?tenant=a"
+        )
 
         from archetype import _obs
 
@@ -112,6 +115,9 @@ def test_otlp_configuration_installs_a_sanitizing_owned_provider() -> None:
 
         assert provider.force_flush()
         (exporter,) = CapturingExporter.instances
+        assert exporter.endpoint == (
+            "https://collector.invalid/otlp/v1/traces?tenant=a"
+        )
         (finished,) = exporter.spans
         assert finished.name == "artifact.publish"
         assert dict(finished.attributes) == {
@@ -151,12 +157,12 @@ def test_otlp_initialization_failure_is_safe_shutdown_and_retryable() -> None:
                 return super().shutdown()
 
         class FailingExporter:
-            def __init__(self):
+            def __init__(self, *, endpoint):
                 raise RuntimeError("Bearer should-not-be-exported")
 
         sdk_trace.TracerProvider = TrackingProvider
         trace_exporter.OTLPSpanExporter = FailingExporter
-        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://collector.invalid/v1/traces"
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://collector.invalid"
 
         from archetype import _obs
 
@@ -167,7 +173,7 @@ def test_otlp_initialization_failure_is_safe_shutdown_and_retryable() -> None:
         assert failed_candidate.shutdown_calls == 1
 
         sdk_trace.TracerProvider = real_provider
-        del os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"]
+        del os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"]
         _obs.configure_tracing(service_name="archetype-test", debug_console=True)
         assert _obs._configured is True
         assert not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
@@ -176,6 +182,63 @@ def test_otlp_initialization_failure_is_safe_shutdown_and_retryable() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert "Bearer should-not-be-exported" not in result.stderr
+
+
+def test_invalid_daft_metrics_config_reports_only_a_fixed_host_diagnostic() -> None:
+    result = _run(
+        """
+        import os
+
+        os.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = (
+            "http://endpoint-canary invalid:4317"
+        )
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in os.environ
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Unsupported Daft metrics telemetry configuration was disabled." in result.stderr
+    assert "endpoint-canary" not in result.stderr
+
+
+def test_malformed_generic_endpoint_reports_only_a_fixed_host_diagnostic() -> None:
+    result = _run(
+        """
+        import os
+
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://[endpoint-canary"
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Malformed generic OTLP trace configuration was disabled." in result.stderr
+    assert "endpoint-canary" not in result.stderr
+
+
+def test_unvalidated_daft_version_disables_native_metrics() -> None:
+    result = _run(
+        """
+        import os
+        from archetype import _dependency_telemetry
+
+        _dependency_telemetry.version = lambda distribution: "0.7.20"
+        os.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = (
+            "http://127.0.0.1:4317"
+        )
+        _dependency_telemetry.prepare_dependency_telemetry()
+
+        assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in os.environ
+        assert _dependency_telemetry.take_diagnostics() == (
+            "Daft native metrics were disabled for an unvalidated dependency version.",
+        )
+        """
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_host_adapter_failure_is_safe_and_does_not_latch() -> None:

--- a/tests/app/test_obs_process.py
+++ b/tests/app/test_obs_process.py
@@ -93,9 +93,7 @@ def test_otlp_configuration_installs_a_sanitizing_owned_provider() -> None:
                 self.shutdown_calls += 1
 
         trace_exporter.OTLPSpanExporter = CapturingExporter
-        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = (
-            "https://collector.invalid/otlp?tenant=a"
-        )
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://collector.invalid/otlp"
 
         from archetype import _obs
 
@@ -115,9 +113,7 @@ def test_otlp_configuration_installs_a_sanitizing_owned_provider() -> None:
 
         assert provider.force_flush()
         (exporter,) = CapturingExporter.instances
-        assert exporter.endpoint == (
-            "https://collector.invalid/otlp/v1/traces?tenant=a"
-        )
+        assert exporter.endpoint == "https://collector.invalid/otlp/v1/traces"
         (finished,) = exporter.spans
         assert finished.name == "artifact.publish"
         assert dict(finished.attributes) == {
@@ -184,6 +180,149 @@ def test_otlp_initialization_failure_is_safe_shutdown_and_retryable() -> None:
     assert "Bearer should-not-be-exported" not in result.stderr
 
 
+def test_failed_processor_attachment_does_not_leak_batch_worker() -> None:
+    result = _run(
+        """
+        import os
+        import threading
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http import trace_exporter
+        from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+        from archetype import _obs
+
+        class TrackingExporter(SpanExporter):
+            instance = None
+
+            def __init__(self, *, endpoint):
+                self.shutdown_calls = 0
+                type(self).instance = self
+
+            def export(self, spans):
+                return SpanExportResult.SUCCESS
+
+            def shutdown(self):
+                self.shutdown_calls += 1
+
+        def fail(processor, *, service_name):
+            raise RuntimeError("filtered-processor-canary")
+
+        trace_exporter.OTLPSpanExporter = TrackingExporter
+        _obs._filtered_processor = fail
+        os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] = (
+            "http://collector.invalid/v1/traces"
+        )
+        before = [thread.name for thread in threading.enumerate()]
+
+        _obs.configure_tracing(service_name="archetype-test")
+
+        after = [thread.name for thread in threading.enumerate()]
+        assert _obs._configured is False
+        assert isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+        assert after == before
+        assert TrackingExporter.instance is not None
+        assert TrackingExporter.instance.shutdown_calls == 1
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OTLP telemetry initialization failed; tracing remains retryable." in result.stderr
+    assert "filtered-processor-canary" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "header_variable",
+    ["OTEL_EXPORTER_OTLP_HEADERS", "OTEL_EXPORTER_OTLP_TRACES_HEADERS"],
+)
+def test_malformed_otlp_header_parser_cannot_echo_credentials(header_variable: str) -> None:
+    result = _run(
+        f"""
+        import os
+        from opentelemetry import trace
+
+        os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] = (
+            "http://127.0.0.1:1/v1/traces"
+        )
+        os.environ[{header_variable!r}] = (
+            "Authorization Bearer header-secret-canary"
+        )
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        assert _obs._configured is True
+        provider = trace.get_tracer_provider()
+        provider.shutdown()
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "header-secret-canary" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "bsp_variable",
+    [
+        "OTEL_BSP_EXPORT_TIMEOUT",
+        "OTEL_BSP_MAX_EXPORT_BATCH_SIZE",
+        "OTEL_BSP_MAX_QUEUE_SIZE",
+        "OTEL_BSP_SCHEDULE_DELAY",
+    ],
+)
+def test_malformed_batch_processor_config_cannot_echo_raw_value(bsp_variable: str) -> None:
+    result = _run(
+        f"""
+        import os
+        from opentelemetry import trace
+
+        os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] = (
+            "http://127.0.0.1:1/v1/traces"
+        )
+        os.environ[{bsp_variable!r}] = "bsp-secret-canary"
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        assert _obs._configured is True
+        trace.get_tracer_provider().shutdown()
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "bsp-secret-canary" not in result.stderr
+
+
+def test_malformed_sampler_config_cannot_echo_raw_value() -> None:
+    result = _run(
+        """
+        import os
+        from opentelemetry import trace
+
+        os.environ["OTEL_TRACES_SAMPLER"] = "sampler-secret-canary"
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test", debug_console=True)
+        assert _obs._configured is True
+        trace.get_tracer_provider().shutdown()
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "sampler-secret-canary" not in result.stderr
+
+
+def test_valid_host_sampler_configuration_remains_authoritative() -> None:
+    result = _run(
+        """
+        import os
+        from opentelemetry import trace
+
+        os.environ["OTEL_TRACES_SAMPLER"] = "always_off"
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test", debug_console=True)
+        with _obs.span("world.query", tick=1):
+            pass
+        trace.get_tracer_provider().shutdown()
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "world.query" not in result.stderr
+
+
 def test_invalid_daft_metrics_config_reports_only_a_fixed_host_diagnostic() -> None:
     result = _run(
         """
@@ -199,7 +338,7 @@ def test_invalid_daft_metrics_config_reports_only_a_fixed_host_diagnostic() -> N
         """
     )
     assert result.returncode == 0, result.stderr
-    assert "Unsupported Daft metrics telemetry configuration was disabled." in result.stderr
+    assert "Unsupported Daft metrics telemetry configuration was removed." in result.stderr
     assert "endpoint-canary" not in result.stderr
 
 
@@ -216,8 +355,109 @@ def test_malformed_generic_endpoint_reports_only_a_fixed_host_diagnostic() -> No
         """
     )
     assert result.returncode == 0, result.stderr
-    assert "Malformed generic OTLP trace configuration was disabled." in result.stderr
+    assert "Unsupported Archetype OTLP trace configuration was removed." in result.stderr
     assert "endpoint-canary" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "endpoint_variable",
+    [
+        "ARCHETYPE_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    ],
+)
+def test_secret_bearing_trace_endpoint_is_rejected_without_disclosure(
+    endpoint_variable: str,
+) -> None:
+    result = _run(
+        f"""
+        import os
+        from opentelemetry import trace
+
+        os.environ[{endpoint_variable!r}] = (
+            "http://127.0.0.1:1/base?token=endpoint-secret-canary"
+        )
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        assert isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+        assert "ARCHETYPE_OTLP_TRACES_ENDPOINT" not in os.environ
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Unsupported Archetype OTLP trace configuration was removed." in result.stderr
+    assert "endpoint-secret-canary" not in result.stderr
+
+
+def test_otlp_export_failure_does_not_disclose_a_valid_endpoint_path() -> None:
+    result = _run(
+        """
+        import os
+        from opentelemetry import trace
+
+        os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] = (
+            "http://127.0.0.1:1/path-endpoint-secret-canary"
+        )
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        provider = trace.get_tracer_provider()
+        with provider.get_tracer("archetype").start_as_current_span(
+            "artifact.publish",
+            attributes={"archetype.operation": "artifact.publish"},
+        ):
+            pass
+        assert provider.force_flush(timeout_millis=5_000)
+        provider.shutdown()
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OTLP trace export failed; telemetry was dropped." in result.stderr
+    assert "path-endpoint-secret-canary" not in result.stderr
+
+
+def test_dependency_exporter_message_and_exception_are_replaced_with_fixed_diagnostic() -> None:
+    result = _run(
+        """
+        import logging
+        import os
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http import trace_exporter
+        from opentelemetry.sdk.trace.export import SpanExporter
+
+        class FailingExporter(SpanExporter):
+            def __init__(self, *, endpoint):
+                pass
+
+            def export(self, spans):
+                logging.getLogger(trace_exporter.__name__).error(
+                    "collector-response-body-canary"
+                )
+                raise RuntimeError("exporter-exception-canary")
+
+            def shutdown(self):
+                return None
+
+        trace_exporter.OTLPSpanExporter = FailingExporter
+        os.environ["ARCHETYPE_OTLP_TRACES_ENDPOINT"] = "http://collector.invalid/v1/traces"
+        from archetype import _obs
+
+        _obs.configure_tracing(service_name="archetype-test")
+        provider = trace.get_tracer_provider()
+        with provider.get_tracer("archetype").start_as_current_span(
+            "artifact.publish",
+            attributes={"archetype.operation": "artifact.publish"},
+        ):
+            pass
+        assert provider.force_flush(timeout_millis=5_000)
+        provider.shutdown()
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OTLP trace export failed; telemetry was dropped." in result.stderr
+    assert "collector-response-body-canary" not in result.stderr
+    assert "exporter-exception-canary" not in result.stderr
 
 
 def test_unvalidated_daft_version_disables_native_metrics() -> None:
@@ -234,7 +474,7 @@ def test_unvalidated_daft_version_disables_native_metrics() -> None:
 
         assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in os.environ
         assert _dependency_telemetry.take_diagnostics() == (
-            "Daft native metrics were disabled for an unvalidated dependency version.",
+            "Daft native metrics configuration was removed for an unvalidated dependency version.",
         )
         """
     )

--- a/tests/app/test_obs_process.py
+++ b/tests/app/test_obs_process.py
@@ -21,7 +21,7 @@ pytestmark = [
 def _run(source: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     for key in tuple(env):
-        if key.startswith(("LOGFIRE_", "OTEL_")) or key == "ARCHETYPE_LOG":
+        if key.startswith(("ARCHETYPE_OTLP_", "LOGFIRE_", "OTEL_")) or key == ("ARCHETYPE_LOG"):
             env.pop(key)
     return subprocess.run(
         [sys.executable, "-c", textwrap.dedent(source)],

--- a/tests/app/test_runtime_contracts.py
+++ b/tests/app/test_runtime_contracts.py
@@ -430,6 +430,13 @@ class TestVendorNeutralObservability:
         from archetype import _obs
 
         monkeypatch.setattr(_obs, "_configured", False)
+        # Exercise first-host selection even when another test installed the
+        # process-global provider earlier in this xdist worker.
+        monkeypatch.setattr(
+            _obs.trace,
+            "get_tracer_provider",
+            _obs.trace.ProxyTracerProvider,
+        )
         monkeypatch.setenv("LOGFIRE_SEND_TO_LOGFIRE", "1")
         monkeypatch.delenv("ARCHETYPE_LOG", raising=False)
 

--- a/tests/core/test_footgun_fixes.py
+++ b/tests/core/test_footgun_fixes.py
@@ -275,6 +275,13 @@ def test_runtime_send_to_logfire_with_token_env(monkeypatch):
     monkeypatch.delenv("LOGFIRE_SEND_TO_LOGFIRE", raising=False)
     monkeypatch.delenv("ARCHETYPE_LOG", raising=False)
     monkeypatch.setattr(_obs, "_configured", False)
+    # The first-host contract also requires the process-global provider proxy;
+    # another xdist-selected test may have installed a provider in this worker.
+    monkeypatch.setattr(
+        _obs.trace,
+        "get_tracer_provider",
+        _obs.trace.ProxyTracerProvider,
+    )
 
     captured: dict = {}
     monkeypatch.setattr(logfire, "configure", lambda **kwargs: captured.update(kwargs))

--- a/tests/eval_framework/test_harness_trial_validation.py
+++ b/tests/eval_framework/test_harness_trial_validation.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 import sys
 
@@ -219,11 +220,19 @@ def test_state_check_preserves_partial_credit_for_nonempty_checks() -> None:
 
 
 def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    # These CLI contracts do not opt into process-host telemetry. Keep them
+    # deterministic when another test or the runner supplies ambient config.
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("ARCHETYPE_OTLP_", "LOGFIRE_", "OTEL_")) and key != "ARCHETYPE_LOG"
+    }
     return subprocess.run(
         [sys.executable, "-m", "evals.run", *args],
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
 
 

--- a/tests/scripts/test_check_observability.py
+++ b/tests/scripts/test_check_observability.py
@@ -1237,19 +1237,26 @@ def sibling() -> None:
     _assert_rejected(_audit(tmp_path))
 
 
-def test_obs_host_adapter_can_register_logging_configuration(tmp_path: Path) -> None:
-    source = """
+@pytest.mark.parametrize("method", ["addFilter", "removeFilter"])
+def test_obs_host_adapter_can_register_logging_configuration(
+    tmp_path: Path,
+    method: str,
+) -> None:
+    source = f"""
 from __future__ import annotations
 
 def approved() -> None:
     import logging
-    logging.getLogger("dependency").addFilter(logging.Filter())
+    logging.getLogger("dependency").{method}(logging.Filter())
 """
+    manifests = _write_fixture(tmp_path, hosts=HOSTS, obs=OBS_VOCABULARY + source)
+    _assert_rejected(_audit(tmp_path))
+
     hosts = _with_host(
         "archetype._obs.approved",
         "logging_configuration",
     )
-    _write_fixture(tmp_path, hosts=hosts, obs=OBS_VOCABULARY + source)
+    (manifests / "hosts.toml").write_text(dedent(hosts).lstrip(), encoding="utf-8")
 
     assert _audit(tmp_path).ok
 

--- a/tests/scripts/test_check_observability.py
+++ b/tests/scripts/test_check_observability.py
@@ -1237,6 +1237,35 @@ def sibling() -> None:
     _assert_rejected(_audit(tmp_path))
 
 
+def test_obs_host_adapter_can_register_logging_configuration(tmp_path: Path) -> None:
+    source = """
+from __future__ import annotations
+
+def approved() -> None:
+    import logging
+    logging.getLogger("dependency").addFilter(logging.Filter())
+"""
+    hosts = _with_host(
+        "archetype._obs.approved",
+        "logging_configuration",
+    )
+    _write_fixture(tmp_path, hosts=hosts, obs=OBS_VOCABULARY + source)
+
+    assert _audit(tmp_path).ok
+
+    unapproved_source = (
+        source
+        + """
+
+def sibling() -> None:
+    import logging
+    logging.basicConfig()
+"""
+    )
+    _write_source_module(tmp_path, "_obs.py", OBS_VOCABULARY + unapproved_source)
+    _assert_rejected(_audit(tmp_path))
+
+
 def test_unrelated_configuration_method_name_is_not_logging(tmp_path: Path) -> None:
     source = (
         SERVICE

--- a/tests/scripts/test_check_observability.py
+++ b/tests/scripts/test_check_observability.py
@@ -1249,8 +1249,15 @@ def approved() -> None:
     import logging
     logging.getLogger("dependency").{method}(logging.Filter())
 """
-    manifests = _write_fixture(tmp_path, hosts=HOSTS, obs=OBS_VOCABULARY + source)
-    _assert_rejected(_audit(tmp_path))
+    manifests = _write_fixture(tmp_path, obs=OBS_VOCABULARY + source)
+    rejected = _audit(tmp_path)
+    assert not rejected.policy_errors
+    assert any(
+        violation.rule == "configuration_boundary"
+        and violation.qualified_scope == "archetype._obs.approved"
+        and violation.target.startswith(f"call:{method}:")
+        for violation in rejected.violations
+    )
 
     hosts = _with_host(
         "archetype._obs.approved",

--- a/uv.lock
+++ b/uv.lock
@@ -241,10 +241,12 @@ sim = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "grpcio" },
     { name = "httpx" },
     { name = "logfire", extra = ["fastapi"] },
     { name = "mujoco" },
     { name = "mutmut" },
+    { name = "opentelemetry-proto" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -292,10 +294,12 @@ provides-extras = ["benchmark", "sim", "otlp", "logfire", "coding-agent", "dev",
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "grpcio", specifier = ">=1.60" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "logfire", extras = ["fastapi"], specifier = ">=4.32.0" },
     { name = "mujoco", specifier = ">=3.2" },
     { name = "mutmut", specifier = ">=3.5" },
+    { name = "opentelemetry-proto", specifier = ">=1.20" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26" },
@@ -1176,6 +1180,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- route generic and signal-specific OTLP host configuration before any Archetype import can initialize Daft's independent native providers
- preserve filtered Archetype HTTP/protobuf traces through `ARCHETYPE_OTLP_TRACES_ENDPOINT` while leaving only validated, metrics-specific Daft telemetry visible to inherited workers
- make exporter initialization, export failures, shutdown races, malformed host configuration, and rejected Daft controls fixed-diagnostic semantic no-ops
- add pinned-version fresh-process receivers for gRPC and HTTP/protobuf, real combined Archetype-trace/Daft-metric coverage, import-order checks, and worker-inheritance checks
- record logical-Archetype versus physical-Daft execution ownership and update runtime/API guidance, contract traceability, and the post-#562 infrastructure classification

## Root cause

Daft 0.7.19 snapshots standard OTLP environment variables inside its compiled-module initializer. A generic OTLP endpoint therefore configured independent native log, trace, and metric providers before Archetype's filtered Python provider existed. Dependency diagnostics could then cross the repository's closed signal boundary, and some otherwise valid-looking Daft environment controls could either panic during provider initialization or create a zero-interval busy loop.

The process host now consumes generic/log/trace endpoint variables before Daft import and never restores them to the process environment, so spawned workers cannot recreate those providers. Generic and trace-specific values are retained only as an Archetype-owned full traces endpoint. Endpoint credentials, query strings, and fragments are rejected; exporter failures are reduced to one fixed diagnostic without response or exception content.

`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` remains the explicit Daft physical-metrics opt-in. It is restricted to the exact characterized Daft version, exact supported protocol spelling, validated endpoint syntax, no compression, and a positive interval when configured. Arbitrary resource attributes and unsupported configuration are removed without changing application work. Daft-first imports cannot be repaired retroactively because 0.7.19 exposes no native provider shutdown/reconfiguration API; detectable late ordering therefore produces only a fixed diagnostic.

## Impact

- no public Python API or REST surface changes
- no application-family or core behavior changes
- no new DataFrame materialization
- disabled, rejected, unreachable, or failing telemetry preserves application behavior and typed outcomes
- native Daft metrics measure physical execution directly; Archetype does not infer execution time from lazy plan construction
- dependency upgrades must explicitly admit a new Daft version through the real-receiver matrix before native metrics are enabled

## Validation

- governance-bypass replay — chained `addFilter`/`removeFilter` calls reject without an exact host grant; checker suite 97 passed; `make static` passed
- final telemetry-host test-isolation replay — 2 focused passed; both affected contract files 28 passed; `make static` passed
- focused observability/process suite — 254 passed
- ambient-telemetry eval CLI isolation replay — 36 passed
- independent adversarial review — no unresolved P0/P1/P2 findings; final focused replay 6 passed
- `make static` — passed on the post-#444 `origin/main`, including 149-file architecture and observability audits, lazy-materialization, contract, registry, version-inventory, and type checks
- `make test` — passed on the post-#444 `origin/main`: 2,075 passed, 1 skipped
- `make verify-full` — passed before the conflict-free #444 rebase: 2,059 passed, 9 skipped, 86.18% coverage; regression 15/15, spec 8/8, capability 10/10, idempotency 23/23; package smoke, examples, process/reliability evidence, and docs build passed

Closes #537
