### PR TITLE
fix(missions): bind validators to the task base revision

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -432,11 +432,19 @@ The task decision processor accepts only when all guards have a result for the
 **current dispatch and exact final repository revision**. Evidence from a
 prior dispatch or pre-repair tree is stale by construction.
 
+Every validator process receives the harness-reserved
+`ARCHETYPE_TASK_BASE_REVISION` environment variable. The harness resolves it
+from `HEAD` immediately before the task's first agent turn and preserves that
+same SHA across retries. This lets repository policy inspect the complete task
+delta even when the agent created commits before validation. The variable is
+context, not authority: acceptance still requires revision-bound validator and
+publication evidence.
+
 ### Git and publication
 
 Git is part of the coding contract:
 
-1. the harness records the dispatch's starting revision;
+1. the harness records the task's starting revision and preserves it across retries;
 2. the agent may create commits during its work;
 3. validators run against the final working tree;
 4. if validated work remains dirty, the publisher creates one final commit;

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -31,6 +31,24 @@ the later task can require that same test to pass. See
 [Agent Missions V1](agent-missions.md#repository-validators-are-authority)
 for the dogfooded protocol.
 
+A changed-path validator must not rely on `git status --porcelain`: an agent
+may commit before the validator runs. Mission validators receive the task's
+stable base SHA as `ARCHETYPE_TASK_BASE_REVISION`. A complete path inventory
+combines committed and untracked changes, for example:
+
+```bash
+test -n "$ARCHETYPE_TASK_BASE_REVISION" \
+  && git merge-base --is-ancestor "$ARCHETYPE_TASK_BASE_REVISION" HEAD \
+  || exit 1
+{
+  git diff --name-only "$ARCHETYPE_TASK_BASE_REVISION" --
+  git ls-files --others --exclude-standard
+} | sort -u
+```
+
+If the base is missing or no longer an ancestor, repository policy should fail
+closed rather than silently narrowing the inspected delta.
+
 ## Evidence types
 
 Each tool answers a different question.

--- a/eval-capability-results.json
+++ b/eval-capability-results.json
@@ -6,15 +6,15 @@
     "capability"
   ],
   "failure_policy": "every architectural capability task and every trial passes",
-  "started_at": "2026-07-20T20:39:36.257863Z",
-  "duration_s": 0.263636,
+  "started_at": "2026-07-23T07:41:37.543161Z",
+  "duration_s": 4.462254,
   "outcome": "passed",
   "revision": {
-    "commit": "4567ab17712d4a4123eddb205fc63ad4b513bfd8",
-    "dirty": true
+    "commit": "650ccfe7b13e965eebf808e5bff7fe09c0d7a497",
+    "dirty": false
   },
   "environment": {
-    "runner_id": "Everetts-MacBook-Pro.local",
+    "runner_id": "Mac",
     "system": "Darwin",
     "release": "25.5.0",
     "machine": "arm64",
@@ -29,7 +29,7 @@
     }
   },
   "invocation": [
-    "/Users/everettkleven/conductor/workspaces/archetype/colombo-v2/evals/run.py",
+    "/Users/everettkleven/conductor/workspaces/archetype/bogota/evals/run.py",
     "--profile",
     "capability",
     "--out",
@@ -62,7 +62,7 @@
           "trial": 0,
           "passed": true,
           "score": 1.0,
-          "elapsed_s": 0.0238,
+          "elapsed_s": 0.0274,
           "error": null,
           "graders": [
             {
@@ -103,7 +103,7 @@
           "trial": 0,
           "passed": true,
           "score": 1.0,
-          "elapsed_s": 0.0271,
+          "elapsed_s": 0.0335,
           "error": null,
           "graders": [
             {
@@ -156,7 +156,7 @@
           "trial": 0,
           "passed": true,
           "score": 1.0,
-          "elapsed_s": 0.0771,
+          "elapsed_s": 0.1027,
           "error": null,
           "graders": [
             {
@@ -221,7 +221,7 @@
           "trial": 0,
           "passed": true,
           "score": 1.0,
-          "elapsed_s": 0.0592,
+          "elapsed_s": 0.0747,
           "error": null,
           "graders": [
             {
@@ -280,7 +280,7 @@
           "trial": 0,
           "passed": true,
           "score": 1.0,
-          "elapsed_s": 0.0749,
+          "elapsed_s": 0.1036,
           "error": null,
           "graders": [
             {
@@ -329,7 +329,7 @@
       "contract_ids": [
         "missions.agent_v1.validator_gated"
       ],
-      "desc": "Explicit task graphs advance from dispatch-bound validation and pushed revisions",
+      "desc": "Runtime missions retry from repository evidence, honor dependency order, publish validated revisions, and clean up terminal resources",
       "trial_count": 1,
       "correct_samples": 1,
       "pass_rate": 1.0,
@@ -345,17 +345,23 @@
           "trial": 0,
           "passed": true,
           "score": 1.0,
-          "elapsed_s": 0.0001,
+          "elapsed_s": 4.1184,
           "error": null,
           "graders": [
             {
-              "name": "mission_graph_is_data",
+              "name": "mission_processors_own_transitions",
               "passed": true,
               "score": 1.0,
               "details": ""
             },
             {
-              "name": "mission_evidence_is_bound",
+              "name": "mission_retry_uses_repository_evidence",
+              "passed": true,
+              "score": 1.0,
+              "details": ""
+            },
+            {
+              "name": "mission_publication_and_cleanup_are_real",
               "passed": true,
               "score": 1.0,
               "details": ""
@@ -386,7 +392,7 @@
           "trial": 0,
           "passed": true,
           "score": 1.0,
-          "elapsed_s": 0.0005,
+          "elapsed_s": 0.0008,
           "error": null,
           "graders": [
             {

--- a/evals/suites/capability/agent_missions.py
+++ b/evals/suites/capability/agent_missions.py
@@ -1,111 +1,423 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Credential-free checks for the Agent Missions V1 state protocol."""
+"""Credential-free end-to-end capability proof for Agent Missions V1."""
 
 from __future__ import annotations
 
+import asyncio
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from archetype import ArchetypeRuntime
+from archetype.core.component import Component
+from archetype.core.config import StorageConfig
 from archetype.missions import (
-    TASK_TRANSITIONS,
     AgentExecution,
-    AgentExecutionStatus,
+    AgentMissionConfig,
     AgentTask,
     CommandValidator,
     Commit,
-    DependsOn,
-    MissionSubmission,
-    RepositoryPublicationPolicy,
-    TaskDispatch,
-    TaskStatus,
+    FrictionLog,
+    Sandbox,
+    TaskState,
     ValidationResult,
 )
+from archetype.missions.coding_agents import (
+    AgentProcessObservation,
+    TaskDispatchRequest,
+)
+from archetype.missions.sandboxes import (
+    CheckpointRef,
+    ProcessRequest,
+    ProcessResult,
+    SandboxCapabilities,
+    SandboxIdentity,
+    SandboxSession,
+    SandboxSpec,
+    SandboxStatus,
+)
+from archetype.projections import latest
+from archetype.runtime.missions import RuntimeMissions
 from evals.graders import state_check
 from evals.harness import EvalHarness
 from evals.types import GraderResult
 
 SUITE = "capability"
+_BRANCH = "agent/capability-transition-authority"
+
+
+def _hermetic_environment(home: Path) -> dict[str, str]:
+    home.mkdir(parents=True, exist_ok=True)
+    return {
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+        "HOME": str(home),
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PATH": os.environ.get("PATH", os.defpath),
+    }
+
+
+def _git(*arguments: str, cwd: Path | None = None) -> str:
+    home = (cwd or Path.cwd()) / ".capability-home"
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_hermetic_environment(home),
+    )
+    return result.stdout.strip()
+
+
+def _local_bare_remote(root: Path) -> Path:
+    seed = root / "seed"
+    seed.mkdir()
+    _git("init", "-b", "main", cwd=seed)
+    _git("config", "user.name", "Capability Fixture", cwd=seed)
+    _git("config", "user.email", "capability@example.com", cwd=seed)
+    (seed / "README.md").write_text("mission capability fixture\n", encoding="utf-8")
+    _git("add", "README.md", cwd=seed)
+    _git("commit", "-m", "seed", cwd=seed)
+    remote = root / "remote.git"
+    _git("clone", "--bare", str(seed), str(remote), cwd=root)
+    return remote
+
+
+def _remote_revision(remote: Path) -> str:
+    result = subprocess.run(
+        ("git", "--git-dir", str(remote), "rev-parse", f"refs/heads/{_BRANCH}"),
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_hermetic_environment(remote.parent / ".capability-home"),
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+async def _latest_rows(
+    missions: RuntimeMissions,
+    component: type[Component],
+) -> list[dict[str, Any]]:
+    try:
+        frame = await missions.query(component)
+    except KeyError:
+        return []
+    return latest(frame).to_pylist()
+
+
+class _CredentialFreeSession:
+    """Run the provider-neutral sandbox protocol in one temporary directory."""
+
+    def __init__(self, spec: SandboxSpec) -> None:
+        self.spec = spec
+        self.close_calls = 0
+        self._environment = _hermetic_environment(Path(spec.workdir).parent / ".capability-home")
+
+    @property
+    def identity(self) -> SandboxIdentity:
+        return SandboxIdentity("capability-local", "mission-capability", self.spec.environment)
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        # The harness requests this symbolic lease for Git operations. A local
+        # file remote needs no credential and the session injects no secret.
+        return SandboxCapabilities(secret_names=("github",))
+
+    async def status(self) -> SandboxStatus:
+        return SandboxStatus.CLOSED if self.close_calls else SandboxStatus.READY
+
+    async def exec(self, request: ProcessRequest) -> ProcessResult:
+        environment = self._environment.copy()
+        environment.update(request.environment_dict())
+        process = await asyncio.create_subprocess_exec(
+            *request.argv,
+            cwd=request.workdir,
+            env=environment,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=request.timeout_seconds,
+            )
+        except TimeoutError:
+            process.kill()
+            await process.communicate()
+            raise
+        if process.returncode is None:
+            raise RuntimeError("sandbox process exited without a return code")
+        return ProcessResult(
+            argv=request.argv,
+            returncode=process.returncode,
+            stdout=stdout.decode(),
+            stderr=stderr.decode(),
+        )
+
+    async def checkpoint(self) -> CheckpointRef:
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class _CredentialFreeBackend:
+    name = "capability-local"
+
+    def __init__(self) -> None:
+        self.create_calls = 0
+        self.session: _CredentialFreeSession | None = None
+
+    async def create(self, spec: SandboxSpec) -> _CredentialFreeSession:
+        self.create_calls += 1
+        self.session = _CredentialFreeSession(spec)
+        return self.session
+
+    async def restore(
+        self,
+        spec: SandboxSpec,
+        checkpoint: CheckpointRef,
+    ) -> _CredentialFreeSession:
+        raise NotImplementedError
+
+
+class _DeterministicAgentDriver:
+    """Produce one rejected revision, repair it, then complete its dependent."""
+
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+        self.requests: list[TaskDispatchRequest] = []
+
+    async def run(
+        self,
+        session: SandboxSession,
+        request: TaskDispatchRequest,
+        prompt: str,
+    ) -> AgentProcessObservation:
+        del prompt
+        self.requests.append(request)
+        if request.task_name == "repair-gate":
+            value = "rejected" if request.dispatch_sequence == 1 else "accepted"
+            command = f"printf '%s\\n' {value} > gate.txt"
+        else:
+            command = "printf '%s\\n' downstream > downstream.txt"
+        result = await session.exec(
+            ProcessRequest(
+                ("sh", "-c", command),
+                workdir=str(self.workspace),
+            )
+        )
+        return AgentProcessObservation(
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            session_id=f"session-{request.task_name}",
+        )
+
+
+@dataclass(frozen=True)
+class _MissionEvidence:
+    mission_status: str
+    task_dispatches: tuple[tuple[str, int], ...]
+    request_order: tuple[tuple[str, int], ...]
+    retry_saw_failed_validation: bool
+    retry_resumed_agent_session: bool
+    validation_returncodes: tuple[int, ...]
+    execution_count: int
+    pushed_final_commits: int
+    friction_count: int
+    prerequisite_accepted_tick: int | None
+    dependent_dispatched_tick: int | None
+    remote_revision: str
+    projected_final_revision: str
+    backend_create_calls: int
+    session_close_calls: int
+    sandbox_status: str
+
+
+async def _run_mission(root: Path) -> _MissionEvidence:
+    remote = _local_bare_remote(root)
+    workspace = root / "sandbox" / "repo"
+    backend = _CredentialFreeBackend()
+    driver = _DeterministicAgentDriver(workspace)
+    storage = StorageConfig(uri=str(root / "state"), namespace="mission_capability")
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "agent-mission-capability",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-eval@sha256:agent-mission-capability",
+                driver=driver,
+                workspace=str(workspace),
+                max_ticks=40,
+            ),
+            storage=storage,
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch=_BRANCH,
+                tasks=(
+                    AgentTask(
+                        name="repair-gate",
+                        prompt="Create the gate marker required by the repository validator.",
+                        validators=(
+                            CommandValidator(
+                                "gate-is-accepted",
+                                ("sh", "-c", 'test "$(cat gate.txt)" = accepted'),
+                            ),
+                        ),
+                        max_dispatches=2,
+                    ),
+                    AgentTask(
+                        name="dependent",
+                        prompt="Create the downstream marker after the gate task is accepted.",
+                        validators=(
+                            CommandValidator(
+                                "downstream-exists",
+                                ("sh", "-c", "test -f downstream.txt"),
+                            ),
+                        ),
+                        depends_on=("repair-gate",),
+                    ),
+                ),
+            )
+            result = await missions.run(submitted)
+
+            validation_rows = await _latest_rows(missions, ValidationResult)
+            execution_rows = await _latest_rows(missions, AgentExecution)
+            commit_rows = await _latest_rows(missions, Commit)
+            friction_rows = await _latest_rows(missions, FrictionLog)
+            sandbox_rows = await _latest_rows(missions, Sandbox)
+            task_state_rows = (await missions.query(TaskState)).to_pylist()
+
+            validation = ValidationResult.get_prefix()
+            commit = Commit.get_prefix()
+            sandbox = Sandbox.get_prefix()
+            state = TaskState.get_prefix()
+            state_ticks: dict[tuple[int, str], list[int]] = {}
+            for row in sorted(task_state_rows, key=lambda item: int(item["tick"])):
+                if row["is_active"]:
+                    key = (int(row["entity_id"]), str(row[f"{state}status"]))
+                    state_ticks.setdefault(key, []).append(int(row["tick"]))
+
+            retry = driver.requests[1] if len(driver.requests) > 1 else None
+            final_commits = result.tasks[-1].commit_shas
+            projected_final_revision = final_commits[-1] if final_commits else ""
+            evidence = _MissionEvidence(
+                mission_status=result.status,
+                task_dispatches=tuple((task.name, task.dispatches) for task in result.tasks),
+                request_order=tuple(
+                    (request.task_name, request.dispatch_sequence) for request in driver.requests
+                ),
+                retry_saw_failed_validation=(
+                    retry is not None
+                    and len(retry.previous_validation) == 1
+                    and retry.previous_validation[0].passed is False
+                ),
+                retry_resumed_agent_session=(
+                    retry is not None and retry.previous_agent_session_id == "session-repair-gate"
+                ),
+                validation_returncodes=tuple(
+                    int(row[f"{validation}actual_returncode"]) for row in validation_rows
+                ),
+                execution_count=len(execution_rows),
+                pushed_final_commits=sum(
+                    bool(row[f"{commit}pushed"]) and bool(row[f"{commit}final_revision"])
+                    for row in commit_rows
+                ),
+                friction_count=len(friction_rows),
+                prerequisite_accepted_tick=(
+                    min(accepted_ticks)
+                    if (
+                        accepted_ticks := state_ticks.get(
+                            (submitted.task_id("repair-gate"), "accepted")
+                        )
+                    )
+                    else None
+                ),
+                dependent_dispatched_tick=(
+                    min(dispatched_ticks)
+                    if (
+                        dispatched_ticks := state_ticks.get(
+                            (submitted.task_id("dependent"), "dispatched")
+                        )
+                    )
+                    else None
+                ),
+                remote_revision="",
+                projected_final_revision=projected_final_revision,
+                backend_create_calls=backend.create_calls,
+                session_close_calls=0,
+                sandbox_status=str(sandbox_rows[-1][f"{sandbox}status"]),
+            )
+
+    if backend.session is None:
+        raise RuntimeError("mission did not create its configured sandbox session")
+    return replace(
+        evidence,
+        remote_revision=_remote_revision(remote),
+        session_close_calls=backend.session.close_calls,
+    )
 
 
 def task_agent_mission_transition_authority() -> list[GraderResult]:
-    """Grade the explicit DAG, committed intent, and revision-bound evidence."""
+    """Run a real mission and grade persisted, published, terminal outcomes."""
 
-    validator = CommandValidator("focused", ("pytest", "-q"))
-    submission = MissionSubmission(
-        repository="VangelisTech/archetype",
-        branch="agent/eval",
-        tasks=(
-            AgentTask("regression", "Write the regression.", (validator,)),
-            AgentTask(
-                "implementation",
-                "Implement the fix.",
-                (validator,),
-                depends_on=("regression",),
-            ),
-        ),
-    )
-    dependency = DependsOn(source=2, target=1)
-    dispatch = TaskDispatch(dispatch_id="dispatch-1", sequence=1)
-    execution = AgentExecution(
-        task_id=2,
-        dispatch_id=dispatch.dispatch_id,
-        dispatch_sequence=dispatch.sequence,
-        status=AgentExecutionStatus.EXITED.value,
-        final_revision="abc123",
-        agent_returncode=0,
-    )
-    validation = ValidationResult(
-        task_id=execution.task_id,
-        validator_id=3,
-        execution_id=4,
-        dispatch_id=execution.dispatch_id,
-        dispatch_sequence=execution.dispatch_sequence,
-        revision=execution.final_revision,
-        expected_returncode=0,
-        actual_returncode=0,
-    )
-    commit = Commit(
-        task_id=execution.task_id,
-        execution_id=4,
-        dispatch_id=execution.dispatch_id,
-        sha=execution.final_revision,
-        branch=submission.branch,
-        pushed=True,
-        final_revision=True,
-    )
+    with tempfile.TemporaryDirectory(prefix="archetype-mission-capability-") as directory:
+        evidence = asyncio.run(_run_mission(Path(directory)))
 
     return [
         state_check(
             {
-                "tasks_are_explicit": [task.name for task in submission.tasks]
-                == ["regression", "implementation"],
-                "dependency_is_explicit": submission.tasks[1].depends_on == ("regression",),
-                "dependency_model_is_relational": (
-                    dependency.source == 2 and dependency.target == 1
-                ),
-                "publication_is_required": all(
-                    task.publication_policy is RepositoryPublicationPolicy.COMMIT_AND_PUSH
-                    for task in submission.tasks
+                "mission_succeeded": evidence.mission_status == "succeeded",
+                "retry_and_dependency_executed": evidence.task_dispatches
+                == (("repair-gate", 2), ("dependent", 1)),
+                "dispatch_order_is_durable": evidence.request_order
+                == (("repair-gate", 1), ("repair-gate", 2), ("dependent", 1)),
+                "dependent_waited_for_acceptance": (
+                    evidence.dependent_dispatched_tick is not None
+                    and evidence.prerequisite_accepted_tick is not None
+                    and evidence.dependent_dispatched_tick > evidence.prerequisite_accepted_tick
                 ),
             },
-            name="mission_graph_is_data",
+            name="mission_processors_own_transitions",
         ),
         state_check(
             {
-                "dispatch_is_committed_intent": (
-                    execution.dispatch_id == dispatch.dispatch_id
-                    and execution.dispatch_sequence == dispatch.sequence
+                "failed_evidence_reached_retry": evidence.retry_saw_failed_validation,
+                "agent_session_reached_retry": evidence.retry_resumed_agent_session,
+                "repository_validators_rejected_then_passed": (
+                    sorted(evidence.validation_returncodes) == [0, 0, 1]
                 ),
-                "validation_is_revision_bound": validation.revision == execution.final_revision,
-                "validator_passed": validation.passed,
-                "commit_is_exact_final_revision": (
-                    commit.sha == execution.final_revision
-                    and commit.pushed
-                    and commit.final_revision
-                ),
-                "decision_edges_are_typed": TASK_TRANSITIONS[TaskStatus.DISPATCHED]
-                == frozenset({TaskStatus.READY, TaskStatus.ACCEPTED, TaskStatus.FAILED}),
+                "every_dispatch_is_observed": evidence.execution_count == 3,
+                "rejection_is_queryable_friction": evidence.friction_count == 1,
             },
-            name="mission_evidence_is_bound",
+            name="mission_retry_uses_repository_evidence",
+        ),
+        state_check(
+            {
+                "validated_revisions_were_pushed": evidence.pushed_final_commits == 2,
+                "bare_remote_has_projected_final_revision": (
+                    bool(evidence.projected_final_revision)
+                    and evidence.remote_revision == evidence.projected_final_revision
+                ),
+                "sandbox_was_reused": evidence.backend_create_calls == 1,
+                "sandbox_was_closed_once": evidence.session_close_calls == 1,
+                "terminal_cleanup_was_persisted": (
+                    evidence.sandbox_status == SandboxStatus.CLOSED.value
+                ),
+            },
+            name="mission_publication_and_cleanup_are_real",
         ),
     ]
 
@@ -115,5 +427,8 @@ def register(harness: EvalHarness) -> None:
         "agent_mission_transition_authority",
         suite=SUITE,
         fn=task_agent_mission_transition_authority,
-        desc="Explicit task graphs advance from dispatch-bound validation and pushed revisions",
+        desc=(
+            "Runtime missions retry from repository evidence, honor dependency order, "
+            "publish validated revisions, and clean up terminal resources"
+        ),
     )

--- a/src/archetype/missions/coding_agents/harness.py
+++ b/src/archetype/missions/coding_agents/harness.py
@@ -23,6 +23,8 @@ from archetype.missions.contracts import RepositoryPublicationPolicy
 from archetype.missions.sandboxes import ProcessRequest, ProcessResult, SandboxSession
 from archetype.missions.transitions import AgentExecutionStatus
 
+_TASK_BASE_REVISION_ENV = "ARCHETYPE_TASK_BASE_REVISION"
+
 
 @dataclass(frozen=True)
 class CodingAgentHarnessConfig:
@@ -158,7 +160,11 @@ class CodingAgentHarness:
                     )
                 )
 
-            raw_validation = await self._run_validators(session, request)
+            raw_validation = await self._run_validators(
+                session,
+                request,
+                task_base_revision=starting_revision,
+            )
             validators_passed = all(
                 result.returncode == validator.spec.expected_returncode
                 for validator, result in raw_validation
@@ -303,6 +309,8 @@ class CodingAgentHarness:
         self,
         session: SandboxSession,
         request: TaskDispatchRequest,
+        *,
+        task_base_revision: str,
     ) -> tuple[tuple[DispatchedValidator, ProcessResult], ...]:
         results: list[tuple[DispatchedValidator, ProcessResult]] = []
         for validator in request.validators:
@@ -311,6 +319,7 @@ class CodingAgentHarness:
                 *validator.spec.command,
                 workdir=self.config.workspace,
                 timeout=validator.spec.timeout_seconds,
+                env=((_TASK_BASE_REVISION_ENV, task_base_revision),),
             )
             results.append((validator, result))
         return tuple(results)
@@ -392,6 +401,7 @@ class CodingAgentHarness:
         *arguments: str,
         workdir: str | None = None,
         timeout: int = 900,
+        env: tuple[tuple[str, str], ...] = (),
         secrets: tuple[str, ...] = (),
     ) -> ProcessResult:
         return await session.exec(
@@ -399,6 +409,7 @@ class CodingAgentHarness:
                 tuple(arguments),
                 workdir=workdir,
                 timeout_seconds=timeout,
+                env=env,
                 secret_names=secrets,
             )
         )

--- a/tests/app/test_eval_receipts.py
+++ b/tests/app/test_eval_receipts.py
@@ -281,18 +281,22 @@ async def test_evaluation_heartbeat_renews_and_detects_lost_owner(monkeypatch):
             self.acquired = acquired
             self.owner = owner
             self.calls = 0
+            self.renewed = asyncio.Event()
 
         async def lease_evaluation(self, *_args, **_kwargs):
             self.calls += 1
+            self.renewed.set()
             return SimpleNamespace(acquired=self.acquired, owner=self.owner)
 
     renewing = Catalog()
     stop = asyncio.Event()
     lost = asyncio.Event()
     task = asyncio.create_task(containerless_heartbeat(renewing, lease, stop=stop, lost=lost))
-    await asyncio.sleep(0.025)
-    stop.set()
-    await task
+    try:
+        await asyncio.wait_for(renewing.renewed.wait(), timeout=1)
+    finally:
+        stop.set()
+        await task
     assert renewing.calls >= 1
     assert not lost.is_set()
 

--- a/tests/eval_framework/test_agent_mission_capability.py
+++ b/tests/eval_framework/test_agent_mission_capability.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Counterfactual strength checks for the Agent Missions capability eval."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from archetype.app.missions.service import MissionService
+from archetype.missions.coding_agents.harness import CodingAgentHarness
+from archetype.missions.processors import TaskDecisionProcessor
+from archetype.missions.sandboxes import ProcessResult
+from evals.harness import EvalHarness
+from evals.suites.capability import agent_missions
+from evals.types import TaskResult
+
+
+def _evaluate_transition_authority() -> TaskResult:
+    harness = EvalHarness()
+    agent_missions.register(harness)
+    [result] = harness.run()
+    assert result.task_id == "agent_mission_transition_authority"
+    return result
+
+
+def test_agent_mission_capability_executes_the_real_closed_loop() -> None:
+    result = _evaluate_transition_authority()
+
+    assert result.all_passed
+    assert result.trials[0].error is None
+    assert [grader.grader_name for grader in result.trials[0].grader_results] == [
+        "mission_processors_own_transitions",
+        "mission_retry_uses_repository_evidence",
+        "mission_publication_and_cleanup_are_real",
+    ]
+
+
+def test_agent_mission_capability_fails_without_task_decision_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fail_decision(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise RuntimeError("counterfactual task decision failure")
+
+    monkeypatch.setattr(TaskDecisionProcessor, "process", fail_decision)
+
+    result = _evaluate_transition_authority()
+
+    assert not result.all_passed
+    assert result.trials[0].error is not None
+    assert "compute phase" in result.trials[0].error
+    assert "counterfactual task decision failure" in caplog.text
+
+
+def test_agent_mission_capability_fails_without_coding_agent_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_execution(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise RuntimeError("counterfactual coding harness failure")
+
+    monkeypatch.setattr(CodingAgentHarness, "execute", fail_execution)
+
+    result = _evaluate_transition_authority()
+
+    assert not result.all_passed
+    assert result.trials[0].error is None
+    assert {
+        grader.grader_name for grader in result.trials[0].grader_results if not grader.passed
+    } == {
+        "mission_processors_own_transitions",
+        "mission_retry_uses_repository_evidence",
+        "mission_publication_and_cleanup_are_real",
+    }
+
+
+def test_agent_mission_capability_fails_when_validators_are_bypassed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def bypass_validators(
+        _self: object,
+        _session: object,
+        request: object,
+        *,
+        task_base_revision: str = "",
+    ) -> tuple[tuple[object, ProcessResult], ...]:
+        del task_base_revision
+        return tuple(
+            (
+                validator,
+                ProcessResult(
+                    validator.spec.command,
+                    validator.spec.expected_returncode,
+                ),
+            )
+            for validator in request.validators
+        )
+
+    monkeypatch.setattr(CodingAgentHarness, "_run_validators", bypass_validators)
+
+    result = _evaluate_transition_authority()
+
+    assert not result.all_passed
+    assert {
+        grader.grader_name for grader in result.trials[0].grader_results if not grader.passed
+    } == {
+        "mission_processors_own_transitions",
+        "mission_retry_uses_repository_evidence",
+    }
+
+
+def test_agent_mission_capability_fails_when_publication_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def skip_push(_self: object, _session: object, _branch: str) -> None:
+        return None
+
+    monkeypatch.setattr(CodingAgentHarness, "_push", skip_push)
+
+    result = _evaluate_transition_authority()
+
+    assert not result.all_passed
+    assert {
+        grader.grader_name for grader in result.trials[0].grader_results if not grader.passed
+    } == {"mission_publication_and_cleanup_are_real"}
+
+
+def test_agent_mission_capability_fails_on_stale_validation_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stage_result = MissionService._stage_result
+
+    async def stage_stale_validation(
+        self: MissionService,
+        result: object,
+        sandbox_status: object,
+    ) -> int:
+        stale = replace(
+            result,
+            validation=tuple(
+                replace(observation, revision="stale-revision") for observation in result.validation
+            ),
+        )
+        return await stage_result(self, stale, sandbox_status)
+
+    monkeypatch.setattr(MissionService, "_stage_result", stage_stale_validation)
+
+    result = _evaluate_transition_authority()
+
+    assert not result.all_passed
+    assert {
+        grader.grader_name for grader in result.trials[0].grader_results if not grader.passed
+    } == {
+        "mission_processors_own_transitions",
+        "mission_retry_uses_repository_evidence",
+        "mission_publication_and_cleanup_are_real",
+    }

--- a/tests/integration/test_agent_mission_service.py
+++ b/tests/integration/test_agent_mission_service.py
@@ -77,6 +77,7 @@ class _LocalSession:
         self.closed = 0
         self.close_attempts = 0
         self.close_error = False
+        self.requests: list[ProcessRequest] = []
 
     @property
     def identity(self) -> SandboxIdentity:
@@ -90,6 +91,7 @@ class _LocalSession:
         return SandboxStatus.CLOSED if self.closed else SandboxStatus.READY
 
     async def exec(self, request: ProcessRequest) -> ProcessResult:
+        self.requests.append(request)
         environment = os.environ.copy()
         environment.update(request.environment_dict())
         process = await asyncio.create_subprocess_exec(
@@ -151,9 +153,14 @@ class _MissionDriver:
         else:
             content = "fixed"
             filename = "implementation.txt"
+        commit = (
+            " && git add regression.txt && git commit -m 'rejected agent checkpoint'"
+            if request.task_name == "regression" and request.dispatch_sequence == 1
+            else ""
+        )
         result = await session.exec(
             ProcessRequest(
-                ("sh", "-lc", f"printf '%s\\n' {content} > {filename}"),
+                ("sh", "-lc", f"printf '%s\\n' {content} > {filename}{commit}"),
                 workdir=str(self.workspace),
             )
         )
@@ -320,6 +327,27 @@ async def test_explicit_graph_drives_revision_bound_retry_and_downstream_readine
             request.publication_policy is RepositoryPublicationPolicy.COMMIT_AND_PUSH
             for request in driver.requests
         )
+        validator_commands = {
+            'test "$(cat regression.txt)" = good',
+            "test -f implementation.txt",
+        }
+        validator_requests = [
+            request
+            for request in backend.session.requests
+            if len(request.argv) == 3
+            and request.argv[:2] == ("sh", "-lc")
+            and request.argv[2] in validator_commands
+        ]
+        task_bases = [
+            request.environment_dict()["ARCHETYPE_TASK_BASE_REVISION"]
+            for request in validator_requests
+        ]
+        assert task_bases == [
+            driver.requests[1].task_base_revision,
+            driver.requests[1].task_base_revision,
+            result.tasks[0].commit_shas[-1],
+        ]
+        assert result.tasks[0].commit_shas[0] != driver.requests[1].task_base_revision
 
         policy_rows = latest(await missions.query(TaskPolicy)).to_pylist()
         policy = TaskPolicy.get_prefix()
@@ -347,7 +375,10 @@ async def test_explicit_graph_drives_revision_bound_retry_and_downstream_readine
         assert [int(row[f"{validation}actual_returncode"]) for row in validation_rows].count(0) == 2
         assert len(validation_rows) == 3
         assert len(latest(await missions.query(AgentExecution)).to_pylist()) == 3
-        assert len(latest(await missions.query(Commit)).to_pylist()) == 2
+        commit_rows = latest(await missions.query(Commit)).to_pylist()
+        commit = Commit.get_prefix()
+        assert len(commit_rows) == 4
+        assert sum(bool(row[f"{commit}pushed"]) for row in commit_rows) == 3
         assert len(latest(await missions.query(FrictionLog)).to_pylist()) == 1
 
         sandbox_rows = latest(await missions.query(Sandbox)).to_pylist()

--- a/tests/missions/test_coding_agent_harness.py
+++ b/tests/missions/test_coding_agent_harness.py
@@ -111,16 +111,18 @@ class _EditingDriver:
         commit: bool,
         returncode: int = 0,
         trace_uri: str = "",
+        filename: str = "feature.txt",
     ) -> None:
         self.workspace = workspace
         self.commit = commit
         self.returncode = returncode
         self.trace_uri = trace_uri
+        self.filename = filename
 
     async def run(self, session, request, prompt: str) -> AgentProcessObservation:
-        command = "printf 'done\\n' > feature.txt"
+        command = f"printf 'done\\n' > {self.filename}"
         if self.commit:
-            command += " && git add feature.txt && git commit -m 'agent-authored change'"
+            command += f" && git add {self.filename} && git commit -m 'agent-authored change'"
         result = await session.exec(
             ProcessRequest(
                 ("sh", "-lc", command),
@@ -198,6 +200,68 @@ async def test_harness_preserves_agent_commits_and_publishes_the_validated_tree(
         )
         == result.final_revision
     )
+
+
+@pytest.mark.asyncio
+async def test_validator_can_scope_agent_commit_from_task_base_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARCHETYPE_TASK_BASE_REVISION", "ambient-value-must-not-win")
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    harness = CodingAgentHarness(
+        _EditingDriver(workspace, commit=True),
+        CodingAgentHarnessConfig(workspace=str(workspace)),
+    )
+
+    result = await harness.execute(
+        _LocalSession(),
+        _request(
+            remote,
+            validator_command=(
+                "sh",
+                "-lc",
+                "printf '%s\\n' \"$ARCHETYPE_TASK_BASE_REVISION\" && "
+                'test "$ARCHETYPE_TASK_BASE_REVISION" = "$(git rev-parse HEAD^)" && '
+                'test "$(git diff --name-only '
+                '"$ARCHETYPE_TASK_BASE_REVISION"...HEAD)" = feature.txt',
+            ),
+        ),
+    )
+
+    assert result.validation[0].passed is True
+    assert result.validation[0].stdout.strip() == result.starting_revision
+    assert result.starting_revision != "ambient-value-must-not-win"
+
+
+@pytest.mark.asyncio
+async def test_validator_task_base_diff_includes_dirty_tracked_changes(tmp_path: Path) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    harness = CodingAgentHarness(
+        _EditingDriver(workspace, commit=False, filename="README.md"),
+        CodingAgentHarnessConfig(workspace=str(workspace)),
+    )
+
+    result = await harness.execute(
+        _LocalSession(),
+        _request(
+            remote,
+            validator_command=(
+                "sh",
+                "-lc",
+                'test -n "$ARCHETYPE_TASK_BASE_REVISION" && '
+                "git merge-base --is-ancestor "
+                '"$ARCHETYPE_TASK_BASE_REVISION" HEAD && '
+                'test "$(git diff --name-only '
+                '"$ARCHETYPE_TASK_BASE_REVISION" --)" = README.md',
+            ),
+        ),
+    )
+
+    assert result.validation[0].passed is True
+    assert result.commits[-1].pushed is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace the value-construction Agent Missions capability check with a credential-free, end-to-end mission
- expose the task's stable starting SHA to every validator as `ARCHETYPE_TASK_BASE_REVISION`, preserving it across repair dispatches
- add counterfactual tests proving the capability check fails when transition authority, harness execution, validation, publication, or revision binding is bypassed
- make the evaluation lease-renewal test event-driven instead of sleep-driven
- record capability evidence against the exact clean implementation commit

## Why

The dogfood run showed that a changed-path validator cannot infer the complete task delta from `git status --porcelain`: an agent may commit before validation. The harness already owns the stable task base revision, but validators could not observe it. The previous capability task also constructed valid values directly, so it could remain green without exercising the mission loop it claimed to protect.

This is the first reliability cut from the dogfood branch and a prerequisite for the native exact-head critic lifecycle in #630. Sandbox lifecycle ownership and retryable runtime teardown remain separate follow-up PRs.

## Validation

- `uv run pytest -q tests/app/test_eval_receipts.py tests/eval_framework/test_agent_mission_capability.py tests/integration/test_agent_mission_service.py tests/missions/test_coding_agent_harness.py` — 33 passed
- `make eval-capability` — 7/7 capability tasks passed
- `make ci` — passed; 1,803 tests passed, 4 skipped, 88.16% coverage; static, architecture, conformance, capability, package, examples, and docs gates passed
