### PR TITLE
fix(ci): bind the review gate to the head, not the draft transition

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,58 @@
+# Codecov status posture. The rationale lives here so the decision is not
+# re-litigated in a triage thread.
+#
+# WHAT WAS WRONG
+# With no config file, Codecov applied its defaults, and the default target is
+# `auto`: the patch status compares the changed lines against the project's own
+# coverage (88.7%) with a 0% threshold. Any diff whose changed lines were less
+# covered than the whole repository failed `codecov/patch` — a red check that
+# was not required, blocked nothing, and cost a triage cycle every time
+# (PRs #646, #647, #649). That is advisory noise, which this repository trades
+# away for fail-loud oracles.
+#
+# THE ONE COVERAGE CONTRACT
+# The repository already commits to exactly one number: the 70% floor in
+# `[tool.coverage.report] fail_under` (pyproject.toml), enforced fail-loud by
+# `make test-cov` inside the required `ci (3.12)` context. Both statuses below
+# restate that same number instead of inventing a second one, so a Codecov
+# status can only go red when the repository breaks a commitment it actually
+# made — not when a refactor happens to land under the current average.
+#
+# WHY `patch` STAYS ON
+# Project coverage is 88.7% against a 70% floor, so every whole-project measure
+# (including `make test-cov` and the `project` status below) has ~18 points of
+# slack and cannot see new untested code arriving. Patch coverage is the only
+# diff-level coverage oracle in the harness; switching it off would delete the
+# signal and keep the redundant one.
+#
+# `project` is deliberately a mirror of the pytest floor rather than `auto`: it
+# fails only when the repository as a whole drops below what it promised, which
+# `make test-cov` fails on first anyway.
+#
+# KNOWN SHARP EDGE
+# Patch percentage quantizes hard on tiny diffs — one uncovered line out of
+# three is 66.7% and goes red. That is intended: the fix is a test, not a
+# looser threshold.
+#
+# NOT REQUIRED (YET)
+# Required contexts live in the repository ruleset, which is not managed in
+# this repo, so this file cannot promote `codecov/patch` to a blocking check.
+# Promoting it is the intended follow-up once the retargeted status has been
+# observed quiet across a few PRs.
+
+coverage:
+  # Match pyproject's `[tool.coverage.report] precision = 1`, and round down so
+  # 69.96% reads as 69.9% and fails the floor rather than passing it.
+  precision: 1
+  round: down
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 0%
+        informational: false
+    patch:
+      default:
+        target: 70%
+        threshold: 0%
+        informational: false

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -24,7 +24,16 @@ concurrency:
   # merge groups cancel each other's check runs, stalling the queue. On
   # merge_group, github.ref is the unique merge-group ref.
   group: deterministic-review-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push supersedes the previous head, so cancelling the older run is
+  # right. `ready_for_review` carries no new head: cancelling there killed a
+  # review that was already running on the exact sha being marked ready
+  # (#639, #646), and the cancelled run then published a contradictory
+  # "incomplete" verdict alongside the replacement run's pass. Queue behind
+  # the in-flight run instead — it publishes this head's verdict, and the
+  # queued run reaffirms it (see "Reaffirm a completed review") rather than
+  # reviewing the same sha twice. A later push still cancels both: its own
+  # run evaluates this expression as true.
+  cancel-in-progress: ${{ github.event.action != 'ready_for_review' }}
 
 jobs:
   footgun-review:
@@ -33,8 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
+      checks: read # Read this head's own prior review-complete conclusion.
       contents: read
       pull-requests: read # Supply PR metadata to the read-only detector.
+    outputs:
+      # Consumed by review-complete: publication is skipped on a reaffirmed
+      # head so one head never accumulates two verdict comments.
+      reaffirmed: ${{ steps.reaffirm.outputs.reaffirmed }}
     env:
       DIFF_FILE: ${{ github.workspace }}/.footgun-review.diff
       REVIEW_DIR: ${{ github.workspace }}/.footgun-review-output
@@ -48,7 +62,51 @@ jobs:
           echo "This PR fails closed: no review ran and merge stays blocked."
           exit 1
 
+      # Draft status is not an input to the verdict — the review binds to the
+      # head sha. Marking a PR ready at a sha whose review already completed
+      # clean therefore buys no new information: it re-spends a full detector
+      # cycle to rediscover the same answer and posts a second verdict comment
+      # for one head. Reaffirm that verdict instead.
+      #
+      # The only accepted evidence is a `review-complete` check run that
+      # concluded `success` on this exact sha — the same evidence
+      # automerge.yml's guard already treats as authoritative. Everything else
+      # (no prior run, a failure, an incomplete review, a cancelled run, or an
+      # API error) falls through to the full review. This can only skip work
+      # that already produced a verified clean verdict for this head; it can
+      # never manufacture one.
+      #
+      # Both jobs still run to success here rather than being skipped: the
+      # workflow run must conclude `success` for automerge.yml to arm the now
+      # non-draft PR, and `review-complete` must report an actual success
+      # check run for its guard to accept that arm. A skipped job would give
+      # neither.
+      - name: Reaffirm a completed review of this exact head
+        id: reaffirm
+        if: github.event.action == 'ready_for_review'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          # `|| passed=0` keeps an API failure from tripping -e before the
+          # decision: failure to positively confirm the prior pass falls
+          # through to a full review (fail closed).
+          passed=$(gh api \
+            "repos/${REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=review-complete&per_page=100" \
+            --jq '[.check_runs[] | select(.conclusion == "success")] | length') || passed=0
+          if [ "${passed:-0}" -gt 0 ]; then
+            echo "reaffirmed=true" >> "${GITHUB_OUTPUT}"
+            echo "review-complete already succeeded on ${HEAD_SHA}; reaffirming that verdict."
+            echo "Reaffirmed the completed clean review of \`${HEAD_SHA}\`; no new review was run." \
+              >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "reaffirmed=false" >> "${GITHUB_OUTPUT}"
+            echo "No completed clean review-complete on ${HEAD_SHA}; running the full review."
+          fi
+
       - name: Checkout trusted base
+        if: steps.reaffirm.outputs.reaffirmed != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Full trusted-base history lets git find the PR merge base after
@@ -60,6 +118,7 @@ jobs:
 
       - name: Materialize deterministic review scope
         id: scope
+        if: steps.reaffirm.outputs.reaffirmed != 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ github.token }}
@@ -106,6 +165,7 @@ jobs:
 
       - name: Compute turn budget from scope
         id: budget
+        if: steps.reaffirm.outputs.reaffirmed != 'true'
         run: |
           python3 - <<'EOF' >> "${GITHUB_OUTPUT}"
           import json, os
@@ -121,6 +181,7 @@ jobs:
 
       - name: Run read-only footgun detector
         id: detector
+        if: steps.reaffirm.outputs.reaffirmed != 'true'
         continue-on-error: true
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c # v1.0.175
         with:
@@ -167,6 +228,7 @@ jobs:
 
       - name: Validate first detector result
         id: first_validation
+        if: steps.reaffirm.outputs.reaffirmed != 'true'
         env:
           STRUCTURED_OUTPUT: ${{ steps.detector.outputs.structured_output }}
         run: |
@@ -182,7 +244,12 @@ jobs:
 
       - name: Retry detector with validator feedback
         id: detector_retry
-        if: steps.first_validation.outputs.valid != 'true'
+        # The reaffirm clause leads every downstream condition: a reaffirmed
+        # head skips first_validation, and its empty output would otherwise
+        # read as "not valid" and spend the retry.
+        if: >-
+          steps.reaffirm.outputs.reaffirmed != 'true' &&
+          steps.first_validation.outputs.valid != 'true'
         continue-on-error: true
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c # v1.0.175
         with:
@@ -220,6 +287,7 @@ jobs:
 
       - name: Require retry completion
         if: >-
+          steps.reaffirm.outputs.reaffirmed != 'true' &&
           steps.first_validation.outputs.valid != 'true' &&
           steps.detector_retry.outcome != 'success'
         run: |
@@ -227,7 +295,9 @@ jobs:
           exit 1
 
       - name: Validate bounded retry
-        if: steps.first_validation.outputs.valid != 'true'
+        if: >-
+          steps.reaffirm.outputs.reaffirmed != 'true' &&
+          steps.first_validation.outputs.valid != 'true'
         env:
           STRUCTURED_OUTPUT: ${{ steps.detector_retry.outputs.structured_output }}
         run: |
@@ -239,6 +309,7 @@ jobs:
             --output "${REVIEW_DIR}/validated/normalized.json"
 
       - name: Upload validated detector result
+        if: steps.reaffirm.outputs.reaffirmed != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           if-no-files-found: error
@@ -249,9 +320,21 @@ jobs:
   review-complete:
     name: review-complete
     needs: footgun-review
-    # always() so a footgun crash cannot skip-satisfy the gate on PRs;
-    # merge groups skip both jobs (see the trigger comment).
-    if: always() && github.event_name != 'merge_group'
+    # `!cancelled()` rather than `always()`: a footgun crash must still land
+    # here and fail the gate (a failed dependency is not "cancelled", so this
+    # job runs), but a run cancelled by its own concurrency group must not.
+    # `always()` ran this job after such a cancellation, where the dependency
+    # read as `cancelled`, the first step failed, and the run published
+    # "Footgun review — incomplete" for a head that a superseding run then
+    # passed — two live contradictory verdicts on one PR (#639, #646).
+    #
+    # This does not soften the oracle. A cancelled run concludes `cancelled`,
+    # never `success`, so automerge.yml cannot arm from it; the superseding
+    # run in the same concurrency group publishes the authoritative
+    # `review-complete` check run for whichever head merges.
+    #
+    # Merge groups skip both jobs (see the trigger comment).
+    if: ${{ !cancelled() && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -270,7 +353,16 @@ jobs:
           echo "Footgun review did not complete successfully."
           exit 1
 
+      # Every publication step below is gated on the reaffirm decision the
+      # detector job made for this head. On a reaffirmed head there is nothing
+      # left to publish — the verdict comment for this exact sha is already on
+      # the PR — so this job runs to a real success check run without adding a
+      # second verdict. Note the polarity: `finding_count` is empty when
+      # `prepare` is skipped, and `'' != '0'` is true, so the publish-findings
+      # and block-merge steps would otherwise fire with no findings behind
+      # them.
       - name: Checkout trusted base
+        if: needs.footgun-review.outputs.reaffirmed != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Rebuild the same inert diff independently before publication.
@@ -279,6 +371,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Materialize exact review scope
+        if: needs.footgun-review.outputs.reaffirmed != 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ github.token }}
@@ -323,6 +416,7 @@ jobs:
           fi
 
       - name: Download detector result
+        if: needs.footgun-review.outputs.reaffirmed != 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: footgun-review-validated-${{ github.run_id }}
@@ -330,6 +424,7 @@ jobs:
 
       - name: Validate and render publishable evidence
         id: prepare
+        if: needs.footgun-review.outputs.reaffirmed != 'true'
         env:
           ARTIFACT_NAME: footgun-review-validated-${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -345,14 +440,18 @@ jobs:
             --run-url "${RUN_URL}"
 
       - name: Publish contextual no-findings evidence
-        if: steps.prepare.outputs.finding_count == '0'
+        if: >-
+          needs.footgun-review.outputs.reaffirmed != 'true' &&
+          steps.prepare.outputs.finding_count == '0'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr comment "${PR_NUMBER}" --body-file "${REVIEW_DIR}/evidence.md"
 
       - name: Publish findings as blocking review threads
-        if: steps.prepare.outputs.finding_count != '0'
+        if: >-
+          needs.footgun-review.outputs.reaffirmed != 'true' &&
+          steps.prepare.outputs.finding_count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -363,6 +462,7 @@ jobs:
             --input "${REVIEW_DIR}/review.json"
 
       - name: Fetch posted review evidence
+        if: needs.footgun-review.outputs.reaffirmed != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -379,6 +479,7 @@ jobs:
             > "${RUNNER_TEMP}/review-comments.json"
 
       - name: Verify exact review completion evidence
+        if: needs.footgun-review.outputs.reaffirmed != 'true'
         env:
           ARTIFACT_DIGEST: ${{ steps.prepare.outputs.artifact_digest }}
           FINDING_COUNT: ${{ steps.prepare.outputs.finding_count }}
@@ -394,7 +495,9 @@ jobs:
 
       - name: Block merge on findings
         id: finding_gate
-        if: steps.prepare.outputs.finding_count != '0'
+        if: >-
+          needs.footgun-review.outputs.reaffirmed != 'true' &&
+          steps.prepare.outputs.finding_count != '0'
         env:
           FINDING_COUNT: ${{ steps.prepare.outputs.finding_count }}
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -51,6 +51,11 @@ jobs:
       # existed). Skips: merge groups (synthetic commits carry no coverage
       # signal, and a Codecov hiccup must not block the queue) and fork PRs
       # (GitHub withholds secrets there, so the upload can only fail).
+      #
+      # What Codecov then does with the upload — the `project` and `patch`
+      # status targets, and why they mirror the 70% `fail_under` floor rather
+      # than the default `auto` — is configured and argued in
+      # `.github/codecov.yml`.
       - name: Upload coverage to Codecov
         if: >-
           matrix.python-version == '3.12' &&

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ node_modules/
 !.claude/hooks/
 !.claude/skills/
 !.claude/agents/
+# Local agent/session state: plans, ledgers, evidence archives, transcripts.
+# Was excluded only by .git/info/exclude, which no fresh clone gets.
+.context/
+# Local lakehouse data, sibling of archetype_data/ above. Never commit either.
+archetype_db/
 data/
 
 .venv/

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -487,6 +487,94 @@ def test_workflow_materializes_large_diffs_from_inert_git_objects():
     assert workflow.count('cmp --silent "${RUNNER_TEMP}/git-scope.json" "${SCOPE_FILE}"') == 2
 
 
+REVIEW_WORKFLOW = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deterministic-review.yml"
+)
+
+# The reaffirm gate turns "this head already has a completed clean review" into
+# a no-op run. Every step that spends the detector, publishes a verdict, or
+# blocks the merge must therefore be skipped on a reaffirmed head. These four
+# are the deliberate exceptions.
+UNGATED_REVIEW_STEPS = frozenset(
+    {
+        # Fails closed for non-maintainers before any spend; must always run.
+        "Restrict to maintainer PRs",
+        # The decision itself.
+        "Reaffirm a completed review of this exact head",
+        # A real guard: the detector job must have succeeded either way.
+        "Require successful detector job",
+        # failure()-gated, so a reaffirmed (nothing-failed) run never reaches it.
+        "Report incomplete review",
+    }
+)
+
+REAFFIRM_GATES = (
+    "steps.reaffirm.outputs.reaffirmed != 'true'",
+    "needs.footgun-review.outputs.reaffirmed != 'true'",
+)
+
+
+def _review_workflow_steps() -> list[tuple[str, str]]:
+    """Return (name, body) for every step in the review workflow."""
+
+    chunks = re.split(r"\n      - name: ", REVIEW_WORKFLOW.read_text(encoding="utf-8"))[1:]
+    return [(chunk.split("\n", 1)[0], chunk) for chunk in chunks]
+
+
+def test_ready_for_review_never_cancels_the_running_review_of_the_same_head():
+    workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+
+    # A push supersedes the head and still cancels. Marking a draft ready
+    # carries no new head, so it queues behind the in-flight review instead of
+    # destroying it (#639, #646).
+    assert "cancel-in-progress: ${{ github.event.action != 'ready_for_review' }}" in workflow
+    assert "cancel-in-progress: true" not in workflow
+
+
+def test_reaffirm_accepts_only_a_completed_clean_review_of_the_exact_head():
+    workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "if: github.event.action == 'ready_for_review'" in workflow
+    assert "checks: read" in workflow
+    assert "reaffirmed: ${{ steps.reaffirm.outputs.reaffirmed }}" in workflow
+    # Bound to this exact sha, and only a concluded success counts.
+    assert "commits/${HEAD_SHA}/check-runs?check_name=review-complete" in workflow
+    assert '[.check_runs[] | select(.conclusion == "success")] | length' in workflow
+    # An API failure falls through to the full review rather than reaffirming.
+    assert "|| passed=0" in workflow
+
+
+def test_reaffirmed_head_skips_every_spending_and_publishing_step():
+    ungated = [
+        name
+        for name, body in _review_workflow_steps()
+        if name not in UNGATED_REVIEW_STEPS and not any(gate in body for gate in REAFFIRM_GATES)
+    ]
+
+    assert ungated == []
+
+
+def test_reaffirmed_head_cannot_fire_the_empty_finding_count_steps():
+    # `finding_count` is empty when `prepare` is skipped, and '' != '0' is
+    # true, so these two would otherwise fire with no findings behind them.
+    bodies = {name: body for name, body in _review_workflow_steps()}
+
+    for name in ("Publish findings as blocking review threads", "Block merge on findings"):
+        assert "needs.footgun-review.outputs.reaffirmed != 'true' &&" in bodies[name]
+
+
+def test_a_superseded_review_never_publishes_an_incomplete_verdict():
+    workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+
+    # always() ran review-complete after the run was cancelled by its own
+    # concurrency group, which failed the first step and posted "Footgun
+    # review — incomplete" beside the superseding run's pass. !cancelled()
+    # still runs the job when the detector job merely failed.
+    assert "if: ${{ !cancelled() && github.event_name != 'merge_group' }}" in workflow
+    assert "if: always() && github.event_name != 'merge_group'" not in workflow
+    assert "if: needs.footgun-review.result != 'success'" in workflow
+
+
 def test_review_payload_batches_each_finding_as_an_inline_thread():
     normalized = validate_result(_result(findings=[_finding()]), _scope(), DIFF)
     digest = artifact_digest(normalized)

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -71,6 +71,26 @@ def test_quality_workflow_keeps_fail_loud_coverage_and_infrastructure() -> None:
     )
 
 
+def test_codecov_statuses_restate_the_repository_coverage_floor() -> None:
+    """Codecov judges diffs against the 70% floor, not the moving project average.
+
+    The default `target: auto` pinned `codecov/patch` to whole-project coverage
+    (88.7%), so ordinary refactors failed a non-required check and cost triage
+    (#646, #647, #649). Both statuses now restate `fail_under`, and this test
+    keeps the two numbers from drifting apart.
+    """
+
+    config = (ROOT / ".github" / "codecov.yml").read_text(encoding="utf-8")
+    with (ROOT / "pyproject.toml").open("rb") as stream:
+        floor = tomllib.load(stream)["tool"]["coverage"]["report"]["fail_under"]
+
+    assert re.search(r"^    project:\n      default:\n        target: ", config, re.MULTILINE)
+    assert re.search(r"^    patch:\n      default:\n        target: ", config, re.MULTILINE)
+    assert config.count(f"target: {floor}%") == 2
+    assert config.count("threshold: 0%") == 2
+    assert config.count("informational: false") == 2
+
+
 def test_r2_job_runs_each_oracle_once_and_retains_the_redacted_receipt() -> None:
     workflow = QUALITY_WORKFLOW.read_text(encoding="utf-8")
     infrastructure = _job(workflow, "infrastructure-idempotency")


### PR DESCRIPTION
## Problem 1 — draft→ready destroyed an in-flight review

Marking a draft PR ready re-triggered `Deterministic Review Gate` on an
**unchanged head**. The new run cancelled the in-flight one; the cancelled run
still posted "Footgun review — incomplete"; the replacement run posted a pass.
The PR then showed two live contradictory verdicts for one sha, and a full
detector cycle was spent to rediscover the same answer (#639, #646).

Root cause of the stale comment: `review-complete` used `if: always()`, which
GitHub runs *even when the workflow run is cancelled*. Its first step saw
`needs.footgun-review.result == 'cancelled'`, failed, and the failure()-gated
report step commented.

### The fix (three coordinated changes, all fail-closed)

1. **`concurrency.cancel-in-progress: ${{ github.event.action != 'ready_for_review' }}`**
   A push supersedes the head and still cancels. `ready_for_review` carries no
   new head, so it queues behind the in-flight review instead of killing it.

2. **`review-complete: if: ${{ !cancelled() && github.event_name != 'merge_group' }}`**
   A *failed* detector job is not "cancelled", so a crash still lands here and
   fails the gate — the anti-skip-satisfy property the old `always()` comment
   was protecting. A run cancelled by its own concurrency group no longer
   publishes an incomplete verdict.

3. **Reaffirm step.** On `ready_for_review`, if a `review-complete` check run
   already concluded `success` on this **exact** sha, every detector and
   publication step is skipped. Both jobs still run to a real `success` check
   run.

### Why the oracle is not weakened

- The reaffirm branch is reachable only from a `review-complete` check run that
  concluded `success` on the exact head — the same evidence `automerge.yml`'s
  guard already treats as authoritative. Missing run, `failure`, `cancelled`,
  in-progress, or an API error all fall through to the full review
  (`|| passed=0`).
- A cancelled run concludes `cancelled`, never `success`, so `automerge.yml`'s
  arm job cannot arm from one.
- The reaffirm path deliberately does **not** skip the jobs. A skipped job
  would (a) let a required context be skip-satisfied and (b) make the workflow
  run conclude non-`success`, which would break arming outright.
- Step-gating polarity was checked: `finding_count` is empty when `prepare` is
  skipped and `'' != '0'` is **true**, so "Publish findings" and "Block merge
  on findings" carry the gate explicitly. A test pins this.

### Alternatives rejected

- **Drop `ready_for_review` from the trigger list.** Simplest, but it silently
  breaks auto-merge. `automerge.yml`'s arm job only fires on a
  `workflow_run: completed` of this workflow and skips draft PRs, so a PR
  reviewed while draft would never produce an arming event after being marked
  ready. It would sit un-armed until an unrelated push.
- **Only suppress the stale comment (candidate 2 alone).** Fixes the
  contradiction but still burns a full detector cycle per draft→ready
  transition, which is a third of the reported problem.
- **Supersede/rewrite the older comment (candidate 3).** Mutates published
  review evidence to hide a contradiction rather than not producing one. With
  1 and 2 in place no contradictory pair is generated, so there is nothing to
  supersede.

## Problem 2 — `codecov/patch` posture

With no config file, Codecov used `target: auto`: the patch status compared
changed lines against whole-project coverage (88.7%) at a 0% threshold. Any
diff less covered than the repository average failed a **non-required** check
that blocked nothing and cost a triage cycle (#646, #647, #649).

**Chosen: option (a), an explicit target that makes a failure mean something.**
`.github/codecov.yml` sets both `project` and `patch` to `target: 70%`,
`threshold: 0%` — the floor the repository already commits to in
`[tool.coverage.report] fail_under`, enforced fail-loud by `make test-cov`
inside the required `ci (3.12)` context. Restating the existing number avoids
inventing a second contract. `test_codecov_statuses_restate_the_repository_coverage_floor`
reads `fail_under` from `pyproject.toml` and asserts the config matches, so the
two cannot drift.

- **Rejected (b) turn `patch` off:** project coverage has ~18 points of slack
  over the floor, so every whole-project measure is blind to new untested code
  arriving. Patch is the only diff-level coverage oracle in the harness;
  turning it off deletes the unique signal and keeps the redundant one.
- **Rejected (c) keep it and make it required as-is:** an `auto` target that
  tracks project coverage is a moving merge blocker, and required contexts live
  in the repository ruleset, which is not managed in this repo. Promotion is the
  intended follow-up once the retargeted status is observed quiet — noted in the
  config.

Known sharp edge, documented in the config: patch percentage quantizes hard on
tiny diffs (1 uncovered line out of 3 is 66.7% and goes red). Intended — the
fix is a test, not a looser threshold.

## Repo hygiene — `.context/` and `archetype_db/` (folded in, same family)

`.context/` was excluded **only** by `.git/info/exclude`, a per-clone file that
is not part of the repository; the committed `.gitignore` never mentioned it. In
any fresh clone — a cloud container, a CI checkout, a new workspace, a
contributor — the exclusion does not apply, so a routine `git add -A` would
commit refactor plans, execution ledgers, sealed evidence archives, and raw
agent transcripts (75 MB in one working copy) to a public repository.
`archetype_db/` is local lakehouse data matched by nothing: `archetype_data/`
was ignored, `archetype_db/` was not.

Both are now in `.gitignore` next to the `.worktrees/` and `.claude/*` local-state
entries. Verified after the change:

```
$ git check-ignore -v .context/ .context/refactor-v050/00-rulings.md archetype_db/ archetype_db/some_table.lance
.gitignore:42:.context/	.context/
.gitignore:42:.context/	.context/refactor-v050/00-rulings.md
.gitignore:44:archetype_db/	archetype_db/
.gitignore:44:archetype_db/	archetype_db/some_table.lance
```

The source is now `.gitignore`, not `.git/info/exclude`. Creating real files
under both paths and re-running `git status --short` produced zero `??` entries
(only the tracked `M .gitignore`); the scratch files were then removed.

No test guards this. `tests/scripts/` has no file whose subject is repo hygiene
— every file there tests a named `scripts/*.py`, and there is no
`scripts/check_gitignore.py`. The one existing `.gitignore` assertion
(`test_validate_operational_scenarios.py`) mirrors literal ignore lines, which is
the style to avoid, and its subject is operational-scenario receipts. Adding a
harness file for this was judged worse than leaving it unguarded.

## Event-matrix reasoning (static analysis, NOT an executed test)

These paths cannot be exercised locally; the following is reasoning about the
workflow semantics, not a run.

**A. draft opened → synchronize → ready_for_review → new push**

1. `opened` (draft, head1): action ≠ `ready_for_review` → `cancel-in-progress`
   true (nothing to cancel). Reaffirm step skipped → its output is empty →
   every gate `!= 'true'` is true → full review on head1, verdict published.
   `arm` skips (PR is draft). *Unchanged from today.*
2. `synchronize` (head2): cancels the head1 run if in flight. The cancelled run
   now skips `review-complete` entirely → **no "incomplete" comment**. Full
   review on head2, verdict published. `arm` skips (draft).
3. `ready_for_review` (still head2):
   - 3a. head2 already reviewed clean → reaffirm true → all detector and
     publication steps skipped → both jobs succeed → run concludes `success` →
     `arm` sees a non-draft PR at head2 → arms. No second comment, no model
     spend. *(Today: full re-review plus a second comment.)*
   - 3b. head2's review still in flight → the ready run queues instead of
     cancelling. The in-flight run publishes head2's verdict and its
     `workflow_run` success arms the now non-draft PR. The queued run then
     reaffirms and re-arms (no-op). *(Today: the in-flight run is cancelled,
     comments "incomplete", and a full re-review follows.)*
   - 3c. head2's review failed, was cancelled, or never ran → reaffirm false →
     full review. Fail closed.
4. `synchronize` (head3): `cancel-in-progress` true cancels both in-progress and
   queued runs for the group, including a pending ready run. `automerge.yml`
   disarms on the push and re-arms only after head3's review succeeds.

**B. non-draft opened → synchronize**

1. `opened`: reaffirm step skipped (action ≠ `ready_for_review`) → full review →
   publish → arm. Identical to today.
2. `synchronize`: cancels the previous run (now without the stale "incomplete"
   comment) → full review on the new head → publish → arm.

**C. merge_group**: payload action is `checks_requested`, so
`cancel-in-progress` stays true; both jobs still skip on
`github.event_name != 'merge_group'`. Unchanged.

**D. non-maintainer PR**: "Restrict to maintainer PRs" still fails before the
reaffirm step, before any checkout, API call, or model spend. Unchanged.

## Validation actually run

- `make check` — passed ("All checks passed!"; ruff reformatted one line of the
  new test, included in the commit).
- `uv run pytest tests/scripts/ -q` — **339 passed**.
- Mutation-checked the five new tests by reverting each change in the working
  tree and confirming a red: `always()` restored → `test_a_superseded_review_never_publishes_an_incomplete_verdict`
  fails; `cancel-in-progress: true` restored → `test_ready_for_review_never_cancels_the_running_review_of_the_same_head`
  fails; gate removed from "Block merge on findings" → two tests fail;
  `target: auto` in codecov.yml → the codecov test fails. All files restored and
  re-verified green.
- Parsed the workflow with PyYAML and dumped every job/step condition to confirm
  the gates landed where intended.
- After the `.gitignore` commit: `uv run pytest tests/scripts/ -q` again **339
  passed**, `make check` again passed, plus the `git check-ignore` and
  `git status` checks quoted above.

## Not fixed here (out of lane, `automerge.yml` is owned by another agent)

- In path 3b the arm job can run twice for one head (once from the in-flight
  run, once from the reaffirm run). `gh pr merge --auto` on an already-armed PR
  should be a no-op; if it is not, the second arm job goes red without affecting
  merge safety.
- `automerge.yml` does not disarm on `converted_to_draft` (not in its trigger
  types), so an armed PR converted back to draft stays armed. GitHub will not
  merge a draft, so this is cosmetic.
