### PR TITLE
fix(missions): preserve sandbox cleanup ownership

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -344,6 +344,23 @@ class SandboxService:
 - Service selects a backend, reuses sessions according to policy, and owns
   shutdown.
 
+Execution and checkpoint capabilities require a `READY` session. An
+`ERRORED` or `INTERRUPTED` handle cannot run more work or capture another
+checkpoint. The service keeps it registered until teardown succeeds: a later
+acquisition may close and replace it, while a teardown failure retains the
+handle for explicit restore or close retry instead of silently evicting a
+possibly live provider resource. Close is single-flight per sandbox key and
+continues if its caller is cancelled; concurrent acquisition waits for that
+teardown and never receives the closing handle. A provider session returned
+while shutdown is winning the race remains cleanup-owned until close succeeds,
+and failed shutdown cleanup is reported and retryable.
+
+Durable lifecycle evidence follows physical ownership. A failed terminal close
+projects the retained session's non-ready status and a `sandbox_teardown`
+friction before the error returns. Once replacement or cleanup has closed a
+sandbox, staging an earlier same-tick execution cannot move its durable status
+backward from `closed`.
+
 The coding-agent harness works through `SandboxSession`. It owns clone and
 branch preparation, agent invocation, validator execution, Git publication,
 and translation into factual Components. Provider adapters do not know task
@@ -402,10 +419,13 @@ and exposes the provider identity as soon as acquisition completes, while
 `ModalSandboxSession.monitor("sb-...")` can attach from another process with
 byte-offset reads and bounded disconnect recovery. Each successfully captured
 agent invocation is also copied to an execution-scoped spool path; only that
-per-call success returns the `trace_uri` persisted on `AgentExecution`. A
-failed best-effort trace setup leaves `trace_uri` empty instead of advertising
-a missing or stale file. The authoritative ECS copy of execution and validator
-output is bounded and redacted before persistence.
+per-call success returns the exact `trace_uri` persisted on `AgentExecution`;
+static live-output capability alone never proves a trace exists. A failed
+best-effort trace setup leaves the URI empty instead of advertising a missing
+or stale file. Raw trace URIs are ephemeral operational evidence: checkpoint
+sanitization or teardown can make them unavailable, and snapshots remove both
+current and execution-scoped raw output. The authoritative ECS copy of execution
+and validator output is bounded and redacted before persistence.
 Provider-native snapshots are recovery objects, not portable or sanitized
 artifact bundles. The consolidated `ArtifactService` accepts explicit file
 sources, but V1 intentionally does not crawl or publish arbitrary sandbox

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -754,6 +755,23 @@ class MissionService:
         retained = self._sandbox_entities.get(identity.sandbox_id)
         if retained is not None:
             entity_id, sandbox_state = retained
+            if sandbox_state.status == SandboxStatus.CLOSED.value:
+                # Deferred observations may arrive after another request has
+                # replaced and closed this session. Preserve terminal evidence;
+                # only fill a previously empty error with the late observation.
+                if not sandbox_state.error and error:
+                    updated = sandbox_state.model_copy(
+                        update={
+                            "error": self._redact_and_tail(
+                                error,
+                                limit=4_000,
+                                scope=f"mission:{mission_id}:sandbox-error",
+                            )
+                        }
+                    )
+                    await self._world.update(entity_id, updated)
+                    self._sandbox_entities[identity.sandbox_id] = (entity_id, updated)
+                return entity_id
             if sandbox_state.status != status.value or sandbox_state.error:
                 updated = sandbox_state.model_copy(
                     update={
@@ -791,6 +809,12 @@ class MissionService:
         sandbox_id = self._mission_sandboxes.get(mission_id)
         try:
             await self._sandboxes.close(key)
+        except asyncio.CancelledError:
+            # SandboxService.close() shields provider teardown. Caller
+            # cancellation is not evidence that the provider cleanup failed;
+            # a later run or service shutdown reconciles the retained entity
+            # with the single-flight close result.
+            raise
         except BaseException as exc:
             if sandbox_id is not None:
                 await self._record_sandbox_teardown_failure(

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -20,6 +20,7 @@ from archetype.core.hooks import PostTick
 from archetype.graph import GraphView
 from archetype.missions.coding_agents.contracts import (
     AgentExecutionResult,
+    FrictionObservation,
     TaskDispatchRequest,
 )
 from archetype.missions.coding_agents.harness import (
@@ -84,6 +85,7 @@ class _ExecutionEnvelope:
     result: AgentExecutionResult
     sandbox_status: SandboxStatus
     session: SandboxSession | None
+    bind_mission: bool = True
 
 
 @dataclass(frozen=True)
@@ -329,6 +331,7 @@ class MissionService:
                 execution_id = await self._stage_result(
                     envelope.result,
                     envelope.sandbox_status,
+                    bind_mission=envelope.bind_mission,
                 )
                 if (
                     self._checkpoint_after_dispatch
@@ -385,11 +388,22 @@ class MissionService:
 
     async def close(self) -> None:
         failures: list[BaseException] = []
-        for close in (self._sandboxes.shutdown, self._world.shutdown):
-            try:
-                await close()
-            except BaseException as exc:
-                failures.append(exc)
+        sandbox_failure: BaseException | None = None
+        try:
+            await self._sandboxes.shutdown()
+        except BaseException as exc:
+            sandbox_failure = exc
+            failures.append(exc)
+
+        try:
+            await self._reconcile_sandboxes_after_shutdown(sandbox_failure)
+        except BaseException as exc:
+            failures.append(exc)
+
+        try:
+            await self._world.shutdown()
+        except BaseException as exc:
+            failures.append(exc)
         if failures:
             raise BaseExceptionGroup(
                 f"Agent Missions shutdown failed for {len(failures)} operation(s)",
@@ -416,8 +430,16 @@ class MissionService:
             key = SandboxKey(f"mission:{request.mission_id}")
             spec = self._sandbox_spec(request.mission_id, request.branch)
             session: SandboxSession | None = None
+            previous_sandbox_id = self._mission_sandboxes.get(request.mission_id)
+            bind_mission = True
             try:
                 session = await self._sandboxes.acquire(key, spec)
+                if (
+                    previous_sandbox_id is not None
+                    and previous_sandbox_id != session.identity.sandbox_id
+                    and previous_sandbox_id in self._sandbox_entities
+                ):
+                    await self._mark_sandbox_closed(previous_sandbox_id)
                 await self._ensure_sandbox_entity(
                     request.mission_id,
                     session.identity,
@@ -437,23 +459,63 @@ class MissionService:
                     operation="coding-agent",
                     returncode=result.agent_returncode,
                 )
-            except Exception as exc:
+            except SandboxTeardownError as exc:
                 sandbox_status = SandboxStatus.ERRORED
+                bind_mission = False
+                if exc.identity.sandbox_id in self._sandbox_entities:
+                    await self._mark_sandbox_errored(exc.identity.sandbox_id, exc)
+                error = f"{type(exc).__name__}: {exc}"
                 result = AgentExecutionResult(
                     mission_id=request.mission_id,
                     task_id=request.task_id,
                     dispatch_id=request.dispatch_id,
                     dispatch_sequence=request.dispatch_sequence,
                     status=AgentExecutionStatus.ERRORED,
-                    sandbox=(
-                        session.identity
-                        if session is not None
-                        else SandboxIdentity(
-                            self._sandbox_provider,
-                            f"unavailable-{request.dispatch_id}",
-                            self._sandbox_environment,
-                        )
+                    sandbox=exc.identity,
+                    worktree=self._workspace,
+                    agent_session_id="",
+                    agent_returncode=-1,
+                    starting_revision=request.task_base_revision,
+                    final_revision="",
+                    friction=(
+                        FrictionObservation(
+                            kind="sandbox_teardown",
+                            message=error,
+                        ),
                     ),
+                    error=error,
+                )
+            except Exception as exc:
+                sandbox_status = SandboxStatus.ERRORED
+                retained = self._sandboxes.session(key)
+                if session is None and previous_sandbox_id is not None:
+                    replaced_is_gone = retained is None or (
+                        retained.identity.sandbox_id != previous_sandbox_id
+                    )
+                    if replaced_is_gone:
+                        if previous_sandbox_id in self._sandbox_entities:
+                            await self._mark_sandbox_closed(previous_sandbox_id)
+                        if self._mission_sandboxes.get(request.mission_id) == previous_sandbox_id:
+                            self._mission_sandboxes.pop(request.mission_id, None)
+                failed_identity = (
+                    session.identity
+                    if session is not None
+                    else retained.identity
+                    if retained is not None
+                    else SandboxIdentity(
+                        self._sandbox_provider,
+                        f"unavailable-{request.dispatch_id}",
+                        self._sandbox_environment,
+                    )
+                )
+                bind_mission = session is not None or retained is not None
+                result = AgentExecutionResult(
+                    mission_id=request.mission_id,
+                    task_id=request.task_id,
+                    dispatch_id=request.dispatch_id,
+                    dispatch_sequence=request.dispatch_sequence,
+                    status=AgentExecutionStatus.ERRORED,
+                    sandbox=failed_identity,
                     worktree=self._workspace,
                     agent_session_id="",
                     agent_returncode=-1,
@@ -461,13 +523,22 @@ class MissionService:
                     final_revision="",
                     error=f"{type(exc).__name__}: {exc}",
                 )
-            results.append(_ExecutionEnvelope(result, sandbox_status, session))
+            results.append(
+                _ExecutionEnvelope(
+                    result,
+                    sandbox_status,
+                    session,
+                    bind_mission=bind_mission,
+                )
+            )
         return tuple(results)
 
     async def _stage_result(
         self,
         result: AgentExecutionResult,
         sandbox_status: SandboxStatus,
+        *,
+        bind_mission: bool,
     ) -> int:
         retained_sandbox = self._sandbox_entities.get(result.sandbox.sandbox_id)
         if retained_sandbox is None:
@@ -476,17 +547,28 @@ class MissionService:
                 result.sandbox,
                 status=sandbox_status,
                 error=result.error if sandbox_status is SandboxStatus.ERRORED else "",
+                bind_mission=bind_mission,
             )
         else:
             sandbox_entity, sandbox_state = retained_sandbox
+            observed_error = self._redact_and_tail(
+                result.error if sandbox_status is SandboxStatus.ERRORED else "",
+                limit=4_000,
+                scope=f"mission:{result.mission_id}:sandbox-error",
+            )
+            if sandbox_state.status == SandboxStatus.CLOSED.value:
+                # A later request in the same execution batch may already have
+                # replaced and closed this session. Staging the earlier envelope
+                # must not move durable lifecycle evidence backwards.
+                updated_status = SandboxStatus.CLOSED.value
+                updated_error = sandbox_state.error or observed_error
+            else:
+                updated_status = sandbox_status.value
+                updated_error = observed_error
             updated = sandbox_state.model_copy(
                 update={
-                    "status": sandbox_status.value,
-                    "error": self._redact_and_tail(
-                        result.error if sandbox_status is SandboxStatus.ERRORED else "",
-                        limit=4_000,
-                        scope=f"mission:{result.mission_id}:sandbox-error",
-                    ),
+                    "status": updated_status,
+                    "error": updated_error,
                 }
             )
             if updated != sandbox_state:
@@ -616,6 +698,17 @@ class MissionService:
                 )
             )
             await self._world.spawn(ProducedBy(source=friction_id, target=candidate.execution_id))
+            try:
+                sandbox_status = await candidate.session.status()
+            except Exception:
+                sandbox_status = SandboxStatus.ERRORED
+            if sandbox_status is not SandboxStatus.READY:
+                await self._ensure_sandbox_entity(
+                    result.mission_id,
+                    identity,
+                    status=sandbox_status,
+                    error=checkpoint_error,
+                )
         else:
             self._emit_sandbox_event(
                 SandboxEventType.CHECKPOINT_FINISHED,
@@ -656,6 +749,7 @@ class MissionService:
         *,
         status: SandboxStatus,
         error: str = "",
+        bind_mission: bool = True,
     ) -> int:
         retained = self._sandbox_entities.get(identity.sandbox_id)
         if retained is not None:
@@ -688,27 +782,103 @@ class MissionService:
         )
         entity_id = await self._world.spawn(sandbox_state)
         self._sandbox_entities[identity.sandbox_id] = (entity_id, sandbox_state)
-        self._mission_sandboxes[mission_id] = identity.sandbox_id
+        if bind_mission:
+            self._mission_sandboxes[mission_id] = identity.sandbox_id
         return entity_id
 
     async def _close_mission_sandbox(self, mission_id: int) -> None:
-        await self._sandboxes.close(SandboxKey(f"mission:{mission_id}"))
+        key = SandboxKey(f"mission:{mission_id}")
         sandbox_id = self._mission_sandboxes.get(mission_id)
+        try:
+            await self._sandboxes.close(key)
+        except BaseException as exc:
+            if sandbox_id is not None:
+                await self._record_sandbox_teardown_failure(
+                    mission_id,
+                    sandbox_id,
+                    self._sandboxes.session(key),
+                    exc,
+                )
+                await self._world.step()
+            raise
         if sandbox_id is None:
             return
         await self._mark_sandbox_closed(sandbox_id)
 
-    async def _mark_sandbox_closed(self, sandbox_id: str) -> None:
+    async def _reconcile_sandboxes_after_shutdown(
+        self,
+        shutdown_failure: BaseException | None,
+    ) -> None:
+        if not self._mission_sandboxes:
+            return
+        changed = False
+        for mission_id, sandbox_id in tuple(self._mission_sandboxes.items()):
+            key = SandboxKey(f"mission:{mission_id}")
+            retained = self._sandboxes.session(key)
+            if retained is None:
+                changed = await self._mark_sandbox_closed(sandbox_id) or changed
+                continue
+            failure = shutdown_failure or RuntimeError("sandbox teardown remained incomplete")
+            await self._record_sandbox_teardown_failure(
+                mission_id,
+                sandbox_id,
+                retained,
+                failure,
+            )
+            changed = True
+        if changed:
+            await self._world.step()
+
+    async def _record_sandbox_teardown_failure(
+        self,
+        mission_id: int,
+        sandbox_id: str,
+        session: SandboxSession | None,
+        exc: BaseException,
+    ) -> None:
+        status = SandboxStatus.ERRORED
+        if session is not None:
+            try:
+                observed_status = await session.status()
+            except BaseException:
+                pass
+            else:
+                if observed_status is not SandboxStatus.READY:
+                    status = observed_status
+        await self._mark_sandbox_failed(sandbox_id, status, exc)
+        await self._world.spawn(
+            FrictionLog(
+                kind="sandbox_teardown",
+                message=self._redact_and_tail(
+                    f"{type(exc).__name__}: {exc}",
+                    limit=4_000,
+                    scope=f"mission:{mission_id}:sandbox-teardown",
+                ),
+            )
+        )
+
+    async def _mark_sandbox_closed(self, sandbox_id: str) -> bool:
         entity_id, sandbox_state = self._sandbox_entities[sandbox_id]
+        if sandbox_state.status == SandboxStatus.CLOSED.value:
+            return False
         closed = sandbox_state.model_copy(update={"status": SandboxStatus.CLOSED.value})
         await self._world.update(entity_id, closed)
         self._sandbox_entities[sandbox_id] = (entity_id, closed)
+        return True
 
     async def _mark_sandbox_errored(self, sandbox_id: str, exc: BaseException) -> None:
+        await self._mark_sandbox_failed(sandbox_id, SandboxStatus.ERRORED, exc)
+
+    async def _mark_sandbox_failed(
+        self,
+        sandbox_id: str,
+        status: SandboxStatus,
+        exc: BaseException,
+    ) -> None:
         entity_id, sandbox_state = self._sandbox_entities[sandbox_id]
         errored = sandbox_state.model_copy(
             update={
-                "status": SandboxStatus.ERRORED.value,
+                "status": status.value,
                 "error": self._redact_and_tail(
                     f"{type(exc).__name__}: {exc}",
                     limit=4_000,

--- a/src/archetype/missions/sandboxes/_image.py
+++ b/src/archetype/missions/sandboxes/_image.py
@@ -132,7 +132,7 @@ async def verify_coding_agent_environment(
     for name, request in requests.items():
         result = await session.exec(request)
         if result.returncode != 0:
-            detail = (result.stderr or result.stdout)[-1000:]
+            detail = result.stderr or result.stdout
             raise RuntimeError(
                 f"sandbox environment probe {name} failed with "
                 f"exit code {result.returncode}: {detail}"

--- a/src/archetype/missions/sandboxes/apple_container.py
+++ b/src/archetype/missions/sandboxes/apple_container.py
@@ -377,7 +377,7 @@ class AppleContainerSandboxSession:
     @staticmethod
     def _raise(result: ProcessResult, label: str) -> None:
         if result.returncode != 0:
-            detail = (result.stderr or result.stdout)[-4000:]
+            detail = result.stderr or result.stdout
             raise RuntimeError(f"{label} failed with exit code {result.returncode}: {detail}")
 
 

--- a/src/archetype/missions/sandboxes/docker.py
+++ b/src/archetype/missions/sandboxes/docker.py
@@ -340,7 +340,7 @@ class DockerSandboxSession:
     @staticmethod
     def _raise(result: ProcessResult, label: str) -> None:
         if result.returncode != 0:
-            detail = (result.stderr or result.stdout)[-4000:]
+            detail = result.stderr or result.stdout
             raise RuntimeError(f"{label} failed with exit code {result.returncode}: {detail}")
 
 

--- a/src/archetype/missions/sandboxes/modal.py
+++ b/src/archetype/missions/sandboxes/modal.py
@@ -249,8 +249,8 @@ class ModalSandboxSession:
             except Exception:
                 pass
             await self._emit_event_best_effort(SandboxEventType.CHECKPOINT_STARTED)
-            await self._scrub_live_output()
             try:
+                await self._scrub_live_output()
                 image = await self._sandbox.snapshot_filesystem.aio(
                     timeout=self._checkpoint_timeout_seconds,
                     ttl=self._checkpoint_ttl_seconds,
@@ -659,7 +659,7 @@ class ModalSandboxSession:
     @staticmethod
     def _raise(result: ProcessResult, label: str) -> None:
         if result.returncode != 0:
-            detail = (result.stderr or result.stdout)[-4000:]
+            detail = result.stderr or result.stdout
             raise RuntimeError(f"{label} failed with exit code {result.returncode}: {detail}")
 
     @staticmethod

--- a/src/archetype/missions/sandboxes/service.py
+++ b/src/archetype/missions/sandboxes/service.py
@@ -35,7 +35,11 @@ class SandboxService:
             SandboxKey,
             tuple[SandboxSpec, CheckpointRef | None, asyncio.Task[SandboxSession]],
         ] = {}
+        self._closing: dict[SandboxKey, asyncio.Task[None]] = {}
+        self._cleanup_sessions: dict[int, SandboxSession] = {}
+        self._lifecycle_generations: dict[SandboxKey, int] = {}
         self._lock = asyncio.Lock()
+        self._shutdown_lock = asyncio.Lock()
         self._accepting = True
         for backend in backends:
             self.register_backend(backend)
@@ -72,33 +76,44 @@ class SandboxService:
         """Explicitly replace a retained session or restore an absent key."""
 
         validate_checkpoint_for_spec(checkpoint, spec)
-        async with self._lock:
-            if not self._accepting:
-                raise RuntimeError("SandboxService is shutting down")
-            pending_entry = self._pending.get(key)
-            if pending_entry is not None:
-                pending_spec, pending_checkpoint, pending = pending_entry
-                if (pending_spec, pending_checkpoint) != (spec, checkpoint):
-                    raise ValueError(
-                        f"sandbox key {key.value!r} is already pending with another spec"
-                    )
-            else:
-                retained = self._sessions.get(key)
-                if retained is not None:
-                    retained_spec, replaced = retained
-                    if retained_spec != spec:
-                        raise ValueError(
-                            f"sandbox key {key.value!r} is already bound to another spec"
+        while True:
+            async with self._lock:
+                if not self._accepting:
+                    raise RuntimeError("SandboxService is shutting down")
+                closing = self._closing.get(key)
+                if closing is None:
+                    pending_entry = self._pending.get(key)
+                    if pending_entry is not None:
+                        pending_spec, pending_checkpoint, pending = pending_entry
+                        if (pending_spec, pending_checkpoint) != (spec, checkpoint):
+                            raise ValueError(
+                                f"sandbox key {key.value!r} is already pending with another spec"
+                            )
+                    else:
+                        retained = self._sessions.get(key)
+                        if retained is not None:
+                            retained_spec, replaced = retained
+                            if retained_spec != spec:
+                                raise ValueError(
+                                    f"sandbox key {key.value!r} is already bound to another spec"
+                                )
+                        else:
+                            replaced = None
+                        backend = self._backend(spec.provider)
+                        pending = self._schedule_create(
+                            key,
+                            spec,
+                            backend,
+                            checkpoint,
+                            replaced=replaced,
                         )
-                else:
-                    replaced = None
-                backend = self._backend(spec.provider)
-                pending = asyncio.create_task(
-                    self._create(key, spec, backend, checkpoint, replaced=replaced),
-                    name=f"sandbox-restore:{key.value}",
-                )
-                self._pending[key] = (spec, checkpoint, pending)
-        return await asyncio.shield(pending)
+            if closing is None:
+                session = await asyncio.shield(pending)
+                ready, closing = await self._is_current_ready(key, session)
+                if ready:
+                    return session
+            if closing is not None:
+                await asyncio.gather(asyncio.shield(closing), return_exceptions=True)
 
     async def _acquire(
         self,
@@ -107,40 +122,149 @@ class SandboxService:
         *,
         checkpoint: CheckpointRef | None,
     ) -> SandboxSession:
+        while True:
+            candidate: SandboxSession | None = None
+            candidate_generation: int | None = None
+            pending: asyncio.Task[SandboxSession] | None = None
+            async with self._lock:
+                if not self._accepting:
+                    raise RuntimeError("SandboxService is shutting down")
+                closing = self._closing.get(key)
+                if closing is None:
+                    pending_entry = self._pending.get(key)
+                    if pending_entry is not None:
+                        pending_spec, pending_checkpoint, pending = pending_entry
+                        if (pending_spec, pending_checkpoint) != (spec, checkpoint):
+                            raise ValueError(
+                                f"sandbox key {key.value!r} is already pending with another spec"
+                            )
+                    else:
+                        retained = self._sessions.get(key)
+                        replaced: SandboxSession | None = None
+                        if retained is not None:
+                            retained_spec, session = retained
+                            if retained_spec != spec:
+                                raise ValueError(
+                                    f"sandbox key {key.value!r} is already bound to another spec"
+                                )
+                            candidate = session
+                            candidate_generation = self._lifecycle_generations.get(key, 0)
+                        else:
+                            backend = self._backend(spec.provider)
+                            pending = self._schedule_create(
+                                key,
+                                spec,
+                                backend,
+                                checkpoint,
+                                replaced=replaced,
+                            )
+            if closing is not None:
+                await asyncio.gather(asyncio.shield(closing), return_exceptions=True)
+                continue
+            if candidate is not None:
+                status = await candidate.status()
+                async with self._lock:
+                    if not self._accepting:
+                        raise RuntimeError("SandboxService is shutting down")
+                    closing = self._closing.get(key)
+                    pending_entry = self._pending.get(key)
+                    retained = self._sessions.get(key)
+                    if (
+                        closing is None
+                        and pending_entry is None
+                        and retained is not None
+                        and retained[1] is candidate
+                        and self._lifecycle_generations.get(key, 0) == candidate_generation
+                    ):
+                        if status is SandboxStatus.READY:
+                            return candidate
+                        if status is SandboxStatus.CLOSED:
+                            self._sessions.pop(key, None)
+                            self._session_ids.pop(candidate.identity.sandbox_id, None)
+                            replaced = None
+                        else:
+                            replaced = candidate
+                        backend = self._backend(spec.provider)
+                        pending = self._schedule_create(
+                            key,
+                            spec,
+                            backend,
+                            checkpoint,
+                            replaced=replaced,
+                        )
+                if closing is not None:
+                    await asyncio.gather(asyncio.shield(closing), return_exceptions=True)
+                    continue
+                if pending is None:
+                    continue
+            if closing is None:
+                assert pending is not None
+                session = await asyncio.shield(pending)
+                ready, closing = await self._is_current_ready(key, session)
+                if ready:
+                    return session
+            if closing is not None:
+                await asyncio.gather(asyncio.shield(closing), return_exceptions=True)
+
+    def _schedule_create(
+        self,
+        key: SandboxKey,
+        spec: SandboxSpec,
+        backend: SandboxBackend,
+        checkpoint: CheckpointRef | None,
+        *,
+        replaced: SandboxSession | None,
+    ) -> asyncio.Task[SandboxSession]:
+        """Register one creator while the service registry lock is held."""
+
+        operation = "sandbox-restore" if checkpoint is not None else "sandbox"
+        pending = asyncio.create_task(
+            self._create(key, spec, backend, checkpoint, replaced=replaced),
+            name=f"{operation}:{key.value}",
+        )
+        pending.add_done_callback(self._consume_creator_result)
+        self._pending[key] = (spec, checkpoint, pending)
+        self._advance_lifecycle(key)
+        return pending
+
+    async def _is_current_ready(
+        self,
+        key: SandboxKey,
+        session: SandboxSession,
+    ) -> tuple[bool, asyncio.Task[None] | None]:
         async with self._lock:
             if not self._accepting:
                 raise RuntimeError("SandboxService is shutting down")
-            pending_entry = self._pending.get(key)
-            if pending_entry is not None:
-                pending_spec, pending_checkpoint, pending = pending_entry
-                if (pending_spec, pending_checkpoint) != (spec, checkpoint):
-                    raise ValueError(
-                        f"sandbox key {key.value!r} is already pending with another spec"
-                    )
-            else:
-                retained = self._sessions.get(key)
-                replaced: SandboxSession | None = None
-                if retained is not None:
-                    retained_spec, session = retained
-                    if retained_spec != spec:
-                        raise ValueError(
-                            f"sandbox key {key.value!r} is already bound to another spec"
-                        )
-                    status = await session.status()
-                    if status is SandboxStatus.READY:
-                        return session
-                    if status is SandboxStatus.CLOSED:
-                        self._sessions.pop(key, None)
-                        self._session_ids.pop(session.identity.sandbox_id, None)
-                    else:
-                        replaced = session
-                backend = self._backend(spec.provider)
-                pending = asyncio.create_task(
-                    self._create(key, spec, backend, checkpoint, replaced=replaced),
-                    name=f"sandbox:{key.value}",
-                )
-                self._pending[key] = (spec, checkpoint, pending)
-        return await asyncio.shield(pending)
+            closing = self._closing.get(key)
+            retained = self._sessions.get(key)
+            if (
+                closing is not None
+                or self._pending.get(key) is not None
+                or retained is None
+                or retained[1] is not session
+            ):
+                return False, closing
+            generation = self._lifecycle_generations.get(key, 0)
+
+        status = await session.status()
+
+        async with self._lock:
+            if not self._accepting:
+                raise RuntimeError("SandboxService is shutting down")
+            closing = self._closing.get(key)
+            retained = self._sessions.get(key)
+            ready = (
+                closing is None
+                and self._pending.get(key) is None
+                and retained is not None
+                and retained[1] is session
+                and self._lifecycle_generations.get(key, 0) == generation
+                and status is SandboxStatus.READY
+            )
+            return ready, closing
+
+    def _advance_lifecycle(self, key: SandboxKey) -> None:
+        self._lifecycle_generations[key] = self._lifecycle_generations.get(key, 0) + 1
 
     async def _create(
         self,
@@ -152,6 +276,9 @@ class SandboxService:
         replaced: SandboxSession | None = None,
     ) -> SandboxSession:
         session: SandboxSession | None = None
+        cleanup_id: int | None = None
+        cleanup_deferred = False
+        registered = False
         try:
             if replaced is not None:
                 try:
@@ -168,8 +295,13 @@ class SandboxService:
                 if checkpoint is None
                 else await backend.restore(spec, checkpoint)
             )
+            cleanup_id = id(session)
+            # Claim cleanup ownership before another await can cancel this
+            # creator or let shutdown observe an unowned provider handle.
+            self._cleanup_sessions[cleanup_id] = session
             async with self._lock:
                 if not self._accepting:
+                    cleanup_deferred = True
                     raise RuntimeError("SandboxService is shutting down")
                 sandbox_id = session.identity.sandbox_id
                 existing_key = self._session_ids.get(sandbox_id)
@@ -177,10 +309,17 @@ class SandboxService:
                     raise RuntimeError(f"duplicate live sandbox id: {sandbox_id}")
                 self._sessions[key] = (spec, session)
                 self._session_ids[sandbox_id] = key
+                self._cleanup_sessions.pop(cleanup_id, None)
+                registered = True
             return session
         except BaseException:
-            if session is not None:
+            if session is not None and not registered and not cleanup_deferred:
                 await session.close()
+                async with self._lock:
+                    if cleanup_id is not None:
+                        current = self._cleanup_sessions.get(cleanup_id)
+                        if current is session:
+                            self._cleanup_sessions.pop(cleanup_id, None)
             raise
         finally:
             async with self._lock:
@@ -199,37 +338,110 @@ class SandboxService:
         """Close and forget one live session; a missing key is a no-op."""
 
         async with self._lock:
-            retained = self._sessions.pop(key, None)
+            closing = self._closing.get(key)
+            if closing is None:
+                self._advance_lifecycle(key)
+                closing = asyncio.create_task(
+                    self._close_registered(key),
+                    name=f"sandbox-close:{key.value}",
+                )
+                closing.add_done_callback(self._consume_task_result)
+                self._closing[key] = closing
+        await asyncio.shield(closing)
+
+    async def _close_registered(self, key: SandboxKey) -> None:
+        try:
+            async with self._lock:
+                pending_entry = self._pending.get(key)
+            if pending_entry is not None:
+                await asyncio.gather(
+                    asyncio.shield(pending_entry[2]),
+                    return_exceptions=True,
+                )
+            async with self._lock:
+                retained = self._sessions.get(key)
             if retained is not None:
-                self._session_ids.pop(retained[1].identity.sandbox_id, None)
-        if retained is not None:
-            await retained[1].close()
+                await retained[1].close()
+                async with self._lock:
+                    current = self._sessions.get(key)
+                    if current is not None and current[1] is retained[1]:
+                        self._sessions.pop(key, None)
+                        self._session_ids.pop(retained[1].identity.sandbox_id, None)
+        finally:
+            async with self._lock:
+                current = asyncio.current_task()
+                if self._closing.get(key) is current:
+                    self._closing.pop(key, None)
 
     async def shutdown(self) -> None:
         """Stop acquisition, await creators, and attempt every session close."""
 
+        async with self._shutdown_lock:
+            await self._shutdown()
+
+    async def _shutdown(self) -> None:
         async with self._lock:
-            if not self._accepting and not self._sessions and not self._pending:
+            if (
+                not self._accepting
+                and not self._sessions
+                and not self._pending
+                and not self._closing
+                and not self._cleanup_sessions
+            ):
                 return
             self._accepting = False
             pending = tuple(entry[2] for entry in self._pending.values())
-        if pending:
+            closing = tuple(self._closing.values())
+        if pending or closing:
             await asyncio.gather(
-                *(asyncio.shield(task) for task in pending), return_exceptions=True
+                *(asyncio.shield(task) for task in (*pending, *closing)),
+                return_exceptions=True,
             )
         async with self._lock:
-            sessions = tuple(session for _, session in self._sessions.values())
-            self._sessions.clear()
-            self._session_ids.clear()
-        results = await asyncio.gather(
-            *(session.close() for session in sessions),
+            keys = tuple(self._sessions)
+            cleanup = tuple(self._cleanup_sessions.items())
+        registered_results = await asyncio.gather(
+            *(self.close(key) for key in keys),
             return_exceptions=True,
         )
-        failures = [result for result in results if isinstance(result, BaseException)]
+        cleanup_results = await asyncio.gather(
+            *(session.close() for _cleanup_id, session in cleanup),
+            return_exceptions=True,
+        )
+        async with self._lock:
+            for (cleanup_id, session), result in zip(
+                cleanup,
+                cleanup_results,
+                strict=True,
+            ):
+                if isinstance(result, BaseException):
+                    continue
+                current = self._cleanup_sessions.get(cleanup_id)
+                if current is session:
+                    self._cleanup_sessions.pop(cleanup_id, None)
+        failures = [
+            result
+            for result in (*registered_results, *cleanup_results)
+            if isinstance(result, BaseException)
+        ]
         if failures:
             raise BaseExceptionGroup(
                 f"failed to close {len(failures)} sandbox session(s)", failures
             )
+
+    @staticmethod
+    def _consume_task_result(task: asyncio.Task[None]) -> None:
+        """Retrieve background close failures when every waiter was cancelled."""
+
+        if not task.cancelled():
+            task.exception()
+
+    @staticmethod
+    def _consume_creator_result(task: asyncio.Task[SandboxSession]) -> None:
+        """Retrieve creator failures even when every shielded waiter was cancelled."""
+
+        if not task.cancelled():
+            task.exception()
 
 
 __all__ = ["SandboxService"]

--- a/src/archetype/missions/sandboxes/service.py
+++ b/src/archetype/missions/sandboxes/service.py
@@ -253,15 +253,18 @@ class SandboxService:
                 raise RuntimeError("SandboxService is shutting down")
             closing = self._closing.get(key)
             retained = self._sessions.get(key)
-            ready = (
+            current = (
                 closing is None
                 and self._pending.get(key) is None
                 and retained is not None
                 and retained[1] is session
                 and self._lifecycle_generations.get(key, 0) == generation
-                and status is SandboxStatus.READY
             )
-            return ready, closing
+            if current and status is not SandboxStatus.READY:
+                raise RuntimeError(
+                    f"sandbox {session.identity.sandbox_id!r} became non-ready: {status.value}"
+                )
+            return current, closing
 
     def _advance_lifecycle(self, key: SandboxKey) -> None:
         self._lifecycle_generations[key] = self._lifecycle_generations.get(key, 0) + 1

--- a/tests/eval_framework/test_agent_mission_capability.py
+++ b/tests/eval_framework/test_agent_mission_capability.py
@@ -138,6 +138,8 @@ def test_agent_mission_capability_fails_on_stale_validation_revision(
         self: MissionService,
         result: object,
         sandbox_status: object,
+        *,
+        bind_mission: bool,
     ) -> int:
         stale = replace(
             result,
@@ -145,7 +147,12 @@ def test_agent_mission_capability_fails_on_stale_validation_revision(
                 replace(observation, revision="stale-revision") for observation in result.validation
             ),
         )
-        return await stage_result(self, stale, sandbox_status)
+        return await stage_result(
+            self,
+            stale,
+            sandbox_status,
+            bind_mission=bind_mission,
+        )
 
     monkeypatch.setattr(MissionService, "_stage_result", stage_stale_validation)
 

--- a/tests/integration/test_agent_mission_service.py
+++ b/tests/integration/test_agent_mission_service.py
@@ -153,6 +153,34 @@ class _LiveOutputBackend(_LocalBackend):
         return session
 
 
+class _BlockingCloseSession(_LocalSession):
+    def __init__(self, spec: SandboxSpec) -> None:
+        super().__init__(spec)
+        self.close_started = asyncio.Event()
+        self.close_release = asyncio.Event()
+        self.close_finished = asyncio.Event()
+
+    async def close(self) -> None:
+        self.close_attempts += 1
+        self.close_started.set()
+        await self.close_release.wait()
+        self.closed += 1
+        self.close_finished.set()
+
+
+class _BlockingCloseBackend(_LocalBackend):
+    def __init__(self) -> None:
+        super().__init__()
+        self.created = asyncio.Event()
+
+    async def create(self, spec: SandboxSpec) -> _BlockingCloseSession:
+        self.creates += 1
+        session = _BlockingCloseSession(spec)
+        self.session = session
+        self.created.set()
+        return session
+
+
 class _AutoReplacementSession(_LocalSession):
     def __init__(
         self,
@@ -187,6 +215,8 @@ class _AutoReplacementSession(_LocalSession):
 
     async def checkpoint(self) -> CheckpointRef:
         self.checkpoints += 1
+        if self._status is not SandboxStatus.READY:
+            raise RuntimeError(f"local sandbox session is {self._status.value}")
         if self.fail_checkpoint:
             self._status = SandboxStatus.ERRORED
             raise RuntimeError("simulated checkpoint restart failure")
@@ -715,7 +745,7 @@ async def test_same_tick_replacement_keeps_prior_sandbox_closed(
                 sandbox_environment="local-replacement-test",
                 driver=driver,
                 workspace=str(workspace),
-                checkpoint_after_dispatch=False,
+                checkpoint_after_dispatch=True,
             ),
             storage=StorageConfig(
                 uri=str(tmp_path / "batched_replacement_missions"),
@@ -750,6 +780,7 @@ async def test_same_tick_replacement_keeps_prior_sandbox_closed(
             assert result.status == "succeeded"
             assert len(driver.calls) == 3
             assert len(backend.sessions) == 2
+            assert [session.checkpoints for session in backend.sessions] == [1, 2]
             assert [await session.status() for session in backend.sessions] == [
                 SandboxStatus.CLOSED,
                 SandboxStatus.CLOSED,
@@ -767,6 +798,74 @@ async def test_same_tick_replacement_keeps_prior_sandbox_closed(
             assert by_id["sandbox-replacement-2"][f"{sandbox}status"] == (
                 SandboxStatus.CLOSED.value
             )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_terminal_close_does_not_record_teardown_failure(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _BlockingCloseBackend()
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "cancelled-terminal-close",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-close-cancellation-test",
+                driver=_MissionDriver(workspace),
+                workspace=str(workspace),
+                checkpoint_after_dispatch=False,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "cancelled_terminal_close_missions"),
+                namespace="cancelled_terminal_close_contract",
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch="agent/cancelled-terminal-close",
+                tasks=(
+                    AgentTask(
+                        "implementation",
+                        "Create implementation.txt containing fixed.",
+                        (
+                            CommandValidator(
+                                "focused",
+                                (
+                                    "sh",
+                                    "-lc",
+                                    'test "$(cat implementation.txt)" = fixed',
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+
+            running = asyncio.create_task(missions.run(submitted))
+            await backend.created.wait()
+            assert isinstance(backend.session, _BlockingCloseSession)
+            session = backend.session
+            await session.close_started.wait()
+            running.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await running
+
+            session.close_release.set()
+            await asyncio.wait_for(session.close_finished.wait(), timeout=1)
+            result = await missions.run(submitted)
+
+            assert result.status == "succeeded"
+            assert session.close_attempts == 1
+            sandbox = Sandbox.get_prefix()
+            sandbox_rows = latest(await missions.query(Sandbox)).to_pylist()
+            assert sandbox_rows[0][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+            assert sandbox_rows[0][f"{sandbox}error"] == ""
+            with pytest.raises(KeyError, match="FrictionLog has never been spawned"):
+                await missions.query(FrictionLog)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_agent_mission_service.py
+++ b/tests/integration/test_agent_mission_service.py
@@ -43,6 +43,7 @@ from archetype.missions.sandboxes import (
     SandboxSpec,
     SandboxStatus,
 )
+from archetype.missions.sandboxes.apple_container import AppleContainerSandboxSession
 from archetype.projections import latest
 
 
@@ -138,6 +139,138 @@ class _LocalBackend:
         raise NotImplementedError
 
 
+class _LiveOutputSession(_LocalSession):
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(live_output=True, secret_names=("github",))
+
+
+class _LiveOutputBackend(_LocalBackend):
+    async def create(self, spec: SandboxSpec) -> _LiveOutputSession:
+        self.creates += 1
+        session = _LiveOutputSession(spec)
+        self.session = session
+        return session
+
+
+class _AutoReplacementSession(_LocalSession):
+    def __init__(
+        self,
+        spec: SandboxSpec,
+        sandbox_id: str,
+        *,
+        fail_checkpoint: bool = False,
+        close_failures: int = 0,
+    ) -> None:
+        super().__init__(spec)
+        self.sandbox_id = sandbox_id
+        self.fail_checkpoint = fail_checkpoint
+        self.checkpoints = 0
+        self.close_failures = close_failures
+        self._status = SandboxStatus.READY
+
+    @property
+    def identity(self) -> SandboxIdentity:
+        return SandboxIdentity("local", self.sandbox_id, self.spec.environment)
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(checkpoints=True, secret_names=("github",))
+
+    async def status(self) -> SandboxStatus:
+        return self._status
+
+    async def exec(self, request: ProcessRequest) -> ProcessResult:
+        if self._status is not SandboxStatus.READY:
+            raise RuntimeError(f"local sandbox session is {self._status.value}")
+        return await super().exec(request)
+
+    async def checkpoint(self) -> CheckpointRef:
+        self.checkpoints += 1
+        if self.fail_checkpoint:
+            self._status = SandboxStatus.ERRORED
+            raise RuntimeError("simulated checkpoint restart failure")
+        return CheckpointRef(
+            "local",
+            f"checkpoint-{self.sandbox_id}",
+            f"local-checkpoint://{self.sandbox_id}",
+            1,
+            environment=self.spec.environment,
+            source_sandbox_id=self.sandbox_id,
+            owner_id=self.spec.metadata_dict()["mission"],
+        )
+
+    async def close(self) -> None:
+        self.close_attempts += 1
+        if self.close_error or self.close_failures:
+            self.close_failures = max(0, self.close_failures - 1)
+            self._status = SandboxStatus.ERRORED
+            raise RuntimeError("provider close unavailable")
+        self.closed += 1
+        self._status = SandboxStatus.CLOSED
+
+    def simulate_transport_loss(self) -> None:
+        self._status = SandboxStatus.ERRORED
+
+
+class _AutoReplacementBackend:
+    name = "local"
+
+    def __init__(
+        self,
+        *,
+        fail_first_checkpoint: bool = False,
+        fail_first_close: bool = False,
+        fail_create_sequences: tuple[int, ...] = (),
+    ) -> None:
+        self.fail_first_checkpoint = fail_first_checkpoint
+        self.fail_first_close = fail_first_close
+        self.fail_create_sequences = fail_create_sequences
+        self.create_attempts = 0
+        self.sessions: list[_AutoReplacementSession] = []
+
+    async def create(self, spec: SandboxSpec) -> _AutoReplacementSession:
+        self.create_attempts += 1
+        sequence = self.create_attempts
+        if sequence in self.fail_create_sequences:
+            raise RuntimeError(f"simulated create failure {sequence}")
+        session = _AutoReplacementSession(
+            spec,
+            f"sandbox-replacement-{sequence}",
+            fail_checkpoint=self.fail_first_checkpoint and sequence == 1,
+            close_failures=1 if self.fail_first_close and sequence == 1 else 0,
+        )
+        self.sessions.append(session)
+        return session
+
+    async def restore(
+        self,
+        spec: SandboxSpec,
+        checkpoint: CheckpointRef,
+    ) -> _AutoReplacementSession:
+        del spec, checkpoint
+        raise NotImplementedError
+
+
+class _ProviderFailureBackend:
+    name = "local"
+
+    async def create(self, spec: SandboxSpec) -> _LocalSession:
+        del spec
+        token = "ghp_" + "A" * 36
+        output = "x" * 100 + token + "s" * 3_970
+        assert len(output) == 4_110
+        AppleContainerSandboxSession._raise(  # noqa: SLF001 - provider/app boundary probe
+            ProcessResult(("container", "run"), 7, stderr=output),
+            "provider preflight",
+        )
+        raise AssertionError("provider failure must raise")
+
+    async def restore(self, spec: SandboxSpec, checkpoint: CheckpointRef) -> _LocalSession:
+        del spec, checkpoint
+        raise NotImplementedError
+
+
 class _MissionDriver:
     """Fail one validator, repair in place, then complete the dependent task."""
 
@@ -161,6 +294,72 @@ class _MissionDriver:
         result = await session.exec(
             ProcessRequest(
                 ("sh", "-lc", f"printf '%s\\n' {content} > {filename}{commit}"),
+                workdir=str(self.workspace),
+            )
+        )
+        return AgentProcessObservation(
+            result.returncode,
+            result.stdout,
+            result.stderr,
+            session_id=f"session-{request.task_name}",
+        )
+
+
+class _TransportLossThenRepairDriver:
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+        self.calls = 0
+
+    async def run(
+        self,
+        session,
+        request,
+        prompt: str,
+    ) -> AgentProcessObservation:
+        del request, prompt
+        self.calls += 1
+        assert isinstance(session, _AutoReplacementSession)
+        if self.calls == 1:
+            session.simulate_transport_loss()
+            raise RuntimeError("simulated provider transport loss")
+
+        result = await session.exec(
+            ProcessRequest(
+                ("sh", "-lc", "printf 'good\\n' > artifact.txt"),
+                workdir=str(self.workspace),
+            )
+        )
+        return AgentProcessObservation(
+            result.returncode,
+            result.stdout,
+            result.stderr,
+            session_id="repaired-session",
+        )
+
+
+class _SameTickTransportLossDriver:
+    """Fail the first ready task while allowing its sibling to replace the session."""
+
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+        self.calls: list[str] = []
+
+    async def run(
+        self,
+        session,
+        request,
+        prompt: str,
+    ) -> AgentProcessObservation:
+        del prompt
+        self.calls.append(request.task_name)
+        assert isinstance(session, _AutoReplacementSession)
+        if len(self.calls) == 1:
+            session.simulate_transport_loss()
+            raise RuntimeError("simulated batched provider transport loss")
+
+        result = await session.exec(
+            ProcessRequest(
+                ("sh", "-lc", f"printf 'good\\n' > {request.task_name}.txt"),
                 workdir=str(self.workspace),
             )
         )
@@ -246,6 +445,28 @@ class _SecretOutputDriver:
             result.returncode,
             stdout=output,
             session_id="session-redaction",
+        )
+
+
+class _TraceOutputDriver:
+    def __init__(self, workspace: Path, trace_uri: str) -> None:
+        self.workspace = workspace
+        self.trace_uri = trace_uri
+
+    async def run(self, session, request, prompt: str) -> AgentProcessObservation:
+        del request, prompt
+        result = await session.exec(
+            ProcessRequest(
+                ("sh", "-lc", "printf 'done\\n' > feature.txt"),
+                workdir=str(self.workspace),
+            )
+        )
+        return AgentProcessObservation(
+            result.returncode,
+            result.stdout,
+            result.stderr,
+            session_id="session-trace",
+            trace_uri=self.trace_uri,
         )
 
 
@@ -407,6 +628,528 @@ async def test_explicit_graph_drives_revision_bound_retry_and_downstream_readine
         )
         == result.tasks[-1].commit_shas[-1]
     )
+
+
+@pytest.mark.asyncio
+async def test_automatic_replacement_closes_prior_sandbox_evidence(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _AutoReplacementBackend()
+    driver = _TransportLossThenRepairDriver(workspace)
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "automatic-replacement-lifecycle",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-replacement-test",
+                driver=driver,
+                workspace=str(workspace),
+                checkpoint_after_dispatch=False,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "automatic_replacement_missions"),
+                namespace="automatic_replacement_contract",
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch="agent/automatic-replacement",
+                tasks=(
+                    AgentTask(
+                        "repair",
+                        "Create artifact.txt containing good.",
+                        (
+                            CommandValidator(
+                                "focused",
+                                ("sh", "-lc", 'test "$(cat artifact.txt)" = good'),
+                            ),
+                        ),
+                        max_dispatches=2,
+                    ),
+                ),
+            )
+
+            result = await missions.run(submitted)
+
+            assert result.status == "succeeded"
+            assert driver.calls == 2
+            assert len(backend.sessions) == 2
+            assert [session.closed for session in backend.sessions] == [1, 1]
+            assert [await session.status() for session in backend.sessions] == [
+                SandboxStatus.CLOSED,
+                SandboxStatus.CLOSED,
+            ]
+
+            sandbox = Sandbox.get_prefix()
+            rows = latest(await missions.query(Sandbox)).to_pylist()
+            by_id = {str(row[f"{sandbox}sandbox_id"]): row for row in rows}
+
+            assert set(by_id) == {
+                "sandbox-replacement-1",
+                "sandbox-replacement-2",
+            }
+            assert by_id["sandbox-replacement-1"][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+            assert "simulated provider transport loss" in str(
+                by_id["sandbox-replacement-1"][f"{sandbox}error"]
+            )
+            assert by_id["sandbox-replacement-2"][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+
+
+@pytest.mark.asyncio
+async def test_same_tick_replacement_keeps_prior_sandbox_closed(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _AutoReplacementBackend()
+    driver = _SameTickTransportLossDriver(workspace)
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "batched-replacement-lifecycle",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-replacement-test",
+                driver=driver,
+                workspace=str(workspace),
+                checkpoint_after_dispatch=False,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "batched_replacement_missions"),
+                namespace="batched_replacement_contract",
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch="agent/batched-replacement",
+                tasks=tuple(
+                    AgentTask(
+                        task_name,
+                        f"Create {task_name}.txt containing good.",
+                        (
+                            CommandValidator(
+                                task_name,
+                                (
+                                    "sh",
+                                    "-lc",
+                                    f'test "$(cat {task_name}.txt)" = good',
+                                ),
+                            ),
+                        ),
+                        max_dispatches=2,
+                    )
+                    for task_name in ("first", "second")
+                ),
+            )
+
+            result = await missions.run(submitted)
+
+            assert result.status == "succeeded"
+            assert len(driver.calls) == 3
+            assert len(backend.sessions) == 2
+            assert [await session.status() for session in backend.sessions] == [
+                SandboxStatus.CLOSED,
+                SandboxStatus.CLOSED,
+            ]
+
+            sandbox = Sandbox.get_prefix()
+            rows = latest(await missions.query(Sandbox)).to_pylist()
+            by_id = {str(row[f"{sandbox}sandbox_id"]): row for row in rows}
+            assert by_id["sandbox-replacement-1"][f"{sandbox}status"] == (
+                SandboxStatus.CLOSED.value
+            )
+            assert "simulated batched provider transport loss" in str(
+                by_id["sandbox-replacement-1"][f"{sandbox}error"]
+            )
+            assert by_id["sandbox-replacement-2"][f"{sandbox}status"] == (
+                SandboxStatus.CLOSED.value
+            )
+
+
+@pytest.mark.asyncio
+async def test_terminal_close_failure_is_durable_and_retryable(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _AutoReplacementBackend(fail_first_close=True)
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "terminal-close-retry",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-replacement-test",
+                driver=_MissionDriver(workspace),
+                workspace=str(workspace),
+                checkpoint_after_dispatch=False,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "terminal_close_retry_missions"),
+                namespace="terminal_close_retry_contract",
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch="agent/terminal-close-retry",
+                tasks=(
+                    AgentTask(
+                        "implementation",
+                        "Create implementation.txt containing fixed.",
+                        (
+                            CommandValidator(
+                                "focused",
+                                (
+                                    "sh",
+                                    "-lc",
+                                    'test "$(cat implementation.txt)" = fixed',
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+
+            with pytest.raises(RuntimeError, match="provider close unavailable"):
+                await missions.run(submitted)
+
+            assert len(backend.sessions) == 1
+            session = backend.sessions[0]
+            assert await session.status() is SandboxStatus.ERRORED
+            sandbox = Sandbox.get_prefix()
+            rows = latest(await missions.query(Sandbox)).to_pylist()
+            assert rows[0][f"{sandbox}status"] == SandboxStatus.ERRORED.value
+            assert "provider close unavailable" in str(rows[0][f"{sandbox}error"])
+            friction = FrictionLog.get_prefix()
+            friction_rows = latest(await missions.query(FrictionLog)).to_pylist()
+            assert any(
+                row[f"{friction}kind"] == "sandbox_teardown"
+                and "provider close unavailable" in str(row[f"{friction}message"])
+                for row in friction_rows
+            )
+
+            result = await missions.run(submitted)
+
+            assert result.status == "succeeded"
+            assert session.close_attempts == 2
+            assert await session.status() is SandboxStatus.CLOSED
+            rows = latest(await missions.query(Sandbox)).to_pylist()
+            assert rows[0][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+            assert "provider close unavailable" in str(rows[0][f"{sandbox}error"])
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_failure_replacement_closes_prior_sandbox_evidence(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _AutoReplacementBackend(fail_first_checkpoint=True)
+    driver = _MissionDriver(workspace)
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "checkpoint-replacement-lifecycle",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-replacement-test",
+                driver=driver,
+                workspace=str(workspace),
+                checkpoint_after_dispatch=True,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "checkpoint_replacement_missions"),
+                namespace="checkpoint_replacement_contract",
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch="agent/checkpoint-replacement",
+                tasks=(
+                    AgentTask(
+                        "regression",
+                        "Create regression.txt containing good.",
+                        (
+                            CommandValidator(
+                                "focused",
+                                ("sh", "-lc", 'test "$(cat regression.txt)" = good'),
+                            ),
+                        ),
+                        max_dispatches=2,
+                    ),
+                ),
+            )
+
+            result = await missions.run(submitted)
+
+            assert result.status == "succeeded"
+            assert len(backend.sessions) == 2
+            assert [session.closed for session in backend.sessions] == [1, 1]
+            assert [session.checkpoints for session in backend.sessions] == [1, 1]
+
+            sandbox = Sandbox.get_prefix()
+            rows = latest(await missions.query(Sandbox)).to_pylist()
+            by_id = {str(row[f"{sandbox}sandbox_id"]): row for row in rows}
+
+            assert set(by_id) == {
+                "sandbox-replacement-1",
+                "sandbox-replacement-2",
+            }
+            assert by_id["sandbox-replacement-1"][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+            assert "simulated checkpoint restart failure" in str(
+                by_id["sandbox-replacement-1"][f"{sandbox}error"]
+            )
+            assert by_id["sandbox-replacement-2"][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+
+            friction = FrictionLog.get_prefix()
+            friction_rows = latest(await missions.query(FrictionLog)).to_pylist()
+            assert any(
+                row[f"{friction}kind"] == "checkpoint"
+                and "simulated checkpoint restart failure" in str(row[f"{friction}message"])
+                for row in friction_rows
+            )
+
+
+@pytest.mark.asyncio
+async def test_failed_automatic_replacement_uses_retained_sandbox_identity(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _AutoReplacementBackend(fail_first_close=True)
+    driver = _TransportLossThenRepairDriver(workspace)
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "automatic-replacement-close-retry",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-replacement-test",
+                driver=driver,
+                workspace=str(workspace),
+                checkpoint_after_dispatch=False,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "automatic_replacement_close_retry"),
+                namespace="automatic_replacement_close_retry_contract",
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch="agent/automatic-replacement-close-retry",
+                tasks=(
+                    AgentTask(
+                        "repair",
+                        "Create artifact.txt containing good.",
+                        (
+                            CommandValidator(
+                                "focused",
+                                ("sh", "-lc", 'test "$(cat artifact.txt)" = good'),
+                            ),
+                        ),
+                        max_dispatches=3,
+                    ),
+                ),
+            )
+
+            result = await missions.run(submitted)
+
+            assert result.status == "succeeded"
+            assert driver.calls == 2
+            assert len(backend.sessions) == 2
+            assert backend.sessions[0].close_attempts == 2
+            assert [session.closed for session in backend.sessions] == [1, 1]
+
+            sandbox = Sandbox.get_prefix()
+            rows = latest(await missions.query(Sandbox)).to_pylist()
+            by_id = {str(row[f"{sandbox}sandbox_id"]): row for row in rows}
+            assert set(by_id) == {
+                "sandbox-replacement-1",
+                "sandbox-replacement-2",
+            }
+            assert all(
+                row[f"{sandbox}status"] == SandboxStatus.CLOSED.value for row in by_id.values()
+            )
+            assert "provider close unavailable" in str(
+                by_id["sandbox-replacement-1"][f"{sandbox}error"]
+            )
+
+            friction = FrictionLog.get_prefix()
+            friction_rows = latest(await missions.query(FrictionLog)).to_pylist()
+            assert any(
+                row[f"{friction}kind"] == "sandbox_teardown"
+                and "provider close unavailable" in str(row[f"{friction}message"])
+                for row in friction_rows
+            )
+
+
+@pytest.mark.asyncio
+async def test_failed_replacement_create_does_not_bind_unavailable_evidence(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _AutoReplacementBackend(fail_create_sequences=(2,))
+    driver = _TransportLossThenRepairDriver(workspace)
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "automatic-replacement-create-retry",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-replacement-test",
+                driver=driver,
+                workspace=str(workspace),
+                checkpoint_after_dispatch=False,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "automatic_replacement_create_retry"),
+                namespace="automatic_replacement_create_retry_contract",
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch="agent/automatic-replacement-create-retry",
+                tasks=(
+                    AgentTask(
+                        "repair",
+                        "Create artifact.txt containing good.",
+                        (
+                            CommandValidator(
+                                "focused",
+                                ("sh", "-lc", 'test "$(cat artifact.txt)" = good'),
+                            ),
+                        ),
+                        max_dispatches=3,
+                    ),
+                ),
+            )
+
+            result = await missions.run(submitted)
+
+            assert result.status == "succeeded"
+            assert driver.calls == 2
+            assert backend.create_attempts == 3
+            assert [session.identity.sandbox_id for session in backend.sessions] == [
+                "sandbox-replacement-1",
+                "sandbox-replacement-3",
+            ]
+            assert [session.closed for session in backend.sessions] == [1, 1]
+
+            sandbox = Sandbox.get_prefix()
+            rows = latest(await missions.query(Sandbox)).to_pylist()
+            by_id = {str(row[f"{sandbox}sandbox_id"]): row for row in rows}
+            unavailable = [
+                sandbox_id for sandbox_id in by_id if sandbox_id.startswith("unavailable-")
+            ]
+            assert len(unavailable) == 1
+            assert by_id["sandbox-replacement-1"][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+            assert by_id["sandbox-replacement-3"][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+            assert by_id[unavailable[0]][f"{sandbox}status"] == SandboxStatus.ERRORED.value
+            assert "simulated create failure 2" in str(by_id[unavailable[0]][f"{sandbox}error"])
+
+
+@pytest.mark.parametrize(
+    "trace_uri",
+    (
+        "",
+        "local-sandbox://sandbox-contract/live/executions/process-1/agent.stdout.log",
+    ),
+    ids=("untraced", "provider-scoped-trace"),
+)
+@pytest.mark.asyncio
+async def test_execution_trace_requires_exact_per_call_provider_evidence(
+    tmp_path: Path,
+    trace_uri: str,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _LiveOutputBackend()
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "per-call-trace-evidence",
+            config=AgentMissionConfig(
+                sandbox_backend=backend,
+                sandbox_environment="local-live-output-test",
+                driver=_TraceOutputDriver(workspace, trace_uri),
+                workspace=str(workspace),
+                checkpoint_after_dispatch=False,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "per_call_trace_evidence"),
+                namespace=("per_call_trace_present" if trace_uri else "per_call_trace_absent"),
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch=(
+                    "agent/per-call-trace-present" if trace_uri else "agent/per-call-trace-absent"
+                ),
+                tasks=(
+                    AgentTask(
+                        "implementation",
+                        "Create feature.txt.",
+                        (CommandValidator("focused", ("test", "-f", "feature.txt")),),
+                    ),
+                ),
+            )
+
+            result = await missions.run(submitted)
+
+            assert result.status == "succeeded"
+            execution = AgentExecution.get_prefix()
+            rows = latest(await missions.query(AgentExecution)).to_pylist()
+            assert len(rows) == 1
+            assert rows[0][f"{execution}trace_uri"] == trace_uri
+
+
+@pytest.mark.asyncio
+async def test_provider_error_is_redacted_before_persistence_bound(tmp_path: Path) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+
+    async with ArchetypeRuntime() as runtime:
+        async with runtime.missions(
+            "provider-error-redaction",
+            config=AgentMissionConfig(
+                sandbox_backend=_ProviderFailureBackend(),
+                sandbox_environment="local-test@sha256:contract",
+                driver=_MissionDriver(workspace),
+                workspace=str(workspace),
+                max_ticks=20,
+            ),
+            storage=StorageConfig(
+                uri=str(tmp_path / "provider_error_redaction"),
+                namespace="contract",
+            ),
+        ) as missions:
+            submitted = await missions.submit(
+                repository=str(remote),
+                branch="agent/provider-error-redaction",
+                tasks=(
+                    AgentTask(
+                        "implementation",
+                        "This provider fails before the agent starts.",
+                        (CommandValidator("focused", ("true",)),),
+                        max_dispatches=1,
+                    ),
+                ),
+            )
+
+            result = await missions.run(submitted)
+
+            assert result.status == "failed"
+            rows = latest(await missions.query(AgentExecution)).to_pylist()
+            execution = AgentExecution.get_prefix()
+            error = str(rows[0][f"{execution}error"])
+            assert 0 < len(error) <= 4_000
+            assert "ghp_" not in error
+            assert "A" * 20 not in error
+            assert "<redacted:github-token>" in error
 
 
 @pytest.mark.asyncio

--- a/tests/missions/test_apple_container_sandbox.py
+++ b/tests/missions/test_apple_container_sandbox.py
@@ -443,10 +443,20 @@ async def test_apple_oauth_round_trip_and_session_error_states(
     with pytest.raises(asyncio.CancelledError):
         await session.exec(ProcessRequest(("true",)))
     assert await session.status() is SandboxStatus.INTERRUPTED
+
+    executed = False
+
+    async def should_not_execute(_request: ProcessRequest) -> ProcessResult:
+        nonlocal executed
+        executed = True
+        return ProcessResult(("true",), 0)
+
+    monkeypatch.setattr(session, "_exec_request", should_not_execute)
     with pytest.raises(RuntimeError, match="interrupted"):
         await session.exec(ProcessRequest(("true",)))
     with pytest.raises(RuntimeError, match="interrupted"):
         await session.checkpoint()
+    assert executed is False
 
     async def errored(_request: ProcessRequest) -> ProcessResult:
         raise RuntimeError("provider exec failed")
@@ -460,6 +470,13 @@ async def test_apple_oauth_round_trip_and_session_error_states(
         await errored_session.exec(ProcessRequest(("true",)))
     with pytest.raises(RuntimeError, match="errored"):
         await errored_session.checkpoint()
+
+    monkeypatch.setattr(errored_session, "_exec_request", should_not_execute)
+    with pytest.raises(RuntimeError, match="errored"):
+        await errored_session.exec(ProcessRequest(("true",)))
+    with pytest.raises(RuntimeError, match="errored"):
+        await errored_session.checkpoint()
+    assert executed is False
 
     errored_session._status = SandboxStatus.CLOSED
     with pytest.raises(RuntimeError, match="closed"):

--- a/tests/missions/test_coding_agent_harness.py
+++ b/tests/missions/test_coding_agent_harness.py
@@ -19,6 +19,7 @@ from archetype.missions import (
 )
 from archetype.missions.coding_agents import (
     AgentProcessObservation,
+    CodexDriver,
     CodingAgentHarness,
     CodingAgentHarnessConfig,
     DispatchedValidator,
@@ -138,6 +139,43 @@ class _EditingDriver:
         )
 
 
+class _TraceSession:
+    def __init__(self) -> None:
+        self.requests: list[ProcessRequest] = []
+
+    @property
+    def identity(self) -> SandboxIdentity:
+        return SandboxIdentity("modal", "sb-trace", "test-environment")
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            live_output=True,
+            secret_names=("codex_oauth",),
+        )
+
+    async def status(self) -> SandboxStatus:
+        return SandboxStatus.READY
+
+    async def exec(self, request: ProcessRequest) -> ProcessResult:
+        self.requests.append(request)
+        return ProcessResult(
+            request.argv,
+            0,
+            stdout='{"type":"thread.started","thread_id":"thread-1"}\n',
+            trace_uri=(
+                "modal-sandbox://sb-trace/tmp/archetype-agent-missions/live/"
+                "executions/process-1/agent.stdout.log"
+            ),
+        )
+
+    async def checkpoint(self) -> CheckpointRef:
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        return None
+
+
 def _request(remote: Path, *, validator_command: tuple[str, ...]) -> TaskDispatchRequest:
     return TaskDispatchRequest(
         mission_id=1,
@@ -156,6 +194,21 @@ def _request(remote: Path, *, validator_command: tuple[str, ...]) -> TaskDispatc
             ),
         ),
         publication_policy=RepositoryPublicationPolicy.COMMIT_AND_PUSH,
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_driver_forwards_provider_trace() -> None:
+    session = _TraceSession()
+    request = _request(Path("/tmp/remote.git"), validator_command=("true",))
+
+    observed = await CodexDriver().run(session, request, "Fix it.")
+
+    assert len(session.requests) == 1
+    assert observed.session_id == "thread-1"
+    assert observed.trace_uri == (
+        "modal-sandbox://sb-trace/tmp/archetype-agent-missions/live/"
+        "executions/process-1/agent.stdout.log"
     )
 
 

--- a/tests/missions/test_docker_sandbox.py
+++ b/tests/missions/test_docker_sandbox.py
@@ -349,10 +349,20 @@ async def test_docker_oauth_round_trip_and_session_error_states(
     with pytest.raises(asyncio.CancelledError):
         await session.exec(ProcessRequest(("true",)))
     assert await session.status() is SandboxStatus.INTERRUPTED
+
+    executed = False
+
+    async def should_not_execute(_request: ProcessRequest) -> ProcessResult:
+        nonlocal executed
+        executed = True
+        return ProcessResult(("true",), 0)
+
+    monkeypatch.setattr(session, "_exec_request", should_not_execute)
     with pytest.raises(RuntimeError, match="interrupted"):
         await session.exec(ProcessRequest(("true",)))
     with pytest.raises(RuntimeError, match="interrupted"):
         await session.checkpoint()
+    assert executed is False
 
     async def errored(_request: ProcessRequest) -> ProcessResult:
         raise RuntimeError("provider exec failed")
@@ -366,6 +376,13 @@ async def test_docker_oauth_round_trip_and_session_error_states(
         await errored_session.exec(ProcessRequest(("true",)))
     with pytest.raises(RuntimeError, match="errored"):
         await errored_session.checkpoint()
+
+    monkeypatch.setattr(errored_session, "_exec_request", should_not_execute)
+    with pytest.raises(RuntimeError, match="errored"):
+        await errored_session.exec(ProcessRequest(("true",)))
+    with pytest.raises(RuntimeError, match="errored"):
+        await errored_session.checkpoint()
+    assert executed is False
 
     errored_session._status = SandboxStatus.CLOSED
     with pytest.raises(RuntimeError, match="closed"):

--- a/tests/missions/test_modal_agent_sandbox.py
+++ b/tests/missions/test_modal_agent_sandbox.py
@@ -18,6 +18,7 @@ from archetype.missions.sandboxes import (
     ProcessRequest,
     ProcessResult,
     SandboxBackend,
+    SandboxEventType,
     SandboxSpec,
     SandboxStatus,
 )
@@ -616,6 +617,7 @@ async def test_modal_checkpoint_fails_closed_when_live_output_scrub_fails(
     sandbox = _LifecycleSandbox("sb-agent")
     session = _lifecycle_session(sandbox)
     snapshot_called = False
+    events: list[str] = []
 
     class _Snapshot:
         async def aio(self, **kwargs):
@@ -632,13 +634,19 @@ async def test_modal_checkpoint_fails_closed_when_live_output_scrub_fails(
             stderr="scrub failed",
         )
 
+    async def record_event(kind: SandboxEventType, **kwargs) -> None:
+        del kwargs
+        events.append(kind.value)
+
     sandbox.snapshot_filesystem = _Snapshot()
     monkeypatch.setattr(session, "_exec_on", execute)
+    monkeypatch.setattr(session, "_emit_event", record_event)
 
     with pytest.raises(RuntimeError, match="remove raw live output before checkpoint"):
         await session.checkpoint()
 
     assert snapshot_called is False
+    assert events == ["checkpoint_started", "checkpoint_failed"]
 
 
 @pytest.mark.asyncio
@@ -656,6 +664,8 @@ async def test_modal_session_error_checkpoint_and_close_states(
     assert await session.status() is SandboxStatus.ERRORED
     with pytest.raises(RuntimeError, match="errored"):
         await session.exec(ProcessRequest(("true",)))
+    with pytest.raises(RuntimeError, match="errored"):
+        await session.checkpoint()
 
     session = _lifecycle_session(_LifecycleSandbox("sb-cancelled"))
 
@@ -667,10 +677,21 @@ async def test_modal_session_error_checkpoint_and_close_states(
     with pytest.raises(asyncio.CancelledError):
         await session.exec(ProcessRequest(("true",)))
     assert await session.status() is SandboxStatus.INTERRUPTED
+
+    executed = False
+
+    async def should_not_execute(*args, **kwargs):
+        nonlocal executed
+        del args, kwargs
+        executed = True
+        return ProcessResult(("true",), 0)
+
+    monkeypatch.setattr(session, "_exec_on", should_not_execute)
     with pytest.raises(RuntimeError, match="interrupted"):
         await session.exec(ProcessRequest(("true",)))
     with pytest.raises(RuntimeError, match="interrupted"):
         await session.checkpoint()
+    assert executed is False
 
     async def errored(*args, **kwargs):
         del args, kwargs
@@ -685,6 +706,13 @@ async def test_modal_session_error_checkpoint_and_close_states(
         await errored_session.exec(ProcessRequest(("true",)))
     with pytest.raises(RuntimeError, match="errored"):
         await errored_session.checkpoint()
+
+    monkeypatch.setattr(errored_session, "_exec_on", should_not_execute)
+    with pytest.raises(RuntimeError, match="errored"):
+        await errored_session.exec(ProcessRequest(("true",)))
+    with pytest.raises(RuntimeError, match="errored"):
+        await errored_session.checkpoint()
+    assert executed is False
 
     errored_session._status = SandboxStatus.CLOSED
     with pytest.raises(RuntimeError, match="closed"):

--- a/tests/missions/test_sandbox_service.py
+++ b/tests/missions/test_sandbox_service.py
@@ -142,6 +142,7 @@ async def test_new_non_ready_session_fails_once_without_creation_churn() -> None
 
     assert backend.creates == 1
     assert service.session(key) is backend.sessions[0]
+    assert await backend.sessions[0].status() is SandboxStatus.ERRORED
     await service.shutdown()
 
 

--- a/tests/missions/test_sandbox_service.py
+++ b/tests/missions/test_sandbox_service.py
@@ -144,6 +144,8 @@ async def test_new_non_ready_session_fails_once_without_creation_churn() -> None
     assert service.session(key) is backend.sessions[0]
     assert await backend.sessions[0].status() is SandboxStatus.ERRORED
     await service.shutdown()
+    assert backend.sessions[0].closed == 1
+    assert service.session(key) is None
 
 
 def test_process_request_requires_explicit_portable_inputs() -> None:

--- a/tests/missions/test_sandbox_service.py
+++ b/tests/missions/test_sandbox_service.py
@@ -36,6 +36,13 @@ class _Session:
         self.closed = 0
         self.close_attempts = 0
         self.close_error = False
+        self.close_failures = 0
+        self.close_started = asyncio.Event()
+        self.close_release = asyncio.Event()
+        self.close_release.set()
+        self.status_started = asyncio.Event()
+        self.status_release = asyncio.Event()
+        self.status_release.set()
 
     @property
     def identity(self) -> SandboxIdentity:
@@ -46,7 +53,10 @@ class _Session:
         return SandboxCapabilities(checkpoints=True)
 
     async def status(self) -> SandboxStatus:
-        return self._status
+        observed = self._status
+        self.status_started.set()
+        await self.status_release.wait()
+        return observed
 
     async def exec(self, request: ProcessRequest) -> ProcessResult:
         return ProcessResult(request.argv, 0, stdout="ok")
@@ -63,7 +73,10 @@ class _Session:
 
     async def close(self) -> None:
         self.close_attempts += 1
-        if self.close_error:
+        self.close_started.set()
+        await self.close_release.wait()
+        if self.close_error or self.close_failures:
+            self.close_failures = max(0, self.close_failures - 1)
             self._status = SandboxStatus.ERRORED
             raise RuntimeError("provider close unavailable")
         self.closed += 1
@@ -78,12 +91,18 @@ class _Backend:
         self.restores = 0
         self.started = asyncio.Event()
         self.release = asyncio.Event()
+        self.sessions: list[_Session] = []
+        self.create_error: Exception | None = None
 
     async def create(self, spec: SandboxSpec) -> _Session:
         self.creates += 1
+        session = _Session(SandboxIdentity(self.name, f"sandbox-{self.creates}", spec.environment))
+        self.sessions.append(session)
         self.started.set()
         await self.release.wait()
-        return _Session(SandboxIdentity(self.name, f"sandbox-{self.creates}", spec.environment))
+        if self.create_error is not None:
+            raise self.create_error
+        return session
 
     async def restore(self, spec: SandboxSpec, checkpoint: CheckpointRef) -> _Session:
         self.restores += 1
@@ -366,6 +385,386 @@ async def test_failed_replacement_close_retains_the_session_for_cleanup_retry() 
     assert original.closed == 1
     assert backend.restores == 1
     assert service.session(key) is restored
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_failed_direct_close_retains_the_session_for_cleanup_retry() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:direct-close-retry")
+    session = await service.acquire(key, _spec())
+    session.close_error = True
+
+    with pytest.raises(RuntimeError, match="provider close unavailable"):
+        await service.close(key)
+
+    assert service.session(key) is session
+    assert await session.status() is SandboxStatus.ERRORED
+
+    session.close_error = False
+    await service.close(key)
+
+    assert session.close_attempts == 2
+    assert await session.status() is SandboxStatus.CLOSED
+    assert service.session(key) is None
+
+
+@pytest.mark.asyncio
+async def test_acquire_waits_for_direct_close_then_returns_a_replacement() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:close-acquire-race")
+    spec = _spec()
+    original = await service.acquire(key, spec)
+    original.close_release.clear()
+
+    closing = asyncio.create_task(service.close(key))
+    await original.close_started.wait()
+    acquiring = asyncio.create_task(service.acquire(key, spec))
+    await asyncio.sleep(0)
+
+    assert not acquiring.done()
+    assert backend.creates == 1
+
+    original.close_release.set()
+    replacement = await acquiring
+    await closing
+
+    assert replacement is not original
+    assert original.close_attempts == 1
+    assert await original.status() is SandboxStatus.CLOSED
+    assert service.session(key) is replacement
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_close_linearizes_before_an_inflight_successful_acquire_returns() -> None:
+    backend = _Backend()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:pending-acquire-close-race")
+    spec = _spec()
+
+    acquiring = asyncio.create_task(service.acquire(key, spec))
+    await backend.started.wait()
+    created = backend.sessions[0]
+    created.close_release.clear()
+    closing = asyncio.create_task(service.close(key))
+    await asyncio.sleep(0)
+    backend.release.set()
+    await created.close_started.wait()
+    await asyncio.sleep(0)
+
+    assert not acquiring.done()
+    assert not closing.done()
+
+    created.close_release.set()
+    await closing
+    replacement = await acquiring
+
+    assert replacement is not created
+    assert created.close_attempts == 1
+    assert await created.status() is SandboxStatus.CLOSED
+    assert backend.creates == 2
+    assert service.session(key) is replacement
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_acquire_retries_after_a_concurrent_direct_close_failure() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:failed-close-acquire-race")
+    spec = _spec()
+    original = await service.acquire(key, spec)
+    original.close_failures = 1
+    original.close_release.clear()
+
+    closing = asyncio.create_task(service.close(key))
+    await original.close_started.wait()
+    acquiring = asyncio.create_task(service.acquire(key, spec))
+    await asyncio.sleep(0)
+    assert not acquiring.done()
+
+    original.close_release.set()
+    with pytest.raises(RuntimeError, match="provider close unavailable"):
+        await closing
+    replacement = await acquiring
+
+    assert replacement is not original
+    assert original.close_attempts == 2
+    assert await original.status() is SandboxStatus.CLOSED
+    assert service.session(key) is replacement
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_close_waiter_does_not_cancel_provider_teardown() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:cancelled-close-waiter")
+    spec = _spec()
+    original = await service.acquire(key, spec)
+    original.close_release.clear()
+
+    closing = asyncio.create_task(service.close(key))
+    await original.close_started.wait()
+    closing.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await closing
+
+    acquiring = asyncio.create_task(service.acquire(key, spec))
+    await asyncio.sleep(0)
+    assert not acquiring.done()
+
+    original.close_release.set()
+    replacement = await acquiring
+
+    assert replacement is not original
+    assert original.close_attempts == 1
+    assert await original.status() is SandboxStatus.CLOSED
+    assert service.session(key) is replacement
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_a_shielded_creator_after_its_waiter_is_cancelled() -> None:
+    backend = _Backend()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:cancelled-create-waiter")
+    spec = _spec()
+
+    acquiring = asyncio.create_task(service.acquire(key, spec))
+    await backend.started.wait()
+    created = backend.sessions[0]
+    acquiring.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await acquiring
+
+    closing = asyncio.create_task(service.close(key))
+    await asyncio.sleep(0)
+    assert not closing.done()
+    assert created.close_attempts == 0
+
+    backend.release.set()
+    await closing
+
+    assert created.close_attempts == 1
+    assert await created.status() is SandboxStatus.CLOSED
+    assert service.session(key) is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_acquire_consumes_a_later_creator_failure() -> None:
+    backend = _Backend()
+    backend.create_error = RuntimeError("creator exploded")
+    service = SandboxService((backend,))
+    completed = asyncio.Event()
+
+    acquiring = asyncio.create_task(
+        service.acquire(SandboxKey("mission:abandoned-create"), _spec())
+    )
+    await backend.started.wait()
+    pending = next(iter(service._pending.values()))[2]  # noqa: SLF001
+    pending.add_done_callback(lambda _task: completed.set())
+
+    acquiring.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await acquiring
+    backend.release.set()
+    await completed.wait()
+    await asyncio.sleep(0)
+
+    assert pending.done()
+    assert pending._log_traceback is False  # noqa: SLF001 - exception was retrieved
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_failed_shutdown_retains_sessions_for_cleanup_retry() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:shutdown-retry")
+    session = await service.acquire(key, _spec())
+    session.close_error = True
+
+    with pytest.raises(BaseExceptionGroup, match="failed to close 1"):
+        await service.shutdown()
+
+    assert service.session(key) is session
+    assert await session.status() is SandboxStatus.ERRORED
+
+    session.close_error = False
+    await service.shutdown()
+
+    assert session.close_attempts == 2
+    assert await session.status() is SandboxStatus.CLOSED
+    assert service.session(key) is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_retains_failed_cleanup_from_an_inflight_create() -> None:
+    backend = _Backend()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:pending-shutdown-cleanup")
+
+    acquiring = asyncio.create_task(service.acquire(key, _spec()))
+    await backend.started.wait()
+    created = backend.sessions[0]
+    created.close_failures = 1
+    shutting_down = asyncio.create_task(service.shutdown())
+    while service._accepting:  # noqa: SLF001 - deterministic concurrency contract
+        await asyncio.sleep(0)
+    backend.release.set()
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        await acquiring
+    with pytest.raises(BaseExceptionGroup, match="failed to close 1"):
+        await shutting_down
+
+    assert created.close_attempts == 1
+    assert await created.status() is SandboxStatus.ERRORED
+    assert service.session(key) is None
+    assert len(service._cleanup_sessions) == 1  # noqa: SLF001 - retained cleanup ownership
+
+    await service.shutdown()
+
+    assert created.close_attempts == 2
+    assert await created.status() is SandboxStatus.CLOSED
+    assert not service._cleanup_sessions  # noqa: SLF001 - successful retry releases ownership
+
+
+@pytest.mark.asyncio
+async def test_concurrent_direct_close_and_shutdown_close_the_session_once() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:close-shutdown-race")
+    session = await service.acquire(key, _spec())
+    session.close_release.clear()
+
+    closing = asyncio.create_task(service.close(key))
+    await session.close_started.wait()
+    shutting_down = asyncio.create_task(service.shutdown())
+    while service._accepting:  # noqa: SLF001 - deterministic concurrency contract
+        await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert session.close_attempts == 1
+
+    session.close_release.set()
+    await asyncio.gather(closing, shutting_down)
+
+    assert session.close_attempts == 1
+    assert await session.status() is SandboxStatus.CLOSED
+    assert service.session(key) is None
+
+
+@pytest.mark.asyncio
+async def test_closing_one_key_does_not_block_acquisition_for_another() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    first_key = SandboxKey("mission:independent-close")
+    second_key = SandboxKey("mission:independent-acquire")
+    spec = _spec()
+    first = await service.acquire(first_key, spec)
+    second = await service.acquire(second_key, spec)
+    first.close_release.clear()
+
+    closing = asyncio.create_task(service.close(first_key))
+    await first.close_started.wait()
+    acquiring = asyncio.create_task(service.acquire(second_key, spec))
+    await asyncio.sleep(0)
+
+    assert acquiring.done()
+    assert await acquiring is second
+
+    first.close_release.set()
+    await closing
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_observing_one_key_status_does_not_block_another_key() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    first_key = SandboxKey("mission:slow-status")
+    second_key = SandboxKey("mission:status-independent")
+    spec = _spec()
+    first = await service.acquire(first_key, spec)
+    second = await service.acquire(second_key, spec)
+    first.status_started.clear()
+    first.status_release.clear()
+
+    blocked = asyncio.create_task(service.acquire(first_key, spec))
+    await first.status_started.wait()
+    second.status_started.clear()
+    unrelated = asyncio.create_task(service.acquire(second_key, spec))
+
+    try:
+        await asyncio.wait_for(second.status_started.wait(), timeout=1)
+        assert await unrelated is second
+    finally:
+        first.status_release.set()
+        await asyncio.gather(blocked, unrelated, return_exceptions=True)
+        await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_acquire_revalidates_a_status_observation_after_concurrent_close() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:stale-status")
+    spec = _spec()
+    original = await service.acquire(key, spec)
+    original.status_started.clear()
+    original.status_release.clear()
+
+    acquiring = asyncio.create_task(service.acquire(key, spec))
+    await original.status_started.wait()
+    await asyncio.wait_for(service.close(key), timeout=1)
+    replacement = await service.acquire(key, spec)
+    original.status_release.set()
+
+    assert await acquiring is replacement
+    assert replacement is not original
+    assert await original.status() is SandboxStatus.CLOSED
+    assert service.session(key) is replacement
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_acquire_discards_stale_ready_after_concurrent_close_failure() -> None:
+    backend = _Backend()
+    backend.release.set()
+    service = SandboxService((backend,))
+    key = SandboxKey("mission:stale-status-close-failure")
+    spec = _spec()
+    original = await service.acquire(key, spec)
+    original.close_failures = 1
+    original.status_started.clear()
+    original.status_release.clear()
+
+    acquiring = asyncio.create_task(service.acquire(key, spec))
+    await original.status_started.wait()
+    with pytest.raises(RuntimeError, match="provider close unavailable"):
+        await service.close(key)
+    original.status_release.set()
+
+    replacement = await acquiring
+
+    assert replacement is not original
+    assert original.close_attempts == 2
+    assert await original.status() is SandboxStatus.CLOSED
+    assert service.session(key) is replacement
     await service.shutdown()
 
 

--- a/tests/missions/test_sandbox_service.py
+++ b/tests/missions/test_sandbox_service.py
@@ -126,6 +126,25 @@ def test_sandbox_contracts_describe_resources_not_task_outcomes() -> None:
     assert isinstance(SandboxService(), SandboxServiceProtocol)
 
 
+@pytest.mark.asyncio
+async def test_new_non_ready_session_fails_once_without_creation_churn() -> None:
+    backend = _Backend()
+    service = SandboxService([backend])
+    key = SandboxKey("mission:non-ready")
+
+    acquiring = asyncio.create_task(service.acquire(key, _spec()))
+    await backend.started.wait()
+    backend.sessions[0]._status = SandboxStatus.ERRORED
+    backend.release.set()
+
+    with pytest.raises(RuntimeError, match="became non-ready: errored"):
+        await asyncio.wait_for(acquiring, timeout=1)
+
+    assert backend.creates == 1
+    assert service.session(key) is backend.sessions[0]
+    await service.shutdown()
+
+
 def test_process_request_requires_explicit_portable_inputs() -> None:
     request = ProcessRequest(
         ("python", "-V"),


### PR DESCRIPTION
## Summary

- require retained sandbox sessions to be `READY` before reuse and close/replace non-ready sessions without exposing the closing handle
- serialize close ownership per sandbox key, shield cleanup from caller cancellation, and retain provider handles until teardown actually succeeds
- make shutdown account for in-flight creators, replacement cleanup, and retryable cleanup failures
- keep durable mission sandbox evidence aligned with physical ownership, including teardown friction and monotonic `closed` state
- bind trace evidence to successful provider calls and make checkpoint/raw-output scrubbing failures explicit
- stop current non-ready creations after one surfaced failure while retaining provider cleanup ownership
- add deterministic cancellation, replacement, shutdown-race, provider-parity, lifecycle-evidence, and non-ready creation-churn contracts

## Why

The dogfood run exposed a gap between logical registry state and physical provider ownership. Cancellation or teardown failure could forget a still-live provider resource, concurrent acquisition could observe a closing or non-ready handle, and later staging could move durable sandbox state backward after replacement. That is especially dangerous before adding an independent critic sandbox.

This supersedes #634, whose merge-queue entry pinned its PR ref to a superseded SHA even after the source branch advanced. The original reviewer thread and the implementation reply remain preserved there. This replacement starts directly from the corrected final head.

This is the second reliability cut after #633. Runtime handle retention and whole-runtime teardown remain in the next PR; the native exact-head critic remains in #630.

## Validation

- `uv run pytest -q tests/missions/test_sandbox_service.py tests/missions/test_apple_container_sandbox.py tests/missions/test_docker_sandbox.py tests/missions/test_modal_agent_sandbox.py tests/missions/test_coding_agent_harness.py tests/integration/test_agent_mission_service.py tests/eval_framework/test_agent_mission_capability.py` — 118 passed before the review fix; focused sandbox suite revalidated at 26 passed after the fix
- `make ci` — passed after the review fix; 1,828 tests passed, 4 skipped, 88.20% coverage; static, architecture, conformance, capability, package, examples, and docs gates passed
