### PR TITLE
fix(quality): close the license gate's silent-pass holes and wire it into CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ format:
 	@uv run ruff format $(RUFF_PATHS)
 
 .PHONY: lint
-lint: lazy-audit architecture-audit observability-audit version-inventory-audit python-api-audit api-boundary-audit idempotency-audit gate-coverage-audit operational-audit
+lint: lazy-audit architecture-audit observability-audit version-inventory-audit python-api-audit api-boundary-audit license-audit idempotency-audit gate-coverage-audit operational-audit
 	@uv run ruff check $(RUFF_PATHS)
 
 .PHONY: lint-fix
@@ -152,6 +152,13 @@ lazy-audit:
 .PHONY: api-boundary-audit
 api-boundary-audit:
 	@uv run python scripts/check_api_import_boundaries.py
+
+# Apache-2.0 license headers on every shipped source file. The pre-commit
+# hook alone was bypassable, which is how 142 of 199 files stayed red without
+# anyone noticing, so the gate also runs in the required `format` job.
+.PHONY: license-audit
+license-audit:
+	@uv run python scripts/check_license_headers.py
 
 .PHONY: python-api-audit
 python-api-audit:

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -14,12 +14,18 @@ compact-header file read as "missing" — and `--fix` then prepended a second,
 stale-dated copyright block onto 130+ correctly headered files while exiting 0.
 `--fix` now refuses to touch any file that already carries a copyright line it
 cannot classify, and a missing or refused header always exits 1.
+
+The gate also fails loudly rather than silently: an empty audit set and a path
+that does not exist are errors, not passes, and skip rules match whole path
+components so `.github/` is audited instead of being swallowed by a `.git`
+substring match.
 """
 
 import argparse
 import datetime
 import re
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 COPYRIGHT_RE = re.compile(r"Copyright \d{4}(?:-\d{4})? Vangelis Technologies Inc\.")
@@ -100,12 +106,10 @@ def add_license_header(file_path: Path) -> bool:
 
 def should_skip_file(file_path: Path) -> bool:
     """Check if a file should be skipped for license header checking."""
-    # Skip __pycache__ directories and .pyc files
-    if "__pycache__" in str(file_path) or file_path.suffix == ".pyc":
-        return True
-
-    # Skip files in .git directory
-    if ".git" in str(file_path):
+    # Match whole path components. A substring test for ".git" also matched
+    # ".github/...", silently exempting every workflow helper from the gate —
+    # a hole that is invisible precisely because it reports success.
+    if {".git", "__pycache__"}.intersection(file_path.parts) or file_path.suffix == ".pyc":
         return True
 
     # Skip setup.py files that might have special requirements
@@ -113,6 +117,42 @@ def should_skip_file(file_path: Path) -> bool:
         return True
 
     return False
+
+
+def resolve_files(names: Sequence[str]) -> tuple[list[Path], list[str]]:
+    """Resolve the audit set, naming every reason it might be unusable.
+
+    Returns ``(files, errors)``. An empty audit set is an error rather than a
+    pass: a gate that inspects nothing and prints success is how this checker
+    stayed green while most of the tree drifted out from under it.
+    """
+    errors: list[str] = []
+
+    if names:
+        candidates = [Path(name) for name in names if name.endswith(".py")]
+    else:
+        # No files specified: audit every Python file under src/.
+        src_dir = Path(__file__).parent.parent / "src"
+        if not src_dir.is_dir():
+            return [], [f"source root does not exist: {src_dir}"]
+        candidates = sorted(src_dir.glob("**/*.py"))
+
+    files: list[Path] = []
+    for path in candidates:
+        if should_skip_file(path):
+            continue
+        # A path that does not exist is a bad argument, not an unlicensed
+        # file. Reporting it as "missing a license header" sends the reader
+        # off to add a header to a file that is not there.
+        if not path.exists():
+            errors.append(f"path does not exist: {path}")
+            continue
+        files.append(path)
+
+    if not files and not errors:
+        errors.append("no Python files to audit — an empty file set is an error, not a pass")
+
+    return files, errors
 
 
 def main() -> int:
@@ -126,23 +166,11 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    if not args.files:
-        # If no files specified, check all Python files in the src directory
-        project_root = Path(__file__).parent.parent
-        src_dir = project_root / "src"
-        if src_dir.exists():
-            python_files = list(src_dir.glob("**/*.py"))
-        else:
-            python_files = []
-    else:
-        python_files = [Path(f) for f in args.files if f.endswith(".py")]
+    python_files, errors = resolve_files(args.files)
 
     missing_headers = []
 
     for file_path in python_files:
-        if should_skip_file(file_path):
-            continue
-
         if not has_license_header(file_path):
             missing_headers.append(file_path)
 
@@ -157,15 +185,20 @@ def main() -> int:
         # 130+ files were once rewritten wrongly under a green exit.
         missing_headers = [f for f in missing_headers if not has_license_header(f)]
 
+    for message in errors:
+        print(f"error: {message}")
+
     if missing_headers:
         print("The following files are missing Apache 2.0 license headers:")
         for file_path in missing_headers:
             print(f"  {file_path}")
         if not args.fix:
             print("\nRun with --fix to automatically add license headers.")
+
+    if missing_headers or errors:
         return 1
 
-    print("All Python files have proper license headers.")
+    print(f"All {len(python_files)} Python files have proper license headers.")
 
     return 0
 

--- a/tests/scripts/test_check_license_headers.py
+++ b/tests/scripts/test_check_license_headers.py
@@ -109,3 +109,86 @@ def test_fix_run_that_repairs_everything_exits_green(tmp_path: Path, monkeypatch
 def test_empty_file_is_skipped_by_fix(tmp_path: Path) -> None:
     path = _write(tmp_path, "\n")
     assert not checker.add_license_header(path)
+
+
+# --- the gate must fail loudly, never silently ------------------------------
+#
+# A checker only protects what it actually inspects. Each case below is a way
+# the gate could report success while auditing nothing.
+
+
+def test_an_empty_audit_set_is_an_error(tmp_path: Path) -> None:
+    not_python = tmp_path / "README.md"
+    not_python.write_text("# not python\n", encoding="utf-8")
+
+    files, errors = checker.resolve_files([str(not_python)])
+
+    assert files == []
+    assert errors
+
+
+def test_a_run_that_audits_nothing_exits_red(tmp_path: Path, monkeypatch) -> None:
+    not_python = tmp_path / "README.md"
+    not_python.write_text("# not python\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["check_license_headers.py", str(not_python)])
+
+    assert checker.main() == 1
+
+
+def test_a_missing_source_root_is_an_error_not_an_empty_pass(tmp_path: Path, monkeypatch) -> None:
+    # No arguments means "audit src/". If that root is absent, the audit set is
+    # empty for a structural reason and must not read as success.
+    monkeypatch.setattr(checker, "__file__", str(tmp_path / "scripts" / "checker.py"))
+
+    files, errors = checker.resolve_files([])
+
+    assert files == []
+    assert any("source root does not exist" in message for message in errors)
+
+
+def test_a_nonexistent_path_is_an_error_not_a_missing_header(tmp_path: Path) -> None:
+    absent = tmp_path / "gone.py"
+
+    files, errors = checker.resolve_files([str(absent)])
+
+    assert files == []
+    assert any("path does not exist" in message for message in errors)
+
+
+def test_fix_cannot_launder_a_nonexistent_path_into_a_pass(tmp_path: Path, monkeypatch) -> None:
+    absent = tmp_path / "gone.py"
+    monkeypatch.setattr(sys, "argv", ["check_license_headers.py", "--fix", str(absent)])
+
+    assert checker.main() == 1
+    assert not absent.exists()
+
+
+def test_dot_github_is_audited_while_dot_git_is_skipped() -> None:
+    # ".git" as a substring also matches ".github", which silently exempted
+    # every workflow helper. Skip rules match whole path components.
+    assert not checker.should_skip_file(Path(".github/workflows/helper.py"))
+    assert checker.should_skip_file(Path(".git/hooks/helper.py"))
+    assert checker.should_skip_file(Path("src/archetype/__pycache__/mod.py"))
+
+
+def test_a_github_file_reaches_the_audit_set(tmp_path: Path) -> None:
+    scripts_dir = tmp_path / ".github" / "scripts"
+    scripts_dir.mkdir(parents=True)
+    helper = scripts_dir / "helper.py"
+    helper.write_text("x = 1\n", encoding="utf-8")
+
+    files, errors = checker.resolve_files([str(helper)])
+
+    assert files == [helper]
+    assert not errors
+
+
+def test_every_shipped_source_file_is_audited_and_licensed(monkeypatch) -> None:
+    """Regression lock: the state this checker failed to report for 142 files."""
+    files, errors = checker.resolve_files([])
+
+    assert not errors
+    assert files, "the default audit set must never resolve to nothing"
+
+    monkeypatch.setattr(sys, "argv", ["check_license_headers.py"])
+    assert checker.main() == 0


### PR DESCRIPTION
## What is left after #659

#659 fixed the three loud defects in `scripts/check_license_headers.py` — the stale year literal, the always-green `--fix`, and the destructive header stacking — and stamped the 3 genuinely header-less files. This PR is now scoped to what survived it.

Three defects remain, and they share a shape: **the gate reports success while auditing nothing.** Verified on `09bd32c2`:

| | Behavior on main | |
|---|---|---|
| **Empty audit set** | `check_license_headers.py README.md` → `All Python files have proper license headers.`, **exit 0** | Pass it only non-`.py` arguments and it congratulates you. An absent `src/` root does the same via `if src_dir.exists() else []`. |
| **Nonexistent path** | `check_license_headers.py /tmp/nope.py` → `The following files are missing Apache 2.0 license headers: /tmp/nope.py` | Exit code is right, diagnosis is wrong. A stale path in a pre-commit invocation reads as a license violation. |
| **`.git` substring** | `should_skip_file(Path(".github/workflows/x.py"))` → `True` | Every file under `.github/` is silently exempt from the gate. |

## The repairs

- An empty audit set is an **error**, as is a missing `src/` root. A gate that inspects nothing must not print success.
- A path that does not exist is named as a bad argument, not as an unlicensed file.
- Skip rules match whole **path components**, so `.github/` is audited.
- Errors — not just missing headers — redden the run.
- The success line now reports how many files were actually inspected (`All 199 Python files have proper license headers.`), so a silently shrinking audit set is visible rather than indistinguishable from a clean one.

## The wiring — the reason this PR exists

The checker's only consumer was the `check-license-headers` pre-commit hook. **It is in no CI workflow.** That is how 142 of 199 files stayed red without anyone noticing: the hook was bypassable, and bypassing it was the only way to commit.

`make lint` now depends on a new `license-audit` target. One line, in an already-required job:

- CI's **`format`** job runs `make lint` → the gate blocks merge.
- `make check` runs `format lint` → contributors get it locally.

No new top-level workflow, and no edit to `.github/workflows/python-tests.yml`.

## Scope: no `src/` file is touched

```
$ git diff origin/main -- src/
$ git diff --name-only origin/main -- src/ | wc -l
0
```

An earlier revision of this PR converted 61 long-form headers to SPDX. **That is deliberately dropped.** The long form is not wrong — it is valid Apache-2.0 attribution and 61 files use it. The checker's job is to verify a license header exists, not to enforce a house style.

Consolidating on SPDX is a whole-repo cosmetic pass, and it collides with work already in motion: 1 of those files is deleted by PR-8's cutover, and 16 more sit under directories the remaining Wave-2 family slices will move or rewrite. **PR-11 (final topology) is the natural place for it**, since it is already a whole-repo pass. Until then the convention converges on its own — `--fix` stamps compact SPDX on new files and refuses to touch any file that already has a valid header, so old code is left alone until its owning slice touches it.

Three files changed: `Makefile`, the checker, and its tests.

## Validation

Run on `09bd32c2`:

| Command | Result |
|---|---|
| `make check` | pass |
| `make typecheck` | pass |
| `uv run pytest tests/scripts/ -q` | **373 passed** |
| `make test` | **2431 passed, 6 skipped** |
| `python3 scripts/check_license_headers.py` over `src/` | exit 0 — `All 199 Python files have proper license headers.` |

## Mutation check

#659's 10 tests are kept as-is; 8 were added for the surviving defects (18 total). Each repair was reverted one at a time. **5 mutations, 5 caught, 0 survived.**

| Reverted repair | Tests that failed |
|---|---|
| Empty audit set → vacuous pass | 2 |
| Missing source root → silent empty set | 1 |
| Existence check removed | 1 |
| `.git` component → substring | 2 |
| Errors no longer redden the run | 2 |

Includes a regression lock (`test_every_shipped_source_file_is_audited_and_licensed`) asserting both that the default audit set is non-empty and that it passes — the pair of conditions whose absence let the 142-file red state go unreported.