### PR TITLE
feat(graph): exclusive relations replace in-batch on link (stage 5a)

### DIFF
--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -176,6 +176,6 @@ reason = "Bundle-index idempotency boundary: the Iceberg query is filtered to on
 
 [[entries]]
 path = "src/archetype/graph/frames.py"
-line = 52
+line = 65
 method = "to_pylist"
-reason = "Mutation-planning boundary shared by async and sync unlink: despawn takes concrete entity ids, not a frame, so live_edge_ids materializes the matching ids at the latest persisted tick; all filters run in the lazy plan and only ids cross into Python."
+reason = "Mutation-planning boundary shared by async and sync unlink: despawn takes concrete entity ids, not a frame, so _ids_at (shared by unlink and exclusive link replacement) materializes the matching ids at the latest persisted tick; all filters run in the lazy plan and only ids cross into Python."

--- a/src/archetype/graph/components.py
+++ b/src/archetype/graph/components.py
@@ -20,6 +20,8 @@ Arrow-serialization rules as any component.
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from archetype.core.component import Component
 
 
@@ -29,7 +31,15 @@ class Relation(Component):
     ``Relation`` itself is abstract by convention: spawn subclasses, never the
     base (``link`` enforces this). ``source`` and ``target`` are entity ids as
     stamped by the engine (``BASE_SCHEMA.entity_id``).
+
+    ``exclusive`` declares that an entity holds at most one live edge of this
+    relation as ``source`` (design stage 5a): ``link`` stages the replacement
+    despawn of the previous edge in the same batch. Enforcement reads
+    persisted state — linking the same exclusive source twice before a step
+    stages both edges, so the step boundary is the consistency unit.
     """
+
+    exclusive: ClassVar[bool] = False
 
     source: int = 0
     target: int = 0

--- a/src/archetype/graph/edges.py
+++ b/src/archetype/graph/edges.py
@@ -61,16 +61,21 @@ async def link(world: WorldLike, rel: Relation) -> int:
     require_relation(rel)
     _require_async(world, "spawn")
     rel_type = type(rel)
-    if rel_type.exclusive:
-        latest = (await world.info()).tick - 1
-        try:
-            frame = await world.query(rel_type)
-        except KeyError:
-            frame = None  # first edge of this relation: nothing to replace
-        if frame is not None:
-            for edge_id in live_edge_ids_from(frame, rel_type, rel.source, latest):
-                await world.despawn(edge_id)
-    return await world.spawn(rel)
+    if not rel_type.exclusive:
+        return await world.spawn(rel)
+
+    latest = (await world.info()).tick - 1
+    try:
+        frame = await world.query(rel_type)
+    except KeyError:
+        frame = None  # first edge of this relation: nothing to replace
+    replaced = set() if frame is None else live_edge_ids_from(frame, rel_type, rel.source, latest)
+    # Spawn before despawn: a failure between the two degrades to the
+    # documented two-live-edges race, never to zero live edges.
+    edge_id = await world.spawn(rel)
+    for old_id in replaced:
+        await world.despawn(old_id)
+    return edge_id
 
 
 async def edges(world: WorldLike, rel: type[Relation], *, at: int | None = None) -> DataFrame:

--- a/src/archetype/graph/edges.py
+++ b/src/archetype/graph/edges.py
@@ -21,7 +21,7 @@ from daft import DataFrame, Expression, col
 
 from archetype.core.component import Component
 from archetype.graph.components import Relation, require_relation
-from archetype.graph.frames import live_edge_ids
+from archetype.graph.frames import live_edge_ids, live_edge_ids_from
 
 
 class _InfoLike(Protocol):
@@ -53,11 +53,23 @@ async def link(world: WorldLike, rel: Relation) -> int:
     """Spawn an edge entity for ``rel``.
 
     The edge lands as raw initial conditions at the next persisted tick, like
-    every staged spawn. Exclusive-relation replacement arrives in stage 5a;
-    today ``link`` is deliberately a thin seam over ``spawn``.
+    every staged spawn. For an ``exclusive`` relation, the live edges from the
+    same source are staged for despawn in the same batch: old edge out, new
+    edge in, both landing at the next persisted tick. Replacement reads
+    persisted state, so the step boundary is the consistency unit.
     """
     require_relation(rel)
     _require_async(world, "spawn")
+    rel_type = type(rel)
+    if rel_type.exclusive:
+        latest = (await world.info()).tick - 1
+        try:
+            frame = await world.query(rel_type)
+        except KeyError:
+            frame = None  # first edge of this relation: nothing to replace
+        if frame is not None:
+            for edge_id in live_edge_ids_from(frame, rel_type, rel.source, latest):
+                await world.despawn(edge_id)
     return await world.spawn(rel)
 
 

--- a/src/archetype/graph/frames.py
+++ b/src/archetype/graph/frames.py
@@ -43,11 +43,24 @@ def live_edge_ids(
 ) -> set[int]:
     """Entity ids of the ``rel`` edges from ``source`` to ``target`` live at
     tick ``latest``.
+    """
+    return _ids_at(between(edges, rel, source, target), latest)
 
-    This is the mutation-planning boundary shared by the async and sync
-    ``unlink``: despawn takes concrete ids, so the matching ids — and only
-    the ids — cross into Python. The filters run in the lazy plan.
+
+def live_edge_ids_from(edges: DataFrame, rel: type[Relation], source: int, latest: int) -> set[int]:
+    """Entity ids of every ``rel`` edge outgoing from ``source`` live at
+    tick ``latest`` — the exclusive-relation replacement set (stage 5a).
+    """
+    return _ids_at(with_source(edges, rel, source), latest)
+
+
+def _ids_at(edges: DataFrame, latest: int) -> set[int]:
+    """Materialize the entity ids of the rows at tick ``latest``.
+
+    The single mutation-planning boundary shared by ``unlink`` and exclusive
+    ``link``: despawn takes concrete ids, so the matching ids — and only the
+    ids — cross into Python. All filters run in the lazy plan.
     """
     at_latest = cast(Expression, col("tick") == latest)
-    rows = between(edges, rel, source, target).where(at_latest).select("entity_id").to_pylist()
+    rows = edges.where(at_latest).select("entity_id").to_pylist()
     return {row["entity_id"] for row in rows}

--- a/src/archetype/graph/sync.py
+++ b/src/archetype/graph/sync.py
@@ -17,7 +17,7 @@ from daft import DataFrame, Expression, col
 
 from archetype.core.component import Component
 from archetype.graph.components import Relation, require_relation
-from archetype.graph.frames import live_edge_ids
+from archetype.graph.frames import live_edge_ids, live_edge_ids_from
 
 
 class _InfoLike(Protocol):
@@ -45,9 +45,23 @@ def _require_sync(world: SyncWorldLike, method: str) -> None:
 
 
 def link(world: SyncWorldLike, rel: Relation) -> int:
-    """Spawn an edge entity for ``rel``. See :func:`archetype.graph.edges.link`."""
+    """Spawn an edge entity for ``rel``. See :func:`archetype.graph.edges.link`.
+
+    Exclusive relations replace the live edges from the same source in the
+    same batch, mirroring the async flavor.
+    """
     require_relation(rel)
     _require_sync(world, "spawn")
+    rel_type = type(rel)
+    if rel_type.exclusive:
+        latest = world.info().tick - 1
+        try:
+            frame = world.query(rel_type)
+        except KeyError:
+            frame = None  # first edge of this relation: nothing to replace
+        if frame is not None:
+            for edge_id in live_edge_ids_from(frame, rel_type, rel.source, latest):
+                world.despawn(edge_id)
     return world.spawn(rel)
 
 

--- a/src/archetype/graph/sync.py
+++ b/src/archetype/graph/sync.py
@@ -53,16 +53,21 @@ def link(world: SyncWorldLike, rel: Relation) -> int:
     require_relation(rel)
     _require_sync(world, "spawn")
     rel_type = type(rel)
-    if rel_type.exclusive:
-        latest = world.info().tick - 1
-        try:
-            frame = world.query(rel_type)
-        except KeyError:
-            frame = None  # first edge of this relation: nothing to replace
-        if frame is not None:
-            for edge_id in live_edge_ids_from(frame, rel_type, rel.source, latest):
-                world.despawn(edge_id)
-    return world.spawn(rel)
+    if not rel_type.exclusive:
+        return world.spawn(rel)
+
+    latest = world.info().tick - 1
+    try:
+        frame = world.query(rel_type)
+    except KeyError:
+        frame = None  # first edge of this relation: nothing to replace
+    replaced = set() if frame is None else live_edge_ids_from(frame, rel_type, rel.source, latest)
+    # Spawn before despawn: a failure between the two degrades to the
+    # documented two-live-edges race, never to zero live edges.
+    edge_id = world.spawn(rel)
+    for old_id in replaced:
+        world.despawn(old_id)
+    return edge_id
 
 
 def edges(world: SyncWorldLike, rel: type[Relation], *, at: int | None = None) -> DataFrame:

--- a/tests/graph/test_edge_contract.py
+++ b/tests/graph/test_edge_contract.py
@@ -212,6 +212,89 @@ def test_async_helpers_reject_sync_world(tmp_path):
         assert graph_sync.unlink(world, ChildOf, a, b) == 0
 
 
+class Assigned(Relation):
+    """Exclusive test relation: one live assignment per source."""
+
+    exclusive = True
+
+
+def test_exclusive_link_replaces_across_steps(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("exclusive", storage=_storage(tmp_path))
+            worker = await world.spawn(Node(name="worker"))
+            first = await world.spawn(Node(name="first"))
+            second = await world.spawn(Node(name="second"))
+            await link(world, Assigned(source=worker, target=first))
+            await world.step()
+
+            await link(world, Assigned(source=worker, target=second))
+            await world.step()
+
+            latest = (await world.info()).tick - 1
+            live = (await edges(world, Assigned, at=latest)).to_pylist()
+            assert len(live) == 1
+            assert live[0]["assigned__target"] == second
+
+            # Replacement is history, not erasure: the first edge's rows remain.
+            history = (await edges(world, Assigned)).to_pylist()
+            assert {r["assigned__target"] for r in history} == {first, second}
+            return True
+
+    assert _run(go())
+
+
+def test_exclusive_first_link_without_table(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("exclusive-first", storage=_storage(tmp_path))
+            worker = await world.spawn(Node(name="worker"))
+            task = await world.spawn(Node(name="task"))
+            await world.step()  # unrelated signature exists; no Assigned table
+            await link(world, Assigned(source=worker, target=task))
+            await world.step()
+            latest = (await world.info()).tick - 1
+            assert len((await edges(world, Assigned, at=latest)).to_pylist()) == 1
+            return True
+
+    assert _run(go())
+
+
+def test_non_exclusive_link_keeps_both(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world("nonexclusive", storage=_storage(tmp_path))
+            a = await world.spawn(Node(name="a"))
+            b = await world.spawn(Node(name="b"))
+            c = await world.spawn(Node(name="c"))
+            await link(world, ChildOf(source=a, target=b))
+            await world.step()
+            await link(world, ChildOf(source=a, target=c))
+            await world.step()
+            latest = (await world.info()).tick - 1
+            live = (await edges(world, ChildOf, at=latest)).to_pylist()
+            assert len(live) == 2
+            return True
+
+    assert _run(go())
+
+
+def test_exclusive_sync_parity(tmp_path):
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world("exclusive-sync", storage=_storage(tmp_path))
+        worker = world.spawn(Node(name="worker"))
+        first = world.spawn(Node(name="first"))
+        second = world.spawn(Node(name="second"))
+        graph_sync.link(world, Assigned(source=worker, target=first))
+        world.step()
+        graph_sync.link(world, Assigned(source=worker, target=second))
+        world.step()
+        latest = world.info().tick - 1
+        live = graph_sync.edges(world, Assigned, at=latest).to_pylist()
+        assert len(live) == 1
+        assert live[0]["assigned__target"] == second
+
+
 def test_sync_parity_roundtrip(tmp_path):
     """graph.sync mirrors link/edges/unlink without await (runtime.md R5)."""
     with ArchetypeRuntime.sync() as runtime:

--- a/tests/graph/test_edge_contract.py
+++ b/tests/graph/test_edge_contract.py
@@ -279,6 +279,80 @@ def test_non_exclusive_link_keeps_both(tmp_path):
     assert _run(go())
 
 
+def _edge_frame(source: int, target: int):
+    import daft
+
+    return daft.from_pydict(
+        {
+            "entity_id": [5],
+            "tick": [0],
+            "assigned__source": [source],
+            "assigned__target": [target],
+        }
+    )
+
+
+class _ExplodingAsyncWorld:
+    """WorldLike fake whose despawn raises: proves spawn precedes despawn."""
+
+    def __init__(self, source: int, target: int):
+        self._frame = _edge_frame(source, target)
+        self.spawned: list[Relation] = []
+
+    async def info(self):
+        class _Info:
+            tick = 1
+
+        return _Info()
+
+    async def query(self, *_components):
+        return self._frame
+
+    async def spawn(self, *components) -> int:
+        self.spawned.extend(components)
+        return 99
+
+    async def despawn(self, entity_id: int) -> None:
+        raise RuntimeError("despawn boom")
+
+
+class _ExplodingSyncWorld:
+    def __init__(self, source: int, target: int):
+        self._frame = _edge_frame(source, target)
+        self.spawned: list[Relation] = []
+
+    def info(self):
+        class _Info:
+            tick = 1
+
+        return _Info()
+
+    def query(self, *_components):
+        return self._frame
+
+    def spawn(self, *components) -> int:
+        self.spawned.extend(components)
+        return 99
+
+    def despawn(self, entity_id: int) -> None:
+        raise RuntimeError("despawn boom")
+
+
+def test_exclusive_link_spawns_before_despawn():
+    """A failure mid-replacement degrades to two live edges, never zero."""
+    fake = _ExplodingAsyncWorld(source=1, target=2)
+    with pytest.raises(RuntimeError, match="despawn boom"):
+        _run(link(fake, Assigned(source=1, target=3)))
+    assert len(fake.spawned) == 1  # replacement was created before the failure
+
+
+def test_exclusive_sync_link_spawns_before_despawn():
+    fake = _ExplodingSyncWorld(source=1, target=2)
+    with pytest.raises(RuntimeError, match="despawn boom"):
+        graph_sync.link(fake, Assigned(source=1, target=3))
+    assert len(fake.spawned) == 1
+
+
 def test_exclusive_sync_parity(tmp_path):
     with ArchetypeRuntime.sync() as runtime:
         world = runtime.world("exclusive-sync", storage=_storage(tmp_path))


### PR DESCRIPTION
Closes #551. Stage 5a of the graph/PreFab track — design: `docs/design/graph-system.md` (#545), decision D2/stage 5a.

## What ships

- `Relation.exclusive: ClassVar[bool]` — an exclusive relation holds at most one live edge per source. `link()` (async and sync) stages the despawn of the live same-source edges in the same batch as the new spawn: old edge out, new edge in, both landing at the next persisted tick. Replacement is history, not erasure — the superseded edge's rows stay on the ledger.
- Stated consistency contract, documented on the class: enforcement reads persisted state, so linking the same exclusive source twice before a step stages both — the step boundary is the consistency unit.
- The id materialization is factored into `frames._ids_at`, the single audited boundary now shared by `unlink` and exclusive `link` (lazy-audit entry updated in place); `live_edge_ids_from` provides the source-wildcard replacement set.

**Deliberately not here:** `ChildOf` and cleanup policies (stage 5b, #552 — see the design-assumption report there before implementing).

## Verification

- 21/21 graph tests: replacement across steps with history retained, first-link with no relation table, non-exclusive relations keeping both edges, sync parity, plus all prior stage-1/4 contracts.
- `make typecheck` and `make check` green, rebased over #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)