### PR TITLE
feat(graph): driver-level cascade with cleanup policies (stage 5b)

### DIFF
--- a/docs/design/graph-system.md
+++ b/docs/design/graph-system.md
@@ -81,12 +81,20 @@ query-service reentrancy, wired through the declarative world config
 
 ### D4 — Cleanup is policy, propagated by ticks
 
-A relation declares `on_delete_target`: `REMOVE` (default; treat edges to
-inactive targets as absent at read time), `DELETE` (cascade despawn), or
-`FLAG` (surface to evals; the ledger-world replacement for Flecs' `Panic`).
-A late-priority `CascadeDespawn` processor applies the policy using GraphView
-liveness. Cascades propagate one generation per tick and land in history —
-correct for an append-only world, and every step is auditable.
+A relation declares `on_delete_target`: `REMOVE` (default; despawn the
+dangling edge, leave the source), `DELETE` (despawn edge and source — the
+hierarchy cascade), or `FLAG` (mutate nothing; surface the dangling edges to
+the caller — the ledger-world replacement for Flecs' `Panic`).
+
+Amended 2026-07-19 (decision on issue #552): the original text specified a
+`CascadeDespawn` *processor*, but processors are pure `DataFrame → DataFrame`
+with no mutation channel — `is_active` is engine-owned. The policy is applied
+by the driver-level `graph.cascade(world, rel, view)` helper instead: it
+reads liveness from the GraphView as a lazy anti-join, stages despawns
+through the world API, and advances one generation per invocation — calling
+it once per step yields the one-generation-per-tick propagation, every step
+on the ledger. A processor-native sibling requires the staged-mutation core
+seam tracked in issue #604.
 
 ### D5 — `IsA` copies at instantiation
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -179,3 +179,9 @@ path = "src/archetype/graph/frames.py"
 line = 65
 method = "to_pylist"
 reason = "Mutation-planning boundary shared by async and sync unlink: despawn takes concrete entity ids, not a frame, so _ids_at (shared by unlink and exclusive link replacement) materializes the matching ids at the latest persisted tick; all filters run in the lazy plan and only ids cross into Python."
+
+[[entries]]
+path = "src/archetype/graph/cascade.py"
+line = 81
+method = "to_pylist"
+reason = "Mutation-planning boundary for cascade: despawn takes concrete ids, so _plan materializes the (edge id, source) pairs of the dangling edges; the liveness union, anti-join, and filters all run in the lazy plan and only ids cross into Python."

--- a/src/archetype/graph/__init__.py
+++ b/src/archetype/graph/__init__.py
@@ -10,14 +10,20 @@ the R5 sync-parity counterparts.
 """
 
 from archetype.graph import sync
-from archetype.graph.components import Relation, require_relation
+from archetype.graph.cascade import CascadeResult, cascade, dangling_edges
+from archetype.graph.components import ChildOf, Policy, Relation, require_relation
 from archetype.graph.edges import WorldLike, edges, link, unlink
 from archetype.graph.frames import between, live_edge_ids, with_source, with_target
 from archetype.graph.view import GraphView
 
 __all__ = [
+    "CascadeResult",
+    "ChildOf",
     "GraphView",
+    "Policy",
     "Relation",
+    "cascade",
+    "dangling_edges",
     "WorldLike",
     "between",
     "edges",

--- a/src/archetype/graph/cascade.py
+++ b/src/archetype/graph/cascade.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Driver-level cascade: apply a relation's cleanup policy, one generation
+per invocation.
+
+Design D4 as amended (docs/design/graph-system.md; decision recorded on
+issue #552, option (a)): processors are pure ``DataFrame → DataFrame`` and
+cannot stage mutations, so cleanup runs at the driver level. ``cascade``
+reads liveness from a :class:`GraphView`, finds the relation's live edges
+whose target is no longer alive, and applies the relation's
+``on_delete_target`` policy through the world API. Despawns are staged like
+any mutation and land at the next persisted tick — calling ``cascade`` once
+per step yields exactly the one-generation-per-tick propagation the design
+promises, with every generation on the ledger.
+
+Typical driver loop::
+
+    view = GraphView()
+    world = runtime.world("sim", resources=[view], hooks=[(PostTick, view.on_post_tick)])
+    ...
+    await world.despawn(parent)
+    await world.step()
+    await cascade(world, ChildOf, view)   # children staged for despawn
+    await world.step()                    # ... landing here
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from daft import DataFrame, col
+
+from archetype.graph.components import Policy, Relation
+from archetype.graph.edges import WorldLike, _require_async
+from archetype.graph.view import GraphView
+
+
+@dataclass(frozen=True, slots=True)
+class CascadeResult:
+    """What one cascade pass did (or, for ``FLAG``, found)."""
+
+    policy: Policy
+    removed_edges: tuple[int, ...] = field(default=())
+    deleted_entities: tuple[int, ...] = field(default=())
+    flagged_edges: tuple[int, ...] = field(default=())
+
+    @property
+    def total(self) -> int:
+        return len(self.removed_edges) + len(self.deleted_entities) + len(self.flagged_edges)
+
+
+def dangling_edges(edges: DataFrame, rel: type[Relation], population: DataFrame) -> DataFrame:
+    """Frame-pure: the edges whose target is absent from ``population``.
+
+    Liveness as an anti-join — no per-row Python, no lookups.
+    """
+    prefix = rel.get_prefix()
+    return edges.join(
+        population,
+        left_on=col(f"{prefix}target"),
+        right_on=col("entity_id"),
+        how="anti",
+    )
+
+
+def _plan(view: GraphView, rel: type[Relation]) -> list[dict]:
+    """Materialize the (edge id, source) pairs of the dangling edges.
+
+    Mutation-planning boundary: despawn takes concrete ids. Everything up to
+    this point — liveness union, anti-join, tick filter — runs lazily.
+    """
+    population = view.population()
+    edges = view.frame(rel)
+    if population is None or edges is None:
+        return []
+    prefix = rel.get_prefix()
+    return (
+        dangling_edges(edges, rel, population)
+        .select(col("entity_id"), col(f"{prefix}source").alias("source"))
+        .to_pylist()
+    )
+
+
+async def cascade(world: WorldLike, rel: type[Relation], view: GraphView) -> CascadeResult:
+    """Apply ``rel.on_delete_target`` to the dangling edges, one generation.
+
+    Reads liveness at the view's captured tick; stages mutations through the
+    world handle, landing at the next persisted tick. Deleting a generation
+    of sources creates the next generation's dangling edges — the following
+    ``cascade`` call collects them.
+    """
+    _require_async(world, "despawn")
+    rows = _plan(view, rel)
+    policy = rel.on_delete_target
+    if not rows:
+        return CascadeResult(policy=policy)
+    edge_ids = tuple(row["entity_id"] for row in rows)
+    if policy is Policy.FLAG:
+        return CascadeResult(policy=policy, flagged_edges=edge_ids)
+    for edge_id in edge_ids:
+        await world.despawn(edge_id)
+    if policy is Policy.REMOVE:
+        return CascadeResult(policy=policy, removed_edges=edge_ids)
+    sources = tuple({row["source"] for row in rows})
+    for source in sources:
+        await world.despawn(source)
+    return CascadeResult(policy=policy, removed_edges=edge_ids, deleted_entities=sources)

--- a/src/archetype/graph/components.py
+++ b/src/archetype/graph/components.py
@@ -20,9 +20,25 @@ Arrow-serialization rules as any component.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import ClassVar
 
 from archetype.core.component import Component
+
+
+class Policy(StrEnum):
+    """What ``cascade`` does to a relation's edges when their target dies.
+
+    Design D4 (as amended for the driver-level cascade): ``REMOVE`` despawns
+    the dangling edge and leaves the source entity alone; ``DELETE`` despawns
+    the edge and its source entity (the hierarchy cascade); ``FLAG`` mutates
+    nothing and surfaces the dangling edges to the caller — the ledger-world
+    replacement for a panic.
+    """
+
+    REMOVE = "remove"
+    DELETE = "delete"
+    FLAG = "flag"
 
 
 class Relation(Component):
@@ -40,9 +56,22 @@ class Relation(Component):
     """
 
     exclusive: ClassVar[bool] = False
+    on_delete_target: ClassVar[Policy] = Policy.REMOVE
 
     source: int = 0
     target: int = 0
+
+
+class ChildOf(Relation):
+    """The blessed hierarchy relation: ``source`` is a child of ``target``.
+
+    One parent per child (``exclusive``); when the parent dies, the child
+    dies with it on the next ``cascade`` pass (``Policy.DELETE``), one
+    generation per invocation, every step recorded in history.
+    """
+
+    exclusive = True
+    on_delete_target = Policy.DELETE
 
 
 def require_relation(rel: Relation) -> None:

--- a/src/archetype/graph/sync.py
+++ b/src/archetype/graph/sync.py
@@ -16,8 +16,10 @@ from typing import Protocol, cast
 from daft import DataFrame, Expression, col
 
 from archetype.core.component import Component
-from archetype.graph.components import Relation, require_relation
+from archetype.graph.cascade import CascadeResult, _plan
+from archetype.graph.components import Policy, Relation, require_relation
 from archetype.graph.frames import live_edge_ids, live_edge_ids_from
+from archetype.graph.view import GraphView
 
 
 class _InfoLike(Protocol):
@@ -95,3 +97,26 @@ def unlink(world: SyncWorldLike, rel: type[Relation], source: int, target: int) 
     for edge_id in edge_ids:
         world.despawn(edge_id)
     return len(edge_ids)
+
+
+def cascade(world: SyncWorldLike, rel: type[Relation], view: GraphView) -> CascadeResult:
+    """Apply ``rel.on_delete_target`` to the dangling edges, one generation.
+
+    Blocking counterpart of :func:`archetype.graph.cascade.cascade`.
+    """
+    _require_sync(world, "despawn")
+    rows = _plan(view, rel)
+    policy = rel.on_delete_target
+    if not rows:
+        return CascadeResult(policy=policy)
+    edge_ids = tuple(row["entity_id"] for row in rows)
+    if policy is Policy.FLAG:
+        return CascadeResult(policy=policy, flagged_edges=edge_ids)
+    for edge_id in edge_ids:
+        world.despawn(edge_id)
+    if policy is Policy.REMOVE:
+        return CascadeResult(policy=policy, removed_edges=edge_ids)
+    sources = tuple({row["source"] for row in rows})
+    for source in sources:
+        world.despawn(source)
+    return CascadeResult(policy=policy, removed_edges=edge_ids, deleted_entities=sources)

--- a/src/archetype/graph/view.py
+++ b/src/archetype/graph/view.py
@@ -73,6 +73,26 @@ class GraphView:
         self._frames = dict(event.results)
         self.tick = event.tick - 1  # PostTick.tick is the next tick
 
+    def population(self) -> DataFrame | None:
+        """Distinct ids of every entity alive at the captured tick.
+
+        The lazy union of ``entity_id`` across all captured frames — the
+        liveness authority for cascade's dangling-edge anti-join. ``None``
+        before the first tick.
+        """
+        parts: list[DataFrame] = []
+        for frame in self._frames.values():
+            part = frame
+            if "is_active" in part.column_names:
+                part = part.where(col("is_active"))
+            parts.append(part.select("entity_id"))
+        if not parts:
+            return None
+        out = parts[0]
+        for part in parts[1:]:
+            out = out.concat(part)
+        return out.distinct()
+
     def frame(self, *components: type[Component]) -> DataFrame | None:
         """Concat the frames whose archetype contains all ``components``.
 

--- a/tests/graph/test_cascade_contract.py
+++ b/tests/graph/test_cascade_contract.py
@@ -1,0 +1,190 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for driver-level cascade (stage 5b, design D4 as amended).
+
+Each test pins a D4 claim: DELETE propagates one generation per invocation
+with every step on the ledger, REMOVE drops the edge but spares the source,
+FLAG mutates nothing, and the sync flavor mirrors the async one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.component import Component  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.core.hooks import PostTick  # noqa: E402
+from archetype.graph import (  # noqa: E402
+    ChildOf,
+    GraphView,
+    Policy,
+    Relation,
+    cascade,
+    edges,
+    link,
+)
+from archetype.graph import sync as graph_sync  # noqa: E402
+
+
+class Node(Component):
+    name: str = ""
+
+
+class Watches(Relation):
+    on_delete_target = Policy.FLAG
+
+
+class Cites(Relation):
+    pass  # Policy.REMOVE default
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "cascade_data"), namespace="cascade_tests")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _world(runtime, name, tmp_path, view):
+    return runtime.world(
+        name,
+        storage=_storage(tmp_path),
+        resources=[view],
+        hooks=[(PostTick, view.on_post_tick)],
+    )
+
+
+def test_delete_cascades_one_generation_per_call(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "generations", tmp_path, view)
+            parent = await world.spawn(Node(name="parent"))
+            child = await world.spawn(Node(name="child"))
+            grandchild = await world.spawn(Node(name="grandchild"))
+            await link(world, ChildOf(source=child, target=parent))
+            await link(world, ChildOf(source=grandchild, target=child))
+            await world.step()
+
+            await world.despawn(parent)
+            await world.step()
+
+            first = await cascade(world, ChildOf, view)
+            await world.step()
+            assert first.policy is Policy.DELETE
+            assert child in first.deleted_entities
+            assert grandchild not in first.deleted_entities  # one generation only
+
+            second = await cascade(world, ChildOf, view)
+            await world.step()
+            assert grandchild in second.deleted_entities
+
+            third = await cascade(world, ChildOf, view)
+            assert third.total == 0  # converged
+
+            # Every generation is history: the edges' pre-cascade rows remain.
+            history = (await edges(world, ChildOf)).to_pylist()
+            assert len(history) > 0
+            return True
+
+    assert _run(go())
+
+
+def test_remove_drops_edge_and_spares_source(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "remove", tmp_path, view)
+            paper = await world.spawn(Node(name="paper"))
+            citer = await world.spawn(Node(name="citer"))
+            await link(world, Cites(source=citer, target=paper))
+            await world.step()
+
+            await world.despawn(paper)
+            await world.step()
+
+            result = await cascade(world, Cites, view)
+            await world.step()
+            assert result.policy is Policy.REMOVE
+            assert len(result.removed_edges) == 1
+            assert result.deleted_entities == ()
+
+            population = view.population()
+            assert population is not None
+            alive = {row["entity_id"] for row in population.to_pylist()}
+            assert citer in alive  # the source survives
+            return True
+
+    assert _run(go())
+
+
+def test_flag_mutates_nothing(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "flag", tmp_path, view)
+            star = await world.spawn(Node(name="star"))
+            watcher = await world.spawn(Node(name="watcher"))
+            await link(world, Watches(source=watcher, target=star))
+            await world.step()
+
+            await world.despawn(star)
+            await world.step()
+
+            result = await cascade(world, Watches, view)
+            await world.step()
+            assert result.policy is Policy.FLAG
+            assert len(result.flagged_edges) == 1
+            assert result.removed_edges == ()
+
+            # Nothing was despawned: the dangling edge is still flagged next pass.
+            again = await cascade(world, Watches, view)
+            assert len(again.flagged_edges) == 1
+            return True
+
+    assert _run(go())
+
+
+def test_cascade_empty_view_and_absent_relation(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "empty", tmp_path, view)
+            assert (await cascade(world, ChildOf, view)).total == 0  # pre-first-tick
+            await world.spawn(Node(name="only"))
+            await world.step()
+            assert (await cascade(world, ChildOf, view)).total == 0  # no edge table
+            return True
+
+    assert _run(go())
+
+
+def test_sync_cascade_parity(tmp_path):
+    view = GraphView()
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world(
+            "sync-cascade",
+            storage=_storage(tmp_path),
+            resources=[view],
+            hooks=[(PostTick, view.on_post_tick_sync)],
+        )
+        parent = world.spawn(Node(name="parent"))
+        child = world.spawn(Node(name="child"))
+        graph_sync.link(world, ChildOf(source=child, target=parent))
+        world.step()
+
+        world.despawn(parent)
+        world.step()
+
+        result = graph_sync.cascade(world, ChildOf, view)
+        world.step()
+        assert result.policy is Policy.DELETE
+        assert child in result.deleted_entities


### PR DESCRIPTION
Closes #552. Stage 5b of the graph/PreFab track, implemented per **option (a)** of the design-assumption report on the issue (the D4 processor assumption broke against the pure-processor contract; decision recorded there, core-seam alternative tracked as #604, revert lever documented).

## What ships

- **`Policy`** (`REMOVE`/`DELETE`/`FLAG`) and `Relation.on_delete_target`; **`ChildOf`** ships as the blessed hierarchy relation (`exclusive = True`, `DELETE`).
- **`graph.cascade(world, rel, view)`** (+ sync twin): dangling edges = a lazy **anti-join** of the relation's live edges against **`GraphView.population()`** (new — the lazy distinct union of live entity ids across all captured frames). The policy applies through the world API: despawns stage like any mutation and land at the next persisted tick. **One generation per invocation** — calling per step yields the design's one-generation-per-tick, every step on the ledger. `FLAG` mutates nothing and surfaces the dangling edge ids (the ledger-world panic).
- **D4 amended in this diff** so doc and code agree; the amendment names the decision, the issue, and #604.
- One `lazy_audit.toml` entry — `_plan`'s single materialization of (edge id, source) pairs; liveness union, anti-join, and filters all stay in the lazy plan. Called out here per the audit's sign-off rule.

## Verification

- 28/28 graph tests, including five new cascade contracts: DELETE propagates parent → child → grandchild one generation per call to convergence, with pre-cascade history retained; REMOVE drops the edge and spares the source; FLAG changes nothing and re-flags next pass; empty-view and absent-relation guards; sync parity.
- `make typecheck` and `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)