### PR TITLE
feat(projections): possession read model — one entity's field of view (stage 3)

### DIFF
--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -93,7 +93,9 @@ allowed_families = []
 [[top_level_family_rule]]
 name = "projections-domain-family"
 consumer = "archetype.projections"
-allowed_families = []
+# First reviewed family-to-family edge: possession composes graph traversal.
+# Acyclic: graph does not import projections.
+allowed_families = ["archetype.graph"]
 
 [[package_rule]]
 name = "core-does-not-import-outward"

--- a/src/archetype/projections/__init__.py
+++ b/src/archetype/projections/__init__.py
@@ -14,6 +14,7 @@ cross-family read models.
 
 from archetype.projections import sync
 from archetype.projections.frames import activity, latest, overview
+from archetype.projections.possession import possession, possession_view
 from archetype.projections.worlds import QueriesLike, world_overview
 
 __all__ = [
@@ -21,6 +22,8 @@ __all__ = [
     "activity",
     "latest",
     "overview",
+    "possession",
+    "possession_view",
     "sync",
     "world_overview",
 ]

--- a/src/archetype/projections/possession.py
+++ b/src/archetype/projections/possession.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The possession read model: one entity's relational field of view (stage 3).
+
+The FPS half of the RTS/FPS operating model: ``possession`` computes what one
+entity can reach through its relations — both directions, labeled, with hop
+distances — as a single lazy frame. Fog of war is a ``where`` clause on this
+frame; stepping into an agent's seat is rendering it.
+
+This module declares the projections family's first family-to-family edge:
+it consumes :mod:`archetype.graph` traversal (granted in
+``quality/architecture.toml``; acyclic — graph does not import projections).
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Sequence
+from typing import Protocol, cast
+
+from daft import DataFrame, Expression, col, lit
+
+from archetype.core.component import Component
+from archetype.graph.components import Relation
+from archetype.graph.traverse import neighborhood
+
+
+class QueriesLike(Protocol):
+    """Structural surface the async possession helper needs from a handle."""
+
+    async def query(self, *components: type[Component]) -> DataFrame: ...
+
+
+def possession(
+    edges_by_relation: Sequence[tuple[type[Relation], DataFrame]],
+    entity: int,
+    depth: int = 1,
+) -> DataFrame:
+    """What ``entity`` reaches through each relation, in both directions.
+
+    Returns a lazy frame of ``entity_id``, ``hops``, ``relation``, and
+    ``direction`` (``"out"`` follows source→target, ``"in"`` the reverse),
+    excluding the possessed entity itself. Historical points of view are the
+    caller passing historical edge slices.
+    """
+    if not edges_by_relation:
+        raise ValueError("possession requires at least one (relation, edges) pair")
+    parts: list[DataFrame] = []
+    for rel, edges in edges_by_relation:
+        for direction in ("out", "in"):
+            reached = neighborhood(edges, rel, [entity], depth, direction=direction)
+            beyond_root = cast(Expression, col("hops") > 0)  # ty: ignore[unsupported-operator]
+            parts.append(
+                reached.where(beyond_root)
+                .with_column("relation", lit(rel.get_prefix().rstrip("_")))
+                .with_column("direction", lit(direction))
+            )
+    out = parts[0]
+    for part in parts[1:]:
+        out = out.concat(part)
+    return out.sort(["relation", "direction", "hops"])
+
+
+def _require_async(world: QueriesLike) -> None:
+    if not inspect.iscoroutinefunction(world.query):
+        raise TypeError(
+            "world.query is not async; for SyncRuntimeWorld-shaped handles "
+            "use archetype.projections.sync"
+        )
+
+
+async def possession_view(
+    world: QueriesLike,
+    entity: int,
+    *relations: type[Relation],
+    depth: int = 1,
+    at: int | None = None,
+) -> DataFrame:
+    """Handle sugar: query each relation's edges and compose ``possession``.
+
+    ``at`` slices every relation to one tick; the default reads full history,
+    which callers typically narrow first. A relation with no committed table
+    surfaces the engine's missing-table error, matching ``graph.edges``.
+    """
+    if not relations:
+        raise ValueError("possession_view requires at least one relation type")
+    _require_async(world)
+    pairs: list[tuple[type[Relation], DataFrame]] = []
+    for rel in relations:
+        frame = await world.query(rel)
+        if at is not None:
+            frame = frame.where(cast(Expression, col("tick") == at))
+        pairs.append((rel, frame))
+    return possession(pairs, entity, depth)

--- a/src/archetype/projections/sync.py
+++ b/src/archetype/projections/sync.py
@@ -11,12 +11,14 @@ before any query.
 from __future__ import annotations
 
 import inspect
-from typing import Protocol
+from typing import Protocol, cast
 
-from daft import DataFrame
+from daft import DataFrame, Expression, col
 
 from archetype.core.component import Component
+from archetype.graph.components import Relation
 from archetype.projections.frames import overview
+from archetype.projections.possession import possession
 from archetype.projections.worlds import require_unique_labels
 
 
@@ -45,3 +47,23 @@ def world_overview(world: SyncQueriesLike, *components: type[Component]) -> Data
     require_unique_labels(components)
     frames = {comp.__name__.lower(): world.query(comp) for comp in components}
     return overview(**frames)
+
+
+def possession_view(
+    world: SyncQueriesLike,
+    entity: int,
+    *relations: type[Relation],
+    depth: int = 1,
+    at: int | None = None,
+) -> DataFrame:
+    """Blocking counterpart of :func:`archetype.projections.possession.possession_view`."""
+    if not relations:
+        raise ValueError("possession_view requires at least one relation type")
+    _require_sync(world)
+    pairs: list[tuple[type[Relation], DataFrame]] = []
+    for rel in relations:
+        frame = world.query(rel)
+        if at is not None:
+            frame = frame.where(cast(Expression, col("tick") == at))
+        pairs.append((rel, frame))
+    return possession(pairs, entity, depth)

--- a/tests/projections/test_possession_contract.py
+++ b/tests/projections/test_possession_contract.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for the possession read model (stage 3).
+
+Each test pins a claim: possession labels reachability per relation and
+direction with hop distances, excludes the possessed entity, bounds by
+depth, and mirrors in sync.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+import daft  # noqa: E402
+import pytest  # noqa: E402
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.component import Component  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.graph import ChildOf, Relation, link  # noqa: E402
+from archetype.projections import possession, possession_view  # noqa: E402
+from archetype.projections import sync as projections_sync  # noqa: E402
+
+
+class Sees(Relation):
+    pass
+
+
+class Node(Component):
+    name: str = ""
+
+
+def _edges(prefix: str, pairs: list[tuple[int, int]]) -> daft.DataFrame:
+    return daft.from_pydict(
+        {
+            f"{prefix}__source": [p[0] for p in pairs],
+            f"{prefix}__target": [p[1] for p in pairs],
+        }
+    )
+
+
+def _tuples(frame: daft.DataFrame) -> set[tuple[int, str, str, int]]:
+    return {
+        (row["entity_id"], row["relation"], row["direction"], row["hops"])
+        for row in frame.to_pylist()
+    }
+
+
+def test_possession_labels_relations_and_directions():
+    childof = _edges("childof", [(2, 1), (3, 2)])  # 1 <- 2 <- 3
+    sees = _edges("sees", [(2, 9)])  # 2 watches 9
+    got = _tuples(possession([(ChildOf, childof), (Sees, sees)], entity=2, depth=1))
+    assert got == {
+        (1, "childof", "out", 1),  # my parent
+        (3, "childof", "in", 1),  # my child
+        (9, "sees", "out", 1),  # what I watch
+    }
+
+
+def test_possession_excludes_self_and_bounds_depth():
+    childof = _edges("childof", [(2, 1), (3, 2), (4, 3)])
+    got = _tuples(possession([(ChildOf, childof)], entity=1, depth=2))
+    assert all(entity != 1 for entity, *_ in got)
+    assert got == {(2, "childof", "in", 1), (3, "childof", "in", 2)}
+
+
+def test_possession_requires_relations():
+    with pytest.raises(ValueError):
+        possession([], entity=1)
+
+
+def test_possession_view_roundtrip(tmp_path):
+    async def go():
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "pov",
+                storage=StorageConfig(uri=str(tmp_path / "p"), namespace="possession_tests"),
+            )
+            hq = await world.spawn(Node(name="hq"))
+            squad = await world.spawn(Node(name="squad"))
+            await link(world, ChildOf(source=squad, target=hq))
+            await world.step()
+
+            latest = (await world.info()).tick - 1
+            got = _tuples(await possession_view(world, squad, ChildOf, at=latest))
+            assert got == {(hq, "childof", "out", 1)}
+            return True
+
+    assert asyncio.run(go())
+
+
+def test_possession_view_sync_parity(tmp_path):
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world(
+            "pov-sync",
+            storage=StorageConfig(uri=str(tmp_path / "s"), namespace="possession_tests"),
+        )
+        hq = world.spawn(Node(name="hq"))
+        squad = world.spawn(Node(name="squad"))
+        from archetype.graph import sync as graph_sync
+
+        graph_sync.link(world, ChildOf(source=squad, target=hq))
+        world.step()
+
+        latest = world.info().tick - 1
+        got = _tuples(projections_sync.possession_view(world, squad, ChildOf, at=latest))
+        assert got == {(hq, "childof", "out", 1)}


### PR DESCRIPTION
Closes #549 — the final implementation stage of the graph/PreFab chain (design: `docs/design/graph-system.md`, #545; claimed alongside #548 after the reserved agent didn't materialize).

## What ships

- **`possession(edges_by_relation, entity, depth)`** — one entity's relational field of view as a single lazy frame: everything reachable through each relation, both directions, labeled (`relation`, `direction`, `hops`), self excluded. Fog of war is a `where` clause on this frame; a historical point of view is a historical edge slice. Fully lazy — no audit entries.
- **`possession_view(world, entity, *relations, depth, at)`** handle sugar with an R5 sync twin in `projections.sync`.
- **The registry's first family-to-family edge**: `projections` is granted `archetype.graph` in `quality/architecture.toml` (acyclic — graph does not import projections; rationale in the TOML comment). This exercises the family policy's central mechanism for the first time.

Context for where this points: the creed's "FPS is chat" note — the camera is a query. `possession()` is that query.

## Verification

- 62/62 across projections + graph on the rebased (post-#608) head. Five new contracts: relation/direction labeling, self-exclusion + depth bounding, empty-input rejection, live-world roundtrip, sync parity.
- `make typecheck` (one `cast + ty:ignore` per the htn precedent) and `make check` green — including the architecture audit validating the new family edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)