### PR TITLE
docs(claude): daft-antipatterns reviewer + Daft mental model

### DIFF
--- a/.claude/agents/daft-antipatterns.md
+++ b/.claude/agents/daft-antipatterns.md
@@ -1,0 +1,36 @@
+---
+name: daft-antipatterns
+description: "Autonomous PR review agent that hunts for wrong-shape Daft usage (lazy-plan breaks, UDF theater, multimodal/lakehouse/physical-AI antipatterns). Use when reviewing a PR for Daft patterns, or when the user says 'daft antipatterns'."
+when_to_use: "When reviewing a PR diff for Daft antipatterns, when the user asks to review Daft/DataFrame changes for wrong-shape usage, or when invoked alongside footgun review on heavy Daft PRs."
+tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+model: sonnet
+---
+
+# Daft Antipatterns Agent
+
+You are an autonomous code review agent for the **archetype** repository. Your
+sole purpose is to find **wrong-shape Daft** — code that may pass CI and even
+produce plausible results, but fights the lazy/streaming/AI-as-expression
+mental model, or violates Archetype's physical-AI / lakehouse dialect.
+
+`.claude/skills/daft-antipatterns/SKILL.md` is the single source of truth for
+this review: diff resolution, knowledge-base files, every category, output
+format, and quality rules. Read it first and follow it end to end.
+
+Agent-specific notes:
+
+- You run non-interactively. If the skill's diff-resolution steps find nothing
+  to scan, report that and stop.
+- Use Bash only to acquire the diff (`git diff`, `gh pr diff`). Never execute
+  repository code.
+- You are NOT the footgun detector. Skip pure runtime footguns already owned
+  by `.claude/skills/footgun-detector/SKILL.md` unless the same line is also
+  wrong-shape Daft (then report the antipattern angle only).
+- You are NOT a general simplifier. Pathlib theater for object stores is in
+  scope; unrelated over-engineering is not.
+- Prefer concrete fixes that point at builtins, `physical_ai.boundary` helpers,
+  or a single intentional materialization boundary.

--- a/.claude/skills/daft-antipatterns/SKILL.md
+++ b/.claude/skills/daft-antipatterns/SKILL.md
@@ -34,8 +34,9 @@ Same priority as footgun-detector:
 1. `.footgun-review-scope.json` + `.footgun-review.diff` if present (CI scope)
 2. User-provided PR: `gh pr diff <number>`
 3. Feature branch: `git diff origin/main...HEAD` (or `main...HEAD`)
-4. Staged / unstaged `git diff`
-5. Clean tree on main → nothing to scan
+4. If there are staged changes: `git diff --cached`
+5. If there are unstaged changes: `git diff`
+6. Clean tree on main → nothing to scan
 
 ## Step 2: Scan categories
 

--- a/.claude/skills/daft-antipatterns/SKILL.md
+++ b/.claude/skills/daft-antipatterns/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: daft-antipatterns
+description: "Review a diff for wrong-shape Daft usage: broken lazy plans, UDF theater, multimodal/lakehouse/physical-AI antipatterns. Use when reviewing Daft/DataFrame changes, or when the user says 'daft antipatterns' / 'review this for Daft'."
+user_invocable: true
+---
+
+# Daft Antipatterns Reviewer
+
+You review **archetype** diffs for **wrong-shape Daft** — code that may run
+but fights the engine: broken laziness, expression-avoidance, multimodal
+memory landmines, lakehouse IO theater, and physical-AI boundary violations.
+
+This is complementary to `/footgun-detector`:
+
+| Reviewer | Owns |
+|----------|------|
+| `footgun-detector` | Silently wrong / crashy runtime bugs (DAG-breaking collects as *correctness* failures, non-serializable closures, deprecated APIs, row dropping, …) |
+| `daft-antipatterns` | Correct-but-wrong architecture and taste (UDF when a builtin exists, `collect` for peeking, pathlib object walks, PAI boundary bypass, …) |
+
+Do **not** re-litigate footgun categories. If a finding is a silent runtime
+bug that footgun already names, skip it or mention “also a footgun” once.
+
+Load before reviewing (if not already in context):
+
+- `.claude/skills/daft-patterns/SKILL.md` — mental model + authoring rules
+- `LEARNINGS.md` — Archetype-specific Daft lessons (read-then-overwrite, lazy audit, GL)
+- For PAI diffs: `src/archetype/physical_ai/boundary.py` and `docs/guide/physical-ai.md`
+- Optional workspace note: `.context/daft-deep-wiki-mental-model.md` if present
+
+## Step 1: Get the diff
+
+Same priority as footgun-detector:
+
+1. `.footgun-review-scope.json` + `.footgun-review.diff` if present (CI scope)
+2. User-provided PR: `gh pr diff <number>`
+3. Feature branch: `git diff origin/main...HEAD` (or `main...HEAD`)
+4. Staged / unstaged `git diff`
+5. Clean tree on main → nothing to scan
+
+## Step 2: Scan categories
+
+Check changed Python (and adjacent docs/examples) against the categories below.
+Read surrounding context; do not pattern-match only the hunk lines.
+
+### Plan / laziness
+
+#### Premature materialization
+`.collect()`, `.to_pydict()`, `.to_pylist()`, or `.show()` mid-plan used for
+control flow, debugging left in, or “just to look” when `explain` / `show(n)`
+/ a single terminal sink would do. Exception: one deliberate collect before
+merge/upload to prevent re-executing side effects (eventual-analytics
+pattern) — that collect must be at the sink boundary and commented why.
+
+#### Re-triggering expensive plans
+Multiple materializing actions on the same lazy chain without holding the
+concrete result (downloads/inference run twice).
+
+#### Filter-after-explode
+Decoding video/HDF5/frames or exploding lists *before* episode/path filters
+and limits (LeRobot / EgoDex / DROID antipattern).
+
+### Expressions vs UDFs
+
+#### Builtin avoidance
+Hand-rolled `@daft.func` / `@daft.cls` for something `daft.functions` already
+covers (`prompt`, `embed_*`, `classify_*`, `download`, `decode_image`,
+string/numeric/distance helpers, `jq`, etc.).
+
+#### Fake batch
+`@daft.func.batch` that only loops `to_pylist()` over a pure Python transform
+with no vectorized/external batch API. Prefer `@daft.func`.
+Exception: PAI / external-system `@daft.method.batch` per daft-patterns
+Rule 2/7 — never flag `_EnvStepper` / `_PolicyCaller` / `_CartpoleStepper`-style
+UDFs.
+
+#### AI-client theater
+Ad-hoc OpenAI/Anthropic clients inside processors when `prompt` /
+`daft.set_provider` would do. Prefer structured Pydantic output over
+regex-parsing free text.
+
+#### Deprecated / internal imports
+`@daft.udf`, `daft.functions.ai`, `.struct.get(...)`, legacy `.str.*` /
+`.image.*` accessors when the flat API exists. Prefer `from daft import col`
+over `daft.col` in new code.
+
+### Multimodal / memory
+
+#### Inflation without batch control
+`decode_image` / explode / decompress on large frames without prior
+`into_batches`, selective filters, or capped `download(..., max_connections=)`.
+
+#### Missing dirty-data hygiene
+Multimodal IO without `on_error="null"` (or equivalent soft-fail) on large
+dirty corpora — one bad row kills the job.
+
+#### Fat UDF returns
+Returning giant `list[Image]`, raw video tensors, or huge blobs from UDFs /
+Modal instead of writing artifacts to disk/Volume and returning thin
+path/metadata structs.
+
+#### Split GPU stages with host round-trips
+Separating device-resident stages (e.g. VAD → ASR → diarize) across UDF
+boundaries when one fused `@daft.cls` actor would keep state on-device.
+
+### Lakehouse / IO
+
+#### Pathlib / local-FS theater for object data
+Walking `Path(...)` trees or opening local files for lakehouse / `gs://` /
+HF datasets when `from_glob_path`, `read_csv`/`read_parquet` with `io_config`,
+or URI connectors exist.
+
+#### Empty Iceberg batches / inferred null schemas
+Yielding empty `RecordBatch`es or relying on inferred `Null` dtypes for sparse
+drops that must stay schema-stable.
+
+#### Mid-query scalar collect for analytics
+`.collect().to_pydict()` just to branch on a total when a Window / join /
+conditional expression could stay lazy (flag unless genuinely irreducible).
+
+### Physical AI / Archetype boundary
+
+#### Do not flag (sanctioned Archetype PAI)
+- `series_to_rows` / `Series.to_pylist` inside `@daft.method.batch`
+- Module-level `_EnvStepper` / `_FramedEnvStepper` / `_PolicyCaller` /
+  `_PolicyCallerNoRefs` / `_CartpoleStepper` batch bodies that loop or
+  `series_to_rows` then make **one** external/batched client or C call,
+  with inactive/`done` pass-through where those columns exist
+- Continuous physics steppers with no episode `done`/`is_active` (e.g.
+  cartpole) — Lifecycle leak applies only when an episodic contract exists
+- Constructor injection of an in-process test double / fake client in tests
+
+#### Boundary bypass
+Env / policy / MuJoCo logic as row `@daft.func`, free Python in
+`process()` after an illicit collect, or expressions pretending to be the sim.
+
+#### Unpickleable worker state
+Dynamic/factory `@daft.cls`, live sockets/Modal stubs stuffed into Resources,
+non-scalar non-picklable spec fields expected to cross workers.
+Also: `spec.build()` on the **driver** then passing the live client into
+`@daft.cls(...)`. Pass the picklable Spec into the cls; call `build()` in
+`__init__` on the worker (see `_PolicyCaller`).
+
+#### Lifecycle leak
+Episodic env/policy batch UDFs that *have* `is_active`/`done` (or equivalent)
+but call the external system on frozen rows — missing `external_call_indices`
+(or equivalent). Do not flag non-episodic physics steppers that lack those
+columns.
+
+#### Latch / provenance mistakes
+Overwriting `success` without latching prior; policy processor priority ≥ env
+so ledger provenance breaks.
+
+#### Frame / grading contract
+Image blobs on ledger components instead of `ManipFrameRef`; grading via
+live env memory instead of `StorageService.materialize` of terminal rows.
+
+#### Renderer / CUDA init landmines
+GL/EGL create on one thread and render inside a Daft UDF worker thread;
+first `import torch` inside the worker rather than the caller process.
+
+#### Identity chimera (eval / daft-physical-ai style)
+`groupby("episode_id")` without policy keys; joining demos↔rollouts on
+`task_id` / `episode_id` instead of `(suite, task_name)`.
+
+### Read-then-overwrite
+
+#### UDF sees final column value
+`with_column("x", udf_that_reads_x(col("x")))` combined with other
+projections that assume the pre-overwrite value — silent wrongness. Fix:
+one struct-returning UDF that owns the whole read-modify-write (LEARNINGS).
+
+## Step 3: Report findings
+
+For each antipattern found:
+
+```
+### <CATEGORY> in `<file>:<line>`
+
+**What it does:** <one sentence>
+
+**Why it's wrong-shape:** <mental-model link — plan, stream, AI-as-expression, runner, or PAI boundary>
+
+**Fix:**
+<concrete alternative>
+```
+
+If none:
+
+```
+No Daft antipatterns detected in this diff.
+```
+
+## Rules for this skill
+
+- **No style nits** unrelated to Daft shape (import order, naming taste).
+- **No false positives** on sanctioned PAI batch loops / `series_to_rows` /
+  lazy_audit-exempt `Series.to_pylist` inside `@daft.method.batch`.
+- **Diff-scoped.** Changed lines + enough context; sibling sweep only when the
+  diff establishes a new invariant twins must share.
+- **Concrete fixes.** Prefer the builtin / boundary helper / sink pattern.
+- **Defer to footgun** for pure runtime footguns already in its category list.
+- **Advisory.** This reviewer is not the deterministic merge gate unless CI
+  is later wired to it; still be high-signal.

--- a/.claude/skills/daft-patterns/SKILL.md
+++ b/.claude/skills/daft-patterns/SKILL.md
@@ -1,9 +1,44 @@
 ---
 name: daft-patterns
-description: Enforces correct Daft DataFrame patterns. Use when writing or editing Python that touches Daft, DataFrames, UDFs, or column expressions — anywhere under src/, tests/, or examples/.
+description: Enforces correct Daft DataFrame patterns and the Daft mental model. Use when writing or editing Python that touches Daft, DataFrames, UDFs, column expressions, multimodal IO, lakehouse sinks, or physical-AI boundaries — anywhere under src/, tests/, or examples/.
 paths: "src/**/*.py,tests/**/*.py,examples/**/*.py"
 user_invocable: true
 ---
+
+## Mental model (internalize first)
+
+One-sentence essence: Daft is a **lazy, streaming query engine with a DataFrame
+skin**, built so that a multi-megabyte image or a GPU model inference is just
+another column expression — treated by the optimizer like `col("a") + 1`.
+
+Four core ideas:
+
+1. **You are building a plan, not running code.** Transformations append to a
+   `LogicalPlan`. Nothing runs until a materializing action (`collect`, `show`,
+   `write_*`, `to_pydict`, Archetype's `StorageService.materialize`). The
+   optimizer must see the whole pipeline at once.
+2. **Data streams in bounded batches.** Memory stays bounded except at
+   inflationary ops (decode, explode), blocking ops (sort, agg, join),
+   memory-hungry UDFs, and over-concurrent downloads.
+3. **An AI / multimodal op is just an expression.** `prompt(...)`, `download`,
+   `decode_image`, and Python UDFs are plan nodes. The optimizer isolates
+   expensive projections and runs them as late as correctness allows — so it
+   does not waste GPU work on rows a later filter would discard.
+4. **Logic is runner-agnostic.** Same plan on Swordfish (local) or Flotilla
+   (Ray). Correctness transfers; shuffle/cost characteristics do not.
+
+What this predicts in practice:
+
+- Printing a DataFrame shows schema + "not materialized" — that is success, not a bug.
+- An expensive `prompt` written early may execute last (or not at all on filtered rows).
+- A UDF bug surfaces at materialization, not at the `with_column` line.
+- Calling `.collect()` twice re-runs the whole plan unless you hold the concrete result.
+- `show(n)` is cheap (limit pushes upstream); `collect()` computes everything.
+
+Full distillation lives in-repo under this skill's Mental model section.
+Workspace notes (optional): `.context/daft-deep-wiki-mental-model.md`.
+For silently-wrong runtime bugs, use `/footgun-detector`. For wrong-shape
+Daft usage on a diff, use `/daft-antipatterns`.
 
 ## Daft built-ins to reach for first
 
@@ -335,7 +370,8 @@ Check in this order — stop at the first match:
 
 **`@daft.udf` is removed.** Deprecated 0.7.0, gone 0.8.0. Never use it. Use `@daft.func.batch` instead.
 
-**If you loop inside a batch UDF, you're not batching.** Use `@daft.func` row-wise instead.
+**If you loop inside a batch UDF for a pure Python transform, you're not
+batching.** Use `@daft.func` row-wise instead.
 
 ```python
 # WRONG — looping inside batch, no batching benefit
@@ -348,6 +384,17 @@ def process(values: Series) -> Series:
 def process(value: str) -> str:
     return transform(value)
 ```
+
+**Exception — Physical AI / external-system boundaries.** A loop (or
+`series_to_rows` → filtered live rows → one batched client call / C step)
+inside `@daft.method.batch` is the *sanctioned* pattern when:
+
+- state is loaded once in `@daft.cls.__init__` (model, env handle, Modal stub),
+- the UDF talks to an external system that cannot be a lazy expression, and
+- inactive/`done` rows are pass-through via `external_call_indices`.
+
+See `src/archetype/physical_ai/boundary.py` and Rule 7 below. Do **not**
+false-flag `_EnvStepper` / `_PolicyCaller` / `_CartpoleStepper` style UDFs.
 
 ### 3. Struct access
 
@@ -427,3 +474,115 @@ df = df.with_column("response", agent.respond(col("agent__name"), col("context")
 def flaky_call(x: str) -> str:
     return external_api(x)
 ```
+
+### 7. Physical AI / external-boundary stack
+
+External systems (MuJoCo, env RPC, policy inference) are escape hatches, not
+expressions. Canonical stack in Archetype:
+
+1. Module-level `@daft.cls` (must be importable — dynamic/factory classes fail to pickle).
+2. `@daft.method.batch` → `series_to_rows` → call external system → struct `Series`.
+3. Processor: UDF via `col(...)` → `unpack_struct` → exclude scratch.
+
+```python
+from archetype.physical_ai.boundary import (
+    external_call_indices,
+    series_to_rows,
+    unpack_struct,
+)
+
+@daft.cls()
+class _EnvStepper:
+    def __init__(self, spec):
+        self.client = spec.build()  # live handle — created on the worker
+
+    @daft.method.batch(return_dtype=OBS_STRUCT)
+    def step(self, is_active: Series, done: Series, action: Series) -> Series:
+        rows = series_to_rows(
+            ["is_active", "done", "action"], is_active, done, action
+        )
+        out = [None] * len(rows)
+        for i in external_call_indices(rows):
+            out[i] = self.client.step(rows[i]["action"])
+        for i, row in enumerate(rows):
+            if out[i] is None:
+                out[i] = {...passthrough from row...}
+        return Series.from_pylist(out)
+```
+
+Invariants:
+
+- **Specs in Resources, live handles in `__init__`.** Non-picklable sockets /
+  stubs must not ride in Resources across workers.
+- **`Series.to_pylist` on batch-UDF params is sanctioned** (lazy_audit exemption).
+  `DataFrame.collect().to_pylist()` mid-processor is not.
+- **Lifecycle freeze.** Only `is_active && !done` cross the boundary.
+- **Success latches.** `success = obs["success"] or prior_success`.
+- **Policy before env.** Policy processor priority < env priority so ledger
+  provenance stays `a_t = π(obs_{t-1})`, `obs_t = env.step(a_t)`.
+- **Thin ledger columns.** Prefer `ManipFrameRef` volume refs over image blobs
+  on components.
+- **App grading boundary.** Await `StorageService.materialize(...)` before
+  converting terminal frames to Python at HTTP/report boundaries.
+- **GL/EGL is thread-bound.** Marshal all create/reset/step/render onto one
+  persistent thread — Daft UDF worker threads go blind (LEARNINGS Jul 2026).
+- **Torch/CUDA:** first `import torch` in the driver/caller process before the
+  class-UDF runs on a worker (daft-physical-ai hands facade lesson).
+
+### 8. Materialization boundaries
+
+| Intent | Reach for |
+|--------|-----------|
+| Inspect during development | `df.show(n)` or `df.limit(n).collect()` once |
+| Large result to storage | `write_parquet` / `write_iceberg` / `write_lance` (streams out) |
+| Full result in memory for Python work | `collect()` — rare, deliberate |
+| Archetype terminal / grading | `await StorageService.materialize(df)` then `to_pylist` |
+| Debug plan shape | `df.explain()` — never mid-pipeline collect |
+
+Re-materializing re-runs the plan. If an expensive stage must be reused,
+materialize once and hold the concrete result (or write a checkpoint parquet /
+Lance table — the daft-examples pattern after costly AI).
+
+Filter and `limit` **before** explode/decode/frame expansion (LeRobot,
+EgoDex, DROID lesson): never decode video/HDF5 then filter episodes.
+
+### 9. Lakehouse / object IO (eventual-analytics practice)
+
+- Prefer lazy `sess.read_table` → `where` / `groupby` / `Window` / `daft.functions`
+  until the sink.
+- `collect()` once before merge/upload when the plan would otherwise re-scan
+  and re-execute side effects.
+- Discover files with `daft.from_glob_path` + URI/`IOConfig`, not pathlib walks
+  of object-store data. `Path` is fine for local catalog roots only.
+- Explicit schemas; never yield empty `RecordBatch`es into Iceberg (null-typed
+  columns reject).
+- Stream + aggregate huge event feeds inside DataSource tasks; fan out tasks
+  for parallelism.
+- Custom streaming IO that Daft cannot express yet → `@daft.func` inside the
+  plan (constant-memory chunked upload), not a driver-side `for path in paths`.
+
+### 10. Judgment calls (taste)
+
+1. **Expression vs UDF.** Exhaust built-ins first. Every UDF is a known
+   performance liability.
+2. **AI function vs hand-rolled client.** Use `prompt` / `embed_*` /
+   `classify_*` + `daft.set_provider(...)` for provider calls. Hand-roll
+   `@daft.cls` only for local/custom models or exotic batching.
+3. **Structured LLM output.** Pass a Pydantic `response_format` /
+   `return_format`; index struct fields. Do not regex free-text.
+4. **Dirty multimodal IO.** Pass `on_error="null"` on `download` /
+   `decode_image`, then quarantine nulls.
+5. **Inflation points.** `into_batches(small_n)` and capped `max_connections`
+   before decode/explode; decode late after selective filters.
+6. **UDF memory knobs.** `concurrency × batch_size` is the budget. OOM-kill
+   churn → lower concurrency first.
+7. **Thin UDF returns.** Write large media/tensors to disk/Volume; return
+   paths + metadata structs (cosmos3 / pose_sequence lesson).
+8. **Fuse GPU stages** when host round-trips dominate (VAD→ASR→diarize in one
+   device-resident actor), rather than splitting across separate UDF stages.
+9. **Read-then-overwrite.** UDF column args resolve to the column's *final*
+   value in a plan. Consolidate every read-then-overwrite into one
+   struct-returning UDF (LEARNINGS). Do not `with_column("x", udf(col("x")))`
+   then read the pre-overwrite `x` elsewhere in the same projection set.
+10. **Know when not to use Daft.** Batch/streaming transform engine — not a
+    serving layer, transactional store, or interactive BI cache.

--- a/.claude/skills/daft-patterns/SKILL.md
+++ b/.claude/skills/daft-patterns/SKILL.md
@@ -73,7 +73,7 @@ df = df.with_columns({
     "agent__decision": prompt(
         col("agent__context"),
         model="gpt-5-mini",
-        response_format=Decision,
+        return_format=Decision,
     ),
 })
 # Access fields: col("agent__decision")["action"]
@@ -95,7 +95,7 @@ df = df.with_columns({
 })
 ```
 
-**Key parameters:** `model`, `messages` (list of expressions — text, image, file), `system_message`, `response_format` (Pydantic model), `tools`, `tool_choice`, `max_output_tokens`, `use_chat_completions` (set `True` for vLLM/OpenAI-compatible endpoints).
+**Key parameters:** `model`, `messages` (list of expressions — text, image, file), `system_message`, `return_format` (Pydantic model), plus provider options (`tools`, `tool_choice`, `max_output_tokens`, `use_chat_completions`, …).
 
 #### `embed_text()` / `embed_image()` — embeddings
 
@@ -568,8 +568,8 @@ EgoDex, DROID lesson): never decode video/HDF5 then filter episodes.
 2. **AI function vs hand-rolled client.** Use `prompt` / `embed_*` /
    `classify_*` + `daft.set_provider(...)` for provider calls. Hand-roll
    `@daft.cls` only for local/custom models or exotic batching.
-3. **Structured LLM output.** Pass a Pydantic `response_format` /
-   `return_format`; index struct fields. Do not regex free-text.
+3. **Structured LLM output.** Pass a Pydantic `return_format` to `prompt()`;
+   index struct fields. Do not regex free-text.
 4. **Dirty multimodal IO.** Pass `on_error="null"` on `download` /
    `decode_image`, then quarantine nulls.
 5. **Inflation points.** `into_batches(small_n)` and capped `max_connections`

--- a/.claude/skills/footgun-detector/SKILL.md
+++ b/.claude/skills/footgun-detector/SKILL.md
@@ -31,7 +31,9 @@ Before analyzing, read these files for context — they contain the rules the di
 - `AGENTS.md` — Architecture, service layer, RBAC, conventions
 - `.claude/skills/archetype-processors/SKILL.md` — Processor rules
 - `.claude/skills/archetype-components/SKILL.md` — Component rules
-- `.claude/skills/daft-patterns/SKILL.md` — Daft DataFrame rules
+- `.claude/skills/daft-patterns/SKILL.md` — Daft DataFrame rules (mental model + authoring)
+- For wrong-shape Daft that is not a silent runtime bug, defer to `/daft-antipatterns`
+  rather than stretching these categories into taste nits.
 
 You do NOT need to read these if you already have them in context from this session.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ locally just moves the failure to review.
 
 | Skill | How it loads | What it enforces |
 |-------|--------------|------------------|
-| `daft-patterns` | `/daft-patterns`, or model-invoked for Daft/DataFrame/UDF code within its configured paths | Daft built-in functions to reach for first, UDF decision tree, lazy DAG rules |
+| `daft-patterns` | `/daft-patterns`, or model-invoked for Daft/DataFrame/UDF code within its configured paths | Mental model (lazy plan / streaming / AI-as-expression), builtins first, UDF decision tree, physical-AI boundary, lakehouse sinks |
+| `daft-antipatterns` | `/daft-antipatterns` | Diff review for wrong-shape Daft (UDF theater, premature materialization, multimodal/lakehouse/PAI antipatterns) — complementary to footgun |
 | `archetype-components` | `/archetype-components`, or model-invoked for Component/schema code within its configured paths | Component definitions, Arrow serialization, field conventions |
 | `archetype-processors` | `/archetype-processors`, or model-invoked for processor/pipeline code within its configured paths | AsyncProcessor patterns, priority ordering, resource access |
 | `footgun-detector` | `/footgun-detector` | Scans the current diff for archetype-specific runtime bugs across three perspectives: actor (code), observed (data), observer (review) |
@@ -31,6 +32,7 @@ Agents in `.claude/agents/` are invoked autonomously — by CI, by other agents,
 | Agent | When to use |
 |-------|-------------|
 | `footgun-detector` | Review a PR diff for runtime bugs. Use when the user asks to review a PR for footguns, or invoke from CI on pull requests. |
+| `daft-antipatterns` | Review a PR diff for wrong-shape Daft. Use when the user asks for a Daft antipatterns review, or on heavy DataFrame/multimodal/physical-AI PRs alongside footgun. |
 
 ## Layers
 


### PR DESCRIPTION
## Summary
- Encode the [Daft Deep Intuition](https://www.deeptechintuition.com/articles/daft-deep-intuition/) mental model (lazy plan / streaming batches / AI-as-expression / two runners) into `daft-patterns`, with lakehouse and physical-AI amendments from eventual-analytics, daft-examples, and Archetype PAI.
- Add advisory `daft-antipatterns` agent + skill for wrong-shape Daft review (complementary to footgun; not on the deterministic merge gate).
- Dogfood on `physical_ai/` + `examples/05_llm_agents.py`: 3 true positives, 0 false positives; hardened PAI allowlist / episodic lifecycle / driver-side `spec.build()` wording before merge.

## Test plan
- [ ] Confirm CLAUDE.md skills/agents index lists `daft-antipatterns`
- [ ] Spot-check `daft-patterns` Rule 7 + Rule 2 PAI batch-loop exception
- [ ] Optional: `/daft-antipatterns` on a Daft-heavy PR and verify no PAI false positives on `_EnvStepper` / `_PolicyCaller` / `_CartpoleStepper`
- [ ] Footgun gate passes (docs-only change; expect clean or N/A coverage)


Made with [Cursor](https://cursor.com)