### PR TITLE
feat(ci): gate merges on blocking findings only

### DIFF
--- a/.claude/skills/footgun-detector/SKILL.md
+++ b/.claude/skills/footgun-detector/SKILL.md
@@ -168,6 +168,8 @@ For each footgun found, output exactly this format:
 ```
 ### <CATEGORY> in `<file>:<line>`
 
+**Severity:** <blocking | advisory>
+
 **What it does:** <one sentence describing the code>
 
 **What goes wrong:** <the runtime consequence — data loss, silent wrong results, crash, cost waste>
@@ -175,6 +177,22 @@ For each footgun found, output exactly this format:
 **Fix:**
 <concrete code suggestion or description of the fix>
 ```
+
+### Severity
+
+Every finding carries exactly one severity:
+
+- **blocking** — a reproducible defect: you can name the concrete input,
+  state, or sequence under which the change misbehaves. In deterministic CI,
+  blocking findings fail the merge gate until the code changes.
+- **advisory** — a real risk whose harm depends on judgment, convention, or
+  context the diff cannot settle. Advisory findings post as review threads
+  and must be resolved before merge, but resolving one with a written
+  disposition — no code change — is a sanctioned outcome.
+
+Reserve `blocking` for findings you would stake the review on: if you cannot
+name the failing input or sequence, it is advisory. A finding too speculative
+for advisory is not a finding at all.
 
 If no footguns are found, say so explicitly:
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,8 +25,12 @@
 # naming it in `on:` invalidates the whole file). Queue-readiness is
 # therefore re-evaluated on the signals Actions does deliver — a review
 # gate run completing, and any review being submitted, edited, or
-# dismissed. After resolving the last thread, re-run Deterministic Review
-# Gate or push to re-evaluate.
+# dismissed. After resolving the last thread, SUBMIT A REVIEW: it is the
+# only one of those that re-evaluates arming without re-reviewing the
+# head. Re-running Deterministic Review Gate also re-evaluates, but on a
+# head whose findings were all advisory the gate succeeds and republishes
+# those findings as fresh unresolved threads — straight back to
+# not-queue-ready. Pushing is fine: a new head earns a fresh review.
 #
 # Why the dequeue job exists: arming covers queue-ready → armed, but #646
 # lost the reverse transition. Two real findings arrived after

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -892,6 +892,12 @@ jobs:
       # documented". An advisory-only review therefore concludes
       # `review-complete` success while its threads keep the PR out of the
       # merge queue until each is addressed.
+      #
+      # Re-arming after those dispositions: submit a review. Do NOT re-run
+      # this gate — this head already passed, the run would review it again,
+      # and the publish step above would post the same advisory findings as
+      # fresh unresolved threads, undoing the resolution that was the whole
+      # point. See automerge.yml's queue-ready comment.
       - name: Block merge on findings
         id: finding_gate
         if: >-

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -269,7 +269,10 @@ jobs:
             lists every scoped file exactly once, lists exactly your lens's
             categories as `reviewed_categories`, places every file in a
             context-relevant reviewed area, gives a substantive diff-specific
-            summary, and anchors every finding to an actual changed line. An
+            summary, and anchors every finding to an actual changed line.
+            Every finding carries a severity per the skill's severity
+            contract: `blocking` only when you can name the concrete failing
+            input or sequence, `advisory` for judgment-dependent risk. An
             empty findings array is valid only after that complete lens
             review. Cover each changed file in at least one review_context
             entry; a file may appear in more than one area when it genuinely
@@ -366,7 +369,10 @@ jobs:
           `reviewed_categories`, places every file in a context-relevant reviewed
           area, gives a substantive diff-specific summary, and anchors every
           finding to an actual changed line. An empty findings array is valid
-          only after that complete lens review. Cover each changed file in at
+          only after that complete lens review. Every finding carries a
+          severity per the skill's severity contract: `blocking` only when you
+          can name the concrete failing input or sequence, `advisory` for
+          judgment-dependent risk. Cover each changed file in at
           least one review_context entry. `review_context.files` may contain only
           paths listed in `.footgun-review-scope.json`; name other evidence paths
           in assessment prose instead. Never return schema examples or
@@ -439,7 +445,8 @@ jobs:
             result must bind to the exact head, list every scoped file exactly
             once, list exactly your lens's categories as
             `reviewed_categories`, cover every changed file in
-            `review_context`, and anchor findings to changed lines.
+            `review_context`, anchor findings to changed lines, and give
+            every finding a severity per the skill's severity contract.
             `review_context.files` may contain changed paths only; mention
             other evidence paths in assessment prose. Do not return schema
             examples or placeholder values.
@@ -520,7 +527,8 @@ jobs:
           {os.environ["CATEGORIES"]}. The corrected result must bind to the
           exact head, list every scoped file exactly once, list exactly your
           lens's categories as `reviewed_categories`, cover every changed file
-          in `review_context`, and anchor findings to changed lines.
+          in `review_context`, anchor findings to changed lines, and give every
+          finding a severity per the skill's severity contract.
           `review_context.files` may contain changed paths only; mention other
           evidence paths in assessment prose. Do not return schema examples or
           placeholder values.
@@ -740,10 +748,10 @@ jobs:
       # detector job made for this head. On a reaffirmed head there is nothing
       # left to publish — the verdict comment for this exact sha is already on
       # the PR — so this job runs to a real success check run without adding a
-      # second verdict. Note the polarity: `finding_count` is empty when
-      # `prepare` is skipped, and `'' != '0'` is true, so the publish-findings
-      # and block-merge steps would otherwise fire with no findings behind
-      # them.
+      # second verdict. Note the polarity: `finding_count` and
+      # `blocking_finding_count` are empty when `prepare` is skipped, and
+      # `'' != '0'` is true, so the publish-findings and block-merge steps
+      # would otherwise fire with no findings behind them.
       - name: Checkout trusted base
         if: needs.footgun-review.outputs.reaffirmed != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -876,16 +884,25 @@ jobs:
             --finding-count "${FINDING_COUNT}" \
             --digest "${ARTIFACT_DIGEST}"
 
+      # Severity tier (ruled 2026-07-24): only `blocking` findings — those the
+      # detector binds to a reproducible defect — fail this gate. Advisory
+      # findings still post as resolvable threads above and still gate
+      # queue-ready until resolved; resolving one with a written disposition
+      # and no code change is the sanctioned channel for "reviewed, disagree,
+      # documented". An advisory-only review therefore concludes
+      # `review-complete` success while its threads keep the PR out of the
+      # merge queue until each is addressed.
       - name: Block merge on findings
         id: finding_gate
         if: >-
           needs.footgun-review.outputs.reaffirmed != 'true' &&
-          steps.prepare.outputs.finding_count != '0'
+          steps.prepare.outputs.blocking_finding_count != '0'
         env:
+          BLOCKING_FINDING_COUNT: ${{ steps.prepare.outputs.blocking_finding_count }}
           FINDING_COUNT: ${{ steps.prepare.outputs.finding_count }}
         run: |
-          echo "Footgun review reported ${FINDING_COUNT} blocking finding(s)."
-          echo "Resolve the published review threads and push the fix before merging."
+          echo "Footgun review reported ${BLOCKING_FINDING_COUNT} blocking finding(s) of ${FINDING_COUNT} total."
+          echo "Fix the blocking findings and push. Advisory threads may instead be resolved with a written disposition."
           exit 1
 
       - name: Report incomplete review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,8 +193,14 @@ automerge workflow arms only when the head is queue-ready: latest
 resolved (premature arms are auto-reverted; arming early only skips the
 review, it never merges sooner). Reply to footgun review threads with
 what you changed, then resolve them. GitHub Actions cannot observe thread
-resolution, so re-run **Deterministic Review Gate** (or push) once the
-last thread is resolved to re-evaluate arming. The reverse also holds: a
+resolution, so once the last thread is resolved, submit a review
+(`gh pr review --comment`) to re-evaluate arming — the one arming signal
+Actions delivers without re-reviewing the head. Do not re-run
+**Deterministic Review Gate** to re-arm: on a head whose findings were
+all advisory the gate succeeds again and republishes those same findings
+as fresh unresolved threads, putting the PR back where it started.
+Pushing also works, since a new head earns a fresh review. The reverse
+also holds: a
 review submitted on an armed PR that is no longer queue-ready disarms it
 (best-effort — the merge queue may already hold the PR).
 

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -59,6 +59,14 @@ REQUIRED_CATEGORIES = (
     "observability-boundary-and-authority",
     "telemetry-safety-and-cardinality",
 )
+# Merge-gate severity tier. The skill rulebook defines the semantics and tests
+# derive this tuple from it: `blocking` findings fail `review-complete`;
+# `advisory` findings post as resolvable threads that gate queue-ready until
+# resolved, where a written disposition is a sanctioned resolution.
+SEVERITIES = (
+    "blocking",
+    "advisory",
+)
 
 # The parallel review matrix runs one detector job per lens. Every lens
 # reviews the full diff against its category subset; `merge` reassembles the
@@ -392,6 +400,9 @@ def validate_result(
         category = finding.get("category")
         if category not in categories:
             raise GateError(f"findings[{index}].category is not a reviewed category")
+        severity = finding.get("severity")
+        if severity not in SEVERITIES:
+            raise GateError(f"findings[{index}].severity must be one of {', '.join(SEVERITIES)}")
         path = finding.get("path")
         if path not in scoped_files:
             raise GateError(f"findings[{index}].path is outside the reviewed diff")
@@ -408,6 +419,7 @@ def validate_result(
         normalized_findings.append(
             {
                 "category": category,
+                "severity": severity,
                 "title": _text(finding.get("title"), f"findings[{index}].title", minimum=5),
                 "path": path,
                 "side": side,
@@ -466,9 +478,10 @@ def merge_lens_results(
         )
 
     merged_context: list[dict[str, Any]] = []
-    merged_findings: list[dict[str, Any]] = []
     summaries: list[str] = []
-    seen: set[tuple[str, str, str, int]] = set()
+    # Dedupe on the anchoring identity; when duplicates disagree on severity,
+    # the blocking one wins — a dedupe must never soften the gate.
+    findings_by_key: dict[tuple[str, str, str, int], dict[str, Any]] = {}
     for lens in LENSES:
         validated = validate_result(lens_results[lens], scope, diff, categories=LENSES[lens])
         summaries.append(f"[{lens}] {validated['summary']}")
@@ -476,10 +489,12 @@ def merge_lens_results(
             merged_context.append({**entry, "area": f"{lens}: {entry['area']}"})
         for finding in validated["findings"]:
             key = (finding["category"], finding["path"], finding["side"], finding["line"])
-            if key in seen:
-                continue
-            seen.add(key)
-            merged_findings.append(finding)
+            kept = findings_by_key.get(key)
+            if kept is None or (
+                kept["severity"] == "advisory" and finding["severity"] == "blocking"
+            ):
+                findings_by_key[key] = finding
+    merged_findings = list(findings_by_key.values())
 
     merged = {
         "head_sha": scope.get("head_sha"),
@@ -571,6 +586,7 @@ def result_schema(categories: Sequence[str] = REQUIRED_CATEGORIES) -> dict[str, 
                     "type": "object",
                     "properties": {
                         "category": {"type": "string", "enum": list(categories)},
+                        "severity": {"type": "string", "enum": list(SEVERITIES)},
                         "title": {"type": "string", "minLength": 5},
                         "path": text,
                         "side": {"type": "string", "enum": ["LEFT", "RIGHT"]},
@@ -581,6 +597,7 @@ def result_schema(categories: Sequence[str] = REQUIRED_CATEGORIES) -> dict[str, 
                     },
                     "required": [
                         "category",
+                        "severity",
                         "title",
                         "path",
                         "side",
@@ -671,7 +688,19 @@ def render_evidence(
     context = _expect_list(result.get("review_context"), "review_context")
     head_sha = str(result["head_sha"])
     finding_count = len(findings)
-    outcome = "no findings" if finding_count == 0 else f"{finding_count} finding(s)"
+    blocking_count = sum(
+        1
+        for finding in findings
+        if _expect_mapping(finding, "findings entry").get("severity") == "blocking"
+    )
+    outcome = (
+        "no findings"
+        if finding_count == 0
+        else (
+            f"{finding_count} finding(s) — "
+            f"{blocking_count} blocking, {finding_count - blocking_count} advisory"
+        )
+    )
     lines = [
         f"## Footgun review — {outcome}",
         "",
@@ -731,9 +760,17 @@ def render_evidence(
 
 
 def render_finding(finding: Mapping[str, Any], head_sha: str) -> str:
+    severity = str(finding["severity"])
+    disposition = (
+        "fix before merge"
+        if severity == "blocking"
+        else "fix, or resolve this thread with a written disposition"
+    )
     return "\n".join(
         [
             f"### {finding['category']}: {finding['title']}",
+            "",
+            f"**Severity:** {severity} — {disposition}",
             "",
             f"**What it does:** {finding['what_it_does']}",
             "",
@@ -915,6 +952,9 @@ def _prepare_command(args: argparse.Namespace) -> None:
     result = _validated_result(args)
     digest = artifact_digest(result)
     finding_count = len(result["findings"])
+    blocking_finding_count = sum(
+        1 for finding in result["findings"] if finding["severity"] == "blocking"
+    )
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
     _write_json(args.output_dir / "normalized.json", result)
@@ -933,6 +973,7 @@ def _prepare_command(args: argparse.Namespace) -> None:
         {
             "head_sha": str(result["head_sha"]),
             "finding_count": finding_count,
+            "blocking_finding_count": blocking_finding_count,
             "artifact_digest": digest,
         },
     )

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -116,6 +116,7 @@ def _result(*, findings: list[dict] | None = None) -> dict:
 def _finding(**overrides) -> dict:
     finding = {
         "category": "fail-open-failure-paths",
+        "severity": "blocking",
         "title": "Validation silently fails open",
         "path": "old.py",
         "side": "RIGHT",
@@ -320,6 +321,118 @@ def test_result_fails_closed_when_completion_evidence_is_incomplete(mutation, me
 def test_finding_must_anchor_to_a_changed_line():
     with pytest.raises(GateError, match="not anchored"):
         validate_result(_result(findings=[_finding(line=2)]), _scope(), DIFF)
+
+
+def test_finding_requires_a_recognized_severity():
+    with pytest.raises(GateError, match="severity"):
+        validate_result(_result(findings=[_finding(severity="cosmetic")]), _scope(), DIFF)
+
+    missing = _finding()
+    del missing["severity"]
+    with pytest.raises(GateError, match="severity"):
+        validate_result(_result(findings=[missing]), _scope(), DIFF)
+
+
+def test_schema_requires_severity_on_findings():
+    finding_schema = gate.result_schema()["properties"]["findings"]["items"]
+
+    assert finding_schema["properties"]["severity"]["enum"] == list(gate.SEVERITIES)
+    assert "severity" in finding_schema["required"]
+
+
+def test_rendered_finding_carries_its_severity_disposition():
+    blocking = validate_result(_result(findings=[_finding()]), _scope(), DIFF)
+
+    assert "**Severity:** blocking — fix before merge" in gate.render_finding(
+        blocking["findings"][0], HEAD_SHA
+    )
+
+    advisory = validate_result(_result(findings=[_finding(severity="advisory")]), _scope(), DIFF)
+
+    assert (
+        "**Severity:** advisory — fix, or resolve this thread with a written disposition"
+        in gate.render_finding(advisory["findings"][0], HEAD_SHA)
+    )
+
+
+def test_prepare_reports_blocking_and_total_finding_counts(tmp_path):
+    advisory = _finding(
+        severity="advisory",
+        category="dead-code-contracts",
+        title="New assignment is never consumed",
+        path="new.py",
+        line=1,
+        what_it_does="The new module assigns a value that no caller reads.",
+        what_goes_wrong="Readers assume the field is wired to behavior when nothing consumes it.",
+        fix="Wire the value to its consumer or remove the assignment.",
+    )
+    result = _result(findings=[_finding(), advisory])
+    scope_path = tmp_path / "scope.json"
+    diff_path = tmp_path / "review.diff"
+    result_path = tmp_path / "result.json"
+    output_dir = tmp_path / "out"
+    github_output = tmp_path / "github-output.txt"
+    scope_path.write_text(json.dumps(_scope()), encoding="utf-8")
+    diff_path.write_text(DIFF, encoding="utf-8")
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+
+    assert (
+        gate.main(
+            [
+                "prepare",
+                "--scope",
+                str(scope_path),
+                "--diff",
+                str(diff_path),
+                "--result",
+                str(result_path),
+                "--output-dir",
+                str(output_dir),
+                "--github-output",
+                str(github_output),
+            ]
+        )
+        == 0
+    )
+
+    outputs = github_output.read_text(encoding="utf-8")
+    assert "finding_count=2\n" in outputs
+    assert "blocking_finding_count=1\n" in outputs
+    evidence = (output_dir / "evidence.md").read_text(encoding="utf-8")
+    assert "2 finding(s) — 1 blocking, 1 advisory" in evidence
+
+
+def test_block_step_fires_only_on_blocking_findings():
+    bodies = dict(_review_workflow_steps())
+
+    assert (
+        "steps.prepare.outputs.blocking_finding_count != '0'" in bodies["Block merge on findings"]
+    )
+    # Advisory findings still publish as resolvable threads: the publish step
+    # keys on the total count, only the merge block keys on the blocking count.
+    assert (
+        "steps.prepare.outputs.finding_count != '0'"
+        in bodies["Publish findings as blocking review threads"]
+    )
+
+
+def _skill_severities() -> tuple[str, ...]:
+    skill = (
+        Path(__file__).resolve().parents[2] / ".claude" / "skills" / "footgun-detector" / "SKILL.md"
+    )
+    return tuple(
+        re.findall(r"^- \*\*([a-z]+)\*\* — ", skill.read_text(encoding="utf-8"), re.MULTILINE)
+    )
+
+
+def test_severities_track_the_skill_rulebook():
+    """The skill file is the single source of truth for the severity tier.
+
+    SEVERITIES is the merge gate's machine-readable copy of the severity
+    bullets in .claude/skills/footgun-detector/SKILL.md — same discipline as
+    the category slugs: drift between the rulebook and the gate fails here.
+    """
+    assert _skill_severities() == gate.SEVERITIES
 
 
 def test_finding_can_anchor_to_the_removed_side():
@@ -886,3 +999,14 @@ def test_workflow_matrix_names_every_lens_exactly_once():
     matrix_lenses = re.findall(r"- lens: ([a-z-]+)", workflow)
 
     assert sorted(matrix_lenses) == sorted(gate.LENSES)
+
+
+def test_merge_dedupe_never_softens_a_blocking_finding():
+    # Duplicate findings inside one lens that disagree on severity collapse
+    # to the blocking one — deduplication must never soften the gate.
+    lens_results = {lens: _lens_result(lens) for lens in gate.LENSES}
+    lens_results["authority"]["findings"] = [_finding(severity="advisory"), _finding()]
+
+    merged = gate.merge_lens_results(lens_results, _scope(), DIFF)
+
+    assert [finding["severity"] for finding in merged["findings"]] == ["blocking"]


### PR DESCRIPTION
## What this does

Implements the ruled severity tier (2026-07-24) on top of the #661 lens matrix. Every finding now carries `severity: blocking | advisory`:

- **blocking** — a reproducible defect: the detector can name the concrete input, state, or sequence that misbehaves. Only these fail `review-complete`.
- **advisory** — real but judgment-dependent risk. Still posts as a resolvable review thread that gates queue-ready; resolving with a written disposition and no code change is a sanctioned outcome — this is the documented-disagreement channel the deletion proposal wanted, without giving up the hard stop.

## Mechanics

- The skill rulebook (`.claude/skills/footgun-detector/SKILL.md`) defines the semantics; `SEVERITIES` in the gate script is its derived machine copy with a drift test (`test_severities_track_the_skill_rulebook`), same discipline as the category slugs.
- `severity` is required in every per-lens schema and validated per finding; all four lens prompts (Claude Code + OpenCode, first attempt + retry) state the contract.
- `review-complete` blocks on `blocking_finding_count != 0`; the publish step still keys on the total count so advisory threads always post.
- Lens-merge dedupe keeps the blocking side when duplicates disagree — deduplication can never soften the gate (`test_merge_dedupe_never_softens_a_blocking_finding`).
- Evidence and inline threads render the severity and its disposition ("fix before merge" vs "fix, or resolve with a written disposition").

Supersedes the pre-lens-matrix branch `everettVT/footgun-severity-tier` (same design, rebuilt for the lens shape); that branch can be deleted.

This PR is reviewed by the newly-merged lens gate — its run doubles as the first live validation of the OpenCode/Kimi lenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)