### PR TITLE
fix(runtime): retry retained mission cleanup

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -353,7 +353,16 @@ possibly live provider resource. Close is single-flight per sandbox key and
 continues if its caller is cancelled; concurrent acquisition waits for that
 teardown and never receives the closing handle. A provider session returned
 while shutdown is winning the race remains cleanup-owned until close succeeds,
-and failed shutdown cleanup is reported and retryable.
+and failed shutdown cleanup is reported and retryable. The runtime mission
+handle becomes closed only after that cleanup and durable reconciliation
+succeed, so a failed public `close()` can be retried while its mission world is
+still available. If runtime-owned cleanup fails, public runtime admission stays
+closed and a later serialized `runtime.shutdown()` retries the retained mission
+before world handles or shared services are finalized. The runtime keeps a
+strong ownership reference to that handle until cleanup succeeds, so dropping
+the caller's reference cannot discard a still-live provider resource. Public
+and runtime-owned close calls are single-flight on the handle; a public close
+already in progress retains cleanup authority while runtime shutdown waits.
 
 Durable lifecycle evidence follows physical ownership. A failed terminal close
 projects the retained session's non-ready status and a `sandbox_teardown`

--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -362,7 +362,9 @@ before world handles or shared services are finalized. The runtime keeps a
 strong ownership reference to that handle until cleanup succeeds, so dropping
 the caller's reference cannot discard a still-live provider resource. Public
 and runtime-owned close calls are single-flight on the handle; a public close
-already in progress retains cleanup authority while runtime shutdown waits.
+already in progress retains cleanup authority for its exact mission world while
+runtime shutdown waits. That authority cannot admit operations against a
+sibling world on the same runtime.
 
 Durable lifecycle evidence follows physical ownership. A failed terminal close
 projects the retained session's non-ready status and a `sandbox_teardown`

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -66,8 +66,17 @@ Shutdown must:
 2. wait for every already-admitted world operation;
 3. close handles without destroying attached or runtime-owned durable worlds;
 4. call `container.shutdown()` only after admitted work drains;
-5. attempt every cleanup step and aggregate failures; and
+5. attempt every independent cleanup step in the current phase and aggregate
+   failures; and
 6. be idempotent.
+
+Shutdown phases preserve cleanup dependencies. Runtime-owned mission handles
+are attempted first. If any mission cleanup fails, the runtime rejects public
+work but retains its internal cleanup authority and does not close world
+handles or finalize the shared container. A later, serialized `shutdown()` call
+retries every retained mission cleanup. World-handle and container finalization
+begin only after that phase succeeds; calls after successful finalization are
+no-ops.
 
 ### R5 — Sync parity
 

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -72,11 +72,12 @@ Shutdown must:
 
 Shutdown phases preserve cleanup dependencies. Runtime-owned mission handles
 are attempted first. If any mission cleanup fails, the runtime rejects public
-work but retains its internal cleanup authority and does not close world
-handles or finalize the shared container. A later, serialized `shutdown()` call
-retries every retained mission cleanup. World-handle and container finalization
-begin only after that phase succeeds; calls after successful finalization are
-no-ops.
+work, drains every operation admitted before shutdown, and retains cleanup
+authority only for the exact mission world being reconciled. It does not close
+world handles or finalize the shared container. A later, serialized
+`shutdown()` call retries every retained mission cleanup. World-handle and
+container finalization begin only after that phase succeeds; calls after
+successful finalization are no-ops.
 
 ### R5 — Sync parity
 

--- a/src/archetype/app/missions/service.py
+++ b/src/archetype/app/missions/service.py
@@ -401,15 +401,19 @@ class MissionService:
         except BaseException as exc:
             failures.append(exc)
 
-        try:
-            await self._world.shutdown()
-        except BaseException as exc:
-            failures.append(exc)
         if failures:
             raise BaseExceptionGroup(
                 f"Agent Missions shutdown failed for {len(failures)} operation(s)",
                 failures,
             )
+
+        try:
+            await self._world.shutdown()
+        except BaseException as exc:
+            raise BaseExceptionGroup(
+                "Agent Missions shutdown failed for 1 operation(s)",
+                [exc],
+            ) from exc
 
     async def query(self, *components: type[Component]) -> DataFrame:
         """Query persisted mission state through the mission-world read path."""
@@ -874,7 +878,7 @@ class MissionService:
             FrictionLog(
                 kind="sandbox_teardown",
                 message=self._redact_and_tail(
-                    f"{type(exc).__name__}: {exc}",
+                    self._format_exception(exc),
                     limit=4_000,
                     scope=f"mission:{mission_id}:sandbox-teardown",
                 ),
@@ -904,7 +908,7 @@ class MissionService:
             update={
                 "status": status.value,
                 "error": self._redact_and_tail(
-                    f"{type(exc).__name__}: {exc}",
+                    self._format_exception(exc),
                     limit=4_000,
                     scope=f"sandbox:{sandbox_id}:close-error",
                 ),
@@ -912,6 +916,13 @@ class MissionService:
         )
         await self._world.update(entity_id, errored)
         self._sandbox_entities[sandbox_id] = (entity_id, errored)
+
+    @classmethod
+    def _format_exception(cls, exc: BaseException) -> str:
+        if isinstance(exc, BaseExceptionGroup):
+            nested = "; ".join(cls._format_exception(child) for child in exc.exceptions)
+            return f"{type(exc).__name__}: {exc.message}: {nested}"
+        return f"{type(exc).__name__}: {exc}"
 
     def _redact(self, value: str, *, scope: str) -> str:
         if not value:

--- a/src/archetype/runtime/missions.py
+++ b/src/archetype/runtime/missions.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from daft import DataFrame
 
@@ -19,7 +19,7 @@ from archetype.missions.contracts import (
     SubmittedMission,
 )
 from archetype.missions.sandboxes import CheckpointRef, SandboxIdentity
-from archetype.runtime.world import _runtime_cleanup_scope
+from archetype.runtime.world import RuntimeWorld, _runtime_cleanup_scope
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -40,12 +40,23 @@ class RuntimeMissions:
         storage: str | Path | StorageConfig | None = None,
     ) -> None:
         self._runtime = runtime
+
+        mission_world: RuntimeWorld | None = None
+
+        def world_factory(*args: Any, **kwargs: Any) -> RuntimeWorld:
+            nonlocal mission_world
+            mission_world = runtime.world(*args, **kwargs)
+            return mission_world
+
         self._service = runtime._agent_mission_service(
-            world_factory=runtime.world,
+            world_factory=world_factory,
             name=name,
             config=config,
             storage=storage,
         )
+        if mission_world is None:
+            raise RuntimeError("Agent Missions service did not create its mission world")
+        self._world = mission_world
         self._shutdown_lock = asyncio.Lock()
         self._closed = False
 
@@ -98,13 +109,12 @@ class RuntimeMissions:
         async with self._shutdown_lock:
             if self._closed:
                 return
-            if from_runtime:
+            # Public and runtime callers share one exact cleanup capability.
+            # Keeping the parameter distinguishes the internal protocol while
+            # preventing that capability from admitting unrelated worlds.
+            _ = from_runtime
+            with _runtime_cleanup_scope(self._world._state):
                 await self._service.close()
-            else:
-                # A public close admitted before runtime shutdown must retain
-                # cleanup authority while a concurrent runtime close waits.
-                with _runtime_cleanup_scope(self._runtime):
-                    await self._service.close()
             self._closed = True
             self._runtime._unregister_mission_handle(self)
 

--- a/src/archetype/runtime/missions.py
+++ b/src/archetype/runtime/missions.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,7 @@ from archetype.missions.contracts import (
     SubmittedMission,
 )
 from archetype.missions.sandboxes import CheckpointRef, SandboxIdentity
+from archetype.runtime.world import _runtime_cleanup_scope
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -44,6 +46,7 @@ class RuntimeMissions:
             config=config,
             storage=storage,
         )
+        self._shutdown_lock = asyncio.Lock()
         self._closed = False
 
     async def __aenter__(self) -> RuntimeMissions:
@@ -92,12 +95,17 @@ class RuntimeMissions:
         await self._shutdown_internal(from_runtime=False)
 
     async def _shutdown_internal(self, *, from_runtime: bool) -> None:
-        if self._closed:
-            return
-        self._closed = True
-        try:
-            await self._service.close()
-        finally:
+        async with self._shutdown_lock:
+            if self._closed:
+                return
+            if from_runtime:
+                await self._service.close()
+            else:
+                # A public close admitted before runtime shutdown must retain
+                # cleanup authority while a concurrent runtime close waits.
+                with _runtime_cleanup_scope(self._runtime):
+                    await self._service.close()
+            self._closed = True
             self._runtime._unregister_mission_handle(self)
 
     async def query(self, *components: type[Component]) -> DataFrame:

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -31,7 +31,12 @@ from archetype.artifacts.contracts import ArtifactStoreConfig
 from archetype.core.config import CacheConfig, StorageConfig
 from archetype.core.hooks import HookEvent
 from archetype.runtime._config import coerce_cache, coerce_storage
-from archetype.runtime.world import RuntimeWorld, SyncRuntimeWorld, _RuntimeWorldState
+from archetype.runtime.world import (
+    RuntimeWorld,
+    SyncRuntimeWorld,
+    _runtime_cleanup_scope,
+    _RuntimeWorldState,
+)
 
 if TYPE_CHECKING:
     from archetype.missions.contracts import AgentMissionConfig
@@ -85,11 +90,16 @@ class ArchetypeRuntime:
         self._container = ServiceContainer(artifact_store_config=artifact_store)
         self._application: iRuntimeApplication = self._container.application
         self._handles: WeakSet[RuntimeWorld] = WeakSet()
-        self._mission_handles: WeakSet[RuntimeMissions] = WeakSet()
+        # Mission handles own external provider resources. Keep them strongly
+        # reachable until successful cleanup unregisters them, including
+        # across a failed runtime shutdown attempt.
+        self._mission_handles: set[RuntimeMissions] = set()
+        self._shutdown_lock = asyncio.Lock()
+        self._shutdown_started = False
         self._closed = False
 
     async def __aenter__(self) -> ArchetypeRuntime:
-        if self._closed:
+        if self._shutdown_started or self._closed:
             raise RuntimeError("ArchetypeRuntime cannot be reused after close")
         return self
 
@@ -102,33 +112,39 @@ class ArchetypeRuntime:
         New operations are rejected as soon as shutdown starts. Each shared
         world state waits for its current lock-protected operation to finish
         before closing, so storage stays available to an admitted call.
-        Repeated calls have no effect.
+        Cleanup is phased and serialized. A failed mission cleanup keeps the
+        runtime's internal cleanup authority and shared services alive; a
+        later call retries that phase while public admission remains closed.
+        Repeated calls after successful finalization have no effect.
         """
-        if self._closed:
-            return
-        self._closed = True
+        async with self._shutdown_lock:
+            if self._closed:
+                return
+            self._shutdown_started = True
 
-        errors: list[BaseException] = []
-        for handle in list(self._mission_handles):
+            errors: list[BaseException] = []
+            for handle in list(self._mission_handles):
+                try:
+                    with _runtime_cleanup_scope(self):
+                        await handle._shutdown_internal(from_runtime=True)
+                except BaseException as e:
+                    errors.append(e)
+            self._raise_shutdown_failures(errors)
+
+            for handle in list(self._handles):
+                try:
+                    await handle._shutdown_internal(from_runtime=True)
+                except BaseException as e:
+                    errors.append(e)
+            self._raise_shutdown_failures(errors)
+
             try:
-                await handle._shutdown_internal(from_runtime=True)
-            except BaseException as e:
-                errors.append(e)
-        for handle in list(self._handles):
-            try:
-                await handle._shutdown_internal(from_runtime=True)
-            except Exception as e:
+                await self._container.shutdown()
+            except (Exception, BaseExceptionGroup) as e:
                 errors.append(e)
 
-        try:
-            await self._container.shutdown()
-        except (Exception, BaseExceptionGroup) as e:
-            errors.append(e)
-
-        if errors:
-            raise RuntimeError(
-                f"ArchetypeRuntime shutdown encountered {len(errors)} error(s): {errors[0]!r}"
-            ) from errors[0]
+            self._raise_shutdown_failures(errors)
+            self._closed = True
 
     def world(
         self,
@@ -153,8 +169,7 @@ class ArchetypeRuntime:
         Returns:
             A handle that activates the world on its first operation.
         """
-        if self._closed:
-            raise RuntimeError("ArchetypeRuntime is closed")
+        self._ensure_open()
 
         state = _RuntimeWorldState(
             runtime=self,
@@ -179,8 +194,7 @@ class ArchetypeRuntime:
     ) -> RuntimeMissions:
         """Create a lazy, batteries-included Agent Missions handle."""
 
-        if self._closed:
-            raise RuntimeError("ArchetypeRuntime is closed")
+        self._ensure_open()
         from archetype.runtime.missions import RuntimeMissions
 
         handle = RuntimeMissions(self, name, config=config, storage=storage)
@@ -244,8 +258,7 @@ class ArchetypeRuntime:
             storage: Storage containing the world.
             name: Local name for the returned handle.
         """
-        if self._closed:
-            raise RuntimeError("ArchetypeRuntime is closed")
+        self._ensure_open()
         info = await self._container.application.resume_world(
             coerce_storage(storage) or StorageConfig(), world_id
         )
@@ -263,8 +276,7 @@ class ArchetypeRuntime:
         Returns:
             Durable descriptors for every world recorded in that storage.
         """
-        if self._closed:
-            raise RuntimeError("ArchetypeRuntime is closed")
+        self._ensure_open()
         return await self._container.application.discover_worlds(
             coerce_storage(storage) or StorageConfig()
         )
@@ -288,8 +300,7 @@ class ArchetypeRuntime:
             name: Local name for the returned handle.
             storage: Storage containing a cold world. Omit it for a live world.
         """
-        if self._closed:
-            raise RuntimeError("ArchetypeRuntime is closed")
+        self._ensure_open()
 
         state = _RuntimeWorldState(
             runtime=self,
@@ -331,8 +342,15 @@ class ArchetypeRuntime:
     def _unregister_mission_handle(self, handle: RuntimeMissions) -> None:
         self._mission_handles.discard(handle)
 
+    @staticmethod
+    def _raise_shutdown_failures(failures: list[BaseException]) -> None:
+        if failures:
+            raise RuntimeError(
+                f"ArchetypeRuntime shutdown encountered {len(failures)} error(s): {failures[0]!r}"
+            ) from failures[0]
+
     def _ensure_open(self) -> None:
-        if self._closed:
+        if self._shutdown_started or self._closed:
             raise RuntimeError("ArchetypeRuntime is closed")
 
 

--- a/src/archetype/runtime/runtime.py
+++ b/src/archetype/runtime/runtime.py
@@ -34,7 +34,6 @@ from archetype.runtime._config import coerce_cache, coerce_storage
 from archetype.runtime.world import (
     RuntimeWorld,
     SyncRuntimeWorld,
-    _runtime_cleanup_scope,
     _RuntimeWorldState,
 )
 
@@ -125,11 +124,20 @@ class ArchetypeRuntime:
             errors: list[BaseException] = []
             for handle in list(self._mission_handles):
                 try:
-                    with _runtime_cleanup_scope(self):
-                        await handle._shutdown_internal(from_runtime=True)
+                    await handle._shutdown_internal(from_runtime=True)
                 except BaseException as e:
                     errors.append(e)
-            self._raise_shutdown_failures(errors)
+            if errors:
+                # A mission cleanup failure must preserve its world for retry,
+                # but shutdown still owes every already-admitted world call a
+                # drain before returning the retryable failure.
+                states = {handle._state for handle in list(self._handles)}
+                for state in states:
+                    try:
+                        await state.drain_admitted_operations()
+                    except BaseException as e:
+                        errors.append(e)
+                self._raise_shutdown_failures(errors)
 
             for handle in list(self._handles):
                 try:

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -256,7 +256,6 @@ class _RuntimeWorldState:
         async with self.op_lock:
             if self.closed:
                 return
-            self.closed = True
 
             if (
                 not from_runtime
@@ -268,6 +267,7 @@ class _RuntimeWorldState:
 
             for alias in list(self.aliases):
                 self.runtime._unregister_handle(alias)
+            self.closed = True
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -292,12 +292,13 @@ class RuntimeWorld:
         return self._state.runtime._application
 
     async def _ensure_id(self) -> str | UUID:
-        if (
-            _ADMITTED_STATE.get() is not self._state
-            and _RUNTIME_CLEANUP_STATE.get() is not self._state
-        ):
+        operation_is_admitted = _ADMITTED_STATE.get() is self._state
+        cleanup_owns_state = _RUNTIME_CLEANUP_STATE.get() is self._state
+        if not operation_is_admitted and not cleanup_owns_state:
             self._state.runtime._ensure_open()
-        if self._state.closed:
+        if self._state.closed or (
+            self._state.closing and not operation_is_admitted and not cleanup_owns_state
+        ):
             raise RuntimeError("World handle is closed")
         return await self._state.ensure_init()
 

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 from weakref import WeakSet
@@ -68,6 +68,20 @@ _FireMode = Any  # Literal["blocking", "spawn"] — kept loose for forward compa
 _ADMITTED_STATE: ContextVar[_RuntimeWorldState | None] = ContextVar(
     "archetype_runtime_admitted_state", default=None
 )
+_RUNTIME_CLEANUP_OWNER: ContextVar[object | None] = ContextVar(
+    "archetype_runtime_cleanup_owner", default=None
+)
+
+
+@contextmanager
+def _runtime_cleanup_scope(runtime: object):
+    """Authorize runtime-owned cleanup without reopening public admission."""
+
+    token = _RUNTIME_CLEANUP_OWNER.set(runtime)
+    try:
+        yield
+    finally:
+        _RUNTIME_CLEANUP_OWNER.reset(token)
 
 
 def _clone_components(components: tuple[Component, ...]) -> list[Component]:
@@ -158,7 +172,13 @@ class _RuntimeWorldState:
             return
 
         async with self.admission_lock:
-            if self.closing or self.closed or self.runtime._closed:
+            runtime_rejects_public_work = self.runtime._shutdown_started or self.runtime._closed
+            runtime_owns_cleanup = _RUNTIME_CLEANUP_OWNER.get() is self.runtime
+            if (
+                self.closing
+                or self.closed
+                or (runtime_rejects_public_work and not runtime_owns_cleanup)
+            ):
                 raise RuntimeError("World handle is closed")
             self.active_operations += 1
             self.drained.clear()
@@ -265,7 +285,10 @@ class RuntimeWorld:
         return self._state.runtime._application
 
     async def _ensure_id(self) -> str | UUID:
-        if _ADMITTED_STATE.get() is not self._state:
+        if (
+            _ADMITTED_STATE.get() is not self._state
+            and _RUNTIME_CLEANUP_OWNER.get() is not self._state.runtime
+        ):
             self._state.runtime._ensure_open()
         if self._state.closed:
             raise RuntimeError("World handle is closed")

--- a/src/archetype/runtime/world.py
+++ b/src/archetype/runtime/world.py
@@ -68,20 +68,20 @@ _FireMode = Any  # Literal["blocking", "spawn"] — kept loose for forward compa
 _ADMITTED_STATE: ContextVar[_RuntimeWorldState | None] = ContextVar(
     "archetype_runtime_admitted_state", default=None
 )
-_RUNTIME_CLEANUP_OWNER: ContextVar[object | None] = ContextVar(
-    "archetype_runtime_cleanup_owner", default=None
+_RUNTIME_CLEANUP_STATE: ContextVar[_RuntimeWorldState | None] = ContextVar(
+    "archetype_runtime_cleanup_state", default=None
 )
 
 
 @contextmanager
-def _runtime_cleanup_scope(runtime: object):
-    """Authorize runtime-owned cleanup without reopening public admission."""
+def _runtime_cleanup_scope(state: _RuntimeWorldState):
+    """Authorize cleanup only for one exact mission-world state."""
 
-    token = _RUNTIME_CLEANUP_OWNER.set(runtime)
+    token = _RUNTIME_CLEANUP_STATE.set(state)
     try:
         yield
     finally:
-        _RUNTIME_CLEANUP_OWNER.reset(token)
+        _RUNTIME_CLEANUP_STATE.reset(token)
 
 
 def _clone_components(components: tuple[Component, ...]) -> list[Component]:
@@ -173,7 +173,7 @@ class _RuntimeWorldState:
 
         async with self.admission_lock:
             runtime_rejects_public_work = self.runtime._shutdown_started or self.runtime._closed
-            runtime_owns_cleanup = _RUNTIME_CLEANUP_OWNER.get() is self.runtime
+            runtime_owns_cleanup = _RUNTIME_CLEANUP_STATE.get() is self
             if (
                 self.closing
                 or self.closed
@@ -192,6 +192,13 @@ class _RuntimeWorldState:
                 self.active_operations -= 1
                 if self.active_operations == 0:
                     self.drained.set()
+
+    async def drain_admitted_operations(self) -> None:
+        """Wait for tracked workflows and the current serialized operation."""
+
+        await self.drained.wait()
+        async with self.op_lock:
+            pass
 
     async def ensure_init(self) -> str | UUID:
         """Single-flight activation. Returns world_id."""
@@ -287,7 +294,7 @@ class RuntimeWorld:
     async def _ensure_id(self) -> str | UUID:
         if (
             _ADMITTED_STATE.get() is not self._state
-            and _RUNTIME_CLEANUP_OWNER.get() is not self._state.runtime
+            and _RUNTIME_CLEANUP_STATE.get() is not self._state
         ):
             self._state.runtime._ensure_open()
         if self._state.closed:
@@ -637,6 +644,9 @@ class RuntimeWorld:
 
     async def _shutdown_internal(self, *, from_runtime: bool) -> None:
         await self._state.shutdown(from_runtime=from_runtime)
+
+    async def _drain_admitted_operations(self) -> None:
+        await self._state.drain_admitted_operations()
 
     # ── Queries ───────────────────────────────────────────────────────────
 

--- a/tests/app/test_runtime_contracts.py
+++ b/tests/app/test_runtime_contracts.py
@@ -11,6 +11,8 @@ shutdown idempotency, fork handles, and pre-activation hook rejection.
 from __future__ import annotations
 
 import asyncio
+import gc
+import weakref
 
 import pytest
 
@@ -251,14 +253,20 @@ class TestShutdownIdempotency:
             await world.spawn(Pos())
 
     @pytest.mark.asyncio
-    async def test_container_cancellation_group_uses_runtime_error_contract(self, monkeypatch):
+    async def test_container_cancellation_group_uses_retryable_runtime_error_contract(
+        self, monkeypatch
+    ):
         runtime = ArchetypeRuntime()
+        attempts = 0
 
         async def fail_container_shutdown():
-            raise BaseExceptionGroup(
-                "container shutdown failed",
-                [asyncio.CancelledError("sandbox close cancelled")],
-            )
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise BaseExceptionGroup(
+                    "container shutdown failed",
+                    [asyncio.CancelledError("sandbox close cancelled")],
+                )
 
         monkeypatch.setattr(runtime._container, "shutdown", fail_container_shutdown)
 
@@ -268,16 +276,28 @@ class TestShutdownIdempotency:
         assert isinstance(captured.value.__cause__, BaseExceptionGroup)
         assert isinstance(captured.value.__cause__.exceptions[0], asyncio.CancelledError)
 
+        with pytest.raises(RuntimeError, match="closed"):
+            runtime.world("rejected-after-container-failure")
+
+        await runtime.shutdown()
+
+        assert attempts == 2
+
     @pytest.mark.asyncio
-    async def test_runtime_shutdown_closes_mission_handles_before_container(self, monkeypatch):
+    async def test_runtime_shutdown_retries_mission_handles_before_container(self, monkeypatch):
         runtime = ArchetypeRuntime()
         calls: list[str] = []
 
         class FailingMissionHandle:
+            attempts = 0
+
             async def _shutdown_internal(self, *, from_runtime: bool) -> None:
                 assert from_runtime
                 calls.append("mission")
-                raise RuntimeError("mission close failed")
+                self.attempts += 1
+                if self.attempts == 1:
+                    raise RuntimeError("mission close failed")
+                runtime._mission_handles.discard(self)  # type: ignore[arg-type]
 
         mission = FailingMissionHandle()
         runtime._mission_handles.add(mission)  # type: ignore[arg-type]
@@ -290,9 +310,146 @@ class TestShutdownIdempotency:
         with pytest.raises(RuntimeError, match="encountered 1 error") as captured:
             await runtime.shutdown()
 
-        assert calls == ["mission", "container"]
+        assert calls == ["mission"]
         assert isinstance(captured.value.__cause__, RuntimeError)
         assert "mission close failed" in str(captured.value.__cause__)
+
+        mission_ref = weakref.ref(mission)
+        del mission
+        gc.collect()
+        assert mission_ref() is not None
+        with pytest.raises(RuntimeError, match="closed"):
+            runtime.world("rejected-after-failed-shutdown")
+
+        await runtime.shutdown()
+        await runtime.shutdown()
+
+        assert calls == ["mission", "mission", "container"]
+        assert not runtime._mission_handles
+
+    @pytest.mark.asyncio
+    async def test_concurrent_runtime_shutdown_is_single_flight(self, monkeypatch):
+        runtime = ArchetypeRuntime()
+        close_started = asyncio.Event()
+        close_release = asyncio.Event()
+        second_started = asyncio.Event()
+        calls: list[str] = []
+
+        class BlockingMissionHandle:
+            async def _shutdown_internal(self, *, from_runtime: bool) -> None:
+                assert from_runtime
+                calls.append("mission")
+                close_started.set()
+                await close_release.wait()
+                runtime._mission_handles.discard(self)  # type: ignore[arg-type]
+
+        mission = BlockingMissionHandle()
+        runtime._mission_handles.add(mission)  # type: ignore[arg-type]
+
+        async def shutdown_container() -> None:
+            calls.append("container")
+
+        async def second_shutdown() -> None:
+            second_started.set()
+            await runtime.shutdown()
+
+        monkeypatch.setattr(runtime._container, "shutdown", shutdown_container)
+        first = asyncio.create_task(runtime.shutdown())
+        await close_started.wait()
+        second = asyncio.create_task(second_shutdown())
+        await second_started.wait()
+        assert not second.done()
+
+        close_release.set()
+        await asyncio.gather(first, second)
+
+        assert calls == ["mission", "container"]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_runtime_shutdown_retains_cleanup_for_retry(self, monkeypatch):
+        runtime = ArchetypeRuntime()
+        close_started = asyncio.Event()
+        never_release = asyncio.Event()
+        calls: list[str] = []
+
+        class CancelledOnceMissionHandle:
+            attempts = 0
+
+            async def _shutdown_internal(self, *, from_runtime: bool) -> None:
+                assert from_runtime
+                calls.append("mission")
+                self.attempts += 1
+                if self.attempts == 1:
+                    close_started.set()
+                    await never_release.wait()
+                runtime._mission_handles.discard(self)  # type: ignore[arg-type]
+
+        mission = CancelledOnceMissionHandle()
+        runtime._mission_handles.add(mission)  # type: ignore[arg-type]
+
+        async def shutdown_container() -> None:
+            calls.append("container")
+
+        monkeypatch.setattr(runtime._container, "shutdown", shutdown_container)
+        interrupted = asyncio.create_task(runtime.shutdown())
+        await close_started.wait()
+        interrupted.cancel()
+        with pytest.raises(RuntimeError, match="encountered 1 error") as captured:
+            await interrupted
+
+        assert isinstance(captured.value.__cause__, asyncio.CancelledError)
+        assert calls == ["mission"]
+        with pytest.raises(RuntimeError, match="closed"):
+            runtime.world("rejected-after-cancelled-shutdown")
+
+        await runtime.shutdown()
+
+        assert calls == ["mission", "mission", "container"]
+
+    @pytest.mark.asyncio
+    async def test_world_shutdown_cancellation_does_not_skip_sibling_cleanup(self, monkeypatch):
+        runtime = ArchetypeRuntime()
+        calls: list[str] = []
+
+        class CancelledOnceWorldHandle:
+            attempts = 0
+
+            async def _shutdown_internal(self, *, from_runtime: bool) -> None:
+                assert from_runtime
+                calls.append("cancelled-world")
+                self.attempts += 1
+                if self.attempts == 1:
+                    raise asyncio.CancelledError("world close cancelled")
+
+        class SiblingWorldHandle:
+            async def _shutdown_internal(self, *, from_runtime: bool) -> None:
+                assert from_runtime
+                calls.append("sibling-world")
+
+        first = CancelledOnceWorldHandle()
+        second = SiblingWorldHandle()
+        runtime._handles = (first, second)  # type: ignore[assignment]
+
+        async def shutdown_container() -> None:
+            calls.append("container")
+
+        monkeypatch.setattr(runtime._container, "shutdown", shutdown_container)
+
+        with pytest.raises(RuntimeError, match="encountered 1 error") as captured:
+            await runtime.shutdown()
+
+        assert isinstance(captured.value.__cause__, asyncio.CancelledError)
+        assert calls == ["cancelled-world", "sibling-world"]
+
+        await runtime.shutdown()
+
+        assert calls == [
+            "cancelled-world",
+            "sibling-world",
+            "cancelled-world",
+            "sibling-world",
+            "container",
+        ]
 
 
 class TestStructuredStepFailures:

--- a/tests/app/test_runtime_contracts.py
+++ b/tests/app/test_runtime_contracts.py
@@ -254,6 +254,40 @@ class TestShutdownIdempotency:
             await world.spawn(Pos())
 
     @pytest.mark.asyncio
+    async def test_failed_world_destroy_remains_retryable(self, tmp_path, monkeypatch):
+        runtime = ArchetypeRuntime()
+        world = runtime.world(
+            "retry-destroy",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns"),
+        )
+        await world.spawn(Pos())
+        application = runtime._application
+        original_destroy = application.destroy_world
+        attempts = 0
+
+        async def fail_once(world_id):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("destroy failed")
+            await original_destroy(world_id)
+
+        monkeypatch.setattr(application, "destroy_world", fail_once)
+
+        with pytest.raises(RuntimeError, match="destroy failed"):
+            await world.shutdown()
+
+        assert not world._state.closed
+        assert world in runtime._handles
+
+        await world.shutdown()
+
+        assert attempts == 2
+        assert world._state.closed
+        assert world not in runtime._handles
+        await runtime.shutdown()
+
+    @pytest.mark.asyncio
     async def test_container_cancellation_group_uses_retryable_runtime_error_contract(
         self, monkeypatch
     ):

--- a/tests/app/test_runtime_contracts.py
+++ b/tests/app/test_runtime_contracts.py
@@ -22,6 +22,7 @@ from archetype.core.aio import AsyncProcessor
 from archetype.core.config import StorageConfig
 from archetype.core.errors import TickExecutionError
 from archetype.core.hooks import PreTick
+from archetype.runtime.world import _runtime_cleanup_scope
 
 
 class Pos(Component):
@@ -326,6 +327,81 @@ class TestShutdownIdempotency:
 
         assert calls == ["mission", "mission", "container"]
         assert not runtime._mission_handles
+
+    @pytest.mark.asyncio
+    async def test_failed_mission_cleanup_still_drains_admitted_world_work(
+        self, tmp_path, monkeypatch
+    ):
+        runtime = ArchetypeRuntime()
+        world = runtime.world(
+            "drain-before-mission-failure",
+            storage=StorageConfig(uri=str(tmp_path / "store"), namespace="ns"),
+        )
+        await world.spawn(Pos())
+
+        run_started = asyncio.Event()
+        run_release = asyncio.Event()
+        mission_attempted = asyncio.Event()
+
+        async def blocking_run(*args, **kwargs):
+            run_started.set()
+            await run_release.wait()
+            return object()
+
+        monkeypatch.setattr(runtime._application, "run", blocking_run)
+
+        class FailingOnceMissionHandle:
+            attempts = 0
+
+            async def _shutdown_internal(self, *, from_runtime: bool) -> None:
+                assert from_runtime
+                self.attempts += 1
+                mission_attempted.set()
+                if self.attempts == 1:
+                    raise RuntimeError("mission close failed")
+                runtime._mission_handles.discard(self)  # type: ignore[arg-type]
+
+        mission = FailingOnceMissionHandle()
+        runtime._mission_handles.add(mission)  # type: ignore[arg-type]
+
+        admitted_run = asyncio.create_task(world.run())
+        await run_started.wait()
+        shutdown = asyncio.create_task(runtime.shutdown())
+        await mission_attempted.wait()
+        await asyncio.sleep(0)
+
+        assert not shutdown.done()
+
+        run_release.set()
+        await admitted_run
+        with pytest.raises(RuntimeError, match="mission close failed"):
+            await shutdown
+
+        assert not world._state.closed
+        with pytest.raises(RuntimeError, match="closed"):
+            await world.spawn(Pos())
+
+        await runtime.shutdown()
+        assert world._state.closed
+
+    @pytest.mark.asyncio
+    async def test_cleanup_capability_does_not_admit_a_sibling_world(self, tmp_path):
+        runtime = ArchetypeRuntime()
+        storage = StorageConfig(uri=str(tmp_path / "store"), namespace="ns")
+        mission_world = runtime.world("mission", storage=storage)
+        sibling_world = runtime.world("sibling", storage=storage)
+        await mission_world.spawn(Pos())
+        await sibling_world.spawn(Pos())
+
+        runtime._shutdown_started = True
+        try:
+            with _runtime_cleanup_scope(mission_world._state):
+                await mission_world.spawn(Pos())
+                with pytest.raises(RuntimeError, match="closed"):
+                    await sibling_world.spawn(Pos())
+        finally:
+            runtime._shutdown_started = False
+            await runtime.shutdown()
 
     @pytest.mark.asyncio
     async def test_concurrent_runtime_shutdown_is_single_flight(self, monkeypatch):

--- a/tests/app/test_runtime_contracts.py
+++ b/tests/app/test_runtime_contracts.py
@@ -279,6 +279,8 @@ class TestShutdownIdempotency:
 
         assert not world._state.closed
         assert world in runtime._handles
+        with pytest.raises(RuntimeError, match="closed"):
+            await world.spawn(Pos())
 
         await world.shutdown()
 
@@ -428,6 +430,7 @@ class TestShutdownIdempotency:
         await sibling_world.spawn(Pos())
 
         runtime._shutdown_started = True
+        mission_world._state.closing = True
         try:
             with _runtime_cleanup_scope(mission_world._state):
                 await mission_world.spawn(Pos())
@@ -435,6 +438,7 @@ class TestShutdownIdempotency:
                     await sibling_world.spawn(Pos())
         finally:
             runtime._shutdown_started = False
+            mission_world._state.closing = False
             await runtime.shutdown()
 
     @pytest.mark.asyncio

--- a/tests/integration/test_agent_mission_service.py
+++ b/tests/integration/test_agent_mission_service.py
@@ -6,8 +6,10 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import os
 import subprocess
+import weakref
 from pathlib import Path
 
 import pytest
@@ -40,6 +42,7 @@ from archetype.missions.sandboxes import (
     SandboxEvent,
     SandboxEventType,
     SandboxIdentity,
+    SandboxKey,
     SandboxSpec,
     SandboxStatus,
 )
@@ -251,10 +254,12 @@ class _AutoReplacementBackend:
         *,
         fail_first_checkpoint: bool = False,
         fail_first_close: bool = False,
+        first_close_failures: int = 0,
         fail_create_sequences: tuple[int, ...] = (),
     ) -> None:
         self.fail_first_checkpoint = fail_first_checkpoint
         self.fail_first_close = fail_first_close
+        self.first_close_failures = first_close_failures
         self.fail_create_sequences = fail_create_sequences
         self.create_attempts = 0
         self.sessions: list[_AutoReplacementSession] = []
@@ -268,7 +273,9 @@ class _AutoReplacementBackend:
             spec,
             f"sandbox-replacement-{sequence}",
             fail_checkpoint=self.fail_first_checkpoint and sequence == 1,
-            close_failures=1 if self.fail_first_close and sequence == 1 else 0,
+            close_failures=(
+                max(self.first_close_failures, int(self.fail_first_close)) if sequence == 1 else 0
+            ),
         )
         self.sessions.append(session)
         return session
@@ -938,6 +945,309 @@ async def test_terminal_close_failure_is_durable_and_retryable(
             rows = latest(await missions.query(Sandbox)).to_pylist()
             assert rows[0][f"{sandbox}status"] == SandboxStatus.CLOSED.value
             assert "provider close unavailable" in str(rows[0][f"{sandbox}error"])
+
+
+@pytest.mark.asyncio
+async def test_public_mission_close_remains_retryable_after_cleanup_failure(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    backend = _AutoReplacementBackend(first_close_failures=2)
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "public-terminal-close-retry",
+        config=AgentMissionConfig(
+            sandbox_backend=backend,
+            sandbox_environment="local-replacement-test",
+            driver=_MissionDriver(workspace),
+            workspace=str(workspace),
+            checkpoint_after_dispatch=False,
+        ),
+        storage=StorageConfig(
+            uri=str(tmp_path / "public_terminal_close_retry_missions"),
+            namespace="public_terminal_close_retry_contract",
+        ),
+    )
+    try:
+        submitted = await missions.submit(
+            repository=str(remote),
+            branch="agent/public-terminal-close-retry",
+            tasks=(
+                AgentTask(
+                    "implementation",
+                    "Create implementation.txt containing fixed.",
+                    (
+                        CommandValidator(
+                            "focused",
+                            (
+                                "sh",
+                                "-lc",
+                                'test "$(cat implementation.txt)" = fixed',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="provider close unavailable"):
+            await missions.run(submitted)
+        with pytest.raises(BaseExceptionGroup, match="Agent Missions shutdown failed"):
+            await missions.close()
+
+        assert len(backend.sessions) == 1
+        session = backend.sessions[0]
+        assert session.close_attempts == 2
+        assert await session.status() is SandboxStatus.ERRORED
+        sandbox = Sandbox.get_prefix()
+        rows = latest(await missions.query(Sandbox)).to_pylist()
+        assert rows[0][f"{sandbox}status"] == SandboxStatus.ERRORED.value
+
+        await missions.close()
+
+        assert session.close_attempts == 3
+        assert await session.status() is SandboxStatus.CLOSED
+        retained = missions._service._sandbox_entities[  # noqa: SLF001 - durable retry oracle
+            session.identity.sandbox_id
+        ][1]
+        assert retained.status == SandboxStatus.CLOSED.value
+        assert "provider close unavailable" in retained.error
+    finally:
+        await runtime.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_public_and_runtime_mission_close_are_single_flight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = _LocalBackend()
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "single-flight-mission-close",
+        config=AgentMissionConfig(
+            sandbox_backend=backend,
+            sandbox_environment="local-test",
+            driver=_MissionDriver(tmp_path / "sandbox" / "repo"),
+            workspace=str(tmp_path / "sandbox" / "repo"),
+            checkpoint_after_dispatch=False,
+        ),
+        storage=StorageConfig(
+            uri=str(tmp_path / "single_flight_mission_close"),
+            namespace="single_flight_mission_close_contract",
+        ),
+    )
+    close_started = asyncio.Event()
+    close_release = asyncio.Event()
+    runtime_shutdown_started = asyncio.Event()
+    close_calls = 0
+    concurrent_closes = 0
+    max_concurrent_closes = 0
+    await missions._service._world.info()  # noqa: SLF001 - activate cleanup authority oracle
+
+    async def blocking_service_close() -> None:
+        nonlocal close_calls, concurrent_closes, max_concurrent_closes
+        close_calls += 1
+        concurrent_closes += 1
+        max_concurrent_closes = max(max_concurrent_closes, concurrent_closes)
+        close_started.set()
+        try:
+            await close_release.wait()
+            await missions._service._world.info()  # noqa: SLF001 - admitted cleanup oracle
+        finally:
+            concurrent_closes -= 1
+
+    async def runtime_shutdown() -> None:
+        runtime_shutdown_started.set()
+        await runtime.shutdown()
+
+    monkeypatch.setattr(missions._service, "close", blocking_service_close)  # noqa: SLF001
+    public_close = asyncio.create_task(missions.close())
+    await close_started.wait()
+    runtime_close = asyncio.create_task(runtime_shutdown())
+    await runtime_shutdown_started.wait()
+
+    assert close_calls == 1
+    assert max_concurrent_closes == 1
+    assert runtime._shutdown_started  # noqa: SLF001 - deterministic race position
+
+    close_release.set()
+    await asyncio.gather(public_close, runtime_close)
+
+    assert close_calls == 1
+    assert max_concurrent_closes == 1
+    assert missions._closed  # noqa: SLF001 - handle lifecycle oracle
+
+
+@pytest.mark.asyncio
+async def test_runtime_shutdown_reconciles_a_retained_ready_mission_sandbox(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    storage = StorageConfig(
+        uri=str(tmp_path / "runtime_shutdown_reconciliation"),
+        namespace="runtime_shutdown_reconciliation_contract",
+    )
+    backend = _AutoReplacementBackend()
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "runtime-shutdown-reconciliation",
+        config=AgentMissionConfig(
+            sandbox_backend=backend,
+            sandbox_environment="local-replacement-test",
+            driver=_MissionDriver(workspace),
+            workspace=str(workspace),
+            checkpoint_after_dispatch=False,
+        ),
+        storage=storage,
+    )
+    submitted = await missions.submit(
+        repository=str(remote),
+        branch="agent/runtime-shutdown-reconciliation",
+        tasks=(
+            AgentTask(
+                "implementation",
+                "Create implementation.txt containing fixed.",
+                (
+                    CommandValidator(
+                        "focused",
+                        (
+                            "sh",
+                            "-lc",
+                            'test "$(cat implementation.txt)" = fixed',
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    service = missions._service  # noqa: SLF001 - runtime cleanup integration seam
+    key = SandboxKey(f"mission:{submitted.mission_id}")
+    session = await service._sandboxes.acquire(  # noqa: SLF001
+        key,
+        service._sandbox_spec(submitted.mission_id, submitted.branch),  # noqa: SLF001
+    )
+    await service._ensure_sandbox_entity(  # noqa: SLF001
+        submitted.mission_id,
+        session.identity,
+        status=SandboxStatus.READY,
+    )
+    await service._world.step()  # noqa: SLF001 - commit the READY counterfactual
+    world_id = missions.world_id
+
+    close_started = asyncio.Event()
+    close_release = asyncio.Event()
+    provider_close = session.close
+
+    async def blocking_close() -> None:
+        close_started.set()
+        await close_release.wait()
+        await provider_close()
+
+    monkeypatch.setattr(session, "close", blocking_close)
+    shutting_down = asyncio.create_task(runtime.shutdown())
+    await close_started.wait()
+    try:
+        with pytest.raises(RuntimeError, match="closed"):
+            runtime.world("rejected-during-runtime-shutdown")
+        with pytest.raises(RuntimeError, match="closed"):
+            await missions.query(Sandbox)
+    finally:
+        close_release.set()
+
+    await shutting_down
+
+    assert await session.status() is SandboxStatus.CLOSED
+    assert missions._closed  # noqa: SLF001 - runtime-owned handle lifecycle oracle
+    async with ArchetypeRuntime() as reader:
+        attached = reader.attach(world_id, storage=storage)
+        sandbox = Sandbox.get_prefix()
+        rows = latest(await attached.query(Sandbox)).to_pylist()
+        assert rows[-1][f"{sandbox}sandbox_id"] == session.identity.sandbox_id
+        assert rows[-1][f"{sandbox}status"] == SandboxStatus.CLOSED.value
+
+
+@pytest.mark.asyncio
+async def test_runtime_shutdown_retries_failed_mission_cleanup_before_finalization(
+    tmp_path: Path,
+) -> None:
+    remote = _remote(tmp_path)
+    workspace = tmp_path / "sandbox" / "repo"
+    storage = StorageConfig(
+        uri=str(tmp_path / "runtime_shutdown_cleanup_retry"),
+        namespace="runtime_shutdown_cleanup_retry_contract",
+    )
+    backend = _AutoReplacementBackend(first_close_failures=2)
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "runtime-shutdown-cleanup-retry",
+        config=AgentMissionConfig(
+            sandbox_backend=backend,
+            sandbox_environment="local-replacement-test",
+            driver=_MissionDriver(workspace),
+            workspace=str(workspace),
+            checkpoint_after_dispatch=False,
+        ),
+        storage=storage,
+    )
+    submitted = await missions.submit(
+        repository=str(remote),
+        branch="agent/runtime-shutdown-cleanup-retry",
+        tasks=(
+            AgentTask(
+                "implementation",
+                "Create implementation.txt containing fixed.",
+                (
+                    CommandValidator(
+                        "focused",
+                        (
+                            "sh",
+                            "-lc",
+                            'test "$(cat implementation.txt)" = fixed',
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="provider close unavailable"):
+        await missions.run(submitted)
+    with pytest.raises(RuntimeError, match="Agent Missions shutdown failed"):
+        await runtime.shutdown()
+
+    session = backend.sessions[0]
+    assert session.close_attempts == 2
+    assert await session.status() is SandboxStatus.ERRORED
+    assert not missions._closed  # noqa: SLF001 - retry ownership oracle
+    with pytest.raises(RuntimeError, match="closed"):
+        runtime.world("rejected-while-cleanup-is-retryable")
+    with pytest.raises(RuntimeError, match="closed"):
+        await missions.query(Sandbox)
+
+    world_id = missions.world_id
+    mission_ref = weakref.ref(missions)
+    del missions
+    gc.collect()
+    assert mission_ref() is not None
+
+    await runtime.shutdown()
+    await runtime.shutdown()
+
+    assert session.close_attempts == 3
+    assert await session.status() is SandboxStatus.CLOSED
+    assert not runtime._mission_handles  # noqa: SLF001 - cleanup ownership oracle
+    gc.collect()
+    assert mission_ref() is None
+    async with ArchetypeRuntime() as reader:
+        attached = reader.attach(world_id, storage=storage)
+        sandbox = Sandbox.get_prefix()
+        rows = latest(await attached.query(Sandbox)).to_pylist()
+        assert rows[-1][f"{sandbox}sandbox_id"] == session.identity.sandbox_id
+        assert rows[-1][f"{sandbox}status"] == SandboxStatus.CLOSED.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- retain runtime mission handles strongly until their provider cleanup and durable reconciliation succeed
- serialize public mission close and whole-runtime shutdown so one caller owns cleanup while concurrent callers wait
- phase runtime shutdown as mission cleanup, world-handle cleanup, then shared-container finalization
- keep public admission closed after a failed shutdown while preserving internal cleanup authority for a later retry
- delay mission-world shutdown until sandbox cleanup succeeds, and retain failed handles rather than losing live provider ownership
- render nested cleanup failures into redacted durable friction evidence
- document the retryable runtime teardown contract and add deterministic cancellation, dropped-handle, concurrent-close, and retry coverage

## Why

The sandbox lifecycle stage makes provider cleanup retryable, but the runtime also has to preserve the handle and the services needed to perform that retry. A failed mission close must not unregister the handle, close its world, or finalize the shared container; doing so would turn a recoverable provider failure into a leaked resource with no remaining cleanup authority.

This is the third reliability cut after #633 and #635. The native exact-head critic remains the final stage in #630.

## Validation

- `uv run pytest -q tests/app/test_runtime_contracts.py tests/integration/test_agent_mission_service.py` — 45 passed
- `make ci` on the final combined sandbox-plus-runtime stack — passed; 1,836 tests passed, 4 skipped; static, architecture, conformance, capability, package, examples, and docs gates passed
