### PR TITLE
feat(projections): family library with world-overview read models (stage 0)

### DIFF
--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -90,6 +90,11 @@ name = "missions-domain-family"
 consumer = "archetype.missions"
 allowed_families = []
 
+[[top_level_family_rule]]
+name = "projections-domain-family"
+consumer = "archetype.projections"
+allowed_families = []
+
 [[package_rule]]
 name = "core-does-not-import-outward"
 consumer = "archetype.core"

--- a/src/archetype/projections/__init__.py
+++ b/src/archetype/projections/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Projections family library: read models over the append-only ledger.
+
+Design: ``docs/design/graph-system.md`` (stage 0). Frame-pure read models in
+:mod:`archetype.projections.frames`; async handle sugar in
+:mod:`archetype.projections.worlds`; R5 sync parity in
+:mod:`archetype.projections.sync`. Imports only core and third-party
+packages (design D1); every layer may import it. Family-specific projection
+logic belongs inside its family — this package holds the generic,
+cross-family read models.
+"""
+
+from archetype.projections import sync
+from archetype.projections.frames import activity, latest, overview
+from archetype.projections.worlds import QueriesLike, world_overview
+
+__all__ = [
+    "QueriesLike",
+    "activity",
+    "latest",
+    "overview",
+    "sync",
+    "world_overview",
+]

--- a/src/archetype/projections/frames.py
+++ b/src/archetype/projections/frames.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frame-pure world read models (design D1, docs/design/graph-system.md, stage 0).
+
+Projections are read models over the append-only ledger: functions from lazy
+frames to lazy frames, importing nothing above core. They operate on the base
+columns every archetype table carries (``entity_id``, ``tick``), so they work
+on any queried frame — component tables and EdgeTables alike. Nothing here
+materializes; callers own the terminal collect at their boundary.
+"""
+
+from __future__ import annotations
+
+from daft import DataFrame, col, lit
+
+
+def activity(frame: DataFrame, *, table: str = "entities") -> DataFrame:
+    """Per-tick population of a queried frame: one row per tick.
+
+    Every live entity persists one row per tick, so the row count per tick is
+    the population at that tick. Output columns: ``table``, ``tick``,
+    ``population``.
+    """
+    per_tick = frame.groupby("tick").agg(col("entity_id").count().alias("population"))
+    return per_tick.with_column("table", lit(table)).select(
+        col("table"), col("tick"), col("population")
+    )
+
+
+def overview(**frames: DataFrame) -> DataFrame:
+    """Union of :func:`activity` across named frames.
+
+    ``overview(nodes=node_frame, edges=edge_frame)`` yields one population
+    series per name — the minimap primitive: what lives where, over time.
+    """
+    if not frames:
+        raise ValueError("overview requires at least one named frame")
+    parts = [activity(frame, table=name) for name, frame in frames.items()]
+    out = parts[0]
+    for part in parts[1:]:
+        out = out.concat(part)
+    return out.sort(["table", "tick"])
+
+
+def latest(frame: DataFrame) -> DataFrame:
+    """Rows at the frame's maximum tick.
+
+    The maximum is found with a one-row aggregate joined back on ``tick``, so
+    the whole read stays in the lazy plan.
+    """
+    max_tick = frame.agg(col("tick").max().alias("tick"))
+    return frame.join(max_tick, on="tick")

--- a/src/archetype/projections/sync.py
+++ b/src/archetype/projections/sync.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Handle-level projection sugar, sync flavor (runtime.md R5 parity).
+
+Blocking counterpart of :mod:`archetype.projections.worlds` for
+``SyncRuntimeWorld``-shaped handles. Passing an async handle here raises
+before any query.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Protocol
+
+from daft import DataFrame
+
+from archetype.core.component import Component
+from archetype.projections.frames import overview
+
+
+class SyncQueriesLike(Protocol):
+    """Structural surface the sync projection helpers need from a handle."""
+
+    def query(self, *components: type[Component]) -> DataFrame: ...
+
+
+def _require_sync(world: SyncQueriesLike) -> None:
+    if inspect.iscoroutinefunction(world.query):
+        raise TypeError(
+            "world.query is async; for async world handles use archetype.projections.worlds"
+        )
+
+
+def world_overview(world: SyncQueriesLike, *components: type[Component]) -> DataFrame:
+    """Per-tick population series for each component type, labeled by name."""
+    if not components:
+        raise ValueError("world_overview requires at least one component type")
+    _require_sync(world)
+    frames = {comp.__name__.lower(): world.query(comp) for comp in components}
+    return overview(**frames)

--- a/src/archetype/projections/sync.py
+++ b/src/archetype/projections/sync.py
@@ -17,6 +17,7 @@ from daft import DataFrame
 
 from archetype.core.component import Component
 from archetype.projections.frames import overview
+from archetype.projections.worlds import require_unique_labels
 
 
 class SyncQueriesLike(Protocol):
@@ -33,9 +34,14 @@ def _require_sync(world: SyncQueriesLike) -> None:
 
 
 def world_overview(world: SyncQueriesLike, *components: type[Component]) -> DataFrame:
-    """Per-tick population series for each component type, labeled by name."""
+    """Per-tick population series for each component type, labeled by name.
+
+    Label collisions raise, mirroring the async flavor; use
+    :func:`archetype.projections.overview` with explicit labels instead.
+    """
     if not components:
         raise ValueError("world_overview requires at least one component type")
     _require_sync(world)
+    require_unique_labels(components)
     frames = {comp.__name__.lower(): world.query(comp) for comp in components}
     return overview(**frames)

--- a/src/archetype/projections/worlds.py
+++ b/src/archetype/projections/worlds.py
@@ -18,6 +18,25 @@ from archetype.core.component import Component
 from archetype.projections.frames import overview
 
 
+def require_unique_labels(components: tuple[type[Component], ...]) -> None:
+    """Reject distinct component types whose lowercased names collide.
+
+    A duplicate label would silently drop one component's series from the
+    overview; failing loud preserves the read model's completeness. Shared
+    by the async and sync ``world_overview``.
+    """
+    labels: dict[str, type[Component]] = {}
+    for comp in components:
+        label = comp.__name__.lower()
+        other = labels.get(label)
+        if other is not None and other is not comp:
+            raise ValueError(
+                f"components {other!r} and {comp!r} both label as '{label}'; "
+                "call archetype.projections.overview with explicit labels"
+            )
+        labels[label] = comp
+
+
 class QueriesLike(Protocol):
     """Structural surface the async projection helpers need from a handle."""
 
@@ -33,9 +52,16 @@ def _require_async(world: QueriesLike) -> None:
 
 
 async def world_overview(world: QueriesLike, *components: type[Component]) -> DataFrame:
-    """Per-tick population series for each component type, labeled by name."""
+    """Per-tick population series for each component type, labeled by name.
+
+    Labels are lowercased class names. Two distinct components sharing a
+    name would silently shadow each other, so collisions raise instead —
+    call :func:`archetype.projections.overview` with explicit labels to
+    disambiguate.
+    """
     if not components:
         raise ValueError("world_overview requires at least one component type")
     _require_async(world)
+    require_unique_labels(components)
     frames = {comp.__name__.lower(): await world.query(comp) for comp in components}
     return overview(**frames)

--- a/src/archetype/projections/worlds.py
+++ b/src/archetype/projections/worlds.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Handle-level projection sugar, async flavor.
+
+Sync-parity counterparts live in :mod:`archetype.projections.sync`
+(runtime.md R5). Passing a sync handle here raises before any query.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Protocol
+
+from daft import DataFrame
+
+from archetype.core.component import Component
+from archetype.projections.frames import overview
+
+
+class QueriesLike(Protocol):
+    """Structural surface the async projection helpers need from a handle."""
+
+    async def query(self, *components: type[Component]) -> DataFrame: ...
+
+
+def _require_async(world: QueriesLike) -> None:
+    if not inspect.iscoroutinefunction(world.query):
+        raise TypeError(
+            "world.query is not async; for SyncRuntimeWorld-shaped handles "
+            "use archetype.projections.sync"
+        )
+
+
+async def world_overview(world: QueriesLike, *components: type[Component]) -> DataFrame:
+    """Per-tick population series for each component type, labeled by name."""
+    if not components:
+        raise ValueError("world_overview requires at least one component type")
+    _require_async(world)
+    frames = {comp.__name__.lower(): await world.query(comp) for comp in components}
+    return overview(**frames)

--- a/tests/projections/test_overview_contract.py
+++ b/tests/projections/test_overview_contract.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for the projections family's world read models (stage 0).
+
+Each test pins a claim from docs/design/graph-system.md stage 0: projections
+are frame-pure functions over base columns, populations track the ledger
+tick-by-tick, and handle sugar has async and sync parity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.component import Component  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.projections import latest, overview, world_overview  # noqa: E402
+from archetype.projections import sync as projections_sync  # noqa: E402
+
+
+class Crew(Component):
+    name: str = ""
+
+
+class Cargo(Component):
+    kind: str = ""
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "proj_data"), namespace="projection_tests")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_activity_tracks_population_over_ticks(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("activity", storage=_storage(tmp_path))
+            a = await world.spawn(Crew(name="a"))
+            await world.spawn(Crew(name="b"))
+            await world.run(steps=2)
+            await world.despawn(a)
+            await world.run(steps=2)
+
+            series = (await world_overview(world, Crew)).to_pylist()
+            populations = [row["population"] for row in series]
+            assert populations[0] == 2  # both spawned at tick 0
+            assert populations[-1] == 1  # one despawned
+            assert all(row["table"] == "crew" for row in series)
+            return True
+
+    assert _run(go())
+
+
+def test_overview_labels_multiple_tables(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("labels", storage=_storage(tmp_path))
+            await world.spawn(Crew(name="a"))
+            await world.spawn(Cargo(kind="ore"))
+            await world.spawn(Cargo(kind="ice"))
+            await world.step()
+
+            rows = (await world_overview(world, Crew, Cargo)).to_pylist()
+            by_table = {row["table"]: row["population"] for row in rows}
+            assert by_table == {"crew": 1, "cargo": 2}
+            return True
+
+    assert _run(go())
+
+
+def test_overview_requires_a_frame():
+    with pytest.raises(ValueError):
+        overview()
+
+
+def test_world_overview_requires_components(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("nocomp", storage=_storage(tmp_path))
+            with pytest.raises(ValueError):
+                await world_overview(world)
+            return True
+
+    assert _run(go())
+
+
+def test_latest_returns_max_tick_rows(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("latest", storage=_storage(tmp_path))
+            await world.spawn(Crew(name="a"))
+            await world.spawn(Crew(name="b"))
+            await world.run(steps=3)
+
+            info = await world.info()
+            rows = latest(await world.query(Crew)).to_pylist()
+            assert len(rows) == 2
+            assert all(row["tick"] == info.tick - 1 for row in rows)
+            return True
+
+    assert _run(go())
+
+
+def test_async_helper_rejects_sync_world(tmp_path):
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world("syncguard", storage=_storage(tmp_path))
+        world.spawn(Crew(name="a"))
+        world.step()
+        with pytest.raises(TypeError, match="archetype.projections.sync"):
+            _run(world_overview(world, Crew))
+
+
+def test_sync_parity_roundtrip(tmp_path):
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world("syncpar", storage=_storage(tmp_path))
+        world.spawn(Crew(name="a"))
+        world.spawn(Cargo(kind="ore"))
+        world.spawn(Cargo(kind="ice"))
+        world.step()
+
+        rows = projections_sync.world_overview(world, Crew, Cargo).to_pylist()
+        by_table = {row["table"]: row["population"] for row in rows}
+        assert by_table == {"crew": 1, "cargo": 2}
+
+
+def test_sync_helper_rejects_async_world(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("asyncguard", storage=_storage(tmp_path))
+            await world.spawn(Crew(name="a"))
+            await world.step()
+            with pytest.raises(TypeError, match="archetype.projections.worlds"):
+                projections_sync.world_overview(world, Crew)
+            return True
+
+    assert _run(go())

--- a/tests/projections/test_overview_contract.py
+++ b/tests/projections/test_overview_contract.py
@@ -134,6 +134,35 @@ def test_sync_parity_roundtrip(tmp_path):
         assert by_table == {"crew": 1, "cargo": 2}
 
 
+def _make_named_component(field_default: str) -> type[Component]:
+    class Clash(Component):
+        marker: str = field_default
+
+    return Clash
+
+
+def test_label_collision_raises(tmp_path):
+    """Two distinct components with the same lowercased name must not
+    silently shadow each other in the overview."""
+    first = _make_named_component("a")
+    second = _make_named_component("b")
+    assert first is not second
+
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("clash", storage=_storage(tmp_path))
+            with pytest.raises(ValueError, match="clash"):
+                await world_overview(world, first, second)
+            return True
+
+    assert _run(go())
+
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world("clash-sync", storage=_storage(tmp_path / "s"))
+        with pytest.raises(ValueError, match="clash"):
+            projections_sync.world_overview(world, first, second)
+
+
 def test_sync_helper_rejects_async_world(tmp_path):
     async def go():
         async with ArchetypeRuntime() as runtime:


### PR DESCRIPTION
Closes #546. Stage 0 of the graph/PreFab track — design: `docs/design/graph-system.md` (#545).

## What ships

- `src/archetype/projections/` — new family library, imports only core and Daft (D1):
  - `frames.py`: frame-pure read models over the base columns every archetype table carries — `activity()` per-tick population, `overview()` labeled union across named frames (the minimap primitive), `latest()` max-tick rows via a one-row aggregate joined back on `tick`. **Nothing materializes in src** — no lazy-audit entries needed; callers own the terminal collect.
  - `worlds.py`: `world_overview(world, *components)` async handle sugar over a structural `QueriesLike` protocol.
  - `sync.py`: R5 sync parity, with handle-kind guards in both directions raising before any query (the #574 review lesson, applied at birth).
- Registers `archetype.projections` in the exhaustive family registry, rebased over the expanded registry (artifacts/evaluation/missions entries) with `missions` and `projections` both kept, alphabetical.

**Deliberately not here:** no REST exposure; no mission columns (those arrive via `archetype.missions.projections` per the family split); no FPS possession view (stage 3, #549, needs traversal).

## Verification

- `pytest tests/projections/`: 8/8 — population tracking across spawn/despawn, multi-table labeling, empty-input rejection, latest-tick rows, sync-parity roundtrip driving `ArchetypeRuntime.sync()` end to end, and both handle-kind guards.
- `make typecheck` and `make check` green on this head (exit codes verified explicitly, not piped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)