### PR TITLE
feat(graph): hierarchy depth as stored data (stage 6)

### DIFF
--- a/src/archetype/graph/__init__.py
+++ b/src/archetype/graph/__init__.py
@@ -12,6 +12,7 @@ the R5 sync-parity counterparts.
 from archetype.graph import sync
 from archetype.graph.cascade import CascadeResult, cascade, dangling_edges
 from archetype.graph.components import ChildOf, Policy, Relation, require_relation
+from archetype.graph.depth import Depth, DepthProcessor, toposorted
 from archetype.graph.edges import WorldLike, edges, link, unlink
 from archetype.graph.frames import between, live_edge_ids, with_source, with_target
 from archetype.graph.view import GraphView
@@ -19,11 +20,14 @@ from archetype.graph.view import GraphView
 __all__ = [
     "CascadeResult",
     "ChildOf",
+    "Depth",
+    "DepthProcessor",
     "GraphView",
     "Policy",
     "Relation",
     "cascade",
     "dangling_edges",
+    "toposorted",
     "WorldLike",
     "between",
     "edges",

--- a/src/archetype/graph/depth.py
+++ b/src/archetype/graph/depth.py
@@ -27,7 +27,7 @@ Wiring::
 
 from __future__ import annotations
 
-from daft import DataFrame, col
+from daft import DataFrame, col, lit
 
 from archetype.core.aio.async_processor import AsyncProcessor
 from archetype.core.component import Component
@@ -57,12 +57,15 @@ class DepthProcessor(AsyncProcessor):
         self, df: DataFrame, resources: Resources | None = None, **kwargs
     ) -> DataFrame:
         view = resources.get(GraphView) if resources is not None else None
-        if view is None:
+        if view is None or view.tick < 0:
             return df
         edges = view.frame(ChildOf)
         parents = view.frame(Depth)
         if edges is None or parents is None:
-            return df
+            # No edges (or no prior depth) at the captured tick: every entity
+            # is a root. Rewrite to 0 so seeded or stale values cannot
+            # persist — the root contract holds even before any hierarchy.
+            return df.with_column("depth__value", lit(0))
 
         prefix = ChildOf.get_prefix()
         # Exclusive ChildOf guarantees one live parent per child at persisted

--- a/src/archetype/graph/depth.py
+++ b/src/archetype/graph/depth.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hierarchy depth as stored data (stage 6, docs/design/graph-system.md).
+
+Sander's breadth-first trick — sorting query caches by hierarchy depth —
+lands here as a column. Entities that carry :class:`Depth` get their level
+recomputed every tick by :class:`DepthProcessor` from the live ``ChildOf``
+edges: a root is depth 0, a child is its parent's depth plus one. The
+processor reads the previous tick through :class:`GraphView`, so depth
+propagates one level per tick and a D-level hierarchy converges in D ticks;
+re-parenting reconverges the same way. Top-down iteration is then
+``frame.sort("depth__value")`` — no traversal engine, no cache to
+invalidate.
+
+Wiring::
+
+    view = GraphView()
+    world = runtime.world(
+        "sim",
+        processors=[DepthProcessor()],
+        resources=[view],
+        hooks=[(PostTick, view.on_post_tick)],
+    )
+    await world.spawn(Node(), Depth())   # participate in depth ordering
+"""
+
+from __future__ import annotations
+
+from daft import DataFrame, col
+
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.core.component import Component
+from archetype.core.resources import Resources
+from archetype.graph.components import ChildOf
+from archetype.graph.view import GraphView
+
+
+class Depth(Component):
+    """Hierarchy level: 0 for roots, parent's depth + 1 otherwise."""
+
+    value: int = 0
+
+
+class DepthProcessor(AsyncProcessor):
+    """Recompute ``Depth`` from live ``ChildOf`` edges, one level per tick.
+
+    Fully lazy: two left joins against the previous tick's edge and depth
+    frames, no materialization. Before the first tick (or with no edges) the
+    frame passes through unchanged.
+    """
+
+    components = (Depth,)
+    priority = 20
+
+    async def process(
+        self, df: DataFrame, resources: Resources | None = None, **kwargs
+    ) -> DataFrame:
+        view = resources.get(GraphView) if resources is not None else None
+        if view is None:
+            return df
+        edges = view.frame(ChildOf)
+        parents = view.frame(Depth)
+        if edges is None or parents is None:
+            return df
+
+        prefix = ChildOf.get_prefix()
+        # Exclusive ChildOf guarantees one live parent per child at persisted
+        # state; the max() collapse also absorbs the documented same-batch race.
+        child_parent = (
+            edges.select(
+                col(f"{prefix}source").alias("__child"),
+                col(f"{prefix}target").alias("__parent"),
+            )
+            .groupby("__child")
+            .agg(col("__parent").max().alias("__parent"))
+        )
+        parent_depth = parents.select(
+            col("entity_id").alias("__parent_id"),
+            col("depth__value").alias("__parent_depth"),
+        )
+        return (
+            df.join(child_parent, left_on=col("entity_id"), right_on=col("__child"), how="left")
+            .join(parent_depth, left_on=col("__parent"), right_on=col("__parent_id"), how="left")
+            .with_column("depth__value", (col("__parent_depth") + 1).fill_null(0))
+            .exclude("__child", "__parent", "__parent_id", "__parent_depth")
+        )
+
+
+def toposorted(frame: DataFrame) -> DataFrame:
+    """Order a Depth-carrying frame top-down: parents before children."""
+    return frame.sort("depth__value")

--- a/tests/graph/test_depth_contract.py
+++ b/tests/graph/test_depth_contract.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for hierarchy depth (stage 6, design stage table).
+
+Each test pins a claim: depth converges one level per tick from ChildOf
+edges, roots stay 0, re-parenting reconverges, and toposorted() orders
+parents before children.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+from daft import col  # noqa: E402
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.component import Component  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.core.hooks import PostTick  # noqa: E402
+from archetype.graph import (  # noqa: E402
+    ChildOf,
+    Depth,
+    DepthProcessor,
+    GraphView,
+    link,
+    toposorted,
+)
+
+
+class Node(Component):
+    name: str = ""
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "depth_data"), namespace="depth_tests")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _depths(world, at: int) -> dict[int, int]:
+    rows = (await world.query(Depth)).where(col("tick") == at).to_pylist()
+    return {row["entity_id"]: row["depth__value"] for row in rows}
+
+
+def test_depth_converges_one_level_per_tick(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "converge",
+                storage=_storage(tmp_path),
+                processors=[DepthProcessor()],
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            root = await world.spawn(Node(name="root"), Depth())
+            mid = await world.spawn(Node(name="mid"), Depth())
+            leaf = await world.spawn(Node(name="leaf"), Depth())
+            await link(world, ChildOf(source=mid, target=root))
+            await link(world, ChildOf(source=leaf, target=mid))
+            await world.run(steps=4)  # tick 0 raw + >= depth ticks to converge
+
+            latest = (await world.info()).tick - 1
+            depths = await _depths(world, latest)
+            assert depths[root] == 0
+            assert depths[mid] == 1
+            assert depths[leaf] == 2
+            return True
+
+    assert _run(go())
+
+
+def test_reparenting_reconverges(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "reparent",
+                storage=_storage(tmp_path),
+                processors=[DepthProcessor()],
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            a = await world.spawn(Node(name="a"), Depth())
+            b = await world.spawn(Node(name="b"), Depth())
+            c = await world.spawn(Node(name="c"), Depth())
+            await link(world, ChildOf(source=c, target=b))  # a  b -> c
+            await world.run(steps=3)
+
+            # Re-parent c under a chain a -> b -> c: exclusive link replaces.
+            await link(world, ChildOf(source=b, target=a))
+            await world.run(steps=4)
+
+            latest = (await world.info()).tick - 1
+            depths = await _depths(world, latest)
+            assert depths[a] == 0
+            assert depths[b] == 1
+            assert depths[c] == 2
+            return True
+
+    assert _run(go())
+
+
+def test_roots_stay_zero_without_view_or_edges(tmp_path):
+    async def go():
+        # No GraphView resource at all: processor passes frames through.
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "noview", storage=_storage(tmp_path), processors=[DepthProcessor()]
+            )
+            lone = await world.spawn(Node(name="lone"), Depth())
+            await world.run(steps=2)
+            latest = (await world.info()).tick - 1
+            depths = await _depths(world, latest)
+            assert depths[lone] == 0
+            return True
+
+    assert _run(go())
+
+
+def test_toposorted_orders_parents_first(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "topo",
+                storage=_storage(tmp_path),
+                processors=[DepthProcessor()],
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            root = await world.spawn(Node(name="root"), Depth())
+            mid = await world.spawn(Node(name="mid"), Depth())
+            leaf = await world.spawn(Node(name="leaf"), Depth())
+            await link(world, ChildOf(source=mid, target=root))
+            await link(world, ChildOf(source=leaf, target=mid))
+            await world.run(steps=4)
+
+            latest = (await world.info()).tick - 1
+            ordered = [
+                row["entity_id"]
+                for row in toposorted(
+                    (await world.query(Depth)).where(col("tick") == latest)
+                ).to_pylist()
+            ]
+            assert ordered == [root, mid, leaf]
+            return True
+
+    assert _run(go())

--- a/tests/graph/test_depth_contract.py
+++ b/tests/graph/test_depth_contract.py
@@ -155,3 +155,26 @@ def test_toposorted_orders_parents_first(tmp_path):
             return True
 
     assert _run(go())
+
+
+def test_seeded_depth_normalizes_without_edges(tmp_path):
+    """A caller-supplied Depth value cannot survive: no edges means root, 0."""
+
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "seeded",
+                storage=_storage(tmp_path),
+                processors=[DepthProcessor()],
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            seeded = await world.spawn(Node(name="seeded"), Depth(value=5))
+            await world.run(steps=3)
+            latest = (await world.info()).tick - 1
+            depths = await _depths(world, latest)
+            assert depths[seeded] == 0
+            return True
+
+    assert _run(go())


### PR DESCRIPTION
Closes #553. Stage 6 of the graph/PreFab track — design: `docs/design/graph-system.md` (#545), stage table row 6 (roadmap item 12 reshaped as data).

## What ships

- `Depth(Component)` + `DepthProcessor` (priority 20): recomputes each entity's level every tick from live `ChildOf` edges read through `GraphView` at tick N−1 — roots 0, children parent+1. Depth propagates one level per tick; a D-level hierarchy converges in D ticks, and re-parenting reconverges identically. **This is also the first shipped processor that consumes GraphView**, exercising D3 end to end.
- Fully lazy processor: two left joins plus a groupby-max collapse (absorbing the documented exclusive same-batch race); no materialization, no lazy-audit entries.
- `toposorted(frame)` — top-down iteration as `sort("depth__value")`.

**Deliberately not here:** no cycle detection (a ChildOf cycle would oscillate rather than converge — worth a FLAG-style eval later, noted for the #555 registry design), no cross-relation depth.

## Verification

- 32/32 graph tests; the four new contracts pin exact depths after convergence, reconvergence after exclusive re-parenting, pass-through without a view, and parents-before-children ordering.
- `make typecheck` and `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)