### PR TITLE
feat: add the durable Activity control plane

### DIFF
--- a/docs/guide/atomic-visibility.md
+++ b/docs/guide/atomic-visibility.md
@@ -96,10 +96,10 @@ processors and command materialization are not replayed, and the same retained
 receipt is retried before another tick. Required projection is not a public
 hook. It runs under exact-world authority and is limited to idempotently
 persisting deterministic intent keyed by its consumer and receipt identity; it
-MUST NOT perform provider or sandbox I/O. A downstream resource consumer may
-claim that intent and perform external effects outside the world lock. When
-that work is durably coordinated into a later committed observation, it follows
-the [Activity](activities.md) contract: at-least-once delivery, fenced control
+MUST NOT perform provider or sandbox I/O. An Activity worker may claim that
+intent and perform external effects outside the world lock. When that work is
+durably coordinated into a later committed observation, it follows the
+[Activity](activities.md) contract: at-least-once delivery, fenced control
 writes, provider reconciliation, durable result reference, and exact-receipt
 settlement.
 

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -24,6 +24,7 @@ machine authority; this page is its review surface.
 | `commands.failure.preserves_progress` | `commands` | high | [docs/guide/specification.md](../guide/specification.md) — Command ledger, scheduler, and dispatcher | pytest: 1; eval: 4 | `pr`, `main`, `release` |
 | `world.tick.atomic_visibility` | `world` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 10. Supported durability profile | pytest: 1; eval: 2 | `pr`, `main`, `release` |
 | `world.writer.fenced` | `world` | high | [docs/guide/world-lifecycle.md](../guide/world-lifecycle.md) — 6. `resume_world` (fenced mutable cold resume) | pytest: 2; eval: 3 | `pr`, `main`, `release` |
+| `activities.durable_control` | `activities` | high | [docs/guide/activities.md](../guide/activities.md) — 2. The committed-state protocol | pytest: 1; static: 2 | `pr`, `main`, `release` |
 | `world.lifecycle.idempotent` | `world` | high | [docs/guide/world-lifecycle.md](../guide/world-lifecycle.md) — 2. World lifecycle operations | pytest: 2; eval: 2 | `pr`, `main`, `release` |
 | `world.fork.lineage` | `world` | high | [docs/guide/world-lifecycle.md](../guide/world-lifecycle.md) — 4. `fork_world` | pytest: 2; eval: 1 | `pr`, `main`, `release` |
 | `world.run_identity.cold_resume` | `world` | high | [docs/guide/world-lifecycle.md](../guide/world-lifecycle.md) — 6. `resume_world` (fenced mutable cold resume) | pytest: 2; eval: 1 | `pr`, `main`, `release` |

--- a/quality/architecture.d/activities.toml
+++ b/quality/architecture.d/activities.toml
@@ -1,0 +1,16 @@
+# Architecture policy fragment: activities.
+# Merged into quality/architecture.toml by scripts/check_architecture.py;
+# fragments may declare only rule/exception arrays, never scalar policy.
+
+[[top_level_family_rule]]
+name = "activities-domain-family"
+consumer = "archetype.activities"
+allowed_families = ["archetype.storage"]
+
+[[module_rule]]
+module = "archetype.activities.service"
+allowed_interfaces = [
+  "archetype.core.interfaces.CommittedTickReceipt",
+  "archetype.storage.activity_catalog.interfaces.ActivityCatalog",
+]
+allowed_app = []

--- a/quality/architecture.toml
+++ b/quality/architecture.toml
@@ -3,6 +3,7 @@ source_root = "src"
 
 [concrete_services]
 types = [
+  "ActivityCoordinator",
   "AuditLog",
   "CommandScheduler",
   "MissionService",

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -265,6 +265,21 @@ benchmarks = []
 profiles = ["pr", "main", "release"]
 
 [[contract]]
+id = "activities.durable_control"
+source = "docs/guide/activities.md"
+section = "2. The committed-state protocol"
+owner = "activities"
+risk = "high"
+pytest = ["tests/activities/test_activity_catalog_contracts.py"]
+static = [
+  "scripts/check_architecture.py",
+  "scripts/check_observability.py",
+]
+evals = []
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
 id = "world.lifecycle.idempotent"
 source = "docs/guide/world-lifecycle.md"
 section = "2. World lifecycle operations"

--- a/quality/observability/activities.toml
+++ b/quality/observability/activities.toml
@@ -1,0 +1,26 @@
+version = 1
+owner = "activities"
+family = "activities"
+
+[[disposition]]
+operations = [
+  "interfaces.iActivityCoordinator.admit",
+  "interfaces.iActivityCoordinator.bind_provider_operation",
+  "interfaces.iActivityCoordinator.claim",
+  "interfaces.iActivityCoordinator.confirm_provider_operation_absent",
+  "interfaces.iActivityCoordinator.get",
+  "interfaces.iActivityCoordinator.has_unsettled",
+  "interfaces.iActivityCoordinator.pending",
+  "interfaces.iActivityCoordinator.pending_results",
+  "interfaces.iActivityCoordinator.record_result",
+  "interfaces.iActivityCoordinator.release",
+  "interfaces.iActivityCoordinator.settle_observation",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The local activity catalog's immutable admission, fenced attempt, provider-operation binding, bounded result reference, and exact observation settlement remain authoritative."
+evidence = [
+  "docs/guide/activities.md",
+  "tests/activities/test_activity_catalog_contracts.py",
+]
+rationale = "The coordinator emits no second authority signal; durable control facts and typed return values expose every admitted, ambiguous, recovered, and settled transition."

--- a/quality/observability/storage.toml
+++ b/quality/observability/storage.toml
@@ -8,6 +8,18 @@ replaces = ["interfaces.iStorageService"]
 
 [[disposition]]
 operations = [
+  "activity_catalog.interfaces.ActivityCatalog.admit_activity",
+  "activity_catalog.interfaces.ActivityCatalog.bind_provider_operation",
+  "activity_catalog.interfaces.ActivityCatalog.claim_activity",
+  "activity_catalog.interfaces.ActivityCatalog.close",
+  "activity_catalog.interfaces.ActivityCatalog.confirm_provider_operation_absent",
+  "activity_catalog.interfaces.ActivityCatalog.get_activity",
+  "activity_catalog.interfaces.ActivityCatalog.has_unsettled_activities",
+  "activity_catalog.interfaces.ActivityCatalog.list_incomplete_activities",
+  "activity_catalog.interfaces.ActivityCatalog.list_unobserved_results",
+  "activity_catalog.interfaces.ActivityCatalog.record_activity_result",
+  "activity_catalog.interfaces.ActivityCatalog.release_activity",
+  "activity_catalog.interfaces.ActivityCatalog.settle_activity_observation",
   "catalog.interface.ControlCatalog.register_world",
   "catalog.interface.ControlCatalog.retire_world_registration",
   "catalog.interface.ControlCatalog.set_world_status",
@@ -58,6 +70,7 @@ evidence = [
   "docs/guide/atomic-visibility.md",
   "docs/guide/artifacts.md",
   "docs/guide/service-protocols.md",
+  "tests/activities/test_activity_catalog_contracts.py",
   "tests/app/test_application_atomic_visibility.py",
   "tests/storage/test_remote_catalog_parity.py",
   "tests/storage/test_storage_execution.py",

--- a/src/archetype/activities/__init__.py
+++ b/src/archetype/activities/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Durable coordination of work between committed world states."""
+
+from archetype.activities.contracts import (
+    ActivityAdmission,
+    ActivityClaim,
+    ActivityClaimError,
+    ActivityConflictError,
+    ActivityNotFoundError,
+    ActivityResultRef,
+    ActivityRetryGuard,
+    ActivitySettlement,
+    ActivitySnapshot,
+)
+from archetype.activities.interfaces import iActivityCoordinator
+from archetype.activities.service import ActivityCoordinator
+
+__all__ = [
+    "ActivityAdmission",
+    "ActivityClaim",
+    "ActivityClaimError",
+    "ActivityConflictError",
+    "ActivityCoordinator",
+    "ActivityNotFoundError",
+    "ActivityResultRef",
+    "ActivityRetryGuard",
+    "ActivitySettlement",
+    "ActivitySnapshot",
+    "iActivityCoordinator",
+]

--- a/src/archetype/activities/contracts.py
+++ b/src/archetype/activities/contracts.py
@@ -1,0 +1,307 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic durable-activity control contracts.
+
+These values describe coordination between committed world states.  They do
+not describe a family's domain intent, provider recovery meaning, or ECS
+observation schema.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+
+from archetype.core.interfaces import CommittedTickReceipt
+from archetype.errors import ConflictError
+
+_MAX_ID_CHARS = 512
+_MAX_KIND_CHARS = 255
+_MAX_REF_CHARS = 4096
+_MAX_DIGEST_CHARS = 255
+_MAX_MEDIA_TYPE_CHARS = 255
+_MAX_PROVIDER_CHARS = 255
+_MAX_PROVIDER_OPERATION_CHARS = 1024
+
+
+def _require_bounded_text(value: str, field_name: str, max_chars: int) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{field_name} must be non-empty")
+    if len(value) > max_chars:
+        raise ValueError(f"{field_name} must be at most {max_chars} characters")
+
+
+def _require_receipt(value: CommittedTickReceipt, field_name: str) -> None:
+    if not isinstance(value, CommittedTickReceipt):
+        raise TypeError(f"{field_name} must be a CommittedTickReceipt")
+    _require_bounded_text(value.world_id, f"{field_name}.world_id", _MAX_ID_CHARS)
+    _require_bounded_text(value.run_id, f"{field_name}.run_id", _MAX_ID_CHARS)
+    if value.committed_tick < 0:
+        raise ValueError(f"{field_name}.committed_tick must be non-negative")
+    if value.visibility_token is None:
+        raise ValueError(f"{field_name}.visibility_token must be present")
+    _require_bounded_text(
+        value.visibility_token,
+        f"{field_name}.visibility_token",
+        _MAX_ID_CHARS,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityAdmission:
+    """One logical activity admitted from an exact committed tick.
+
+    ``activity_id`` is scoped to ``(source.world_id, kind)``.  Family-owned
+    identifiers such as mission dispatch IDs need not be globally unique.
+    """
+
+    activity_id: str
+    kind: str
+    source: CommittedTickReceipt
+    input_ref: str
+    input_digest: str
+
+    def __post_init__(self) -> None:
+        _require_bounded_text(self.activity_id, "activity_id", _MAX_ID_CHARS)
+        _require_bounded_text(self.kind, "activity kind", _MAX_KIND_CHARS)
+        _require_receipt(self.source, "activity source")
+        object.__setattr__(self, "source", _identity_receipt(self.source))
+        _require_bounded_text(self.input_ref, "activity input_ref", _MAX_REF_CHARS)
+        _require_bounded_text(
+            self.input_digest,
+            "activity input_digest",
+            _MAX_DIGEST_CHARS,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityResultRef:
+    """Bounded durable reference to an activity result.
+
+    Large payloads belong in Iceberg or an artifact store.  The control plane
+    retains only this address, digest, media type, and byte count.
+    """
+
+    ref: str
+    digest: str
+    media_type: str
+    size_bytes: int
+
+    def __post_init__(self) -> None:
+        _require_bounded_text(self.ref, "activity result ref", _MAX_REF_CHARS)
+        _require_bounded_text(
+            self.digest,
+            "activity result digest",
+            _MAX_DIGEST_CHARS,
+        )
+        _require_bounded_text(
+            self.media_type,
+            "activity result media_type",
+            _MAX_MEDIA_TYPE_CHARS,
+        )
+        if isinstance(self.size_bytes, bool) or not isinstance(self.size_bytes, int):
+            raise TypeError("activity result size_bytes must be an integer")
+        if self.size_bytes < 0:
+            raise ValueError("activity result size_bytes must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityRetryGuard:
+    """Bounded proof that confirmed absence makes a fresh attempt safe.
+
+    The owning provider adapter retains the guard's meaning.  Its durable
+    reference and digest must prove either provider-side atomic
+    idempotency/fencing or that every stale claimant is irrevocably unable to
+    start the prior operation.
+    """
+
+    ref: str
+    digest: str
+
+    def __post_init__(self) -> None:
+        _require_bounded_text(self.ref, "activity retry guard ref", _MAX_REF_CHARS)
+        _require_bounded_text(
+            self.digest,
+            "activity retry guard digest",
+            _MAX_DIGEST_CHARS,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ActivitySettlement:
+    """The exact later commit and result digest it durably observed."""
+
+    receipt: CommittedTickReceipt
+    result_digest: str
+
+    def __post_init__(self) -> None:
+        _require_receipt(self.receipt, "activity settlement receipt")
+        object.__setattr__(self, "receipt", _identity_receipt(self.receipt))
+        _require_bounded_text(
+            self.result_digest,
+            "activity settlement result_digest",
+            _MAX_DIGEST_CHARS,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ActivitySnapshot:
+    """Current durable facts for one logical activity, without a status enum."""
+
+    admission: ActivityAdmission
+    result: ActivityResultRef | None = None
+    settlement: ActivitySettlement | None = None
+    result_attempt: int | None = None
+    result_fence: int | None = None
+
+    def __post_init__(self) -> None:
+        result_identity = (self.result_attempt, self.result_fence)
+        if self.result is None and any(value is not None for value in result_identity):
+            raise ValueError("activity result identity cannot exist without a result")
+        if self.result is not None and any(value is None for value in result_identity):
+            raise ValueError("activity result requires attempt and fence identity")
+        if self.result_attempt is not None and self.result_attempt < 1:
+            raise ValueError("activity result_attempt must be positive")
+        if self.result_fence is not None and self.result_fence < 1:
+            raise ValueError("activity result_fence must be positive")
+        if self.settlement is not None and self.result is None:
+            raise ValueError("an activity cannot be settled before it has a result")
+        if (
+            self.settlement is not None
+            and self.result is not None
+            and self.settlement.result_digest != self.result.digest
+        ):
+            raise ValueError("activity settlement must bind the exact result digest")
+
+    @property
+    def result_pending_observation(self) -> bool:
+        """Whether a durable result still needs a later committed observation."""
+
+        return self.result is not None and self.settlement is None
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityClaim:
+    """One fenced worker claim over an activity.
+
+    An acquired claim with ``reconciliation_required`` authorizes only
+    provider-specific reconciliation and result recording.  It never
+    authorizes invocation of a new provider operation.
+    """
+
+    snapshot: ActivitySnapshot
+    acquired: bool
+    attempt: int | None = None
+    fence: int | None = None
+    owner: str | None = None
+    lease_expires_at: float | None = None
+    provider: str | None = None
+    provider_operation_id: str | None = None
+    retry_guard: ActivityRetryGuard | None = None
+    reconciles_attempt: int | None = None
+    reconciles_provider: str | None = None
+    reconciles_provider_operation_id: str | None = None
+
+    def __post_init__(self) -> None:
+        claim_values = (
+            self.attempt,
+            self.fence,
+            self.owner,
+            self.lease_expires_at,
+        )
+        if self.acquired and any(value is None for value in claim_values):
+            raise ValueError("an acquired activity claim requires complete lease identity")
+        if self.attempt is not None and self.attempt < 1:
+            raise ValueError("activity claim attempt must be positive")
+        if self.fence is not None and self.fence < 1:
+            raise ValueError("activity claim fence must be positive")
+        if self.lease_expires_at is not None and not isfinite(self.lease_expires_at):
+            raise ValueError("activity claim lease_expires_at must be finite")
+        if self.owner is not None:
+            _require_bounded_text(self.owner, "activity claim owner", _MAX_ID_CHARS)
+        if self.provider is not None:
+            _require_bounded_text(
+                self.provider,
+                "activity claim provider",
+                _MAX_PROVIDER_CHARS,
+            )
+        if self.provider_operation_id is not None:
+            _require_bounded_text(
+                self.provider_operation_id,
+                "activity claim provider_operation_id",
+                _MAX_PROVIDER_OPERATION_CHARS,
+            )
+        if self.retry_guard is not None and not isinstance(
+            self.retry_guard,
+            ActivityRetryGuard,
+        ):
+            raise TypeError("activity claim retry_guard must be an ActivityRetryGuard")
+        reconciliation_values = (
+            self.reconciles_attempt,
+            self.reconciles_provider,
+            self.reconciles_provider_operation_id,
+        )
+        if any(value is not None for value in reconciliation_values) and any(
+            value is None for value in reconciliation_values
+        ):
+            raise ValueError("activity reconciliation identity must be complete")
+
+    @property
+    def world_id(self) -> str:
+        return self.snapshot.admission.source.world_id
+
+    @property
+    def activity_id(self) -> str:
+        return self.snapshot.admission.activity_id
+
+    @property
+    def kind(self) -> str:
+        return self.snapshot.admission.kind
+
+    @property
+    def reconciliation_required(self) -> bool:
+        """Whether provider-specific reconciliation is required before settlement."""
+
+        return self.reconciles_provider_operation_id is not None
+
+
+class ActivityConflictError(ConflictError):
+    """A logical activity identity or immutable fact conflicts."""
+
+
+class ActivityNotFoundError(KeyError):
+    """No activity exists for the supplied world-and-kind-scoped identity."""
+
+
+class ActivityClaimError(ConflictError):
+    """A claim is stale or does not authorize the requested operation."""
+
+
+def _identity_receipt(receipt: CommittedTickReceipt) -> CommittedTickReceipt:
+    """Discard diagnostic command count while preserving exact commit identity."""
+
+    if receipt.commands_applied == 0:
+        return receipt
+    return CommittedTickReceipt(
+        world_id=receipt.world_id,
+        run_id=receipt.run_id,
+        committed_tick=receipt.committed_tick,
+        visibility_token=receipt.visibility_token,
+        commands_applied=0,
+    )
+
+
+__all__ = [
+    "ActivityAdmission",
+    "ActivityClaim",
+    "ActivityClaimError",
+    "ActivityConflictError",
+    "ActivityNotFoundError",
+    "ActivityResultRef",
+    "ActivityRetryGuard",
+    "ActivitySettlement",
+    "ActivitySnapshot",
+]

--- a/src/archetype/activities/interfaces.py
+++ b/src/archetype/activities/interfaces.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structural port for generic durable-activity coordination."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from archetype.activities.contracts import (
+    ActivityAdmission,
+    ActivityClaim,
+    ActivityResultRef,
+    ActivityRetryGuard,
+    ActivitySettlement,
+    ActivitySnapshot,
+)
+
+
+@runtime_checkable
+class iActivityCoordinator(Protocol):
+    """Coordinate durable work between two exact committed world states."""
+
+    async def admit(self, admission: ActivityAdmission) -> ActivitySnapshot: ...
+
+    async def get(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+    ) -> ActivitySnapshot | None: ...
+
+    async def claim(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        owner: str,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaim: ...
+
+    async def bind_provider_operation(
+        self,
+        claim: ActivityClaim,
+        provider: str,
+        operation_id: str,
+    ) -> ActivityClaim: ...
+
+    async def confirm_provider_operation_absent(
+        self,
+        claim: ActivityClaim,
+        guard: ActivityRetryGuard,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaim: ...
+
+    async def record_result(
+        self,
+        claim: ActivityClaim,
+        result: ActivityResultRef,
+    ) -> ActivitySnapshot: ...
+
+    async def release(self, claim: ActivityClaim) -> None: ...
+
+    async def has_unsettled(self, world_id: str) -> bool: ...
+
+    async def pending(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+    ) -> tuple[ActivitySnapshot, ...]: ...
+
+    async def pending_results(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+    ) -> tuple[ActivitySnapshot, ...]: ...
+
+    async def settle_observation(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        settlement: ActivitySettlement,
+    ) -> ActivitySnapshot: ...
+
+
+__all__ = ["iActivityCoordinator"]

--- a/src/archetype/activities/service.py
+++ b/src/archetype/activities/service.py
@@ -1,0 +1,371 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic durable-activity coordination over a physical catalog."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+
+from archetype.activities.contracts import (
+    ActivityAdmission,
+    ActivityClaim,
+    ActivityClaimError,
+    ActivityConflictError,
+    ActivityNotFoundError,
+    ActivityResultRef,
+    ActivityRetryGuard,
+    ActivitySettlement,
+    ActivitySnapshot,
+)
+from archetype.core.interfaces import CommittedTickReceipt
+from archetype.storage.activity_catalog.interfaces import ActivityCatalog
+from archetype.storage.activity_catalog.records import (
+    ActivityAdmissionRecord,
+    ActivityCatalogClaimError,
+    ActivityCatalogConflictError,
+    ActivityCatalogNotFoundError,
+    ActivityClaimRecord,
+    ActivityRecord,
+)
+
+
+class ActivityCoordinator:
+    """Coordinate admissions, fenced attempts, results, and observations.
+
+    Provider-specific execution and recovery remain above this class.  In
+    particular, a reconciliation claim carries prior provider identity but
+    provides no generic decision about whether an effect happened.
+    """
+
+    def __init__(self, catalog: ActivityCatalog) -> None:
+        self._catalog = catalog
+
+    async def admit(self, admission: ActivityAdmission) -> ActivitySnapshot:
+        record = await _translate_catalog_errors(
+            self._catalog.admit_activity(_admission_record(admission))
+        )
+        return _snapshot(record)
+
+    async def get(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+    ) -> ActivitySnapshot | None:
+        record = await _translate_catalog_errors(
+            self._catalog.get_activity(world_id, kind, activity_id)
+        )
+        return _snapshot(record) if record is not None else None
+
+    async def claim(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        owner: str,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaim:
+        record = await _translate_catalog_errors(
+            self._catalog.claim_activity(
+                world_id,
+                kind,
+                activity_id,
+                owner,
+                lease_seconds=lease_seconds,
+            )
+        )
+        return _claim(record)
+
+    async def bind_provider_operation(
+        self,
+        claim: ActivityClaim,
+        provider: str,
+        operation_id: str,
+    ) -> ActivityClaim:
+        record = await _translate_catalog_errors(
+            self._catalog.bind_provider_operation(
+                _claim_record(claim),
+                provider,
+                operation_id,
+            )
+        )
+        return _claim(record)
+
+    async def confirm_provider_operation_absent(
+        self,
+        claim: ActivityClaim,
+        guard: ActivityRetryGuard,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaim:
+        if not isinstance(guard, ActivityRetryGuard):
+            raise TypeError("guard must be an ActivityRetryGuard")
+        record = await _translate_catalog_errors(
+            self._catalog.confirm_provider_operation_absent(
+                _claim_record(claim),
+                guard.ref,
+                guard.digest,
+                lease_seconds=lease_seconds,
+            )
+        )
+        return _claim(record)
+
+    async def record_result(
+        self,
+        claim: ActivityClaim,
+        result: ActivityResultRef,
+    ) -> ActivitySnapshot:
+        record = await _translate_catalog_errors(
+            self._catalog.record_activity_result(
+                _claim_record(claim),
+                result_ref=result.ref,
+                result_digest=result.digest,
+                result_media_type=result.media_type,
+                result_size_bytes=result.size_bytes,
+            )
+        )
+        return _snapshot(record)
+
+    async def release(self, claim: ActivityClaim) -> None:
+        await _translate_catalog_errors(self._catalog.release_activity(_claim_record(claim)))
+
+    async def has_unsettled(self, world_id: str) -> bool:
+        return await _translate_catalog_errors(self._catalog.has_unsettled_activities(world_id))
+
+    async def pending(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+    ) -> tuple[ActivitySnapshot, ...]:
+        records = await _translate_catalog_errors(
+            self._catalog.list_incomplete_activities(
+                kind=kind,
+                world_id=world_id,
+                limit=limit,
+            )
+        )
+        return tuple(_snapshot(record) for record in records)
+
+    async def pending_results(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+    ) -> tuple[ActivitySnapshot, ...]:
+        records = await _translate_catalog_errors(
+            self._catalog.list_unobserved_results(
+                kind=kind,
+                world_id=world_id,
+                limit=limit,
+            )
+        )
+        return tuple(_snapshot(record) for record in records)
+
+    async def settle_observation(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        settlement: ActivitySettlement,
+    ) -> ActivitySnapshot:
+        receipt = settlement.receipt
+        record = await _translate_catalog_errors(
+            self._catalog.settle_activity_observation(
+                world_id,
+                kind,
+                activity_id,
+                observed_world_id=receipt.world_id,
+                observed_run_id=receipt.run_id,
+                observed_tick=receipt.committed_tick,
+                observed_visibility_token=receipt.visibility_token,
+                expected_result_digest=settlement.result_digest,
+            )
+        )
+        return _snapshot(record)
+
+
+def _admission_record(admission: ActivityAdmission) -> ActivityAdmissionRecord:
+    return ActivityAdmissionRecord(
+        activity_id=admission.activity_id,
+        kind=admission.kind,
+        source_world_id=admission.source.world_id,
+        source_run_id=admission.source.run_id,
+        source_tick=admission.source.committed_tick,
+        source_visibility_token=admission.source.visibility_token,
+        input_ref=admission.input_ref,
+        input_digest=admission.input_digest,
+    )
+
+
+def _claim_record(claim: ActivityClaim) -> ActivityClaimRecord:
+    return ActivityClaimRecord(
+        activity=_activity_record(claim.snapshot),
+        acquired=claim.acquired,
+        attempt=claim.attempt,
+        fence=claim.fence,
+        owner=claim.owner,
+        lease_expires_at=claim.lease_expires_at,
+        provider=claim.provider,
+        provider_operation_id=claim.provider_operation_id,
+        retry_guard_ref=(claim.retry_guard.ref if claim.retry_guard is not None else None),
+        retry_guard_digest=(claim.retry_guard.digest if claim.retry_guard is not None else None),
+        reconciles_attempt=claim.reconciles_attempt,
+        reconciles_provider=claim.reconciles_provider,
+        reconciles_provider_operation_id=claim.reconciles_provider_operation_id,
+    )
+
+
+def _activity_record(snapshot: ActivitySnapshot) -> ActivityRecord:
+    admission = snapshot.admission
+    result = snapshot.result
+    settlement = snapshot.settlement
+    return ActivityRecord(
+        activity_id=admission.activity_id,
+        kind=admission.kind,
+        source_world_id=admission.source.world_id,
+        source_run_id=admission.source.run_id,
+        source_tick=admission.source.committed_tick,
+        source_visibility_token=admission.source.visibility_token,
+        input_ref=admission.input_ref,
+        input_digest=admission.input_digest,
+        result_ref=result.ref if result is not None else None,
+        result_digest=result.digest if result is not None else None,
+        result_media_type=result.media_type if result is not None else None,
+        result_size_bytes=result.size_bytes if result is not None else None,
+        result_attempt=snapshot.result_attempt,
+        result_fence=snapshot.result_fence,
+        result_recorded_at=None,
+        observed_world_id=(settlement.receipt.world_id if settlement is not None else None),
+        observed_run_id=settlement.receipt.run_id if settlement is not None else None,
+        observed_tick=(settlement.receipt.committed_tick if settlement is not None else None),
+        observed_visibility_token=(
+            settlement.receipt.visibility_token if settlement is not None else None
+        ),
+        observed_result_digest=(settlement.result_digest if settlement is not None else None),
+        observed_at=None,
+        created_at="",
+        updated_at="",
+    )
+
+
+def _claim(record: ActivityClaimRecord) -> ActivityClaim:
+    return ActivityClaim(
+        snapshot=_snapshot(record.activity),
+        acquired=record.acquired,
+        attempt=record.attempt,
+        fence=record.fence,
+        owner=record.owner,
+        lease_expires_at=record.lease_expires_at,
+        provider=record.provider,
+        provider_operation_id=record.provider_operation_id,
+        retry_guard=_retry_guard(record),
+        reconciles_attempt=record.reconciles_attempt,
+        reconciles_provider=record.reconciles_provider,
+        reconciles_provider_operation_id=record.reconciles_provider_operation_id,
+    )
+
+
+def _retry_guard(record: ActivityClaimRecord) -> ActivityRetryGuard | None:
+    values = (record.retry_guard_ref, record.retry_guard_digest)
+    if all(value is None for value in values):
+        return None
+    if any(value is None for value in values):
+        raise RuntimeError("activity catalog contains a partial retry guard")
+    assert record.retry_guard_ref is not None
+    assert record.retry_guard_digest is not None
+    return ActivityRetryGuard(
+        ref=record.retry_guard_ref,
+        digest=record.retry_guard_digest,
+    )
+
+
+def _snapshot(record: ActivityRecord) -> ActivitySnapshot:
+    source = CommittedTickReceipt(
+        world_id=record.source_world_id,
+        run_id=record.source_run_id,
+        committed_tick=record.source_tick,
+        visibility_token=record.source_visibility_token,
+        commands_applied=0,
+    )
+    admission = ActivityAdmission(
+        activity_id=record.activity_id,
+        kind=record.kind,
+        source=source,
+        input_ref=record.input_ref,
+        input_digest=record.input_digest,
+    )
+    result_fields = (
+        record.result_ref,
+        record.result_digest,
+        record.result_media_type,
+        record.result_size_bytes,
+    )
+    result: ActivityResultRef | None
+    if all(value is None for value in result_fields):
+        result = None
+    elif any(value is None for value in result_fields):
+        raise RuntimeError("activity catalog contains a partial result reference")
+    else:
+        assert record.result_ref is not None
+        assert record.result_digest is not None
+        assert record.result_media_type is not None
+        assert record.result_size_bytes is not None
+        result = ActivityResultRef(
+            ref=record.result_ref,
+            digest=record.result_digest,
+            media_type=record.result_media_type,
+            size_bytes=record.result_size_bytes,
+        )
+
+    observation_fields = (
+        record.observed_world_id,
+        record.observed_run_id,
+        record.observed_tick,
+        record.observed_result_digest,
+    )
+    settlement: ActivitySettlement | None
+    if all(value is None for value in observation_fields):
+        settlement = None
+    elif any(value is None for value in observation_fields):
+        raise RuntimeError("activity catalog contains a partial observation settlement")
+    else:
+        assert record.observed_world_id is not None
+        assert record.observed_run_id is not None
+        assert record.observed_tick is not None
+        assert record.observed_result_digest is not None
+        settlement = ActivitySettlement(
+            CommittedTickReceipt(
+                world_id=record.observed_world_id,
+                run_id=record.observed_run_id,
+                committed_tick=record.observed_tick,
+                visibility_token=record.observed_visibility_token,
+                commands_applied=0,
+            ),
+            result_digest=record.observed_result_digest,
+        )
+    return ActivitySnapshot(
+        admission=admission,
+        result=result,
+        settlement=settlement,
+        result_attempt=record.result_attempt,
+        result_fence=record.result_fence,
+    )
+
+
+async def _translate_catalog_errors[T](awaitable: Awaitable[T]) -> T:
+    try:
+        return await awaitable
+    except ActivityCatalogNotFoundError as exc:
+        raise ActivityNotFoundError(*exc.args) from exc
+    except ActivityCatalogClaimError as exc:
+        raise ActivityClaimError(str(exc)) from exc
+    except ActivityCatalogConflictError as exc:
+        raise ActivityConflictError(str(exc)) from exc
+
+
+__all__ = ["ActivityCoordinator"]

--- a/src/archetype/storage/activity_catalog/__init__.py
+++ b/src/archetype/storage/activity_catalog/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Physical records and local control authority for durable activities."""
+
+from archetype.storage.activity_catalog.interfaces import ActivityCatalog
+from archetype.storage.activity_catalog.records import (
+    ActivityAdmissionRecord,
+    ActivityCatalogClaimError,
+    ActivityCatalogConflictError,
+    ActivityCatalogNotFoundError,
+    ActivityClaimRecord,
+    ActivityRecord,
+)
+from archetype.storage.activity_catalog.sqlite import (
+    SqliteActivityCatalog,
+    activity_catalog_path_for,
+)
+
+__all__ = [
+    "ActivityAdmissionRecord",
+    "ActivityCatalog",
+    "ActivityCatalogClaimError",
+    "ActivityCatalogConflictError",
+    "ActivityCatalogNotFoundError",
+    "ActivityClaimRecord",
+    "ActivityRecord",
+    "SqliteActivityCatalog",
+    "activity_catalog_path_for",
+]

--- a/src/archetype/storage/activity_catalog/interfaces.py
+++ b/src/archetype/storage/activity_catalog/interfaces.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structural contract for the local durable-activity control plane."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from archetype.storage.activity_catalog.records import (
+    ActivityAdmissionRecord,
+    ActivityClaimRecord,
+    ActivityRecord,
+)
+
+
+@runtime_checkable
+class ActivityCatalog(Protocol):
+    """Physical activity authority; intentionally separate from ControlCatalog."""
+
+    async def admit_activity(self, admission: ActivityAdmissionRecord) -> ActivityRecord: ...
+
+    async def get_activity(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+    ) -> ActivityRecord | None: ...
+
+    async def claim_activity(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        owner: str,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaimRecord: ...
+
+    async def bind_provider_operation(
+        self,
+        claim: ActivityClaimRecord,
+        provider: str,
+        operation_id: str,
+    ) -> ActivityClaimRecord: ...
+
+    async def confirm_provider_operation_absent(
+        self,
+        claim: ActivityClaimRecord,
+        retry_guard_ref: str,
+        retry_guard_digest: str,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaimRecord: ...
+
+    async def record_activity_result(
+        self,
+        claim: ActivityClaimRecord,
+        *,
+        result_ref: str,
+        result_digest: str,
+        result_media_type: str,
+        result_size_bytes: int,
+    ) -> ActivityRecord: ...
+
+    async def release_activity(self, claim: ActivityClaimRecord) -> None: ...
+
+    async def has_unsettled_activities(self, world_id: str) -> bool: ...
+
+    async def list_incomplete_activities(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+    ) -> list[ActivityRecord]: ...
+
+    async def list_unobserved_results(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+    ) -> list[ActivityRecord]: ...
+
+    async def settle_activity_observation(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        *,
+        observed_world_id: str,
+        observed_run_id: str,
+        observed_tick: int,
+        observed_visibility_token: str | None,
+        expected_result_digest: str,
+    ) -> ActivityRecord: ...
+
+    async def close(self) -> None: ...
+
+
+__all__ = ["ActivityCatalog"]

--- a/src/archetype/storage/activity_catalog/records.py
+++ b/src/archetype/storage/activity_catalog/records.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Physical control records for the local durable-activity catalog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from archetype.errors import ConflictError
+
+
+class ActivityCatalogConflictError(ConflictError):
+    """Stored immutable activity facts conflict with the requested operation."""
+
+
+class ActivityCatalogNotFoundError(KeyError):
+    """No physical activity record exists for one world-and-kind-scoped identity."""
+
+
+class ActivityCatalogClaimError(ConflictError):
+    """A physical claim is stale or insufficient for an operation."""
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityAdmissionRecord:
+    activity_id: str
+    kind: str
+    source_world_id: str
+    source_run_id: str
+    source_tick: int
+    source_visibility_token: str | None
+    input_ref: str
+    input_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityRecord:
+    activity_id: str
+    kind: str
+    source_world_id: str
+    source_run_id: str
+    source_tick: int
+    source_visibility_token: str | None
+    input_ref: str
+    input_digest: str
+    result_ref: str | None
+    result_digest: str | None
+    result_media_type: str | None
+    result_size_bytes: int | None
+    result_attempt: int | None
+    result_fence: int | None
+    result_recorded_at: str | None
+    observed_world_id: str | None
+    observed_run_id: str | None
+    observed_tick: int | None
+    observed_visibility_token: str | None
+    observed_result_digest: str | None
+    observed_at: str | None
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityClaimRecord:
+    activity: ActivityRecord
+    acquired: bool
+    attempt: int | None
+    fence: int | None
+    owner: str | None
+    lease_expires_at: float | None
+    provider: str | None
+    provider_operation_id: str | None
+    retry_guard_ref: str | None
+    retry_guard_digest: str | None
+    reconciles_attempt: int | None
+    reconciles_provider: str | None
+    reconciles_provider_operation_id: str | None
+
+
+__all__ = [
+    "ActivityAdmissionRecord",
+    "ActivityCatalogClaimError",
+    "ActivityCatalogConflictError",
+    "ActivityCatalogNotFoundError",
+    "ActivityClaimRecord",
+    "ActivityRecord",
+]

--- a/src/archetype/storage/activity_catalog/sqlite.py
+++ b/src/archetype/storage/activity_catalog/sqlite.py
@@ -1,0 +1,1328 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQLite reference control plane for durable activities.
+
+This catalog is intentionally separate from ``ControlCatalog``.  It proves
+single-host restart and concurrency semantics without claiming parity from the
+remote control plane before that backend implements the same crash contracts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import sqlite3
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from archetype.core.config import StorageConfig
+from archetype.storage.activity_catalog.records import (
+    ActivityAdmissionRecord,
+    ActivityCatalogClaimError,
+    ActivityCatalogConflictError,
+    ActivityCatalogNotFoundError,
+    ActivityClaimRecord,
+    ActivityRecord,
+)
+from archetype.storage.catalog.sqlite import catalog_path_for
+from archetype.storage.config import ControlCatalogConfig
+
+_SCHEMA_VERSION = 1
+
+_DDL = f"""
+CREATE TABLE IF NOT EXISTS activity_catalog_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS activities (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_world_id TEXT NOT NULL,
+    activity_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    source_run_id TEXT NOT NULL,
+    source_tick INTEGER NOT NULL,
+    source_visibility_token TEXT NOT NULL,
+    input_ref TEXT NOT NULL,
+    input_digest TEXT NOT NULL,
+    result_ref TEXT,
+    result_digest TEXT,
+    result_media_type TEXT,
+    result_size_bytes INTEGER,
+    result_attempt INTEGER,
+    result_fence INTEGER,
+    result_recorded_at TEXT,
+    observed_world_id TEXT,
+    observed_run_id TEXT,
+    observed_tick INTEGER,
+    observed_visibility_token TEXT,
+    observed_result_digest TEXT,
+    observed_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (source_world_id, kind, activity_id)
+);
+CREATE INDEX IF NOT EXISTS activities_unobserved_result_idx
+    ON activities (source_world_id, kind, observed_at, sequence)
+    WHERE result_ref IS NOT NULL;
+CREATE TABLE IF NOT EXISTS activity_provider_operations (
+    provider TEXT NOT NULL,
+    provider_operation_id TEXT NOT NULL,
+    source_world_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    activity_id TEXT NOT NULL,
+    bound_at TEXT NOT NULL,
+    PRIMARY KEY (provider, provider_operation_id),
+    FOREIGN KEY (source_world_id, kind, activity_id)
+        REFERENCES activities (source_world_id, kind, activity_id)
+);
+CREATE TABLE IF NOT EXISTS activity_attempts (
+    source_world_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    activity_id TEXT NOT NULL,
+    attempt INTEGER NOT NULL,
+    fence INTEGER NOT NULL,
+    owner TEXT NOT NULL,
+    lease_expires_at REAL,
+    provider TEXT,
+    provider_operation_id TEXT,
+    provider_bound_at TEXT,
+    reconciles_attempt INTEGER,
+    provider_absence_confirmed_at TEXT,
+    retry_guard_ref TEXT,
+    retry_guard_digest TEXT,
+    authorized_by_reconciliation_attempt INTEGER,
+    released_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (source_world_id, kind, activity_id, attempt),
+    UNIQUE (source_world_id, kind, activity_id, fence),
+    FOREIGN KEY (source_world_id, kind, activity_id)
+        REFERENCES activities (source_world_id, kind, activity_id)
+);
+INSERT OR IGNORE INTO activity_catalog_meta (key, value)
+    VALUES ('schema_version', '{_SCHEMA_VERSION}');
+"""
+
+
+def activity_catalog_path_for(
+    config: StorageConfig,
+    catalog_config: ControlCatalogConfig | None = None,
+) -> Path:
+    """Derive a local activity-catalog path from the same storage identity."""
+
+    control_path = catalog_path_for(config, catalog_config)
+    return control_path.with_name(f"{control_path.stem}-activities{control_path.suffix}")
+
+
+class SqliteActivityCatalog:
+    """Single-host durable authority for activity claims and settlement."""
+
+    def __init__(self, path: Path, *, busy_timeout_ms: int = 5000) -> None:
+        if busy_timeout_ms < 0:
+            raise ValueError("busy_timeout_ms must be non-negative")
+        self.path = Path(path)
+        self._busy_timeout_ms = busy_timeout_ms
+        self._conn: sqlite3.Connection | None = None
+        self._lock = asyncio.Lock()
+
+    def _connect_sync(self) -> sqlite3.Connection:
+        if self._conn is not None:
+            return self._conn
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        deadline = time.monotonic() + self._busy_timeout_ms / 1000
+        delay = 0.005
+        while True:
+            conn = sqlite3.connect(
+                self.path,
+                timeout=self._busy_timeout_ms / 1000,
+                check_same_thread=False,
+            )
+            try:
+                conn.row_factory = sqlite3.Row
+                conn.execute(f"PRAGMA busy_timeout={self._busy_timeout_ms}")
+                conn.execute("PRAGMA foreign_keys=ON")
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("PRAGMA synchronous=FULL")
+                conn.executescript(_DDL)
+                row = conn.execute(
+                    "SELECT value FROM activity_catalog_meta WHERE key='schema_version'"
+                ).fetchone()
+                assert row is not None
+                version = int(row["value"])
+                if version != _SCHEMA_VERSION:
+                    raise RuntimeError(
+                        f"activity catalog {self.path} has schema_version={version}, "
+                        f"this build expects {_SCHEMA_VERSION}"
+                    )
+                self._conn = conn
+                return conn
+            except sqlite3.OperationalError as exc:
+                conn.close()
+                busy = "locked" in str(exc).lower() or "busy" in str(exc).lower()
+                remaining = deadline - time.monotonic()
+                if not busy or remaining <= 0:
+                    raise
+                time.sleep(min(delay, remaining))
+                delay = min(delay * 2, 0.1)
+            except BaseException:
+                conn.close()
+                raise
+
+    async def _run(self, fn, *args):
+        async with self._lock:
+            worker = asyncio.create_task(asyncio.to_thread(fn, *args))
+            cancellation: asyncio.CancelledError | None = None
+            while True:
+                try:
+                    await asyncio.shield(worker)
+                except asyncio.CancelledError as exc:
+                    cancellation = cancellation or exc
+                    if worker.done():
+                        break
+                except BaseException:
+                    if cancellation is None:
+                        raise
+                    break
+                else:
+                    break
+            if cancellation is not None:
+                try:
+                    worker.result()
+                except BaseException:
+                    # Caller cancellation remains the public outcome, but
+                    # retrieving the worker outcome prevents an orphaned task.
+                    pass
+                raise cancellation
+            return worker.result()
+
+    async def close(self) -> None:
+        def _close() -> None:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+        await self._run(_close)
+
+    async def admit_activity(self, admission: ActivityAdmissionRecord) -> ActivityRecord:
+        """Idempotently admit immutable activity content."""
+
+        _require_bounded_text(
+            admission.source_visibility_token,
+            "activity source visibility token",
+            512,
+        )
+
+        def _admit() -> ActivityRecord:
+            conn = self._connect_sync()
+            now = _utcnow()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = _select_activity(
+                    conn,
+                    admission.source_world_id,
+                    admission.kind,
+                    admission.activity_id,
+                )
+                if row is not None:
+                    existing = _activity_from_row(row)
+                    immutable = (
+                        existing.kind,
+                        existing.source_run_id,
+                        existing.source_tick,
+                        existing.source_visibility_token,
+                        existing.input_ref,
+                        existing.input_digest,
+                    )
+                    requested = (
+                        admission.kind,
+                        admission.source_run_id,
+                        admission.source_tick,
+                        admission.source_visibility_token,
+                        admission.input_ref,
+                        admission.input_digest,
+                    )
+                    if immutable != requested:
+                        raise ActivityCatalogConflictError(
+                            f"activity ({admission.source_world_id}, {admission.kind}, "
+                            f"{admission.activity_id}) already has different immutable content"
+                        )
+                    return existing
+                conn.execute(
+                    "INSERT INTO activities "
+                    "(source_world_id, activity_id, kind, source_run_id, source_tick, "
+                    "source_visibility_token, input_ref, input_digest, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        admission.source_world_id,
+                        admission.activity_id,
+                        admission.kind,
+                        admission.source_run_id,
+                        admission.source_tick,
+                        admission.source_visibility_token,
+                        admission.input_ref,
+                        admission.input_digest,
+                        now,
+                        now,
+                    ),
+                )
+                inserted = _select_activity(
+                    conn,
+                    admission.source_world_id,
+                    admission.kind,
+                    admission.activity_id,
+                )
+                assert inserted is not None
+                return _activity_from_row(inserted)
+
+        return await self._run(_admit)
+
+    async def get_activity(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+    ) -> ActivityRecord | None:
+        def _get() -> ActivityRecord | None:
+            row = _select_activity(self._connect_sync(), world_id, kind, activity_id)
+            return _activity_from_row(row) if row is not None else None
+
+        return await self._run(_get)
+
+    async def claim_activity(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        owner: str,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaimRecord:
+        """Claim safe execution or provider-specific reconciliation.
+
+        Expiry of a provider-bound attempt never produces an ordinary
+        execution claim.  The new fenced claim points at the unresolved
+        provider operation and authorizes reconciliation only.
+        """
+
+        _require_bounded_text(owner, "activity claim owner", 512)
+        _require_lease_seconds(lease_seconds)
+
+        def _claim() -> ActivityClaimRecord:
+            conn = self._connect_sync()
+            now_seconds = time.time()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                activity_row = _select_activity(conn, world_id, kind, activity_id)
+                if activity_row is None:
+                    raise ActivityCatalogNotFoundError((world_id, kind, activity_id))
+                activity = _activity_from_row(activity_row)
+                latest = _latest_attempt(conn, world_id, kind, activity_id)
+
+                if activity.result_ref is not None:
+                    return _claim_from_row(
+                        conn,
+                        activity,
+                        latest,
+                        acquired=False,
+                    )
+
+                if latest is not None:
+                    live = (
+                        latest["released_at"] is None
+                        and latest["lease_expires_at"] is not None
+                        and float(latest["lease_expires_at"]) > now_seconds
+                    )
+                    if live:
+                        return _claim_from_row(
+                            conn,
+                            activity,
+                            latest,
+                            acquired=False,
+                        )
+
+                unresolved = conn.execute(
+                    "SELECT provider_attempt.* FROM activity_attempts AS provider_attempt "
+                    "WHERE provider_attempt.source_world_id=? "
+                    "AND provider_attempt.kind=? "
+                    "AND provider_attempt.activity_id=? "
+                    "AND provider_attempt.provider_operation_id IS NOT NULL "
+                    "AND NOT EXISTS ("
+                    "SELECT 1 FROM activity_attempts AS reconciliation "
+                    "WHERE reconciliation.source_world_id=provider_attempt.source_world_id "
+                    "AND reconciliation.kind=provider_attempt.kind "
+                    "AND reconciliation.activity_id=provider_attempt.activity_id "
+                    "AND reconciliation.reconciles_attempt=provider_attempt.attempt "
+                    "AND reconciliation.provider_absence_confirmed_at IS NOT NULL"
+                    ") ORDER BY provider_attempt.attempt DESC LIMIT 1",
+                    (world_id, kind, activity_id),
+                ).fetchone()
+                attempt = int(latest["attempt"]) + 1 if latest is not None else 1
+                fence_row = conn.execute(
+                    "SELECT MAX(fence) AS fence FROM activity_attempts "
+                    "WHERE source_world_id=? AND kind=? AND activity_id=?",
+                    (world_id, kind, activity_id),
+                ).fetchone()
+                fence = int(fence_row["fence"] or 0) + 1
+                now = _utcnow()
+                conn.execute(
+                    "INSERT INTO activity_attempts "
+                    "(source_world_id, kind, activity_id, attempt, fence, owner, "
+                    "lease_expires_at, reconciles_attempt, retry_guard_ref, "
+                    "retry_guard_digest, authorized_by_reconciliation_attempt, "
+                    "created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        world_id,
+                        kind,
+                        activity_id,
+                        attempt,
+                        fence,
+                        owner,
+                        now_seconds + lease_seconds,
+                        int(unresolved["attempt"]) if unresolved is not None else None,
+                        (
+                            str(latest["retry_guard_ref"])
+                            if latest is not None and latest["retry_guard_ref"] is not None
+                            else None
+                        ),
+                        (
+                            str(latest["retry_guard_digest"])
+                            if latest is not None and latest["retry_guard_digest"] is not None
+                            else None
+                        ),
+                        (
+                            int(latest["authorized_by_reconciliation_attempt"])
+                            if latest is not None
+                            and latest["authorized_by_reconciliation_attempt"] is not None
+                            else None
+                        ),
+                        now,
+                        now,
+                    ),
+                )
+                inserted = _attempt(conn, world_id, kind, activity_id, attempt)
+                assert inserted is not None
+                return _claim_from_row(
+                    conn,
+                    activity,
+                    inserted,
+                    acquired=True,
+                )
+
+        return await self._run(_claim)
+
+    async def bind_provider_operation(
+        self,
+        claim: ActivityClaimRecord,
+        provider: str,
+        operation_id: str,
+    ) -> ActivityClaimRecord:
+        """Durably bind provider identity before the external invocation."""
+
+        _require_bounded_text(provider, "activity provider", 255)
+        _require_bounded_text(operation_id, "provider operation_id", 1024)
+
+        def _bind() -> ActivityClaimRecord:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                activity = _require_activity(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                )
+                row = _require_live_claim(conn, claim)
+                if row["reconciles_attempt"] is not None:
+                    raise ActivityCatalogClaimError(
+                        "a reconciliation claim cannot invoke a new provider operation"
+                    )
+                authorization_attempt = row["authorized_by_reconciliation_attempt"]
+                if authorization_attempt is not None:
+                    reconciliation = _attempt(
+                        conn,
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                        int(authorization_attempt),
+                    )
+                    if reconciliation is None or reconciliation["reconciles_attempt"] is None:
+                        raise ActivityCatalogConflictError(
+                            "activity retry authorization provenance is incomplete"
+                        )
+                    provider_attempt = _attempt(
+                        conn,
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                        int(reconciliation["reconciles_attempt"]),
+                    )
+                    expected = (
+                        provider_attempt["provider"] if provider_attempt is not None else None,
+                        (
+                            provider_attempt["provider_operation_id"]
+                            if provider_attempt is not None
+                            else None
+                        ),
+                    )
+                    if None in expected:
+                        raise ActivityCatalogConflictError(
+                            "activity retry authorization has no provider identity"
+                        )
+                    if (provider, operation_id) != expected:
+                        raise ActivityCatalogConflictError(
+                            "retry-authorized activity attempt must bind the reconciled "
+                            "provider operation identity"
+                        )
+                existing = (row["provider"], row["provider_operation_id"])
+                requested = (provider, operation_id)
+                if existing[1] is not None:
+                    if existing != requested:
+                        raise ActivityCatalogConflictError(
+                            "activity attempt already has a different provider operation"
+                        )
+                    _bind_provider_identity(
+                        conn,
+                        claim,
+                        provider=provider,
+                        operation_id=operation_id,
+                    )
+                    return _claim_from_row(conn, activity, row, acquired=True)
+                now = _utcnow()
+                _bind_provider_identity(
+                    conn,
+                    claim,
+                    provider=provider,
+                    operation_id=operation_id,
+                    bound_at=now,
+                )
+                conn.execute(
+                    "UPDATE activity_attempts SET provider=?, provider_operation_id=?, "
+                    "provider_bound_at=?, updated_at=? WHERE source_world_id=? "
+                    "AND kind=? AND activity_id=? AND attempt=?",
+                    (
+                        provider,
+                        operation_id,
+                        now,
+                        now,
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                        claim.attempt,
+                    ),
+                )
+                updated = _attempt(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                    _required_int(claim.attempt),
+                )
+                assert updated is not None
+                return _claim_from_row(conn, activity, updated, acquired=True)
+
+        return await self._run(_bind)
+
+    async def confirm_provider_operation_absent(
+        self,
+        claim: ActivityClaimRecord,
+        retry_guard_ref: str,
+        retry_guard_digest: str,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaimRecord:
+        """Record provider-confirmed absence and mint a fresh execution claim.
+
+        The provider adapter owns the evidence and decision behind this call.
+        The catalog only preserves the reconciliation fact before authorizing
+        another fenced attempt.
+        """
+
+        _require_bounded_text(retry_guard_ref, "activity retry guard ref", 4096)
+        _require_bounded_text(retry_guard_digest, "activity retry guard digest", 255)
+        _require_lease_seconds(lease_seconds)
+
+        def _confirm() -> ActivityClaimRecord:
+            conn = self._connect_sync()
+            now_seconds = time.time()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                activity = _require_activity(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                )
+                if activity.result_ref is not None:
+                    raise ActivityCatalogClaimError(
+                        "a completed activity cannot confirm provider absence"
+                    )
+                claim_attempt = _required_int(claim.attempt)
+                existing = _attempt(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                    claim_attempt,
+                )
+                if existing is not None and existing["provider_absence_confirmed_at"] is not None:
+                    existing_guard = (
+                        existing["retry_guard_ref"],
+                        existing["retry_guard_digest"],
+                    )
+                    requested_guard = (retry_guard_ref, retry_guard_digest)
+                    if existing_guard != requested_guard:
+                        raise ActivityCatalogConflictError(
+                            "provider absence was confirmed with a different retry guard"
+                        )
+                    authorized = conn.execute(
+                        "SELECT * FROM activity_attempts WHERE source_world_id=? "
+                        "AND kind=? AND activity_id=? "
+                        "AND authorized_by_reconciliation_attempt=? "
+                        "ORDER BY attempt DESC LIMIT 1",
+                        (
+                            claim.activity.source_world_id,
+                            claim.activity.kind,
+                            claim.activity.activity_id,
+                            claim_attempt,
+                        ),
+                    ).fetchone()
+                    latest = _latest_attempt(
+                        conn,
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                    )
+                    exact_retry = (
+                        claim.acquired
+                        and authorized is not None
+                        and latest is not None
+                        and int(latest["attempt"]) == int(authorized["attempt"])
+                        and existing["owner"] == claim.owner
+                        and int(existing["fence"]) == claim.fence
+                        and authorized["owner"] == claim.owner
+                        and authorized["released_at"] is None
+                        and authorized["lease_expires_at"] is not None
+                        and float(authorized["lease_expires_at"]) > now_seconds
+                    )
+                    if exact_retry:
+                        conn.execute(
+                            "UPDATE activity_attempts SET lease_expires_at=?, updated_at=? "
+                            "WHERE source_world_id=? AND kind=? AND activity_id=? "
+                            "AND attempt=?",
+                            (
+                                now_seconds + lease_seconds,
+                                _utcnow(),
+                                claim.activity.source_world_id,
+                                claim.activity.kind,
+                                claim.activity.activity_id,
+                                int(authorized["attempt"]),
+                            ),
+                        )
+                        renewed = _attempt(
+                            conn,
+                            claim.activity.source_world_id,
+                            claim.activity.kind,
+                            claim.activity.activity_id,
+                            int(authorized["attempt"]),
+                        )
+                        assert renewed is not None
+                        return _claim_from_row(
+                            conn,
+                            activity,
+                            renewed,
+                            acquired=True,
+                        )
+                    raise ActivityCatalogClaimError("provider-absence confirmation claim is stale")
+
+                reconciliation = _require_live_claim(conn, claim)
+                reconciles_attempt = reconciliation["reconciles_attempt"]
+                if reconciles_attempt is None:
+                    raise ActivityCatalogClaimError(
+                        "provider absence requires a reconciliation claim"
+                    )
+                provider_attempt = _attempt(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                    int(reconciles_attempt),
+                )
+                if provider_attempt is None or provider_attempt["provider_operation_id"] is None:
+                    raise ActivityCatalogClaimError(
+                        "reconciliation claim has no provider operation identity"
+                    )
+
+                now = _utcnow()
+                conn.execute(
+                    "UPDATE activity_attempts SET provider_absence_confirmed_at=?, "
+                    "retry_guard_ref=?, retry_guard_digest=?, lease_expires_at=NULL, "
+                    "released_at=?, updated_at=? WHERE source_world_id=? AND kind=? "
+                    "AND activity_id=? AND attempt=?",
+                    (
+                        now,
+                        retry_guard_ref,
+                        retry_guard_digest,
+                        now,
+                        now,
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                        claim_attempt,
+                    ),
+                )
+                latest = _latest_attempt(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                )
+                assert latest is not None
+                next_attempt = int(latest["attempt"]) + 1
+                next_fence = int(latest["fence"]) + 1
+                conn.execute(
+                    "INSERT INTO activity_attempts "
+                    "(source_world_id, kind, activity_id, attempt, fence, owner, "
+                    "lease_expires_at, retry_guard_ref, retry_guard_digest, "
+                    "authorized_by_reconciliation_attempt, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                        next_attempt,
+                        next_fence,
+                        claim.owner,
+                        now_seconds + lease_seconds,
+                        retry_guard_ref,
+                        retry_guard_digest,
+                        claim_attempt,
+                        now,
+                        now,
+                    ),
+                )
+                authorized = _attempt(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                    next_attempt,
+                )
+                assert authorized is not None
+                return _claim_from_row(
+                    conn,
+                    activity,
+                    authorized,
+                    acquired=True,
+                )
+
+        return await self._run(_confirm)
+
+    async def record_activity_result(
+        self,
+        claim: ActivityClaimRecord,
+        *,
+        result_ref: str,
+        result_digest: str,
+        result_media_type: str,
+        result_size_bytes: int,
+    ) -> ActivityRecord:
+        """Record a bounded result reference under the current fence."""
+
+        requested = (
+            result_ref,
+            result_digest,
+            result_media_type,
+            result_size_bytes,
+        )
+
+        def _record() -> ActivityRecord:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                activity = _require_activity(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                )
+                if activity.result_ref is not None:
+                    existing = (
+                        activity.result_ref,
+                        activity.result_digest,
+                        activity.result_media_type,
+                        activity.result_size_bytes,
+                    )
+                    if existing != requested:
+                        raise ActivityCatalogConflictError(
+                            "activity already has a different durable result"
+                        )
+                    return activity
+
+                attempt_row = _require_live_claim(conn, claim)
+                if (
+                    attempt_row["provider_operation_id"] is None
+                    and attempt_row["reconciles_attempt"] is None
+                ):
+                    raise ActivityCatalogClaimError(
+                        "recording a result requires a pre-bound provider operation "
+                        "or a reconciliation claim"
+                    )
+                now = _utcnow()
+                conn.execute(
+                    "UPDATE activities SET result_ref=?, result_digest=?, "
+                    "result_media_type=?, result_size_bytes=?, result_attempt=?, "
+                    "result_fence=?, result_recorded_at=?, updated_at=? "
+                    "WHERE source_world_id=? AND kind=? AND activity_id=?",
+                    (
+                        result_ref,
+                        result_digest,
+                        result_media_type,
+                        result_size_bytes,
+                        claim.attempt,
+                        claim.fence,
+                        now,
+                        now,
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                    ),
+                )
+                conn.execute(
+                    "UPDATE activity_attempts SET lease_expires_at=NULL, updated_at=? "
+                    "WHERE source_world_id=? AND kind=? AND activity_id=? AND attempt=?",
+                    (
+                        now,
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                        claim.attempt,
+                    ),
+                )
+                updated = _select_activity(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                )
+                assert updated is not None
+                return _activity_from_row(updated)
+
+        return await self._run(_record)
+
+    async def release_activity(self, claim: ActivityClaimRecord) -> None:
+        """Release an unbound attempt that performed no external operation."""
+
+        def _release() -> None:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = _attempt(
+                    conn,
+                    claim.activity.source_world_id,
+                    claim.activity.kind,
+                    claim.activity.activity_id,
+                    _required_int(claim.attempt),
+                )
+                if row is not None and row["released_at"] is not None:
+                    if int(row["fence"]) == claim.fence and row["owner"] == claim.owner:
+                        return
+                row = _require_live_claim(conn, claim)
+                if (
+                    row["provider_operation_id"] is not None
+                    or row["reconciles_attempt"] is not None
+                ):
+                    raise ActivityCatalogClaimError(
+                        "provider-bound or reconciliation work cannot be released for replay"
+                    )
+                now = _utcnow()
+                conn.execute(
+                    "UPDATE activity_attempts SET lease_expires_at=NULL, released_at=?, "
+                    "updated_at=? WHERE source_world_id=? AND kind=? AND activity_id=? "
+                    "AND attempt=?",
+                    (
+                        now,
+                        now,
+                        claim.activity.source_world_id,
+                        claim.activity.kind,
+                        claim.activity.activity_id,
+                        claim.attempt,
+                    ),
+                )
+
+        await self._run(_release)
+
+    async def list_incomplete_activities(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+    ) -> list[ActivityRecord]:
+        """Discover admitted work without relying on a process-local queue."""
+
+        return await self._list_by_completion(
+            completed=False,
+            kind=kind,
+            world_id=world_id,
+            limit=limit,
+        )
+
+    async def list_unobserved_results(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+    ) -> list[ActivityRecord]:
+        """Discover durable results that a later world tick has not observed."""
+
+        return await self._list_by_completion(
+            completed=True,
+            kind=kind,
+            world_id=world_id,
+            limit=limit,
+        )
+
+    async def has_unsettled_activities(self, world_id: str) -> bool:
+        """Whether conservative fork/destroy admission must refuse this world."""
+
+        def _has_unsettled() -> bool:
+            row = (
+                self._connect_sync()
+                .execute(
+                    "SELECT 1 FROM activities WHERE source_world_id=? "
+                    "AND observed_at IS NULL LIMIT 1",
+                    (world_id,),
+                )
+                .fetchone()
+            )
+            return row is not None
+
+        return await self._run(_has_unsettled)
+
+    async def _list_by_completion(
+        self,
+        *,
+        completed: bool,
+        kind: str | None,
+        world_id: str | None,
+        limit: int,
+    ) -> list[ActivityRecord]:
+        if limit < 1:
+            raise ValueError("limit must be positive")
+
+        def _list() -> list[ActivityRecord]:
+            conditions = (
+                ["result_ref IS NOT NULL", "observed_at IS NULL"]
+                if completed
+                else ["result_ref IS NULL"]
+            )
+            parameters: list[object] = []
+            if kind is not None:
+                conditions.append("kind=?")
+                parameters.append(kind)
+            if world_id is not None:
+                conditions.append("source_world_id=?")
+                parameters.append(world_id)
+            parameters.append(limit)
+            rows = (
+                self._connect_sync()
+                .execute(
+                    "SELECT * FROM activities WHERE "
+                    + " AND ".join(conditions)
+                    + " ORDER BY sequence LIMIT ?",
+                    parameters,
+                )
+                .fetchall()
+            )
+            return [_activity_from_row(row) for row in rows]
+
+        return await self._run(_list)
+
+    async def settle_activity_observation(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        *,
+        observed_world_id: str,
+        observed_run_id: str,
+        observed_tick: int,
+        observed_visibility_token: str | None,
+        expected_result_digest: str,
+    ) -> ActivityRecord:
+        """Bind a result to the exact later commit that observed it."""
+
+        _require_bounded_text(
+            observed_visibility_token,
+            "activity observation visibility token",
+            512,
+        )
+        _require_bounded_text(
+            expected_result_digest,
+            "activity observation result digest",
+            255,
+        )
+        requested = (
+            observed_world_id,
+            observed_run_id,
+            observed_tick,
+            observed_visibility_token,
+            expected_result_digest,
+        )
+
+        def _settle() -> ActivityRecord:
+            conn = self._connect_sync()
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                activity = _require_activity(conn, world_id, kind, activity_id)
+                if activity.result_ref is None:
+                    raise ActivityCatalogConflictError(
+                        "an activity cannot be observed before its result is durable"
+                    )
+                if activity.result_digest != expected_result_digest:
+                    raise ActivityCatalogConflictError(
+                        "activity observation does not bind the durable result digest"
+                    )
+                if (
+                    observed_world_id != activity.source_world_id
+                    or observed_run_id != activity.source_run_id
+                ):
+                    raise ActivityCatalogConflictError(
+                        "activity observation must commit in its source world and run"
+                    )
+                if observed_tick <= activity.source_tick:
+                    raise ActivityCatalogConflictError(
+                        "activity observation must be committed by a later tick"
+                    )
+                if activity.observed_world_id is not None:
+                    existing = (
+                        activity.observed_world_id,
+                        activity.observed_run_id,
+                        activity.observed_tick,
+                        activity.observed_visibility_token,
+                        activity.observed_result_digest,
+                    )
+                    if existing != requested:
+                        raise ActivityCatalogConflictError(
+                            "activity already has a different observation settlement"
+                        )
+                    return activity
+                now = _utcnow()
+                conn.execute(
+                    "UPDATE activities SET observed_world_id=?, observed_run_id=?, "
+                    "observed_tick=?, observed_visibility_token=?, "
+                    "observed_result_digest=?, observed_at=?, updated_at=? "
+                    "WHERE source_world_id=? AND kind=? AND activity_id=?",
+                    (
+                        observed_world_id,
+                        observed_run_id,
+                        observed_tick,
+                        observed_visibility_token,
+                        expected_result_digest,
+                        now,
+                        now,
+                        world_id,
+                        kind,
+                        activity_id,
+                    ),
+                )
+                updated = _select_activity(conn, world_id, kind, activity_id)
+                assert updated is not None
+                return _activity_from_row(updated)
+
+        return await self._run(_settle)
+
+
+def _select_activity(
+    conn: sqlite3.Connection,
+    world_id: str,
+    kind: str,
+    activity_id: str,
+) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM activities WHERE source_world_id=? AND kind=? AND activity_id=?",
+        (world_id, kind, activity_id),
+    ).fetchone()
+
+
+def _require_activity(
+    conn: sqlite3.Connection,
+    world_id: str,
+    kind: str,
+    activity_id: str,
+) -> ActivityRecord:
+    row = _select_activity(conn, world_id, kind, activity_id)
+    if row is None:
+        raise ActivityCatalogNotFoundError((world_id, kind, activity_id))
+    return _activity_from_row(row)
+
+
+def _latest_attempt(
+    conn: sqlite3.Connection,
+    world_id: str,
+    kind: str,
+    activity_id: str,
+) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM activity_attempts WHERE source_world_id=? AND kind=? AND activity_id=? "
+        "ORDER BY attempt DESC LIMIT 1",
+        (world_id, kind, activity_id),
+    ).fetchone()
+
+
+def _attempt(
+    conn: sqlite3.Connection,
+    world_id: str,
+    kind: str,
+    activity_id: str,
+    attempt: int,
+) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM activity_attempts WHERE source_world_id=? AND kind=? "
+        "AND activity_id=? AND attempt=?",
+        (world_id, kind, activity_id, attempt),
+    ).fetchone()
+
+
+def _require_live_claim(
+    conn: sqlite3.Connection,
+    claim: ActivityClaimRecord,
+) -> sqlite3.Row:
+    if not claim.acquired:
+        raise ActivityCatalogClaimError("activity claim was not acquired")
+    attempt = _required_int(claim.attempt)
+    row = _attempt(
+        conn,
+        claim.activity.source_world_id,
+        claim.activity.kind,
+        claim.activity.activity_id,
+        attempt,
+    )
+    if row is None:
+        raise ActivityCatalogClaimError("activity claim attempt does not exist")
+    latest = _latest_attempt(
+        conn,
+        claim.activity.source_world_id,
+        claim.activity.kind,
+        claim.activity.activity_id,
+    )
+    exact = (
+        latest is not None
+        and int(latest["attempt"]) == attempt
+        and int(row["fence"]) == claim.fence
+        and row["owner"] == claim.owner
+    )
+    if not exact:
+        raise ActivityCatalogClaimError("activity claim is stale")
+    if row["released_at"] is not None:
+        raise ActivityCatalogClaimError("activity claim was released")
+    expires = row["lease_expires_at"]
+    if expires is None or float(expires) <= time.time():
+        raise ActivityCatalogClaimError("activity claim lease expired")
+    return row
+
+
+def _claim_from_row(
+    conn: sqlite3.Connection,
+    activity: ActivityRecord,
+    attempt_row: sqlite3.Row | None,
+    *,
+    acquired: bool,
+) -> ActivityClaimRecord:
+    if attempt_row is None:
+        return ActivityClaimRecord(
+            activity=activity,
+            acquired=False,
+            attempt=None,
+            fence=None,
+            owner=None,
+            lease_expires_at=None,
+            provider=None,
+            provider_operation_id=None,
+            retry_guard_ref=None,
+            retry_guard_digest=None,
+            reconciles_attempt=None,
+            reconciles_provider=None,
+            reconciles_provider_operation_id=None,
+        )
+    reconciles_attempt = attempt_row["reconciles_attempt"]
+    reconciles = (
+        _attempt(
+            conn,
+            activity.source_world_id,
+            activity.kind,
+            activity.activity_id,
+            int(reconciles_attempt),
+        )
+        if reconciles_attempt is not None
+        else None
+    )
+    return ActivityClaimRecord(
+        activity=activity,
+        acquired=acquired,
+        attempt=int(attempt_row["attempt"]),
+        fence=int(attempt_row["fence"]),
+        owner=str(attempt_row["owner"]),
+        lease_expires_at=(
+            float(attempt_row["lease_expires_at"])
+            if attempt_row["lease_expires_at"] is not None
+            else None
+        ),
+        provider=(str(attempt_row["provider"]) if attempt_row["provider"] is not None else None),
+        provider_operation_id=(
+            str(attempt_row["provider_operation_id"])
+            if attempt_row["provider_operation_id"] is not None
+            else None
+        ),
+        retry_guard_ref=(
+            str(attempt_row["retry_guard_ref"])
+            if attempt_row["retry_guard_ref"] is not None
+            else None
+        ),
+        retry_guard_digest=(
+            str(attempt_row["retry_guard_digest"])
+            if attempt_row["retry_guard_digest"] is not None
+            else None
+        ),
+        reconciles_attempt=(int(reconciles_attempt) if reconciles_attempt is not None else None),
+        reconciles_provider=(
+            str(reconciles["provider"])
+            if reconciles is not None and reconciles["provider"] is not None
+            else None
+        ),
+        reconciles_provider_operation_id=(
+            str(reconciles["provider_operation_id"])
+            if reconciles is not None and reconciles["provider_operation_id"] is not None
+            else None
+        ),
+    )
+
+
+def _activity_from_row(row: sqlite3.Row) -> ActivityRecord:
+    return ActivityRecord(
+        activity_id=str(row["activity_id"]),
+        kind=str(row["kind"]),
+        source_world_id=str(row["source_world_id"]),
+        source_run_id=str(row["source_run_id"]),
+        source_tick=int(row["source_tick"]),
+        source_visibility_token=(
+            str(row["source_visibility_token"])
+            if row["source_visibility_token"] is not None
+            else None
+        ),
+        input_ref=str(row["input_ref"]),
+        input_digest=str(row["input_digest"]),
+        result_ref=str(row["result_ref"]) if row["result_ref"] is not None else None,
+        result_digest=(str(row["result_digest"]) if row["result_digest"] is not None else None),
+        result_media_type=(
+            str(row["result_media_type"]) if row["result_media_type"] is not None else None
+        ),
+        result_size_bytes=(
+            int(row["result_size_bytes"]) if row["result_size_bytes"] is not None else None
+        ),
+        result_attempt=(int(row["result_attempt"]) if row["result_attempt"] is not None else None),
+        result_fence=(int(row["result_fence"]) if row["result_fence"] is not None else None),
+        result_recorded_at=(
+            str(row["result_recorded_at"]) if row["result_recorded_at"] is not None else None
+        ),
+        observed_world_id=(
+            str(row["observed_world_id"]) if row["observed_world_id"] is not None else None
+        ),
+        observed_run_id=(
+            str(row["observed_run_id"]) if row["observed_run_id"] is not None else None
+        ),
+        observed_tick=(int(row["observed_tick"]) if row["observed_tick"] is not None else None),
+        observed_visibility_token=(
+            str(row["observed_visibility_token"])
+            if row["observed_visibility_token"] is not None
+            else None
+        ),
+        observed_result_digest=(
+            str(row["observed_result_digest"])
+            if row["observed_result_digest"] is not None
+            else None
+        ),
+        observed_at=str(row["observed_at"]) if row["observed_at"] is not None else None,
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def _bind_provider_identity(
+    conn: sqlite3.Connection,
+    claim: ActivityClaimRecord,
+    *,
+    provider: str,
+    operation_id: str,
+    bound_at: str | None = None,
+) -> None:
+    """Reserve one provider operation for exactly one logical Activity."""
+
+    identity = (
+        claim.activity.source_world_id,
+        claim.activity.kind,
+        claim.activity.activity_id,
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO activity_provider_operations "
+        "(provider, provider_operation_id, source_world_id, kind, activity_id, bound_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            provider,
+            operation_id,
+            *identity,
+            bound_at or _utcnow(),
+        ),
+    )
+    row = conn.execute(
+        "SELECT source_world_id, kind, activity_id "
+        "FROM activity_provider_operations "
+        "WHERE provider=? AND provider_operation_id=?",
+        (provider, operation_id),
+    ).fetchone()
+    if row is None:
+        raise AssertionError("provider operation reservation disappeared")
+    bound_identity = (
+        str(row["source_world_id"]),
+        str(row["kind"]),
+        str(row["activity_id"]),
+    )
+    if bound_identity != identity:
+        raise ActivityCatalogConflictError(
+            "provider operation is already bound to another activity"
+        )
+
+
+def _required_int(value: int | None) -> int:
+    if value is None:
+        raise ActivityCatalogClaimError("activity claim lacks attempt identity")
+    return value
+
+
+def _require_bounded_text(value: str | None, field_name: str, max_chars: int) -> None:
+    if value is None:
+        raise ValueError(f"{field_name} must be non-empty")
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{field_name} must be non-empty")
+    if len(value) > max_chars:
+        raise ValueError(f"{field_name} must be at most {max_chars} characters")
+
+
+def _require_lease_seconds(value: float) -> None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError("lease_seconds must be a number")
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError("lease_seconds must be finite and positive")
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = ["SqliteActivityCatalog", "activity_catalog_path_for"]

--- a/tests/activities/test_activity_catalog_contracts.py
+++ b/tests/activities/test_activity_catalog_contracts.py
@@ -1,0 +1,866 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Crash contracts for the first local durable-activity control plane."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from archetype.activities import (
+    ActivityAdmission,
+    ActivityClaimError,
+    ActivityConflictError,
+    ActivityCoordinator,
+    ActivityNotFoundError,
+    ActivityResultRef,
+    ActivityRetryGuard,
+    ActivitySettlement,
+    iActivityCoordinator,
+)
+from archetype.core.interfaces import CommittedTickReceipt
+from archetype.storage.activity_catalog import (
+    ActivityAdmissionRecord,
+    ActivityCatalog,
+    SqliteActivityCatalog,
+)
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.contract("activities.durable_control"),
+]
+
+_KIND = "missions.author"
+_OPERATION_ID = "missions.author:world-a:dispatch-1"
+
+
+def _receipt(
+    world_id: str = "world-a",
+    *,
+    run_id: str = "run-a",
+    tick: int = 4,
+    token: str | None = "manifest-4",
+) -> CommittedTickReceipt:
+    return CommittedTickReceipt(
+        world_id=world_id,
+        run_id=run_id,
+        committed_tick=tick,
+        visibility_token=token,
+        commands_applied=7,
+    )
+
+
+def _admission(
+    world_id: str = "world-a",
+    *,
+    kind: str = _KIND,
+    activity_id: str = "dispatch-1",
+    input_digest: str = "input-digest",
+) -> ActivityAdmission:
+    return ActivityAdmission(
+        activity_id=activity_id,
+        kind=kind,
+        source=_receipt(world_id),
+        input_ref=f"mission-input://{world_id}/{kind}/{activity_id}",
+        input_digest=input_digest,
+    )
+
+
+def _result(digest: str = "result-digest") -> ActivityResultRef:
+    return ActivityResultRef(
+        ref=f"artifact://mission-results/{digest}",
+        digest=digest,
+        media_type="application/vnd.archetype.mission-author+json",
+        size_bytes=123,
+    )
+
+
+def _guard(digest: str = "retry-guard-digest") -> ActivityRetryGuard:
+    return ActivityRetryGuard(
+        ref=f"provider-guard://git/{digest}",
+        digest=digest,
+    )
+
+
+def _settlement(
+    *,
+    tick: int = 5,
+    token: str = "manifest-5",
+    run_id: str = "run-a",
+    result_digest: str = "result-digest",
+) -> ActivitySettlement:
+    return ActivitySettlement(
+        _receipt("world-a", run_id=run_id, tick=tick, token=token),
+        result_digest=result_digest,
+    )
+
+
+async def test_admission_is_idempotent_and_activity_identity_is_world_scoped(
+    tmp_path,
+) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        first = await coordinator.admit(_admission("world-a"))
+        repeated = await coordinator.admit(_admission("world-a"))
+        collision = await coordinator.admit(
+            _admission("world-b", input_digest="different-world-input")
+        )
+
+        assert first == repeated
+        assert first.admission.activity_id == collision.admission.activity_id
+        assert first.admission.source.world_id == "world-a"
+        assert collision.admission.source.world_id == "world-b"
+        assert await coordinator.get("world-a", _KIND, "dispatch-1") == first
+        assert await coordinator.get("world-b", _KIND, "dispatch-1") == collision
+
+        with pytest.raises(ActivityConflictError, match="different immutable content"):
+            await coordinator.admit(_admission("world-a", input_digest="changed"))
+
+        assert [
+            item.admission.source.world_id for item in await coordinator.pending(kind=_KIND)
+        ] == ["world-a", "world-b"]
+        assert [
+            item.admission.source.world_id for item in await coordinator.pending(world_id="world-b")
+        ] == ["world-b"]
+    finally:
+        await catalog.close()
+
+
+async def test_same_local_id_is_isolated_by_world_and_kind(tmp_path) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    coordinator = ActivityCoordinator(catalog)
+    critic_kind = "missions.critic"
+    try:
+        author = await coordinator.admit(_admission())
+        critic = await coordinator.admit(_admission(kind=critic_kind, input_digest="critic-input"))
+        other_world = await coordinator.admit(_admission("world-b"))
+
+        author_claim = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "author-worker",
+        )
+        critic_claim = await coordinator.claim(
+            "world-a",
+            critic_kind,
+            "dispatch-1",
+            "critic-worker",
+        )
+        other_world_claim = await coordinator.claim(
+            "world-b",
+            _KIND,
+            "dispatch-1",
+            "other-author-worker",
+        )
+
+        assert author.admission.kind == _KIND
+        assert critic.admission.kind == critic_kind
+        assert other_world.admission.source.world_id == "world-b"
+        assert author_claim.acquired and critic_claim.acquired and other_world_claim.acquired
+        assert author_claim.attempt == critic_claim.attempt == other_world_claim.attempt == 1
+        assert author_claim.fence == critic_claim.fence == other_world_claim.fence == 1
+        assert await coordinator.get("world-a", _KIND, "dispatch-1") == author
+        assert await coordinator.get("world-a", critic_kind, "dispatch-1") == critic
+        assert await coordinator.get("world-b", _KIND, "dispatch-1") == other_world
+
+        author_bound = await coordinator.bind_provider_operation(
+            author_claim,
+            "local",
+            _OPERATION_ID,
+        )
+        with pytest.raises(
+            ActivityConflictError,
+            match="provider operation is already bound to another activity",
+        ):
+            await coordinator.bind_provider_operation(
+                critic_claim,
+                "local",
+                _OPERATION_ID,
+            )
+        with pytest.raises(
+            ActivityConflictError,
+            match="provider operation is already bound to another activity",
+        ):
+            await coordinator.bind_provider_operation(
+                other_world_claim,
+                "local",
+                _OPERATION_ID,
+            )
+        critic_bound = await coordinator.bind_provider_operation(
+            critic_claim,
+            "local",
+            "missions.critic:world-a:dispatch-1",
+        )
+        other_world_bound = await coordinator.bind_provider_operation(
+            other_world_claim,
+            "local",
+            "missions.author:world-b:dispatch-1",
+        )
+        assert critic_bound.provider_operation_id != author_bound.provider_operation_id
+        assert other_world_bound.provider_operation_id != author_bound.provider_operation_id
+        recorded = await coordinator.record_result(author_bound, _result())
+        assert await coordinator.pending(kind=_KIND, world_id="world-a") == ()
+        assert await coordinator.pending(kind=critic_kind, world_id="world-a") == (critic,)
+        assert await coordinator.pending_results(kind=_KIND, world_id="world-a") == (recorded,)
+        await coordinator.settle_observation(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            _settlement(),
+        )
+        assert await coordinator.pending_results(kind=_KIND, world_id="world-a") == ()
+        assert await coordinator.get("world-a", critic_kind, "dispatch-1") == critic
+    finally:
+        await catalog.close()
+
+
+async def test_provider_operation_reservation_survives_restart_and_settlement(
+    tmp_path,
+) -> None:
+    path = tmp_path / "activities.db"
+    first_catalog = SqliteActivityCatalog(path)
+    first = ActivityCoordinator(first_catalog)
+    try:
+        await first.admit(_admission())
+        await first.admit(_admission("world-b"))
+        claim = await first.claim("world-a", _KIND, "dispatch-1", "owner-a")
+        bound = await first.bind_provider_operation(
+            claim,
+            "local",
+            _OPERATION_ID,
+        )
+        await first.record_result(bound, _result())
+        await first.settle_observation(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            _settlement(),
+        )
+    finally:
+        await first_catalog.close()
+
+    recovered_catalog = SqliteActivityCatalog(path)
+    recovered = ActivityCoordinator(recovered_catalog)
+    try:
+        other = await recovered.claim(
+            "world-b",
+            _KIND,
+            "dispatch-1",
+            "owner-b",
+        )
+        with pytest.raises(
+            ActivityConflictError,
+            match="provider operation is already bound to another activity",
+        ):
+            await recovered.bind_provider_operation(
+                other,
+                "local",
+                _OPERATION_ID,
+            )
+        unique = await recovered.bind_provider_operation(
+            other,
+            "local",
+            "missions.author:world-b:dispatch-1",
+        )
+        assert unique.provider_operation_id == "missions.author:world-b:dispatch-1"
+    finally:
+        await recovered_catalog.close()
+
+
+async def test_two_catalog_instances_serialize_one_live_claim(tmp_path) -> None:
+    path = tmp_path / "activities.db"
+    first_catalog = SqliteActivityCatalog(path)
+    second_catalog = SqliteActivityCatalog(path)
+    first = ActivityCoordinator(first_catalog)
+    second = ActivityCoordinator(second_catalog)
+    try:
+        await first.admit(_admission())
+        owner_a = await first.claim("world-a", _KIND, "dispatch-1", "owner-a")
+        waiting = await second.claim("world-a", _KIND, "dispatch-1", "owner-b")
+        same_owner = await first.claim("world-a", _KIND, "dispatch-1", "owner-a")
+
+        assert owner_a.acquired
+        assert owner_a.attempt == owner_a.fence == 1
+        assert not waiting.acquired
+        assert waiting.owner == "owner-a"
+        assert not same_owner.acquired
+        assert same_owner.attempt == owner_a.attempt
+        assert same_owner.fence == owner_a.fence
+        assert same_owner.lease_expires_at == owner_a.lease_expires_at
+    finally:
+        await second_catalog.close()
+        await first_catalog.close()
+
+
+async def test_released_pre_provider_claim_is_safely_fenced_and_reclaimable(
+    tmp_path,
+) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        await coordinator.admit(_admission())
+        first = await coordinator.claim("world-a", _KIND, "dispatch-1", "owner-a")
+        await coordinator.release(first)
+        await coordinator.release(first)
+
+        second = await coordinator.claim("world-a", _KIND, "dispatch-1", "owner-b")
+        assert second.acquired
+        assert second.attempt == 2
+        assert second.fence == 2
+        assert not second.reconciliation_required
+
+        with pytest.raises(ActivityClaimError, match="stale"):
+            await coordinator.bind_provider_operation(
+                first,
+                "local",
+                _OPERATION_ID,
+            )
+
+        bound = await coordinator.bind_provider_operation(
+            second,
+            "local",
+            _OPERATION_ID,
+        )
+        with pytest.raises(ActivityClaimError, match="cannot be released"):
+            await coordinator.release(bound)
+    finally:
+        await catalog.close()
+
+
+async def test_expired_provider_bound_attempt_becomes_reconcile_only(tmp_path) -> None:
+    path = tmp_path / "activities.db"
+    first_catalog = SqliteActivityCatalog(path)
+    second_catalog = SqliteActivityCatalog(path)
+    first = ActivityCoordinator(first_catalog)
+    second = ActivityCoordinator(second_catalog)
+    try:
+        await first.admit(_admission())
+        initial = await first.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-a",
+            lease_seconds=0.01,
+        )
+        bound = await first.bind_provider_operation(
+            initial,
+            "git",
+            _OPERATION_ID,
+        )
+        await first_catalog.close()
+        same_owner_after_restart = await second.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-a",
+            lease_seconds=30,
+        )
+        assert not same_owner_after_restart.acquired
+        assert same_owner_after_restart.attempt == bound.attempt
+        assert same_owner_after_restart.fence == bound.fence
+        assert same_owner_after_restart.provider_operation_id == _OPERATION_ID
+        await asyncio.sleep(0.02)
+
+        recovery = await second.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-b",
+            lease_seconds=30,
+        )
+
+        assert recovery.acquired
+        assert recovery.fence == 2
+        assert recovery.reconciliation_required
+        assert recovery.reconciles_attempt == 1
+        assert recovery.reconciles_provider == "git"
+        assert recovery.reconciles_provider_operation_id == _OPERATION_ID
+        with pytest.raises(ActivityClaimError, match="cannot invoke"):
+            await second.bind_provider_operation(
+                recovery,
+                "git",
+                "missions.author:world-a:dispatch-1-replay",
+            )
+        with pytest.raises(ActivityClaimError, match="cannot be released"):
+            await second.release(recovery)
+        with pytest.raises(ActivityClaimError, match="stale"):
+            await first.record_result(bound, _result())
+
+        reconciled = await second.record_result(recovery, _result())
+        assert reconciled.result == _result()
+        assert reconciled.result_attempt == 2
+        assert reconciled.result_fence == 2
+    finally:
+        await second_catalog.close()
+        await first_catalog.close()
+
+
+async def test_confirmed_provider_absence_mints_fresh_execution_fence(tmp_path) -> None:
+    path = tmp_path / "activities.db"
+    catalog = SqliteActivityCatalog(path)
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        await coordinator.admit(_admission())
+        initial = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-a",
+            lease_seconds=0.01,
+        )
+        bound = await coordinator.bind_provider_operation(
+            initial,
+            "git",
+            _OPERATION_ID,
+        )
+        await asyncio.sleep(0.02)
+
+        unknown = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-b",
+            lease_seconds=0.01,
+        )
+        assert unknown.reconciliation_required
+        await asyncio.sleep(0.02)
+
+        recovery = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-c",
+            lease_seconds=30,
+        )
+        assert recovery.reconciliation_required
+        assert recovery.reconciles_provider_operation_id == _OPERATION_ID
+        with pytest.raises(ActivityClaimError, match="stale"):
+            await coordinator.confirm_provider_operation_absent(unknown, _guard())
+        with pytest.raises(ActivityClaimError, match="stale"):
+            await coordinator.confirm_provider_operation_absent(bound, _guard())
+        with pytest.raises(TypeError, match="ActivityRetryGuard"):
+            await coordinator.confirm_provider_operation_absent(
+                recovery,
+                None,  # type: ignore[arg-type] - absence must not authorize replay
+            )
+
+        authorized = await coordinator.confirm_provider_operation_absent(
+            recovery,
+            _guard(),
+        )
+        with pytest.raises(ActivityConflictError, match="different retry guard"):
+            await coordinator.confirm_provider_operation_absent(
+                recovery,
+                _guard("different-guard"),
+            )
+        repeated = await coordinator.confirm_provider_operation_absent(
+            recovery,
+            _guard(),
+        )
+
+        assert authorized.acquired
+        assert authorized.attempt == authorized.fence == 4
+        assert not authorized.reconciliation_required
+        assert authorized.provider_operation_id is None
+        assert authorized.retry_guard == _guard()
+        assert repeated.attempt == authorized.attempt
+        assert repeated.fence == authorized.fence
+        assert repeated.retry_guard == _guard()
+
+        with pytest.raises(
+            ActivityConflictError,
+            match="reconciled provider operation identity",
+        ):
+            await coordinator.bind_provider_operation(
+                authorized,
+                "modal",
+                _OPERATION_ID,
+            )
+        with pytest.raises(
+            ActivityConflictError,
+            match="reconciled provider operation identity",
+        ):
+            await coordinator.bind_provider_operation(
+                authorized,
+                "git",
+                "missions.author:world-a:different-dispatch",
+            )
+
+        await coordinator.release(authorized)
+        await catalog.close()
+
+        catalog = SqliteActivityCatalog(path)
+        coordinator = ActivityCoordinator(catalog)
+        replacement = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-d",
+        )
+        assert replacement.acquired
+        assert replacement.attempt == replacement.fence == 5
+        assert replacement.retry_guard == _guard()
+        with pytest.raises(
+            ActivityConflictError,
+            match="reconciled provider operation identity",
+        ):
+            await coordinator.bind_provider_operation(
+                replacement,
+                "git",
+                "missions.author:world-a:different-dispatch",
+            )
+
+        rebound = await coordinator.bind_provider_operation(
+            replacement,
+            "git",
+            _OPERATION_ID,
+        )
+        result = await coordinator.record_result(rebound, _result())
+        assert result.result_attempt == result.result_fence == 5
+    finally:
+        await catalog.close()
+
+
+async def test_result_survives_restart_until_exact_later_tick_settles_it(
+    tmp_path,
+) -> None:
+    path = tmp_path / "activities.db"
+    first_catalog = SqliteActivityCatalog(path)
+    first = ActivityCoordinator(first_catalog)
+    await first.admit(_admission())
+    claim = await first.claim("world-a", _KIND, "dispatch-1", "worker")
+    bound = await first.bind_provider_operation(
+        claim,
+        "local",
+        _OPERATION_ID,
+    )
+    recorded = await first.record_result(bound, _result())
+    await first_catalog.close()
+
+    second_catalog = SqliteActivityCatalog(path)
+    second = ActivityCoordinator(second_catalog)
+    try:
+        assert recorded.result_pending_observation
+        assert await second.pending(kind=_KIND, world_id="world-a") == ()
+        assert await second.pending_results(kind=_KIND, world_id="world-a") == (recorded,)
+
+        completed_claim = await second.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "new-worker",
+        )
+        assert not completed_claim.acquired
+        assert completed_claim.snapshot == recorded
+
+        observation = _settlement()
+        settled = await second.settle_observation(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            observation,
+        )
+        repeated = await second.settle_observation(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            observation,
+        )
+
+        assert settled == repeated
+        assert settled.settlement == observation
+        assert await second.pending_results(world_id="world-a") == ()
+
+        with pytest.raises(ActivityConflictError, match="different observation"):
+            await second.settle_observation(
+                "world-a",
+                _KIND,
+                "dispatch-1",
+                _settlement(tick=6, token="manifest-6"),
+            )
+    finally:
+        await second_catalog.close()
+
+
+async def test_result_recording_requires_prebound_provider_and_is_idempotent(
+    tmp_path,
+) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        await coordinator.admit(_admission())
+        claim = await coordinator.claim("world-a", _KIND, "dispatch-1", "worker")
+        with pytest.raises(ActivityClaimError, match="pre-bound"):
+            await coordinator.record_result(claim, _result())
+
+        bound = await coordinator.bind_provider_operation(
+            claim,
+            "local",
+            _OPERATION_ID,
+        )
+        first = await coordinator.record_result(bound, _result())
+        repeated = await coordinator.record_result(bound, _result())
+        assert first == repeated
+
+        with pytest.raises(ActivityConflictError, match="different durable result"):
+            await coordinator.record_result(bound, _result("different-result"))
+    finally:
+        await catalog.close()
+
+
+async def test_settlement_rejects_missing_result_wrong_run_and_non_later_tick(
+    tmp_path,
+) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        await coordinator.admit(_admission())
+        with pytest.raises(ActivityConflictError, match="before its result"):
+            await coordinator.settle_observation(
+                "world-a",
+                _KIND,
+                "dispatch-1",
+                _settlement(),
+            )
+
+        claim = await coordinator.claim("world-a", _KIND, "dispatch-1", "worker")
+        bound = await coordinator.bind_provider_operation(
+            claim,
+            "local",
+            _OPERATION_ID,
+        )
+        await coordinator.record_result(bound, _result())
+
+        with pytest.raises(ActivityConflictError, match="durable result digest"):
+            await coordinator.settle_observation(
+                "world-a",
+                _KIND,
+                "dispatch-1",
+                _settlement(result_digest="different-result"),
+            )
+        assert len(await coordinator.pending_results(world_id="world-a")) == 1
+        with pytest.raises(ActivityConflictError, match="source world and run"):
+            await coordinator.settle_observation(
+                "world-a",
+                _KIND,
+                "dispatch-1",
+                _settlement(run_id="other-run"),
+            )
+        with pytest.raises(ActivityConflictError, match="later tick"):
+            await coordinator.settle_observation(
+                "world-a",
+                _KIND,
+                "dispatch-1",
+                _settlement(tick=4, token="manifest-4-observation"),
+            )
+    finally:
+        await catalog.close()
+
+
+async def test_unsettled_oracle_covers_pending_and_result_pending_observation(
+    tmp_path,
+) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        assert not await coordinator.has_unsettled("world-a")
+        admitted = await coordinator.admit(_admission())
+
+        assert await coordinator.has_unsettled("world-a")
+        assert await coordinator.pending(world_id="world-a") == (admitted,)
+        assert await coordinator.pending_results(world_id="world-a") == ()
+        assert not await coordinator.has_unsettled("world-b")
+
+        claim = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "worker",
+        )
+        bound = await coordinator.bind_provider_operation(
+            claim,
+            "local",
+            _OPERATION_ID,
+        )
+        recorded = await coordinator.record_result(bound, _result())
+
+        assert await coordinator.has_unsettled("world-a")
+        assert await coordinator.pending(world_id="world-a") == ()
+        assert await coordinator.pending_results(world_id="world-a") == (recorded,)
+
+        await coordinator.settle_observation(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            _settlement(),
+        )
+        assert not await coordinator.has_unsettled("world-a")
+    finally:
+        await catalog.close()
+
+
+async def test_protocols_and_unknown_activity_are_truthful(tmp_path) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        assert isinstance(catalog, ActivityCatalog)
+        assert isinstance(coordinator, iActivityCoordinator)
+        assert await coordinator.get("world", _KIND, "missing") is None
+        with pytest.raises(ActivityNotFoundError):
+            await coordinator.claim("world", _KIND, "missing", "worker")
+    finally:
+        await catalog.close()
+
+
+async def test_claim_and_provider_coordinates_reject_unbounded_or_nonfinite_values(
+    tmp_path,
+) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        await coordinator.admit(_admission())
+
+        with pytest.raises(ValueError, match="at most 512"):
+            await coordinator.claim("world-a", _KIND, "dispatch-1", "x" * 513)
+        with pytest.raises(ValueError, match="finite and positive"):
+            await coordinator.claim(
+                "world-a",
+                _KIND,
+                "dispatch-1",
+                "worker",
+                lease_seconds=float("nan"),
+            )
+        with pytest.raises(ValueError, match="finite and positive"):
+            await coordinator.claim(
+                "world-a",
+                _KIND,
+                "dispatch-1",
+                "worker",
+                lease_seconds=float("inf"),
+            )
+        with pytest.raises(TypeError, match="must be a number"):
+            await coordinator.claim(
+                "world-a",
+                _KIND,
+                "dispatch-1",
+                "worker",
+                lease_seconds=True,
+            )
+
+        claim = await coordinator.claim("world-a", _KIND, "dispatch-1", "worker")
+        assert claim.attempt == 1, "invalid claims must not mutate durable attempts"
+        with pytest.raises(ValueError, match="at most 255"):
+            await coordinator.bind_provider_operation(claim, "p" * 256, "operation")
+        with pytest.raises(ValueError, match="at most 1024"):
+            await coordinator.bind_provider_operation(claim, "local", "o" * 1025)
+
+        bound = await coordinator.bind_provider_operation(
+            claim,
+            "local",
+            _OPERATION_ID,
+        )
+        assert bound.provider == "local"
+        assert bound.provider_operation_id == _OPERATION_ID
+    finally:
+        await catalog.close()
+
+
+async def test_activity_boundary_rejects_uncoordinated_commit_receipts() -> None:
+    with pytest.raises(ValueError, match="visibility_token must be present"):
+        ActivityAdmission(
+            activity_id="dispatch",
+            kind=_KIND,
+            source=_receipt(token=None),
+            input_ref="mission-input://world/dispatch",
+            input_digest="digest",
+        )
+
+
+async def test_physical_catalog_rejects_tokenless_commit_coordinates(
+    tmp_path,
+) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    try:
+        with pytest.raises(ValueError, match="source visibility token"):
+            await catalog.admit_activity(
+                ActivityAdmissionRecord(
+                    activity_id="dispatch",
+                    kind=_KIND,
+                    source_world_id="world",
+                    source_run_id="run",
+                    source_tick=1,
+                    source_visibility_token=None,
+                    input_ref="mission-input://world/dispatch",
+                    input_digest="digest",
+                )
+            )
+        with pytest.raises(ValueError, match="observation visibility token"):
+            await catalog.settle_activity_observation(
+                "world",
+                _KIND,
+                "dispatch",
+                observed_world_id="world",
+                observed_run_id="run",
+                observed_tick=2,
+                observed_visibility_token=None,
+                expected_result_digest="result-digest",
+            )
+    finally:
+        await catalog.close()
+
+
+async def test_cancelled_sqlite_worker_retains_lock_until_failed_thread_finishes(
+    tmp_path,
+) -> None:
+    catalog = SqliteActivityCatalog(tmp_path / "activities.db")
+    await catalog.admit_activity(
+        ActivityAdmissionRecord(
+            activity_id="dispatch",
+            kind=_KIND,
+            source_world_id="world",
+            source_run_id="run",
+            source_tick=1,
+            source_visibility_token="manifest-1",
+            input_ref="mission-input://world/dispatch",
+            input_digest="digest",
+        )
+    )
+    started = threading.Event()
+    release = threading.Event()
+
+    def _blocked_failure() -> None:
+        conn = catalog._connect_sync()  # noqa: SLF001 - shared-connection race oracle
+        started.set()
+        assert release.wait(timeout=5)
+        conn.execute("SELECT 1").fetchone()
+        raise RuntimeError("worker failed after caller cancellation")
+
+    running = asyncio.create_task(
+        catalog._run(_blocked_failure)  # noqa: SLF001 - cancellation boundary oracle
+    )
+    assert await asyncio.to_thread(started.wait, 5)
+
+    running.cancel("first cancellation")
+    await asyncio.sleep(0)
+    assert not running.done()
+    running.cancel("repeated cancellation")
+    await asyncio.sleep(0)
+    assert not running.done()
+
+    closing = asyncio.create_task(catalog.close())
+    follow_on = asyncio.create_task(catalog.get_activity("world", _KIND, "dispatch"))
+    await asyncio.sleep(0)
+    assert not closing.done()
+    assert not follow_on.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError, match="first cancellation"):
+        await running
+    await closing
+    assert (await follow_on) is not None
+    await catalog.close()


### PR DESCRIPTION
## Outcome

Adds the smallest durable control plane needed to coordinate consequential work
between two exact committed world states.

This is inert substrate: it does not switch Missions, Physical AI, commands, or
runtime wiring to Activities.

## What lands

- `archetype.activities` value contracts, structural coordinator port, and
  concrete coordinator
- storage-owned `activity_catalog` records, structural port, and local SQLite
  authority
- kind-qualified `(world_id, kind, activity_id)` identity and immutable
  admission
- fenced claims, attempts, leases, and stable provider-operation binding
- provider-operation reservation that prevents one external operation from
  being bound to different worlds, kinds, or logical Activities
- no implicit claim renewal from a reusable owner label; a replacement process
  waits for expiry and then receives reconciliation-only authority
- reconciliation-only recovery after an expired provider-bound attempt
- fresh execution only after a live-fence `confirmed absent` transition and a
  bounded durable retry guard
- retry-authorized attempts remain constrained to the exact reconciled
  provider operation across release, restart, and reclaim
- bounded result reference/digest recording and restart discovery
- settlement against the exact later committed receipt and recorded result
  digest
- a conservative world-scoped unsettled-work oracle for later fork/destroy
  integration
- cancellation-safe SQLite serialization that retains its connection lock
  until an in-flight worker thread exits
- no generic lifecycle status or recovery-policy enum

Large values remain outside the control catalog; it stores only bounded
references and digests. Provider-specific evidence and the meaning of
recovered/absent/unknown remain with the family adapter.

Implements A2 from #671 and the contract in #673.

## Crash/control oracles

The focused contracts cover:

- idempotent admission and immutable conflicts
- equal Activity IDs across separate worlds and separate kinds
- cross-world and cross-kind provider-operation collision rejection
- provider-operation reservations surviving catalog reconstruction and
  settlement
- two SQLite instances contending for one live claim
- process reconstruction with the same owner label unable to resume a live
  provider-bound attempt
- safe reclamation of an unbound/no-effect attempt
- reconciliation-only fencing after provider-bound expiry
- stale-worker rejection
- confirmed absence without a retry guard failing closed
- confirmed absence plus exact retry-guard evidence yielding a fresh fence
- wrong-provider and wrong-operation substitution rejection
- retry-guard and authorization-provenance retention across restart/reclaim
- result persistence and discovery after catalog reconstruction
- exact duplicate versus conflicting result/settlement writes
- settlement digest mismatch remaining discoverable and unsettled
- source/run/tick/visibility-token settlement constraints
- pending and result-pending-observation lifecycle discovery
- repeated cancellation, worker failure, close, and follow-on transaction
  serialization
- bounded owner/provider identity and finite lease validation
- rejection of tokenless uncoordinated receipts at both public and physical
  boundaries

## Validation

- `uv run pytest -q tests/activities/test_activity_catalog_contracts.py`
  (`16 passed`)
- full suite (`2568 passed, 6 skipped`)
- `make static`
