### PR TITLE
feat(graph): GraphView — previous-tick frames for processors (stage 4)

### DIFF
--- a/src/archetype/graph/__init__.py
+++ b/src/archetype/graph/__init__.py
@@ -13,8 +13,10 @@ from archetype.graph import sync
 from archetype.graph.components import Relation, require_relation
 from archetype.graph.edges import WorldLike, edges, link, unlink
 from archetype.graph.frames import between, live_edge_ids, with_source, with_target
+from archetype.graph.view import GraphView
 
 __all__ = [
+    "GraphView",
     "Relation",
     "WorldLike",
     "between",

--- a/src/archetype/graph/view.py
+++ b/src/archetype/graph/view.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GraphView: previous-tick frames for cross-archetype reads in processors.
+
+Design D3 (docs/design/graph-system.md). ``PostTick`` delivers every
+just-persisted frame (``results: dict[ArchetypeSignature, DataFrame]``), so a
+``GraphView`` registered as a resource and a ``PostTick`` hook gives
+processors at tick N read-only, lazy frames of tick N−1 state — strictly
+previous-tick visibility, no core changes, no query-service reentrancy.
+
+Wiring is the declarative world config::
+
+    view = GraphView()
+    world = runtime.world(
+        "sim",
+        processors=[MyEdgeProcessor()],
+        resources=[view],
+        hooks=[(PostTick, view.on_post_tick)],
+    )
+
+Sync worlds register ``view.on_post_tick_sync`` instead. Inside a processor::
+
+    view = resources.require(GraphView)
+    nodes = view.frame(Node)   # tick N-1 rows, or None before the first tick
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from daft import DataFrame, col
+
+from archetype.core.component import Component
+from archetype.core.hooks import PostTick
+
+if TYPE_CHECKING:
+    from archetype.core.interfaces import ArchetypeSignature
+
+
+class GraphView:
+    """Read-only window onto the last persisted tick's frames.
+
+    Frames stay lazy; this class never materializes. The view is empty
+    (``tick == -1``, ``frame(...) is None``) until the first tick persists.
+    """
+
+    def __init__(self) -> None:
+        self._frames: dict[ArchetypeSignature, DataFrame] = {}
+        self.tick: int = -1
+
+    async def on_post_tick(self, event: PostTick) -> None:
+        """Async hook handler: capture the tick's persisted frames."""
+        self._capture(event)
+
+    def on_post_tick_sync(self, event: PostTick) -> None:
+        """Sync hook handler for sync worlds (runtime.md R5 parity)."""
+        self._capture(event)
+
+    def _capture(self, event: PostTick) -> None:
+        self._frames = dict(event.results)
+        self.tick = event.tick - 1  # PostTick.tick is the next tick
+
+    def frame(self, *components: type[Component]) -> DataFrame | None:
+        """Concat the frames whose archetype contains all ``components``.
+
+        Each matching frame is projected to ``entity_id``, ``tick``, and the
+        requested components' prefixed columns, so heterogeneous archetypes
+        concat cleanly. Rows despawned at capture time are filtered out.
+        Returns ``None`` before the first tick or when nothing matches.
+        """
+        if not components:
+            raise ValueError("frame requires at least one component type")
+        columns = ["entity_id", "tick"]
+        for comp in components:
+            prefix = comp.get_prefix()
+            columns.extend(f"{prefix}{field}" for field in comp.model_fields)
+
+        matches: list[DataFrame] = []
+        for signature, frame in self._frames.items():
+            if all(comp in signature for comp in components):
+                part = frame
+                if "is_active" in part.column_names:
+                    part = part.where(col("is_active"))
+                matches.append(part.select(*columns))
+        if not matches:
+            return None
+        out = matches[0]
+        for part in matches[1:]:
+            out = out.concat(part)
+        return out

--- a/tests/graph/test_graph_view_contract.py
+++ b/tests/graph/test_graph_view_contract.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for GraphView (stage 4, design D3).
+
+Each test pins a D3 claim: processors at tick N read tick N−1 frames, the
+view is empty before the first tick, matching is by signature membership
+with clean cross-archetype concat, despawned rows are filtered, and sync
+worlds get hook parity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+from daft import DataFrame, lit  # noqa: E402
+
+from archetype import ArchetypeRuntime, AsyncProcessor  # noqa: E402
+from archetype.core.component import Component  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.core.hooks import PostTick  # noqa: E402
+from archetype.core.resources import Resources  # noqa: E402
+from archetype.graph import GraphView  # noqa: E402
+
+
+class Beacon(Component):
+    strength: float = 1.0
+
+
+class Extra(Component):
+    note: str = ""
+
+
+class Observer(Component):
+    seen_tick: int = -99
+    seen_count: int = -99
+
+
+class RecordView(AsyncProcessor):
+    """Writes what the GraphView shows into the Observer row each tick."""
+
+    components = (Observer,)
+    priority = 10
+
+    async def process(self, df: DataFrame, resources: Resources | None = None, **_) -> DataFrame:
+        assert resources is not None
+        view = resources.require(GraphView)
+        beacons = view.frame(Beacon)
+        count = -1 if beacons is None else beacons.count_rows()
+        df = df.with_column("observer__seen_tick", lit(view.tick))
+        return df.with_column("observer__seen_count", lit(count))
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "view_data"), namespace="view_tests")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_processors_see_previous_tick(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "nminus1",
+                storage=_storage(tmp_path),
+                processors=[RecordView()],
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            await world.spawn(Beacon(strength=1.0))
+            await world.spawn(Beacon(strength=2.0))
+            observer = await world.spawn(Observer())
+            await world.run(steps=3)
+
+            rows = sorted((await world.query(Observer)).to_pylist(), key=lambda r: r["tick"])
+            # Tick 0 rows are raw initial conditions; the processor first runs
+            # at tick 1, seeing the view captured after tick 0 persisted.
+            by_tick = {r["tick"]: r for r in rows if r["entity_id"] == observer}
+            assert by_tick[0]["observer__seen_tick"] == -99  # raw, untransformed
+            assert by_tick[1]["observer__seen_tick"] == 0  # N-1 visibility
+            assert by_tick[1]["observer__seen_count"] == 2
+            assert by_tick[2]["observer__seen_tick"] == 1
+            return True
+
+    assert _run(go())
+
+
+def test_view_empty_before_first_tick():
+    view = GraphView()
+    assert view.tick == -1
+    assert view.frame(Beacon) is None
+
+
+def test_frame_requires_components():
+    with pytest.raises(ValueError):
+        GraphView().frame()
+
+
+def test_frame_matches_signature_membership(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "membership",
+                storage=_storage(tmp_path),
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            await world.spawn(Beacon(strength=1.0))
+            await world.spawn(Beacon(strength=2.0), Extra(note="both"))
+            await world.step()
+
+            beacons = view.frame(Beacon)
+            assert beacons is not None
+            assert beacons.count_rows() == 2  # concat across both archetypes
+            both = view.frame(Beacon, Extra)
+            assert both is not None
+            assert both.count_rows() == 1
+            assert view.frame(Observer) is None
+            return True
+
+    assert _run(go())
+
+
+def test_despawned_rows_are_filtered(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "liveness",
+                storage=_storage(tmp_path),
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            keep = await world.spawn(Beacon(strength=1.0))
+            drop = await world.spawn(Beacon(strength=2.0))
+            await world.step()
+            await world.despawn(drop)
+            await world.step()
+
+            beacons = view.frame(Beacon)
+            assert beacons is not None
+            rows = beacons.to_pylist()
+            assert {r["entity_id"] for r in rows} == {keep}
+            return True
+
+    assert _run(go())
+
+
+def test_sync_hook_parity(tmp_path):
+    view = GraphView()
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world(
+            "syncview",
+            storage=_storage(tmp_path),
+            resources=[view],
+            hooks=[(PostTick, view.on_post_tick_sync)],
+        )
+        world.spawn(Beacon(strength=1.0))
+        world.step()
+        assert view.tick == 0
+        frame = view.frame(Beacon)
+        assert frame is not None
+        assert frame.count_rows() == 1


### PR DESCRIPTION
Closes #550. Stage 4 of the graph/PreFab track — design: `docs/design/graph-system.md` (#545), decision D3.

## What ships

- `src/archetype/graph/view.py`: `GraphView`, a `Resource` whose `PostTick` hook captures the tick's persisted frames (`PostTick.results`). Processors at tick N read tick N−1 by construction — strictly previous-tick visibility, read-only, frames stay lazy, zero core changes and zero query-service reentrancy. Wired through the declarative world config (`resources=[view], hooks=[(PostTick, view.on_post_tick)]`); sync worlds register `on_post_tick_sync` (R5 parity).
- `frame(*components)` matches archetypes by signature membership, projects each match to `entity_id`/`tick` plus the requested prefixed columns so heterogeneous archetypes concat cleanly, and filters rows despawned at capture time. Returns `None` before the first tick or with no match.

**Deliberately not here:** no eager refresh policy, no same-tick visibility, no materialization anywhere (no lazy-audit entries), no cascade processors (that's #552, which consumes this).

## Verification

- 16/16 graph tests. The D3 headline claim is proven through a real processor: an `Observer` component records what the view showed each tick via `resources.require(GraphView)` — tick-1 rows show tick-0 state exactly, with the tick-0 row raw as the lifecycle demands. Also covered: signature-membership matching across archetypes, despawn filtering at capture, empty-before-first-tick, and sync hook parity.
- `make typecheck` and `make check` green on this head, rebased over #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)