### PR TITLE
docs(design): registry rulings + library-object registration model

### DIFF
--- a/docs/design/mutation-outbox.md
+++ b/docs/design/mutation-outbox.md
@@ -1,0 +1,61 @@
+# Mutation Outbox — Design
+
+**Status:** Ruled (#604, 2026-07-20), not implemented. This document makes
+the seam's design repo-resident; the rulings are recorded on issue #604.
+
+---
+
+## 1. Motivation
+
+Processors are pure ``DataFrame → DataFrame`` and cannot spawn or despawn:
+``is_active`` is engine-owned, flipped only by mutations staged through the
+world API. Cleanup therefore shipped as a driver-level helper
+(``graph.cascade``) called between steps. The outbox lets mutation-producing
+logic run *inside* the tick without giving processors effects: they declare
+intents; the engine applies them.
+
+## 2. Shape
+
+A per-tick resource the engine injects; processors require it and emit:
+
+```python
+class MutationOutbox:
+    def despawn(self, entity_id: int) -> None: ...
+    def spawn(self, *components: Component) -> None: ...
+```
+
+The engine drains the outbox through the same staging path
+``world.spawn``/``world.despawn`` use, so intents emitted at tick N land at
+tick N+1, and ``OnSpawn``/``OnDespawn`` hooks and audit fire identically to
+driver calls.
+
+## 3. Rulings (issue #604)
+
+1. The outbox-as-Resource pattern is accepted, and it stays internal.
+2. Built-in processors raise concrete error types per failure mode and
+   double as the demonstrations of the mature processor pattern.
+3. Determinism rides existing machinery: entity ids are a world concern,
+   assigned at drain; priority orders emission; the drain applies a stable
+   sort so id assignment is reproducible.
+4. No actor context on the outbox — authority is which processors are
+   installed (consistent with runtime R3); the command gate remains the
+   boundary for external mutation.
+5. The outbox is tick-scoped: intents die with an aborted tick, which is
+   stricter than driver-level staging and is the contract.
+6. Processor-native ``instantiate`` is in scope once the seam lands —
+   programmatic entity creation from inside the sim is a requirement.
+
+## 4. Invariants
+
+- Intents at tick N take effect at N+1; one generation per tick is preserved
+  by construction.
+- Frames returned by processors are unchanged by intents; the outbox is not
+  a data channel.
+- Draining reuses the staged-mutation path; no second mutation mechanism.
+
+## 5. Non-goals
+
+- No update/overlay intents in the first cut; spawn and despawn only.
+- No cross-world intents.
+- No relaxation of processor purity: emitting an intent is declaring data,
+  not performing an effect.

--- a/docs/design/prefab-registry.md
+++ b/docs/design/prefab-registry.md
@@ -93,9 +93,9 @@ version without evidence receipts is visibly ungraded in the index.
 - No central naming authority beyond the namespace directory (§7); cross-org
   trust and signing are future work.
 - No automatic migration of drifted schemas (R4 forbids silent coercion).
-- Processor-native instantiation is IN scope: #604 was ruled greenlit
-  (2026-07-20) — the MutationOutbox seam makes it possible; see the #604
-  issue for the recorded rulings.
+- Processor-native instantiation is IN scope once the mutation-outbox seam
+  lands: ruled on #604 (2026-07-20), design in
+  `docs/design/mutation-outbox.md` — designed, not implemented.
 - No declarative prefab file format yet (Biome's `.flecs` layer); Python
   authoring through the library object comes first.
 

--- a/docs/design/prefab-registry.md
+++ b/docs/design/prefab-registry.md
@@ -1,8 +1,8 @@
 # PreFab Registry — Design
 
-**Status:** Proposed, for review. Written after stages 1–7 of the graph track
-landed (`docs/design/graph-system.md`), per issue #555's design-doc-first
-rule. Nothing here is implemented.
+**Status:** Ruled. Written after stages 1–7 landed; Everett's rulings
+recorded 2026-07-20 (§5, §7). Implementation may proceed per §6; nothing is
+implemented yet.
 
 ---
 
@@ -90,33 +90,93 @@ version without evidence receipts is visibly ungraded in the index.
 
 ## 4. What stays out
 
-- No central naming authority beyond the artifact index in this design;
-  cross-org trust and signing are future work.
+- No central naming authority beyond the namespace directory (§7); cross-org
+  trust and signing are future work.
 - No automatic migration of drifted schemas (R4 forbids silent coercion).
-- No processor-native instantiation; the driver-level seam stands until the
-  #604 core discussion resolves.
+- Processor-native instantiation is IN scope: #604 was ruled greenlit
+  (2026-07-20) — the MutationOutbox seam makes it possible; see the #604
+  issue for the recorded rulings.
+- No declarative prefab file format yet (Biome's `.flecs` layer); Python
+  authoring through the library object comes first.
 
 ---
 
-## 5. Open questions for review
+## 5. Rulings (Everett, 2026-07-20)
 
-1. **Naming ownership** — is a name bound in the control catalog (one
-   authority per storage identity) or per library world? The catalog is the
-   natural home but couples the registry to app-layer authority; the family
-   split suggests manifest models live in a family and the binding service
-   lives under `app`.
-2. **`IsA` payload rollout** — R2 changes a shipped component's schema.
-   Land it immediately (small blast radius now) or version the relation?
-3. **Registry family placement** — `archetype.prefabs` as its own family
-   (manifest models + frame-pure index readers), with the publishing service
-   under `app.artifacts`? This mirrors the missions split.
+1. **Naming ownership — hybrid, split by rate of change.** The control
+   catalog holds only the namespace directory (library name → library world
+   id): small, authoritative, RBAC'd, rarely changing. Prefab names below a
+   namespace are world content (`Prefab.name` rows), unique-per-library via
+   a FLAG eval, versioned by ticks, forking with the library. Resolution is
+   two hops: catalog for the namespace, ledger for the name at a version.
+2. **`IsA` payload — land now.** Necessary for cross-world lineage; the
+   installed base is a week old, so the schema change is nearly free today
+   and expensive later (#543's lesson). First implementation step.
+3. **Family placement — `archetype.prefabs` is its own family**, separate
+   from `archetype.graph` (mechanics stay in graph, governance in prefabs);
+   manifest models + frame-pure index readers in the family, the binding
+   service under `app`. Registered via its own
+   `quality/architecture.d/prefabs.toml` fragment.
 
 ---
 
-## 6. Implementation sketch (post-review)
+## 6. Implementation sketch (rulings applied)
 
 1. `IsA` provenance payload + migration note (R2) — small, ships first.
-2. Manifest models + schema-hash capture in a family package (R3, R4).
-3. Publish/lookup through the artifact bundle service (R3).
-4. Eval-binding conventions + library-world validations (R5).
-5. Cross-world import example: a library world feeding the RTS toy (#603).
+2. `PrefabLibrary` authoring object in `archetype.prefabs` (§7): emit and
+   register components/relations/processors/hooks under a namespace; publish
+   prefab entities into a library world; install into consumer worlds.
+3. Manifest models + schema-hash capture in the family (R3, R4).
+4. Namespace directory in the control catalog + binding service under `app`
+   (§5.1); publish/lookup rides the artifact bundle service (R3).
+5. #604 MutationOutbox seam in core (rulings on the issue), then
+   processor-native instantiate.
+6. Eval-binding conventions + library-world validations (R5).
+7. Cross-world import example: a library world feeding the RTS toy (#603).
+
+## 7. Registration model (ruled 2026-07-20)
+
+Biome's registration is two layers: C modules (`ECS_IMPORT`) register
+component types, systems, observers, and hooks under a module namespace;
+`.flecs` scripts then declaratively compose prefabs from those registered
+parts, namespaced by blocks (`buildings.Solar`). Archetype adopts the same
+split with what already exists:
+
+- **Layer 1 — the library object (code).** `PrefabLibrary(name)` is the
+  authoring surface: it emits and registers the primitives you build with —
+  component and relation classes, processors, hooks — under its namespace,
+  and carries the prefab-authoring API. Installing a library into a world is
+  the `ECS_IMPORT` analog and rides the declarative world config (R6:
+  processors, resources, hooks in declared order). Registration is explicit,
+  not import-magic.
+- **Layer 2 — the library world (data).** Prefab entities composed from
+  layer-1 parts, exactly what stage 7 built. Publishing writes them and the
+  manifest artifact; the catalog's namespace directory points at the world.
+
+Sketch of the authoring surface:
+
+```python
+units = PrefabLibrary("vangelis.units")
+
+@units.component
+class Chassis(Component):
+    armor: int = 10
+
+@units.processor
+class Locomotion(AsyncProcessor): ...
+
+harvester = units.prefab("harvester", Chassis(armor=42))
+
+world = runtime.world("sim", **units.install())      # layer 1 into a world
+await units.publish(library_world)                    # layer 2 + manifest
+```
+
+**Collision rule:** component names are registered under the library's
+namespace in the directory at publish/install time; installing two
+libraries whose component names collide fails loudly at install, before any
+table exists. No column-prefix mangling — the prefix convention stands.
+
+Biome's auto-wiring (`EcsWith` pairs, on-add hooks assigning building bits)
+needs no new machinery here: a library bundles the equivalent `OnSpawn`/
+`OnComponentAdded` hooks and counter resources, which the hook system
+already supports. Biome's declarative script layer is deferred (§4).


### PR DESCRIPTION
Records Everett's 2026-07-20 rulings into `docs/design/prefab-registry.md` so implementers read decisions, not conversation:

- **§5 is now rulings, not questions**: naming = rate-of-change hybrid (catalog holds the namespace directory only; prefab names are world content, unique-per-library via FLAG eval, forking with the library); `IsA` payload lands now; `archetype.prefabs` is its own family, separate from graph, registered via its own `architecture.d` fragment.
- **New §7 — the registration model**, mapping Biome's two layers onto ours: `PrefabLibrary(name)` as the `ECS_IMPORT` analog (emits/registers components, relations, processors, hooks under a namespace; publishes prefab entities + manifest into a library world; installs into consumer worlds via the declarative config). Collisions fail loudly at install; no column-prefix mangling. Biome's `EcsWith` auto-wiring maps to existing hooks; its declarative script layer is explicitly deferred.
- **§4/§6 updated**: processor-native instantiate is in scope per the #604 greenlight (rulings recorded on that issue); the implementation sketch now sequences IsA payload → PrefabLibrary → manifests → namespace directory → #604 seam → eval binding → cross-world example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)