### PR TITLE
fix(graph): match GraphView signatures by schema identity

### DIFF
--- a/src/archetype/graph/view.py
+++ b/src/archetype/graph/view.py
@@ -38,6 +38,18 @@ if TYPE_CHECKING:
     from archetype.core.interfaces import ArchetypeSignature
 
 
+def _same_component(a: type[Component], b: type[Component]) -> bool:
+    """Schema identity, as the query path defines it.
+
+    A resumed durable world may register a different but schema-identical
+    class object, so class identity alone under-matches; name plus prefixed
+    schema is the identity the engine keys tables by.
+    """
+    return a is b or (
+        a.__name__ == b.__name__ and a.get_prefixed_schema() == b.get_prefixed_schema()
+    )
+
+
 class GraphView:
     """Read-only window onto the last persisted tick's frames.
 
@@ -64,10 +76,14 @@ class GraphView:
     def frame(self, *components: type[Component]) -> DataFrame | None:
         """Concat the frames whose archetype contains all ``components``.
 
-        Each matching frame is projected to ``entity_id``, ``tick``, and the
-        requested components' prefixed columns, so heterogeneous archetypes
-        concat cleanly. Rows despawned at capture time are filtered out.
-        Returns ``None`` before the first tick or when nothing matches.
+        Membership uses schema identity — name plus prefixed schema — not
+        Python class identity, matching the engine's query path: a resumed
+        durable world may hold a different but schema-identical class object
+        in its signatures. Each matching frame is projected to ``entity_id``,
+        ``tick``, and the requested components' prefixed columns, so
+        heterogeneous archetypes concat cleanly. Rows despawned at capture
+        time are filtered out. Returns ``None`` before the first tick or when
+        nothing matches.
         """
         if not components:
             raise ValueError("frame requires at least one component type")
@@ -78,7 +94,9 @@ class GraphView:
 
         matches: list[DataFrame] = []
         for signature, frame in self._frames.items():
-            if all(comp in signature for comp in components):
+            if all(
+                any(_same_component(comp, member) for member in signature) for comp in components
+            ):
                 part = frame
                 if "is_active" in part.column_names:
                     part = part.where(col("is_active"))

--- a/tests/graph/test_graph_view_contract.py
+++ b/tests/graph/test_graph_view_contract.py
@@ -132,6 +132,39 @@ def test_frame_matches_signature_membership(tmp_path):
     assert _run(go())
 
 
+def _make_beacon_twin() -> type[Component]:
+    class Beacon(Component):
+        strength: float = 1.0
+
+    return Beacon
+
+
+def test_frame_matches_schema_identical_twin(tmp_path):
+    """A different class object with the same name and prefixed schema must
+    match — the cold-resume scenario, where the world holds its own class."""
+
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "twin",
+                storage=_storage(tmp_path),
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            await world.spawn(Beacon(strength=1.0))
+            await world.step()
+
+            twin = _make_beacon_twin()
+            assert twin is not Beacon
+            frame = view.frame(twin)
+            assert frame is not None
+            assert frame.count_rows() == 1
+            return True
+
+    assert _run(go())
+
+
 def test_despawned_rows_are_filtered(tmp_path):
     async def go():
         view = GraphView()


### PR DESCRIPTION
Completes the open P2 from #600's review (the PR merged while this fix was in flight).

`GraphView.frame()` matched archetype signatures by Python class identity; a resumed durable world may register a different but schema-identical class object, which would make `frame()` return `None` for a live matching table. Membership now uses the same identity the engine's query path keys tables by — name plus prefixed schema (`_same_component`).

Regression test: a dynamically constructed schema-identical twin class matches the live table (`test_frame_matches_schema_identical_twin`), pinning the cold-resume scenario without cold-resume machinery.

Verification: 17/17 graph tests, `make typecheck`, `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)