### PR TITLE
fix: keep Modal mission sandboxes alive

### DIFF
--- a/src/archetype/missions/sandboxes/modal.py
+++ b/src/archetype/missions/sandboxes/modal.py
@@ -729,6 +729,8 @@ class ModalSandboxBackend:
             else self._default_image(modal)
         )
         sandbox = await modal.Sandbox.create.aio(
+            "sleep",
+            "infinity",
             app=app,
             image=image,
             timeout=self.config.login_timeout_seconds,
@@ -855,6 +857,8 @@ class ModalSandboxBackend:
         )
         metadata = spec.metadata_dict()
         auth_sandbox = await modal.Sandbox.create.aio(
+            "sleep",
+            "infinity",
             app=app,
             image=image,
             timeout=spec.timeout_seconds,
@@ -865,6 +869,8 @@ class ModalSandboxBackend:
         )
         try:
             sandbox = await modal.Sandbox.create.aio(
+                "sleep",
+                "infinity",
                 app=app,
                 image=image,
                 timeout=spec.timeout_seconds,

--- a/tests/missions/test_modal_agent_sandbox.py
+++ b/tests/missions/test_modal_agent_sandbox.py
@@ -1023,7 +1023,8 @@ def _fake_modal(sandboxes: list[object]):
         calls: list[dict[str, object]] = []
 
         @classmethod
-        async def aio(cls, **kwargs):
+        async def aio(cls, *args, **kwargs):
+            kwargs["command"] = args
             cls.calls.append(kwargs)
             candidate = sandboxes.pop(0)
             if isinstance(candidate, BaseException):
@@ -1112,6 +1113,7 @@ async def test_modal_backend_create_restore_and_login_lifecycle(
         command[:3] == ("codex", "login", "--device-auth") for command in resources[4].commands
     )
     assert resources[4].terminate.result is None
+    assert all(call["command"] == ("sleep", "infinity") for call in fake_modal.Sandbox.create.calls)
 
     with pytest.raises(ValueError, match="non-Modal"):
         await backend.create(SandboxSpec("docker", backend.environment, "/workspace/repo"))


### PR DESCRIPTION
## Summary

- start login, author, and restore Modal sandboxes with a long-lived command
- prevent the image's default `uv` entrypoint from exiting before mission work
- assert every sandbox creation receives the explicit keepalive command

## Why

The real Agent Mission proof reached Modal but found that a bare sandbox using
the base image exited immediately because its default entrypoint is not a
long-lived process. This is an independent provider-lifetime defect and blocks
the later Activity/Modal parity slice.

Closes no issue; this is the independent prerequisite found while proving
#671.

## Validation

- `uv run pytest -q tests/missions/test_modal_agent_sandbox.py` — 29 passed
- `uv run ruff check src/archetype/missions/sandboxes/modal.py tests/missions/test_modal_agent_sandbox.py`
