### PR TITLE
feat(graph): bounded-depth traversal as iterated joins (stage 2)

### DIFF
--- a/examples/11_graph_relationships.py
+++ b/examples/11_graph_relationships.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Graph Relationships
+====================
+
+Relationships are edge entities: a relation is a component with source and
+target ids, its archetype table is an EdgeTable, and every edge inherits
+ticks, history, and fork lineage. This example builds a small command
+hierarchy, walks it with bounded traversal, reads the graph at an earlier
+tick, and lets a cascade clean up after a despawn.
+
+No external dependencies — runs entirely in-process.
+
+Usage:
+    uv run python examples/11_graph_relationships.py
+"""
+
+import asyncio
+
+from archetype import ArchetypeRuntime, Component
+from archetype.core.config import StorageConfig
+from archetype.core.hooks import PostTick
+from archetype.graph import ChildOf, GraphView, cascade, descendants, edges, link
+
+
+class Unit(Component):
+    name: str = ""
+
+
+async def main():
+    storage = StorageConfig(uri="./archetype_data", namespace="graph_relationships")
+    view = GraphView()
+
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "hierarchy",
+            storage=storage,
+            resources=[view],
+            hooks=[(PostTick, view.on_post_tick)],
+        )
+
+        # ── 1. BUILD THE HIERARCHY ────────────────────────────────────────────
+        hq = await world.spawn(Unit(name="hq"))
+        squad = await world.spawn(Unit(name="squad"))
+        scout = await world.spawn(Unit(name="scout"))
+        await world.step()  # tick 0: units exist, no edges yet
+        await link(world, ChildOf(source=squad, target=hq))
+        await link(world, ChildOf(source=scout, target=squad))
+        await world.step()  # tick 1: the hierarchy lands
+        print(f"1. hierarchy: hq={hq} <- squad={squad} <- scout={scout}")
+
+        # ── 2. TRAVERSE ───────────────────────────────────────────────────────
+        latest = (await world.info()).tick - 1
+        live = await edges(world, ChildOf, at=latest)
+        subtree = descendants(live, [hq], depth=2).sort("hops").to_pylist()
+        print("2. subtree of hq:", [(r["entity_id"], r["hops"]) for r in subtree])
+
+        # ── 3. TIME TRAVEL ────────────────────────────────────────────────────
+        # The EdgeTable keeps every tick; the graph at any moment is a filter.
+        before = (await edges(world, ChildOf, at=0)).count_rows()
+        print(f"3. edges at tick 0: {before} (the graph before it was built)")
+
+        # ── 4. CASCADE ────────────────────────────────────────────────────────
+        # ChildOf deletes children when the parent dies, one generation per pass.
+        await world.despawn(squad)
+        await world.step()
+        first = await cascade(world, ChildOf, view)
+        await world.step()
+        second = await cascade(world, ChildOf, view)
+        await world.step()
+        print(
+            f"4. cascade after squad despawn: pass 1 deleted {list(first.deleted_entities)}, "
+            f"pass 2 deleted {list(second.deleted_entities)}"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ uv run python examples/<filename>.py
 | 7 | [`07_hooks.py`](07_hooks.py) | Lifecycle hooks for audit logs, tick metrics, and temporary debug traces | None |
 | 8 | [`08_htn_resolution.py`](08_htn_resolution.py) | HTN plan resolution as a fan-out AND/OR forest | None |
 | 9 | [`09_cloud_storage.py`](09_cloud_storage.py) | Cloud storage configurations through `StorageConfig` and the runtime API | Optional cloud credentials |
+| 11 | [`11_graph_relationships.py`](11_graph_relationships.py) | Edge entities: build a hierarchy, traverse it, read the graph at an earlier tick, cascade after a despawn | None |
 
 ### Supplementary
 

--- a/src/archetype/graph/__init__.py
+++ b/src/archetype/graph/__init__.py
@@ -15,6 +15,7 @@ from archetype.graph.components import ChildOf, Policy, Relation, require_relati
 from archetype.graph.depth import Depth, DepthProcessor, toposorted
 from archetype.graph.edges import WorldLike, edges, link, unlink
 from archetype.graph.frames import between, live_edge_ids, with_source, with_target
+from archetype.graph.traverse import ancestors, descendants, neighborhood
 from archetype.graph.view import GraphView
 
 __all__ = [
@@ -25,16 +26,19 @@ __all__ = [
     "GraphView",
     "Policy",
     "Relation",
+    "WorldLike",
+    "ancestors",
+    "between",
     "cascade",
     "dangling_edges",
-    "toposorted",
-    "WorldLike",
-    "between",
+    "descendants",
     "edges",
     "link",
     "live_edge_ids",
+    "neighborhood",
     "require_relation",
     "sync",
+    "toposorted",
     "unlink",
     "with_source",
     "with_target",

--- a/src/archetype/graph/traverse.py
+++ b/src/archetype/graph/traverse.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frame-pure traversal: bounded-depth reachability as iterated joins.
+
+Stage 2 (docs/design/graph-system.md). No traversal engine, no caches to
+invalidate: each hop is a join in the lazy plan, and the result is a frame
+of reached entity ids with their minimum hop distance. Cycles are harmless —
+reachability is bounded by ``depth`` and duplicates collapse to the shortest
+hop count.
+
+Direction is stated from the edge's point of view: ``"out"`` follows
+``source → target`` (for ``ChildOf``, child to parent — ancestors), ``"in"``
+follows ``target → source`` (parent to children — descendants).
+:func:`ancestors` and :func:`descendants` name those two readings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal
+
+import daft
+from daft import DataFrame, col, lit
+
+from archetype.graph.components import ChildOf, Relation
+
+Direction = Literal["out", "in"]
+
+
+def neighborhood(
+    edges: DataFrame,
+    rel: type[Relation],
+    roots: Iterable[int],
+    depth: int,
+    *,
+    direction: Direction = "out",
+) -> DataFrame:
+    """Entities reachable from ``roots`` in at most ``depth`` hops.
+
+    Returns a frame with ``entity_id`` and ``hops`` (minimum distance,
+    ``0`` for the roots themselves). ``edges`` is the relation's frame at
+    whatever tick slice the caller chose — traversal over history is the
+    caller passing a historical slice.
+    """
+    if depth < 1:
+        raise ValueError("depth must be at least 1")
+    root_ids = list(roots)
+    if not root_ids:
+        raise ValueError("neighborhood requires at least one root")
+
+    prefix = rel.get_prefix()
+    from_col, to_col = (f"{prefix}source", f"{prefix}target")
+    if direction == "in":
+        from_col, to_col = to_col, from_col
+    hop_edges = edges.select(col(from_col).alias("__from"), col(to_col).alias("__to")).distinct()
+
+    frontier = daft.from_pydict({"entity_id": root_ids})
+    reached = frontier.with_column("hops", lit(0))
+    for hop in range(1, depth + 1):
+        frontier = (
+            frontier.join(hop_edges, left_on=col("entity_id"), right_on=col("__from"))
+            .select(col("__to").alias("entity_id"))
+            .distinct()
+        )
+        reached = reached.concat(frontier.with_column("hops", lit(hop)))
+    return reached.groupby("entity_id").agg(col("hops").min().alias("hops"))
+
+
+def ancestors(edges: DataFrame, roots: Iterable[int], depth: int) -> DataFrame:
+    """``ChildOf`` reachability child → parent: the chain of command above."""
+    return neighborhood(edges, ChildOf, roots, depth, direction="out")
+
+
+def descendants(edges: DataFrame, roots: Iterable[int], depth: int) -> DataFrame:
+    """``ChildOf`` reachability parent → children: the subtree below."""
+    return neighborhood(edges, ChildOf, roots, depth, direction="in")

--- a/tests/graph/test_traverse_contract.py
+++ b/tests/graph/test_traverse_contract.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for frame-pure traversal (stage 2).
+
+Traversal is iterated joins over an edge frame, so most contracts are pure
+frame tests with no world at all; one integration test proves the same
+calls compose with live EdgeTables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import daft
+import pytest
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.component import Component  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.graph import (  # noqa: E402
+    ChildOf,
+    ancestors,
+    descendants,
+    edges,
+    link,
+    neighborhood,
+)
+
+
+class Node(Component):
+    name: str = ""
+
+
+def _edges(pairs: list[tuple[int, int]]) -> daft.DataFrame:
+    """A ChildOf edge frame: (source=child, target=parent) pairs."""
+    return daft.from_pydict(
+        {
+            "childof__source": [p[0] for p in pairs],
+            "childof__target": [p[1] for p in pairs],
+        }
+    )
+
+
+def _reached(frame: daft.DataFrame) -> dict[int, int]:
+    return {row["entity_id"]: row["hops"] for row in frame.to_pylist()}
+
+
+def test_descendants_walk_down_with_hop_counts():
+    # 1 -> 2 -> 3 -> 4 (chain), plus 2 -> 5 (branch)
+    frame = _edges([(2, 1), (3, 2), (4, 3), (5, 2)])
+    got = _reached(descendants(frame, [1], depth=3))
+    assert got == {1: 0, 2: 1, 3: 2, 5: 2, 4: 3}
+
+
+def test_depth_bounds_the_walk():
+    frame = _edges([(2, 1), (3, 2), (4, 3)])
+    got = _reached(descendants(frame, [1], depth=1))
+    assert got == {1: 0, 2: 1}
+
+
+def test_ancestors_walk_up():
+    frame = _edges([(2, 1), (3, 2), (4, 3)])
+    got = _reached(ancestors(frame, [4], depth=2))
+    assert got == {4: 0, 3: 1, 2: 2}
+
+
+def test_diamond_collapses_to_min_hops():
+    # 1 -> {2, 3} -> 4: two paths to 4, min hops wins
+    frame = _edges([(2, 1), (3, 1), (4, 2), (4, 3)])
+    got = _reached(descendants(frame, [1], depth=3))
+    assert got[4] == 2
+
+
+def test_cycle_is_bounded():
+    # 1 -> 2 -> 1 cycle: traversal terminates at depth, roots keep hops 0
+    frame = _edges([(2, 1), (1, 2)])
+    got = _reached(descendants(frame, [1], depth=5))
+    assert got == {1: 0, 2: 1}
+
+
+def test_neighborhood_validates_inputs():
+    frame = _edges([(2, 1)])
+    with pytest.raises(ValueError):
+        neighborhood(frame, ChildOf, [1], depth=0)
+    with pytest.raises(ValueError):
+        neighborhood(frame, ChildOf, [], depth=1)
+
+
+def test_traversal_composes_with_live_edgetables(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "traverse",
+                storage=StorageConfig(uri=str(tmp_path / "t"), namespace="traverse_tests"),
+            )
+            root = await world.spawn(Node(name="root"))
+            mid = await world.spawn(Node(name="mid"))
+            leaf = await world.spawn(Node(name="leaf"))
+            await link(world, ChildOf(source=mid, target=root))
+            await link(world, ChildOf(source=leaf, target=mid))
+            await world.step()
+
+            latest = (await world.info()).tick - 1
+            live = await edges(world, ChildOf, at=latest)
+            got = _reached(descendants(live, [root], depth=2))
+            assert got == {root: 0, mid: 1, leaf: 2}
+            return True
+
+    assert asyncio.run(go())


### PR DESCRIPTION
Closes #548. Stage 2 of the graph/PreFab track — design: `docs/design/graph-system.md` (#545). Claimed after the reserved traversal agent produced no assignee, comments, branch, or PR while #554 sat hard-blocked behind it; rationale and yield-offer are on the issue.

## What ships

- `graph/traverse.py` — frame-pure: `neighborhood(edges, rel, roots, depth, direction)` walks reachability as depth-many lazy joins, returning `entity_id` + minimum `hops`. Cycles are bounded by depth; diamonds collapse to shortest distance via groupby-min. `ancestors`/`descendants` name the two `ChildOf` readings. Traversal over history is the caller passing a historical edge slice — no engine, no caches to invalidate (roadmap items 10/13 dissolved by the dataframe substrate).
- `examples/11_graph_relationships.py` (credential-free, examples gate): build a hierarchy, traverse the subtree, read the genuinely-empty graph at tick 0, cascade after a despawn. README row added. Verification of the example caught its own honesty bug — staged edges land *at* tick 0, so the temporal read needed a real pre-link tick.

## Verification

- 40/40 graph tests on the rebased head; seven new contracts are mostly world-free pure frame tests (hop counts, depth bounding, upward walk, diamond dedup, cycle bounding, input validation) plus one composition test against a live EdgeTable.
- Example run end-to-end; `make typecheck` and `make check` green. Rebase over #606 merged both export sets in `graph/__init__` (now alphabetized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)