### PR TITLE
fix(ci): arm auto-merge only when review threads are resolved

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,6 +1,8 @@
-# Arm auto-merge (squash) on maintainer PRs ONLY after the deterministic
-# review gate succeeds on the current head — and disarm on every new push
-# until it succeeds again.
+# Arm auto-merge (squash) on maintainer PRs ONLY after the PR is queue-ready —
+# and disarm on every new push until it is queue-ready again.
+#
+# Queue-ready = latest review-complete on the exact head succeeded AND every
+# non-outdated review thread is resolved. See scripts/gh_pr_queue_ready.sh.
 #
 # Why arming is the review gate now: with the merge queue, required review
 # checks deliberately SKIP on merge groups (the substantive review binds to
@@ -8,15 +10,23 @@
 # failing/incomplete `review-complete` on the head blocked the merge — PRs
 # #446/#448/#449 merged carrying "Footgun review — incomplete" comments.
 # Queue entry must therefore imply a completed, clean review: disarm on
-# push, arm on review success. A PR whose review never completes, or whose
-# findings are unfixed, simply never enters the queue.
+# push, arm on queue-ready. A PR whose review never completes, whose
+# findings are unfixed, or whose threads stay open simply never enters the
+# queue.
+#
+# Why threads are part of queue-ready: Main — Review requires thread
+# resolution. Arming on review-complete alone left #645 armed for hours
+# while conversations stayed open. The guard job reported success
+# ("arming is legitimate") without disarming, which shepherds misread as
+# "reverted". Defer arming until threads resolve; re-arm when the last
+# thread resolves.
 #
 # Token note: the arm job prefers AUTOMERGE_PAT (a fine-grained PAT with
 # contents:write + pull-requests:write) because the eventual merge commit
 # must trigger `on: push` workflows — pushes made by the default
 # GITHUB_TOKEN do not, so the docs deploy to Cloudflare Pages on main
-# would be skipped for auto-merged PRs. The disarm job deliberately uses
-# only github.token: disarming needs no downstream triggers, and a job
+# would be skipped for auto-merged PRs. The disarm/guard jobs deliberately
+# use only github.token: disarming needs no downstream triggers, and a job
 # whose YAML executes from the PR ref (plain `pull_request`) should not
 # reference secrets it doesn't need — least privilege, even though GitHub
 # already withholds repo secrets from fork-triggered pull_request runs.
@@ -26,25 +36,30 @@ name: Auto-merge
 on:
   # Every new head invalidates the previous head's review verdict.
   # auto_merge_enabled feeds the guard job only: a manual `gh pr merge
-  # --auto` ahead of the verdict is reverted, closing the last arming path
+  # --auto` ahead of queue-ready is reverted, closing the last arming path
   # this workflow does not control.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, auto_merge_enabled]
-  # The review gate's completion is the arming signal.
+  # Last-thread resolution is the second arming signal: review may have
+  # already passed while conversations were still open.
+  pull_request_review_thread:
+    types: [resolved]
+  # The review gate's completion is the first arming signal.
   workflow_run:
     workflows: ["Deterministic Review Gate"]
     types: [completed]
 
 permissions:
-  checks: read # Guard queries review-complete check runs on the armed head.
+  checks: read # Guard/arm query review-complete check runs on the head.
   contents: write
   pull-requests: write
 
 jobs:
   disarm:
-    name: Disarm until the head's review completes
+    name: Disarm until the head is queue-ready
     # Not on auto_merge_enabled: that event is the guard job's input, and
     # unconditional disarm there would also revert the arm job's own arming.
+    # Not on review_thread: resolving a thread must not wipe a legitimate arm.
     if: github.event_name == 'pull_request' && github.event.action != 'auto_merge_enabled'
     runs-on: ubuntu-latest
     steps:
@@ -76,29 +91,41 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'auto_merge_enabled'
     runs-on: ubuntu-latest
     steps:
-      # Arming is the review gate (see header). The arm job below is the
-      # sanctioned arming path and always follows a green review, so this
-      # guard sees its arms as legitimate no-ops. A manual arm ahead of the
-      # verdict is reverted here; when the review later succeeds on this
-      # head, the arm job re-arms — nothing legitimate slows down.
-      - name: Disarm unless the head's review has passed
+      - name: Checkout queue-ready helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Arming is the queue-ready gate (see header). The arm job below is the
+      # sanctioned arming path and always follows queue-ready, so this guard
+      # sees its arms as legitimate no-ops. A manual arm ahead of queue-ready
+      # is reverted here; when the PR later becomes queue-ready, the arm job
+      # re-arms — nothing legitimate slows down.
+      #
+      # Log text deliberately distinguishes "left armed" from "reverted" so a
+      # green "Revert premature arming" check is never misread as a disarm
+      # (the #645 shepherd failure mode).
+      - name: Disarm unless the head is queue-ready
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          # LATEST run only: a head's review can be re-triggered without a
-          # new commit (reopen, manual re-run), and a stale success must not
-          # outvote a newer failure. `|| latest=""` keeps an API failure
-          # from tripping -e before the revert loop — failure to positively
-          # confirm the verdict falls through to the revert (fail closed).
-          latest=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=review-complete&per_page=100" \
-            --jq '[.check_runs[]] | sort_by(.started_at) | last | .conclusion // empty') || latest=""
-          if [ "$latest" = "success" ]; then
-            echo "latest review-complete on ${HEAD_SHA} succeeded; arming is legitimate."
+          chmod +x scripts/gh_pr_queue_ready.sh
+          set +e
+          reason=$(scripts/gh_pr_queue_ready.sh "${GITHUB_REPOSITORY}" "${PR_NUMBER}" "${HEAD_SHA}")
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "PR #${PR_NUMBER} is queue-ready on ${HEAD_SHA}; leaving auto-merge armed (not a revert)."
             exit 0
           fi
-          echo "No authoritative passing review-complete on ${HEAD_SHA} (latest: ${latest:-none}); reverting premature arming."
+          if [ "$status" -ne 1 ]; then
+            echo "::error::queue-ready helper failed (exit ${status}): ${reason}"
+            exit 1
+          fi
+          echo "Not queue-ready (${reason}); reverting premature arming."
           for attempt in 1 2 3; do
             gh pr merge --disable-auto "$PR_URL" || true
             armed=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest // empty')
@@ -114,27 +141,64 @@ jobs:
   arm:
     name: Arm auto-merge for maintainer PRs
     if: >-
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review_thread' &&
+       github.event.action == 'resolved')
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout queue-ready helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # workflow_run / review_thread execute against the default-branch
+          # workflow file, so this checkout is always the trusted main helper.
+          # persist-credentials false: the arm step uses AUTOMERGE_PAT.
+          persist-credentials: false
+
       # Look the PR up by listing open PRs and filtering on headRefOid
       # client-side — NOT via `--search "sha:..."`. SHA search rides the
       # search index through an undocumented qualifier: it can lag a fresh
       # push or stop matching entirely, and either way this job would take
       # the empty-result exit and silently never arm anything again.
-      - name: Arm the reviewed head
+      - name: Arm the queue-ready head
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || github.token }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          THREAD_PR: ${{ github.event.pull_request.number }}
         run: |
-          pr=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --limit 100 \
-            --json number,author,isDraft,headRefOid \
-            --jq ".[] | select(.headRefOid == \"${HEAD_SHA}\" and .author.login == \"everettVT\" and (.isDraft | not)) | .number" | head -1)
-          if [ -z "$pr" ]; then
-            echo "No open non-draft everettVT PR currently at ${HEAD_SHA} (superseded, closed, or draft); nothing to arm."
+          chmod +x scripts/gh_pr_queue_ready.sh
+
+          if [ "$EVENT_NAME" = "pull_request_review_thread" ]; then
+            pr="$THREAD_PR"
+            meta=$(gh pr view "$pr" --repo "${GITHUB_REPOSITORY}" \
+              --json number,author,isDraft,headRefOid \
+              --jq 'select(.author.login == "everettVT" and (.isDraft | not)) | "\(.number) \(.headRefOid)"')
+            if [ -z "$meta" ]; then
+              echo "PR #${pr} is draft, closed, or not authored by everettVT; nothing to arm."
+              exit 0
+            fi
+            head_sha="${meta##* }"
+          else
+            head_sha="$WORKFLOW_HEAD_SHA"
+            pr=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --limit 100 \
+              --json number,author,isDraft,headRefOid \
+              --jq ".[] | select(.headRefOid == \"${head_sha}\" and .author.login == \"everettVT\" and (.isDraft | not)) | .number" | head -1)
+            if [ -z "$pr" ]; then
+              echo "No open non-draft everettVT PR currently at ${head_sha} (superseded, closed, or draft); nothing to arm."
+              exit 0
+            fi
+          fi
+
+          set +e
+          reason=$(scripts/gh_pr_queue_ready.sh "${GITHUB_REPOSITORY}" "${pr}" "${head_sha}")
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "Deferring arm on #${pr}: ${reason}"
             exit 0
           fi
-          echo "Review gate succeeded on ${HEAD_SHA}; arming #${pr}."
+
+          echo "PR #${pr} is queue-ready on ${head_sha}; arming."
           gh pr merge --auto --squash --repo "${GITHUB_REPOSITORY}" "$pr"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,18 +18,43 @@
 # resolution. Arming on review-complete alone left #645 armed for hours
 # while conversations stayed open. The guard job reported success
 # ("arming is legitimate") without disarming, which shepherds misread as
-# "reverted". Defer arming until threads resolve; re-arm when the last
-# thread resolves.
+# "reverted". Defer arming until threads resolve.
+#
+# Thread resolution itself is NOT observable here: GitHub Actions has no
+# trigger for it (`pull_request_review_thread` is an Apps webhook only, and
+# naming it in `on:` invalidates the whole file). Queue-readiness is
+# therefore re-evaluated on the signals Actions does deliver — a review
+# gate run completing, and any review being submitted, edited, or
+# dismissed. After resolving the last thread, re-run Deterministic Review
+# Gate or push to re-evaluate.
+#
+# Why the dequeue job exists: arming covers queue-ready → armed, but #646
+# lost the reverse transition. Two real findings arrived after
+# review-complete had already passed, the PR was queue-locked, the repair
+# push was rejected GH006, both manual dequeue attempts failed, and the
+# merge won by seconds — known defects landed on main and needed a
+# mandatory hotfix (#647). The dequeue job applies the symmetric
+# back-pressure: a review re-checks queue-readiness and disarms if it has
+# lapsed.
+#
+# Trusted-checkout rule for every job here: any job that executes a repo
+# script must check out the default branch explicitly. GitHub resolves the
+# workflow *file* from the default branch for non-`pull_request` events,
+# but `actions/checkout` without `ref:` follows GITHUB_SHA — which is the
+# PR merge ref on `pull_request`, `pull_request_review`, and
+# `pull_request_review_thread` events. Unpinned, a PR could edit
+# scripts/gh_pr_queue_ready.sh into declaring itself queue-ready.
 #
 # Token note: the arm job prefers AUTOMERGE_PAT (a fine-grained PAT with
 # contents:write + pull-requests:write) because the eventual merge commit
 # must trigger `on: push` workflows — pushes made by the default
 # GITHUB_TOKEN do not, so the docs deploy to Cloudflare Pages on main
-# would be skipped for auto-merged PRs. The disarm/guard jobs deliberately
-# use only github.token: disarming needs no downstream triggers, and a job
-# whose YAML executes from the PR ref (plain `pull_request`) should not
-# reference secrets it doesn't need — least privilege, even though GitHub
-# already withholds repo secrets from fork-triggered pull_request runs.
+# would be skipped for auto-merged PRs. The disarm/guard/dequeue jobs
+# deliberately use only github.token: disarming needs no downstream
+# triggers, and a job whose YAML executes from the PR ref (plain
+# `pull_request`) should not reference secrets it doesn't need — least
+# privilege, even though GitHub already withholds repo secrets from
+# fork-triggered pull_request runs.
 
 name: Auto-merge
 
@@ -40,17 +65,29 @@ on:
   # this workflow does not control.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, auto_merge_enabled]
-  # Last-thread resolution is the second arming signal: review may have
-  # already passed while conversations were still open.
-  pull_request_review_thread:
-    types: [resolved]
+  # Review activity is the second arming signal, and the dequeue signal.
+  # The review gate may have passed while conversations were still open, and
+  # a review submitted after arming can carry findings the gate never saw
+  # (#646). The arm and dequeue jobs both run on this trigger and cannot
+  # conflict: each one re-runs the same queue-ready check and only acts on
+  # the answer the other does not.
+  #
+  # NOT `pull_request_review_thread`. Thread resolution is a webhook event
+  # for GitHub Apps, NOT a GitHub Actions trigger — naming it makes the
+  # entire workflow file invalid, so GitHub loads no jobs at all and every
+  # push gets a bare "Invalid workflow file" run instead. Actions cannot
+  # observe thread resolution at all; to re-evaluate arming after resolving
+  # the last thread, re-run Deterministic Review Gate (that fires the
+  # workflow_run trigger below) or push.
+  pull_request_review:
+    types: [submitted, edited, dismissed]
   # The review gate's completion is the first arming signal.
   workflow_run:
     workflows: ["Deterministic Review Gate"]
     types: [completed]
 
 permissions:
-  checks: read # Guard/arm query review-complete check runs on the head.
+  checks: read # Guard/arm/dequeue query review-complete check runs on the head.
   contents: write
   pull-requests: write
 
@@ -94,6 +131,13 @@ jobs:
       - name: Checkout queue-ready helper
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # Trusted ref, NOT the PR head: this job runs the PR's own copy of
+          # the workflow file (plain `pull_request`), and an unpinned
+          # checkout would also hand it the PR's copy of the helper — a PR
+          # could edit gh_pr_queue_ready.sh to print "queue-ready", exit 0,
+          # and keep its own premature arm. The default branch is the only
+          # version of the helper this repo has reviewed.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       # Arming is the queue-ready gate (see header). The arm job below is the
@@ -144,16 +188,19 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_repository.full_name == github.repository) ||
-      (github.event_name == 'pull_request_review_thread' &&
-       github.event.action == 'resolved')
+      github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout queue-ready helper
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # workflow_run / review_thread execute against the default-branch
-          # workflow file, so this checkout is always the trusted main helper.
+          # workflow_run / pull_request_review execute the default-branch
+          # workflow FILE, but that does not make the checkout trusted: on
+          # pull_request_review GITHUB_SHA resolves to the PR merge ref, so
+          # an unpinned checkout would run the PR's helper with
+          # AUTOMERGE_PAT in the environment. Pin the ref (see header).
           # persist-credentials false: the arm step uses AUTOMERGE_PAT.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       # Look the PR up by listing open PRs and filtering on headRefOid
@@ -166,15 +213,22 @@ jobs:
           GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || github.token }}
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          THREAD_PR: ${{ github.event.pull_request.number }}
+          REVIEW_PR: ${{ github.event.pull_request.number }}
         run: |
           chmod +x scripts/gh_pr_queue_ready.sh
 
-          if [ "$EVENT_NAME" = "pull_request_review_thread" ]; then
-            pr="$THREAD_PR"
+          # `.state == "OPEN"` is what `--state open` gives the branch below;
+          # both paths must agree field-for-field on what makes a PR eligible.
+          # gh pr view serves closed and merged PRs just as readily as open
+          # ones, and neither is ever isDraft — so without it, reviewing a
+          # merged PR would reach `gh pr merge --auto` on something that can
+          # no longer be merged, and the "closed" in the message below would
+          # be a claim the code did not implement.
+          if [ "$EVENT_NAME" = "pull_request_review" ]; then
+            pr="$REVIEW_PR"
             meta=$(gh pr view "$pr" --repo "${GITHUB_REPOSITORY}" \
-              --json number,author,isDraft,headRefOid \
-              --jq 'select(.author.login == "everettVT" and (.isDraft | not)) | "\(.number) \(.headRefOid)"')
+              --json number,state,author,isDraft,headRefOid \
+              --jq 'select(.state == "OPEN" and .author.login == "everettVT" and (.isDraft | not)) | "\(.number) \(.headRefOid)"')
             if [ -z "$meta" ]; then
               echo "PR #${pr} is draft, closed, or not authored by everettVT; nothing to arm."
               exit 0
@@ -202,3 +256,75 @@ jobs:
 
           echo "PR #${pr} is queue-ready on ${head_sha}; arming."
           gh pr merge --auto --squash --repo "${GITHUB_REPOSITORY}" "$pr"
+
+  dequeue:
+    name: Disarm when new findings land
+    # The queue-ready → not-queue-ready transition (#646 → #647): a review
+    # submitted after the gate already passed invalidates the verdict the
+    # arm was based on. Runs on the same trigger as the arm job above and
+    # is its mirror image — both re-run the same queue-ready check, so
+    # exactly one of them acts on any given review.
+    if: github.event_name == 'pull_request_review'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout queue-ready helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Trusted ref: pull_request_review resolves GITHUB_SHA to the PR
+          # merge ref, so an unpinned checkout runs the PR's own helper
+          # (see header).
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      # Best-effort back-pressure, not a guarantee: GitHub's merge queue may
+      # already hold this PR, in which case the dequeue loses the race exactly
+      # as the manual attempts on #646 did. The durable guarantee stays
+      # "arming requires queue-ready" — this only shortens the window in which
+      # an already-armed PR carries findings into the queue.
+      #
+      # Head comes from the API, not github.event.pull_request.head.sha: the
+      # review payload can carry a superseded head if a push raced the review,
+      # and readiness must be judged on what would actually merge.
+      - name: Disarm if the head is no longer queue-ready
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          chmod +x scripts/gh_pr_queue_ready.sh
+          head_sha=$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --json headRefOid --jq '.headRefOid')
+
+          set +e
+          reason=$(scripts/gh_pr_queue_ready.sh "${GITHUB_REPOSITORY}" "${PR_NUMBER}" "${head_sha}")
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "PR #${PR_NUMBER} is still queue-ready on ${head_sha}; nothing to disarm."
+            exit 0
+          fi
+          if [ "$status" -ne 1 ]; then
+            echo "::error::queue-ready helper failed (exit ${status}): ${reason}"
+            exit 1
+          fi
+
+          armed=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest // empty')
+          if [ -z "$armed" ]; then
+            echo "PR #${PR_NUMBER} is no longer queue-ready (${reason}); auto-merge was not armed, nothing to disarm."
+            exit 0
+          fi
+
+          echo "PR #${PR_NUMBER} is no longer queue-ready (${reason}); disarming auto-merge."
+          # Postcondition, not exit code: `--disable-auto` exits nonzero on the
+          # benign already-unarmed no-op, so read autoMergeRequest back.
+          for attempt in 1 2 3; do
+            gh pr merge --disable-auto "$PR_URL" || true
+            armed=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest // empty')
+            if [ -z "$armed" ]; then
+              echo "auto-merge disarmed on new findings (attempt ${attempt})."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::could not disarm #${PR_NUMBER} after new review findings; the merge queue may already have locked it (the #646 race)."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,8 +192,11 @@ automerge workflow arms only when the head is queue-ready: latest
 `review-complete` succeeded and every non-outdated review thread is
 resolved (premature arms are auto-reverted; arming early only skips the
 review, it never merges sooner). Reply to footgun review threads with
-what you changed, then resolve them — resolving the last thread is what
-re-arms after a review that posted findings.
+what you changed, then resolve them. GitHub Actions cannot observe thread
+resolution, so re-run **Deterministic Review Gate** (or push) once the
+last thread is resolved to re-evaluate arming. The reverse also holds: a
+review submitted on an armed PR that is no longer queue-ready disarms it
+(best-effort — the merge queue may already hold the PR).
 
 ## Application flow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,10 +188,12 @@ make test-cov    # coverage report
 ```
 
 PR flow: open the PR and stop — never run `gh pr merge --auto`. The
-automerge workflow arms after the review gate passes your current head
-(premature arms are auto-reverted; arming early only skips the review, it
-never merges sooner). Reply to footgun review threads with what you
-changed before resolving them.
+automerge workflow arms only when the head is queue-ready: latest
+`review-complete` succeeded and every non-outdated review thread is
+resolved (premature arms are auto-reverted; arming early only skips the
+review, it never merges sooner). Reply to footgun review threads with
+what you changed, then resolve them — resolving the last thread is what
+re-arms after a review that posted findings.
 
 ## Application flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,13 @@ make check                      # Auto-format + lint
 ## PR flow
 
 Open the PR and stop — never run `gh pr merge --auto`. The automerge
-workflow arms auto-merge only after the deterministic review gate passes
-your current head; arming earlier does not merge sooner, it only lets the
-PR enter the merge queue before its review verdict (premature arms are
-auto-reverted). Reply to footgun review threads with what you changed
-before resolving them.
+workflow arms auto-merge only once your head is queue-ready: the latest
+`review-complete` succeeded on that exact sha **and** every non-outdated
+review thread is resolved. Arming earlier does not merge sooner, it only
+lets the PR enter the merge queue before its review verdict (premature
+arms are auto-reverted). Reply to footgun review threads with what you
+changed, then resolve them — then re-run **Deterministic Review Gate**,
+because GitHub Actions cannot observe thread resolution and nothing
+re-evaluates arming on its own. A review submitted on an armed PR that is
+no longer queue-ready disarms it, best-effort. Full mechanism in
+`AGENTS.md`.

--- a/scripts/gh_pr_queue_ready.sh
+++ b/scripts/gh_pr_queue_ready.sh
@@ -74,12 +74,28 @@ fi
 
 # Count non-outdated unresolved threads. Outdated threads on superseded lines
 # must not block arming after the author pushed a fix that moved the hunk.
-unresolved="$(
+#
+# hasNextPage is not decoration. Truncation is not an error: past 100 threads
+# GitHub returns a clean, valid response containing exactly 100 nodes, so the
+# count below is a perfectly good integer computed from an incomplete set and
+# the guards cannot fire — nothing failed. If every unresolved thread sat past
+# node 100 this would print "queue-ready" and exit 0 while the PR was actually
+# blocked: a fail-open inside the one mechanism whose whole purpose is to fail
+# closed. So ask whether there is more, and refuse when there is.
+#
+# Deliberately NOT a cursor loop. Paging adds a retry surface, more API calls,
+# and a partial-failure mode midway through that would itself need a
+# fail-closed decision. A PR carrying more than 100 review threads is
+# pathological and deserves a human look, so refusing to arm it is the correct
+# outcome and is honest about what was not checked. Five lines that refuse to
+# guess beat forty that might — do not "improve" this into pagination.
+threads="$(
   gh api graphql \
     -f query='query($owner:String!, $name:String!, $number:Int!) {
       repository(owner:$owner, name:$name) {
         pullRequest(number:$number) {
           reviewThreads(first:100) {
+            pageInfo { hasNextPage }
             nodes { isResolved isOutdated }
           }
         }
@@ -88,13 +104,24 @@ unresolved="$(
     -f owner="$OWNER" \
     -f name="$NAME" \
     -F number="$PR_NUMBER" \
-    --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-           | select(.isResolved == false and .isOutdated == false)] | length' \
+    --jq '.data.repository.pullRequest.reviewThreads
+          | "\(.pageInfo.hasNextPage) \([.nodes[]
+              | select(.isResolved == false and .isOutdated == false)] | length)"' \
     2>/dev/null || true
 )"
 
+truncated="${threads%% *}"
+unresolved="${threads##* }"
+
 if [[ -z "$unresolved" || ! "$unresolved" =~ ^[0-9]+$ ]]; then
   echo "could not enumerate review threads on #${PR_NUMBER}; refusing to treat as queue-ready"
+  exit 1
+fi
+
+# Anything other than an explicit "false" — "true", "null", a shape change —
+# means the page may be incomplete. Fail closed on all of them.
+if [[ "$truncated" != "false" ]]; then
+  echo "more than 100 review threads on #${PR_NUMBER}; refusing to treat as queue-ready without seeing them all"
   exit 1
 fi
 

--- a/scripts/gh_pr_queue_ready.sh
+++ b/scripts/gh_pr_queue_ready.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Copyright 2025 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Decide whether a PR is ready for auto-merge arming / may keep an existing arm.
+#
+# Queue-ready means:
+#   1. latest review-complete check on the exact head concluded success, and
+#   2. every non-outdated review thread is resolved.
+#
+# Why (2): Main — Review requires thread resolution. Arming on review-complete
+# alone leaves auto-merge armed for hours while conversations stay open
+# (PR #645). The "Revert premature arming" job then reports success because it
+# classifies the arm as legitimate, which shepherds misread as "disarmed".
+#
+# Usage:
+#   gh_pr_queue_ready.sh <owner/repo> <pr-number> <head-sha>
+#
+# Exit codes:
+#   0 — queue-ready (stdout: "queue-ready")
+#   1 — not queue-ready (stdout: one-line reason; never exits 0 on doubt)
+#   2 — usage / tool failure
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <owner/repo> <pr-number> <head-sha>" >&2
+  exit 2
+fi
+
+REPO="$1"
+PR_NUMBER="$2"
+HEAD_SHA="$3"
+
+if [[ ! "$REPO" =~ ^[^/]+/[^/]+$ ]]; then
+  echo "invalid repository: ${REPO}" >&2
+  exit 2
+fi
+if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "invalid PR number: ${PR_NUMBER}" >&2
+  exit 2
+fi
+if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "invalid head sha: ${HEAD_SHA}" >&2
+  exit 2
+fi
+
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+# LATEST run only: a head's review can be re-triggered without a new commit,
+# and a stale success must not outvote a newer failure. API failure falls
+# through as not-ready (fail closed).
+latest="$(
+  gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?check_name=review-complete&per_page=100" \
+    --jq '[.check_runs[]] | sort_by(.started_at) | last | .conclusion // empty' \
+    2>/dev/null || true
+)"
+if [[ "$latest" != "success" ]]; then
+  echo "no authoritative passing review-complete on ${HEAD_SHA} (latest: ${latest:-none})"
+  exit 1
+fi
+
+# Count non-outdated unresolved threads. Outdated threads on superseded lines
+# must not block arming after the author pushed a fix that moved the hunk.
+unresolved="$(
+  gh api graphql \
+    -f query='query($owner:String!, $name:String!, $number:Int!) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$number) {
+          reviewThreads(first:100) {
+            nodes { isResolved isOutdated }
+          }
+        }
+      }
+    }' \
+    -f owner="$OWNER" \
+    -f name="$NAME" \
+    -F number="$PR_NUMBER" \
+    --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+           | select(.isResolved == false and .isOutdated == false)] | length' \
+    2>/dev/null || true
+)"
+
+if [[ -z "$unresolved" || ! "$unresolved" =~ ^[0-9]+$ ]]; then
+  echo "could not enumerate review threads on #${PR_NUMBER}; refusing to treat as queue-ready"
+  exit 1
+fi
+
+if [[ "$unresolved" -gt 0 ]]; then
+  echo "review-complete passed on ${HEAD_SHA} but ${unresolved} unresolved review thread(s) remain"
+  exit 1
+fi
+
+echo "queue-ready"
+exit 0

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import ast
 import json
+import os
 import re
+import shutil
 import subprocess
 import tomllib
 from pathlib import Path
@@ -19,6 +21,7 @@ from scripts.run_operational_scenarios import run_scenarios
 ROOT = Path(__file__).resolve().parents[2]
 QUALITY_WORKFLOW = ROOT / ".github" / "workflows" / "python-tests.yml"
 AUTOMERGE_WORKFLOW = ROOT / ".github" / "workflows" / "automerge.yml"
+QUEUE_READY_HELPER = ROOT / "scripts" / "gh_pr_queue_ready.sh"
 MAKEFILE = ROOT / "Makefile"
 OPERATIONAL_SCENARIOS = ROOT / "quality" / "operational_scenarios.toml"
 
@@ -31,6 +34,35 @@ def _job(workflow: str, job_id: str) -> str:
     )
     assert match is not None, f"workflow lost the {job_id!r} job"
     return match.group("body")
+
+
+def _job_ids(workflow: str) -> list[str]:
+    """Every job in the workflow, so new jobs inherit the checks by default."""
+    _, _, jobs = workflow.partition("\njobs:\n")
+    assert jobs, "workflow lost its jobs: block"
+    ids = re.findall(r"^  ([a-z][a-z0-9-]*):$", jobs, re.MULTILINE)
+    assert ids, "workflow declares no jobs"
+    return ids
+
+
+def _code_only(text: str) -> str:
+    """Drop whole-line comments.
+
+    Assertions must bind to what runs, not to prose about what runs. A comment
+    that quotes the very expression it explains — as the ones in this workflow
+    do — otherwise satisfies the assertion after the code has been deleted.
+    """
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+
+
+_HELPER_PATH = QUEUE_READY_HELPER.relative_to(ROOT).as_posix()
+
+
+def _helper_call(head_sha: str = r"\w+") -> re.Pattern[str]:
+    """Match a real three-argument invocation, not a bare mention of the path."""
+    return re.compile(
+        rf'{re.escape(_HELPER_PATH)} "\$\{{GITHUB_REPOSITORY\}}" "\$\{{\w+\}}" "\$\{{{head_sha}\}}"'
+    )
 
 
 def test_quality_workflow_preserves_active_required_context_names() -> None:
@@ -389,16 +421,311 @@ def test_quality_gate_aggregates_every_applicable_job() -> None:
         assert f"      - {job_id}\n" in gate
 
 
+# The four tests below protect ONE invariant, split by the file that owns each
+# half: auto-merge may only ever be armed for a head whose latest review verdict
+# passed cleanly, and the arm must not survive that verdict changing.
+#
+#   * `scripts/gh_pr_queue_ready.sh` owns the *decision* — latest-run-wins on the
+#     exact head, plus zero open non-outdated threads, failing closed on doubt.
+#   * `.github/workflows/automerge.yml` owns the *plumbing* — which events
+#     re-evaluate arming, that every arm/guard/dequeue path delegates the
+#     decision to that one script, and that the sha it arms is the sha it
+#     checked.
+#
+# If the decision logic moves again, re-anchor these assertions to the file that
+# owns it afterwards — do NOT copy the string literals across. Mirroring
+# literals is how this test broke in the first place: it pinned workflow text
+# that had since moved into the helper, so the test failed while the behaviour
+# it guards was intact. Assert the property, in its home, against a value
+# derived from the file — never a copy of a line that lives somewhere else.
+
+
+def test_queue_ready_helper_owns_latest_run_wins_and_fails_closed() -> None:
+    helper = QUEUE_READY_HELPER.read_text(encoding="utf-8")
+
+    # Latest run wins. review-complete can be re-run on an unchanged head, so
+    # ordering the check runs and taking the newest is what stops a stale
+    # success outvoting a fresh failure.
+    assert "sort_by(.started_at) | last" in helper
+
+    # The verdict is read for the sha the caller passed, never for whatever
+    # GitHub currently calls the PR head.
+    sha_arg = re.search(r'^(\w+)="\$3"$', helper, re.MULTILINE)
+    assert sha_arg is not None, "helper no longer takes the head sha as its third argument"
+    assert re.search(rf"commits/\$\{{{sha_arg.group(1)}\}}/check-runs", helper)
+    assert "check_name=review-complete" in helper
+
+    # Fail closed. Only an explicit success is ready; a missing conclusion, an
+    # API error, and an unparsable thread count all land on the not-ready path.
+    assert re.search(r'!=\s*"success"', helper)
+    assert "refusing to treat as queue-ready" in helper
+    assert "isResolved == false and .isOutdated == false" in helper
+
+    # Exit-code contract: exactly one success exit, and it is the last word of
+    # the script — every guard above it exits non-zero.
+    assert re.findall(r"^exit 0$", helper, re.MULTILINE) == ["exit 0"]
+    assert helper.rstrip().endswith("exit 0")
+
+
+# The tests below run the helper for real against a stubbed `gh`, so they
+# assert the decision it reaches rather than the text of its queries. The stub
+# evaluates the helper's own `--jq` filters with real jq, which is what makes
+# "did it even ask for hasNextPage?" observable without pinning the query.
+_STUB_HEAD_SHA = "0" * 40
+_STUB_REPO = "VangelisTech/archetype"
+_STUB_PR = "654"
+
+# `gh api [graphql] ... --jq FILTER` reduced to: pick the canned payload for
+# whichever endpoint was called, then apply the filter the helper passed.
+#
+# GraphQL returns only the fields the query selected, so the stub prunes
+# pageInfo when the query did not ask for it. Without that, a helper that
+# reads `.pageInfo.hasNextPage` while querying only `nodes` would still be
+# handed a value here and would look correct against a server that would
+# never have sent one.
+_GH_STUB = """#!/bin/sh
+filter='.'
+query=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = "--jq" ]; then filter="$arg"; fi
+  case "$arg" in query=*) query="$arg" ;; esac
+  prev="$arg"
+done
+
+payload="$QUEUE_READY_STUB_DIR/check_runs.json"
+case " $* " in
+  *" graphql "*)
+    payload="$QUEUE_READY_STUB_DIR/graphql.json"
+    # Inspect the QUERY, not the whole argv: the --jq filter names the same
+    # fields, so matching on argv would report every field as selected.
+    case "$query" in
+      *pageInfo*) ;;
+      *) jq 'del(.data.repository.pullRequest.reviewThreads.pageInfo)' "$payload" \
+           > "$QUEUE_READY_STUB_DIR/pruned.json"
+         payload="$QUEUE_READY_STUB_DIR/pruned.json" ;;
+    esac
+    ;;
+esac
+exec jq -r "$filter" "$payload"
+"""
+
+
+def _thread(*, resolved: bool, outdated: bool = False) -> dict[str, bool]:
+    return {"isResolved": resolved, "isOutdated": outdated}
+
+
+def _run_queue_ready(
+    tmp_path: Path,
+    *,
+    threads: list[dict[str, bool]],
+    has_next_page: bool,
+    review_conclusion: str = "success",
+) -> subprocess.CompletedProcess[str]:
+    """Run the real helper with `gh` stubbed to serve the given API responses."""
+    if shutil.which("jq") is None:
+        pytest.skip("jq is required to evaluate the helper's own --jq filters")
+
+    stub_dir = tmp_path / "stubs"
+    bin_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    bin_dir.mkdir()
+
+    (stub_dir / "check_runs.json").write_text(
+        json.dumps(
+            {
+                "check_runs": [
+                    {"started_at": "2026-07-24T10:00:00Z", "conclusion": review_conclusion}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (stub_dir / "graphql.json").write_text(
+        json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "pageInfo": {"hasNextPage": has_next_page},
+                                "nodes": threads,
+                            }
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    gh = bin_dir / "gh"
+    gh.write_text(_GH_STUB, encoding="utf-8")
+    gh.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["QUEUE_READY_STUB_DIR"] = str(stub_dir)
+    return subprocess.run(
+        [str(QUEUE_READY_HELPER), _STUB_REPO, _STUB_PR, _STUB_HEAD_SHA],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_queue_ready_refuses_a_truncated_review_thread_page(tmp_path: Path) -> None:
+    """Truncation is a clean response, so no other guard can catch it."""
+    # 100 returned threads, all resolved, and more beyond the page. Every
+    # unresolved thread could be sitting past node 100 — the count is a valid
+    # integer over an incomplete set, so nothing "fails" and the helper would
+    # otherwise call this queue-ready and arm a blocked PR.
+    result = _run_queue_ready(
+        tmp_path,
+        threads=[_thread(resolved=True) for _ in range(100)],
+        has_next_page=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "queue-ready" != result.stdout.strip()
+    assert "refusing to treat as queue-ready" in result.stdout
+
+
+def test_queue_ready_accepts_a_complete_page_with_every_thread_resolved(tmp_path: Path) -> None:
+    """Control: the truncation refusal must not swallow the ready path."""
+    result = _run_queue_ready(
+        tmp_path,
+        threads=[_thread(resolved=True), _thread(resolved=False, outdated=True)],
+        has_next_page=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "queue-ready"
+
+
+def test_queue_ready_still_counts_unresolved_threads_on_a_complete_page(tmp_path: Path) -> None:
+    result = _run_queue_ready(
+        tmp_path,
+        threads=[_thread(resolved=False), _thread(resolved=False), _thread(resolved=True)],
+        has_next_page=False,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "2 unresolved review thread(s) remain" in result.stdout
+
+
+def test_queue_ready_refuses_a_head_whose_review_did_not_pass(tmp_path: Path) -> None:
+    result = _run_queue_ready(
+        tmp_path,
+        threads=[],
+        has_next_page=False,
+        review_conclusion="failure",
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "no authoritative passing review-complete" in result.stdout
+
+
 def test_automerge_remains_bound_to_latest_reviewed_head() -> None:
     workflow = AUTOMERGE_WORKFLOW.read_text(encoding="utf-8")
 
+    # Every new head and every review signal re-evaluates arming.
     assert (
         "types: [opened, synchronize, reopened, ready_for_review, auto_merge_enabled]" in workflow
     )
     assert 'workflows: ["Deterministic Review Gate"]' in workflow
     assert "github.event.workflow_run.conclusion == 'success'" in workflow
     assert "github.event.workflow_run.head_repository.full_name == github.repository" in workflow
-    assert "sort_by(.started_at) | last | .conclusion // empty" in workflow
-    assert r".headRefOid == \"${HEAD_SHA}\"" in workflow
-    assert ".isDraft | not" in workflow
-    assert 'gh pr merge --auto --squash --repo "${GITHUB_REPOSITORY}" "$pr"' in workflow
+
+    # Every job that decides whether an arm may stand runs the one helper and
+    # branches on its exit status, instead of re-deriving readiness inline...
+    for job_id in ("guard", "arm", "dequeue"):
+        body = _code_only(_job(workflow, job_id))
+        assert _helper_call().search(body), (
+            f"the {job_id!r} job stopped invoking {_HELPER_PATH} for its decision"
+        )
+        assert "status=$?" in body, f"the {job_id!r} job ignores the queue-ready verdict"
+    # ...and the decision has not leaked back into the workflow.
+    assert "check_name=review-complete" not in workflow
+    assert "reviewThreads" not in workflow
+
+    arm = _code_only(_job(workflow, "arm"))
+    head_match = re.search(r'\.headRefOid == \\"\$\{?(\w+)\}?\\"', arm)
+    assert head_match is not None, "the arm job no longer resolves the PR by matching its head sha"
+    # The sha the PR was matched on is the sha readiness is checked for: an arm
+    # is never granted on one head's verdict and applied to another.
+    assert _helper_call(head_sha=head_match.group(1)).search(arm), (
+        "the arm job checks readiness for a different sha than the one it matched the PR on"
+    )
+
+    # Both PR-resolution paths (workflow_run and review) filter, so a new path
+    # cannot quietly arm a draft or a non-maintainer PR.
+    pr_filters = re.findall(r"select\((.+?)\)\s*\|", arm, re.DOTALL)
+    assert pr_filters, "the arm job no longer filters the PRs it resolves"
+    for pr_filter in pr_filters:
+        assert ".isDraft | not" in pr_filter
+        assert "author.login" in pr_filter
+        # Conjunction, never disjunction: an `or` would make either predicate
+        # optional and arm exactly what the other one exists to exclude.
+        assert " or " not in pr_filter
+
+    # ...and both agree on state, by whichever mechanism each path has. gh pr
+    # view serves closed and merged PRs, and neither is ever isDraft, so
+    # without an explicit state check the review path would try to arm a PR
+    # that can no longer be merged.
+    assert "--state open" in arm, "the gh pr list path stopped restricting to open PRs"
+    assert '.state == "OPEN"' in arm, "the review path stopped restricting to open PRs"
+
+    assert 'gh pr merge --auto --squash --repo "${GITHUB_REPOSITORY}" "$pr"' in arm
+
+
+def test_automerge_runs_repo_scripts_from_the_trusted_default_branch() -> None:
+    """A PR must not be able to edit the script that judges it."""
+    workflow = AUTOMERGE_WORKFLOW.read_text(encoding="utf-8")
+
+    checked = 0
+    for job_id in _job_ids(workflow):
+        body = _code_only(_job(workflow, job_id))
+        if "scripts/" not in body:
+            continue
+        checked += 1
+        # `actions/checkout` without `ref:` follows GITHUB_SHA, which is the PR
+        # merge ref on pull_request and pull_request_review* events.
+        assert "ref: ${{ github.event.repository.default_branch }}" in body, (
+            f"the {job_id!r} job executes a repo script from an untrusted checkout"
+        )
+    assert checked, "no job executes a repo script; re-anchor this test"
+
+
+def test_automerge_triggers_are_real_github_actions_events() -> None:
+    """A webhook name Actions does not support invalidates the whole file."""
+    workflow = AUTOMERGE_WORKFLOW.read_text(encoding="utf-8")
+
+    # `pull_request_review_thread` is an Apps-only webhook. Naming it in `on:`
+    # makes GitHub reject the file outright: no job runs, every push gets a
+    # bare "Invalid workflow file" run, and the arming gate silently does
+    # nothing at all. Actions has no trigger for thread resolution — do not
+    # reintroduce one. See the workflow header.
+    assert "pull_request_review_thread:" not in workflow
+
+
+def test_automerge_disarms_when_new_findings_land_on_an_armed_pr() -> None:
+    workflow = AUTOMERGE_WORKFLOW.read_text(encoding="utf-8")
+
+    # The #646 -> #647 race: findings arrived after review-complete passed,
+    # while the PR was already armed and queue-locked. A submitted review is
+    # the signal Actions actually delivers for that.
+    assert "  pull_request_review:\n    types: [submitted, edited, dismissed]\n" in workflow
+
+    dequeue = _code_only(_job(workflow, "dequeue"))
+    assert "github.event_name == 'pull_request_review'" in dequeue
+    # Judged on what would actually merge, not on the event's cached head.
+    assert "--json headRefOid" in dequeue
+    # Disarm is verified by reading autoMergeRequest back, not by exit code:
+    # `--disable-auto` exits nonzero on the benign already-unarmed no-op.
+    assert dequeue.count("--json autoMergeRequest --jq '.autoMergeRequest // empty'") >= 2
+    assert "gh pr merge --disable-auto" in dequeue
+    # Both outcomes are distinguishable in the log (the #645 shepherd failure).
+    assert "nothing to disarm" in dequeue
+    assert "auto-merge disarmed on new findings" in dequeue


### PR DESCRIPTION
## Summary
- Fixes the #645 failure mode where **Revert premature arming** went green while auto-merge stayed armed: the guard treated `review-complete` success alone as legitimate, even with unresolved review threads still blocking the PR.
- Introduces `scripts/gh_pr_queue_ready.sh` — queue-ready means latest `review-complete` success **and** zero non-outdated unresolved threads.
- Arm defers until queue-ready. Guard logs explicitly distinguish "leaving armed (not a revert)" from an actual revert.

### The workflow was invalid and no job was running
`pull_request_review_thread` is a **GitHub Apps webhook, not a GitHub Actions trigger.** Naming it in `on:` made GitHub reject the entire file, so this branch produced a bare **"Invalid workflow file"** run on every push (runs `30114557878`, `30116242600` — zero jobs, instant failure, attributed to `push` even though the workflow declares no `push` trigger) and **no Auto-merge job ran at all** — not `disarm`, not `guard`, not `arm`. Confirmed by GitHub's own docs (`pull_request_review*` triggers are `pull_request_review` and `pull_request_review_comment` only), SchemaStore's `github-workflow.json`, and `actionlint` — which flagged it as the sole error in the file. Live proof of the repair: the fixed head produced a real `pull_request` run (`30116971550`) instead of the startup failure.

Actions cannot observe thread resolution by any trigger, so queue-readiness is now re-evaluated on the signals it does deliver — `workflow_run` (review gate completes) and `pull_request_review` `[submitted, edited, dismissed]`. **After resolving the last thread, re-run Deterministic Review Gate (or push) to re-evaluate arming.** `AGENTS.md` and `CLAUDE.md` say so too, and a test refuses the Apps-only trigger so the invalid-file failure cannot return.

### Trusted checkout closes a live privilege path on `arm`, not just `guard`
`guard` checked out the pull request head and then executed `scripts/gh_pr_queue_ready.sh` from it, so a PR could edit the script to print `queue-ready`, exit 0, and keep its own premature arm.

**`arm` had the same hole while holding `AUTOMERGE_PAT` (`contents:write` + `pull-requests:write`).** Its comment asserted a safety it did not have — `workflow_run` / review events resolve the *workflow file* from the default branch, but `actions/checkout` without `ref:` follows `GITHUB_SHA`, which is the **PR merge ref** on `pull_request_review` events. An unpinned checkout therefore ran the PR's own copy of the helper with that PAT in the step environment. That is a real privilege path from "open a PR" to "run attacker-chosen code with a write-scoped PAT", not a theoretical one.

`guard`, `arm`, and the new `dequeue` now all pin `ref: ${{ github.event.repository.default_branch }}`, and a test enforces it for *every* job in the workflow that references `scripts/`, so new jobs inherit the rule.

### Fail-closed on a truncated review-thread page
`reviewThreads(first:100)` had no `pageInfo`, and **truncation is not an error.** Past 100 threads GitHub returns a clean, valid response containing exactly 100 nodes, so `unresolved` computed as a legitimate integer over an incomplete set and the `-z`/not-a-number guard could not fire — nothing failed. With every unresolved thread past node 100 the helper printed `queue-ready` and exited 0 on a blocked PR: a fail-open inside the one mechanism whose purpose is to fail closed. The query now selects `pageInfo { hasNextPage }` and anything other than an explicit `false` exits 1. Deliberately **not** a cursor loop — paging adds a retry surface, more API calls, and a partial-failure mode midway through that would itself need a fail-closed decision; a PR with 100+ threads is pathological and deserves a human. That reasoning sits in a comment above the query.

### Both arm paths now agree on PR eligibility
The review branch resolved the PR with `gh pr view`, which serves closed and merged PRs as readily as open ones — and neither is ever `isDraft`, so the `select()` passed for them while the sibling `gh pr list --state open` branch excluded them. Its own fallback message claimed closed PRs were filtered out. Reviews can be submitted on merged PRs, so this reached `gh pr merge --auto` on unmergeable PRs. The review path now selects `.state == "OPEN"`, matching `--state open` field-for-field.

### Dequeue when new findings land on an armed PR
Closes the remaining half of the #646 → #647 race. `pull_request_review` re-runs the queue-ready check against the PR's current head — read from the API, not the event's cached head, which can be superseded by a racing push — and disarms if readiness has lapsed, verifying by reading `autoMergeRequest` back rather than trusting `--disable-auto`'s exit code (it exits nonzero on the benign already-unarmed no-op). Logs either "still queue-ready ... nothing to disarm" or "auto-merge disarmed on new findings". `arm` and `dequeue` share the trigger and cannot conflict: both run the same check and only one acts on any given answer. Best-effort back-pressure — the merge queue may already hold the PR, so the durable guarantee remains "arming requires queue-ready".

### Mirror test now asserts invariants, not string literals
`test_automerge_remains_bound_to_latest_reviewed_head` was red because two assertions pinned workflow text that had moved into the helper — the test failed while the behaviour it guards was intact. Assertions now live with the file that owns each half: latest-run-wins and fail-closed against `scripts/gh_pr_queue_ready.sh`, event wiring and delegation against `.github/workflows/automerge.yml`. The head-binding check derives the shell variable name from the file and requires the sha the PR was *matched* on to be the sha readiness is *checked* for, instead of pinning a variable's spelling.

## Test plan
- [x] `uv run pytest tests/scripts/test_quality_workflow.py -q` — **21 passed** (was 1 failed / 12 passed)
- [x] `make check` — all checks passed (format, lazy/architecture/observability/version/API/boundary/idempotency/gate-coverage/operational audits, ruff)
- [x] `make typecheck` — all checks passed
- [x] `make ci` — PR verification profile passed: **2399 passed, 6 skipped** in 103s, plus evals, package smoke, 27 operational scenarios, docs build
- [x] `actionlint` on `.github/workflows/automerge.yml` — **clean** (it reported the invalid trigger as the file's only error before the fix)
- [x] `yaml.safe_load` on the workflow + `bash -n` on all four step scripts — parse clean
- [x] `npx markdownlint-cli2 CLAUDE.md AGENTS.md` — 0 issues
- [x] Helper smoke against this PR, every head, exit 1 each time — correctly refuses to call a red or unreviewed head queue-ready:
  - `./scripts/gh_pr_queue_ready.sh VangelisTech/archetype 654 878bd1d9e4b24de92a3282ed2129d8fcd772651d` → `no authoritative passing review-complete on 878bd1d9e4b24de92a3282ed2129d8fcd772651d (latest: failure)`
  - `./scripts/gh_pr_queue_ready.sh VangelisTech/archetype 654 5a6a86ba0fe0898cf7c958b13fec6cded454e742` → `no authoritative passing review-complete on 5a6a86ba0fe0898cf7c958b13fec6cded454e742 (latest: none)`
- [x] Live: the fixed head produced an actual `pull_request` Auto-merge run (`30116971550`), where both prior heads produced only "Invalid workflow file" push runs — the workflow loads now. Job matrix was exactly right: `Disarm until the head is queue-ready | success`, and `guard` / `arm` / `dequeue` all correctly `skipped` on this event
- [x] Live: **push a new commit while armed → disarm.** This PR was armed at 17:53 and stayed armed across two pushes because the workflow never loaded. On the fixed head the disarm job ran and logged `auto-merge disarmed (attempt 1).`; `gh pr view 654 --json autoMergeRequest` now reads back empty. The retry-then-verify-postcondition pattern the `dequeue` job reuses is confirmed working in production
- [x] **Behavioral** test of the helper against a stubbed `gh` that evaluates its own `--jq` filters with real jq: a truncated page with zero visible unresolved threads must exit 1. Verified against the **pre-fix** script — it returned `queue-ready` / exit 0, the exact fail-open, while the other 20 tests stayed green
- [x] Mutation-tested every assertion: **28 targeted mutations, all 28 caught** — drop latest-run-wins, query a different sha, accept a non-success conclusion, drop the fail-closed thread guard, add a second success exit, stop taking the sha as arg 3, reintroduce the invalid trigger, remove the trusted `ref:` from each of the three jobs, check readiness for a sha other than the one matched, stop delegating to the helper (guard and dequeue), ignore the helper's verdict, re-inline readiness into the workflow, trust the event's cached head, trust `--disable-auto`'s exit code, narrow the review types, disable the dequeue job or its trigger, weaken either draft/author filter including `and` → `or`, drop either state restriction, delete `pageInfo` from the query, invert or remove the truncation guard, drop `--squash`
- [ ] Live: submit a review with findings on an armed, no-longer-queue-ready PR → `dequeue` logs "no longer queue-ready ... disarming auto-merge" and `autoMergeRequest` reads back empty
- [ ] Live: submit a review on a queue-ready armed PR → `dequeue` logs "still queue-ready ... nothing to disarm" and exits 0
- [ ] Live: push a new commit while armed → `disarm` clears the arm until the new head is queue-ready again (could not be exercised before this fix — the workflow was not loading)

### Known limits, deliberately not papered over
- **Thread resolution is invisible to Actions.** There is no trigger for it, so resolving the last thread does not re-arm on its own; re-run Deterministic Review Gate or push. This is a platform limit, not an omission.
- **`dequeue` cannot beat a PR the merge queue has already locked** — the residual #646 exposure, documented in the job comment rather than hidden behind a polling loop.
- **The pinned checkout runs *main's* helper.** Until this merges, a `guard` run would fail closed (`chmod` on a missing script aborts the step) rather than fail open. Correct direction of failure; resolves on merge.
- **Left alone:** `python-tests.yml`'s `infrastructure-idempotency` job checks out the PR head unpinned and runs a repo script, but that is ordinary CI — the job tests the PR's code and makes no authorization decision about itself, and fork PRs get no secrets on `pull_request`. Not the same class of flaw. `deterministic-review.yml` already pins to `github.event.pull_request.base.sha`, which is correct for `pull_request_target`.

Made with [Cursor](https://cursor.com)
