### PR TITLE
feat: add Biome prefab library reference

### DIFF
--- a/docs/design/prefab-registry.md
+++ b/docs/design/prefab-registry.md
@@ -36,8 +36,9 @@ of Sander's relationship roadmap was: the substrate keeps everything.
   world, running a scenario, and grading from history — the autoresearch
   pattern. Fitness rows key naturally by `(prefab, version tick)`.
 
-The registry therefore adds only three genuinely new things: **names**,
-**cross-world provenance**, and **eval binding**.
+The registry therefore adds only four genuinely new things: **names**,
+**cross-world provenance**, **eval binding**, and an explicit declaration of
+the **behavior modules** required to interpret an asset's schemas.
 
 ---
 
@@ -64,11 +65,11 @@ persisted tables bites).
 ### R3 — The manifest is an artifact bundle
 
 A registry entry is a published artifact (the existing bundle machinery, per
-`docs/guide/artifacts.md`): name, source `(world_id, entity_id, tick)`, the
-component set with **prefixed schema hashes**, the subtree inventory, the
-eval-suite reference, and evidence receipts from grading runs. Publishing a
-prefab version is publishing a manifest; the registry index is the artifact
-index. No new storage system.
+`docs/guide/artifacts.md`): name, source `(world_id, entity_id, tick)`, required
+behavior-module identities, the component set with **prefixed schema hashes**,
+the subtree inventory, the eval-suite reference, and evidence receipts from
+grading runs. Publishing a prefab version is publishing a manifest; the
+registry index is the artifact index. No new storage system.
 
 ### R4 — Schema identity is the compatibility contract
 
@@ -86,6 +87,29 @@ eval-suite reference is mandatory; `FLAG`-style validations (cycle checks,
 schema drift, orphaned lineage) run as evals over the library world, and a
 version without evidence receipts is visibly ungraded in the index.
 
+### R6 — Code registration precedes asset loading
+
+Biome imports C modules before evaluating asset scripts. The same ordering is
+required here: a host installs approved component classes, processors,
+resources, and hooks before it loads, imports, or evaluates prefab content.
+Those registrations are executable process state; prefab entities and rules
+are durable world state. They are related, but they are not one registry.
+
+A prefab manifest declares its required behavior modules and their schema
+identities. It never embeds a callable, imports a module by an untrusted string,
+or treats code as automatically executable asset data. The host resolves each
+declared requirement through an allowlisted composition root, installs a fresh
+world-local registration, and then checks the manifest's component schemas
+under R4. A cold resume repeats code registration before the first step; it
+does not reconstruct processors or resources from ledger rows.
+
+This preserves the useful half of Flecs' two-layer model without turning the
+artifact index into a plugin loader. Family examples may provide convenience
+factories such as the example-local `register_biome_rts()`, while durable asset
+authoring remains a separate operation such as
+`author_prefab_library(world)`. That example bundle is not the reusable
+registration contract; the `PrefabLibrary` model in §7 is.
+
 ### R7 — The relation-copy boundary
 
 `instantiate` copies component values, recursively copies the `ChildOf`
@@ -95,7 +119,9 @@ lines — and exposes no source-to-instance id map. Domain wiring belongs in
 rule entities interpreted by a driver or service after instantiation. If
 enough families need arbitrary graph cloning, the sanctioned broadening is a
 separate `InstantiationResult(root_id, id_map)` API with explicit
-relation-copy policies; `instantiate` is never silently widened.
+relation-copy policies; `instantiate` is never silently widened. The Biome
+example's `AssetChildOf` remains example-local until a catalog relation is
+deliberately generalized under `archetype.prefabs`.
 
 ---
 
@@ -109,6 +135,8 @@ relation-copy policies; `instantiate` is never silently widened.
   `docs/design/mutation-outbox.md` — designed, not implemented.
 - No declarative prefab file format yet (Biome's `.flecs` layer); Python
   authoring through the library object comes first.
+- No automatic execution of code named by a manifest. Module resolution is an
+  explicit, allowlisted host-composition decision (R6).
 
 ---
 
@@ -137,13 +165,15 @@ relation-copy policies; `instantiate` is never silently widened.
 2. `PrefabLibrary` authoring object in `archetype.prefabs` (§7): emit and
    register components/relations/processors/hooks under a namespace; publish
    prefab entities into a library world; install into consumer worlds.
-3. Manifest models + schema-hash capture in the family (R3, R4).
+3. Manifest models + schema-hash and required-library capture in the family
+   (R3, R4, R6).
 4. Namespace directory in the control catalog + binding service under `app`
    (§5.1); publish/lookup rides the artifact bundle service (R3).
 5. #604 MutationOutbox seam in core (rulings on the issue), then
    processor-native instantiate.
 6. Eval-binding conventions + library-world validations (R5).
-7. Cross-world import example: a library world feeding the RTS toy (#603).
+7. Cross-world import example: a library world feeding the Biome RTS reference
+   example (#603).
 
 ## 7. Registration model (ruled 2026-07-20)
 
@@ -188,6 +218,21 @@ libraries whose component names collide fails loudly at install, before any
 table exists. No column-prefix mangling — the prefix convention stands.
 
 Biome's auto-wiring (`EcsWith` pairs, on-add hooks assigning building bits)
-needs no new machinery here: a library bundles the equivalent `OnSpawn`/
-`OnComponentAdded` hooks and counter resources, which the hook system
-already supports. Biome's declarative script layer is deferred (§4).
+uses existing registration shapes: a library can bundle `OnSpawn`/
+`OnComponentAdded` hooks and counter resources. That does not make lifecycle
+hooks transactional. Their failures are logged rather than aborting a
+mutation, so correctness-critical auto-wiring must use explicitly authored
+components, pure processors, or the ruled mutation-outbox/application seam.
+Biome's declarative script layer is deferred (§4).
+
+**Security rule:** a manifest may identify the `PrefabLibrary` implementation
+required to interpret its component schemas, but it never embeds a callable or
+causes a module named by an untrusted string to execute. The host composition
+root resolves declared library identities through an allowlist and installs
+them explicitly. The artifact index is not a plugin loader.
+
+**Lifecycle rule:** registrations are process-local and world-local. The same
+approved library bundle must install atomically for a new world and again
+before the first step of a cold-resumed world. New-world configuration already
+has the required processor/resource/hook shape; cold-resume parity remains
+runtime-contract work and must not be bypassed through internal services.

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -438,9 +438,10 @@ evaluation ownership, and co-located protocols are implemented. Runtime calls
 do not fabricate `ActorCtx`; API routes depend on `iCommandGateway`; concrete
 services and the container are not top-level exports.
 
-`quality/architecture.toml` contains both the application-family DAG and the
-registered top-level family dispositions for `artifacts`, `datasets`,
-`evaluation`, `experiments`, `htn`, and `missions`.
+`quality/architecture.toml` and the fragments in `quality/architecture.d/`
+contain both the application-family DAG and the registered top-level family
+dispositions for `artifacts`, `datasets`, `evaluation`, `experiments`,
+`graph`, `htn`, `missions`, `projections`, and `research`.
 `scripts/check_architecture.py` enforces their package direction, protocol
 imports, concrete construction, concrete inheritance, and persistent
 Component placement.

--- a/docs/guide/prefab-libraries.md
+++ b/docs/guide/prefab-libraries.md
@@ -1,0 +1,230 @@
+# Prefab Libraries
+
+Archetype prefab libraries are entity-backed asset graphs.  A library can be
+queried, versioned by tick, forked, graded, and composed with the same
+relationship tools as a runtime scene.  The RTS capstone in
+`examples/biome_rts/` demonstrates the pattern with harvesters, turrets,
+nested tools, command hierarchies, supply lines, visibility, and targeting.
+It is a reference package, not a shipped `archetype` family.
+
+## Registration has two layers
+
+Biome's [`main.c`](https://github.com/SanderMertens/biome/blob/main/src/main.c)
+first imports C modules that register component metadata, systems, observers,
+and hooks.  It then evaluates the root
+[`biome.flecs`](https://github.com/SanderMertens/biome/blob/main/etc/scenes/biome.flecs)
+script, which creates named prefabs and rules from those registered types.
+Archetype keeps the same code-versus-data boundary:
+
+| Biome | Archetype | Lifetime |
+|---|---|---|
+| C module import | `register_biome_rts()` world options | Process-local code wiring |
+| Flecs script | `author_prefab_library(world)` | Durable ECS content |
+| Reflected C component metadata | Imported Python `Component` schemas | Registered on first archetype use |
+
+```python
+from biome_rts import author_prefab_library, register_biome_rts
+
+registration = register_biome_rts()
+world = runtime.world(
+    "biome-rts",
+    **registration.world_options(),
+)
+
+assets = await author_prefab_library(world)
+await world.step()  # publish the declarative asset layer
+```
+
+`registration.world_options()` supplies those three keyword arguments as a
+convenience.  A registration is world-local because its `GraphView` contains
+previous-tick state.  Create a fresh one for each world.  Processors,
+resources, and hooks are executable process state, not ledger rows, so they
+must also be reinstalled when resuming a world.  Prefab entities and their
+relations persist normally.
+
+`BiomeRTSRegistration` is example-local convenience, not the reusable
+registration contract for every prefab family.  The ruled generic surface is
+the future `archetype.prefabs.PrefabLibrary`: its stable identity is resolved
+by an allowlisted host composition root, its `install()` operation composes
+processors/resources/hooks in declared order, and collisions fail before any
+table exists.  A manifest may declare required library identities and schemas,
+but it never embeds a callable or imports code from an untrusted string.
+
+`register_biome_rts()` currently targets new `runtime.world(...)` activation.
+The public cold-resume path does not yet accept a complete
+processor/resource/hook bundle.  Runtime activation will own reinstalling a
+fresh, approved world-local bundle before the first resumed step; resume-safe
+installation remains separate runtime-contract work.  Do not bypass that
+boundary by reaching into application services.
+
+This is not a literal port of Flecs registration.  Flecs `EcsWith`, `on_add`,
+and `on_set` hooks can synchronously enforce invariants while a component is
+attached.  Archetype lifecycle hooks are intentionally non-transactional:
+their failures are logged and do not abort a mutation or tick.  Do not use an
+`OnSpawn` or `OnComponentAdded` hook to emulate correctness-critical automatic
+component insertion.  Author complete prefab component sets explicitly, use
+pure processors for same-archetype derived state, and use a driver or
+application service when cross-entity mutations must be staged durably.
+
+Biome's `BuildingRule2x1` is the useful bridge between the layers: the rule is
+asset data, while imported C behavior interprets it and performs the wiring.
+The Archetype analogue should likewise store mission rules, benchmark
+constraints, placement rules, or connector recipes as Components and
+relations in the library world.  Registered processors can compute pure
+matches; a driver or application service owns any resulting entity creation.
+The rule stays queryable and versioned instead of disappearing into a Python
+callback registry.
+
+## Asset hierarchy and scene hierarchy are different graphs
+
+Sander Mertens distinguishes the hierarchy used to author reusable assets
+from the hierarchy of instantiated objects in a scene.  Archetype makes that
+distinction explicit:
+
+```text
+AssetChildOf                         ChildOf
+biome-rts library                    first-army
+├── units                            └── alpha squad
+│   └── harvester prefab                 ├── commander
+│       └── mining-tool prefab           ├── harvester instance
+└── structures                           │   └── mining-tool instance
+    └── turret prefab                    └── turret instance
+```
+
+`AssetChildOf` is catalog structure.  It provides namespacing, discovery, and
+asset-library cleanup.  `ChildOf` is copied prefab composition and runtime
+lifetime: instantiating the harvester rebuilds its mining-tool subtree with
+new ids, and destroying a squad can cascade through its live descendants.
+Domain meaning stays on named relations such as `AssignedTo`, `CommandedBy`,
+`SupplyLine`, `Targets`, and `VisibleTo`; it is not overloaded onto either
+hierarchy.  `AssetChildOf` remains local to the Biome example until a catalog
+relation is deliberately generalized in `archetype.prefabs`.
+
+## The Biome pattern being translated
+
+Biome's [`buildings.flecs`](https://github.com/SanderMertens/biome/blob/main/etc/scenes/config/buildings.flecs)
+shows the composition directly.  `PoweredBuilding` supplies common state;
+`Drill` composes it with a drill emitter and adds `Building`, `StorageDesc`,
+`Storage`, `Miner`, `Power`, `Recipe`, and rendering components.  The
+[`miner` systems](https://github.com/SanderMertens/biome/blob/main/src/modules/miner.c)
+then match combinations including miner, storage, storage-description, and
+power state.  The prefab is not a class that calls mining behavior.  Its
+component set makes an instance eligible for systems that implement mining.
+
+The same file also contains anonymous child objects, prefab references in
+building rules, and a drone factory function.  Those are three distinct
+asset-graph jobs: nested composition, references between reusable assets, and
+runtime instantiation.  Keeping those jobs distinct is more useful than
+treating every edge as generic parentage.  This follows the separation between
+asset and scene hierarchies in Mertens' article on
+[data-oriented hierarchies](https://ajmmertens.medium.com/building-an-ecs-data-oriented-hierarchies-62fb2847d100)
+and the relationship taxonomy in his
+[entity-relationships roadmap](https://ajmmertens.medium.com/a-roadmap-to-entity-relationships-5b1d11ebb4eb).
+
+## Components are the prefab interface
+
+Biome does not need a separate building-interface type.  A drill behaves as a
+miner because its prefab has the mining, storage, placement, and power
+components required by those systems.  The Biome reference example follows
+the same rule:
+
+| Asset | Static capability components | Dynamic instance state |
+|---|---|---|
+| Harvester | `UnitSpec`, `Mobility`, `Harvester` | `Position`, `Heading`, `Health`, `Cargo` |
+| Turret | `UnitSpec`, `Weapon` | `Position`, `Health` |
+
+`MovementProcessor` requires `Position + Heading + Mobility`.
+`HarvestProcessor` requires `Cargo + Harvester`.  The harvester therefore
+moves and gathers; the turret does neither.  Adding or removing a capability
+component changes which systems match without a central interface registry.
+
+Static descriptions and dynamic state are separated for another reason.  A
+prefab entity has descriptions but no runtime state, so runtime processors do
+not match its archetype.  The catalog remains live and queryable without the
+canonical harvester itself moving or collecting resources.  This is the
+library-level counterpart of Flecs queries excluding its `Prefab` tag by
+default, expressed without a core query change.
+
+## Instantiation is a ledger operation
+
+```python
+unit = await instantiate(
+    world,
+    view,
+    assets.harvester,
+    overrides=[
+        CommandNode(name="harvester-1", kind="unit"),
+        Position(x=4, y=8),
+        Heading(x=1),
+        Health(current=80),
+        Cargo(),
+        Depth(),
+    ],
+)
+```
+
+Archetype deliberately uses copy-on-instantiate rather than Flecs's live
+component inheritance.  The operation copies component values and a bounded
+`ChildOf` subtree, applies root overrides, and records `IsA` lineage.  Editing
+a prefab does not mutate existing instances; a later instantiation receives
+the new values.  Both generations remain in history, which makes a prefab
+population gradeable.
+
+The generic operation copies only that component data and `ChildOf` subtree.
+It does not clone `AssetChildOf` or arbitrary socket, assignment, supply,
+targeting, or other relation entities, and it returns the new root id rather
+than an old-to-new id map.  Libraries express those connections as durable
+rule or recipe entities referencing stable roles.  A domain driver or
+application service traverses the new `ChildOf` subtree, joins `IsA` lineage
+back to its source nodes, resolves those roles, and stages the intended edges.
+Generic relation cloning would require a separate result carrying an id map
+and explicit allowlisted relation-copy policies.
+
+`minimap_overview()` composes the generic `projections.overview()` primitive
+into a per-tick strategic population series, while `minimap()` provides the
+latest spatial rows.  `fog_of_war()` then joins that spatial view to
+`VisibleTo`, and `unit_view()` composes the generic possession projection.
+
+That difference is important when translating Flecs examples:
+
+| Flecs | Archetype |
+|---|---|
+| Shared inherited component lookup | Values copied at instantiation |
+| Asset edit can affect inheriting instances | Existing instances remain unchanged |
+| Fragmenting relationship pairs group storage | Relation entities form non-fragmenting EdgeTables |
+| Query caches amortize inheritance/traversal | Daft plans express joins and bounded traversal |
+
+Do not describe `IsA` as live inheritance in Archetype.  It is durable
+provenance under the accepted D5 contract.
+
+## From an RTS library to missions and physical AI
+
+The pattern transfers by changing the vocabulary, not the substrate:
+
+| RTS asset | Agent-mission analogue | Physical-AI analogue |
+|---|---|---|
+| `UnitSpec` | agent role/model policy | robot embodiment/policy |
+| `Harvester` | tool-use capability | manipulation skill |
+| `Weapon` | validator/reviewer capability | task-specific controller |
+| `CommandNode` hierarchy | mission/team/agent topology | benchmark/suite/episode topology |
+| `SupplyLine` | artifact/context flow | observation/action stream |
+| `VisibleTo` | context-access policy | sensor visibility |
+| prefab generation | mission configuration candidate | policy/environment candidate |
+
+Keep reusable descriptions on prefab entities, add execution or episode state
+at instantiation, and grade populations through history and `IsA` lineage.
+Claims, authorization, artifact publication, and cross-world registry control
+remain application authority; a domain library should not absorb those
+responsibilities.
+
+Run the complete credential-free composition with:
+
+```bash
+uv run python examples/13_biome_rts.py
+```
+
+The generic graph and projection contracts remain the underlying API.  See
+the [graph-system](../design/graph-system.md) and
+[prefab-registry](../design/prefab-registry.md) design records for the
+accepted copy-on-instantiate contract and the ruled, not-yet-implemented
+cross-world registry.

--- a/examples/13_biome_rts.py
+++ b/examples/13_biome_rts.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Biome-inspired RTS prefab library
+=================================
+
+Static component combinations define asset capabilities.  Instantiation adds
+dynamic state, which activates matching processors; relations then assemble a
+live army from those assets.  The asset catalog and runtime scene are both ECS
+graphs, but use distinct hierarchy relations.  Registration wires executable
+behavior first; authoring then publishes the durable asset layer.
+
+No external dependencies or credentials are required.
+
+Usage:
+    uv run python examples/13_biome_rts.py
+"""
+
+import asyncio
+
+from biome_rts import (
+    AssetChildOf,
+    AssignedTo,
+    Cargo,
+    CommandedBy,
+    CommandNode,
+    Harvester,
+    Heading,
+    Health,
+    Position,
+    SupplyLine,
+    Targets,
+    UnitSpec,
+    VisibleTo,
+    author_prefab_library,
+    fog_of_war,
+    minimap,
+    minimap_overview,
+    register_biome_rts,
+    unit_view,
+)
+from daft import col
+
+from archetype import ArchetypeRuntime
+from archetype.core.config import StorageConfig
+from archetype.graph import (
+    ChildOf,
+    Depth,
+    IsA,
+    cascade,
+    edges,
+    instantiate,
+    link,
+    neighborhood,
+    toposorted,
+)
+
+
+async def main():
+    registration = register_biome_rts()
+    view = registration.view
+    storage = StorageConfig(uri="./archetype_data", namespace="biome_rts")
+
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world(
+            "biome-rts",
+            storage=storage,
+            **registration.world_options(),
+        )
+
+        # 1. The library is ECS content, organized independently from runtime
+        # ChildOf composition.
+        assets = await author_prefab_library(world)
+        await world.step()
+        catalog = neighborhood(
+            await edges(world, AssetChildOf, at=0),
+            AssetChildOf,
+            [assets.root],
+            depth=3,
+            direction="in",
+        ).to_pylist()
+        print(f"1. asset library: {len(catalog) - 1} descendants")
+
+        army = await world.spawn(CommandNode(name="first-army", kind="army"), Depth())
+        squad = await world.spawn(CommandNode(name="alpha", kind="squad"), Depth())
+        commander = await world.spawn(CommandNode(name="ada", kind="commander"), Depth())
+        harvester = await instantiate(
+            world,
+            view,
+            assets.harvester,
+            overrides=[
+                CommandNode(name="harvester-1", kind="unit"),
+                Position(),
+                Heading(x=1.0),
+                Health(current=80),
+                Cargo(),
+                Depth(),
+            ],
+        )
+        turret = await instantiate(
+            world,
+            view,
+            assets.turret,
+            overrides=[
+                CommandNode(name="turret-1", kind="unit"),
+                Position(x=4.0),
+                Health(current=150),
+                Depth(),
+            ],
+        )
+
+        for child, parent in (
+            (squad, army),
+            (commander, squad),
+            (harvester, squad),
+            (turret, squad),
+        ):
+            await link(world, ChildOf(source=child, target=parent))
+        await link(world, AssignedTo(source=harvester, target=squad))
+        await link(world, CommandedBy(source=squad, target=commander))
+        await link(world, SupplyLine(source=harvester, target=turret, throughput=3))
+        await link(world, Targets(source=turret, target=harvester))
+        await link(world, VisibleTo(source=harvester, target=turret))
+        # The first tick persists initial state. The second applies the live
+        # capability processors and the prefab edit in one commit.
+        await world.step()
+
+        # Copy-on-instantiate upgrades only future generations.
+        await world.update(assets.harvester, Harvester(rate=5, capacity=32))
+        await world.step()
+        upgraded = await instantiate(
+            world,
+            view,
+            assets.harvester,
+            overrides=[
+                CommandNode(name="harvester-2", kind="unit"),
+                Position(x=6.0),
+                Heading(),
+                Health(current=80),
+                Cargo(),
+                Depth(),
+            ],
+        )
+        await link(world, ChildOf(source=upgraded, target=squad))
+        await link(world, AssignedTo(source=upgraded, target=squad))
+        await world.step()
+
+        latest = (await world.info()).tick - 1
+        command_order = toposorted(
+            (await world.query(CommandNode, Depth))
+            .where(col("tick") == latest)
+            .where(col("entity_id").is_in([army, squad, commander, harvester, turret]))
+        ).to_pylist()
+        unit_history = await world.query(UnitSpec, Position, Health)
+        live_map = minimap(unit_history)
+        map_series = minimap_overview(units=unit_history).to_pylist()
+        visible = fog_of_war(
+            live_map,
+            await edges(world, VisibleTo, at=latest),
+            harvester,
+        ).to_pylist()
+        print(
+            "2. live instances:",
+            [(row["role"], row["x"], row["health"]) for row in live_map.to_pylist()],
+        )
+        print(
+            "3. minimap population:",
+            [(row["tick"], row["population"]) for row in map_series],
+        )
+        print("4. harvester fog of war:", [row["entity_id"] for row in visible])
+
+        possessed = unit_view(
+            [
+                (ChildOf, await edges(world, ChildOf, at=latest)),
+                (AssignedTo, await edges(world, AssignedTo, at=latest)),
+                (SupplyLine, await edges(world, SupplyLine, at=latest)),
+                (Targets, await edges(world, Targets, at=latest)),
+                (VisibleTo, await edges(world, VisibleTo, at=latest)),
+            ],
+            harvester,
+        ).to_pylist()
+        print(
+            "5. possessed unit view:",
+            [(row["relation"], row["direction"], row["entity_id"]) for row in possessed],
+        )
+
+        print(
+            "6. command order:",
+            [(row["commandnode__name"], row["depth__value"]) for row in command_order],
+        )
+
+        rates = {
+            row["entity_id"]: row["harvester__rate"]
+            for row in (
+                (await world.query(Harvester, Position)).where(col("tick") == latest).to_pylist()
+            )
+        }
+        lineage = {
+            (row["isa__source"], row["isa__target"])
+            for row in (await edges(world, IsA, at=latest)).to_pylist()
+        }
+        print(
+            "7. re-instantiated upgrade:",
+            f"old rate={rates[harvester]}, new rate={rates[upgraded]},",
+            f"IsA={((upgraded, assets.harvester) in lineage)}",
+        )
+
+        # The live hierarchy owns lifetime. This pass stages the direct
+        # generation; another step/pass would collect nested prefab children.
+        await world.despawn(squad)
+        await world.step()
+        direct = await cascade(world, ChildOf, view)
+        print(
+            "8. cascade generation staged:",
+            f"direct children={len(direct.deleted_entities)}",
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ uv run python examples/<filename>.py
 | 9 | [`09_cloud_storage.py`](09_cloud_storage.py) | Cloud storage configurations through `StorageConfig` and the runtime API | Optional cloud credentials |
 | 11 | [`11_graph_relationships.py`](11_graph_relationships.py) | Edge entities: build a hierarchy, traverse it, read the graph at an earlier tick, cascade after a despawn | None |
 | 12 | [`12_prefabs.py`](12_prefabs.py) | PreFabs: author a template with a subtree, instantiate copies with overrides and IsA lineage, upgrade by re-instantiation | None |
+| 13 | [`13_biome_rts.py`](13_biome_rts.py) | Biome-inspired prefab asset library composed into an RTS command hierarchy, minimap, fog of war, and possessed-unit view | None |
 
 ### Supplementary
 

--- a/examples/biome_rts/__init__.py
+++ b/examples/biome_rts/__init__.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example-local Biome-inspired assets composed from ECS components and relations.
+
+This reference package dogfoods the graph/PreFab stack; it is not a shipped
+``archetype`` family or a supported generic registration API. Static
+capability components live on prefab entities; dynamic state components are
+added when an asset is instantiated.  Processors match the dynamic state, so
+the live asset catalog remains queryable without being simulated.
+"""
+
+from .components import (
+    AssetNode,
+    Cargo,
+    CommandNode,
+    Harvester,
+    Heading,
+    Health,
+    Mobility,
+    Position,
+    ToolMount,
+    UnitSpec,
+    Weapon,
+)
+from .library import BiomeRTSPrefabLibrary, author_prefab_library
+from .processors import (
+    HarvestProcessor,
+    MovementProcessor,
+    biome_rts_processors,
+)
+from .projections import fog_of_war, minimap, minimap_overview, unit_view
+from .registration import BiomeRTSRegistration, register_biome_rts
+from .relations import (
+    AssetChildOf,
+    AssignedTo,
+    CommandedBy,
+    SupplyLine,
+    Targets,
+    VisibleTo,
+)
+
+__all__ = [
+    "AssetChildOf",
+    "AssetNode",
+    "AssignedTo",
+    "Cargo",
+    "CommandNode",
+    "CommandedBy",
+    "HarvestProcessor",
+    "Harvester",
+    "Heading",
+    "Health",
+    "Mobility",
+    "MovementProcessor",
+    "Position",
+    "BiomeRTSPrefabLibrary",
+    "BiomeRTSRegistration",
+    "SupplyLine",
+    "Targets",
+    "ToolMount",
+    "UnitSpec",
+    "VisibleTo",
+    "Weapon",
+    "author_prefab_library",
+    "fog_of_war",
+    "minimap",
+    "minimap_overview",
+    "biome_rts_processors",
+    "register_biome_rts",
+    "unit_view",
+]

--- a/examples/biome_rts/components.py
+++ b/examples/biome_rts/components.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example-local schemas for the Biome-inspired RTS prefab library.
+
+The component split is intentional:
+
+* description components (``UnitSpec``, ``Mobility``, ``Harvester``, and
+  ``Weapon``) are static capabilities authored on prefab entities;
+* state components (``Position``, ``Heading``, ``Health``, and ``Cargo``) are
+  supplied when a prefab becomes a live unit.
+
+Processors require both a capability and its state.  A prefab therefore
+describes what an instance can do without itself entering the simulation.
+"""
+
+from __future__ import annotations
+
+from archetype.core.component import Component
+
+
+class AssetNode(Component):
+    """One named node in the asset-library hierarchy."""
+
+    name: str = ""
+    kind: str = "asset"
+
+
+class UnitSpec(Component):
+    """Static identity and limits shared by one kind of unit."""
+
+    role: str = "unit"
+    max_health: int = 1
+    sight: float = 0.0
+
+
+class Mobility(Component):
+    """Static movement capability; absence means the asset is stationary."""
+
+    speed: float = 0.0
+
+
+class Harvester(Component):
+    """Static resource-gathering capability."""
+
+    rate: int = 0
+    capacity: int = 0
+
+
+class Weapon(Component):
+    """Static combat capability."""
+
+    damage: int = 0
+    range: float = 0.0
+
+
+class ToolMount(Component):
+    """A nested prefab node copied with its owning asset."""
+
+    tool: str = ""
+
+
+class CommandNode(Component):
+    """Runtime label for an army, squad, commander, or unit."""
+
+    name: str = ""
+    kind: str = "unit"
+
+
+class Position(Component):
+    """Runtime two-dimensional position."""
+
+    x: float = 0.0
+    y: float = 0.0
+
+
+class Heading(Component):
+    """Runtime movement direction; multiplied by ``Mobility.speed``."""
+
+    x: float = 0.0
+    y: float = 0.0
+
+
+class Health(Component):
+    """Runtime hit points."""
+
+    current: int = 1
+
+
+class Cargo(Component):
+    """Runtime amount gathered by a harvester."""
+
+    amount: int = 0

--- a/examples/biome_rts/library.py
+++ b/examples/biome_rts/library.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Author the Biome-inspired RTS prefab catalog as ordinary ECS content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from archetype.graph import ChildOf, Prefab, WorldLike, link
+
+from .components import (
+    AssetNode,
+    Harvester,
+    Mobility,
+    ToolMount,
+    UnitSpec,
+    Weapon,
+)
+from .relations import AssetChildOf
+
+
+@dataclass(frozen=True, slots=True)
+class BiomeRTSPrefabLibrary:
+    """Stable entity ids for one authored catalog."""
+
+    root: int
+    units: int
+    structures: int
+    harvester: int
+    turret: int
+    mining_tool: int
+
+
+async def author_prefab_library(world: WorldLike) -> BiomeRTSPrefabLibrary:
+    """Stage a small, queryable prefab hierarchy in ``world``.
+
+    ``AssetChildOf`` provides catalog/namespace structure.  The mining tool's
+    additional ``ChildOf`` edge makes it part of the harvester prefab's copied
+    runtime subtree.  The caller owns the step that publishes these staged
+    entities and edges.
+    """
+
+    root = await world.spawn(AssetNode(name="biome-rts", kind="library"))
+    units = await world.spawn(AssetNode(name="units", kind="collection"))
+    structures = await world.spawn(AssetNode(name="structures", kind="collection"))
+
+    harvester = await world.spawn(
+        Prefab(name="harvester"),
+        AssetNode(name="harvester", kind="prefab"),
+        UnitSpec(role="harvester", max_health=80, sight=4.0),
+        Mobility(speed=1.0),
+        Harvester(rate=3, capacity=24),
+    )
+    turret = await world.spawn(
+        Prefab(name="turret"),
+        AssetNode(name="turret", kind="prefab"),
+        UnitSpec(role="turret", max_health=150, sight=6.0),
+        Weapon(damage=20, range=5.0),
+    )
+    mining_tool = await world.spawn(
+        Prefab(name="mining-tool"),
+        AssetNode(name="mining-tool", kind="prefab-child"),
+        ToolMount(tool="drill"),
+    )
+
+    for child, parent in (
+        (units, root),
+        (structures, root),
+        (harvester, units),
+        (turret, structures),
+        (mining_tool, harvester),
+    ):
+        await link(world, AssetChildOf(source=child, target=parent))
+
+    # Runtime composition: instantiating a harvester also copies its tool.
+    await link(world, ChildOf(source=mining_tool, target=harvester))
+
+    return BiomeRTSPrefabLibrary(
+        root=root,
+        units=units,
+        structures=structures,
+        harvester=harvester,
+        turret=turret,
+        mining_tool=mining_tool,
+    )

--- a/examples/biome_rts/processors.py
+++ b/examples/biome_rts/processors.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure DataFrame processors activated by prefab capability composition."""
+
+from __future__ import annotations
+
+from daft import DataFrame, col
+from daft.functions import when
+
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.graph import DepthProcessor
+
+from .components import Cargo, Harvester, Heading, Mobility, Position
+
+
+class MovementProcessor(AsyncProcessor):
+    """Move live mobile entities; static prefabs have no Position/Heading."""
+
+    components = (Position, Heading, Mobility)
+    priority = 10
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        return df.with_column(
+            "position__x",
+            col("position__x") + col("heading__x") * col("mobility__speed"),
+        ).with_column(
+            "position__y",
+            col("position__y") + col("heading__y") * col("mobility__speed"),
+        )
+
+
+class HarvestProcessor(AsyncProcessor):
+    """Gather into instance-owned cargo, capped by the prefab capability."""
+
+    components = (Cargo, Harvester)
+    priority = 20
+
+    async def process(self, df: DataFrame, **kwargs) -> DataFrame:
+        gathered = col("cargo__amount") + col("harvester__rate")
+        over_capacity = gathered > col("harvester__capacity")
+        return df.with_column(
+            "cargo__amount",
+            when(over_capacity, then=col("harvester__capacity")).otherwise(gathered),
+        )
+
+
+def biome_rts_processors() -> list[AsyncProcessor]:
+    """Create the processor composition used by the Biome RTS example."""
+
+    return [MovementProcessor(), HarvestProcessor(), DepthProcessor()]

--- a/examples/biome_rts/projections.py
+++ b/examples/biome_rts/projections.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example read models composed from generic projections and graph edges."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import cast
+
+import daft
+from daft import DataFrame, Expression, col
+
+from archetype.graph import Relation
+from archetype.projections import latest, overview, possession
+
+from .relations import VisibleTo
+
+
+def minimap(units: DataFrame) -> DataFrame:
+    """Latest spatial unit view from a ``UnitSpec, Position, Health`` frame."""
+
+    return latest(units).select(
+        col("entity_id"),
+        col("tick"),
+        col("unitspec__role").alias("role"),
+        col("position__x").alias("x"),
+        col("position__y").alias("y"),
+        col("health__current").alias("health"),
+    )
+
+
+def minimap_overview(**layers: DataFrame) -> DataFrame:
+    """Per-tick population series for the strategic minimap layers."""
+
+    return overview(**layers)
+
+
+def fog_of_war(map_frame: DataFrame, visibility: DataFrame, observer: int) -> DataFrame:
+    """Restrict a minimap to ``observer`` and its outgoing visibility edges."""
+
+    prefix = VisibleTo.get_prefix()
+    visible = visibility.where(cast(Expression, col(f"{prefix}source") == observer)).select(
+        col(f"{prefix}target").alias("entity_id")
+    )
+    known = visible.concat(daft.from_pydict({"entity_id": [observer]})).distinct()
+    return map_frame.join(known, on="entity_id")
+
+
+def unit_view(
+    edges_by_relation: Sequence[tuple[type[Relation], DataFrame]],
+    entity: int,
+    depth: int = 1,
+) -> DataFrame:
+    """The relational field of view used when a player possesses one unit."""
+
+    return possession(edges_by_relation, entity, depth)

--- a/examples/biome_rts/registration.py
+++ b/examples/biome_rts/registration.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example-local process wiring for the Biome-inspired RTS world.
+
+This is the Archetype counterpart of importing a Biome C module.  It wires
+processors, the graph resource, and its capture hook into one world.  Durable
+prefab content is authored separately by :func:`author_prefab_library`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from archetype.core.aio.async_processor import AsyncProcessor
+from archetype.core.hooks import PostTick
+from archetype.graph import GraphView
+
+from .processors import biome_rts_processors
+
+
+@dataclass(frozen=True, slots=True)
+class BiomeRTSRegistration:
+    """World-local example wiring created by :func:`register_biome_rts`.
+
+    Create one registration per world.  The contained :class:`GraphView` is
+    mutable previous-tick state and must not be shared between worlds.
+    """
+
+    view: GraphView
+    processors: tuple[AsyncProcessor, ...]
+
+    def world_options(self) -> dict[str, list[Any]]:
+        """Return keyword arguments accepted by ``ArchetypeRuntime.world``."""
+
+        return {
+            "processors": list(self.processors),
+            "resources": [self.view],
+            "hooks": [(PostTick, self.view.on_post_tick)],
+        }
+
+
+def register_biome_rts() -> BiomeRTSRegistration:
+    """Build fresh process-local wiring for one Biome RTS example world."""
+
+    return BiomeRTSRegistration(
+        view=GraphView(),
+        processors=tuple(biome_rts_processors()),
+    )

--- a/examples/biome_rts/relations.py
+++ b/examples/biome_rts/relations.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example relations: catalog structure and live-world semantics stay distinct."""
+
+from __future__ import annotations
+
+from archetype.graph import Policy, Relation
+
+
+class AssetChildOf(Relation):
+    """Catalog hierarchy: asset or collection ``source`` belongs under ``target``.
+
+    This is deliberately not :class:`archetype.graph.ChildOf`.  ``ChildOf``
+    means instantiated composition and runtime lifetime; using a separate
+    relation keeps catalog folders from being copied into every unit.
+    """
+
+    exclusive = True
+    on_delete_target = Policy.DELETE
+
+
+class AssignedTo(Relation):
+    """Operational assignment: one live assignment per source unit."""
+
+    exclusive = True
+
+
+class CommandedBy(Relation):
+    """Command authority: one live commander per source formation."""
+
+    exclusive = True
+
+
+class SupplyLine(Relation):
+    """A directed supply edge with domain payload."""
+
+    throughput: int = 0
+
+
+class Targets(Relation):
+    """A unit's current target; acquiring another target replaces the first."""
+
+    exclusive = True
+
+
+class VisibleTo(Relation):
+    """``source`` currently has visibility of ``target``."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Processors: guide/processors.md
       - Worlds: guide/working-with-worlds.md
       - History and Forks: guide/history-and-forks.md
+      - Prefab Libraries: guide/prefab-libraries.md
       - Resources: guide/resources.md
       - Lifecycle Hooks: guide/hooks.md
       - Storage: guide/stores.md

--- a/tests/examples/test_biome_rts_contract.py
+++ b/tests/examples/test_biome_rts_contract.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the example-local Biome-inspired prefab library (issue #603)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+_EXAMPLES = Path(__file__).resolve().parents[2] / "examples"
+if str(_EXAMPLES) not in sys.path:
+    sys.path.insert(0, str(_EXAMPLES))
+
+from biome_rts import (  # noqa: E402
+    AssetChildOf,
+    AssignedTo,
+    Cargo,
+    CommandedBy,
+    CommandNode,
+    Harvester,
+    Heading,
+    Health,
+    Position,
+    SupplyLine,
+    Targets,
+    UnitSpec,
+    VisibleTo,
+    author_prefab_library,
+    fog_of_war,
+    minimap,
+    minimap_overview,
+    register_biome_rts,
+    unit_view,
+)
+from daft import col  # noqa: E402
+
+from archetype import ArchetypeRuntime  # noqa: E402
+from archetype.core.config import StorageConfig  # noqa: E402
+from archetype.core.hooks import PostTick  # noqa: E402
+from archetype.graph import (  # noqa: E402
+    ChildOf,
+    Depth,
+    GraphView,
+    IsA,
+    Prefab,
+    cascade,
+    edges,
+    instantiate,
+    link,
+    neighborhood,
+    toposorted,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _storage(tmp_path) -> StorageConfig:
+    return StorageConfig(uri=str(tmp_path / "rts_data"), namespace="rts_tests")
+
+
+def test_example_registration_is_fresh_world_local_code_wiring():
+    first = register_biome_rts()
+    second = register_biome_rts()
+
+    assert first.view is not second.view
+    assert all(
+        left is not right for left, right in zip(first.processors, second.processors, strict=True)
+    )
+
+    options = first.world_options()
+    assert options["processors"] == list(first.processors)
+    assert options["resources"] == [first.view]
+    event_type, handler = options["hooks"][0]
+    assert event_type is PostTick
+    assert handler.__self__ is first.view
+
+
+def test_asset_graph_drives_live_scene_without_executing_prefabs(tmp_path):
+    async def go():
+        registration = register_biome_rts()
+        view = registration.view
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "biome-rts",
+                storage=_storage(tmp_path),
+                **registration.world_options(),
+            )
+
+            assets = await author_prefab_library(world)
+            await world.step()
+
+            catalog_edges = await edges(world, AssetChildOf, at=0)
+            catalog = neighborhood(
+                catalog_edges,
+                AssetChildOf,
+                [assets.root],
+                depth=3,
+                direction="in",
+            ).to_pylist()
+            assert {row["entity_id"] for row in catalog} == {
+                assets.root,
+                assets.units,
+                assets.structures,
+                assets.harvester,
+                assets.turret,
+                assets.mining_tool,
+            }
+
+            army = await world.spawn(CommandNode(name="first-army", kind="army"), Depth())
+            squad = await world.spawn(CommandNode(name="alpha", kind="squad"), Depth())
+            commander = await world.spawn(CommandNode(name="ada", kind="commander"), Depth())
+
+            harvester = await instantiate(
+                world,
+                view,
+                assets.harvester,
+                overrides=[
+                    CommandNode(name="harvester-1", kind="unit"),
+                    Position(x=0.0, y=0.0),
+                    Heading(x=1.0, y=0.0),
+                    Health(current=80),
+                    Cargo(),
+                    Depth(),
+                ],
+            )
+            turret = await instantiate(
+                world,
+                view,
+                assets.turret,
+                overrides=[
+                    CommandNode(name="turret-1", kind="unit"),
+                    Position(x=2.0, y=0.0),
+                    Health(current=150),
+                    Depth(),
+                ],
+            )
+            for child, parent in (
+                (squad, army),
+                (commander, squad),
+                (harvester, squad),
+                (turret, squad),
+            ):
+                await link(world, ChildOf(source=child, target=parent))
+            await link(world, AssignedTo(source=harvester, target=squad))
+            await link(world, AssignedTo(source=turret, target=squad))
+            await link(world, CommandedBy(source=squad, target=commander))
+            await link(world, SupplyLine(source=harvester, target=turret, throughput=3))
+            await link(world, Targets(source=turret, target=harvester))
+            await link(world, VisibleTo(source=harvester, target=turret))
+
+            # Tick 1 persists raw initial conditions. Later ticks run the
+            # capability processors and converge the two-level hierarchy.
+            await world.run(steps=3)
+            latest_tick = (await world.info()).tick - 1
+
+            # Capability composition is the interface: only the harvester has
+            # both Cargo and Harvester, and only it has Heading + Mobility.
+            harvest_rows = (
+                (await world.query(Harvester, Cargo, Position))
+                .where(col("tick") == latest_tick)
+                .to_pylist()
+            )
+            assert len(harvest_rows) == 1
+            assert harvest_rows[0]["entity_id"] == harvester
+            assert harvest_rows[0]["cargo__amount"] == 6
+            assert harvest_rows[0]["position__x"] == 2.0
+
+            # Prefabs have descriptions but no dynamic state, so no runtime
+            # processor can match their archetypes.
+            assert view.frame(Prefab, Position) is None
+
+            ordered = toposorted(
+                (await world.query(CommandNode, Depth)).where(col("tick") == latest_tick)
+            ).to_pylist()
+            depths = [row["depth__value"] for row in ordered]
+            assert depths == sorted(depths)
+            by_id = {row["entity_id"]: row["depth__value"] for row in ordered}
+            assert by_id[army] == 0
+            assert by_id[squad] == 1
+            assert by_id[harvester] == 2
+
+            map_frame = minimap(await world.query(UnitSpec, Position, Health))
+            map_rows = map_frame.to_pylist()
+            assert {row["entity_id"] for row in map_rows} == {harvester, turret}
+            overview_rows = minimap_overview(
+                units=await world.query(UnitSpec, Position, Health)
+            ).to_pylist()
+            assert overview_rows[-1] == {
+                "table": "units",
+                "tick": latest_tick,
+                "population": 2,
+            }
+
+            visible_edges = await edges(world, VisibleTo, at=latest_tick)
+            visible = fog_of_war(map_frame, visible_edges, harvester).to_pylist()
+            assert {row["entity_id"] for row in visible} == {harvester, turret}
+
+            possessed = unit_view(
+                [
+                    (ChildOf, await edges(world, ChildOf, at=latest_tick)),
+                    (AssignedTo, await edges(world, AssignedTo, at=latest_tick)),
+                    (SupplyLine, await edges(world, SupplyLine, at=latest_tick)),
+                    (Targets, await edges(world, Targets, at=latest_tick)),
+                    (VisibleTo, visible_edges),
+                ],
+                harvester,
+            ).to_pylist()
+            assert {(row["relation"], row["entity_id"]) for row in possessed} >= {
+                ("assignedto", squad),
+                ("childof", squad),
+                ("supplyline", turret),
+                ("targets", turret),
+                ("visibleto", turret),
+            }
+
+            command_edges = (await edges(world, CommandedBy, at=latest_tick)).to_pylist()
+            assert [
+                (row["commandedby__source"], row["commandedby__target"]) for row in command_edges
+            ] == [(squad, commander)]
+            supply_edges = (await edges(world, SupplyLine, at=latest_tick)).to_pylist()
+            assert supply_edges[0]["supplyline__throughput"] == 3
+
+            assert AssignedTo.exclusive
+            assert CommandedBy.exclusive
+            assert Targets.exclusive
+
+            # Every instance, including the nested tool, keeps IsA lineage.
+            lineage = (await edges(world, IsA, at=latest_tick)).to_pylist()
+            assert {(row["isa__source"], row["isa__target"]) for row in lineage} >= {
+                (harvester, assets.harvester),
+                (turret, assets.turret),
+            }
+            child_edges = (await edges(world, ChildOf, at=latest_tick)).to_pylist()
+            tool_instance = next(
+                row["childof__source"] for row in child_edges if row["childof__target"] == harvester
+            )
+            assert any(
+                row["isa__source"] == tool_instance and row["isa__target"] == assets.mining_tool
+                for row in lineage
+            )
+
+            # The first cascade pass applies ChildOf's DELETE policy to the
+            # squad's direct children. The graph contract separately pins
+            # later-generation propagation and persistence at each tick.
+            await world.despawn(squad)
+            await world.step()
+            first = await cascade(world, ChildOf, view)
+            assert {harvester, turret, commander}.issubset(first.deleted_entities)
+            assert tool_instance not in first.deleted_entities
+            return True
+
+    assert _run(go())
+
+
+def test_harvester_upgrade_is_reinstantiation_not_live_inheritance(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "biome-rts-upgrade",
+                storage=_storage(tmp_path),
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            assets = await author_prefab_library(world)
+            await world.step()
+
+            original = await instantiate(
+                world,
+                view,
+                assets.harvester,
+                overrides=[Position()],
+            )
+            await world.step()
+
+            await world.update(assets.harvester, Harvester(rate=5, capacity=32))
+            await world.step()
+            upgraded = await instantiate(
+                world,
+                view,
+                assets.harvester,
+                overrides=[Position()],
+            )
+            await world.step()
+
+            latest_tick = (await world.info()).tick - 1
+            generations = (
+                (await world.query(Harvester, Position))
+                .where(col("tick") == latest_tick)
+                .to_pylist()
+            )
+            rates = {row["entity_id"]: row["harvester__rate"] for row in generations}
+            assert rates == {original: 3, upgraded: 5}
+
+            lineage = (await edges(world, IsA, at=latest_tick)).to_pylist()
+            pairs = {(row["isa__source"], row["isa__target"]) for row in lineage}
+            assert (original, assets.harvester) in pairs
+            assert (upgraded, assets.harvester) in pairs
+            return True
+
+    assert _run(go())
+
+
+def test_nested_prefab_cascade_records_each_generation(tmp_path):
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = runtime.world(
+                "biome-rts-cascade",
+                storage=_storage(tmp_path),
+                resources=[view],
+                hooks=[(PostTick, view.on_post_tick)],
+            )
+            assets = await author_prefab_library(world)
+            await world.step()
+
+            squad = await world.spawn(CommandNode(name="alpha", kind="squad"))
+            unit = await instantiate(world, view, assets.harvester)
+            await link(world, ChildOf(source=unit, target=squad))
+            await world.step()
+
+            live_edges = (await edges(world, ChildOf, at=1)).to_pylist()
+            tool = next(
+                row["childof__source"] for row in live_edges if row["childof__target"] == unit
+            )
+
+            await world.despawn(squad)
+            await world.step()
+            first = await cascade(world, ChildOf, view)
+            assert unit in first.deleted_entities
+            assert tool not in first.deleted_entities
+            await world.step()
+
+            second = await cascade(world, ChildOf, view)
+            assert tool in second.deleted_entities
+            await world.step()
+            assert (await cascade(world, ChildOf, view)).total == 0
+
+            history = (await edges(world, ChildOf)).to_pylist()
+            direct_ticks = {
+                row["tick"]
+                for row in history
+                if (row["childof__source"], row["childof__target"]) == (unit, squad)
+            }
+            nested_ticks = {
+                row["tick"]
+                for row in history
+                if (row["childof__source"], row["childof__target"]) == (tool, unit)
+            }
+            assert direct_ticks
+            assert nested_ticks
+            assert max(nested_ticks) == max(direct_ticks) + 1
+            return True
+
+    assert _run(go())


### PR DESCRIPTION
## Summary

- preserve the Biome-inspired prefab hierarchy as an example-local reference package instead of shipping a new `archetype.rts` production family
- keep the two-layer executable-registration and durable-authoring pattern with fresh world-local wiring
- document R6 allowlisting, module identity, collision, and cold-resume ownership
- make the prefab instantiation boundary explicit: only `ChildOf` is rebuilt, arbitrary relations are not cloned, and no old-to-new ID map is returned
- retain contract coverage for composition, lineage, upgrades, projections, cascades, and the negative arbitrary-relation case

## Why

The Seoul dogfood demonstrated that the reusable product is the prefab-library pattern, not its RTS vocabulary. Keeping that vocabulary under `examples/biome_rts` preserves the teaching and integration evidence without creating a provisional production family or architecture-policy surface.

## Impact

There is no new supported RTS API and no behavioral expansion of generic `instantiate()`. `AssetChildOf` remains example-local until deliberately generalized under the future `archetype.prefabs` family.

## Validation

- `make static`
- `make docs`
- `uv run pytest -q tests/graph tests/projections tests/examples/test_biome_rts_contract.py` — 67 passed
- `uv run python examples/13_biome_rts.py`
- built-wheel inspection confirms neither `archetype.rts` nor `biome_rts` ships
- full fast suite reached 2,031 passed / 28 skipped with one transient Wrangler startup timeout; the affected test passed on isolated rerun

Closes #603