### PR TITLE
fix(runtime): close PR3 admission and live-input regressions

### DIFF
--- a/src/archetype/app/application/service.py
+++ b/src/archetype/app/application/service.py
@@ -12,7 +12,6 @@ authority.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 from archetype.app.models import Command, deferred_operation
@@ -87,16 +86,6 @@ def _component_values(components) -> tuple[ComponentValue, ...]:
 
 def _component_types(component_types) -> tuple[ComponentTypeRef, ...]:
     return tuple(ComponentTypeRef.from_type(component_type) for component_type in component_types)
-
-
-def _input_kwargs_json(input_kwargs: dict) -> str:
-    return json.dumps(
-        input_kwargs,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
-        allow_nan=False,
-    )
 
 
 class RuntimeApplication:
@@ -278,7 +267,7 @@ class RuntimeApplication:
             Step(
                 world_id=world_id,
                 run_config=run_config,
-                input_kwargs_json=_input_kwargs_json(input_kwargs),
+                input_kwargs=input_kwargs,
             )
         )
 
@@ -287,7 +276,7 @@ class RuntimeApplication:
             Run(
                 world_id=world_id,
                 run_config=run_config,
-                input_kwargs_json=_input_kwargs_json(input_kwargs),
+                input_kwargs=input_kwargs,
             )
         )
 
@@ -296,7 +285,7 @@ class RuntimeApplication:
             RunEpisode(
                 world_id=world_id,
                 config=config,
-                input_kwargs_json=_input_kwargs_json(input_kwargs),
+                input_kwargs=input_kwargs,
             )
         )
 
@@ -305,7 +294,7 @@ class RuntimeApplication:
             RunRollout(
                 world_id=world_id,
                 config=config,
-                input_kwargs_json=_input_kwargs_json(input_kwargs),
+                input_kwargs=input_kwargs,
             )
         )
 
@@ -319,16 +308,19 @@ class RuntimeApplication:
         lab_world_id=None,
         on_iteration=None,
     ):
-        if self._research is None:
-            raise RuntimeError("research service is not wired")
-        return await self._research.run(
-            world_id,
-            config,
-            evaluator,
-            prepare_candidate=prepare_candidate,
-            lab_world_id=lab_world_id,
-            on_iteration=on_iteration,
-        )
+        # PR-4 deletes this finite bridge when the workflow gains its exact
+        # family registration. Keep admission commands-owned in the meantime.
+        async with self._dispatcher._admitted():
+            if self._research is None:
+                raise RuntimeError("research service is not wired")
+            return await self._research.run(
+                world_id,
+                config,
+                evaluator,
+                prepare_candidate=prepare_candidate,
+                lab_world_id=lab_world_id,
+                on_iteration=on_iteration,
+            )
 
     async def evaluate_physical_task(
         self,
@@ -339,13 +331,14 @@ class RuntimeApplication:
     ) -> PhysicalTaskEvalReport:
         """Run one ledger-backed physical evaluation through its owning service."""
 
-        if self._physical_ai is None:
-            raise RuntimeError("physical AI service is not wired")
-        return await self._physical_ai.evaluate_task(
-            config,
-            env_client=env_client,
-            policy_client=policy_client,
-        )
+        async with self._dispatcher._admitted():
+            if self._physical_ai is None:
+                raise RuntimeError("physical AI service is not wired")
+            return await self._physical_ai.evaluate_task(
+                config,
+                env_client=env_client,
+                policy_client=policy_client,
+            )
 
     async def sweep_physical_instructions(
         self,
@@ -356,13 +349,14 @@ class RuntimeApplication:
     ) -> InstructionSweepReport:
         """Run one paired-seed instruction sweep through its owning service."""
 
-        if self._physical_ai is None:
-            raise RuntimeError("physical AI service is not wired")
-        return await self._physical_ai.sweep_instructions(
-            config,
-            env_client=env_client,
-            policy_client=policy_client,
-        )
+        async with self._dispatcher._admitted():
+            if self._physical_ai is None:
+                raise RuntimeError("physical AI service is not wired")
+            return await self._physical_ai.sweep_instructions(
+                config,
+                env_client=env_client,
+                policy_client=policy_client,
+            )
 
     # Query and introspection ----------------------------------------
 
@@ -474,38 +468,54 @@ class RuntimeApplication:
     # Artifacts and evaluation --------------------------------------
 
     async def ingest_artifacts(self, world_id, sources, *, storage_config=None):
-        if self._artifacts is None:
-            raise RuntimeError("artifact service is not wired")
-        return await self._artifacts.ingest(
-            str(world_id),
-            sources,
-            storage_config=storage_config,
-        )
+        async with self._dispatcher._admitted():
+            if self._artifacts is None:
+                raise RuntimeError("artifact service is not wired")
+            return await self._artifacts.ingest(
+                str(world_id),
+                sources,
+                storage_config=storage_config,
+            )
 
     async def ingest_claude_transcript(self, world_id, source, *, storage_config=None):
-        if self._transcripts is None:
-            raise RuntimeError("transcript ingestion service is not wired")
-        return await self._transcripts.ingest(str(world_id), source, storage_config=storage_config)
+        async with self._dispatcher._admitted():
+            if self._transcripts is None:
+                raise RuntimeError("transcript ingestion service is not wired")
+            return await self._transcripts.ingest(
+                str(world_id),
+                source,
+                storage_config=storage_config,
+            )
 
     async def query_transcript_rows(self, world_id, *, storage_config=None):
-        if self._transcripts is None:
-            raise RuntimeError("transcript ingestion service is not wired")
-        return await self._transcripts.read(str(world_id), storage_config=storage_config)
+        async with self._dispatcher._admitted():
+            if self._transcripts is None:
+                raise RuntimeError("transcript ingestion service is not wired")
+            return await self._transcripts.read(
+                str(world_id),
+                storage_config=storage_config,
+            )
 
     async def query_artifacts(self, world_id, *, storage_config=None):
-        if self._artifacts is None:
-            raise RuntimeError("artifact service is not wired")
-        return await self._artifacts.index(str(world_id), storage_config=storage_config)
+        async with self._dispatcher._admitted():
+            if self._artifacts is None:
+                raise RuntimeError("artifact service is not wired")
+            return await self._artifacts.index(
+                str(world_id),
+                storage_config=storage_config,
+            )
 
     async def run_graders(self, df, graders):
-        if self._evaluations is None:
-            raise RuntimeError("evaluation service is not wired")
-        return await self._evaluations.run_graders(df, graders)
+        async with self._dispatcher._admitted():
+            if self._evaluations is None:
+                raise RuntimeError("evaluation service is not wired")
+            return await self._evaluations.run_graders(df, graders)
 
     async def evaluate(self, world_id, components, **kwargs):
-        if self._evaluations is None:
-            raise RuntimeError("evaluation service is not wired")
-        return await self._evaluations.evaluate(str(world_id), components, **kwargs)
+        async with self._dispatcher._admitted():
+            if self._evaluations is None:
+                raise RuntimeError("evaluation service is not wired")
+            return await self._evaluations.evaluate(str(world_id), components, **kwargs)
 
     async def query_trajectory(
         self,
@@ -515,17 +525,18 @@ class RuntimeApplication:
         storage_config=None,
         **kwargs,
     ):
-        if self._trajectories is None:
-            raise RuntimeError("trajectory service is not wired")
-        storage_config = await self._resolve_storage(world_id, storage_config)
-        return await self._trajectories.query(
-            component,
-            world_id=str(world_id),
-            run_id=str(run_id),
-            storage_config=storage_config,
-            lineage=await self._resolve_lineage(world_id, run_id, storage_config),
-            **kwargs,
-        )
+        async with self._dispatcher._admitted():
+            if self._trajectories is None:
+                raise RuntimeError("trajectory service is not wired")
+            storage_config = await self._resolve_storage(world_id, storage_config)
+            return await self._trajectories.query(
+                component,
+                world_id=str(world_id),
+                run_id=str(run_id),
+                storage_config=storage_config,
+                lineage=await self._resolve_lineage(world_id, run_id, storage_config),
+                **kwargs,
+            )
 
     async def grade_trajectory(
         self,
@@ -537,18 +548,19 @@ class RuntimeApplication:
         storage_config=None,
         **kwargs,
     ):
-        if self._trajectories is None:
-            raise RuntimeError("trajectory service is not wired")
-        storage_config = await self._resolve_storage(world_id, storage_config)
-        return await self._trajectories.grade(
-            component,
-            world_id=str(world_id),
-            run_id=str(run_id),
-            graders=graders,
-            storage_config=storage_config,
-            lineage=await self._resolve_lineage(world_id, run_id, storage_config),
-            **kwargs,
-        )
+        async with self._dispatcher._admitted():
+            if self._trajectories is None:
+                raise RuntimeError("trajectory service is not wired")
+            storage_config = await self._resolve_storage(world_id, storage_config)
+            return await self._trajectories.grade(
+                component,
+                world_id=str(world_id),
+                run_id=str(run_id),
+                graders=graders,
+                storage_config=storage_config,
+                lineage=await self._resolve_lineage(world_id, run_id, storage_config),
+                **kwargs,
+            )
 
     # Deferred commands ---------------------------------------------
 

--- a/src/archetype/app/gateway/service.py
+++ b/src/archetype/app/gateway/service.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Literal
 
@@ -74,16 +73,6 @@ def _component_values(components) -> tuple[ComponentValue, ...]:
 
 def _component_types(component_types) -> tuple[ComponentTypeRef, ...]:
     return tuple(ComponentTypeRef.from_type(component_type) for component_type in component_types)
-
-
-def _input_kwargs_json(input_kwargs: dict) -> str:
-    return json.dumps(
-        input_kwargs,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
-        allow_nan=False,
-    )
 
 
 class CommandGateway:
@@ -357,7 +346,7 @@ class CommandGateway:
             Step(
                 world_id=world_id,
                 run_config=run_config,
-                input_kwargs_json=_input_kwargs_json(input_kwargs),
+                input_kwargs=input_kwargs,
             ),
         )
 
@@ -367,7 +356,7 @@ class CommandGateway:
             Run(
                 world_id=world_id,
                 run_config=run_config,
-                input_kwargs_json=_input_kwargs_json(input_kwargs),
+                input_kwargs=input_kwargs,
             ),
         )
 
@@ -377,7 +366,7 @@ class CommandGateway:
             RunEpisode(
                 world_id=world_id,
                 config=config,
-                input_kwargs_json=_input_kwargs_json(input_kwargs),
+                input_kwargs=input_kwargs,
             ),
         )
 
@@ -387,7 +376,7 @@ class CommandGateway:
             RunRollout(
                 world_id=world_id,
                 config=config,
-                input_kwargs_json=_input_kwargs_json(input_kwargs),
+                input_kwargs=input_kwargs,
             ),
         )
 

--- a/src/archetype/commands/scheduler.py
+++ b/src/archetype/commands/scheduler.py
@@ -503,8 +503,14 @@ class CommandScheduler:
             try:
                 entity_ids = await asyncio.shield(task)
             except asyncio.CancelledError:
-                # The task remains retained. An identical retry awaits the same
-                # reservation instead of allocating another ID.
+                # Caller cancellation leaves the shielded reservation live and
+                # owned for an identical retry. A reservation task that
+                # cancelled itself is terminal, so retaining it would pin every
+                # later retry to the same CancelledError forever.
+                if task.cancelled():
+                    async with self._identity_lock:
+                        if self._reservation_tasks.get(key) is task:
+                            self._reservation_tasks.pop(key, None)
                 raise
             except BaseException:
                 async with self._identity_lock:

--- a/src/archetype/commands/scheduler.py
+++ b/src/archetype/commands/scheduler.py
@@ -496,6 +496,9 @@ class CommandScheduler:
                     )
                 self._reservation_requests[key] = request_digest
                 task = self._reservation_tasks.get(key)
+                if task is not None and task.cancelled():
+                    self._reservation_tasks.pop(key, None)
+                    task = None
                 if task is None:
                     task = asyncio.ensure_future(self._reserve_entity_ids(operation.world_id, 1))
                     self._reservation_tasks[key] = task

--- a/src/archetype/world/handlers.py
+++ b/src/archetype/world/handlers.py
@@ -10,7 +10,6 @@ family.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -76,13 +75,6 @@ def _component_types(
     values: tuple[ComponentTypeRef, ...],
 ) -> list[type[Component]]:
     return [value.resolve() for value in values]
-
-
-def _input_kwargs(payload_json: str) -> dict[str, Any]:
-    decoded = json.loads(payload_json)
-    if not isinstance(decoded, dict):
-        raise ValueError("input_kwargs_json must decode to an object")
-    return decoded
 
 
 def _world_info(world: Any) -> WorldInfo:
@@ -374,7 +366,7 @@ async def step(registry: iWorldRegistry, operation: Step) -> int:
         registry,
         operation.world_id,
         operation.run_config,
-        **_input_kwargs(operation.input_kwargs_json),
+        **operation.input_kwargs,
     )
 
 
@@ -383,7 +375,7 @@ async def run(registry: iWorldRegistry, operation: Run):
         registry,
         operation.world_id,
         operation.run_config,
-        **_input_kwargs(operation.input_kwargs_json),
+        **operation.input_kwargs,
     )
 
 
@@ -397,7 +389,7 @@ async def run_episode(
         storage,
         operation.world_id,
         operation.config,
-        **_input_kwargs(operation.input_kwargs_json),
+        **operation.input_kwargs,
     )
 
 
@@ -415,7 +407,7 @@ async def run_rollout(
         destroy,
         operation.world_id,
         operation.config,
-        **_input_kwargs(operation.input_kwargs_json),
+        **operation.input_kwargs,
     )
 
 

--- a/src/archetype/world/models.py
+++ b/src/archetype/world/models.py
@@ -236,22 +236,6 @@ class WorldOperation(_FrozenModel):
     direct_only: ClassVar[bool] = True
     operation: str
 
-    @field_validator("input_kwargs_json", mode="before", check_fields=False)
-    @classmethod
-    def _canonicalize_input_kwargs_json(cls, value: object) -> str:
-        if not isinstance(value, str):
-            raise TypeError("input_kwargs_json must be a JSON string")
-        decoded = json.loads(value)
-        if not isinstance(decoded, dict):
-            raise ValueError("input_kwargs_json must decode to an object")
-        return json.dumps(
-            decoded,
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=True,
-            allow_nan=False,
-        )
-
 
 class Spawn(WorldOperation):
     direct_only: ClassVar[bool] = False
@@ -400,28 +384,28 @@ class Step(WorldOperation):
     operation: Literal["step"] = "step"
     world_id: str | JsonUUID
     run_config: RunConfig = Field(default_factory=RunConfig)
-    input_kwargs_json: str = "{}"
+    input_kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
 class Run(WorldOperation):
     operation: Literal["run"] = "run"
     world_id: str | JsonUUID
     run_config: RunConfig = Field(default_factory=RunConfig)
-    input_kwargs_json: str = "{}"
+    input_kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
 class RunEpisode(WorldOperation):
     operation: Literal["run_episode"] = "run_episode"
     world_id: str | JsonUUID
     config: EpisodeConfig = Field(default_factory=EpisodeConfig)
-    input_kwargs_json: str = "{}"
+    input_kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
 class RunRollout(WorldOperation):
     operation: Literal["run_rollout"] = "run_rollout"
     world_id: str | JsonUUID
     config: RolloutConfig = Field(default_factory=RolloutConfig)
-    input_kwargs_json: str = "{}"
+    input_kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
 class QueryComponents(WorldOperation):

--- a/tests/app/test_application_review_contracts.py
+++ b/tests/app/test_application_review_contracts.py
@@ -1,0 +1,299 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Review regressions for temporary RuntimeApplication command bridges."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from daft import DataFrame
+from uuid_utils import uuid7
+
+from archetype import AsyncProcessor, Component
+from archetype.app.container import ServiceContainer
+from archetype.app.gateway._pr3_commands_bridge import PR3_BRIDGE_MODEL_LITERALS
+from archetype.app.gateway.auth.models import ActorCtx
+from archetype.core.config import RunConfig, StorageConfig, WorldConfig
+
+
+class ReviewValue(Component):
+    value: int = 0
+
+
+class CaptureInputs(AsyncProcessor):
+    components = (ReviewValue,)
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def process(self, df: DataFrame, **input_kwargs: Any) -> DataFrame:
+        self.calls.append(input_kwargs)
+        return df
+
+
+@asynccontextmanager
+async def _container_harness():
+    container = ServiceContainer()
+    try:
+        yield container
+    finally:
+        for world in await container.world_registry.list_worlds():
+            await container.world_lifecycle.destroy_world(world.world_id)
+        await container.shutdown()
+
+
+async def _call_temporary_bridge(application: Any, operation: str) -> None:
+    if operation == "autoresearch":
+        await application.autoresearch("world", object(), object())
+    elif operation == "evaluate_physical_task":
+        await application.evaluate_physical_task(object(), env_client=object())
+    elif operation == "sweep_physical_instructions":
+        await application.sweep_physical_instructions(
+            object(),
+            env_client=object(),
+            policy_client=object(),
+        )
+    elif operation == "ingest_artifacts":
+        await application.ingest_artifacts("world", ("source",))
+    elif operation == "ingest_claude_transcript":
+        await application.ingest_claude_transcript("world", object())
+    elif operation == "query_transcript_rows":
+        await application.query_transcript_rows("world")
+    elif operation == "query_artifacts":
+        await application.query_artifacts("world")
+    elif operation == "run_graders":
+        await application.run_graders(object(), (object(),))
+    elif operation == "evaluate":
+        await application.evaluate("world", ())
+    elif operation == "query_trajectory":
+        await application.query_trajectory(object(), "world", "run")
+    elif operation == "grade_trajectory":
+        await application.grade_trajectory(
+            object(),
+            "world",
+            "run",
+            graders=(object(),),
+        )
+    else:
+        raise AssertionError(f"unknown temporary bridge operation {operation!r}")
+
+
+_TEMPORARY_ASYNC_BRIDGES = (
+    "autoresearch",
+    "evaluate_physical_task",
+    "sweep_physical_instructions",
+    "ingest_artifacts",
+    "ingest_claude_transcript",
+    "query_transcript_rows",
+    "query_artifacts",
+    "run_graders",
+    "evaluate",
+    "query_trajectory",
+    "grade_trajectory",
+)
+_MISSION_SERVICE_BRIDGES = frozenset(
+    {
+        "submit_mission",
+        "run_mission",
+        "restore_mission_sandbox",
+    }
+)
+
+
+def test_temporary_application_bridge_inventory_is_exhaustive() -> None:
+    assert frozenset(_TEMPORARY_ASYNC_BRIDGES) == (
+        frozenset(PR3_BRIDGE_MODEL_LITERALS.values()) - _MISSION_SERVICE_BRIDGES
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", _TEMPORARY_ASYNC_BRIDGES)
+async def test_temporary_application_bridge_rejects_before_service_effect(
+    operation: str,
+) -> None:
+    async with _container_harness() as container:
+        application = cast(Any, container.application)
+        effects = [AsyncMock() for _ in range(11)]
+        application._research = SimpleNamespace(run=effects[0])
+        application._physical_ai = SimpleNamespace(
+            evaluate_task=effects[1],
+            sweep_instructions=effects[2],
+        )
+        application._artifacts = SimpleNamespace(
+            ingest=effects[3],
+            index=effects[6],
+        )
+        application._transcripts = SimpleNamespace(
+            ingest=effects[4],
+            read=effects[5],
+        )
+        application._evaluations = SimpleNamespace(
+            run_graders=effects[7],
+            evaluate=effects[8],
+        )
+        application._trajectories = SimpleNamespace(
+            query=effects[9],
+            grade=effects[10],
+        )
+        application._resolve_storage = AsyncMock(return_value=None)
+        application._resolve_lineage = AsyncMock(return_value=None)
+
+        await application.stop_admission()
+
+        with pytest.raises(RuntimeError, match="not accepting work"):
+            await _call_temporary_bridge(application, operation)
+
+        assert all(effect.await_count == 0 for effect in effects)
+        application._resolve_storage.assert_not_awaited()
+        application._resolve_lineage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_admission_waits_for_admitted_autoresearch() -> None:
+    async with _container_harness() as container:
+        application = cast(Any, container.application)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        calls = 0
+
+        async def blocked_run(*args: Any, **kwargs: Any) -> str:
+            nonlocal calls
+            del args, kwargs
+            calls += 1
+            entered.set()
+            await release.wait()
+            return "finished"
+
+        application._research = SimpleNamespace(run=blocked_run)
+        operation = asyncio.create_task(application.autoresearch("world", object(), object()))
+        await asyncio.wait_for(entered.wait(), timeout=1)
+
+        stop = asyncio.create_task(application.stop_admission())
+        await asyncio.sleep(0)
+
+        assert not stop.done()
+        with pytest.raises(RuntimeError, match="not accepting work"):
+            await application.autoresearch("world", object(), object())
+        assert calls == 1
+
+        release.set()
+        assert await asyncio.wait_for(operation, timeout=1) == "finished"
+        await asyncio.wait_for(stop, timeout=1)
+
+
+async def _invoke_simulation(
+    application: Any,
+    operation: str,
+    world_id: object,
+    **input_kwargs: Any,
+) -> None:
+    config = RunConfig(num_steps=1)
+    if operation == "step":
+        await application.step(world_id, config, **input_kwargs)
+    elif operation == "run":
+        await application.run(world_id, config, **input_kwargs)
+    else:
+        raise AssertionError(f"unknown simulation operation {operation!r}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ("step", "run"))
+async def test_trusted_direct_simulation_preserves_live_kwarg_identity(
+    tmp_path,
+    operation: str,
+) -> None:
+    async with _container_harness() as container:
+        application = container.application
+        info = await application.create_world(
+            WorldConfig(name=f"live-{operation}"),
+            StorageConfig(
+                uri=str(tmp_path / operation),
+                namespace="application-review-live",
+            ),
+        )
+        processor = CaptureInputs()
+        await application.create_entity(info.world_id, [ReviewValue(value=1)])
+        await application.add_processor(info.world_id, processor)
+        capability = object()
+
+        await _invoke_simulation(
+            application,
+            operation,
+            info.world_id,
+            capability=capability,
+        )
+
+        assert len(processor.calls) == 1
+        assert processor.calls[0]["capability"] is capability
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ("step", "run"))
+async def test_trusted_direct_simulation_preserves_tuple_identity_and_shape(
+    tmp_path,
+    operation: str,
+) -> None:
+    async with _container_harness() as container:
+        application = container.application
+        info = await application.create_world(
+            WorldConfig(name=f"tuple-{operation}"),
+            StorageConfig(
+                uri=str(tmp_path / operation),
+                namespace="application-review-tuple",
+            ),
+        )
+        processor = CaptureInputs()
+        await application.create_entity(info.world_id, [ReviewValue(value=1)])
+        await application.add_processor(info.world_id, processor)
+        coordinates = ("outer", ("inner", 3))
+
+        await _invoke_simulation(
+            application,
+            operation,
+            info.world_id,
+            coordinates=coordinates,
+        )
+
+        assert len(processor.calls) == 1
+        assert processor.calls[0]["coordinates"] is coordinates
+        assert processor.calls[0]["coordinates"] == ("outer", ("inner", 3))
+
+
+@pytest.mark.asyncio
+async def test_actor_aware_step_preserves_live_inputs_through_registered_handler(
+    tmp_path,
+) -> None:
+    async with _container_harness() as container:
+        gateway = container.command_gateway
+        actor = ActorCtx(id=uuid7(), roles={"admin"})
+        info = await gateway.create_world(
+            actor,
+            WorldConfig(name="actor-live-input"),
+            StorageConfig(
+                uri=str(tmp_path / "actor"),
+                namespace="application-review-actor",
+            ),
+        )
+        processor = CaptureInputs()
+        await gateway.create_entity(actor, info.world_id, [ReviewValue(value=1)])
+        await gateway.add_processor(actor, info.world_id, processor)
+        capability = object()
+        coordinates = ("outer", ("inner", 3))
+
+        await gateway.step(
+            actor,
+            info.world_id,
+            RunConfig(),
+            capability=capability,
+            coordinates=coordinates,
+        )
+
+        assert len(processor.calls) == 1
+        assert processor.calls[0]["capability"] is capability
+        assert processor.calls[0]["coordinates"] is coordinates

--- a/tests/app/test_gateway_delegation.py
+++ b/tests/app/test_gateway_delegation.py
@@ -11,17 +11,23 @@ from uuid_utils import uuid7
 from archetype.app.gateway.auth.models import ActorCtx
 from archetype.app.gateway.service import CommandGateway
 from archetype.core.component import Component
-from archetype.core.config import StorageConfig
+from archetype.core.config import RunConfig, StorageConfig
 from archetype.world.models import (
     AddComponents,
     AddProcessor,
     ComponentTypeRef,
     ComponentValue,
     DiscoverWorlds,
+    EpisodeConfig,
     OpenWorldReadonly,
     RemoveComponents,
     RemoveProcessor,
     ResumeWorld,
+    RolloutConfig,
+    Run,
+    RunEpisode,
+    RunRollout,
+    Step,
     Update,
 )
 
@@ -111,4 +117,35 @@ async def test_discovery_and_resume_construct_exact_operations_for_dispatch():
             call(ctx, ResumeWorld(storage_config=storage, world_id="world-1")),
         ]
     )
+    assert application.mock_calls == []
+
+
+async def test_actor_aware_simulation_preserves_live_inputs_on_exact_operations():
+    application = AsyncMock()
+    dispatcher = AsyncMock()
+    gateway = _gateway(application, dispatcher)
+    ctx = ActorCtx(id=uuid7(), roles={"admin"})
+    capability = object()
+    coordinates = ("outer", ("inner", 3))
+    input_kwargs = {
+        "capability": capability,
+        "coordinates": coordinates,
+    }
+
+    await gateway.step(ctx, "world-1", RunConfig(), **input_kwargs)
+    await gateway.run(ctx, "world-1", RunConfig(), **input_kwargs)
+    await gateway.run_episode(ctx, "world-1", EpisodeConfig(), **input_kwargs)
+    await gateway.run_rollout(ctx, "world-1", RolloutConfig(), **input_kwargs)
+
+    operations = [awaited.args[1] for awaited in dispatcher.apply_as.await_args_list]
+    assert [type(operation) for operation in operations] == [
+        Step,
+        Run,
+        RunEpisode,
+        RunRollout,
+    ]
+    for operation in operations:
+        assert operation.input_kwargs["capability"] is capability
+        assert operation.input_kwargs["coordinates"] is coordinates
+        assert operation.input_kwargs["coordinates"] == ("outer", ("inner", 3))
     assert application.mock_calls == []

--- a/tests/commands/test_scheduler_audit_contracts.py
+++ b/tests/commands/test_scheduler_audit_contracts.py
@@ -909,6 +909,72 @@ async def test_self_cancelled_reservation_task_is_evicted_before_retry() -> None
 
 
 @pytest.mark.asyncio
+async def test_late_self_cancel_after_waiter_cancellation_retries_on_first_reentry() -> None:
+    api = _scheduler_api()
+
+    async def materialize(_world: object, _operation: BaseModel) -> None:
+        return None
+
+    registry = _OperationRegistry(
+        (
+            _Spec(
+                name="spawn_reserved",
+                model=SpawnReserved,
+                durable=_Durable(
+                    decode=SpawnReserved.model_validate_json,
+                    materialize=materialize,
+                ),
+            ),
+        )
+    )
+    reservation_started = asyncio.Event()
+    cancel_reservation = asyncio.Event()
+    reserve_calls: list[tuple[str, int]] = []
+
+    async def reserve_entity_ids(world_id: object, count: int) -> list[int]:
+        reserve_calls.append((str(world_id), count))
+        if len(reserve_calls) == 1:
+            reservation_started.set()
+            await cancel_reservation.wait()
+            raise asyncio.CancelledError("provider cancelled after its waiter")
+        return [76]
+
+    scheduler = _scheduler(
+        api,
+        registry=registry,
+        catalog=_Catalog(),
+        reserve_entity_ids=reserve_entity_ids,
+    )
+    command_id = uuid7()
+    source = Spawn(world_id="world-late-provider-cancel", components=())
+    options = _options(api, target_tick=5)
+
+    waiter = asyncio.create_task(scheduler.admit_spawn(source, options, command_id=command_id))
+    await reservation_started.wait()
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    owned_task = scheduler._reservation_tasks[str(command_id)]
+    cancel_reservation.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.shield(owned_task)
+
+    entity_id, admitted = await scheduler.admit_spawn(
+        source,
+        options,
+        command_id=command_id,
+    )
+
+    assert entity_id == 76
+    assert str(admitted) == str(command_id)
+    assert reserve_calls == [
+        ("world-late-provider-cancel", 1),
+        ("world-late-provider-cancel", 1),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_lease_order_uses_actual_world_and_only_stages_before_manifest() -> None:
     api = _scheduler_api()
     seen: list[tuple[_World, _PortableOperation]] = []

--- a/tests/commands/test_scheduler_audit_contracts.py
+++ b/tests/commands/test_scheduler_audit_contracts.py
@@ -795,6 +795,120 @@ async def test_scheduler_alone_reserves_once_then_admits_exact_spawn_reserved() 
 
 
 @pytest.mark.asyncio
+async def test_cancelled_reservation_waiter_retains_live_owned_task_for_retry() -> None:
+    api = _scheduler_api()
+
+    async def materialize(_world: object, _operation: BaseModel) -> None:
+        return None
+
+    registry = _OperationRegistry(
+        (
+            _Spec(
+                name="spawn_reserved",
+                model=SpawnReserved,
+                durable=_Durable(
+                    decode=SpawnReserved.model_validate_json,
+                    materialize=materialize,
+                ),
+            ),
+        )
+    )
+    reservation_started = asyncio.Event()
+    release_reservation = asyncio.Event()
+    reservation_completed = asyncio.Event()
+    reserve_calls: list[tuple[str, int]] = []
+
+    async def reserve_entity_ids(world_id: object, count: int) -> list[int]:
+        reserve_calls.append((str(world_id), count))
+        reservation_started.set()
+        await release_reservation.wait()
+        reservation_completed.set()
+        return [74]
+
+    scheduler = _scheduler(
+        api,
+        registry=registry,
+        catalog=_Catalog(),
+        reserve_entity_ids=reserve_entity_ids,
+    )
+    command_id = uuid7()
+    source = Spawn(world_id="world-cancelled-waiter", components=())
+    options = _options(api, target_tick=3)
+
+    waiter = asyncio.create_task(scheduler.admit_spawn(source, options, command_id=command_id))
+    await reservation_started.wait()
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    release_reservation.set()
+    await reservation_completed.wait()
+    entity_id, admitted = await scheduler.admit_spawn(
+        source,
+        options,
+        command_id=command_id,
+    )
+
+    assert entity_id == 74
+    assert str(admitted) == str(command_id)
+    assert reserve_calls == [("world-cancelled-waiter", 1)]
+
+
+@pytest.mark.asyncio
+async def test_self_cancelled_reservation_task_is_evicted_before_retry() -> None:
+    api = _scheduler_api()
+
+    async def materialize(_world: object, _operation: BaseModel) -> None:
+        return None
+
+    registry = _OperationRegistry(
+        (
+            _Spec(
+                name="spawn_reserved",
+                model=SpawnReserved,
+                durable=_Durable(
+                    decode=SpawnReserved.model_validate_json,
+                    materialize=materialize,
+                ),
+            ),
+        )
+    )
+    reserve_calls: list[tuple[str, int]] = []
+
+    async def reserve_entity_ids(world_id: object, count: int) -> list[int]:
+        reserve_calls.append((str(world_id), count))
+        if len(reserve_calls) == 1:
+            raise asyncio.CancelledError("provider reservation self-cancelled")
+        return [75]
+
+    scheduler = _scheduler(
+        api,
+        registry=registry,
+        catalog=_Catalog(),
+        reserve_entity_ids=reserve_entity_ids,
+    )
+    command_id = uuid7()
+    source = Spawn(world_id="world-self-cancelled-reservation", components=())
+    options = _options(api, target_tick=4)
+
+    with pytest.raises(asyncio.CancelledError):
+        await scheduler.admit_spawn(source, options, command_id=command_id)
+
+    entity_id, admitted = await scheduler.admit_spawn(
+        source,
+        options,
+        command_id=command_id,
+    )
+
+    assert entity_id == 75
+    assert str(admitted) == str(command_id)
+    assert reserve_calls == [
+        ("world-self-cancelled-reservation", 1),
+        ("world-self-cancelled-reservation", 1),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_lease_order_uses_actual_world_and_only_stages_before_manifest() -> None:
     api = _scheduler_api()
     seen: list[tuple[_World, _PortableOperation]] = []

--- a/tests/world/test_handler_contracts.py
+++ b/tests/world/test_handler_contracts.py
@@ -20,6 +20,10 @@ from archetype.world.models import (
     ListWorldSignatures,
     QueryArchetype,
     QueryComponents,
+    Run,
+    RunEpisode,
+    RunRollout,
+    Step,
 )
 from archetype.world.registry import WorldRegistry
 
@@ -40,6 +44,60 @@ class _World:
     tick: int
     run_id: str
     lineage: list[tuple[str, str, int]]
+
+
+async def test_direct_simulation_handlers_preserve_live_input_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capability = object()
+    coordinates = ("outer", ("inner", 3))
+    input_kwargs = {
+        "capability": capability,
+        "coordinates": coordinates,
+    }
+    operations = (
+        Step(world_id="world", input_kwargs=input_kwargs),
+        Run(world_id="world", input_kwargs=input_kwargs),
+        RunEpisode(world_id="world", input_kwargs=input_kwargs),
+        RunRollout(world_id="world", input_kwargs=input_kwargs),
+    )
+    marker = object()
+
+    def capture(target: list[tuple[tuple[Any, ...], dict[str, Any]]]):
+        async def execute(*args: Any, **kwargs: Any) -> object:
+            target.append((args, kwargs))
+            return marker
+
+        return execute
+
+    for operation in operations:
+        calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+        monkeypatch.setattr(
+            handlers.simulation,
+            operation.operation,
+            capture(calls),
+        )
+        handler = getattr(handlers, operation.operation)
+        if type(operation) in {Step, Run}:
+            result = await handler(object(), operation)
+        elif type(operation) is RunEpisode:
+            result = await handler(object(), object(), operation)
+        else:
+            result = await handler(
+                object(),
+                object(),
+                object(),
+                object(),
+                operation,
+            )
+
+        assert result is marker
+        assert len(calls) == 1
+        forwarded = calls[0][1]
+        assert forwarded["capability"] is capability
+        assert forwarded["coordinates"] is coordinates
+        assert forwarded["coordinates"] == ("outer", ("inner", 3))
 
 
 async def test_get_world_info_uses_registry_lock_and_reconciles_before_snapshot(

--- a/tests/world/test_world_models.py
+++ b/tests/world/test_world_models.py
@@ -30,7 +30,10 @@ from archetype.world.models import (
     ResourceInfo,
     RolloutConfig,
     RolloutResult,
+    Run,
+    RunEpisode,
     RunResult,
+    RunRollout,
     Spawn,
     Step,
     WorldInfo,
@@ -157,6 +160,36 @@ def test_live_capability_is_explicit_and_identity_preserving() -> None:
     assert type(operation).direct_only is True
     with pytest.raises(TypeError, match="direct-only"):
         require_portable_tick_operation(operation)
+
+
+def test_direct_simulation_operations_preserve_live_input_values() -> None:
+    capability = object()
+    coordinates = ("outer", ("inner", 3))
+    input_kwargs = {
+        "capability": capability,
+        "coordinates": coordinates,
+    }
+    operations = (
+        Step(world_id="world", input_kwargs=input_kwargs),
+        Run(world_id="world", input_kwargs=input_kwargs),
+        RunEpisode(world_id="world", input_kwargs=input_kwargs),
+        RunRollout(world_id="world", input_kwargs=input_kwargs),
+    )
+
+    assert {type(operation) for operation in operations} == {
+        Step,
+        Run,
+        RunEpisode,
+        RunRollout,
+    }
+    for operation in operations:
+        assert operation.input_kwargs["capability"] is capability
+        assert operation.input_kwargs["coordinates"] is coordinates
+        assert operation.input_kwargs["coordinates"] == ("outer", ("inner", 3))
+        assert "input_kwargs_json" not in type(operation).model_fields
+        assert type(operation).direct_only is True
+        with pytest.raises(TypeError, match="direct-only"):
+            require_portable_tick_operation(operation)
 
 
 def test_portable_admission_and_handler_inventories_are_exact() -> None:


### PR DESCRIPTION
## Summary

This is the mandatory post-merge closure follow-up to #646.

- Gate all 11 finite, non-mission `RuntimeApplication` workflow bridges through the commands-owned admission/drain counter. Calls now reject after admission stop before service, storage, or lineage effects, while already-admitted work drains normally.
- Preserve live `input_kwargs` values through the exact registered `Step`, `Run`, `RunEpisode`, and `RunRollout` model → dispatcher → world-handler path. This removes JSON coercion without bypassing `apply` / `apply_as`, so callback identity and nested tuple shape survive.
- Make reserved-spawn retries recover from a provider reservation task that cancels itself, including the late waiter-cancel/provider-cancel race, while retaining a still-live shielded reservation across ordinary caller cancellation.

The three mission-service lifetime operations (`submit_mission`, `run_mission`, and `restore_mission_sandbox`) are intentionally not claimed here; that separate lifecycle/admission work remains tracked under #627 and the planned PR-4/PR-10 slices.

## Root cause

PR #646 entered and completed the merge queue just before two actionable review findings arrived. A read-only audit prompted by the external patch-coverage report also found that a terminal self-cancelled reservation task could remain pinned in scheduler identity state and make every identical retry re-raise `CancelledError`.

## Validation

Exact clean head: `e2e31ff2b06b4531e9c6eb078c976fa832b1d8fa`, based directly on landed main `fd4eb48d34ab7d63d95f6787533c7c2d706911a1`.

- Independent closure review: SHIP, no blockers; 60 focused tests
- Combined focused matrix: 87 passed
- `make static`: passed (only the known unrelated missions redundant-cast warning)
- `make ci`: passed
  - 2,254 passed, 6 skipped, 14 known warnings; 88.46% coverage
  - regression 15/15, specification 8/8, capability 7/7
  - source operational 15/15, commands source 1/1, installed-wheel operational 8/8
  - package smoke and documentation artifact build passed
- DCO: 3/3 commits signed
