### PR TITLE
feat(graph): PreFabs — templates instantiated by copy, with lineage (stage 7)

### DIFF
--- a/examples/12_prefabs.py
+++ b/examples/12_prefabs.py
@@ -72,7 +72,9 @@ async def main():
         latest = (await world.info()).tick - 1
         rows = (await world.query(Chassis)).where(col("tick") == latest).to_pylist()
         armor = {row["entity_id"]: row["chassis__armor"] for row in rows}
-        print(f"3. after the edit: first instance armor={armor[red]}, new instance armor={armor[mk2]}")
+        print(
+            f"3. after the edit: first instance armor={armor[red]}, new instance armor={armor[mk2]}"
+        )
         print("   copy-on-instantiate: the old generation is history, not collateral")
 
 

--- a/examples/12_prefabs.py
+++ b/examples/12_prefabs.py
@@ -65,7 +65,7 @@ async def main():
 
         # ── 3. EDIT THE PREFAB; INSTANCES DO NOT MOVE ─────────────────────────
         await world.update(tank, Chassis(armor=99))
-        await world.run(steps=2)  # the edit persists, then the view captures it
+        await world.step()  # one step: the edit persists and the view captures it
         mk2 = await instantiate(world, view, tank)
         await world.step()
 

--- a/examples/12_prefabs.py
+++ b/examples/12_prefabs.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PreFabs
+========
+
+A prefab is a template entity: the Prefab marker, component values, and
+optionally a ChildOf subtree of child prefabs. instantiate() copies the
+template onto fresh entities, applies overrides, rebuilds the subtree with
+new ids, and records an IsA lineage edge from every copy to its template.
+Editing a prefab never mutates instances — re-instantiation is the upgrade
+path, and both generations stay on the ledger.
+
+No external dependencies — runs entirely in-process.
+
+Usage:
+    uv run python examples/12_prefabs.py
+"""
+
+import asyncio
+
+from daft import col
+
+from archetype import ArchetypeRuntime, Component
+from archetype.core.config import StorageConfig
+from archetype.core.hooks import PostTick
+from archetype.graph import ChildOf, GraphView, IsA, Prefab, edges, instantiate, link
+
+
+class Chassis(Component):
+    armor: int = 10
+    color: str = "grey"
+
+
+class Turret(Component):
+    caliber: int = 30
+
+
+async def main():
+    storage = StorageConfig(uri="./archetype_data", namespace="prefabs")
+    view = GraphView()
+
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "factory",
+            storage=storage,
+            resources=[view],
+            hooks=[(PostTick, view.on_post_tick)],
+        )
+
+        # ── 1. AUTHOR A PREFAB ────────────────────────────────────────────────
+        tank = await world.spawn(Prefab(name="tank"), Chassis(armor=42))
+        gun = await world.spawn(Prefab(name="gun"), Turret(caliber=88))
+        await link(world, ChildOf(source=gun, target=tank))
+        await world.step()
+        print(f"1. prefab authored: tank={tank} with gun={gun}")
+
+        # ── 2. INSTANTIATE, WITH AN OVERRIDE ──────────────────────────────────
+        red = await instantiate(world, view, tank, overrides=[Chassis(armor=42, color="red")])
+        await world.step()
+        latest = (await world.info()).tick - 1
+        lineage = (await edges(world, IsA, at=latest)).to_pylist()
+        print(f"2. instantiated {red} (red): {len(lineage)} IsA lineage edges recorded")
+
+        # ── 3. EDIT THE PREFAB; INSTANCES DO NOT MOVE ─────────────────────────
+        await world.update(tank, Chassis(armor=99))
+        await world.run(steps=2)  # the edit persists, then the view captures it
+        mk2 = await instantiate(world, view, tank)
+        await world.step()
+
+        latest = (await world.info()).tick - 1
+        rows = (await world.query(Chassis)).where(col("tick") == latest).to_pylist()
+        armor = {row["entity_id"]: row["chassis__armor"] for row in rows}
+        print(f"3. after the edit: first instance armor={armor[red]}, new instance armor={armor[mk2]}")
+        print("   copy-on-instantiate: the old generation is history, not collateral")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ uv run python examples/<filename>.py
 | 8 | [`08_htn_resolution.py`](08_htn_resolution.py) | HTN plan resolution as a fan-out AND/OR forest | None |
 | 9 | [`09_cloud_storage.py`](09_cloud_storage.py) | Cloud storage configurations through `StorageConfig` and the runtime API | Optional cloud credentials |
 | 11 | [`11_graph_relationships.py`](11_graph_relationships.py) | Edge entities: build a hierarchy, traverse it, read the graph at an earlier tick, cascade after a despawn | None |
+| 12 | [`12_prefabs.py`](12_prefabs.py) | PreFabs: author a template with a subtree, instantiate copies with overrides and IsA lineage, upgrade by re-instantiation | None |
 
 ### Supplementary
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -185,3 +185,9 @@ path = "src/archetype/graph/cascade.py"
 line = 81
 method = "to_pylist"
 reason = "Mutation-planning boundary for cascade: despawn takes concrete ids, so _plan materializes the (edge id, source) pairs of the dangling edges; the liveness union, anti-join, and filters all run in the lazy plan and only ids cross into Python."
+
+[[entries]]
+path = "src/archetype/graph/prefab.py"
+line = 54
+method = "to_pylist"
+reason = "Mutation-planning boundary for instantiation: spawning copies requires the template's concrete component values and child prefab ids; _rows is the single funnel and every entity filter runs in the lazy plan before it."

--- a/src/archetype/graph/__init__.py
+++ b/src/archetype/graph/__init__.py
@@ -15,6 +15,7 @@ from archetype.graph.components import ChildOf, Policy, Relation, require_relati
 from archetype.graph.depth import Depth, DepthProcessor, toposorted
 from archetype.graph.edges import WorldLike, edges, link, unlink
 from archetype.graph.frames import between, live_edge_ids, with_source, with_target
+from archetype.graph.prefab import IsA, Prefab, instantiate, instantiate_sync
 from archetype.graph.traverse import ancestors, descendants, neighborhood
 from archetype.graph.view import GraphView
 
@@ -24,7 +25,9 @@ __all__ = [
     "Depth",
     "DepthProcessor",
     "GraphView",
+    "IsA",
     "Policy",
+    "Prefab",
     "Relation",
     "WorldLike",
     "ancestors",
@@ -33,6 +36,8 @@ __all__ = [
     "dangling_edges",
     "descendants",
     "edges",
+    "instantiate",
+    "instantiate_sync",
     "link",
     "live_edge_ids",
     "neighborhood",

--- a/src/archetype/graph/prefab.py
+++ b/src/archetype/graph/prefab.py
@@ -105,6 +105,12 @@ def _overlay(components: list[Component], overrides: Sequence[Component]) -> lis
     :meth:`GraphView.frame` applies here so an override always replaces its
     counterpart instead of colliding with it at spawn.
     """
+    for override in overrides:
+        if issubclass(type(override), Prefab | Relation) or _same_component(type(override), Prefab):
+            raise ValueError(
+                f"override {type(override).__name__} is not copyable: markers and "
+                "relations never attach to instances"
+            )
     remaining = list(overrides)
     out: list[Component] = []
     for comp in components:

--- a/src/archetype/graph/prefab.py
+++ b/src/archetype/graph/prefab.py
@@ -32,7 +32,7 @@ from archetype.graph.components import ChildOf, Relation
 from archetype.graph.edges import WorldLike, _require_async, link
 from archetype.graph.sync import SyncWorldLike, _require_sync
 from archetype.graph.sync import link as link_sync
-from archetype.graph.view import GraphView
+from archetype.graph.view import GraphView, _same_component
 
 
 class Prefab(Component):
@@ -62,7 +62,10 @@ def _entity_components(view: GraphView, entity_id: int) -> list[Component]:
     entities.
     """
     for signature, frame in view.frames():
-        matched = _rows(frame.where(cast(Expression, col("entity_id") == entity_id)).limit(1))
+        live = frame
+        if "is_active" in live.column_names:
+            live = live.where(col("is_active"))
+        matched = _rows(live.where(cast(Expression, col("entity_id") == entity_id)).limit(1))
         if not matched:
             continue
         row = matched[0]
@@ -89,8 +92,23 @@ def _child_prefabs(view: GraphView, parent: int) -> list[int]:
 
 
 def _overlay(components: list[Component], overrides: Sequence[Component]) -> list[Component]:
-    by_type = {type(o): o for o in overrides}
-    return [by_type.pop(type(c), c) for c in components] + list(by_type.values())
+    """Overlay ``overrides`` onto ``components`` by schema identity.
+
+    Class-object identity under-matches on resumed durable worlds whose
+    signatures hold schema-identical twin classes; the same identity rule as
+    :meth:`GraphView.frame` applies here so an override always replaces its
+    counterpart instead of colliding with it at spawn.
+    """
+    remaining = list(overrides)
+    out: list[Component] = []
+    for comp in components:
+        match = next((o for o in remaining if _same_component(type(o), type(comp))), None)
+        if match is not None:
+            remaining.remove(match)
+            out.append(match)
+        else:
+            out.append(comp)
+    return out + remaining
 
 
 async def instantiate(

--- a/src/archetype/graph/prefab.py
+++ b/src/archetype/graph/prefab.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""PreFabs: template entities instantiated by copy, with lineage (stage 7, D5).
+
+A prefab is an ordinary entity carrying the :class:`Prefab` marker, its
+component values, and optionally a ``ChildOf`` subtree of child prefabs.
+``instantiate`` copies the template: component values are materialized onto
+fresh entities, overrides applied, the subtree rebuilt with new ids, and an
+``IsA`` edge recorded from every new entity to the prefab entity it copies.
+
+There is no runtime resolution (design D5): editing a prefab does not mutate
+instances. Re-instantiation under the edited prefab is the upgrade path, and
+both generations stay on the ledger — which is what makes prefab populations
+gradeable. The library is world content: prefabs version, fork, and grade
+like everything else.
+
+Reads come from a :class:`GraphView` snapshot, so one ``instantiate`` call is
+internally consistent at the view's captured tick. Spawned copies land as raw
+initial conditions at the next persisted tick, like every staged spawn.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import cast
+
+from daft import DataFrame, Expression, col
+
+from archetype.core.component import Component
+from archetype.graph.components import ChildOf, Relation
+from archetype.graph.edges import WorldLike, _require_async, link
+from archetype.graph.sync import SyncWorldLike, _require_sync
+from archetype.graph.sync import link as link_sync
+from archetype.graph.view import GraphView
+
+
+class Prefab(Component):
+    """Marks an entity as a template. The marker is never copied to instances."""
+
+    name: str = ""
+
+
+class IsA(Relation):
+    """Lineage: ``source`` (the instance) was instantiated from ``target``."""
+
+
+def _rows(frame: DataFrame) -> list[dict]:
+    """Materialize planning rows for instantiation.
+
+    Mutation-planning boundary: spawning copies requires concrete component
+    values and child ids; the entity filters run in the lazy plan.
+    """
+    return frame.to_pylist()
+
+
+def _entity_components(view: GraphView, entity_id: int) -> list[Component]:
+    """Rebuild the entity's component instances from the captured frames.
+
+    ``Prefab`` markers and ``Relation`` components are never copied: the
+    marker is what makes a template a template, and edges are their own
+    entities.
+    """
+    for signature, frame in view.frames():
+        matched = _rows(frame.where(cast(Expression, col("entity_id") == entity_id)).limit(1))
+        if not matched:
+            continue
+        row = matched[0]
+        components: list[Component] = []
+        for cls in signature:
+            if issubclass(cls, Prefab | Relation):
+                continue
+            prefix = cls.get_prefix()
+            components.append(cls(**{f: row[f"{prefix}{f}"] for f in cls.model_fields}))
+        return components
+    raise LookupError(f"entity {entity_id} not found at the view's captured tick")
+
+
+def _child_prefabs(view: GraphView, parent: int) -> list[int]:
+    """Direct ``ChildOf`` children of ``parent`` at the captured tick."""
+    edges = view.frame(ChildOf)
+    if edges is None:
+        return []
+    prefix = ChildOf.get_prefix()
+    rows = _rows(
+        edges.where(cast(Expression, col(f"{prefix}target") == parent)).select(f"{prefix}source")
+    )
+    return [row[f"{prefix}source"] for row in rows]
+
+
+def _overlay(components: list[Component], overrides: Sequence[Component]) -> list[Component]:
+    by_type = {type(o): o for o in overrides}
+    return [by_type.pop(type(c), c) for c in components] + list(by_type.values())
+
+
+async def instantiate(
+    world: WorldLike,
+    view: GraphView,
+    prefab: int,
+    overrides: Sequence[Component] = (),
+    *,
+    max_depth: int = 8,
+) -> int:
+    """Copy ``prefab`` (and its ``ChildOf`` subtree) onto fresh entities.
+
+    Returns the new root's entity id. ``overrides`` overlay the root's
+    components by type; subtree copies are verbatim. Every new entity gets an
+    ``IsA`` edge to the prefab entity it was copied from, and the subtree's
+    ``ChildOf`` wiring is rebuilt between the new ids.
+    """
+    _require_async(world, "spawn")
+    new_id = await world.spawn(*_overlay(_entity_components(view, prefab), overrides))
+    await link(world, IsA(source=new_id, target=prefab))
+    if max_depth > 0:
+        for child in _child_prefabs(view, prefab):
+            new_child = await instantiate(world, view, child, max_depth=max_depth - 1)
+            await link(world, ChildOf(source=new_child, target=new_id))
+    return new_id
+
+
+def instantiate_sync(
+    world: SyncWorldLike,
+    view: GraphView,
+    prefab: int,
+    overrides: Sequence[Component] = (),
+    *,
+    max_depth: int = 8,
+) -> int:
+    """Blocking counterpart of :func:`instantiate` (runtime.md R5 parity)."""
+    _require_sync(world, "spawn")
+    new_id = world.spawn(*_overlay(_entity_components(view, prefab), overrides))
+    link_sync(world, IsA(source=new_id, target=prefab))
+    if max_depth > 0:
+        for child in _child_prefabs(view, prefab):
+            new_child = instantiate_sync(world, view, child, max_depth=max_depth - 1)
+            link_sync(world, ChildOf(source=new_child, target=new_id))
+    return new_id

--- a/src/archetype/graph/prefab.py
+++ b/src/archetype/graph/prefab.py
@@ -71,7 +71,13 @@ def _entity_components(view: GraphView, entity_id: int) -> list[Component]:
         row = matched[0]
         components: list[Component] = []
         for cls in signature:
-            if issubclass(cls, Prefab | Relation):
+            # Exclusion honors schema identity for the marker: a resumed
+            # world's twin Prefab class is not an issubclass of ours, and
+            # copying it would silently turn instances into templates.
+            # Relation exclusion stays hierarchical — relation subclasses
+            # have distinct schemas by design, and edges are their own
+            # entities, never components on a template root.
+            if issubclass(cls, Prefab | Relation) or _same_component(cls, Prefab):
                 continue
             prefix = cls.get_prefix()
             components.append(cls(**{f: row[f"{prefix}{f}"] for f in cls.model_fields}))

--- a/src/archetype/graph/traverse.py
+++ b/src/archetype/graph/traverse.py
@@ -48,6 +48,8 @@ def neighborhood(
     root_ids = list(roots)
     if not root_ids:
         raise ValueError("neighborhood requires at least one root")
+    if direction not in ("out", "in"):
+        raise ValueError(f"direction must be 'out' or 'in', got {direction!r}")
 
     prefix = rel.get_prefix()
     from_col, to_col = (f"{prefix}source", f"{prefix}target")

--- a/src/archetype/graph/view.py
+++ b/src/archetype/graph/view.py
@@ -73,6 +73,10 @@ class GraphView:
         self._frames = dict(event.results)
         self.tick = event.tick - 1  # PostTick.tick is the next tick
 
+    def frames(self) -> list[tuple[ArchetypeSignature, DataFrame]]:
+        """The captured (signature, frame) pairs — read-only iteration order."""
+        return list(self._frames.items())
+
     def population(self) -> DataFrame | None:
         """Distinct ids of every entity alive at the captured tick.
 

--- a/src/archetype/graph/view.py
+++ b/src/archetype/graph/view.py
@@ -74,7 +74,13 @@ class GraphView:
         self.tick = event.tick - 1  # PostTick.tick is the next tick
 
     def frames(self) -> list[tuple[ArchetypeSignature, DataFrame]]:
-        """The captured (signature, frame) pairs — read-only iteration order."""
+        """The RAW captured (signature, frame) pairs.
+
+        Unlike :meth:`frame` and :meth:`population`, no ``is_active``
+        filtering is applied — rows despawned at capture time are included.
+        Callers that need liveness filter it themselves, as
+        ``prefab._entity_components`` does.
+        """
         return list(self._frames.items())
 
     def population(self) -> DataFrame | None:

--- a/tests/graph/test_prefab_contract.py
+++ b/tests/graph/test_prefab_contract.py
@@ -222,3 +222,37 @@ def test_override_matches_schema_identical_twin(tmp_path):
             return True
 
     assert _run(go())
+
+
+def _make_prefab_twin() -> type[Component]:
+    class Prefab(Component):
+        name: str = ""
+
+    return Prefab
+
+
+def test_twin_prefab_marker_is_not_copied():
+    """A schema-identical twin Prefab marker (cold resume) is excluded from
+    the copy exactly like the real one — instances never become templates."""
+    import daft
+
+    from archetype.graph.prefab import _entity_components
+
+    twin_marker = _make_prefab_twin()
+    signature = tuple(sorted((twin_marker, Chassis), key=lambda t: t.__name__))
+    frame = daft.from_pydict(
+        {
+            "entity_id": [7],
+            "tick": [0],
+            "prefab__name": ["ghost"],
+            "chassis__armor": [12],
+            "chassis__color": ["blue"],
+        }
+    )
+    view = GraphView()
+    view._frames = {signature: frame}
+    view.tick = 0
+
+    components = _entity_components(view, 7)
+    assert [type(c).__name__ for c in components] == ["Chassis"]
+    assert components[0].armor == 12

--- a/tests/graph/test_prefab_contract.py
+++ b/tests/graph/test_prefab_contract.py
@@ -256,3 +256,26 @@ def test_twin_prefab_marker_is_not_copied():
     components = _entity_components(view, 7)
     assert [type(c).__name__ for c in components] == ["Chassis"]
     assert components[0].armor == 12
+
+
+def test_marker_and_relation_overrides_are_rejected(tmp_path):
+    """An override that could smuggle a marker or relation onto an instance
+    fails loudly instead of silently minting a second template."""
+
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "smuggle", tmp_path, view)
+            template = await world.spawn(Prefab(name="t"), Chassis(armor=1))
+            await world.step()
+
+            with pytest.raises(ValueError, match="not copyable"):
+                await instantiate(world, view, template, overrides=[Prefab(name="oops")])
+            with pytest.raises(ValueError, match="not copyable"):
+                await instantiate(world, view, template, overrides=[IsA(source=1, target=2)])
+            twin_marker = _make_prefab_twin()
+            with pytest.raises(ValueError, match="not copyable"):
+                await instantiate(world, view, template, overrides=[twin_marker(name="ghost")])
+            return True
+
+    assert _run(go())

--- a/tests/graph/test_prefab_contract.py
+++ b/tests/graph/test_prefab_contract.py
@@ -142,8 +142,7 @@ def test_editing_prefab_does_not_mutate_instances(tmp_path):
             await world.step()
 
             await world.update(template, Chassis(armor=99))
-            await world.step()
-            await world.step()  # view captures the edited template
+            await world.step()  # one step: the edit persists and the view captures it
 
             second = await instantiate(world, view, template)
             await world.step()
@@ -191,3 +190,35 @@ def test_sync_instantiate_parity(tmp_path):
         rows = world.query(Chassis).where(col("tick") == latest).to_pylist()
         by_id = {row["entity_id"]: row["chassis__armor"] for row in rows}
         assert by_id[inst] == 7
+
+
+def _make_chassis_twin() -> type[Component]:
+    class Chassis(Component):
+        armor: int = 10
+        color: str = "grey"
+
+    return Chassis
+
+
+def test_override_matches_schema_identical_twin(tmp_path):
+    """An override from a schema-identical twin class replaces the copied
+    component instead of colliding with it — the cold-resume rule."""
+
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "twin-override", tmp_path, view)
+            template = await world.spawn(Prefab(name="t"), Chassis(armor=3))
+            await world.step()
+
+            twin = _make_chassis_twin()
+            inst = await instantiate(world, view, template, overrides=[twin(armor=77)])
+            await world.step()
+
+            latest = (await world.info()).tick - 1
+            rows = (await world.query(Chassis)).where(col("tick") == latest).to_pylist()
+            by_id = {row["entity_id"]: row["chassis__armor"] for row in rows}
+            assert by_id[inst] == 77
+            return True
+
+    assert _run(go())

--- a/tests/graph/test_prefab_contract.py
+++ b/tests/graph/test_prefab_contract.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for PreFabs (stage 7, design D5).
+
+Each test pins a D5 claim: instantiation copies values with overrides and
+records IsA lineage, the Prefab marker never copies, subtrees rebuild with
+new ids, editing a prefab does not mutate existing instances, and the sync
+flavor mirrors the async one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+from daft import col  # noqa: E402
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.component import Component  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.core.hooks import PostTick  # noqa: E402
+from archetype.graph import (  # noqa: E402
+    ChildOf,
+    GraphView,
+    IsA,
+    Prefab,
+    edges,
+    instantiate,
+    instantiate_sync,
+    link,
+)
+
+
+class Chassis(Component):
+    armor: int = 10
+    color: str = "grey"
+
+
+class Turret(Component):
+    caliber: int = 30
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "prefab_data"), namespace="prefab_tests")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _world(runtime, name, tmp_path, view):
+    return runtime.world(
+        name,
+        storage=_storage(tmp_path),
+        resources=[view],
+        hooks=[(PostTick, view.on_post_tick)],
+    )
+
+
+def test_instantiate_copies_overrides_and_records_lineage(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "copy", tmp_path, view)
+            template = await world.spawn(Prefab(name="tank"), Chassis(armor=42))
+            await world.step()
+
+            inst = await instantiate(
+                world, view, template, overrides=[Chassis(armor=42, color="red")]
+            )
+            await world.step()
+
+            latest = (await world.info()).tick - 1
+            rows = (await world.query(Chassis)).where(col("tick") == latest).to_pylist()
+            by_id = {row["entity_id"]: row for row in rows}
+            assert by_id[inst]["chassis__armor"] == 42
+            assert by_id[inst]["chassis__color"] == "red"  # override applied
+
+            # The Prefab marker was not copied: the instance is not a template.
+            prefab_rows = (await world.query(Prefab)).where(col("tick") == latest).to_pylist()
+            assert {row["entity_id"] for row in prefab_rows} == {template}
+
+            lineage = (await edges(world, IsA, at=latest)).to_pylist()
+            assert len(lineage) == 1
+            assert lineage[0]["isa__source"] == inst
+            assert lineage[0]["isa__target"] == template
+            return True
+
+    assert _run(go())
+
+
+def test_subtree_instantiates_with_new_ids(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "subtree", tmp_path, view)
+            body = await world.spawn(Prefab(name="body"), Chassis(armor=5))
+            gun = await world.spawn(Prefab(name="gun"), Turret(caliber=88))
+            await link(world, ChildOf(source=gun, target=body))
+            await world.step()
+
+            inst = await instantiate(world, view, body)
+            await world.step()
+
+            latest = (await world.info()).tick - 1
+            child_edges = (await edges(world, ChildOf, at=latest)).to_pylist()
+            new_wiring = [row for row in child_edges if row["childof__target"] == inst]
+            assert len(new_wiring) == 1
+            new_gun = new_wiring[0]["childof__source"]
+            assert new_gun not in {body, gun, inst}
+
+            turrets = (await world.query(Turret)).where(col("tick") == latest).to_pylist()
+            by_id = {row["entity_id"]: row for row in turrets}
+            assert by_id[new_gun]["turret__caliber"] == 88
+
+            lineage = (await edges(world, IsA, at=latest)).to_pylist()
+            assert {(row["isa__source"], row["isa__target"]) for row in lineage} == {
+                (inst, body),
+                (new_gun, gun),
+            }
+            return True
+
+    assert _run(go())
+
+
+def test_editing_prefab_does_not_mutate_instances(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "upgrade", tmp_path, view)
+            template = await world.spawn(Prefab(name="mk"), Chassis(armor=1))
+            await world.step()
+
+            first = await instantiate(world, view, template)
+            await world.step()
+
+            await world.update(template, Chassis(armor=99))
+            await world.step()
+            await world.step()  # view captures the edited template
+
+            second = await instantiate(world, view, template)
+            await world.step()
+
+            latest = (await world.info()).tick - 1
+            rows = (await world.query(Chassis)).where(col("tick") == latest).to_pylist()
+            by_id = {row["entity_id"]: row["chassis__armor"] for row in rows}
+            assert by_id[first] == 1  # copy-on-instantiate: old instance untouched
+            assert by_id[second] == 99  # re-instantiation is the upgrade path
+            return True
+
+    assert _run(go())
+
+
+def test_missing_prefab_raises(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "missing", tmp_path, view)
+            await world.spawn(Prefab(name="x"), Chassis())
+            await world.step()
+            with pytest.raises(LookupError):
+                await instantiate(world, view, 424242)
+            return True
+
+    assert _run(go())
+
+
+def test_sync_instantiate_parity(tmp_path):
+    view = GraphView()
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world(
+            "sync-prefab",
+            storage=_storage(tmp_path),
+            resources=[view],
+            hooks=[(PostTick, view.on_post_tick_sync)],
+        )
+        template = world.spawn(Prefab(name="t"), Chassis(armor=7))
+        world.step()
+
+        inst = instantiate_sync(world, view, template)
+        world.step()
+
+        latest = world.info().tick - 1
+        rows = world.query(Chassis).where(col("tick") == latest).to_pylist()
+        by_id = {row["entity_id"]: row["chassis__armor"] for row in rows}
+        assert by_id[inst] == 7

--- a/tests/graph/test_traverse_contract.py
+++ b/tests/graph/test_traverse_contract.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 import asyncio
 import os
 
-import daft
-import pytest
-
 os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
 os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
 os.environ.setdefault("DO_NOT_TRACK", "1")
+
+import daft  # noqa: E402
+import pytest  # noqa: E402
 
 from archetype import ArchetypeRuntime  # noqa: E402
 from archetype.core.component import Component  # noqa: E402
@@ -90,6 +90,8 @@ def test_neighborhood_validates_inputs():
         neighborhood(frame, ChildOf, [1], depth=0)
     with pytest.raises(ValueError):
         neighborhood(frame, ChildOf, [], depth=1)
+    with pytest.raises(ValueError, match="direction"):
+        neighborhood(frame, ChildOf, [1], depth=1, direction="incoming")  # type: ignore[arg-type]
 
 
 def test_traversal_composes_with_live_edgetables(tmp_path):


### PR DESCRIPTION
Closes #554. Stage 7 of the graph/PreFab track — design: `docs/design/graph-system.md` (#545), decision D5. Also carries the two review follow-ups from #607, which merged mid-review (direction validation in `neighborhood`; telemetry opt-outs moved above the daft import in the traverse test).

## What ships

- **`Prefab`** marker + **`IsA`** lineage relation + **`instantiate()` / `instantiate_sync()`**: copy the template's component values onto fresh entities (Prefab markers and Relation components never copy — edges are their own entities), apply overrides by type, rebuild the `ChildOf` subtree with new ids bounded by `max_depth`, and record an `IsA` edge from every copy to its template.
- **No runtime resolution (D5)**: editing a prefab never mutates instances; re-instantiation is the upgrade path, and both generations stay on the ledger — the property that makes prefab populations gradeable. Reads come from a `GraphView` snapshot, so one call is internally consistent; `GraphView` gains a public `frames()` accessor.
- `examples/12_prefabs.py` (credential-free): author a tank prefab with a gun subtree, instantiate a red one, edit the template, prove the first instance doesn't move. README row added.
- One `lazy_audit.toml` entry — `_rows`, the single planning materialization (component values + child ids for spawning); every entity filter runs in the lazy plan. Called out per the audit's sign-off rule.

## Verification

- 45/45 graph tests. Five new contracts: copy+override+lineage, marker non-propagation, subtree rebuild with fresh ids and correct `IsA` pairs, the copy-on-instantiate upgrade proof (old instance keeps armor=1 while the re-instantiation reads 99), missing-prefab error, sync parity.
- Example run end-to-end; `make typecheck` and `make check` green on the rebased head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)