### PR TITLE
feat(core): preserve structured processor failures across step aggregation

### DIFF
--- a/docs/guide/processors.md
+++ b/docs/guide/processors.md
@@ -53,6 +53,29 @@ processor raised. Archetype computes every table before it appends any of
 them. On failure, `step()` raises, the tick does not advance, no table appends,
 and staged mutations remain available for retry.
 
+The raised error is `TickExecutionError`, a `RuntimeError` subclass whose
+`failures` tuple preserves each failed table id and the original exception
+object. Classify failures by type — never by message text, which names the
+failed tables but not the underlying errors:
+
+```python
+from archetype import TickExecutionError
+from openai import APITimeoutError  # or whichever types your processors raise
+
+try:
+    await world.step()
+except TickExecutionError as exc:
+    if all(isinstance(f.error, APITimeoutError) for f in exc.failures):
+        world.add_processor(FallbackProcessor())  # then retry the same tick
+    else:
+        raise  # an unrelated processor bug: do not mask it
+```
+
+`exc.phase` is `"compute"` when a processor raised (nothing was written) and
+`"commit"` when persistence failed (the failed tables keep their staged
+mutations). The original tracebacks stay attached to each `failure.error` and
+render through `exc.__cause__`.
+
 A processor's `components` tuple is a matching predicate, not a request to
 change an entity's component set. Return a DataFrame compatible with the
 current archetype. Widen or narrow an entity explicitly between steps:

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -264,10 +264,30 @@ Failure policy:
 - A store failure during the commit phase preserves the failed archetype's
   staged mutations; archetypes whose appends committed consume their caches
   with the append.
+- The public failure type is `archetype.core.errors.TickExecutionError`, a
+  `RuntimeError` subclass (issue #444). `failures` MUST preserve every failed
+  table identity (`table_id`) and original exception object, in ascending
+  table-id order; `phase` MUST be `"compute"` or `"commit"`. Sync and async
+  stacks share this contract; the async stack chains the originals as an
+  `ExceptionGroup` cause, the fail-fast sync stack chains its single original
+  directly. Task cancellation MUST propagate unwrapped.
+- The aggregate's message names failed tables and the phase only; original
+  exception text MUST NOT enter it. Callers distinguish a provider timeout or
+  rate limit from a processor bug by `isinstance` on `failure.error`, never
+  by parsing message text.
+- Runtime and app layers propagate `TickExecutionError` unchanged. The REST
+  adapter has no public client-recovery contract for it and fails closed as
+  HTTP 500 with a redacted detail
+  (`tests/api/test_errors.py::test_tick_execution_error_remains_a_redacted_internal_error`).
 - Contract tests: `tests/core/test_async_world_error_propagation.py`
   (`test_async_world_processor_error_fails_the_step`,
   `test_failed_tick_commits_nothing_and_is_retryable`,
-  `test_one_failing_archetype_blocks_all_appends`).
+  `test_one_failing_archetype_blocks_all_appends`,
+  `test_step_preserves_ordered_structured_compute_failures`,
+  `test_step_preserves_ordered_structured_commit_failures`,
+  `test_step_does_not_wrap_task_cancellation`);
+  `tests/sync/test_sync_stack_contracts.py::test_sync_world_processor_error_fails_step_without_commit`;
+  `tests/app/test_runtime_contracts.py::TestStructuredStepFailures`.
 - Composed public-boundary evidence: the `processor_adversarial` capability
   eval combines advisory hook failures, one-table processor failure, atomic
   retry, and signature-aware matching across component migrations.

--- a/docs/reference/python/core.md
+++ b/docs/reference/python/core.md
@@ -15,3 +15,7 @@
 ::: archetype.core.AsyncQueryManager
 
 ::: archetype.core.AsyncUpdateManager
+
+::: archetype.core.TickExecutionError
+
+::: archetype.core.TickFailure

--- a/evals/suites/capability/tasks.py
+++ b/evals/suites/capability/tasks.py
@@ -22,6 +22,7 @@ from archetype.app.world.service import WorldService
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.errors import TickExecutionError
 from archetype.core.hooks import PostTick, PreTick
 from evals.graders import exact_match, state_check
 from evals.harness import EvalHarness
@@ -706,9 +707,16 @@ async def _task_processor_adversarial() -> list[GraderResult]:
             ),
             state_check(
                 {
+                    # #444: classify the failure by structure, not message
+                    # text — the aggregate names the table; the original
+                    # exception object rides in failures.
                     "processor_error_surfaced": (
-                        processor_error is not None
-                        and "marked-archetype failure" in str(processor_error)
+                        isinstance(processor_error, TickExecutionError)
+                        and processor_error.phase == "compute"
+                        and any(
+                            "marked-archetype failure" in str(failure.error)
+                            for failure in processor_error.failures
+                        )
                     ),
                     "failed_tick_did_not_advance": (
                         before_failure_info.tick == after_failure_info.tick == 2

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -44,7 +44,7 @@ reason = "Storage write boundary: materialize the incoming frame once for the em
 
 [[entries]]
 path = "src/archetype/core/aio/async_world.py"
-line = 409
+line = 422
 method = "to_pylist"
 reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
 
@@ -56,7 +56,7 @@ reason = "Debug-mode-only logging: materialise so count_rows and df.show emit di
 
 [[entries]]
 path = "src/archetype/core/sync/world.py"
-line = 289
+line = 305
 method = "to_pylist"
 reason = "Cross-archetype entity migration (sync mirror of async_world): extract the latest tick row for component overlay before re-insertion."
 

--- a/scripts/generate_python_api_docs.py
+++ b/scripts/generate_python_api_docs.py
@@ -155,6 +155,8 @@ PAGES: tuple[ReferencePage, ...] = (
             "AsyncSystem",
             "AsyncQueryManager",
             "AsyncUpdateManager",
+            "TickExecutionError",
+            "TickFailure",
         ),
     ),
     ReferencePage(

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -46,6 +46,9 @@ __all__ = [
     "Archetype",
     "ArchetypeSignature",
     "Resources",
+    # Step failure contract
+    "TickExecutionError",
+    "TickFailure",
     # Processor (with alias)
     "Processor",
     "SyncProcessor",
@@ -125,6 +128,9 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "Archetype": ("archetype.core", "Archetype"),
     "ArchetypeSignature": ("archetype.core", "ArchetypeSignature"),
     "Resources": ("archetype.core", "Resources"),
+    # Step failure contract (issue #444)
+    "TickExecutionError": ("archetype.core", "TickExecutionError"),
+    "TickFailure": ("archetype.core", "TickFailure"),
     # Processors (and aliases)
     "SyncProcessor": ("archetype.core", "SyncProcessor"),
     "AsyncProcessor": ("archetype.core", "AsyncProcessor"),

--- a/src/archetype/core/__init__.py
+++ b/src/archetype/core/__init__.py
@@ -35,6 +35,7 @@ from .aio import (
 from .archetype import Archetype
 from .component import Component
 from .config import CacheConfig, RunConfig, StorageConfig, WorldConfig
+from .errors import TickExecutionError, TickFailure
 from .interfaces import ArchetypeSignature
 from .resources import Resources
 
@@ -54,6 +55,9 @@ __all__ = [
     "ArchetypeSignature",
     "Archetype",
     "Resources",
+    # Step failure contract (issue #444)
+    "TickExecutionError",
+    "TickFailure",
     # Config
     "RunConfig",
     "StorageConfig",

--- a/src/archetype/core/aio/async_system.py
+++ b/src/archetype/core/aio/async_system.py
@@ -86,7 +86,7 @@ class AsyncSystem(iAsyncSystem):
                     )
 
                 # A processor failure fails the archetype's tick: the world
-                # step surfaces it (gather → RuntimeError) instead of
+                # step surfaces it (gather → TickExecutionError) instead of
                 # appending a frame the failed processor never transformed.
                 try:
                     # Filter kwargs to what the processor accepts; pass all if it has **kwargs.

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -29,6 +29,7 @@ from archetype.core.aio.async_querier import _canonicalize, _unknown_signature_e
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import RunConfig
+from archetype.core.errors import TickExecutionError, TickFailure
 from archetype.core.hooks import (
     AsyncHookHandler,
     FireMode,
@@ -176,8 +177,16 @@ class AsyncWorld(iAsyncWorld):
                     raise r
 
             if errors:
-                raise RuntimeError(
-                    "; ".join(f"{Archetype.get_name(sig)}: {e}" for sig, e in errors.items())
+                # Failures keep `sigs` order (ascending table id) and the
+                # original exception objects — the public contract (#444).
+                # The ExceptionGroup cause carries every original traceback;
+                # the raised message itself stays free of exception text.
+                failures = [
+                    TickFailure(table_id=Archetype.get_name(sig), error=e)
+                    for sig, e in errors.items()
+                ]
+                raise TickExecutionError(phase="compute", failures=failures) from ExceptionGroup(
+                    "archetype compute failures", [f.error for f in failures]
                 )
 
             # Phase 2 — commit every computed frame concurrently.
@@ -202,11 +211,15 @@ class AsyncWorld(iAsyncWorld):
                 if isinstance(r, Exception):
                     errors[sig] = r
                 elif isinstance(r, BaseException):
-                    # Never mask cancellation behind the aggregate RuntimeError.
+                    # Never mask cancellation behind the aggregate TickExecutionError.
                     raise r
             if errors:
-                raise RuntimeError(
-                    "; ".join(f"{Archetype.get_name(sig)}: {e}" for sig, e in errors.items())
+                failures = [
+                    TickFailure(table_id=Archetype.get_name(sig), error=e)
+                    for sig, e in errors.items()
+                ]
+                raise TickExecutionError(phase="commit", failures=failures) from ExceptionGroup(
+                    "archetype commit failures", [f.error for f in failures]
                 )
 
             # Every remaining commit result is a DataFrame, keeping

--- a/src/archetype/core/errors.py
+++ b/src/archetype/core/errors.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public step-failure contract (issue #444).
+
+``step()`` aggregates per-table failures into one ``TickExecutionError``
+instead of flattening them into message text. The whole-tick failure
+semantics are unchanged — the step raises, the tick counter does not
+advance, nothing is appended, staged mutations survive for retry — what
+this module adds is inspectable composition: every failed table identity
+and original exception object crosses the boundary intact, so callers
+classify a provider timeout or rate limit with ``isinstance`` on
+``failure.error`` rather than parsing strings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+TickPhase = Literal["compute", "commit"]
+
+
+@dataclass(frozen=True)
+class TickFailure:
+    """One archetype table's original failure within a failed tick.
+
+    ``error`` is the exception object the table's compute or commit raised,
+    unwrapped — its type, args, and traceback survive step aggregation.
+    """
+
+    table_id: str
+    error: Exception
+
+
+class TickExecutionError(RuntimeError):
+    """One or more archetype tables failed while stepping a world tick.
+
+    ``failures`` preserves every failed table identity and original
+    exception object in ascending ``table_id`` order (the step's
+    deterministic archetype order). ``phase`` names the step phase that
+    aggregated them: ``"compute"`` (processor execution; nothing was
+    written anywhere) or ``"commit"`` (persistence; the failed tables'
+    staged mutations survive for retry).
+
+    The message carries table identities and the phase only — never the
+    original exception text, which may embed provider payloads or paths.
+    Raise sites chain the originals as ``__cause__`` (an ``ExceptionGroup``
+    at async aggregation boundaries, the single original in the fail-fast
+    sync stack), so tracebacks still render every underlying failure.
+
+    Subclasses ``RuntimeError``: callers that caught the old flattened
+    aggregate keep catching this one; they gain typed classification.
+    """
+
+    def __init__(self, *, phase: TickPhase, failures: Sequence[TickFailure]) -> None:
+        self.phase: TickPhase = phase
+        self.failures: tuple[TickFailure, ...] = tuple(failures)
+        tables = ", ".join(f.table_id for f in self.failures)
+        super().__init__(
+            f"{len(self.failures)} archetype table(s) failed during the {phase} phase: {tables}"
+        )
+
+    def __reduce__(self) -> tuple[object, ...]:
+        # BaseException pickles as cls(*self.args), which cannot satisfy the
+        # keyword-only constructor; rebuild from the structured state instead.
+        return (_rebuild_tick_execution_error, (self.phase, self.failures))
+
+
+def _rebuild_tick_execution_error(
+    phase: TickPhase, failures: tuple[TickFailure, ...]
+) -> TickExecutionError:
+    return TickExecutionError(phase=phase, failures=failures)

--- a/src/archetype/core/sync/world.py
+++ b/src/archetype/core/sync/world.py
@@ -24,6 +24,7 @@ from uuid_utils import uuid7
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import RunConfig
+from archetype.core.errors import TickExecutionError, TickFailure
 from archetype.core.hooks import (
     HookEvent,
     HookHandle,
@@ -116,16 +117,31 @@ class SyncWorld(iWorld):
 
         # Phase 1 — compute. No store writes, no cache consumption: a
         # processor failure leaves the world untouched and the tick retryable.
+        # Sequential execution fails fast, so the public TickExecutionError
+        # carries exactly one failure — same contract as the async stack, with
+        # the single original chained directly as __cause__ (#444).
         computed: dict[ArchetypeSignature, DataFrame] = {}
         for sig in sigs:
-            computed[sig] = self._compute_archetype(sig, run_config, **input_kwargs)
+            try:
+                computed[sig] = self._compute_archetype(sig, run_config, **input_kwargs)
+            except Exception as e:
+                raise TickExecutionError(
+                    phase="compute",
+                    failures=[TickFailure(table_id=Archetype.get_name(sig), error=e)],
+                ) from e
 
         # Phase 2 — commit. Each archetype's caches are consumed only after
         # its rows are appended; a store failure preserves exactly the
         # uncommitted mutations.
         results: dict[ArchetypeSignature, DataFrame] = {}
         for sig, df in computed.items():
-            results[sig] = self.update(df, sig, run_config, self.tick)
+            try:
+                results[sig] = self.update(df, sig, run_config, self.tick)
+            except Exception as e:
+                raise TickExecutionError(
+                    phase="commit",
+                    failures=[TickFailure(table_id=Archetype.get_name(sig), error=e)],
+                ) from e
             self.spawn_cache.pop(sig, None)
             self.despawn_cache.pop(sig, None)
 

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -22,6 +22,7 @@ from archetype.app.storage.catalog import (
     ClaimPendingError,
     SqliteControlCatalog,
 )
+from archetype.core.errors import TickExecutionError, TickFailure
 
 
 @pytest.mark.parametrize(
@@ -103,6 +104,28 @@ def test_catalog_schema_mismatch_remains_an_internal_error() -> None:
 
     assert raised.value.status_code == 500
     assert raised.value.detail == "Internal server error"
+
+
+def test_tick_execution_error_remains_a_redacted_internal_error() -> None:
+    """#444: the structured step failure is a Python-boundary contract; the
+    REST adapter fails closed without leaking table errors or payloads."""
+    secret = "sk-proj-" + "example-secret-never-expose"
+    error = TickExecutionError(
+        phase="commit",
+        failures=(
+            TickFailure(
+                table_id="a_1c_safe_table_id",
+                error=TimeoutError(f"provider failed with {secret}"),
+            ),
+        ),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(error)
+
+    assert raised.value.status_code == 500
+    assert raised.value.detail == "Internal server error"
+    assert secret not in raised.value.detail
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_atomic_visibility.py
+++ b/tests/app/test_atomic_visibility.py
@@ -19,6 +19,7 @@ from archetype.app.storage.commit import CatalogCommitCoordinator
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.errors import TickExecutionError
 from archetype.core.interfaces import StaleWriterError
 
 pytestmark = [
@@ -142,8 +143,12 @@ async def test_partial_archetype_append_is_invisible_and_retry_is_atomic(tmp_pat
             raise RuntimeError("injected second-archetype append failure")
 
         monkeypatch.setattr(store, "append", fail_after_counter)
-        with pytest.raises(RuntimeError, match="second-archetype append failure"):
+        # #444: the commit-phase aggregate names the failed table only; the
+        # injected append error rides in failures with its text intact.
+        with pytest.raises(TickExecutionError) as raised:
             await c.simulation_service.step(world.world_id, RunConfig())
+        assert raised.value.phase == "commit"
+        assert any("second-archetype append failure" in str(f.error) for f in raised.value.failures)
 
         assert world.tick == 0
         assert await _visible_rows(c, world, storage, component=Counter) == []

--- a/tests/app/test_runtime_contracts.py
+++ b/tests/app/test_runtime_contracts.py
@@ -16,7 +16,9 @@ import pytest
 
 from archetype import ArchetypeRuntime, Component
 from archetype.app.gateway.auth.guard import reset_daily_tokens, reset_tick_counters
+from archetype.core.aio import AsyncProcessor
 from archetype.core.config import StorageConfig
+from archetype.core.errors import TickExecutionError
 from archetype.core.hooks import PreTick
 
 
@@ -28,6 +30,17 @@ class Pos(Component):
 class Vel(Component):
     dx: float = 0.0
     dy: float = 0.0
+
+
+class FailPosWith(AsyncProcessor):
+    components = (Pos,)
+    priority = 1
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def process(self, df, **kwargs):
+        raise self.error
 
 
 @pytest.fixture(autouse=True)
@@ -254,6 +267,46 @@ class TestShutdownIdempotency:
 
         assert isinstance(captured.value.__cause__, BaseExceptionGroup)
         assert isinstance(captured.value.__cause__.exceptions[0], asyncio.CancelledError)
+
+
+class TestStructuredStepFailures:
+    """#444: TickExecutionError crosses the runtime boundary unchanged, so
+    scripts classify provider failures by isinstance on failure.error."""
+
+    @pytest.mark.asyncio
+    async def test_runtime_propagates_structured_failure_unchanged(self, tmp_path):
+        processor_error = TimeoutError("private provider detail")
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "structured-failure",
+                storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns"),
+                processors=[FailPosWith(processor_error)],
+            )
+            await world.spawn(Pos())
+
+            with pytest.raises(TickExecutionError) as raised:
+                await world.step()
+
+            assert raised.value.phase == "compute"
+            assert len(raised.value.failures) == 1
+            assert raised.value.failures[0].error is processor_error
+
+    def test_sync_runtime_preserves_the_same_failure_contract(self, tmp_path):
+        processor_error = TimeoutError("private provider detail")
+        with ArchetypeRuntime.sync() as runtime:
+            world = runtime.world(
+                "sync-structured-failure",
+                storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns"),
+                processors=[FailPosWith(processor_error)],
+            )
+            world.spawn(Pos())
+
+            with pytest.raises(TickExecutionError) as raised:
+                world.step()
+
+            assert raised.value.phase == "compute"
+            assert len(raised.value.failures) == 1
+            assert raised.value.failures[0].error is processor_error
 
 
 # ── 5. Fork handles ─────────────────────────────────────────────────────

--- a/tests/core/test_async_world_error_propagation.py
+++ b/tests/core/test_async_world_error_propagation.py
@@ -1,8 +1,13 @@
+import asyncio
+import pickle
+
 import pytest
 
 from archetype.core.aio import AsyncProcessor, AsyncSystem
+from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+from archetype.core.errors import TickExecutionError, TickFailure
 from tests.conftest import make_world_service
 
 
@@ -45,8 +50,14 @@ async def test_async_world_processor_error_fails_the_step(tmp_path, caplog):
         await world.create_entity([Foo(x=1)])
 
         with caplog.at_level("ERROR"):
-            with pytest.raises(RuntimeError, match="boom"):
+            # `except RuntimeError` remains a valid caller contract (#444):
+            # the structured TickExecutionError subclasses it. Its message
+            # names the failed table, not the processor's exception text.
+            with pytest.raises(RuntimeError) as raised:
                 await world.run(RunConfig(num_steps=1))
+        assert isinstance(raised.value, TickExecutionError)
+        assert Archetype.get_name((Foo,)) in str(raised.value)
+        assert "boom" not in str(raised.value)
         assert any("Error processing archetype" in rec.message for rec in caplog.records)
         # The failed tick did not happen: the counter never advanced.
         assert world.tick == 0
@@ -72,7 +83,7 @@ async def test_failed_tick_commits_nothing_and_is_retryable(tmp_path):
         eid = await world.create_entity([Foo(x=1)])
         sig = (Foo,)
 
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(TickExecutionError):
             await world.run(RunConfig(num_steps=1))
 
         # Nothing committed; the pending spawn survived the failure.
@@ -107,7 +118,7 @@ async def test_one_failing_archetype_blocks_all_appends(tmp_path):
         await world.create_entity([Foo(x=1)])
         bar_eid = await world.create_entity([Bar(y=2)])
 
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(TickExecutionError):
             await world.run(RunConfig(num_steps=1))
 
         # The healthy archetype appended nothing either, and keeps its spawn.
@@ -117,3 +128,167 @@ async def test_one_failing_archetype_blocks_all_appends(tmp_path):
         assert world.tick == 0
     finally:
         await ws.shutdown()
+
+
+class RateLimitError(RuntimeError):
+    """Provider-shaped test error without importing a vendor client."""
+
+
+class FailFooWith(AsyncProcessor):
+    components = (Foo,)
+    priority = 1
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def process(self, df, **kwargs):
+        raise self.error
+
+
+class FailBarWith(AsyncProcessor):
+    components = (Bar,)
+    priority = 1
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def process(self, df, **kwargs):
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_step_preserves_ordered_structured_compute_failures(tmp_path):
+    """#444: the aggregate step error preserves every failed table identity
+    and the ORIGINAL exception objects in ascending table-id order, chained
+    as an ExceptionGroup cause — and its own message never leaks the
+    originals' text."""
+    timeout = TimeoutError("private provider timeout detail")
+    rate_limit = RateLimitError("private provider quota detail")
+    errors_by_table = {
+        Archetype.get_name((Foo,)): timeout,
+        Archetype.get_name((Bar,)): rate_limit,
+    }
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        system = AsyncSystem()
+        await system.add_processor(FailFooWith(timeout))
+        await system.add_processor(FailBarWith(rate_limit))
+        world = await ws.create_world(WorldConfig(name="w"), storage_config=storage, system=system)
+        await world.create_entity([Foo(x=1)])
+        await world.create_entity([Bar(y=2)])
+
+        with pytest.raises(TickExecutionError) as raised:
+            await world.step(RunConfig(num_steps=1))
+
+        error = raised.value
+        expected_tables = tuple(sorted(errors_by_table))
+        assert isinstance(error, RuntimeError)
+        assert error.phase == "compute"
+        assert tuple(failure.table_id for failure in error.failures) == expected_tables
+        assert tuple(failure.error for failure in error.failures) == tuple(
+            errors_by_table[table_id] for table_id in expected_tables
+        )
+        assert isinstance(error.__cause__, ExceptionGroup)
+        assert error.__cause__.exceptions == tuple(
+            errors_by_table[table_id] for table_id in expected_tables
+        )
+        assert "private provider" not in str(error)
+        assert world.tick == 0
+        assert set(world.spawn_cache) == {(Foo,), (Bar,)}
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_step_preserves_ordered_structured_commit_failures(tmp_path, monkeypatch):
+    """#444: commit-phase aggregation carries the same structured contract,
+    with phase="commit" and every staged mutation preserved for retry."""
+    foo_error = OSError("private foo commit detail")
+    bar_error = RuntimeError("private bar execution detail")
+    errors_by_table = {
+        Archetype.get_name((Foo,)): foo_error,
+        Archetype.get_name((Bar,)): bar_error,
+    }
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        world = await ws.create_world(WorldConfig(name="w"), storage_config=storage)
+        await world.create_entity([Foo(x=1)])
+        await world.create_entity([Bar(y=2)])
+        world.commit_coordinator = None
+
+        async def fail_commit(sig, df, run_config):
+            raise errors_by_table[Archetype.get_name(sig)]
+
+        monkeypatch.setattr(world, "_commit_archetype", fail_commit)
+
+        with pytest.raises(TickExecutionError) as raised:
+            await world.step(RunConfig(num_steps=1))
+
+        error = raised.value
+        expected_tables = tuple(sorted(errors_by_table))
+        assert error.phase == "commit"
+        assert tuple(failure.table_id for failure in error.failures) == expected_tables
+        assert tuple(failure.error for failure in error.failures) == tuple(
+            errors_by_table[table_id] for table_id in expected_tables
+        )
+        assert isinstance(error.__cause__, ExceptionGroup)
+        assert error.__cause__.exceptions == tuple(
+            errors_by_table[table_id] for table_id in expected_tables
+        )
+        assert "private" not in str(error)
+        assert world.tick == 0
+        assert set(world.spawn_cache) == {(Foo,), (Bar,)}
+    finally:
+        await ws.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_step_does_not_wrap_task_cancellation(tmp_path):
+    """Cancellation is not a table failure: it propagates raw so task
+    teardown is never masked behind the aggregate (#444 keeps the existing
+    cancellation semantics)."""
+
+    class CancelFoo(AsyncProcessor):
+        components = (Foo,)
+        priority = 1
+
+        async def process(self, df, **kwargs):
+            raise asyncio.CancelledError("cancel step")
+
+    ws = make_world_service()
+    try:
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        system = AsyncSystem()
+        await system.add_processor(CancelFoo())
+        world = await ws.create_world(WorldConfig(name="w"), storage_config=storage, system=system)
+        await world.create_entity([Foo(x=1)])
+
+        # asyncio surfaces a task's cancellation as a fresh CancelledError
+        # (the original message does not survive gather); the contract under
+        # test is the TYPE: cancellation is never wrapped in the aggregate.
+        with pytest.raises(asyncio.CancelledError):
+            await world.step(RunConfig(num_steps=1))
+
+        assert world.tick == 0
+        assert (Foo,) in world.spawn_cache
+    finally:
+        await ws.shutdown()
+
+
+def test_tick_execution_error_survives_pickle_round_trip():
+    """The keyword-only constructor needs an explicit __reduce__; without it
+    any process boundary (logging queues, worker pools) drops the error."""
+    error = TickExecutionError(
+        phase="compute",
+        failures=(TickFailure(table_id="a_1c_table", error=ValueError("original detail")),),
+    )
+
+    clone = pickle.loads(pickle.dumps(error))
+
+    assert isinstance(clone, TickExecutionError)
+    assert clone.phase == "compute"
+    assert clone.failures[0].table_id == "a_1c_table"
+    assert isinstance(clone.failures[0].error, ValueError)
+    assert str(clone) == str(error)

--- a/tests/sync/test_sync_stack_contracts.py
+++ b/tests/sync/test_sync_stack_contracts.py
@@ -16,6 +16,7 @@ from archetype.app.storage.session import configure_session
 from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import RunConfig, StorageConfig
+from archetype.core.errors import TickExecutionError
 from archetype.core.hooks import SyncHookRegistry
 from archetype.core.resources import Resources
 from archetype.core.sync import (
@@ -635,12 +636,14 @@ def test_sync_world_execute_passes_resources_and_kwargs(tmp_path):
 
 
 def test_sync_world_processor_error_fails_step_without_commit(tmp_path, caplog):
+    processor_error = RuntimeError("private processor detail")
+
     class BadProc(SyncProcessor):
         components = (Position,)
         priority = 1
 
         def process(self, df: DataFrame, **kwargs) -> DataFrame:
-            raise RuntimeError("boom")
+            raise processor_error
 
     _store, _querier, _updater, system, world = _make_sync_stack(tmp_path, "world_proc_error")
     system.add_processor(BadProc())
@@ -648,13 +651,49 @@ def test_sync_world_processor_error_fails_step_without_commit(tmp_path, caplog):
     entity_id = world.create_entity([Position(x=1, y=2)])
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(TickExecutionError) as raised:
             world.step(RunConfig(num_steps=1))
 
+    # Sync parity for #444: same public type as the async stack, one
+    # fail-fast failure, the single original chained directly as __cause__.
+    assert isinstance(raised.value, RuntimeError)
+    assert raised.value.phase == "compute"
+    assert len(raised.value.failures) == 1
+    assert raised.value.failures[0].table_id == Archetype.get_name(sig)
+    assert raised.value.failures[0].error is processor_error
+    assert raised.value.__cause__ is processor_error
+    assert "private processor detail" not in str(raised.value)
     assert any("Error processing archetype" in rec.message for rec in caplog.records)
     assert world.tick == 0
     assert any(row["entity_id"] == entity_id for row in world.spawn_cache.get(sig, []))
     assert world.query_archetype(sig=sig, ticks=[0]).count_rows() == 0
+
+
+def test_sync_world_commit_error_preserves_structured_failure(tmp_path):
+    """A commit-phase store failure carries the same structured contract
+    (phase="commit") and leaves the staged mutation retryable (#444)."""
+    commit_error = RuntimeError("private append detail")
+
+    _store, _querier, _updater, _system, world = _make_sync_stack(tmp_path, "world_commit_error")
+    sig = Archetype.sig_from_components([Position(x=0, y=0)])
+    entity_id = world.create_entity([Position(x=1, y=2)])
+
+    def failing_update(df, sig, run_config, tick):
+        raise commit_error
+
+    world.update = failing_update
+
+    with pytest.raises(TickExecutionError) as raised:
+        world.step(RunConfig(num_steps=1))
+
+    assert raised.value.phase == "commit"
+    assert len(raised.value.failures) == 1
+    assert raised.value.failures[0].table_id == Archetype.get_name(sig)
+    assert raised.value.failures[0].error is commit_error
+    assert raised.value.__cause__ is commit_error
+    assert "private append detail" not in str(raised.value)
+    assert world.tick == 0
+    assert any(row["entity_id"] == entity_id for row in world.spawn_cache.get(sig, []))
 
 
 def test_sync_world_query_archetype_uses_world_tick_and_world_id():


### PR DESCRIPTION
## Summary

Closes #444.

`step()` previously collected per-table failures and raised one `RuntimeError` built by joining table names and `str(error)`, discarding the structured exception objects at the public boundary. Both aggregation sites (compute and commit) now raise `archetype.core.errors.TickExecutionError`:

- `failures: tuple[TickFailure, ...]` preserves every failed table identity (`table_id`) and the **original exception object** — type, args, and traceback intact — in ascending table-id order (the step's deterministic archetype sort).
- `phase` is `"compute"` (processor execution; nothing written anywhere) or `"commit"` (persistence; failed tables keep their staged mutations).
- The aggregate's own message names tables and phase only — original exception text never enters it, so telemetry (#519) can classify the typed outcome without ever seeing raw provider payloads.
- The async stack chains all originals as an `ExceptionGroup` `__cause__`; the fail-fast sync stack chains its single original directly. Tracebacks still render every underlying failure.
- Exported from `archetype.core` and top-level `archetype`.

## Design decisions (the issue's questions)

- **Not an `ExceptionGroup` as the raised type**: it does not subclass `RuntimeError`, so every existing `except RuntimeError` caller and test would break. `TickExecutionError(RuntimeError)` keeps type-level compatibility; the `ExceptionGroup` rides as `__cause__` where it belongs.
- **One class, no hierarchy**: a single exception with a `phase` discriminant covers both aggregation sites; error data stays inspectable composition (`TickFailure` frozen dataclass), per the issue's smallest-abstraction constraint.
- **Compat contract for `except RuntimeError` callers**: unchanged catch behavior. The message becomes a table-identity summary — deliberate, since message parsing is the anti-pattern this issue removes.
- **Sync parity**: `SyncWorld.step()` raises the same public type (single fail-fast failure). One contract for both stacks.
- **Runtime/API mapping**: `TickExecutionError` propagates unchanged through app and runtime layers (tested async + sync). The REST adapter has no client-recovery contract for it and keeps failing closed as a redacted 500 — no table errors or payloads cross the HTTP boundary.
- **Pickle**: the keyword-only constructor needs an explicit `__reduce__` (default exception pickling calls `cls(*args)` with the formatted message); added with a round-trip test.

## Unchanged semantics (with tests)

- Whole-tick atomicity, staged-mutation retry, and cache-consumption ordering are untouched — the pre-existing error-propagation tests still pass against the new type.
- Task cancellation is never wrapped in the aggregate (`test_step_does_not_wrap_task_cancellation`).

## Also in this PR

- `processor_adversarial` eval now grades the structured contract (`isinstance` + `failure.error` text) instead of matching on the aggregate's message.
- `lazy_audit.toml`: renumbered the two pre-existing world-migration `.to_pylist()` entries (my insertions shifted their lines); **no new materialization points**.
- Spec failure-policy section and `docs/guide/processors.md` document the contract.

## Deferred to #443

The `llm_facing` eval and its temporary message classifier live on unmerged PR #443. Once this lands, #443 rebases onto the structured contract and drops the classifier (that acceptance item completes there).

## Validation

- `make check`, lock-check, and `make lazy-audit` pass (25 audited sites, all accounted for).
- Full suite: 1,819 passed / 23 skipped, coverage 85.4%, with two failures triaged:
  - `test_partial_archetype_append_is_invisible_and_retry_is_atomic` matched on the old flattened message; updated to the structured contract in this PR and passing.
  - `test_worker_recovers_interrupted_legacy_eligibility_backfill` fails identically on clean HEAD in this environment (wrangler's local server never becomes ready in the sandbox) — pre-existing, unrelated.
- All 62 tests in the touched files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
