### PR TITLE
fix(ci): degrade oversized review evidence instead of failing the gate

### DIFF
--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -634,6 +634,17 @@ def _markdown_code(value: str) -> str:
 
 
 _PUBLISHED_BODY_LIMIT = 60000
+_SUMMARY_BUDGET = 6000
+
+
+def _elided(text: str, budget: int | None, label: str) -> str:
+    """Return ``text`` bounded to ``budget`` characters, saying so when cut."""
+    if budget is None or len(text) <= budget:
+        return text
+    return (
+        f"{text[:budget].rstrip()}\n\n_({label} truncated at {budget} characters to fit the "
+        "published comment budget; the complete text is in the validated artifact below.)_"
+    )
 
 
 def _artifact_section(
@@ -701,62 +712,83 @@ def render_evidence(
             f"{blocking_count} blocking, {finding_count - blocking_count} advisory"
         )
     )
-    lines = [
-        f"## Footgun review — {outcome}",
-        "",
-        f"**Exact head:** `{head_sha}`  ",
-        f"**Validated scope:** {len(files)} changed file(s), {len(categories)} detector categories",
-        "",
-        str(result["summary"]),
-        "",
-        "<details>",
-        "<summary>Context reviewed</summary>",
-        "",
-    ]
-    for raw_entry in context:
-        entry = _expect_mapping(raw_entry, "review_context entry")
-        entry_files = ", ".join(
-            f"`{_markdown_code(str(path))}`" for path in _expect_list(entry["files"], "files")
-        )
-        lines.extend(
+    marker = evidence_marker(head_sha, finding_count, digest)
+
+    def prose(*, summary_budget: int | None, context_detail: bool) -> list[str]:
+        rendered_lines = [
+            f"## Footgun review — {outcome}",
+            "",
+            f"**Exact head:** `{head_sha}`  ",
+            f"**Validated scope:** {len(files)} changed file(s), "
+            f"{len(categories)} detector categories",
+            "",
+            _elided(str(result["summary"]), summary_budget, "summary"),
+            "",
+            "<details>",
+            "<summary>Context reviewed</summary>",
+            "",
+        ]
+        if context_detail:
+            for raw_entry in context:
+                entry = _expect_mapping(raw_entry, "review_context entry")
+                entry_files = ", ".join(
+                    f"`{_markdown_code(str(path))}`"
+                    for path in _expect_list(entry["files"], "files")
+                )
+                rendered_lines.extend(
+                    [f"- **{entry['area']}** ({entry_files}): {entry['assessment']}", ""]
+                )
+        else:
+            rendered_lines.extend(
+                [
+                    f"{len(context)} reviewed area(s) covering {len(files)} changed file(s). "
+                    "The per-area assessments exceed the published comment budget; read them "
+                    "in the validated artifact below.",
+                    "",
+                ]
+            )
+        rendered_lines.extend(
             [
-                f"- **{entry['area']}** ({entry_files}): {entry['assessment']}",
+                "</details>",
+                "",
+                "<details>",
+                "<summary>Detector categories completed</summary>",
+                "",
+                *[f"- `{category}`" for category in categories],
+                "",
+                "</details>",
                 "",
             ]
         )
-    lines.extend(
-        [
-            "</details>",
-            "",
-            "<details>",
-            "<summary>Detector categories completed</summary>",
-            "",
-            *[f"- `{category}`" for category in categories],
-            "",
-            "</details>",
-            "",
-        ]
-    )
-    marker = evidence_marker(head_sha, finding_count, digest)
+        return rendered_lines
 
-    def body_with_artifact(*, inline: bool) -> str:
+    def body(*, inline: bool, summary_budget: int | None, context_detail: bool) -> str:
         return "\n".join(
             [
-                *lines,
+                *prose(summary_budget=summary_budget, context_detail=context_detail),
                 *_artifact_section(result, run_url, artifact_name, inline=inline),
                 "",
                 marker,
             ]
         )
 
-    rendered = body_with_artifact(inline=True)
-    if len(rendered.encode("utf-8")) <= _PUBLISHED_BODY_LIMIT:
-        return rendered
-
-    rendered = body_with_artifact(inline=False)
-    if len(rendered.encode("utf-8")) > _PUBLISHED_BODY_LIMIT:
-        raise GateError("rendered review evidence exceeds the published body limit")
-    return rendered
+    # Degrade in a fixed order, cheapest loss first, and never silently: the
+    # validated artifact keeps the complete text, every elision says so, and
+    # the digest is computed over the result rather than this rendering, so
+    # shrinking the body cannot weaken the evidence `verify` matches. A
+    # merged lens review carries one summary and one context set per lens, so
+    # a wide diff overruns the comment limit on prose alone — dropping only
+    # the inline artifact (the pre-matrix ladder) is not enough.
+    for inline, summary_budget, context_detail in (
+        (True, None, True),
+        (False, None, True),
+        (False, _SUMMARY_BUDGET, True),
+        (False, _SUMMARY_BUDGET, False),
+    ):
+        rendered = body(inline=inline, summary_budget=summary_budget, context_detail=context_detail)
+        if len(rendered.encode("utf-8")) <= _PUBLISHED_BODY_LIMIT:
+            return rendered
+    raise GateError("rendered review evidence exceeds the published body limit")
 
 
 def render_finding(finding: Mapping[str, Any], head_sha: str) -> str:

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -1010,3 +1010,52 @@ def test_merge_dedupe_never_softens_a_blocking_finding():
     merged = gate.merge_lens_results(lens_results, _scope(), DIFF)
 
     assert [finding["severity"] for finding in merged["findings"]] == ["blocking"]
+
+
+def test_wide_merged_lens_evidence_degrades_instead_of_failing_closed():
+    """A merged lens review over a wide diff must still publish.
+
+    Every lens contributes its own summary and its own context entry per
+    changed file, so the merged prose is roughly lens-count times a single
+    detector's. On PR #663 (61 files) that overran GitHub's comment limit on
+    prose alone and the pre-matrix ladder — which only dropped the inline
+    artifact — failed the whole gate with "exceeds the published body limit",
+    posting an incomplete verdict for a review that had actually succeeded.
+    """
+    normalized = validate_result(_result(), _scope(), DIFF)
+    normalized["summary"] = "s" * 30000
+    normalized["review_context"] = [
+        {"area": f"lens-{index}: area", "files": ["old.py"], "assessment": "c" * 20000}
+        for index in range(5)
+    ]
+    digest = artifact_digest(normalized)
+
+    rendered = render_evidence(
+        normalized,
+        digest,
+        run_url="https://example.test/runs/9",
+        artifact_name="footgun-review-validated-9",
+    )
+
+    assert len(rendered.encode("utf-8")) <= gate._PUBLISHED_BODY_LIMIT
+    # Degraded, but never silently: both elisions say what was cut and where
+    # the complete text lives.
+    assert f"summary truncated at {gate._SUMMARY_BUDGET} characters" in rendered
+    assert "5 reviewed area(s) covering 2 changed file(s)" in rendered
+    assert "exceed the published comment budget" in rendered
+    assert "[footgun-review-validated-9](https://example.test/runs/9#artifacts)" in rendered
+    # The digest binds the result, not this rendering, so `verify` still
+    # matches the exact evidence marker.
+    assert evidence_marker(HEAD_SHA, 0, digest) in rendered
+
+
+def test_evidence_degradation_keeps_full_prose_whenever_it_fits():
+    normalized = validate_result(_result(), _scope(), DIFF)
+    digest = artifact_digest(normalized)
+
+    rendered = render_evidence(normalized, digest)
+
+    assert "truncated at" not in rendered
+    assert "reviewed area(s) covering" not in rendered
+    assert normalized["summary"] in rendered
+    assert normalized["review_context"][0]["assessment"] in rendered


### PR DESCRIPTION
## Blocking the critical path — hotfix

PR #663 (PR-8 artifacts, 61 files) cannot pass the review gate. Run [30126935364](https://github.com/VangelisTech/archetype/actions/runs/30126935364) shows all five lens jobs **and** the deterministic merge succeeding, then `review-complete` failing in `Validate and render publishable evidence`:

```
footgun review gate failed: rendered review evidence exceeds the published body limit
```

The PR got a "Footgun review — incomplete" comment for a review that had actually completed cleanly, and merge stays blocked. Every subsequent head fails identically, because the cause is the diff's width, not its content.

## Cause — a regression from the lens matrix (#661)

A merged lens review carries **one summary and one context set per lens**, so the rendered prose is roughly five times a single detector's. The existing fallback ladder only had one rung: drop the inline JSON artifact. That rung doesn't touch summary or per-area context — exactly the parts that grew — so on a wide diff both rungs overrun 60 KB and `render_evidence` raised, failing the gate closed on a passing review.

This never appeared on #661/#662 because those diffs are 4 files.

## Fix

Extend the ladder past the artifact, cheapest loss first:

1. inline artifact + full prose
2. artifact link + full prose *(previous last rung)*
3. artifact link + summary bounded to 6000 chars
4. artifact link + bounded summary + per-area context collapsed to a count and a pointer

Properties held:

- **Never silent.** Each elision states what was cut and that the complete text is in the validated artifact — no truncation that reads as "this is all there was."
- **Evidence integrity untouched.** The digest binds the *result*, not the rendering, so `verify_posted_evidence` still matches the exact marker; the uploaded artifact remains complete.
- **Still fails closed** if even the last rung overruns, and the existing "oversized evidence requires a named validated artifact" guard is unchanged.

## Tests

- `test_wide_merged_lens_evidence_degrades_instead_of_failing_closed` — reproduces the #663 shape (5 lens summaries + 5 oversized context entries); asserts it publishes within budget, names both elisions, and keeps the exact marker. Fails on `main`.
- `test_evidence_degradation_keeps_full_prose_whenever_it_fits` — normal reviews are byte-identical to before.
- Existing budget tests unchanged and passing (59 gate tests, 394 `tests/scripts`, `make check` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)