### PR TITLE
fix(quality): close three vacuous or line-keyed repository checkers

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -495,6 +495,14 @@ and Catalog-table operations belong to `StorageService`. A bounded app
 `StorageService.materialize()`, and the conversion still needs its specific
 `lazy_audit.toml` reason.
 
+Entries are keyed by ``(path, symbol, expr, method)``. ``symbol`` is the dotted
+path of the enclosing def/class (``<module>`` at file scope) and ``expr`` is the
+normalized source of the audited attribute access. Adding an unrelated line
+above the call does not invalidate the entry; changing what is materialized
+does. Run ``python scripts/check_lazy_audit.py --list`` to read the current key
+for every site, and paste the emitted ``[[entries]]`` block when the audit
+reports a new one.
+
 See ``lazy_audit.toml`` for the authoritative policy header and
 ``tests/scripts/test_check_lazy_audit.py`` for positive/negative coverage.
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -10,6 +10,15 @@
 # Generic reasons ("needed", "for the test", "convenience") are
 # rejected automatically by scripts/check_lazy_audit.py.
 #
+# Entries are keyed by (path, symbol, expr, method) — never by line
+# number. `symbol` is the dotted path of the enclosing def/class (or
+# "<module>"); `expr` is the normalized source of the audited attribute
+# access. An edit elsewhere in the file cannot invalidate an entry, and
+# reformatting the call cannot either, because `expr` comes from
+# ast.unparse. Editing the audited expression itself does re-open review,
+# which is the intent. Run `python scripts/check_lazy_audit.py --list` to
+# see the current key for every site.
+#
 # Scope: src/ only. Tests are exempt — terminal materialization at the
 # assertion boundary is expected and not part of the audited contract.
 #
@@ -26,210 +35,245 @@
 
 [[entries]]
 path = "src/archetype/api/models.py"
-line = 33
+symbol = "dataframe_to_rows"
+expr = "df.collect"
 method = "collect"
 reason = "HTTP JSON response boundary: FastAPI must receive concrete row dictionaries for response encoding; a Daft lazy DataFrame cannot be represented as JSON without executing the query."
 
 [[entries]]
 path = "src/archetype/api/models.py"
-line = 33
+symbol = "dataframe_to_rows"
+expr = "df.collect().to_pylist"
 method = "to_pylist"
 reason = "HTTP JSON response boundary: convert the already-collected Daft result into row dictionaries for FastAPI's JSON encoder at the terminal REST boundary."
 
 [[entries]]
-path = "src/archetype/storage/service.py"
-line = 680
-method = "collect"
-reason = "Central application execution boundary: StorageService admits the caller's lazy Daft plan through its shared execution gate, materializes it off the event loop, and returns the completed frame."
-
-[[entries]]
-path = "src/archetype/storage/service.py"
-line = 716
-method = "collect"
-reason = "Conflict-safe append boundary: StorageService materializes producer rows exactly once so optimistic Iceberg retries can reuse the same payload instead of re-running external or nondeterministic expressions."
-
-[[entries]]
-path = "src/archetype/storage/service.py"
-line = 768
-method = "collect"
-reason = "Conditional producer boundary: StorageService freezes the aligned candidate plan once so duplicate-key validation and optimistic Iceberg retries cannot re-run external or nondeterministic expressions."
-
-[[entries]]
-path = "src/archetype/storage/service.py"
-line = 795
-method = "collect"
-reason = "Conditional append boundary: StorageService materializes the anti-join after each refreshed Iceberg snapshot so a conflicting writer cannot cause a stale retry to duplicate an existing logical key."
-
-[[entries]]
-path = "src/archetype/core/aio/async_store.py"
-line = 273
-method = "collect"
-reason = "Storage write boundary: materialize the incoming frame once for the empty-row guard and reuse that same materialized frame for the backing-table append."
-
-[[entries]]
-path = "src/archetype/core/aio/async_world.py"
-line = 569
+path = "src/archetype/app/physical_ai/service.py"
+symbol = "_latest_rows"
+expr = "materialized.to_pylist"
 method = "to_pylist"
-reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
-
-[[entries]]
-path = "src/archetype/core/sync/store.py"
-line = 132
-method = "collect"
-reason = "Debug-mode-only logging: materialise so count_rows and df.show emit diagnostics; gated on self.debug and never reached in production execution paths."
-
-[[entries]]
-path = "src/archetype/core/sync/world.py"
-line = 317
-method = "to_pylist"
-reason = "Cross-archetype entity migration (sync mirror of async_world): extract the latest tick row for component overlay before re-insertion."
-
-[[entries]]
-path = "src/archetype/core/lineage.py"
-line = 115
-method = "to_pylist"
-reason = "Lineage metadata extract: a fork's ancestor segments (bounded by fork depth, typically 1-3 rows) must become Python (world_id, run_id, up_to_tick) tuples because they route subsequent per-tick store queries; the routing decision cannot be expressed inside a single Daft plan."
+reason = "Physical-evaluation grading boundary: StorageService admits and materializes latest-tick ledger rows before bounded success and episode-length values become typed task or sweep reports."
 
 [[entries]]
 path = "src/archetype/app/research/service.py"
-line = 498
+symbol = "AutoResearchService._next_iteration"
+expr = "materialized.to_pylist"
+method = "to_pylist"
+reason = "Bounded control-plane history extract: StorageService has already admitted and materialized the query; deterministic Run ids and statuses then enter Python control flow to reject ambiguous resume state."
+
+[[entries]]
+path = "src/archetype/app/research/service.py"
+symbol = "AutoResearchService._read_experiment"
+expr = "materialized.to_pylist"
 method = "to_pylist"
 reason = "Single-row experiment-contract extract: StorageService has already admitted and materialized the query; the persisted identity and JSON configuration digest then enter Python control flow for exact collision rejection before resume."
 
 [[entries]]
 path = "src/archetype/app/research/service.py"
-line = 510
+symbol = "AutoResearchService._read_head"
+expr = "materialized.to_pylist"
 method = "to_pylist"
 reason = "Single-row loop-state extract: StorageService has already admitted and materialized the query; the latest BranchHead then enters Python control flow for incumbent comparison and entity-id routing."
 
 [[entries]]
-path = "src/archetype/app/research/service.py"
-line = 527
-method = "to_pylist"
-reason = "Bounded control-plane history extract: StorageService has already admitted and materialized the query; deterministic Run ids and statuses then enter Python control flow to reject ambiguous resume state."
+path = "src/archetype/core/aio/async_store.py"
+symbol = "AsyncStore.append"
+expr = "df.collect"
+method = "collect"
+reason = "Storage write boundary: materialize the incoming frame once for the empty-row guard and reuse that same materialized frame for the backing-table append."
 
 [[entries]]
-path = "src/archetype/world/simulation.py"
-line = 315
+path = "src/archetype/core/aio/async_world.py"
+symbol = "AsyncWorld._move_entity"
+expr = "df.to_pylist"
 method = "to_pylist"
-reason = "Episode-termination boundary: StorageService admits and materializes the one-row (n_done, n_total) reduction before its all/any values enter Python control flow to stop the episode loop."
+reason = "Cross-archetype entity migration: extract the latest tick row as a Python dict for component-overlay, which mutates field-by-field before re-insertion into the new archetype."
 
 [[entries]]
-path = "src/archetype/world/resume.py"
-line = 125
+path = "src/archetype/core/lineage.py"
+symbol = "load_lineage"
+expr = "df.to_pylist"
 method = "to_pylist"
-reason = "Resume-time entity-directory extract (issue #273 A1-resume): StorageService admits and materializes the groupby-max result before bounded live-entity rows become the imperative entity2sig registry and next_entity_id counter."
+reason = "Lineage metadata extract: a fork's ancestor segments (bounded by fork depth, typically 1-3 rows) must become Python (world_id, run_id, up_to_tick) tuples because they route subsequent per-tick store queries; the routing decision cannot be expressed inside a single Daft plan."
 
 [[entries]]
-path = "src/archetype/physical_ai/boundary.py"
-line = 122
-method = "to_pylist"
-reason = "series_to_rows helper: converts each Series parameter to a Python list inside a list comprehension. This function is called exclusively from @daft.method.batch UDF bodies (MuJoCo C-library boundary, env RPC boundary, policy inference boundary) where the Daft executor has already materialised the batch. The AST checker auto-exempts to_pylist calls on named parameters of @daft.method.batch functions but cannot trace through this plain helper indirection; the call is semantically equivalent to an auto-sanctioned UDF-boundary access."
+path = "src/archetype/core/sync/store.py"
+symbol = "SyncStore.append"
+expr = "df.collect"
+method = "collect"
+reason = "Debug-mode-only logging: materialise so count_rows and df.show emit diagnostics; gated on self.debug and never reached in production execution paths."
 
 [[entries]]
-path = "src/archetype/app/physical_ai/service.py"
-line = 104
+path = "src/archetype/core/sync/world.py"
+symbol = "SyncWorld._move_entity"
+expr = "df.to_pylist"
 method = "to_pylist"
-reason = "Physical-evaluation grading boundary: StorageService admits and materializes latest-tick ledger rows before bounded success and episode-length values become typed task or sweep reports."
-
-[[entries]]
-path = "src/archetype/graph/frames.py"
-line = 65
-method = "to_pylist"
-reason = "Mutation-planning boundary shared by async and sync unlink: despawn takes concrete entity ids, not a frame, so _ids_at (shared by unlink and exclusive link replacement) materializes the matching ids at the latest persisted tick; all filters run in the lazy plan and only ids cross into Python."
+reason = "Cross-archetype entity migration (sync mirror of async_world): extract the latest tick row for component overlay before re-insertion."
 
 [[entries]]
 path = "src/archetype/graph/cascade.py"
-line = 94
+symbol = "_plan"
+expr = "dangling_edges(edges, rel, population).select(col('entity_id'), col(f'{prefix}source').alias('source')).to_pylist"
 method = "to_pylist"
 reason = "Mutation-planning boundary for cascade: despawn takes concrete ids, so _plan materializes the (edge id, source) pairs of the dangling edges; the liveness union, anti-join, and filters all run in the lazy plan and only ids cross into Python."
 
 [[entries]]
+path = "src/archetype/graph/frames.py"
+symbol = "_ids_at"
+expr = "edges.where(at_latest).select('entity_id').to_pylist"
+method = "to_pylist"
+reason = "Mutation-planning boundary shared by async and sync unlink: despawn takes concrete entity ids, not a frame, so _ids_at (shared by unlink and exclusive link replacement) materializes the matching ids at the latest persisted tick; all filters run in the lazy plan and only ids cross into Python."
+
+[[entries]]
 path = "src/archetype/graph/prefab.py"
-line = 68
+symbol = "_rows"
+expr = "frame.to_pylist"
 method = "to_pylist"
 reason = "Mutation-planning boundary for instantiation: spawning copies requires the template's concrete component values and child prefab ids; _rows is the single funnel and every entity filter runs in the lazy plan before it."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-line = 122
-method = "to_pylist"
-reason = "Post-commit external-I/O boundary: the lazy frame is restricted to committed DISPATCHED tasks and joined to mission identity before those bounded intents become Python requests for sandbox processes; an OS process invocation cannot remain a Daft expression."
-
-[[entries]]
-path = "src/archetype/missions/projections.py"
-line = 148
-method = "to_pylist"
-reason = "Post-commit validator-command boundary: Guards and TaskValidator entities are joined lazily first, then the finite validators attached to dispatchable tasks become argv tuples consumed by the repository harness; process argv cannot remain a DataFrame value."
-
-[[entries]]
-path = "src/archetype/missions/projections.py"
-line = 189
-method = "to_pylist"
-reason = "Repair-turn boundary: prior AgentExecution and ValidationResult entities are joined lazily by execution before the finite previous-dispatch observations become a coding-agent prompt and session-resume request; the external driver requires concrete typed observations."
-
-[[entries]]
-path = "src/archetype/missions/projections.py"
-line = 196
-method = "to_pylist"
-reason = "Repair-dispatch external-I/O boundary: persisted candidate identities are materialized after the committed DISPATCHED-task projection so the application can select the immediately superseded candidate whose durable critic findings belong in the next coding-agent request."
-
-[[entries]]
-path = "src/archetype/missions/projections.py"
-line = 197
-method = "to_pylist"
-reason = "Repair-dispatch external-I/O boundary: bounded redacted CriticFinding values must become concrete typed prompt input for the next author process; an external coding-agent request cannot consume a lazy Daft frame."
-
-[[entries]]
-path = "src/archetype/missions/projections.py"
-line = 374
-method = "to_pylist"
-reason = "Post-commit critic-I/O boundary: the lazy frame is restricted to tasks in CANDIDATE state and joined to their immutable candidate subjects before those bounded rows become exact-head reviewer process requests."
-
-[[entries]]
-path = "src/archetype/missions/projections.py"
-line = 387
+symbol = "CriticReviewOutbox.on_post_tick"
+expr = "author_executions.to_pylist"
 method = "to_pylist"
 reason = "Critic identity-binding boundary: persisted author execution identities and sandbox ids become scalar fields in the independent reviewer request and are later compared against the critic session before promotion."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-line = 388
+symbol = "CriticReviewOutbox.on_post_tick"
+expr = "candidate_tasks.join(candidates, left_on='entity_id', right_on=f'{candidate}task_id').to_pylist"
 method = "to_pylist"
-reason = "Critic validator-evidence boundary: finite TaskValidator definitions become concrete command tuples embedded in the exact-head reviewer request; the external critic driver cannot consume a lazy frame."
+reason = "Post-commit critic-I/O boundary: the lazy frame is restricted to tasks in CANDIDATE state and joined to their immutable candidate subjects before those bounded rows become exact-head reviewer process requests."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-line = 389
-method = "to_pylist"
-reason = "Critic validator-evidence boundary: exact-revision ValidationResult observations become concrete immutable values sent to the external critic process after candidate state has committed."
-
-[[entries]]
-path = "src/archetype/missions/projections.py"
-line = 393
+symbol = "CriticReviewOutbox.on_post_tick"
+expr = "critic_executions.to_pylist"
 method = "to_pylist"
 reason = "Bounded review-retry boundary: terminal CriticExecution facts are counted in Python to assign the next finite reviewer-attempt identity consumed by application-owned external I/O."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-line = 395
+symbol = "CriticReviewOutbox.on_post_tick"
+expr = "critic_receipts.to_pylist"
 method = "to_pylist"
 reason = "Review-admission boundary: persisted CriticReceipt completeness is inspected before emitting another external reviewer request so a candidate with durable review evidence is never invoked twice."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-line = 523
+symbol = "CriticReviewOutbox.on_post_tick"
+expr = "validation_results.to_pylist"
+method = "to_pylist"
+reason = "Critic validator-evidence boundary: exact-revision ValidationResult observations become concrete immutable values sent to the external critic process after candidate state has committed."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "CriticReviewOutbox.on_post_tick"
+expr = "validators.to_pylist"
+method = "to_pylist"
+reason = "Critic validator-evidence boundary: finite TaskValidator definitions become concrete command tuples embedded in the exact-head reviewer request; the external critic driver cannot consume a lazy frame."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "TaskDispatchOutbox.on_post_tick"
+expr = "candidate_history.to_pylist"
+method = "to_pylist"
+reason = "Repair-dispatch external-I/O boundary: persisted candidate identities are materialized after the committed DISPATCHED-task projection so the application can select the immediately superseded candidate whose durable critic findings belong in the next coding-agent request."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "TaskDispatchOutbox.on_post_tick"
+expr = "dispatched.to_pylist"
+method = "to_pylist"
+reason = "Post-commit external-I/O boundary: the lazy frame is restricted to committed DISPATCHED tasks and joined to mission identity before those bounded intents become Python requests for sandbox processes; an OS process invocation cannot remain a Daft expression."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "TaskDispatchOutbox.on_post_tick"
+expr = "finding_history.to_pylist"
+method = "to_pylist"
+reason = "Repair-dispatch external-I/O boundary: bounded redacted CriticFinding values must become concrete typed prompt input for the next author process; an external coding-agent request cannot consume a lazy Daft frame."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "TaskDispatchOutbox.on_post_tick"
+expr = "guarded_validators.to_pylist"
+method = "to_pylist"
+reason = "Post-commit validator-command boundary: Guards and TaskValidator entities are joined lazily first, then the finite validators attached to dispatchable tasks become argv tuples consumed by the repository harness; process argv cannot remain a DataFrame value."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "TaskDispatchOutbox.on_post_tick"
+expr = "observations.to_pylist"
+method = "to_pylist"
+reason = "Repair-turn boundary: prior AgentExecution and ValidationResult entities are joined lazily by execution before the finite previous-dispatch observations become a coding-agent prompt and session-resume request; the external driver requires concrete typed observations."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "current_mission_status"
+expr = "frame.where(cast(Expression, col('entity_id') == mission_id)).select(f'{state}status').to_pylist"
 method = "to_pylist"
 reason = "Single-mission control-loop boundary: the frame is filtered to one submitted mission and only its persisted status enters Python to decide whether the application service should tick again or return; no mission payload rows are materialized."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-line = 545
+symbol = "project_mission_result"
+expr = "mission_frame.where(cast(Expression, col('entity_id') == submitted.mission_id)).to_pylist"
 method = "to_pylist"
 reason = "Terminal mission result boundary: the frame is filtered to one terminal mission whose scalar repository, branch, status, and reason must become the immutable MissionResult returned by the public runtime API."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-line = 564
+symbol = "project_mission_result"
+expr = "task_projection.to_pylist"
 method = "to_pylist"
 reason = "Terminal task result boundary: task state is filtered to the submitted ids and left-joined lazily to first-class commit entities before the finite scalar rows become immutable TaskResult values returned by the public runtime API."
+
+[[entries]]
+path = "src/archetype/physical_ai/boundary.py"
+symbol = "series_to_rows"
+expr = "s.to_pylist"
+method = "to_pylist"
+reason = "series_to_rows helper: converts each Series parameter to a Python list inside a list comprehension. This function is called exclusively from @daft.method.batch UDF bodies (MuJoCo C-library boundary, env RPC boundary, policy inference boundary) where the Daft executor has already materialised the batch. The AST checker auto-exempts to_pylist calls on named parameters of @daft.method.batch functions but cannot trace through this plain helper indirection; the call is semantically equivalent to an auto-sanctioned UDF-boundary access."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_missing"
+expr = "aligned.collect"
+method = "collect"
+reason = "Conditional producer boundary: StorageService freezes the aligned candidate plan once so duplicate-key validation and optimistic Iceberg retries cannot re-run external or nondeterministic expressions."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_missing"
+expr = "pending.collect"
+method = "collect"
+reason = "Conditional append boundary: StorageService materializes the anti-join after each refreshed Iceberg snapshot so a conflicting writer cannot cause a stale retry to duplicate an existing logical key."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_table"
+expr = "aligned.collect"
+method = "collect"
+reason = "Conflict-safe append boundary: StorageService materializes producer rows exactly once so optimistic Iceberg retries can reuse the same payload instead of re-running external or nondeterministic expressions."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.materialize"
+expr = "frame.collect"
+method = "collect"
+reason = "Central application execution boundary: StorageService admits the caller's lazy Daft plan through its shared execution gate, materializes it off the event loop, and returns the completed frame."
+
+[[entries]]
+path = "src/archetype/world/resume.py"
+symbol = "_merge_visible_segment"
+expr = "materialized.to_pylist"
+method = "to_pylist"
+reason = "Resume-time entity-directory extract (issue #273 A1-resume): StorageService admits and materializes the groupby-max result before bounded live-entity rows become the imperative entity2sig registry and next_entity_id counter."
+
+[[entries]]
+path = "src/archetype/world/simulation.py"
+symbol = "_entities_terminal"
+expr = "materialized.to_pylist"
+method = "to_pylist"
+reason = "Episode-termination boundary: StorageService admits and materializes the one-row (n_done, n_total) reduction before its all/any values enter Python control flow to stop the episode loop."

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -150,9 +150,9 @@ section = "R4 — Async context manager is canonical"
 owner = "runtime"
 risk = "high"
 pytest = [
-  "tests/app/test_runtime_contracts.py::TestShutdownIdempotency::test_runtime_shutdown_retries_mission_handles_before_container",
+  "tests/app/test_runtime_contracts.py::TestShutdownIdempotency::test_runtime_shutdown_retries_workflow_owners_before_dependencies",
   "tests/app/test_runtime_contracts.py::TestShutdownIdempotency::test_failed_mission_cleanup_still_drains_admitted_world_work",
-  "tests/app/test_runtime_contracts.py::TestShutdownIdempotency::test_cleanup_capability_does_not_admit_a_sibling_world",
+  "tests/app/test_runtime_contracts.py::TestShutdownIdempotency::test_workflow_cleanup_cannot_admit_a_sibling_world",
   "tests/app/test_runtime_contracts.py::TestShutdownIdempotency::test_concurrent_runtime_shutdown_is_single_flight",
   "tests/app/test_runtime_contracts.py::TestShutdownIdempotency::test_cancelled_runtime_shutdown_retains_cleanup_for_retry",
   "tests/integration/test_agent_mission_service.py::test_runtime_shutdown_retries_failed_mission_cleanup_before_finalization",
@@ -205,8 +205,8 @@ owner = "commands"
 risk = "high"
 pytest = [
   "tests/commands/test_durable_runtime_contracts.py",
-  "tests/integration/test_command_flow.py::test_submit_spawn_reserved_id_survives_drain",
-  "tests/integration/test_command_flow.py::test_command_materializer_infrastructure_failure_fails_tick_before_settlement",
+  "tests/integration/test_command_flow.py::test_deferred_spawn_reserved_id_survives_drain",
+  "tests/integration/test_command_flow.py::test_materializer_failure_fails_tick_before_settlement",
 ]
 static = []
 evals = ["command_pipeline", "unhandled_command_noop"]

--- a/scripts/check_lazy_audit.py
+++ b/scripts/check_lazy_audit.py
@@ -22,8 +22,18 @@ Every such reference inside ``src/`` is a contract exception against
 Archetype's lazy execution model. This includes bound callables such as
 ``await blocking(frame.collect)``. This script enumerates production sites and
 gates them against ``lazy_audit.toml``. New, undocumented sites cause a
-non-zero exit; stale entries (allowlisted lines that no longer hold a
-matching call) are also surfaced so the audit stays honest under refactors.
+non-zero exit; stale entries (allowlisted keys that no longer hold a matching
+call) are also surfaced so the audit stays honest under refactors.
+
+**Entry keying**
+
+An entry is keyed by ``(path, symbol, expr, method)`` — never by line number.
+``symbol`` is the dotted path of the enclosing def/class (``<module>`` at file
+scope) and ``expr`` is ``ast.unparse`` of the audited attribute access. An
+unrelated edit above the call cannot invalidate an entry, and neither can
+reformatting the call, because both inputs are structural. Editing the audited
+expression or moving it to another symbol *does* invalidate the entry, which is
+the review the audit exists to force.
 
 **UDF-boundary exemption (sanctioned pattern)**
 
@@ -72,21 +82,35 @@ SELF_RELATIVE = "scripts/check_lazy_audit.py"
 _MATERIALIZATION_METHODS = frozenset({"collect", "to_pylist"})
 
 
+MODULE_SCOPE = "<module>"
+
+
 @dataclass(frozen=True)
 class Site:
     path: str
     line: int
     method: str
     snippet: str
+    symbol: str = MODULE_SCOPE
+    expr: str = ""
     sanctioned: bool = False  # True → udf-boundary, no allowlist entry needed
+
+    @property
+    def key(self) -> tuple[str, str, str, str]:
+        return (self.path, self.symbol, self.expr, self.method)
 
 
 @dataclass(frozen=True)
 class Entry:
     path: str
-    line: int
+    symbol: str
+    expr: str
     method: str
     reason: str
+
+    @property
+    def key(self) -> tuple[str, str, str, str]:
+        return (self.path, self.symbol, self.expr, self.method)
 
 
 def _project_root() -> Path:
@@ -169,15 +193,38 @@ def _collect_batch_udf_param_lines(source: str) -> dict[int, frozenset[str]]:
     return line_to_params
 
 
+def _symbol_scopes(tree: ast.Module) -> dict[int, str]:
+    """Map each line to the dotted symbol path of its innermost def/class.
+
+    Lines outside any definition map to ``<module>``. This is what makes an
+    allowlist entry survive a line shift: the entry names the enclosing symbol,
+    not the offset of the call inside the file.
+    """
+    scopes: dict[int, str] = {}
+
+    def walk(parent: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(parent):
+            if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                walk(child, prefix)
+                continue
+            qualified = f"{prefix}.{child.name}" if prefix else child.name
+            for line in range(child.lineno, (child.end_lineno or child.lineno) + 1):
+                scopes[line] = qualified
+            walk(child, qualified)
+
+    walk(tree, "")
+    return scopes
+
+
 def _scan_file(path: Path, rel: str) -> list[Site]:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return []
+    # A file we cannot read must not read as "no materialization sites here".
+    # Silently returning [] is how an audit reports clean without auditing.
+    text = path.read_text(encoding="utf-8")
 
     tree = ast.parse(text)
 
     batch_line_params = _collect_batch_udf_param_lines(text)
+    symbol_scopes = _symbol_scopes(tree)
     lines = text.splitlines()
     sites: list[Site] = []
     seen: set[tuple[int, str]] = set()
@@ -205,6 +252,10 @@ def _scan_file(path: Path, rel: str) -> list[Site]:
                 line=method_line,
                 method=method,
                 snippet=lines[method_line - 1].lstrip(),
+                symbol=symbol_scopes.get(node.lineno, MODULE_SCOPE),
+                # ast.unparse normalizes formatting, so reflowing the call does
+                # not change the key; editing the expression itself does.
+                expr=ast.unparse(node),
                 sanctioned=sanctioned,
             )
         )
@@ -236,11 +287,18 @@ def load_allowlist(root: Path) -> tuple[list[Entry], str | None]:
     raw_entries = data.get("entries", [])
     out: list[Entry] = []
     for raw in raw_entries:
+        if "line" in raw:
+            return [], (
+                f"entry still keyed by line number in {ALLOWLIST_FILENAME}: {raw!r}. "
+                "Entries are keyed by (path, symbol, expr, method); rerun "
+                "scripts/check_lazy_audit.py --list to regenerate."
+            )
         try:
             out.append(
                 Entry(
                     path=str(raw["path"]),
-                    line=int(raw["line"]),
+                    symbol=str(raw["symbol"]),
+                    expr=str(raw["expr"]),
                     method=str(raw["method"]),
                     reason=str(raw.get("reason", "")).strip(),
                 )
@@ -341,7 +399,7 @@ def main() -> int:
     if "--list" in sys.argv:
         for s in sites:
             tag = " [udf-boundary]" if s.sanctioned else ""
-            print(f"{s.path}:{s.line}  .{s.method}(){tag}  {s.snippet}")
+            print(f"{s.path}:{s.line}  {s.symbol}  .{s.method}(){tag}  {s.expr}")
         return 0
 
     allow, allow_err = load_allowlist(root)
@@ -355,16 +413,16 @@ def main() -> int:
     audited_sites = [s for s in sites if not s.sanctioned]
     sanctioned_sites = [s for s in sites if s.sanctioned]
 
-    site_keys = {(s.path, s.line, s.method): s for s in audited_sites}
-    allow_keys = {(e.path, e.line, e.method): e for e in allow}
+    site_keys = {s.key: s for s in audited_sites}
+    allow_keys = {e.key: e for e in allow}
 
     new_sites = [site_keys[k] for k in site_keys.keys() - allow_keys.keys()]
     stale_entries = [allow_keys[k] for k in allow_keys.keys() - site_keys.keys()]
     weak_reasons = [e for e in allow if not _reason_is_substantive(e.reason)]
 
     new_sites.sort(key=lambda s: (s.path, s.line))
-    stale_entries.sort(key=lambda e: (e.path, e.line))
-    weak_reasons.sort(key=lambda e: (e.path, e.line))
+    stale_entries.sort(key=lambda e: (e.path, e.symbol, e.expr))
+    weak_reasons.sort(key=lambda e: (e.path, e.symbol, e.expr))
 
     # Always print sanctioned summary for visibility.
     if sanctioned_sites:
@@ -380,20 +438,30 @@ def main() -> int:
     print(STERN_HEADER, file=sys.stderr)
 
     if new_sites:
-        rendered = [f"{s.path}:{s.line}  .{s.method}()  {s.snippet}" for s in new_sites]
+        rendered = [
+            f"{s.path}:{s.line}  {s.symbol}  .{s.method}()  {s.expr}\n"
+            f'    [[entries]]\n    path = "{s.path}"\n    symbol = "{s.symbol}"\n'
+            f'    expr = "{s.expr}"\n    method = "{s.method}"\n    reason = "..."'
+            for s in new_sites
+        ]
         sys.stderr.write(_format_section("New, undocumented materialization points:", rendered))
 
     if stale_entries:
-        rendered = [f"{e.path}:{e.line}  .{e.method}()  reason={e.reason!r}" for e in stale_entries]
+        rendered = [
+            f"{e.path}  {e.symbol}  .{e.method}()  {e.expr}  reason={e.reason!r}"
+            for e in stale_entries
+        ]
         sys.stderr.write(
             _format_section(
-                "Stale allowlist entries (line no longer holds a matching call):",
+                "Stale allowlist entries (no matching call for this symbol/expression):",
                 rendered,
             )
         )
 
     if weak_reasons:
-        rendered = [f"{e.path}:{e.line}  .{e.method}()  reason={e.reason!r}" for e in weak_reasons]
+        rendered = [
+            f"{e.path}  {e.symbol}  .{e.method}()  reason={e.reason!r}" for e in weak_reasons
+        ]
         sys.stderr.write(
             _format_section(
                 "Allowlist entries with unjustified reasons (rejected at review):",

--- a/scripts/run_runtime_loopback.py
+++ b/scripts/run_runtime_loopback.py
@@ -77,7 +77,7 @@ def _run_cli(
     *arguments: str,
     env: dict[str, str],
     cwd: Path,
-    tracked_pids: list[int],
+    tracked_groups: list[int],
 ) -> str:
     process = subprocess.Popen(
         [_cli_entrypoint(), *arguments],
@@ -86,8 +86,9 @@ def _run_cli(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        start_new_session=True,
     )
-    tracked_pids.append(process.pid)
+    tracked_groups.append(process.pid)
     try:
         stdout, _stderr = process.communicate(timeout=120)
     except subprocess.TimeoutExpired:
@@ -103,7 +104,7 @@ def _run_cli_failure(
     *arguments: str,
     env: dict[str, str],
     cwd: Path,
-    tracked_pids: list[int],
+    tracked_groups: list[int],
 ) -> str:
     process = subprocess.Popen(
         [_cli_entrypoint(), *arguments],
@@ -112,8 +113,9 @@ def _run_cli_failure(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        start_new_session=True,
     )
-    tracked_pids.append(process.pid)
+    tracked_groups.append(process.pid)
     try:
         stdout, stderr = process.communicate(timeout=120)
     except subprocess.TimeoutExpired:
@@ -125,12 +127,61 @@ def _run_cli_failure(
     return f"{stdout}\n{stderr}".strip()
 
 
-def _pid_is_reaped(pid: int) -> bool:
+_PROCESS_EXIT_GRACE_SECONDS = 5.0
+
+
+def _process_group_alive(process_group: int) -> bool:
+    """Report whether any member of ``process_group`` still exists.
+
+    ``os.killpg(pgid, 0)`` is the portable liveness probe: it raises
+    ``ProcessLookupError`` only when the whole group is gone. This is the same
+    seam ``scripts/run_operational_scenarios.py`` uses.
+    """
     try:
-        os.waitpid(pid, os.WNOHANG)
-    except ChildProcessError:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # A surviving member we cannot signal is still a surviving member.
         return True
-    return False
+    return True
+
+
+def _wait_for_process_group_exit(process_group: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _process_group_alive(process_group):
+            return True
+        time.sleep(0.05)
+    return not _process_group_alive(process_group)
+
+
+def _surviving_process_groups(process_groups: list[int]) -> int:
+    """Count groups that outlive their leader, terminating what remains.
+
+    A leaked provider child is *not* a direct child of this process, so
+    ``os.waitpid`` cannot see it — it raises ``ChildProcessError`` for any pid
+    that is not an unreaped direct child, which reads as "reaped". Every
+    launched process here is reaped before cleanup is scored, so a pid-based
+    probe is structurally incapable of reporting a leak. Process-group liveness
+    is the property that actually distinguishes clean teardown from a leak.
+    """
+    survivors = 0
+    for process_group in process_groups:
+        if _wait_for_process_group_exit(process_group, _PROCESS_EXIT_GRACE_SECONDS):
+            continue
+        survivors += 1
+        # Leave the machine clean even though the receipt records the debt.
+        try:
+            os.killpg(process_group, signal.SIGTERM)
+        except (PermissionError, ProcessLookupError):
+            pass
+        if not _wait_for_process_group_exit(process_group, _PROCESS_EXIT_GRACE_SECONDS):
+            try:
+                os.killpg(process_group, signal.SIGKILL)
+            except (PermissionError, ProcessLookupError):
+                pass
+    return survivors
 
 
 def _uuid_from(output: str, *, label: str) -> str:
@@ -193,14 +244,14 @@ def run_runtime_loopback(workspace: Path) -> dict[str, object]:
     port_closed = False
     port: int | None = None
     route_evidence: dict[str, object] = {}
-    tracked_pids: list[int] = []
+    tracked_groups: list[int] = []
 
     def cli(*arguments: str) -> str:
         return _run_cli(
             *arguments,
             env=env,
             cwd=workspace,
-            tracked_pids=tracked_pids,
+            tracked_groups=tracked_groups,
         )
 
     def rejected_cli(*arguments: str) -> str:
@@ -208,7 +259,7 @@ def run_runtime_loopback(workspace: Path) -> dict[str, object]:
             *arguments,
             env=env,
             cwd=workspace,
-            tracked_pids=tracked_pids,
+            tracked_groups=tracked_groups,
         )
 
     stdout_path = server_logs / "stdout.log"
@@ -230,8 +281,9 @@ def run_runtime_loopback(workspace: Path) -> dict[str, object]:
                     stdout=stdout,
                     stderr=stderr,
                     text=True,
+                    start_new_session=True,
                 )
-                tracked_pids.append(server.pid)
+                tracked_groups.append(server.pid)
                 base_url, port = _wait_for_server(server, stdout_path, stderr_path)
 
                 created = cli(
@@ -446,7 +498,7 @@ def run_runtime_loopback(workspace: Path) -> dict[str, object]:
                             break
                         time.sleep(0.05)
 
-    unreaped_children = sum(not _pid_is_reaped(pid) for pid in tracked_pids)
+    unreaped_children = _surviving_process_groups(tracked_groups)
     if not server_reaped or not server_graceful or not port_closed or unreaped_children:
         raise RuntimeError(
             "shipped API loopback cleanup invariant failed "

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -61,6 +61,53 @@ def _headings(path: Path) -> set[str]:
     return headings
 
 
+def _defined_test_nodes(path: Path) -> set[str]:
+    """Return every ``Class::function`` / ``function`` node defined in a test module.
+
+    Raises ``OSError``/``SyntaxError`` to the caller rather than returning an
+    empty set: an unreadable oracle module must fail the audit loudly instead of
+    silently reporting that no node ids resolve.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    nodes: set[str] = set()
+
+    def walk(parent: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(parent):
+            if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                continue
+            qualified = f"{prefix}::{child.name}" if prefix else child.name
+            nodes.add(qualified)
+            walk(child, qualified)
+
+    walk(tree, "")
+    return nodes
+
+
+def _pytest_oracle_error(root: Path, nodeid: str) -> str | None:
+    """Resolve a pytest oracle to a real file and, when given, a real node.
+
+    ``tests/x.py`` only proves the module exists. ``tests/x.py::Klass::test_y``
+    additionally names a symbol, and the registry is only an oracle if that
+    symbol is still defined — a rename on the test side must fail here rather
+    than leave the contract claiming coverage that no longer runs.
+    """
+    module, separator, node_path = nodeid.partition("::")
+    path = root / module
+    if not path.is_file():
+        return f"missing pytest oracle {nodeid!r}"
+    if not separator:
+        return None
+    # Drop pytest's parametrization suffix: only the defining symbol is static.
+    stem = node_path.split("[", 1)[0]
+    try:
+        defined = _defined_test_nodes(path)
+    except (OSError, SyntaxError) as exc:
+        return f"unparsable pytest oracle module {module!r}: {exc}"
+    if stem not in defined:
+        return f"missing pytest oracle node {nodeid!r} (no such test in {module})"
+    return None
+
+
 def _marker_contract_ids(root: Path) -> list[tuple[Path, int, str]]:
     found: list[tuple[Path, int, str]] = []
     tests = root / "tests"
@@ -176,8 +223,12 @@ def validate_contracts(
                 errors.append(f"{label}: {field} must be an array")
 
         for nodeid in row.get("pytest", []):
-            if not isinstance(nodeid, str) or not (root / nodeid.split("::", 1)[0]).is_file():
+            if not isinstance(nodeid, str):
                 errors.append(f"{label}: missing pytest oracle {nodeid!r}")
+                continue
+            oracle_error = _pytest_oracle_error(root, nodeid)
+            if oracle_error is not None:
+                errors.append(f"{label}: {oracle_error}")
         for script in row.get("static", []):
             if not isinstance(script, str) or not (root / script).is_file():
                 errors.append(f"{label}: missing static oracle {script!r}")

--- a/tests/scripts/test_check_lazy_audit.py
+++ b/tests/scripts/test_check_lazy_audit.py
@@ -16,6 +16,7 @@ Covers the two key policy assertions:
 
 from __future__ import annotations
 
+import json
 import sys
 import textwrap
 from pathlib import Path
@@ -53,7 +54,8 @@ def _write_toml(tmp_path: Path, entries: list[dict]) -> Path:
     for e in entries:
         lines.append("[[entries]]")
         for k, v in e.items():
-            lines.append(f"{k} = {v!r}")
+            # json.dumps, not repr: expressions legitimately contain quotes.
+            lines.append(f"{k} = {json.dumps(v)}")
         lines.append("")
     p = tmp_path / "lazy_audit.toml"
     p.write_text("\n".join(lines), encoding="utf-8")
@@ -294,6 +296,16 @@ def _make_fake_src(tmp_path: Path) -> Path:
     return tmp_path
 
 
+# The single gated site in the fake tree, expressed as a stable-key entry.
+_BOUNDARY_ENTRY = {
+    "path": "src/mypkg/boundary_module.py",
+    "symbol": "query_rows",
+    "expr": "df.to_pylist",
+    "method": "to_pylist",
+    "reason": "Terminal query result returned to caller; cannot remain lazy past function boundary.",
+}
+
+
 def test_full_scan_sanctioned_exempt(tmp_path):
     """Sanctioned sites are exempt; the gated site requires an entry."""
     fake_root = _make_fake_src(tmp_path)
@@ -323,19 +335,7 @@ def test_full_scan_with_allowlist_passes(tmp_path):
     """When the gated site has an allowlist entry the audit exits 0."""
     fake_root = _make_fake_src(tmp_path)
 
-    # Write an allowlist that covers the gated boundary_module.py site.
-    # The fake scan will find it at line 5.
-    _write_toml(
-        fake_root,
-        [
-            {
-                "path": "src/mypkg/boundary_module.py",
-                "line": 5,
-                "method": "to_pylist",
-                "reason": "Terminal query result returned to caller; cannot remain lazy past function boundary.",
-            }
-        ],
-    )
+    _write_toml(fake_root, [_BOUNDARY_ENTRY])
 
     import check_lazy_audit as mod
 
@@ -351,8 +351,8 @@ def test_full_scan_with_allowlist_passes(tmp_path):
 
         assert err is None
         audited = [s for s in sites if not s.sanctioned]
-        site_keys = {(s.path, s.line, s.method) for s in audited}
-        allow_keys = {(e.path, e.line, e.method) for e in allow}
+        site_keys = {s.key for s in audited}
+        allow_keys = {e.key for e in allow}
         new_sites = site_keys - allow_keys
         stale = allow_keys - site_keys
         assert not new_sites, f"unexpected new sites: {new_sites}"
@@ -381,9 +381,132 @@ def test_missing_allowlist_entry_fails(tmp_path):
 
         assert err is None
         audited = [s for s in sites if not s.sanctioned]
-        site_keys = {(s.path, s.line, s.method) for s in audited}
-        allow_keys = {(e.path, e.line, e.method) for e in allow}
-        new_sites = site_keys - allow_keys
+        new_sites = {s.key for s in audited} - {e.key for e in allow}
         assert new_sites, "boundary_module.py gated site must be flagged as missing"
     finally:
         mod._project_root = orig_root  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# Allowlist keying: entries survive line shifts, not content changes
+# ---------------------------------------------------------------------------
+
+
+def _keys_after(fake_root: Path) -> tuple[set, set]:
+    """Return (unaccounted_site_keys, stale_entry_keys) for a scanned tree."""
+    import check_lazy_audit as mod
+
+    sites = [s for s in mod.scan(fake_root) if not s.sanctioned]
+    allow, err = mod.load_allowlist(fake_root)
+    assert err is None, err
+    site_keys = {s.key for s in sites}
+    allow_keys = {e.key for e in allow}
+    return site_keys - allow_keys, allow_keys - site_keys
+
+
+def test_unrelated_line_shift_does_not_invalidate_an_entry(tmp_path):
+    """The regression this keying exists for.
+
+    Inserting an unrelated import above an audited call shifts its line
+    number. A line-keyed allowlist reports both a new undocumented site and a
+    stale entry for a change that touched nothing it audits.
+    """
+    fake_root = _make_fake_src(tmp_path)
+    _write_toml(fake_root, [_BOUNDARY_ENTRY])
+    module = fake_root / "src" / "mypkg" / "boundary_module.py"
+
+    before_line = [s for s in _scan_file(module, "src/mypkg/boundary_module.py")][0].line
+    module.write_text("import os\nimport sys\n" + module.read_text(), encoding="utf-8")
+    after_line = [s for s in _scan_file(module, "src/mypkg/boundary_module.py")][0].line
+
+    assert after_line != before_line, "the edit must actually move the call"
+    assert _keys_after(fake_root) == (set(), set())
+
+
+def test_moving_the_call_to_another_function_invalidates_the_entry(tmp_path):
+    """Keying on the enclosing symbol still fails when the call relocates."""
+    fake_root = _make_fake_src(tmp_path)
+    _write_toml(fake_root, [_BOUNDARY_ENTRY])
+    _write_py(
+        fake_root / "src" / "mypkg",
+        "boundary_module.py",
+        """\
+        import daft
+
+        def renamed_query_rows():
+            df = daft.from_pydict({"x": [1]})
+            return df.to_pylist()
+        """,
+    )
+
+    unaccounted, stale = _keys_after(fake_root)
+
+    assert unaccounted, "a call that moved to a different symbol is a new site"
+    assert stale, "the entry for the old symbol is stale"
+
+
+def test_changing_the_audited_expression_invalidates_the_entry(tmp_path):
+    """Editing what is materialized re-opens review; that is the point."""
+    fake_root = _make_fake_src(tmp_path)
+    _write_toml(fake_root, [_BOUNDARY_ENTRY])
+    _write_py(
+        fake_root / "src" / "mypkg",
+        "boundary_module.py",
+        """\
+        import daft
+
+        def query_rows():
+            df = daft.from_pydict({"x": [1]})
+            return df.where(df["x"] > 0).to_pylist()
+        """,
+    )
+
+    unaccounted, stale = _keys_after(fake_root)
+
+    assert unaccounted and stale
+
+
+def test_reformatting_the_audited_expression_keeps_the_entry(tmp_path):
+    """ast.unparse normalizes layout, so a reflow is not a content change."""
+    fake_root = _make_fake_src(tmp_path)
+    _write_toml(fake_root, [_BOUNDARY_ENTRY])
+    _write_py(
+        fake_root / "src" / "mypkg",
+        "boundary_module.py",
+        """\
+        import daft
+
+        def query_rows():
+            df = daft.from_pydict({"x": [1]})
+            return (
+                df
+                .to_pylist()
+            )
+        """,
+    )
+
+    assert _keys_after(fake_root) == (set(), set())
+
+
+def test_line_keyed_entry_is_rejected(tmp_path):
+    """A stale line-keyed entry fails loudly instead of silently matching nothing."""
+    import check_lazy_audit as mod
+
+    fake_root = _make_fake_src(tmp_path)
+    _write_toml(
+        fake_root,
+        [{**{k: v for k, v in _BOUNDARY_ENTRY.items() if k != "symbol"}, "line": 5}],
+    )
+
+    allow, err = mod.load_allowlist(fake_root)
+
+    assert allow == []
+    assert err is not None and "line number" in err
+
+
+def test_unreadable_module_is_not_silently_clean(tmp_path):
+    """An unreadable file must raise, not report zero materialization sites."""
+    missing = tmp_path / "gone.py"
+
+    with pytest.raises(OSError):
+        _scan_file(missing, "gone.py")

--- a/tests/scripts/test_run_runtime_loopback.py
+++ b/tests/scripts/test_run_runtime_loopback.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Negative controls for the runtime-loopback cleanup probe.
+
+``provider_children`` in the loopback receipt claims to count processes that
+outlive the scenario. A probe for that claim is only worth having if it can
+actually observe a leak, so every test here asserts against a *real* leaked
+process rather than against the constant the receipt happens to print.
+
+The previous implementation counted unreaped direct children via
+``os.waitpid(pid, WNOHANG)``. A leaked provider child is not a direct child, so
+``waitpid`` raised ``ChildProcessError`` and the probe read it as "reaped" —
+and every tracked pid was reaped before the probe ran anyway. The count was
+structurally always zero. ``test_leaked_grandchild_is_counted`` fails against
+that implementation.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from run_runtime_loopback import (  # noqa: E402
+    _process_group_alive,
+    _surviving_process_groups,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_grace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the probe's semantics, shorten only its waiting."""
+    monkeypatch.setattr("run_runtime_loopback._PROCESS_EXIT_GRACE_SECONDS", 1.0)
+
+
+def _spawn_group(child_code: str) -> subprocess.Popen[bytes]:
+    """Start a session leader so its pid is also its process-group id."""
+    return subprocess.Popen(
+        [sys.executable, "-c", child_code],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def test_leaked_grandchild_is_counted() -> None:
+    """A process outliving its reaped leader is cleanup debt, and must be seen.
+
+    This is the regression that the pid-based probe could not express: the
+    leader exits and is reaped, but it leaves a descendant in its process
+    group. Nothing about the leader's exit status reveals that.
+    """
+    leader = _spawn_group(
+        "import subprocess, sys;"
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']);"
+    )
+    group = leader.pid
+    leader.wait()  # leader reaped, exactly as the loopback reaps its processes
+    # Let the orphan settle so we are asserting against a genuinely live process.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not _process_group_alive(group):
+        time.sleep(0.05)
+    assert _process_group_alive(group), "test setup failed to leak a process"
+
+    assert _surviving_process_groups([group]) == 1
+
+
+def test_clean_process_group_reports_no_survivors() -> None:
+    """Positive control: a group that exits fully is not reported as leaked."""
+    leader = _spawn_group("pass")
+    group = leader.pid
+    leader.wait()
+
+    assert _surviving_process_groups([group]) == 0
+
+
+def test_survivors_are_terminated_after_being_counted() -> None:
+    """The probe records the debt and still leaves the machine clean."""
+    leader = _spawn_group(
+        "import subprocess, sys;"
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']);"
+    )
+    group = leader.pid
+    leader.wait()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not _process_group_alive(group):
+        time.sleep(0.05)
+
+    assert _surviving_process_groups([group]) == 1
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and _process_group_alive(group):
+        time.sleep(0.05)
+    assert not _process_group_alive(group), "counted survivors must also be reaped"
+
+
+def test_empty_group_list_reports_no_survivors() -> None:
+    assert _surviving_process_groups([]) == 0
+
+
+def test_process_group_liveness_tracks_a_real_process() -> None:
+    """The underlying probe distinguishes a live group from a dead one."""
+    leader = _spawn_group("import time; time.sleep(60)")
+    group = leader.pid
+
+    assert _process_group_alive(group)
+
+    os.killpg(group, 9)
+    leader.wait()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and _process_group_alive(group):
+        time.sleep(0.05)
+
+    assert not _process_group_alive(group)

--- a/tests/scripts/test_validate_contracts.py
+++ b/tests/scripts/test_validate_contracts.py
@@ -72,6 +72,102 @@ def test_stale_normative_heading_fails_closed(tmp_path: Path) -> None:
     assert any("missing source heading" in error for error in errors)
 
 
+def _oracle_row(nodeid: str) -> str:
+    return f'''[[contract]]
+id = "test.oracle"
+source = "docs/guide/api-stability.md"
+section = "What counts as public"
+owner = "test"
+risk = "low"
+pytest = ["{nodeid}"]
+static = []
+evals = []
+benchmarks = []
+profiles = ["pr"]
+'''
+
+
+def _oracle_errors(tmp_path: Path, nodeid: str) -> list[str]:
+    registry = tmp_path / "contracts.toml"
+    registry.write_text(_registry(_oracle_row(nodeid)))
+    return validate_contracts(root=ROOT, registry_path=registry, check_eval_coverage=False)
+
+
+def test_renamed_pytest_oracle_node_fails_closed(tmp_path: Path) -> None:
+    """A registry node id whose test no longer exists must not pass.
+
+    The file existing is not evidence the contract is executed. Before this
+    check the registry could name any symbol inside a real module and stay
+    green, so a test rename silently emptied the oracle.
+    """
+    errors = _oracle_errors(
+        tmp_path,
+        "tests/scripts/test_validate_contracts.py::test_this_function_does_not_exist",
+    )
+
+    assert any("missing pytest oracle node" in error for error in errors)
+
+
+def test_renamed_pytest_oracle_class_fails_closed(tmp_path: Path) -> None:
+    errors = _oracle_errors(
+        tmp_path,
+        "tests/scripts/test_validate_contracts.py::NoSuchClass::test_repository_contract_registry_is_valid",
+    )
+
+    assert any("missing pytest oracle node" in error for error in errors)
+
+
+def test_resolvable_pytest_oracle_node_passes(tmp_path: Path) -> None:
+    """Negative control: a node id that still resolves raises no oracle error."""
+    errors = _oracle_errors(
+        tmp_path,
+        "tests/scripts/test_validate_contracts.py::test_repository_contract_registry_is_valid",
+    )
+
+    assert [error for error in errors if "pytest oracle" in error] == []
+
+
+def test_parametrized_pytest_oracle_node_resolves_to_its_definition(tmp_path: Path) -> None:
+    errors = _oracle_errors(
+        tmp_path,
+        "tests/scripts/test_validate_contracts.py::test_repository_contract_registry_is_valid[case]",
+    )
+
+    assert [error for error in errors if "pytest oracle" in error] == []
+
+
+def test_unparsable_pytest_oracle_module_fails_closed(tmp_path: Path) -> None:
+    """A module the audit cannot parse fails; it never resolves vacuously."""
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "docs" / "contract.md").write_text("# Contract\n")
+    (tmp_path / "tests" / "test_broken.py").write_text("def test_x(:\n")
+    registry = tmp_path / "contracts.toml"
+    registry.write_text(
+        """version = 1
+[[contract]]
+id = "broken.oracle"
+source = "docs/contract.md"
+section = "Contract"
+owner = "test"
+risk = "low"
+pytest = ["tests/test_broken.py::test_x"]
+static = []
+evals = []
+benchmarks = []
+profiles = ["pr"]
+"""
+    )
+
+    errors = validate_contracts(
+        root=tmp_path,
+        registry_path=registry,
+        check_eval_coverage=False,
+    )
+
+    assert any("unparsable pytest oracle module" in error for error in errors)
+
+
 def test_unknown_contract_marker_fails_closed(tmp_path: Path) -> None:
     (tmp_path / "docs").mkdir()
     (tmp_path / "tests").mkdir()


### PR DESCRIPTION
## What

Three deterministic checkers encoded their invariant by **mirroring a fact from elsewhere** instead of deriving it. Two of them could pass without checking anything. Each fix ships the negative control that fails against the old code.

### 1. Phantom pytest oracles — VACUOUS (live on `main`)

`scripts/validate_contracts.py` resolved a `tests/x.py::Klass::test_y` oracle by stat-ing `tests/x.py` and ignoring the node path. The registry could name any symbol inside a real module and stay green.

The v0.5 rename sweep renamed four oracle tests and nothing noticed. These names existed **only** in `quality/contracts.toml`:

| Contract | Dangling oracle | Renamed to |
| --- | --- | --- |
| `runtime.lifecycle.retryable_teardown` | `…::test_runtime_shutdown_retries_mission_handles_before_container` | `…::test_runtime_shutdown_retries_workflow_owners_before_dependencies` |
| `runtime.lifecycle.retryable_teardown` | `…::test_cleanup_capability_does_not_admit_a_sibling_world` | `…::test_workflow_cleanup_cannot_admit_a_sibling_world` |
| `commands.settlement.atomic` | `…::test_submit_spawn_reserved_id_survives_drain` | `…::test_deferred_spawn_reserved_id_survives_drain` |
| `commands.settlement.atomic` | `…::test_command_materializer_infrastructure_failure_fails_tick_before_settlement` | `…::test_materializer_failure_fails_tick_before_settlement` |

Node ids are now resolved against the module AST, parametrization suffixes (`[case]`) are stripped, and a module that cannot be parsed is an error rather than a skip. The four rows are retargeted; all four retargeted tests exist and pass.

### 2. Line-keyed lazy audit — MIRROR

`lazy_audit.toml` entries were keyed by line number, so an unrelated edit above an audited call reported both a new undocumented site *and* a stale entry. Entries are now keyed by `(path, symbol, expr, method)` — the enclosing symbol path plus `ast.unparse` of the audited attribute access.

A line shift and a reformat are both inert. Moving the call to another symbol, or editing what is materialized, still re-opens review. A leftover line-keyed entry is rejected with an actionable message instead of silently matching nothing.

**Equivalence evidence — the allowed set is unchanged:**

```
old entries: 35   migrated: 35   UNMATCHED: 0
old allowed site triples: 35
new allowed site triples: 35
IDENTICAL: True   only-old: []   only-new: []
reason multiset identical: True
```

**The regression it closes** (insert one unrelated `import` above an audited call):

```
OLD key (path,line,method):        4 new unaccounted sites, 4 stale entries -> FAILS
NEW key (path,symbol,expr,method): 0 new unaccounted sites, 0 stale entries -> PASSES
```

### 3. Structurally-zero leak probe — VACUOUS

`scripts/run_runtime_loopback.py` scored its cleanup invariant with `os.waitpid(pid, WNOHANG)` over direct children. `waitpid` raises `ChildProcessError` for any pid that is not an *unreaped direct child*, which the probe read as "reaped" — and every tracked pid was already reaped by `communicate()`/`wait()` before the probe ran. `provider_children` was **structurally always 0**, and the semantic oracle asserted that constant. This is the same class as the `pgrep -fal` process-leak probe that was silently a no-op.

Verified against a real leaked grandchild:

```
a leaked process really is running: True
OLD probe  unreaped_children = 0   <- the new self-test FAILS against this
NEW probe  provider_children  = 1
```

Processes now lead their own session and cleanup is scored by process-group liveness (`os.killpg(pgid, 0)`), the seam already proven in `run_operational_scenarios.py`. Survivors are counted and then terminated. The receipt is **byte-identical** on the clean path, so the exact-match oracle is unaffected.

## Validation

```
make check                                    -> All checks passed!
uv run pytest tests/scripts/ -q               -> 349 passed
uv run pytest tests/integration/test_runtime_loopback_operational.py -q -> 4 passed
make contract-audit                           -> Contract registry audit passed
generate_contract_traceability.py --check     -> Contract traceability is current
scripts/run_runtime_loopback.py               -> receipt byte-identical to baseline
the 4 retargeted oracle node ids              -> 4 passed
```

## Not done here

Contract `section` keys are still exact documentation headings. That one already fails **loudly** (`validate_contracts` errors when the heading is absent), and converting it to stable anchors means adding explicit ids to 40+ headings across the guide — a docs sweep rather than a focused change. Written up rather than half-done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)