### PR TITLE
fix(quality): recognize both license-header conventions and make --fix idempotent

### DIFF
--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -1,44 +1,68 @@
 #!/usr/bin/env python3
 """
 Pre-commit hook to ensure Apache 2.0 license headers are present in Python files.
+
+Two header conventions are valid, and both must stay valid: the original
+long-form Apache header (2025-era files) and the compact SPDX form newer
+files use:
+
+    # Copyright 2026 Vangelis Technologies Inc.
+    # SPDX-License-Identifier: Apache-2.0
+
+The check is year-agnostic. Recognizing only one literal year made every
+compact-header file read as "missing" — and `--fix` then prepended a second,
+stale-dated copyright block onto 130+ correctly headered files while exiting 0.
+`--fix` now refuses to touch any file that already carries a copyright line it
+cannot classify, and a missing or refused header always exits 1.
 """
 
 import argparse
+import datetime
+import re
 import sys
 from pathlib import Path
 
-APACHE_LICENSE_HEADER = """# Copyright 2025 Vangelis Technologies Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+COPYRIGHT_RE = re.compile(r"Copyright \d{4}(?:-\d{4})? Vangelis Technologies Inc\.")
+LICENSE_MARKERS = ("SPDX-License-Identifier: Apache-2.0", "Apache License")
 
-"""
+# Headers live at the top of the file. Only inspect the head so a docstring or
+# string literal that merely mentions the license cannot satisfy the check.
+HEADER_SEARCH_LIMIT = 2048
+
+
+def _license_header_template() -> str:
+    """Compact SPDX header for newly stamped files, dated to the current year."""
+    year = datetime.date.today().year
+    return (
+        f"# Copyright {year} Vangelis Technologies Inc.\n# SPDX-License-Identifier: Apache-2.0\n\n"
+    )
+
+
+def _file_head(file_path: Path) -> str | None:
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            return f.read(HEADER_SEARCH_LIMIT)
+    except (OSError, UnicodeDecodeError):
+        return None
 
 
 def has_license_header(file_path: Path) -> bool:
-    """Check if a file already has the Apache license header."""
-    try:
-        with open(file_path, encoding="utf-8") as f:
-            content = f.read()
-            return (
-                "Copyright 2025 Vangelis Technologies Inc." in content
-                and "Apache License" in content
-            )
-    except (OSError, UnicodeDecodeError):
+    """Check if a file already has a valid Apache license header."""
+    head = _file_head(file_path)
+    if head is None:
         return False
+    return bool(COPYRIGHT_RE.search(head)) and any(marker in head for marker in LICENSE_MARKERS)
 
 
 def add_license_header(file_path: Path) -> bool:
-    """Add the Apache license header to a file."""
+    """Add the compact SPDX license header to a file.
+
+    Returns True only when the file was rewritten. A file that already carries
+    a Vangelis copyright line is never rewritten: it failed the full check, so
+    its header is malformed in a way this script must not guess at — stacking
+    a second copyright block on top of it would hide the problem behind a
+    green exit.
+    """
     try:
         with open(file_path, encoding="utf-8") as f:
             content = f.read()
@@ -47,14 +71,23 @@ def add_license_header(file_path: Path) -> bool:
         if not content.strip():
             return False
 
+        if COPYRIGHT_RE.search(content[:HEADER_SEARCH_LIMIT]):
+            print(
+                f"Refusing to stack a second header on {file_path}: it already "
+                "contains a Vangelis copyright line but no recognized license "
+                "marker. Repair the existing header by hand."
+            )
+            return False
+
         # Handle files that start with shebang
+        header = _license_header_template()
         lines = content.splitlines(keepends=True)
         if lines and lines[0].startswith("#!"):
             # Insert license after shebang
-            new_content = lines[0] + APACHE_LICENSE_HEADER + "".join(lines[1:])
+            new_content = lines[0] + header + "".join(lines[1:])
         else:
             # Insert license at the beginning
-            new_content = APACHE_LICENSE_HEADER + content
+            new_content = header + content
 
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(new_content)
@@ -119,15 +152,20 @@ def main() -> int:
                 else:
                     print(f"Failed to add license header to {file_path}")
 
-    if missing_headers and not args.fix:
+    if args.fix:
+        # A refused or failed fix must keep the run red; exiting 0 here is how
+        # 130+ files were once rewritten wrongly under a green exit.
+        missing_headers = [f for f in missing_headers if not has_license_header(f)]
+
+    if missing_headers:
         print("The following files are missing Apache 2.0 license headers:")
         for file_path in missing_headers:
             print(f"  {file_path}")
-        print("\nRun with --fix to automatically add license headers.")
+        if not args.fix:
+            print("\nRun with --fix to automatically add license headers.")
         return 1
 
-    if not missing_headers:
-        print("All Python files have proper license headers.")
+    print("All Python files have proper license headers.")
 
     return 0
 

--- a/src/archetype/_storage_uri.py
+++ b/src/archetype/_storage_uri.py
@@ -1,3 +1,6 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 """Canonical storage URI handling shared by stores and control catalogs."""
 
 from __future__ import annotations

--- a/src/archetype/app/artifacts/__init__.py
+++ b/src/archetype/app/artifacts/__init__.py
@@ -1,1 +1,4 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 """One file-artifact service for source policy and typed index publication."""

--- a/src/archetype/app/research/__init__.py
+++ b/src/archetype/app/research/__init__.py
@@ -1,1 +1,4 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 """Autoresearch workflow family."""

--- a/tests/scripts/test_check_license_headers.py
+++ b/tests/scripts/test_check_license_headers.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the license-header checker.
+
+The checker guards two live conventions (long-form 2025 Apache header,
+compact SPDX header) and must never stack a second copyright block onto a
+file that already has one — the 2026-07-24 `--fix` incident rewrote 130+
+correctly headered files under a green exit.
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import check_license_headers as checker  # noqa: E402
+
+LONG_HEADER = """# Copyright 2025 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+x = 1
+"""
+
+COMPACT_HEADER = """# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+x = 1
+"""
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "module.py"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_long_form_2025_header_is_valid(tmp_path: Path) -> None:
+    assert checker.has_license_header(_write(tmp_path, LONG_HEADER))
+
+
+def test_compact_spdx_2026_header_is_valid(tmp_path: Path) -> None:
+    assert checker.has_license_header(_write(tmp_path, COMPACT_HEADER))
+
+
+def test_year_range_header_is_valid(tmp_path: Path) -> None:
+    content = COMPACT_HEADER.replace("Copyright 2026", "Copyright 2025-2026")
+    assert checker.has_license_header(_write(tmp_path, content))
+
+
+def test_license_mention_outside_the_head_is_not_a_header(tmp_path: Path) -> None:
+    filler = "x = 1\n" * 600
+    content = filler + COMPACT_HEADER
+    assert not checker.has_license_header(_write(tmp_path, content))
+
+
+def test_fix_adds_compact_header_once(tmp_path: Path) -> None:
+    path = _write(tmp_path, "x = 1\n")
+    assert not checker.has_license_header(path)
+
+    assert checker.add_license_header(path)
+    assert checker.has_license_header(path)
+    stamped = path.read_text(encoding="utf-8")
+    assert stamped.count("Vangelis Technologies Inc.") == 1
+    assert "SPDX-License-Identifier: Apache-2.0" in stamped
+
+    # A second fix pass must be a no-op: the file now has a valid header, and
+    # add_license_header refuses files whose head already carries a copyright.
+    assert not checker.add_license_header(path)
+    assert path.read_text(encoding="utf-8") == stamped
+
+
+def test_fix_preserves_shebang_line(tmp_path: Path) -> None:
+    path = _write(tmp_path, "#!/usr/bin/env python3\nx = 1\n")
+    assert checker.add_license_header(path)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "#!/usr/bin/env python3"
+    assert lines[1].startswith("# Copyright")
+
+
+def test_fix_never_stacks_a_second_copyright_block(tmp_path: Path) -> None:
+    # Copyright line present but no recognized license marker: the header is
+    # malformed, and the only safe automated action is to refuse and stay red.
+    content = "# Copyright 2026 Vangelis Technologies Inc.\n\nx = 1\n"
+    path = _write(tmp_path, content)
+    assert not checker.has_license_header(path)
+    assert not checker.add_license_header(path)
+    assert path.read_text(encoding="utf-8") == content
+
+
+def test_fix_run_with_unrepairable_file_exits_red(tmp_path: Path, monkeypatch, capsys) -> None:
+    path = _write(tmp_path, "# Copyright 2026 Vangelis Technologies Inc.\n\nx = 1\n")
+    monkeypatch.setattr(sys, "argv", ["check_license_headers.py", "--fix", str(path)])
+    assert checker.main() == 1
+    assert "Refusing to stack" in capsys.readouterr().out
+
+
+def test_fix_run_that_repairs_everything_exits_green(tmp_path: Path, monkeypatch) -> None:
+    path = _write(tmp_path, "x = 1\n")
+    monkeypatch.setattr(sys, "argv", ["check_license_headers.py", "--fix", str(path)])
+    assert checker.main() == 0
+    assert checker.has_license_header(path)
+
+
+def test_empty_file_is_skipped_by_fix(tmp_path: Path) -> None:
+    path = _write(tmp_path, "\n")
+    assert not checker.add_license_header(path)


### PR DESCRIPTION
Closes the `check_license_headers.py --fix` incident from the 2026-07-24 hardening pause (finding #4 in the fix brief).

## What was wrong

- `has_license_header` matched only the literal long-form 2025 header, so all 136 compact-SPDX files (`# Copyright 2026 ... / # SPDX-License-Identifier: Apache-2.0`) read as missing.
- `--fix` then prepended a second, stale-dated 2025 copyright block onto each of those files and exited 0. Observed rewriting 128+ correctly headered files in one run; reverted by hand.
- A failed fix also exited 0 (`Failed to add license header ...` printed under a green exit).
- The hook is wired in `.pre-commit-config.yaml` (`files: ^src/.*\.py$`), so the false-negative class was live for any local pre-commit run.

## The fix

- Year-agnostic copyright regex + either license marker (long-form Apache text or SPDX identifier), matched only in the first 2048 bytes so a deep string mention cannot satisfy the check.
- `--fix` stamps the compact SPDX form with the current year, and **refuses** to touch any file whose head already carries a Vangelis copyright line — repeated runs can never stack headers.
- A refused or failed fix keeps the run red.
- Stamped the three src files that genuinely had no header at all: `_storage_uri.py`, `app/artifacts/__init__.py`, `app/research/__init__.py`.

## Evidence

- `uv run pytest -q tests/scripts/test_check_license_headers.py` → 10 passed.
- `python3 scripts/check_license_headers.py` against the full `src/` tree → green (previously listed 139 files).
- Second `--fix` run is a byte-identical no-op.
- `ruff format --check`, `ruff check`, and `uvx ty@0.0.48 check --python .venv` clean on both files.

## Note for Wave-2 composition

`app/artifacts/__init__.py` and `app/research/__init__.py` are deleted by the in-flight PR-8/PR-6 family transactions. The header stamps here will surface as trivial delete-vs-modify conflicts at composition time — resolve by keeping the deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)