### PR TITLE
fix(tests): read the merged architecture manifest in the family contract test

### DIFF
--- a/tests/missions/test_domain_contracts.py
+++ b/tests/missions/test_domain_contracts.py
@@ -209,10 +209,18 @@ def test_app_authority_stays_internal_while_consuming_the_top_level_domain() -> 
 
 
 def test_architecture_manifest_registers_a_leaf_family_without_legacy_exceptions() -> None:
+    # Family rules and exceptions live in quality/architecture.d fragments
+    # (#611); the contract holds over the merged manifest, the same view
+    # scripts/check_architecture.py assembles.
     root = Path(__file__).resolve().parents[2]
     manifest = tomllib.loads((root / "quality" / "architecture.toml").read_text(encoding="utf-8"))
+    for fragment in sorted((root / "quality" / "architecture.d").glob("*.toml")):
+        data = tomllib.loads(fragment.read_text(encoding="utf-8"))
+        for key in ("top_level_family_rule", "exception"):
+            if key in data:
+                manifest.setdefault(key, []).extend(data[key])
     rules = {
         rule["consumer"]: rule["allowed_families"] for rule in manifest["top_level_family_rule"]
     }
     assert rules["archetype.missions"] == []
-    assert all(exception.get("issue") != 559 for exception in manifest["exception"])
+    assert all(exception.get("issue") != 559 for exception in manifest.get("exception", []))


### PR DESCRIPTION
**Main is deterministically red**: since #611 moved `top_level_family_rule`/`exception` blocks into `quality/architecture.d/` fragments, `tests/missions/test_domain_contracts.py::test_architecture_manifest_registers_a_leaf_family_without_legacy_exceptions` fails with `KeyError: 'top_level_family_rule'` on every PR — it parses the monolithic `architecture.toml`, where those keys no longer live. (Found via #613's ci, whose diff is docs-only.)

Fix: the test merges the fragments into the manifest the same way `scripts/check_architecture.py` does and asserts over the merged view; the issue-559 exception check tolerates an absent key. Test-only diff; 5/5 pass locally, `make check` and `make typecheck` green.

This unblocks ci for every open PR, including #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)