### PR TITLE
chore(governance): CLA + DCO checks and maintainer-only PR gate

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,33 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      github.event.comment.body == 'recheck' ||
+      github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: https://github.com/VangelisTech/archetype/blob/main/CLA.md
+          # Signatures are committed to the cla-signatures branch, not main.
+          path-to-signatures: signatures/v1/cla.json
+          branch: cla-signatures
+          # Keep in sync with dco.yml and pr-gate.yml.
+          allowlist: everettVT,*[bot]

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,38 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  signoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require Signed-off-by on outside contributions
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            // Keep in sync with cla.yml and pr-gate.yml.
+            const allowlist = ['everettVT'];
+            const author = context.payload.pull_request.user.login;
+            if (allowlist.includes(author) || author.endsWith('[bot]')) {
+              core.info(`${author} is exempt from DCO sign-off.`);
+              return;
+            }
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const missing = commits.filter(
+              (c) => !/^Signed-off-by: .+ <.+@.+>/m.test(c.commit.message),
+            );
+            if (missing.length > 0) {
+              const shas = missing.map((c) => c.sha.slice(0, 12)).join(', ');
+              core.setFailed(
+                `${missing.length} commit(s) missing a Signed-off-by line (${shas}). ` +
+                'Sign with `git commit -s`; see CONTRIBUTING.md.',
+              );
+            }

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,41 @@
+name: PR gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  maintainer-only:
+    runs-on: ubuntu-latest
+    # API-only job: never checks out or executes pull-request code.
+    # Keep the allowlist in sync with cla.yml and dco.yml.
+    if: >-
+      github.event.pull_request.user.login != 'everettVT' &&
+      !endsWith(github.event.pull_request.user.login, '[bot]')
+    steps:
+      - name: Close outside pull requests
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: pr.number,
+              body: [
+                'Thanks for the interest — Archetype is not accepting outside pull',
+                'requests right now while the contract surface stabilizes, so this',
+                'PR is being closed automatically (it was not reviewed on its',
+                'merits). Bug reports and design discussion are welcome as issues.',
+                '',
+                'When outside contributions open up, PRs will require DCO sign-off',
+                'and a signed CLA — see CONTRIBUTING.md.',
+              ].join('\n'),
+            });
+            await github.rest.pulls.update({
+              ...context.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,79 @@
+# Vangelis Technologies Individual Contributor License Agreement
+
+Thank you for your interest in contributing to Archetype and other open
+source projects stewarded by Vangelis Technologies Inc. ("Vangelis"). This
+agreement clarifies the intellectual-property license you grant with your
+contributions. It protects you as a contributor as well as Vangelis and the
+project's users; it does not change your rights to use your own
+contributions for any other purpose.
+
+You accept this agreement by posting the signing comment the CLA bot
+requests on your first pull request. One signature covers all your future
+contributions to repositories owned by Vangelis.
+
+## 1. Definitions
+
+**"You"** means the individual who submits a Contribution.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that you intentionally
+submit to Vangelis for inclusion in a project owned or managed by Vangelis,
+in any form (source code, documentation, configuration, or other material).
+
+**"Submit"** means any form of electronic or written communication sent to
+Vangelis or its representatives, including pull requests, issues, and
+patches, but excluding communication conspicuously marked or otherwise
+designated in writing by you as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms of this agreement, you grant Vangelis and recipients of
+software distributed by Vangelis a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license to reproduce, prepare
+derivative works of, publicly display, publicly perform, sublicense, and
+distribute your Contributions and such derivative works. This includes the
+right to license your Contributions, and derivative works of them, under any
+license terms Vangelis chooses, including open source licenses and
+commercial or proprietary licenses.
+
+## 3. Grant of Patent License
+
+Subject to the terms of this agreement, you grant Vangelis and recipients of
+software distributed by Vangelis a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import, and
+otherwise transfer your Contributions, where such license applies only to
+those patent claims licensable by you that are necessarily infringed by your
+Contribution alone or by combination of your Contribution with the project
+to which it was submitted. If any entity institutes patent litigation
+against you or any other entity alleging that your Contribution, or the
+project it was submitted to, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+agreement for that Contribution or project terminate as of the date such
+litigation is filed.
+
+## 4. You Retain Ownership
+
+This agreement is a license, not an assignment. You retain all right,
+title, and interest in your Contributions, and you remain free to use,
+license, and distribute them for any other purpose.
+
+## 5. Your Representations
+
+You represent that:
+
+- You are legally entitled to grant the licenses above.
+- Each Contribution is your original creation, or you have identified in
+  the submission any third-party material and its license.
+- If your employer has rights to intellectual property you create, you have
+  received permission to make the Contribution on behalf of that employer,
+  or your employer has waived such rights for the Contribution.
+- You will notify Vangelis if you become aware that any representation
+  above is inaccurate.
+
+## 6. No Warranty and No Support Obligation
+
+Except for the representations in section 5, you provide your Contributions
+"AS IS", without warranties or conditions of any kind, express or implied,
+including warranties of merchantability or fitness for a particular
+purpose. You are not expected to provide support for your Contributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,27 @@ This guide covers the local workflow, CI, and pull requests. Read
 `LEARNINGS.md` before changing engine behavior; the specification pages define
 the contracts that tests enforce.
 
+## Contribution Policy
+
+Archetype is Apache-2.0 and developed in the open, but pull requests are
+currently maintainer-only while the contract surface stabilizes: a workflow
+closes outside PRs automatically. Bug reports and design discussion are
+welcome as issues.
+
+Two agreements govern outside contributions when they are accepted:
+
+- **DCO** — every commit carries a `Signed-off-by` line (`git commit -s`)
+  certifying you have the right to submit the work under Apache-2.0.
+- **CLA** — on your first pull request, a bot asks you to sign the
+  [Contributor License Agreement](CLA.md), which grants Vangelis
+  Technologies the rights described there, including the right to license
+  the contribution under other terms. One signature covers all future
+  contributions.
+
+Maintainer- and bot-authored pull requests are exempt from both checks; the
+allowlist lives in `.github/workflows/` (`cla.yml`, `dco.yml`,
+`pr-gate.yml`).
+
 ## Choose Package Ownership First
 
 | Kind | Canonical location |


### PR DESCRIPTION
## What

Arms the contribution-governance layer decided in the open-source strategy discussion: Archetype stays Apache-2.0; these files preserve relicensing optionality and enforce the maintainer-only PR posture.

- **CLA.md** — individual Contributor License Agreement for Vangelis Technologies Inc. The copyright grant includes the right to license contributions under other terms (the relicensing escape hatch). Signed via CLA Assistant Lite comment flow on a contributor's first PR; signatures are committed to a `cla-signatures` branch in this repo — no external service, no app install.
- **.github/workflows/cla.yml** — CLA Assistant Lite (SHA-pinned), allowlists `everettVT` and `*[bot]`.
- **.github/workflows/dco.yml** — requires `Signed-off-by` (`git commit -s`) on outside PRs only; maintainer/bot commits exempt.
- **.github/workflows/pr-gate.yml** — auto-closes outside PRs with a polite comment pointing to issues. API-only `pull_request_target` job; never checks out or executes PR code.
- **CONTRIBUTING.md** — new Contribution Policy section documenting all three; allowlist locations noted for future sync.

## Out-of-band (already applied via API, not in this diff)

The four modern main-branch rulesets were re-armed to `active`: CI & Security, Integrity, Merge Queue, Review. The stale `Protect main` ruleset stays disabled — it requires the old `footgun` check name and lacks `ci (3.13)`, so enabling it would deadlock the merge queue. Recommend deleting it once confirmed unneeded.

## Notes

- CLA.md is a standard ICLA-derived template; have counsel skim it before relying on the first outside signature.
- CLA/DCO checks are armed-but-dormant while the PR gate holds: they only fire for non-allowlisted authors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)