### PR TITLE
feat(graph): run-scoped IsA provenance — (world, run, tick) coordinates

### DIFF
--- a/docs/design/prefab-registry.md
+++ b/docs/design/prefab-registry.md
@@ -55,9 +55,11 @@ prefab)` takes the target handle and the source view separately, so
 
 Today `IsA.target` is an entity id, which is world-local: an instance
 imported from a library world holds a dangling reference. `IsA` grows payload
-fields — `world: str = ""` (source world id; empty means same-world) and
-`at_tick: int = -1` (the version instantiated) — so lineage is complete and
-durable across worlds. This is a schema change to a shipped component and
+fields — `world: str = ""` (source world id; empty means same-world),
+`run_id: str = ""` (the source run that persisted the copied row — one
+world's history spans runs, so a tick alone under-identifies a version), and
+`at_tick: int = -1` (the captured tick) — so lineage is complete and durable
+across worlds: the full version coordinate is `(world, run, tick)`. This is a schema change to a shipped component and
 must land before adoption spreads (#543's lesson: schema evolution against
 persisted tables bites).
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -188,6 +188,6 @@ reason = "Mutation-planning boundary for cascade: despawn takes concrete ids, so
 
 [[entries]]
 path = "src/archetype/graph/prefab.py"
-line = 65
+line = 68
 method = "to_pylist"
 reason = "Mutation-planning boundary for instantiation: spawning copies requires the template's concrete component values and child prefab ids; _rows is the single funnel and every entity filter runs in the lazy plan before it."

--- a/src/archetype/graph/prefab.py
+++ b/src/archetype/graph/prefab.py
@@ -44,15 +44,18 @@ class Prefab(Component):
 class IsA(Relation):
     """Lineage: ``source`` (the instance) was instantiated from ``target``.
 
-    ``world`` and ``at_tick`` make the lineage globally unambiguous and
-    version-pinned (registry design R2): ``world`` is the source world id
-    when the template lives in a different world (empty for same-world), and
-    ``at_tick`` is the captured tick the copy was taken from.
+    ``world``, ``run_id``, and ``at_tick`` make the lineage globally
+    unambiguous and version-pinned (registry design R2): ``world`` is the
+    source world id when the template lives in a different world (empty for
+    same-world), ``run_id`` is the source run the copied row was persisted
+    by — one world's history spans runs, so a tick alone under-identifies a
+    version — and ``at_tick`` is the captured tick of the copy.
     """
 
     scope_field = "world"
 
     world: str = ""
+    run_id: str = ""
     at_tick: int = -1
 
 
@@ -65,8 +68,10 @@ def _rows(frame: DataFrame) -> list[dict]:
     return frame.to_pylist()
 
 
-def _entity_components(view: GraphView | GraphSnapshot, entity_id: int) -> list[Component]:
-    """Rebuild the entity's component instances from the captured frames.
+def _entity_components(
+    view: GraphView | GraphSnapshot, entity_id: int
+) -> tuple[list[Component], str]:
+    """Rebuild the entity's components and source run id from the frames.
 
     ``Prefab`` markers and ``Relation`` components are never copied: the
     marker is what makes a template a template, and edges are their own
@@ -80,6 +85,7 @@ def _entity_components(view: GraphView | GraphSnapshot, entity_id: int) -> list[
         if not matched:
             continue
         row = matched[0]
+        run_id = str(row.get("run_id", ""))
         components: list[Component] = []
         for cls in signature:
             # Exclusion honors schema identity for the marker: a resumed
@@ -92,7 +98,7 @@ def _entity_components(view: GraphView | GraphSnapshot, entity_id: int) -> list[
                 continue
             prefix = cls.get_prefix()
             components.append(cls(**{f: row[f"{prefix}{f}"] for f in cls.model_fields}))
-        return components
+        return components, run_id
     raise LookupError(f"entity {entity_id} not found at the view's captured tick")
 
 
@@ -180,9 +186,11 @@ async def _instantiate(
     max_depth: int,
     source_world: str,
 ) -> int:
-    lineage = IsA(target=prefab, world=source_world, at_tick=view.tick)
-    new_id = await world.spawn(*_overlay(_entity_components(view, prefab), overrides))
-    lineage.source = new_id
+    components, run_id = _entity_components(view, prefab)
+    new_id = await world.spawn(*_overlay(components, overrides))
+    lineage = IsA(
+        source=new_id, target=prefab, world=source_world, run_id=run_id, at_tick=view.tick
+    )
     await link(world, lineage)
     if max_depth > 0:
         for child in _child_prefabs(view, prefab):
@@ -218,9 +226,11 @@ def _instantiate_sync(
     max_depth: int,
     source_world: str,
 ) -> int:
-    lineage = IsA(target=prefab, world=source_world, at_tick=view.tick)
-    new_id = world.spawn(*_overlay(_entity_components(view, prefab), overrides))
-    lineage.source = new_id
+    components, run_id = _entity_components(view, prefab)
+    new_id = world.spawn(*_overlay(components, overrides))
+    lineage = IsA(
+        source=new_id, target=prefab, world=source_world, run_id=run_id, at_tick=view.tick
+    )
     link_sync(world, lineage)
     if max_depth > 0:
         for child in _child_prefabs(view, prefab):

--- a/tests/graph/test_prefab_contract.py
+++ b/tests/graph/test_prefab_contract.py
@@ -254,9 +254,10 @@ def test_twin_prefab_marker_is_not_copied():
     view._frames = {signature: frame}
     view.tick = 0
 
-    components = _entity_components(view, 7)
+    components, run_id = _entity_components(view, 7)
     assert [type(c).__name__ for c in components] == ["Chassis"]
     assert components[0].armor == 12
+    assert run_id == ""  # synthetic frame has no run_id column
 
 
 def test_marker_and_relation_overrides_are_rejected(tmp_path):
@@ -521,6 +522,32 @@ def test_undeclared_world_field_has_no_scope_semantics(tmp_path):
 
             result = await cascade(world, SpawnedIn, view)
             assert result.total == 1  # the edge dangles despite world="tundra"
+            return True
+
+    assert _run(go())
+
+
+def test_lineage_carries_source_run_id(tmp_path):
+    """One world's history spans runs: lineage pins (world, run, tick)."""
+
+    async def go():
+        view = GraphView()
+        async with ArchetypeRuntime() as runtime:
+            world = _world(runtime, "run-pin", tmp_path, view)
+            template = await world.spawn(Prefab(name="t"), Chassis(armor=6))
+            await world.step()
+
+            inst = await instantiate(world, view, template)
+            await world.step()
+
+            latest = (await world.info()).tick - 1
+            template_rows = (await world.query(Prefab)).where(col("tick") == view.tick).to_pylist()
+            source_run = str(template_rows[0]["run_id"])
+            lineage = (await edges(world, IsA, at=latest)).to_pylist()
+            assert len(lineage) == 1
+            assert lineage[0]["isa__source"] == inst
+            assert lineage[0]["isa__run_id"] == source_run
+            assert source_run != ""
             return True
 
     assert _run(go())


### PR DESCRIPTION
Follow-up to #615, per Everett's review of its shape: one world's history spans many runs, so `(world, at_tick)` under-identifies a template version. The complete provenance coordinate is **(world, run, tick)**.

- `IsA` gains `run_id: str = ""`, stamped per copied entity from the same snapshot row instantiation already materializes — zero extra reads.
- Design R2 updated to state the full coordinate.
- Landed immediately while `IsA` adopters are zero — the same rollout ruling that landed #615.
- Contract: lineage `run_id` equals the template row's actual run (asserted non-empty against a live world); the synthetic-frame path tolerates an absent column.

55/55 graph tests, `make typecheck` and `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)