### PR TITLE
fix(ci): decouple review evidence from publication

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -278,6 +278,12 @@ jobs:
             entry; a file may appear in more than one area when it genuinely
             spans concerns.
 
+            `summary` is capped at 600 characters and every `assessment` at 300;
+            over-length output is rejected. Spend them on what you observed in
+            this diff. Do not enumerate the categories that did not apply, and
+            do not restate the change — findings carry their own detail and
+            post as separate threads.
+
             `review_context.files` is changed-file coverage metadata and may
             contain only paths listed in `.footgun-review-scope.json`. If you
             inspect other protected-base files as evidence, name those paths in
@@ -377,6 +383,12 @@ jobs:
           paths listed in `.footgun-review-scope.json`; name other evidence paths
           in assessment prose instead. Never return schema examples or
           placeholder values as live output.
+
+          `summary` is capped at 600 characters and every `assessment` at 300;
+          over-length output is rejected. Spend them on what you observed in
+          this diff. Do not enumerate the categories that did not apply, and do
+          not restate the change — findings carry their own detail and post as
+          separate threads.
 
           Use only the read, grep, glob, and list tools. Do not run shell
           commands, edit files, or fetch URLs. Do not post comments or reviews.
@@ -575,7 +587,7 @@ jobs:
           if-no-files-found: error
           name: footgun-review-lens-${{ matrix.lens }}-${{ github.run_id }}
           path: ${{ github.workspace }}/.footgun-review-output/validated/normalized.json
-          retention-days: 1
+          retention-days: 90
 
   footgun-review:
     name: footgun-review
@@ -706,7 +718,7 @@ jobs:
           if-no-files-found: error
           name: footgun-review-validated-${{ github.run_id }}
           path: ${{ github.workspace }}/.footgun-review-output/validated/normalized.json
-          retention-days: 1
+          retention-days: 90
 
   review-complete:
     name: review-complete

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -37,10 +37,12 @@ concurrency:
 
 # The review runs as a lens matrix: `lens-review` fans one detector job out
 # per lens (a category subset from LENSES in scripts/footgun_review_gate.py),
-# each on its own backend, and `footgun-review` deterministically merges the
-# validated lens results back into the one full-coverage artifact that
-# `review-complete` publishes. The two required contexts — `footgun-review`
-# and `review-complete` — keep their names and semantics; lens jobs are not
+# each on its own backend. `footgun-review` retains those complete validated
+# results in one digest-bound bundle; `review-complete` publishes only a small
+# lens/backend/status receipt plus finding threads. Model narration is never
+# duplicated into the PR comment, so publication capacity is not part of the
+# review oracle. The two required contexts — `footgun-review` and
+# `review-complete` — keep their names and semantics; lens jobs are not
 # required contexts, and any lens failure fails `footgun-review` closed.
 jobs:
   reaffirm:
@@ -278,12 +280,6 @@ jobs:
             entry; a file may appear in more than one area when it genuinely
             spans concerns.
 
-            `summary` is capped at 600 characters and every `assessment` at 300;
-            over-length output is rejected. Spend them on what you observed in
-            this diff. Do not enumerate the categories that did not apply, and
-            do not restate the change — findings carry their own detail and
-            post as separate threads.
-
             `review_context.files` is changed-file coverage metadata and may
             contain only paths listed in `.footgun-review-scope.json`. If you
             inspect other protected-base files as evidence, name those paths in
@@ -383,12 +379,6 @@ jobs:
           paths listed in `.footgun-review-scope.json`; name other evidence paths
           in assessment prose instead. Never return schema examples or
           placeholder values as live output.
-
-          `summary` is capped at 600 characters and every `assessment` at 300;
-          over-length output is rejected. Spend them on what you observed in
-          this diff. Do not enumerate the categories that did not apply, and do
-          not restate the change — findings carry their own detail and post as
-          separate threads.
 
           Use only the read, grep, glob, and list tools. Do not run shell
           commands, edit files, or fetch URLs. Do not post comments or reviews.
@@ -587,7 +577,9 @@ jobs:
           if-no-files-found: error
           name: footgun-review-lens-${{ matrix.lens }}-${{ github.run_id }}
           path: ${{ github.workspace }}/.footgun-review-output/validated/normalized.json
-          retention-days: 90
+          # The final bundle below retains every complete result for the review
+          # window; these transport artifacts only bridge the matrix to merge.
+          retention-days: 1
 
   footgun-review:
     name: footgun-review
@@ -693,7 +685,7 @@ jobs:
           pattern: footgun-review-lens-*-${{ github.run_id }}
           path: ${{ runner.temp }}/lens-results
 
-      - name: Merge lens results into one full-coverage review
+      - name: Package lens results into one full-coverage review bundle
         if: needs.reaffirm.outputs.reaffirmed != 'true'
         run: |
           mkdir -p "${RUNNER_TEMP}/lens-normalized"
@@ -709,7 +701,7 @@ jobs:
             --scope "${SCOPE_FILE}" \
             --diff "${DIFF_FILE}" \
             --results-dir "${RUNNER_TEMP}/lens-normalized" \
-            --output "${REVIEW_DIR}/validated/normalized.json"
+            --output "${REVIEW_DIR}/validated/review-bundle.json"
 
       - name: Upload validated detector result
         if: needs.reaffirm.outputs.reaffirmed != 'true'
@@ -717,7 +709,9 @@ jobs:
         with:
           if-no-files-found: error
           name: footgun-review-validated-${{ github.run_id }}
-          path: ${{ github.workspace }}/.footgun-review-output/validated/normalized.json
+          path: ${{ github.workspace }}/.footgun-review-output/validated/review-bundle.json
+          # Operational evidence, not permanent history. The PR receipt keeps
+          # the bundle digest after GitHub expires this artifact.
           retention-days: 90
 
   review-complete:
@@ -818,7 +812,7 @@ jobs:
             exit 1
           fi
 
-      - name: Download detector result
+      - name: Download validated review bundle
         if: needs.footgun-review.outputs.reaffirmed != 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -836,7 +830,7 @@ jobs:
           python3 scripts/footgun_review_gate.py prepare \
             --scope "${SCOPE_FILE}" \
             --diff "${DIFF_FILE}" \
-            --result "${RUNNER_TEMP}/detector-result/normalized.json" \
+            --result "${RUNNER_TEMP}/detector-result/review-bundle.json" \
             --output-dir "${REVIEW_DIR}" \
             --github-output "${GITHUB_OUTPUT}" \
             --artifact-name "${ARTIFACT_NAME}" \

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -68,27 +68,16 @@ SEVERITIES = (
     "advisory",
 )
 
-# Prose ceilings, enforced by the validator and mirrored into the constrained
-# schema. `review_context` must cover every changed file and every lens covers
-# the whole diff, so unbounded prose grows the published evidence as
-# files x lenses: a 71-file diff produced a 51KB comment whose content was
-# mostly per-lens narration of the categories that did not apply. Findings
-# carry their own detail and post as threads, so bounding narration here costs
-# no finding fidelity.
-SUMMARY_MAX = 600
-ASSESSMENT_MAX = 300
-
-# Retention for the uploaded validated artifact. Every elision in the
-# published comment points at that artifact as the complete record, so this
-# must outlive the review it explains; at the previous 1 day, a degraded
-# comment became a permanent record pointing at a dead link the next morning.
-# `retention-days` in the review workflow mirrors this value and a drift test
-# holds the two together.
-ARTIFACT_RETENTION_DAYS = 90
+REVIEW_BUNDLE_KIND = "archetype-footgun-review-bundle"
+REVIEW_BUNDLE_VERSION = 1
+# The final bundle is operational workflow evidence, not permanent history.
+# Its digest remains in the PR receipt after GitHub expires the artifact.
+FINAL_ARTIFACT_RETENTION_DAYS = 90
 
 # The parallel review matrix runs one detector job per lens. Every lens
-# reviews the full diff against its category subset; `merge` reassembles the
-# lens results into one full-coverage review. The partition invariant —
+# reviews the full diff against its category subset; `merge` packages the
+# complete validated lens results without concatenating their narration.
+# The partition invariant —
 # every required category assigned to exactly one lens — is enforced by
 # merge_lens_results, so a category added to REQUIRED_CATEGORIES without a
 # lens assignment fails the gate closed rather than silently going
@@ -130,8 +119,20 @@ LENSES: dict[str, tuple[str, ...]] = {
     ),
 }
 
+# This mirrors the workflow matrix and is held against it by a drift test.
+# The final receipt records who performed each validated lens without making
+# backend identity part of the model-authored result.
+LENS_BACKENDS: dict[str, str] = {
+    "daft-shape": "opencode",
+    "state-lifecycle": "claude-code",
+    "contracts": "claude-code",
+    "authority": "claude-code",
+    "observability": "opencode",
+}
+
 _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class GateError(ValueError):
@@ -326,16 +327,10 @@ def _expect_list(value: Any, label: str) -> list[Any]:
     return value
 
 
-def _text(value: Any, label: str, *, minimum: int, maximum: int | None = None) -> str:
+def _text(value: Any, label: str, *, minimum: int) -> str:
     if not isinstance(value, str) or len(value.strip()) < minimum:
         raise GateError(f"{label} must contain at least {minimum} non-whitespace characters")
-    stripped = value.strip()
-    if maximum is not None and len(stripped) > maximum:
-        raise GateError(
-            f"{label} must contain at most {maximum} characters; got {len(stripped)}. "
-            "State the concrete observation, not the categories that did not apply."
-        )
-    return stripped
+    return value.strip()
 
 
 def _exact_unique_strings(value: Any, expected: Sequence[str], label: str) -> list[str]:
@@ -364,14 +359,11 @@ def validate_result(
     diff: str,
     *,
     categories: Sequence[str] = REQUIRED_CATEGORIES,
-    summary_maximum: int = SUMMARY_MAX,
 ) -> dict[str, Any]:
     """Validate and normalize model output against the exact reviewed diff.
 
     ``categories`` narrows the required coverage to one lens's subset; the
-    default demands the full detector category list. ``summary_maximum``
-    scales for the merged review, which concatenates one bounded summary per
-    lens.
+    default demands the full detector category list.
     """
     head_sha = scope.get("head_sha")
     if raw_result.get("head_sha") != head_sha:
@@ -386,7 +378,7 @@ def validate_result(
         categories,
         "reviewed_categories",
     )
-    summary = _text(raw_result.get("summary"), "summary", minimum=80, maximum=summary_maximum)
+    summary = _text(raw_result.get("summary"), "summary", minimum=80)
 
     context_entries = _expect_list(raw_result.get("review_context"), "review_context")
     if not context_entries:
@@ -410,7 +402,6 @@ def validate_result(
                     entry.get("assessment"),
                     f"review_context[{index}].assessment",
                     minimum=30,
-                    maximum=ASSESSMENT_MAX,
                 ),
             }
         )
@@ -477,29 +468,13 @@ def validate_result(
     }
 
 
-def merged_summary_maximum() -> int:
-    """Return the merged-summary ceiling derived from the lens partition.
-
-    The merge joins one ``[lens] <summary>`` segment per lens with single
-    spaces, so the merged ceiling follows from the per-lens ceiling rather
-    than being a second independently-tuned number.
-    """
-    prefixes = sum(len(f"[{lens}] ") for lens in LENSES)
-    separators = max(0, len(LENSES) - 1)
-    return prefixes + separators + SUMMARY_MAX * len(LENSES)
+def artifact_digest(result: Mapping[str, Any]) -> str:
+    """Return the digest of one canonical structured review value."""
+    canonical = json.dumps(result, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def merge_lens_results(
-    lens_results: Mapping[str, Mapping[str, Any]], scope: Mapping[str, Any], diff: str
-) -> dict[str, Any]:
-    """Reassemble per-lens reviews into one full-coverage validated review.
-
-    Fails closed unless every lens is present, every lens result validates
-    against its own category subset, and the lens partition covers
-    REQUIRED_CATEGORIES exactly — so a category without a lens assignment,
-    or a missing lens artifact, blocks the merge rather than shrinking the
-    reviewed surface.
-    """
+def _validate_lens_partition() -> None:
     assigned = [category for categories in LENSES.values() for category in categories]
     if len(assigned) != len(set(assigned)):
         raise GateError("the lens partition assigns a category to more than one lens")
@@ -507,9 +482,179 @@ def merge_lens_results(
         missing = sorted(set(REQUIRED_CATEGORIES) - set(assigned))
         extra = sorted(set(assigned) - set(REQUIRED_CATEGORIES))
         raise GateError(
-            f"the lens partition does not cover the required categories; "
+            "the lens partition does not cover the required categories; "
             f"missing={missing}, extra={extra}"
         )
+    if set(LENS_BACKENDS) != set(LENSES):
+        missing = sorted(set(LENSES) - set(LENS_BACKENDS))
+        extra = sorted(set(LENS_BACKENDS) - set(LENSES))
+        raise GateError(
+            "the lens backend map does not match the lens partition; "
+            f"missing={missing}, extra={extra}"
+        )
+
+
+def _deduplicate_findings(results: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Combine validated findings without letting dedupe soften severity."""
+    findings_by_key: dict[tuple[str, str, str, int], dict[str, Any]] = {}
+    for result in results:
+        for raw_finding in _expect_list(result.get("findings"), "findings"):
+            finding = dict(_expect_mapping(raw_finding, "findings entry"))
+            key = (finding["category"], finding["path"], finding["side"], finding["line"])
+            kept = findings_by_key.get(key)
+            if kept is None or (
+                kept["severity"] == "advisory" and finding["severity"] == "blocking"
+            ):
+                findings_by_key[key] = finding
+    return list(findings_by_key.values())
+
+
+def validate_review_bundle(
+    raw_bundle: Mapping[str, Any],
+    scope: Mapping[str, Any],
+    diff: str,
+) -> dict[str, Any]:
+    """Validate and normalize the machine-produced full review bundle.
+
+    The bundle keeps every complete per-lens result as the audit artifact.
+    Narration is not concatenated into a second model-shaped result; the
+    human-facing publication is derived later as a compact receipt.
+    """
+    _validate_lens_partition()
+    if raw_bundle.get("kind") != REVIEW_BUNDLE_KIND:
+        raise GateError(f"review bundle kind must be {REVIEW_BUNDLE_KIND!r}")
+    if raw_bundle.get("schema_version") != REVIEW_BUNDLE_VERSION:
+        raise GateError(f"review bundle schema_version must be {REVIEW_BUNDLE_VERSION}")
+
+    head_sha = scope.get("head_sha")
+    if raw_bundle.get("head_sha") != head_sha:
+        raise GateError("review bundle head_sha does not match the pull request head")
+    scoped_files = _expect_list(scope.get("files"), "scope.files")
+    if any(not isinstance(item, str) for item in scoped_files):
+        raise GateError("scope.files must contain only strings")
+    files = _exact_unique_strings(
+        raw_bundle.get("reviewed_files"),
+        scoped_files,
+        "review bundle reviewed_files",
+    )
+    categories = _exact_unique_strings(
+        raw_bundle.get("reviewed_categories"),
+        REQUIRED_CATEGORIES,
+        "review bundle reviewed_categories",
+    )
+
+    raw_receipts = _expect_list(raw_bundle.get("lenses"), "review bundle lenses")
+    receipts_by_lens: dict[str, Mapping[str, Any]] = {}
+    for index, raw_receipt in enumerate(raw_receipts):
+        receipt = _expect_mapping(raw_receipt, f"review bundle lenses[{index}]")
+        lens = receipt.get("lens")
+        if not isinstance(lens, str) or lens not in LENSES:
+            raise GateError(f"review bundle lenses[{index}].lens is not a configured lens")
+        if lens in receipts_by_lens:
+            raise GateError(f"review bundle contains duplicate lens {lens!r}")
+        receipts_by_lens[lens] = receipt
+    if set(receipts_by_lens) != set(LENSES):
+        missing = sorted(set(LENSES) - set(receipts_by_lens))
+        extra = sorted(set(receipts_by_lens) - set(LENSES))
+        raise GateError(
+            f"review bundle lenses do not match the partition; missing={missing}, extra={extra}"
+        )
+
+    normalized_receipts: list[dict[str, Any]] = []
+    for lens in LENSES:
+        receipt = receipts_by_lens[lens]
+        backend = receipt.get("backend")
+        if backend != LENS_BACKENDS[lens]:
+            raise GateError(f"review bundle lens {lens!r} backend must be {LENS_BACKENDS[lens]!r}")
+        if receipt.get("status") != "validated":
+            raise GateError(f"review bundle lens {lens!r} status must be 'validated'")
+        result = validate_result(
+            _expect_mapping(receipt.get("result"), f"review bundle lens {lens!r} result"),
+            scope,
+            diff,
+            categories=LENSES[lens],
+        )
+        digest = artifact_digest(result)
+        if receipt.get("artifact_digest") != digest:
+            raise GateError(f"review bundle lens {lens!r} digest does not match its result")
+        normalized_receipts.append(
+            {
+                "lens": lens,
+                "backend": backend,
+                "status": "validated",
+                "artifact_digest": digest,
+                "result": result,
+            }
+        )
+
+    return {
+        "kind": REVIEW_BUNDLE_KIND,
+        "schema_version": REVIEW_BUNDLE_VERSION,
+        "head_sha": head_sha,
+        "reviewed_files": files,
+        "reviewed_categories": categories,
+        "lenses": normalized_receipts,
+    }
+
+
+def _bundle_receipts(bundle: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    """Return ordered receipts after checking self-contained bundle integrity."""
+    if bundle.get("kind") != REVIEW_BUNDLE_KIND:
+        raise GateError("published evidence requires a validated review bundle")
+    if bundle.get("schema_version") != REVIEW_BUNDLE_VERSION:
+        raise GateError("published evidence has an unsupported review bundle version")
+    head_sha = bundle.get("head_sha")
+    if not isinstance(head_sha, str) or not _SHA_RE.fullmatch(head_sha):
+        raise GateError("review bundle head_sha must be a full lowercase Git SHA")
+
+    raw_receipts = _expect_list(bundle.get("lenses"), "review bundle lenses")
+    receipts_by_lens: dict[str, Mapping[str, Any]] = {}
+    for raw_receipt in raw_receipts:
+        receipt = _expect_mapping(raw_receipt, "review bundle lens receipt")
+        lens = receipt.get("lens")
+        if not isinstance(lens, str) or lens in receipts_by_lens:
+            raise GateError("review bundle lens receipts must have unique string names")
+        receipts_by_lens[lens] = receipt
+    if set(receipts_by_lens) != set(LENSES):
+        raise GateError("review bundle lens receipts do not match the configured partition")
+
+    ordered: list[Mapping[str, Any]] = []
+    for lens in LENSES:
+        receipt = receipts_by_lens[lens]
+        if receipt.get("backend") != LENS_BACKENDS[lens] or receipt.get("status") != "validated":
+            raise GateError(f"review bundle lens {lens!r} has invalid completion metadata")
+        result = _expect_mapping(receipt.get("result"), f"review bundle lens {lens!r} result")
+        if result.get("head_sha") != head_sha:
+            raise GateError(f"review bundle lens {lens!r} is bound to a different head")
+        digest = receipt.get("artifact_digest")
+        if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest):
+            raise GateError(f"review bundle lens {lens!r} has an invalid digest")
+        if artifact_digest(result) != digest:
+            raise GateError(f"review bundle lens {lens!r} digest does not match its result")
+        ordered.append(receipt)
+    return ordered
+
+
+def review_bundle_findings(bundle: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return the bundle's deterministic, severity-preserving finding set."""
+    return _deduplicate_findings(
+        _expect_mapping(receipt["result"], "review bundle lens result")
+        for receipt in _bundle_receipts(bundle)
+    )
+
+
+def merge_lens_results(
+    lens_results: Mapping[str, Mapping[str, Any]], scope: Mapping[str, Any], diff: str
+) -> dict[str, Any]:
+    """Package per-lens reviews into one full-coverage validated bundle.
+
+    Fails closed unless every lens is present, every lens result validates
+    against its own category subset, and the lens partition covers
+    REQUIRED_CATEGORIES exactly — so a category without a lens assignment,
+    or a missing lens artifact, blocks the merge rather than shrinking the
+    reviewed surface.
+    """
+    _validate_lens_partition()
     if set(lens_results) != set(LENSES):
         missing = sorted(set(LENSES) - set(lens_results))
         extra = sorted(set(lens_results) - set(LENSES))
@@ -517,34 +662,28 @@ def merge_lens_results(
             f"lens results do not match the lens partition; missing={missing}, extra={extra}"
         )
 
-    merged_context: list[dict[str, Any]] = []
-    summaries: list[str] = []
-    # Dedupe on the anchoring identity; when duplicates disagree on severity,
-    # the blocking one wins — a dedupe must never soften the gate.
-    findings_by_key: dict[tuple[str, str, str, int], dict[str, Any]] = {}
+    receipts: list[dict[str, Any]] = []
     for lens in LENSES:
         validated = validate_result(lens_results[lens], scope, diff, categories=LENSES[lens])
-        summaries.append(f"[{lens}] {validated['summary']}")
-        for entry in validated["review_context"]:
-            merged_context.append({**entry, "area": f"{lens}: {entry['area']}"})
-        for finding in validated["findings"]:
-            key = (finding["category"], finding["path"], finding["side"], finding["line"])
-            kept = findings_by_key.get(key)
-            if kept is None or (
-                kept["severity"] == "advisory" and finding["severity"] == "blocking"
-            ):
-                findings_by_key[key] = finding
-    merged_findings = list(findings_by_key.values())
+        receipts.append(
+            {
+                "lens": lens,
+                "backend": LENS_BACKENDS[lens],
+                "status": "validated",
+                "artifact_digest": artifact_digest(validated),
+                "result": validated,
+            }
+        )
 
-    merged = {
+    bundle = {
+        "kind": REVIEW_BUNDLE_KIND,
+        "schema_version": REVIEW_BUNDLE_VERSION,
         "head_sha": scope.get("head_sha"),
-        "summary": " ".join(summaries),
         "reviewed_files": list(scope.get("files") or []),
         "reviewed_categories": list(REQUIRED_CATEGORIES),
-        "review_context": merged_context,
-        "findings": merged_findings,
+        "lenses": receipts,
     }
-    return validate_result(merged, scope, diff, summary_maximum=merged_summary_maximum())
+    return validate_review_bundle(bundle, scope, diff)
 
 
 def extract_structured_json(raw: str) -> dict[str, Any] | None:
@@ -591,11 +730,6 @@ def retry_feedback(error: GateError) -> str:
     )
 
 
-def artifact_digest(result: Mapping[str, Any]) -> str:
-    canonical = json.dumps(result, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-
-
 def result_schema(categories: Sequence[str] = REQUIRED_CATEGORIES) -> dict[str, Any]:
     """Return the constrained-output schema used by Claude Code."""
     text = {"type": "string", "minLength": 1}
@@ -603,7 +737,7 @@ def result_schema(categories: Sequence[str] = REQUIRED_CATEGORIES) -> dict[str, 
         "type": "object",
         "properties": {
             "head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
-            "summary": {"type": "string", "minLength": 80, "maxLength": SUMMARY_MAX},
+            "summary": {"type": "string", "minLength": 80},
             "reviewed_files": {"type": "array", "items": text, "minItems": 1},
             "reviewed_categories": {"type": "array", "items": text, "minItems": 1},
             "review_context": {
@@ -614,11 +748,7 @@ def result_schema(categories: Sequence[str] = REQUIRED_CATEGORIES) -> dict[str, 
                     "properties": {
                         "area": {"type": "string", "minLength": 3},
                         "files": {"type": "array", "items": text, "minItems": 1},
-                        "assessment": {
-                            "type": "string",
-                            "minLength": 30,
-                            "maxLength": ASSESSMENT_MAX,
-                        },
+                        "assessment": {"type": "string", "minLength": 30},
                     },
                     "required": ["area", "files", "assessment"],
                     "additionalProperties": False,
@@ -669,7 +799,8 @@ def result_schema(categories: Sequence[str] = REQUIRED_CATEGORIES) -> dict[str, 
 def evidence_marker(head_sha: str, finding_count: int, digest: str) -> str:
     return (
         "<!-- archetype-footgun-review "
-        f"schema={SCHEMA_VERSION} head={head_sha} findings={finding_count} digest={digest} -->"
+        f"schema={REVIEW_BUNDLE_VERSION} head={head_sha} "
+        f"findings={finding_count} digest={digest} -->"
     )
 
 
@@ -680,64 +811,58 @@ def _markdown_code(value: str) -> str:
 _PUBLISHED_BODY_LIMIT = 60000
 
 
-def _artifact_section(
-    result: Mapping[str, Any],
-    run_url: str | None,
-    artifact_name: str | None,
-    *,
-    inline: bool,
-) -> list[str]:
-    lines = [
-        "<details>",
-        "<summary>Validated review artifact</summary>",
-        "",
-    ]
-    if inline:
-        payload = json.dumps(result, indent=2, ensure_ascii=False)
-        # Findings may quote code fences; the outer fence must be longer than
-        # any backtick run inside the payload.
-        longest_run = max((len(match.group(0)) for match in re.finditer(r"`+", payload)), default=0)
-        fence = "`" * max(3, longest_run + 1)
-        lines.extend([f"{fence}json", payload, fence, ""])
-    else:
-        if not run_url or not artifact_name:
-            raise GateError("oversized review evidence requires a named validated artifact")
-        lines.extend(
-            [
-                "The validated structured output exceeds the inline comment budget; "
-                "download the named validated artifact instead.",
-                "",
-            ]
+def _artifact_reference(run_url: str | None, artifact_name: str | None) -> str:
+    """Render controlled artifact metadata without letting it consume the receipt."""
+    linkable = (
+        isinstance(run_url, str)
+        and run_url.startswith("https://")
+        and len(run_url) <= 2048
+        and not any(character.isspace() for character in run_url)
+        and isinstance(artifact_name, str)
+        and 0 < len(artifact_name) <= 256
+        and "\n" not in artifact_name
+        and "\r" not in artifact_name
+    )
+    if linkable:
+        return (
+            f"**Review bundle:** [workflow artifact]({run_url}#artifacts) "
+            f"(`{_markdown_code(artifact_name)}`; "
+            f"{FINAL_ARTIFACT_RETENTION_DAYS}-day operational retention)."
         )
-    if run_url and artifact_name:
-        lines.extend(
-            [
-                f"Validated artifact: [{artifact_name}]({run_url}#artifacts) "
-                f"({ARTIFACT_RETENTION_DAYS}-day retention).",
-                "",
-            ]
-        )
-    lines.append("</details>")
-    return lines
+    return (
+        "**Review bundle:** artifact link unavailable in this rendering; "
+        "the receipt remains bound to the bundle digest."
+    )
 
 
 def render_evidence(
-    result: Mapping[str, Any],
+    bundle: Mapping[str, Any],
     digest: str,
     run_url: str | None = None,
     artifact_name: str | None = None,
 ) -> str:
-    findings = _expect_list(result.get("findings"), "findings")
-    files = _expect_list(result.get("reviewed_files"), "reviewed_files")
-    categories = _expect_list(result.get("reviewed_categories"), "reviewed_categories")
-    context = _expect_list(result.get("review_context"), "review_context")
-    head_sha = str(result["head_sha"])
-    finding_count = len(findings)
-    blocking_count = sum(
-        1
-        for finding in findings
-        if _expect_mapping(finding, "findings entry").get("severity") == "blocking"
+    """Render a compact receipt; complete lens narration stays in the bundle.
+
+    Publication capacity is deliberately not part of the review oracle. The
+    model-authored summaries and context can grow without growing this body,
+    and untrusted artifact metadata falls back to a fixed-size receipt rather
+    than converting completed analysis into an incomplete review.
+    """
+    receipts = _bundle_receipts(bundle)
+    if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest):
+        raise GateError("review bundle digest must be a lowercase SHA-256 value")
+    if artifact_digest(bundle) != digest:
+        raise GateError("published review digest does not match the review bundle")
+
+    files = _expect_list(bundle.get("reviewed_files"), "review bundle reviewed_files")
+    categories = _expect_list(
+        bundle.get("reviewed_categories"),
+        "review bundle reviewed_categories",
     )
+    findings = review_bundle_findings(bundle)
+    head_sha = str(bundle["head_sha"])
+    finding_count = len(findings)
+    blocking_count = sum(1 for finding in findings if finding.get("severity") == "blocking")
     outcome = (
         "no findings"
         if finding_count == 0
@@ -748,81 +873,59 @@ def render_evidence(
     )
     marker = evidence_marker(head_sha, finding_count, digest)
 
-    def prose(*, context_detail: bool) -> list[str]:
-        rendered_lines = [
+    lens_rows: list[str] = []
+    for receipt in receipts:
+        lens_result = _expect_mapping(receipt["result"], "review bundle lens result")
+        lens_findings = _deduplicate_findings([lens_result])
+        lens_blocking = sum(1 for finding in lens_findings if finding.get("severity") == "blocking")
+        lens_rows.append(
+            f"| `{receipt['lens']}` | `{receipt['backend']}` | {receipt['status']} | "
+            f"{len(lens_findings)} ({lens_blocking} blocking, "
+            f"{len(lens_findings) - lens_blocking} advisory) | "
+            f"`sha256:{receipt['artifact_digest']}` |"
+        )
+
+    rendered = "\n".join(
+        [
             f"## Footgun review — {outcome}",
             "",
             f"**Exact head:** `{head_sha}`  ",
             f"**Validated scope:** {len(files)} changed file(s), "
-            f"{len(categories)} detector categories assigned across {len(LENSES)} lenses",
+            f"{len(categories)} detector categories, {len(receipts)}/{len(LENSES)} lenses  ",
+            f"**Bundle digest:** `sha256:{digest}`",
             "",
-            str(result["summary"]),
+            "| Lens | Backend | Status | Findings | Lens evidence digest |",
+            "|---|---|---:|---:|---|",
+            *lens_rows,
             "",
-            "<details>",
-            "<summary>Context reviewed</summary>",
+            "Complete per-lens summaries, reviewed context, and structured findings "
+            "are retained in the digest-bound bundle; they are not duplicated in this receipt.",
             "",
+            _artifact_reference(run_url, artifact_name),
+            "",
+            marker,
         ]
-        if context_detail:
-            for raw_entry in context:
-                entry = _expect_mapping(raw_entry, "review_context entry")
-                entry_files = ", ".join(
-                    f"`{_markdown_code(str(path))}`"
-                    for path in _expect_list(entry["files"], "files")
-                )
-                rendered_lines.extend(
-                    [f"- **{entry['area']}** ({entry_files}): {entry['assessment']}", ""]
-                )
-        else:
-            rendered_lines.extend(
-                [
-                    f"{len(context)} reviewed area(s) covering {len(files)} changed file(s). "
-                    "The per-area assessments exceed the published comment budget; read them "
-                    "in the validated artifact below.",
-                    "",
-                ]
-            )
-        rendered_lines.extend(
-            [
-                "</details>",
-                "",
-                "<details>",
-                "<summary>Detector categories assigned</summary>",
-                "",
-                *[f"- `{category}`" for category in categories],
-                "",
-                "</details>",
-                "",
-            ]
-        )
-        return rendered_lines
+    )
+    if len(rendered.encode("utf-8")) <= _PUBLISHED_BODY_LIMIT:
+        return rendered
 
-    def body(*, inline: bool, context_detail: bool) -> str:
-        return "\n".join(
-            [
-                *prose(context_detail=context_detail),
-                *_artifact_section(result, run_url, artifact_name, inline=inline),
-                "",
-                marker,
-            ]
-        )
-
-    # Summary and assessment prose is bounded by the validator (SUMMARY_MAX,
-    # ASSESSMENT_MAX), so the only term that still scales without limit is
-    # per-area context: every lens must cover every changed file, making the
-    # context section grow as files x lenses. Degrade that, then the inline
-    # artifact, and never silently — the elision says so and points at a
-    # retained artifact. The digest is computed over the result rather than
-    # this rendering, so shrinking the body cannot weaken the evidence
-    # `verify` matches.
-    for inline, context_detail in (
-        (True, True),
-        (False, True),
-        (False, False),
-    ):
-        rendered = body(inline=inline, context_detail=context_detail)
-        if len(rendered.encode("utf-8")) <= _PUBLISHED_BODY_LIMIT:
-            return rendered
-    raise GateError("rendered review evidence exceeds the published body limit")
+    # All remaining fields are fixed-size validated values. This rung cannot
+    # be inflated by model prose, file names, artifact names, or URLs.
+    return "\n".join(
+        [
+            f"## Footgun review — {outcome}",
+            "",
+            f"**Exact head:** `{head_sha}`  ",
+            f"**Validated lenses:** {len(receipts)}/{len(LENSES)}  ",
+            f"**Findings:** {finding_count} total; {blocking_count} blocking  ",
+            f"**Bundle digest:** `sha256:{digest}`",
+            "",
+            "The detailed receipt exceeded the publication budget; complete evidence "
+            "remains in the workflow's digest-bound review bundle.",
+            "",
+            marker,
+        ]
+    )
 
 
 def render_finding(finding: Mapping[str, Any], head_sha: str) -> str:
@@ -851,19 +954,19 @@ def render_finding(finding: Mapping[str, Any], head_sha: str) -> str:
 
 
 def review_payload(
-    result: Mapping[str, Any],
+    bundle: Mapping[str, Any],
     digest: str,
     run_url: str | None = None,
     artifact_name: str | None = None,
 ) -> dict[str, Any]:
-    head_sha = str(result["head_sha"])
-    findings = _expect_list(result.get("findings"), "findings")
+    head_sha = str(bundle["head_sha"])
+    findings = review_bundle_findings(bundle)
     if not findings:
         raise GateError("a review payload requires at least one finding")
     return {
         "commit_id": head_sha,
         "event": "COMMENT",
-        "body": render_evidence(result, digest, run_url, artifact_name),
+        "body": render_evidence(bundle, digest, run_url, artifact_name),
         "comments": [
             {
                 "path": finding["path"],
@@ -991,6 +1094,13 @@ def _validated_result(args: argparse.Namespace) -> dict[str, Any]:
     return validate_result(raw_result, scope, diff, categories=_selected_categories(args))
 
 
+def _validated_review_bundle(args: argparse.Namespace) -> dict[str, Any]:
+    scope = _expect_mapping(_load_json(args.scope), "scope")
+    raw_bundle = _expect_mapping(_load_json(args.result), "review bundle")
+    diff = args.diff.read_text(encoding="utf-8")
+    return validate_review_bundle(raw_bundle, scope, diff)
+
+
 def _normalize_command(args: argparse.Namespace) -> None:
     result = _validated_result(args)
     args.output.parent.mkdir(parents=True, exist_ok=True)
@@ -1015,29 +1125,28 @@ def _attempt_command(args: argparse.Namespace) -> None:
 
 
 def _prepare_command(args: argparse.Namespace) -> None:
-    result = _validated_result(args)
-    digest = artifact_digest(result)
-    finding_count = len(result["findings"])
-    blocking_finding_count = sum(
-        1 for finding in result["findings"] if finding["severity"] == "blocking"
-    )
+    bundle = _validated_review_bundle(args)
+    digest = artifact_digest(bundle)
+    findings = review_bundle_findings(bundle)
+    finding_count = len(findings)
+    blocking_finding_count = sum(1 for finding in findings if finding["severity"] == "blocking")
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    _write_json(args.output_dir / "normalized.json", result)
+    _write_json(args.output_dir / "review-bundle.json", bundle)
     (args.output_dir / "evidence.md").write_text(
-        render_evidence(result, digest, args.run_url, args.artifact_name) + "\n",
+        render_evidence(bundle, digest, args.run_url, args.artifact_name) + "\n",
         encoding="utf-8",
     )
     if finding_count:
         _write_json(
             args.output_dir / "review.json",
-            review_payload(result, digest, args.run_url, args.artifact_name),
+            review_payload(bundle, digest, args.run_url, args.artifact_name),
         )
 
     _append_github_outputs(
         args.github_output,
         {
-            "head_sha": str(result["head_sha"]),
+            "head_sha": str(bundle["head_sha"]),
             "finding_count": finding_count,
             "blocking_finding_count": blocking_finding_count,
             "artifact_digest": digest,
@@ -1113,7 +1222,7 @@ def _parser() -> argparse.ArgumentParser:
     extract.set_defaults(handler=_extract_command)
 
     merge = subparsers.add_parser(
-        "merge", help="merge validated per-lens results into one full-coverage review"
+        "merge", help="package validated per-lens results into one full-coverage bundle"
     )
     merge.add_argument("--scope", type=Path, required=True)
     merge.add_argument("--diff", type=Path, required=True)
@@ -1165,7 +1274,9 @@ def _parser() -> argparse.ArgumentParser:
     attempt.add_argument("--lens", default=None)
     attempt.set_defaults(handler=_attempt_command)
 
-    prepare = subparsers.add_parser("prepare", help="validate and render structured output")
+    prepare = subparsers.add_parser(
+        "prepare", help="validate a review bundle and render its receipt"
+    )
     prepare.add_argument("--scope", type=Path, required=True)
     prepare.add_argument("--diff", type=Path, required=True)
     prepare.add_argument("--result", type=Path, required=True)

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -68,6 +68,24 @@ SEVERITIES = (
     "advisory",
 )
 
+# Prose ceilings, enforced by the validator and mirrored into the constrained
+# schema. `review_context` must cover every changed file and every lens covers
+# the whole diff, so unbounded prose grows the published evidence as
+# files x lenses: a 71-file diff produced a 51KB comment whose content was
+# mostly per-lens narration of the categories that did not apply. Findings
+# carry their own detail and post as threads, so bounding narration here costs
+# no finding fidelity.
+SUMMARY_MAX = 600
+ASSESSMENT_MAX = 300
+
+# Retention for the uploaded validated artifact. Every elision in the
+# published comment points at that artifact as the complete record, so this
+# must outlive the review it explains; at the previous 1 day, a degraded
+# comment became a permanent record pointing at a dead link the next morning.
+# `retention-days` in the review workflow mirrors this value and a drift test
+# holds the two together.
+ARTIFACT_RETENTION_DAYS = 90
+
 # The parallel review matrix runs one detector job per lens. Every lens
 # reviews the full diff against its category subset; `merge` reassembles the
 # lens results into one full-coverage review. The partition invariant —
@@ -308,10 +326,16 @@ def _expect_list(value: Any, label: str) -> list[Any]:
     return value
 
 
-def _text(value: Any, label: str, *, minimum: int) -> str:
+def _text(value: Any, label: str, *, minimum: int, maximum: int | None = None) -> str:
     if not isinstance(value, str) or len(value.strip()) < minimum:
         raise GateError(f"{label} must contain at least {minimum} non-whitespace characters")
-    return value.strip()
+    stripped = value.strip()
+    if maximum is not None and len(stripped) > maximum:
+        raise GateError(
+            f"{label} must contain at most {maximum} characters; got {len(stripped)}. "
+            "State the concrete observation, not the categories that did not apply."
+        )
+    return stripped
 
 
 def _exact_unique_strings(value: Any, expected: Sequence[str], label: str) -> list[str]:
@@ -340,11 +364,14 @@ def validate_result(
     diff: str,
     *,
     categories: Sequence[str] = REQUIRED_CATEGORIES,
+    summary_maximum: int = SUMMARY_MAX,
 ) -> dict[str, Any]:
     """Validate and normalize model output against the exact reviewed diff.
 
     ``categories`` narrows the required coverage to one lens's subset; the
-    default demands the full detector category list.
+    default demands the full detector category list. ``summary_maximum``
+    scales for the merged review, which concatenates one bounded summary per
+    lens.
     """
     head_sha = scope.get("head_sha")
     if raw_result.get("head_sha") != head_sha:
@@ -359,7 +386,7 @@ def validate_result(
         categories,
         "reviewed_categories",
     )
-    summary = _text(raw_result.get("summary"), "summary", minimum=80)
+    summary = _text(raw_result.get("summary"), "summary", minimum=80, maximum=summary_maximum)
 
     context_entries = _expect_list(raw_result.get("review_context"), "review_context")
     if not context_entries:
@@ -383,6 +410,7 @@ def validate_result(
                     entry.get("assessment"),
                     f"review_context[{index}].assessment",
                     minimum=30,
+                    maximum=ASSESSMENT_MAX,
                 ),
             }
         )
@@ -449,6 +477,18 @@ def validate_result(
     }
 
 
+def merged_summary_maximum() -> int:
+    """Return the merged-summary ceiling derived from the lens partition.
+
+    The merge joins one ``[lens] <summary>`` segment per lens with single
+    spaces, so the merged ceiling follows from the per-lens ceiling rather
+    than being a second independently-tuned number.
+    """
+    prefixes = sum(len(f"[{lens}] ") for lens in LENSES)
+    separators = max(0, len(LENSES) - 1)
+    return prefixes + separators + SUMMARY_MAX * len(LENSES)
+
+
 def merge_lens_results(
     lens_results: Mapping[str, Mapping[str, Any]], scope: Mapping[str, Any], diff: str
 ) -> dict[str, Any]:
@@ -504,7 +544,7 @@ def merge_lens_results(
         "review_context": merged_context,
         "findings": merged_findings,
     }
-    return validate_result(merged, scope, diff)
+    return validate_result(merged, scope, diff, summary_maximum=merged_summary_maximum())
 
 
 def extract_structured_json(raw: str) -> dict[str, Any] | None:
@@ -563,7 +603,7 @@ def result_schema(categories: Sequence[str] = REQUIRED_CATEGORIES) -> dict[str, 
         "type": "object",
         "properties": {
             "head_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
-            "summary": {"type": "string", "minLength": 80},
+            "summary": {"type": "string", "minLength": 80, "maxLength": SUMMARY_MAX},
             "reviewed_files": {"type": "array", "items": text, "minItems": 1},
             "reviewed_categories": {"type": "array", "items": text, "minItems": 1},
             "review_context": {
@@ -574,7 +614,11 @@ def result_schema(categories: Sequence[str] = REQUIRED_CATEGORIES) -> dict[str, 
                     "properties": {
                         "area": {"type": "string", "minLength": 3},
                         "files": {"type": "array", "items": text, "minItems": 1},
-                        "assessment": {"type": "string", "minLength": 30},
+                        "assessment": {
+                            "type": "string",
+                            "minLength": 30,
+                            "maxLength": ASSESSMENT_MAX,
+                        },
                     },
                     "required": ["area", "files", "assessment"],
                     "additionalProperties": False,
@@ -634,17 +678,6 @@ def _markdown_code(value: str) -> str:
 
 
 _PUBLISHED_BODY_LIMIT = 60000
-_SUMMARY_BUDGET = 6000
-
-
-def _elided(text: str, budget: int | None, label: str) -> str:
-    """Return ``text`` bounded to ``budget`` characters, saying so when cut."""
-    if budget is None or len(text) <= budget:
-        return text
-    return (
-        f"{text[:budget].rstrip()}\n\n_({label} truncated at {budget} characters to fit the "
-        "published comment budget; the complete text is in the validated artifact below.)_"
-    )
 
 
 def _artifact_section(
@@ -679,7 +712,8 @@ def _artifact_section(
     if run_url and artifact_name:
         lines.extend(
             [
-                f"Validated artifact: [{artifact_name}]({run_url}#artifacts) (1-day retention).",
+                f"Validated artifact: [{artifact_name}]({run_url}#artifacts) "
+                f"({ARTIFACT_RETENTION_DAYS}-day retention).",
                 "",
             ]
         )
@@ -714,15 +748,15 @@ def render_evidence(
     )
     marker = evidence_marker(head_sha, finding_count, digest)
 
-    def prose(*, summary_budget: int | None, context_detail: bool) -> list[str]:
+    def prose(*, context_detail: bool) -> list[str]:
         rendered_lines = [
             f"## Footgun review — {outcome}",
             "",
             f"**Exact head:** `{head_sha}`  ",
             f"**Validated scope:** {len(files)} changed file(s), "
-            f"{len(categories)} detector categories",
+            f"{len(categories)} detector categories assigned across {len(LENSES)} lenses",
             "",
-            _elided(str(result["summary"]), summary_budget, "summary"),
+            str(result["summary"]),
             "",
             "<details>",
             "<summary>Context reviewed</summary>",
@@ -752,7 +786,7 @@ def render_evidence(
                 "</details>",
                 "",
                 "<details>",
-                "<summary>Detector categories completed</summary>",
+                "<summary>Detector categories assigned</summary>",
                 "",
                 *[f"- `{category}`" for category in categories],
                 "",
@@ -762,30 +796,30 @@ def render_evidence(
         )
         return rendered_lines
 
-    def body(*, inline: bool, summary_budget: int | None, context_detail: bool) -> str:
+    def body(*, inline: bool, context_detail: bool) -> str:
         return "\n".join(
             [
-                *prose(summary_budget=summary_budget, context_detail=context_detail),
+                *prose(context_detail=context_detail),
                 *_artifact_section(result, run_url, artifact_name, inline=inline),
                 "",
                 marker,
             ]
         )
 
-    # Degrade in a fixed order, cheapest loss first, and never silently: the
-    # validated artifact keeps the complete text, every elision says so, and
-    # the digest is computed over the result rather than this rendering, so
-    # shrinking the body cannot weaken the evidence `verify` matches. A
-    # merged lens review carries one summary and one context set per lens, so
-    # a wide diff overruns the comment limit on prose alone — dropping only
-    # the inline artifact (the pre-matrix ladder) is not enough.
-    for inline, summary_budget, context_detail in (
-        (True, None, True),
-        (False, None, True),
-        (False, _SUMMARY_BUDGET, True),
-        (False, _SUMMARY_BUDGET, False),
+    # Summary and assessment prose is bounded by the validator (SUMMARY_MAX,
+    # ASSESSMENT_MAX), so the only term that still scales without limit is
+    # per-area context: every lens must cover every changed file, making the
+    # context section grow as files x lenses. Degrade that, then the inline
+    # artifact, and never silently — the elision says so and points at a
+    # retained artifact. The digest is computed over the result rather than
+    # this rendering, so shrinking the body cannot weaken the evidence
+    # `verify` matches.
+    for inline, context_detail in (
+        (True, True),
+        (False, True),
+        (False, False),
     ):
-        rendered = body(inline=inline, summary_budget=summary_budget, context_detail=context_detail)
+        rendered = body(inline=inline, context_detail=context_detail)
         if len(rendered.encode("utf-8")) <= _PUBLISHED_BODY_LIMIT:
             return rendered
     raise GateError("rendered review evidence exceeds the published body limit")

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -517,8 +517,8 @@ def test_oversized_evidence_without_named_validated_artifact_fails_closed():
 
 def test_normalize_command_does_not_render_unpublished_evidence(tmp_path):
     result = _result()
-    result["summary"] = "s" * 40000
-    result["review_context"][0]["assessment"] = "c" * 40000
+    result["summary"] = "s" * gate.SUMMARY_MAX
+    result["review_context"][0]["assessment"] = "c" * gate.ASSESSMENT_MAX
     scope_path = tmp_path / "scope.json"
     diff_path = tmp_path / "review.diff"
     result_path = tmp_path / "result.json"
@@ -544,7 +544,7 @@ def test_normalize_command_does_not_render_unpublished_evidence(tmp_path):
         == 0
     )
 
-    assert json.loads(output_path.read_text(encoding="utf-8"))["summary"] == "s" * 40000
+    assert json.loads(output_path.read_text(encoding="utf-8"))["summary"] == "s" * gate.SUMMARY_MAX
     assert list(output_path.parent.iterdir()) == [output_path]
 
 
@@ -585,6 +585,83 @@ def test_workflow_has_one_bounded_validator_feedback_retry():
     assert "steps.first_validation.outputs.valid != 'true'" in workflow
     assert ".footgun-review-validation.txt" in workflow
     assert "Require detector completion" not in workflow
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda result: result.update(summary="s" * (gate.SUMMARY_MAX + 1)),
+            f"summary must contain at most {gate.SUMMARY_MAX} characters",
+        ),
+        (
+            lambda result: result["review_context"][0].update(
+                assessment="c" * (gate.ASSESSMENT_MAX + 1)
+            ),
+            f"assessment must contain at most {gate.ASSESSMENT_MAX} characters",
+        ),
+    ],
+)
+def test_narration_over_the_prose_ceiling_is_rejected(mutation, message):
+    """Bound the prose at the source, not at render time.
+
+    `review_context` must cover every changed file and every lens reviews the
+    whole diff, so unbounded narration grows the published evidence as
+    files x lenses. #663 (71 files) rendered a 51KB comment that was mostly
+    per-lens narration of the categories that did not apply, and the head
+    before it overran the 60KB limit outright.
+    """
+    result = _result()
+    mutation(result)
+
+    with pytest.raises(GateError) as error:
+        validate_result(result, _scope(), DIFF)
+
+    assert message in str(error.value)
+
+
+def test_constrained_schema_mirrors_the_validator_prose_ceilings():
+    """Claude Code decodes against this schema; drift would spend a retry."""
+    schema = gate.result_schema()
+    properties = schema["properties"]
+
+    assert properties["summary"]["maxLength"] == gate.SUMMARY_MAX
+    context_item = properties["review_context"]["items"]["properties"]
+    assert context_item["assessment"]["maxLength"] == gate.ASSESSMENT_MAX
+
+
+def test_merged_summary_ceiling_is_derived_from_the_lens_partition():
+    """The merged ceiling follows from the per-lens one, not a second knob."""
+    merged = gate.merge_lens_results(
+        {lens: _lens_result(lens) for lens in gate.LENSES}, _scope(), DIFF
+    )
+
+    assert len(merged["summary"]) <= gate.merged_summary_maximum()
+    # Derived, not a tuned literal: adding a lens moves the ceiling with it.
+    assert gate.merged_summary_maximum() >= gate.SUMMARY_MAX * len(gate.LENSES)
+
+
+def test_published_artifact_outlives_the_elisions_that_point_at_it():
+    """Every degraded rung says "read the complete text in the artifact".
+
+    At the previous `retention-days: 1`, a degraded comment became a permanent
+    record pointing at a link that died the next morning, and
+    `verify_posted_evidence` only checks the marker, so nothing noticed.
+    """
+    workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+
+    assert gate.ARTIFACT_RETENTION_DAYS > 1
+    uploads = workflow.count("uses: actions/upload-artifact@")
+    assert uploads == 2
+    assert workflow.count(f"retention-days: {gate.ARTIFACT_RETENTION_DAYS}") == uploads
+
+
+def test_workflow_prompts_state_the_prose_ceilings_to_both_backends():
+    """OpenCode has no constrained decoding; an unstated cap burns the retry."""
+    workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.count(f"`summary` is capped at {gate.SUMMARY_MAX} characters") == 2
+    assert workflow.count(f"every `assessment` at {gate.ASSESSMENT_MAX}") == 2
 
 
 def test_workflow_materializes_large_diffs_from_inert_git_objects():
@@ -921,7 +998,12 @@ def test_merge_reassembles_one_full_coverage_review(tmp_path):
 
     merged = json.loads(output_path.read_text(encoding="utf-8"))
     # The merged result is itself a fully valid full-coverage review.
-    assert validate_result(merged, _scope(), DIFF) == merged
+    # The merged result is itself a fully valid full-coverage review, under the
+    # ceiling that matches its shape: one bounded summary per lens.
+    assert (
+        validate_result(merged, _scope(), DIFF, summary_maximum=gate.merged_summary_maximum())
+        == merged
+    )
     assert merged["reviewed_categories"] == sorted(REQUIRED_CATEGORIES)
     assert [finding["category"] for finding in merged["findings"]] == ["fail-open-failure-paths"]
     assert all(entry["area"].split(": ", 1)[0] in gate.LENSES for entry in merged["review_context"])
@@ -1023,10 +1105,18 @@ def test_wide_merged_lens_evidence_degrades_instead_of_failing_closed():
     posting an incomplete verdict for a review that had actually succeeded.
     """
     normalized = validate_result(_result(), _scope(), DIFF)
-    normalized["summary"] = "s" * 30000
+    # Every value here is within the per-field ceilings the validator now
+    # enforces: the overflow is the files-times-lenses count of legitimately
+    # bounded entries, not one runaway string.
+    summary = normalized["summary"]
+    normalized["summary"] = summary + "s" * (gate.merged_summary_maximum() - len(summary))
     normalized["review_context"] = [
-        {"area": f"lens-{index}: area", "files": ["old.py"], "assessment": "c" * 20000}
-        for index in range(5)
+        {
+            "area": f"lens-{index % len(gate.LENSES)}: area {index}",
+            "files": ["old.py" if index % 2 else "new.py"],
+            "assessment": "c" * gate.ASSESSMENT_MAX,
+        }
+        for index in range(200)
     ]
     digest = artifact_digest(normalized)
 
@@ -1038,12 +1128,15 @@ def test_wide_merged_lens_evidence_degrades_instead_of_failing_closed():
     )
 
     assert len(rendered.encode("utf-8")) <= gate._PUBLISHED_BODY_LIMIT
-    # Degraded, but never silently: both elisions say what was cut and where
-    # the complete text lives.
-    assert f"summary truncated at {gate._SUMMARY_BUDGET} characters" in rendered
-    assert "5 reviewed area(s) covering 2 changed file(s)" in rendered
+    # Degraded, but never silently: the elision says what was cut and where the
+    # complete text lives.
+    assert "200 reviewed area(s) covering 2 changed file(s)" in rendered
     assert "exceed the published comment budget" in rendered
     assert "[footgun-review-validated-9](https://example.test/runs/9#artifacts)" in rendered
+    assert f"({gate.ARTIFACT_RETENTION_DAYS}-day retention)" in rendered
+    # The summary is bounded at the source, so it survives degradation whole —
+    # no lens loses its narrative to a character cut on the joined string.
+    assert normalized["summary"] in rendered
     # The digest binds the result, not this rendering, so `verify` still
     # matches the exact evidence marker.
     assert evidence_marker(HEAD_SHA, 0, digest) in rendered

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -37,8 +37,10 @@ from footgun_review_gate import (  # noqa: E402
     changed_line_anchors,
     evidence_marker,
     render_evidence,
+    review_bundle_findings,
     review_payload,
     validate_result,
+    validate_review_bundle,
     verify_posted_evidence,
 )
 
@@ -127,6 +129,17 @@ def _finding(**overrides) -> dict:
     }
     finding.update(overrides)
     return finding
+
+
+def _lens_result(lens: str, *, findings: list[dict] | None = None) -> dict:
+    result = _result(findings=findings)
+    result["reviewed_categories"] = list(reversed(gate.LENSES[lens]))
+    return result
+
+
+def _bundle(*, lens_results: dict[str, dict] | None = None) -> dict:
+    results = lens_results or {lens: _lens_result(lens) for lens in gate.LENSES}
+    return gate.merge_lens_results(results, _scope(), DIFF)
 
 
 def _run_attempt(tmp_path: Path, result: dict | None) -> tuple[Path, Path, Path]:
@@ -366,7 +379,10 @@ def test_prepare_reports_blocking_and_total_finding_counts(tmp_path):
         what_goes_wrong="Readers assume the field is wired to behavior when nothing consumes it.",
         fix="Wire the value to its consumer or remove the assignment.",
     )
-    result = _result(findings=[_finding(), advisory])
+    lens_results = {lens: _lens_result(lens) for lens in gate.LENSES}
+    lens_results["authority"]["findings"] = [_finding()]
+    lens_results["contracts"]["findings"] = [advisory]
+    bundle = _bundle(lens_results=lens_results)
     scope_path = tmp_path / "scope.json"
     diff_path = tmp_path / "review.diff"
     result_path = tmp_path / "result.json"
@@ -374,7 +390,7 @@ def test_prepare_reports_blocking_and_total_finding_counts(tmp_path):
     github_output = tmp_path / "github-output.txt"
     scope_path.write_text(json.dumps(_scope()), encoding="utf-8")
     diff_path.write_text(DIFF, encoding="utf-8")
-    result_path.write_text(json.dumps(result), encoding="utf-8")
+    result_path.write_text(json.dumps(bundle), encoding="utf-8")
 
     assert (
         gate.main(
@@ -400,6 +416,7 @@ def test_prepare_reports_blocking_and_total_finding_counts(tmp_path):
     assert "blocking_finding_count=1\n" in outputs
     evidence = (output_dir / "evidence.md").read_text(encoding="utf-8")
     assert "2 finding(s) — 1 blocking, 1 advisory" in evidence
+    assert json.loads((output_dir / "review-bundle.json").read_text(encoding="utf-8")) == bundle
 
 
 def test_block_step_fires_only_on_blocking_findings():
@@ -446,79 +463,83 @@ def test_finding_can_anchor_to_the_removed_side():
 
 
 def test_rendered_no_findings_evidence_is_specific_and_digest_bound():
-    normalized = validate_result(_result(), _scope(), DIFF)
-    digest = artifact_digest(normalized)
-    rendered = render_evidence(normalized, digest)
+    bundle = _bundle()
+    digest = artifact_digest(bundle)
+    rendered = render_evidence(bundle, digest)
 
     assert "no findings" in rendered
-    assert "2 changed file(s), 24 detector categories" in rendered
-    assert "old.py" in rendered
+    assert "2 changed file(s), 24 detector categories, 5/5 lenses" in rendered
+    assert "| `daft-shape` | `opencode` | validated |" in rendered
+    assert "| `authority` | `claude-code` | validated |" in rendered
+    assert "The change replaces an unsafe call" not in rendered
     assert evidence_marker(HEAD_SHA, 0, digest) in rendered
 
 
-def test_rendered_evidence_inlines_validated_artifact_and_run_link():
-    normalized = validate_result(_result(), _scope(), DIFF)
-    digest = artifact_digest(normalized)
+def test_rendered_evidence_links_to_operational_bundle_without_inlining_it():
+    bundle = _bundle()
+    digest = artifact_digest(bundle)
     rendered = render_evidence(
-        normalized,
+        bundle,
         digest,
         run_url="https://example.test/runs/7",
         artifact_name="footgun-review-validated-7",
     )
 
-    assert "<summary>Validated review artifact</summary>" in rendered
-    start = rendered.index("```json\n") + len("```json\n")
-    end = rendered.index("\n```\n", start)
-    assert json.loads(rendered[start:end]) == normalized
-    assert "[footgun-review-validated-7](https://example.test/runs/7#artifacts)" in rendered
-
-
-def test_inline_artifact_fence_outruns_backticks_in_findings():
-    finding = _finding(fix="Replace the call:\n```python\nsafe_call()\n```\nand keep the guard.")
-    normalized = validate_result(_result(findings=[finding]), _scope(), DIFF)
-    digest = artifact_digest(normalized)
-    rendered = render_evidence(normalized, digest)
-
-    assert "````json\n" in rendered
-    assert rendered.count("````") == 2
-
-
-def test_full_published_body_budget_defers_duplicated_artifact_to_workflow_run():
-    normalized = validate_result(_result(), _scope(), DIFF)
-    normalized["summary"] = "s" * 20000
-    normalized["review_context"][0]["assessment"] = "c" * 20000
-    digest = artifact_digest(normalized)
-    rendered = render_evidence(
-        normalized,
-        digest,
-        run_url="https://example.test/runs/7",
-        artifact_name="footgun-review-validated-7",
-    )
-
-    assert (
-        len(json.dumps(normalized, ensure_ascii=False).encode("utf-8")) < gate._PUBLISHED_BODY_LIMIT
-    )
-    assert len(rendered.encode("utf-8")) <= gate._PUBLISHED_BODY_LIMIT
-    assert "exceeds the inline comment budget" in rendered
     assert "```json" not in rendered
-    assert "[footgun-review-validated-7](https://example.test/runs/7#artifacts)" in rendered
+    assert "[workflow artifact](https://example.test/runs/7#artifacts)" in rendered
+    assert "`footgun-review-validated-7`" in rendered
+    assert f"{gate.FINAL_ARTIFACT_RETENTION_DAYS}-day operational retention" in rendered
+    assert f"`sha256:{digest}`" in rendered
+
+
+def test_receipt_size_is_independent_of_unbounded_lens_narration():
+    lens_results = {lens: _lens_result(lens) for lens in gate.LENSES}
+    for result in lens_results.values():
+        result["summary"] = "summary-" + "s" * 20000
+        result["review_context"][0]["assessment"] = "assessment-" + "c" * 20000
+    bundle = _bundle(lens_results=lens_results)
+    digest = artifact_digest(bundle)
+    rendered = render_evidence(
+        bundle,
+        digest,
+        run_url="https://example.test/runs/7",
+        artifact_name="footgun-review-validated-7",
+    )
+
+    assert len(json.dumps(bundle, ensure_ascii=False).encode("utf-8")) > gate._PUBLISHED_BODY_LIMIT
+    assert len(rendered.encode("utf-8")) <= gate._PUBLISHED_BODY_LIMIT
+    assert "summary-" not in rendered
+    assert "assessment-" not in rendered
+    assert "[workflow artifact](https://example.test/runs/7#artifacts)" in rendered
     assert evidence_marker(HEAD_SHA, 0, digest) in rendered
 
 
-def test_oversized_evidence_without_named_validated_artifact_fails_closed():
-    normalized = validate_result(_result(), _scope(), DIFF)
-    normalized["summary"] = "s" * 20000
-    normalized["review_context"][0]["assessment"] = "c" * 20000
-    digest = artifact_digest(normalized)
+def test_untrusted_artifact_metadata_cannot_turn_a_completed_review_incomplete():
+    bundle = _bundle()
+    digest = artifact_digest(bundle)
+    rendered = render_evidence(
+        bundle,
+        digest,
+        run_url=f"https://example.test/{'r' * 70000}",
+        artifact_name="a" * 70000,
+    )
 
-    with pytest.raises(GateError, match="named validated artifact"):
-        render_evidence(normalized, digest, run_url="https://example.test/runs/7")
+    assert len(rendered.encode("utf-8")) <= gate._PUBLISHED_BODY_LIMIT
+    assert "artifact link unavailable in this rendering" in rendered
+    assert evidence_marker(HEAD_SHA, 0, digest) in rendered
+
+
+def test_receipt_rejects_a_digest_that_does_not_bind_its_bundle():
+    bundle = _bundle()
+
+    with pytest.raises(GateError, match="digest does not match"):
+        render_evidence(bundle, "0" * 64)
 
 
 def test_normalize_command_does_not_render_unpublished_evidence(tmp_path):
     result = _result()
-    result["summary"] = "s" * gate.SUMMARY_MAX
-    result["review_context"][0]["assessment"] = "c" * gate.ASSESSMENT_MAX
+    result["summary"] = "summary-" + "s" * 20000
+    result["review_context"][0]["assessment"] = "assessment-" + "c" * 20000
     scope_path = tmp_path / "scope.json"
     diff_path = tmp_path / "review.diff"
     result_path = tmp_path / "result.json"
@@ -544,7 +565,11 @@ def test_normalize_command_does_not_render_unpublished_evidence(tmp_path):
         == 0
     )
 
-    assert json.loads(output_path.read_text(encoding="utf-8"))["summary"] == "s" * gate.SUMMARY_MAX
+    normalized = json.loads(output_path.read_text(encoding="utf-8"))
+    assert normalized["summary"] == result["summary"]
+    assert (
+        normalized["review_context"][0]["assessment"] == result["review_context"][0]["assessment"]
+    )
     assert list(output_path.parent.iterdir()) == [output_path]
 
 
@@ -587,81 +612,59 @@ def test_workflow_has_one_bounded_validator_feedback_retry():
     assert "Require detector completion" not in workflow
 
 
-@pytest.mark.parametrize(
-    ("mutation", "message"),
-    [
-        (
-            lambda result: result.update(summary="s" * (gate.SUMMARY_MAX + 1)),
-            f"summary must contain at most {gate.SUMMARY_MAX} characters",
-        ),
-        (
-            lambda result: result["review_context"][0].update(
-                assessment="c" * (gate.ASSESSMENT_MAX + 1)
-            ),
-            f"assessment must contain at most {gate.ASSESSMENT_MAX} characters",
-        ),
-    ],
-)
-def test_narration_over_the_prose_ceiling_is_rejected(mutation, message):
-    """Bound the prose at the source, not at render time.
-
-    `review_context` must cover every changed file and every lens reviews the
-    whole diff, so unbounded narration grows the published evidence as
-    files x lenses. #663 (71 files) rendered a 51KB comment that was mostly
-    per-lens narration of the categories that did not apply, and the head
-    before it overran the 60KB limit outright.
-    """
+def test_review_narration_is_not_generation_capped_without_quality_evidence():
     result = _result()
-    mutation(result)
+    result["summary"] = "summary-" + "s" * 20000
+    result["review_context"][0]["assessment"] = "assessment-" + "c" * 20000
 
-    with pytest.raises(GateError) as error:
-        validate_result(result, _scope(), DIFF)
+    normalized = validate_result(result, _scope(), DIFF)
 
-    assert message in str(error.value)
+    assert normalized["summary"] == result["summary"]
+    assert (
+        normalized["review_context"][0]["assessment"] == result["review_context"][0]["assessment"]
+    )
 
 
-def test_constrained_schema_mirrors_the_validator_prose_ceilings():
-    """Claude Code decodes against this schema; drift would spend a retry."""
+def test_constrained_schema_does_not_turn_publication_budget_into_model_policy():
     schema = gate.result_schema()
     properties = schema["properties"]
 
-    assert properties["summary"]["maxLength"] == gate.SUMMARY_MAX
+    assert "maxLength" not in properties["summary"]
     context_item = properties["review_context"]["items"]["properties"]
-    assert context_item["assessment"]["maxLength"] == gate.ASSESSMENT_MAX
+    assert "maxLength" not in context_item["assessment"]
 
 
-def test_merged_summary_ceiling_is_derived_from_the_lens_partition():
-    """The merged ceiling follows from the per-lens one, not a second knob."""
-    merged = gate.merge_lens_results(
-        {lens: _lens_result(lens) for lens in gate.LENSES}, _scope(), DIFF
+def test_bundle_preserves_each_lens_without_concatenating_narration():
+    lens_results = {lens: _lens_result(lens) for lens in gate.LENSES}
+    for lens, result in lens_results.items():
+        result["summary"] = f"{lens} " + "s" * 100
+
+    bundle = _bundle(lens_results=lens_results)
+
+    assert "summary" not in bundle
+    assert "review_context" not in bundle
+    assert [receipt["result"]["summary"] for receipt in bundle["lenses"]] == [
+        lens_results[lens]["summary"] for lens in gate.LENSES
+    ]
+
+
+def test_workflow_retains_the_complete_bundle_as_operational_evidence():
+    workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.count("retention-days: 1") == 1
+    assert workflow.count(f"retention-days: {gate.FINAL_ARTIFACT_RETENTION_DAYS}") == 1
+    assert "path: ${{ github.workspace }}/.footgun-review-output/validated/review-bundle.json" in (
+        workflow
     )
-
-    assert len(merged["summary"]) <= gate.merged_summary_maximum()
-    # Derived, not a tuned literal: adding a lens moves the ceiling with it.
-    assert gate.merged_summary_maximum() >= gate.SUMMARY_MAX * len(gate.LENSES)
+    assert '--output "${REVIEW_DIR}/validated/review-bundle.json"' in workflow
+    assert '--result "${RUNNER_TEMP}/detector-result/review-bundle.json"' in workflow
 
 
-def test_published_artifact_outlives_the_elisions_that_point_at_it():
-    """Every degraded rung says "read the complete text in the artifact".
-
-    At the previous `retention-days: 1`, a degraded comment became a permanent
-    record pointing at a link that died the next morning, and
-    `verify_posted_evidence` only checks the marker, so nothing noticed.
-    """
+def test_workflow_prompts_do_not_impose_unevaluated_prose_caps():
     workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
 
-    assert gate.ARTIFACT_RETENTION_DAYS > 1
-    uploads = workflow.count("uses: actions/upload-artifact@")
-    assert uploads == 2
-    assert workflow.count(f"retention-days: {gate.ARTIFACT_RETENTION_DAYS}") == uploads
-
-
-def test_workflow_prompts_state_the_prose_ceilings_to_both_backends():
-    """OpenCode has no constrained decoding; an unstated cap burns the retry."""
-    workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
-
-    assert workflow.count(f"`summary` is capped at {gate.SUMMARY_MAX} characters") == 2
-    assert workflow.count(f"every `assessment` at {gate.ASSESSMENT_MAX}") == 2
+    assert "`summary` is capped at" not in workflow
+    assert "every `assessment` at" not in workflow
 
 
 def test_workflow_materializes_large_diffs_from_inert_git_objects():
@@ -804,9 +807,11 @@ def test_a_superseded_review_never_publishes_an_incomplete_verdict():
 
 
 def test_review_payload_batches_each_finding_as_an_inline_thread():
-    normalized = validate_result(_result(findings=[_finding()]), _scope(), DIFF)
-    digest = artifact_digest(normalized)
-    payload = review_payload(normalized, digest)
+    lens_results = {lens: _lens_result(lens) for lens in gate.LENSES}
+    lens_results["authority"]["findings"] = [_finding()]
+    bundle = _bundle(lens_results=lens_results)
+    digest = artifact_digest(bundle)
+    payload = review_payload(bundle, digest)
 
     assert payload["commit_id"] == HEAD_SHA
     assert payload["event"] == "COMMENT"
@@ -917,12 +922,6 @@ def test_observability_categories_extend_failure_and_unwind_review():
     assert "error-path-unwind" in REQUIRED_CATEGORIES
 
 
-def _lens_result(lens: str, *, findings: list[dict] | None = None) -> dict:
-    result = _result(findings=findings)
-    result["reviewed_categories"] = list(reversed(gate.LENSES[lens]))
-    return result
-
-
 def test_lenses_partition_required_categories():
     """Every required category belongs to exactly one non-empty lens.
 
@@ -965,7 +964,7 @@ def test_lens_schema_narrows_the_category_enum():
     ] == list(REQUIRED_CATEGORIES)
 
 
-def test_merge_reassembles_one_full_coverage_review(tmp_path):
+def test_merge_packages_one_full_coverage_review_bundle(tmp_path):
     results_dir = tmp_path / "lenses"
     results_dir.mkdir()
     for lens in gate.LENSES:
@@ -975,7 +974,7 @@ def test_merge_reassembles_one_full_coverage_review(tmp_path):
         )
     scope_path = tmp_path / "scope.json"
     diff_path = tmp_path / "review.diff"
-    output_path = tmp_path / "validated" / "normalized.json"
+    output_path = tmp_path / "validated" / "review-bundle.json"
     scope_path.write_text(json.dumps(_scope()), encoding="utf-8")
     diff_path.write_text(DIFF, encoding="utf-8")
 
@@ -996,18 +995,56 @@ def test_merge_reassembles_one_full_coverage_review(tmp_path):
         == 0
     )
 
-    merged = json.loads(output_path.read_text(encoding="utf-8"))
-    # The merged result is itself a fully valid full-coverage review.
-    # The merged result is itself a fully valid full-coverage review, under the
-    # ceiling that matches its shape: one bounded summary per lens.
-    assert (
-        validate_result(merged, _scope(), DIFF, summary_maximum=gate.merged_summary_maximum())
-        == merged
+    bundle = json.loads(output_path.read_text(encoding="utf-8"))
+    assert validate_review_bundle(bundle, _scope(), DIFF) == bundle
+    assert bundle["kind"] == gate.REVIEW_BUNDLE_KIND
+    assert bundle["reviewed_categories"] == sorted(REQUIRED_CATEGORIES)
+    assert "summary" not in bundle
+    assert "review_context" not in bundle
+    assert "findings" not in bundle
+    assert [receipt["lens"] for receipt in bundle["lenses"]] == list(gate.LENSES)
+    assert [receipt["backend"] for receipt in bundle["lenses"]] == [
+        gate.LENS_BACKENDS[lens] for lens in gate.LENSES
+    ]
+    assert all(receipt["status"] == "validated" for receipt in bundle["lenses"])
+    assert all(
+        receipt["artifact_digest"] == artifact_digest(receipt["result"])
+        for receipt in bundle["lenses"]
     )
-    assert merged["reviewed_categories"] == sorted(REQUIRED_CATEGORIES)
-    assert [finding["category"] for finding in merged["findings"]] == ["fail-open-failure-paths"]
-    assert all(entry["area"].split(": ", 1)[0] in gate.LENSES for entry in merged["review_context"])
-    assert all(f"[{lens}]" in merged["summary"] for lens in gate.LENSES)
+    assert [finding["category"] for finding in review_bundle_findings(bundle)] == [
+        "fail-open-failure-paths"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda bundle: bundle["lenses"][0].update(backend="claude-code"),
+            "backend must be",
+        ),
+        (
+            lambda bundle: bundle["lenses"][0].update(status="failed"),
+            "status must be 'validated'",
+        ),
+        (
+            lambda bundle: bundle["lenses"][0]["result"].update(
+                summary=bundle["lenses"][0]["result"]["summary"] + " tampered"
+            ),
+            "digest does not match",
+        ),
+        (
+            lambda bundle: bundle["lenses"].pop(),
+            "lenses do not match",
+        ),
+    ],
+)
+def test_review_bundle_rejects_completion_metadata_or_evidence_tampering(mutation, message):
+    bundle = json.loads(json.dumps(_bundle()))
+    mutation(bundle)
+
+    with pytest.raises(GateError, match=message):
+        validate_review_bundle(bundle, _scope(), DIFF)
 
 
 def test_merge_fails_closed_on_a_missing_lens_result(tmp_path):
@@ -1042,9 +1079,9 @@ def test_merge_deduplicates_identical_findings_within_a_lens():
     lens_results = {lens: _lens_result(lens) for lens in gate.LENSES}
     lens_results["authority"]["findings"] = [_finding(), _finding()]
 
-    merged = gate.merge_lens_results(lens_results, _scope(), DIFF)
+    bundle = gate.merge_lens_results(lens_results, _scope(), DIFF)
 
-    assert len(merged["findings"]) == 1
+    assert len(review_bundle_findings(bundle)) == 1
 
 
 def test_extract_recovers_the_structured_object_from_fenced_prose():
@@ -1076,11 +1113,14 @@ def test_extract_command_passes_unparsable_output_through(tmp_path):
     assert output_path.read_text(encoding="utf-8") == "no structured result here { broken"
 
 
-def test_workflow_matrix_names_every_lens_exactly_once():
+def test_workflow_matrix_names_every_lens_and_backend_exactly_once():
     workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
-    matrix_lenses = re.findall(r"- lens: ([a-z-]+)", workflow)
+    matrix_entries = re.findall(
+        r"- lens: ([a-z-]+)\n\s+backend: ([a-z-]+)",
+        workflow,
+    )
 
-    assert sorted(matrix_lenses) == sorted(gate.LENSES)
+    assert dict(matrix_entries) == gate.LENS_BACKENDS
 
 
 def test_merge_dedupe_never_softens_a_blocking_finding():
@@ -1089,66 +1129,113 @@ def test_merge_dedupe_never_softens_a_blocking_finding():
     lens_results = {lens: _lens_result(lens) for lens in gate.LENSES}
     lens_results["authority"]["findings"] = [_finding(severity="advisory"), _finding()]
 
-    merged = gate.merge_lens_results(lens_results, _scope(), DIFF)
+    bundle = gate.merge_lens_results(lens_results, _scope(), DIFF)
 
-    assert [finding["severity"] for finding in merged["findings"]] == ["blocking"]
+    assert [finding["severity"] for finding in review_bundle_findings(bundle)] == ["blocking"]
 
 
-def test_wide_merged_lens_evidence_degrades_instead_of_failing_closed():
-    """A merged lens review over a wide diff must still publish.
+def test_merge_prepare_publish_contract_is_independent_of_narration_size(tmp_path):
+    """Exercise the workflow's real merge → prepare → publish identity path."""
+    results_dir = tmp_path / "lenses"
+    results_dir.mkdir()
+    for lens in gate.LENSES:
+        findings = [_finding()] if lens == "authority" else None
+        result = _lens_result(lens, findings=findings)
+        result["summary"] = f"summary-{lens}-" + "s" * 20000
+        for entry in result["review_context"]:
+            entry["assessment"] = f"assessment-{lens}-" + "a" * 20000
+        (results_dir / f"{lens}.json").write_text(json.dumps(result), encoding="utf-8")
 
-    Every lens contributes its own summary and its own context entry per
-    changed file, so the merged prose is roughly lens-count times a single
-    detector's. On PR #663 (61 files) that overran GitHub's comment limit on
-    prose alone and the pre-matrix ladder — which only dropped the inline
-    artifact — failed the whole gate with "exceeds the published body limit",
-    posting an incomplete verdict for a review that had actually succeeded.
-    """
-    normalized = validate_result(_result(), _scope(), DIFF)
-    # Every value here is within the per-field ceilings the validator now
-    # enforces: the overflow is the files-times-lenses count of legitimately
-    # bounded entries, not one runaway string.
-    summary = normalized["summary"]
-    normalized["summary"] = summary + "s" * (gate.merged_summary_maximum() - len(summary))
-    normalized["review_context"] = [
-        {
-            "area": f"lens-{index % len(gate.LENSES)}: area {index}",
-            "files": ["old.py" if index % 2 else "new.py"],
-            "assessment": "c" * gate.ASSESSMENT_MAX,
-        }
-        for index in range(200)
-    ]
-    digest = artifact_digest(normalized)
+    scope_path = tmp_path / "scope.json"
+    diff_path = tmp_path / "review.diff"
+    bundle_path = tmp_path / "merge-output" / "review-bundle.json"
+    output_dir = tmp_path / "prepare-output"
+    github_output = tmp_path / "github-output.txt"
+    scope_path.write_text(json.dumps(_scope()), encoding="utf-8")
+    diff_path.write_text(DIFF, encoding="utf-8")
 
-    rendered = render_evidence(
-        normalized,
-        digest,
-        run_url="https://example.test/runs/9",
-        artifact_name="footgun-review-validated-9",
+    assert (
+        gate.main(
+            [
+                "merge",
+                "--scope",
+                str(scope_path),
+                "--diff",
+                str(diff_path),
+                "--results-dir",
+                str(results_dir),
+                "--output",
+                str(bundle_path),
+            ]
+        )
+        == 0
+    )
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    assert len(json.dumps(bundle).encode("utf-8")) > gate._PUBLISHED_BODY_LIMIT
+
+    assert (
+        gate.main(
+            [
+                "prepare",
+                "--scope",
+                str(scope_path),
+                "--diff",
+                str(diff_path),
+                "--result",
+                str(bundle_path),
+                "--output-dir",
+                str(output_dir),
+                "--github-output",
+                str(github_output),
+                "--artifact-name",
+                "footgun-review-validated-9",
+                "--run-url",
+                "https://example.test/runs/9",
+            ]
+        )
+        == 0
     )
 
-    assert len(rendered.encode("utf-8")) <= gate._PUBLISHED_BODY_LIMIT
-    # Degraded, but never silently: the elision says what was cut and where the
-    # complete text lives.
-    assert "200 reviewed area(s) covering 2 changed file(s)" in rendered
-    assert "exceed the published comment budget" in rendered
-    assert "[footgun-review-validated-9](https://example.test/runs/9#artifacts)" in rendered
-    assert f"({gate.ARTIFACT_RETENTION_DAYS}-day retention)" in rendered
-    # The summary is bounded at the source, so it survives degradation whole —
-    # no lens loses its narrative to a character cut on the joined string.
-    assert normalized["summary"] in rendered
-    # The digest binds the result, not this rendering, so `verify` still
-    # matches the exact evidence marker.
-    assert evidence_marker(HEAD_SHA, 0, digest) in rendered
+    prepared_bundle = json.loads((output_dir / "review-bundle.json").read_text(encoding="utf-8"))
+    assert prepared_bundle == bundle
+    digest = artifact_digest(bundle)
+    outputs = github_output.read_text(encoding="utf-8")
+    assert f"artifact_digest={digest}\n" in outputs
+    assert "finding_count=1\n" in outputs
+    assert "blocking_finding_count=1\n" in outputs
+
+    evidence = (output_dir / "evidence.md").read_text(encoding="utf-8")
+    assert len(evidence.encode("utf-8")) <= gate._PUBLISHED_BODY_LIMIT
+    assert "summary-authority-" not in evidence
+    assert "assessment-authority-" not in evidence
+    assert "[workflow artifact](https://example.test/runs/9#artifacts)" in evidence
+    assert evidence_marker(HEAD_SHA, 1, digest) in evidence
+
+    payload = json.loads((output_dir / "review.json").read_text(encoding="utf-8"))
+    assert payload["body"] == evidence.rstrip("\n")
+    assert len(payload["comments"]) == 1
+    review = _bot_item(id=17, commit_id=HEAD_SHA, body=payload["body"])
+    comments = [
+        _bot_item(pull_request_review_id=17, body=comment["body"])
+        for comment in payload["comments"]
+    ]
+    verify_posted_evidence(
+        issue_comments=[],
+        reviews=[review],
+        review_comments=comments,
+        head_sha=HEAD_SHA,
+        finding_count=1,
+        digest=digest,
+    )
 
 
-def test_evidence_degradation_keeps_full_prose_whenever_it_fits():
-    normalized = validate_result(_result(), _scope(), DIFF)
-    digest = artifact_digest(normalized)
+def test_compact_receipt_omits_model_narration_even_when_it_would_fit():
+    bundle = _bundle()
+    digest = artifact_digest(bundle)
 
-    rendered = render_evidence(normalized, digest)
+    rendered = render_evidence(bundle, digest)
 
-    assert "truncated at" not in rendered
-    assert "reviewed area(s) covering" not in rendered
-    assert normalized["summary"] in rendered
-    assert normalized["review_context"][0]["assessment"] in rendered
+    for receipt in bundle["lenses"]:
+        assert receipt["result"]["summary"] not in rendered
+        for entry in receipt["result"]["review_context"]:
+            assert entry["assessment"] not in rendered


### PR DESCRIPTION
## Why

#664 exposed a publication-contract failure: five complete lens reviews were
concatenated into another model-shaped result, repeated as prose, and embedded
again as JSON in one GitHub comment. A successful analysis could therefore
become an "incomplete" review solely because its presentation exceeded the
comment budget.

The first implementation on this branch tried to control that growth with
model-generation caps. It also revalidated the merged result through the
single-lens path during `prepare`, so ordinary multi-lens summaries failed
after a successful merge. More importantly, prose length is not evidence of
review quality and should not be part of the completion oracle.

## Contract

- Preserve every complete validated lens result in one
  `archetype-footgun-review-bundle`.
- Record lens, backend, validated status, and a canonical SHA-256 digest beside
  each result; bind the bundle itself to the exact head, files, categories, and
  another canonical digest.
- Revalidate the bundle as a bundle during `prepare`; never reinterpret it as a
  single model response.
- Publish a compact receipt containing exact head, scope counts, lens/backend
  status, finding counts, per-lens digests, bundle digest, and workflow artifact
  location.
- Keep substantive findings in their existing inline review threads, with the
  existing blocking/advisory semantics.
- Never duplicate model summaries, context narration, or the structured bundle
  in the PR comment. Publication size is therefore independent of narration
  size.
- Treat untrusted/oversized artifact metadata as a presentation degradation,
  not a failed review; the fixed-size digest receipt remains publishable.
- Retain matrix transfer artifacts for one day and the complete final bundle
  for 90 days of explicitly operational—not permanent—evidence. The digest
  remains in the PR receipt after artifact expiry.
- Remove the unevaluated summary and assessment generation caps.

## Executable evidence

- `uv run pytest -q tests/scripts/test_footgun_review_gate.py` — 68 passed.
- `make static` — passed.
- `make ci` — passed: 2,491 tests passed, 6 skipped, 89.01% coverage;
  regression/spec/capability evaluations, package/install smoke, operational
  scenarios, and documentation build all passed.

The focused contract includes a real
`merge → prepare → publish payload → verify` path whose complete bundle exceeds
the 60 KB publication budget. It proves the bundle survives unchanged, the
receipt remains bounded, and the posted marker matches the exact bundle digest.
Tampered backend/status metadata, lens evidence, or digests fail closed.

The deterministic review on this PR necessarily publishes with the protected
base's pre-change renderer: every detector job intentionally checks out
`base.sha` and treats the candidate head as inert diff data. Candidate behavior
is exercised by the focused and Quality CI tests above; once merged, this
implementation becomes the trusted renderer for subsequent PRs.

## Deliberate follow-ups

This PR establishes the evidence substrate only. Separate changes should:

1. expand the matrix from one reviewer per lens to `lens × reviewer`, preserve
   reviewer provenance, and deterministically aggregate the union of findings
   within each lens without majority-vote suppression; and
2. generate a head-bound human design-review brief from the issue/specification,
   repository architecture sources, exact diff, and validated lens aggregates.
   The generator prepares the decision surface; human approval remains human.
