### PR TITLE
feat: add safe Modal Activity start barrier

### DIFF
--- a/src/archetype/missions/sandboxes/__init__.py
+++ b/src/archetype/missions/sandboxes/__init__.py
@@ -34,13 +34,30 @@ from archetype.missions.sandboxes.docker import (
     DockerSandboxSession,
 )
 from archetype.missions.sandboxes.modal import (
+    MODAL_ACTIVITY_PROTOCOL_EPOCH,
     ModalSandboxBackend,
     ModalSandboxConfig,
+    ModalSandboxOperationCapability,
+    ModalSandboxOperationIdentity,
+    ModalSandboxOperationReconciliation,
+    ModalSandboxOperationRunning,
+    ModalSandboxOperationUnknown,
     ModalSandboxSession,
+)
+from archetype.missions.sandboxes.modal_barrier import (
+    ModalOperationGuardAcquisition,
+    ModalPersistentDictMarker,
+    ModalProviderBarrierUnknown,
+    ModalProviderMarkerExists,
+    ModalProviderOperationGuard,
+    ModalProviderRunPermit,
+    ModalProviderStartBarrier,
+    ModalRunPermitAcquisition,
 )
 from archetype.missions.sandboxes.service import SandboxService
 
 __all__ = [
+    "MODAL_ACTIVITY_PROTOCOL_EPOCH",
     "AppleContainerSandboxBackend",
     "AppleContainerSandboxConfig",
     "AppleContainerSandboxSession",
@@ -51,7 +68,20 @@ __all__ = [
     "DockerSandboxSession",
     "ModalSandboxBackend",
     "ModalSandboxConfig",
+    "ModalSandboxOperationCapability",
+    "ModalSandboxOperationIdentity",
+    "ModalSandboxOperationReconciliation",
+    "ModalSandboxOperationRunning",
+    "ModalSandboxOperationUnknown",
     "ModalSandboxSession",
+    "ModalOperationGuardAcquisition",
+    "ModalPersistentDictMarker",
+    "ModalProviderBarrierUnknown",
+    "ModalProviderMarkerExists",
+    "ModalProviderOperationGuard",
+    "ModalProviderRunPermit",
+    "ModalProviderStartBarrier",
+    "ModalRunPermitAcquisition",
     "ProcessRequest",
     "ProcessResult",
     "SandboxBackend",

--- a/src/archetype/missions/sandboxes/modal.py
+++ b/src/archetype/missions/sandboxes/modal.py
@@ -6,9 +6,11 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import os
+import re
 import sys
 import time
 from collections.abc import Callable
@@ -46,6 +48,15 @@ _CODEX_HOME = "/root/.codex"
 _MISSION_AUTH_PATH = f"{_CODEX_HOME}/auth.json"
 _CODEX_SECRET = "codex_oauth"
 _GITHUB_SECRET = "github"
+_MAX_PROVIDER_OPERATION_ID_LENGTH = 1024
+_MAX_PROVIDER_OBJECT_ID_LENGTH = 256
+_MAX_PROVIDER_COHORT_ID_LENGTH = 256
+_MODAL_NAMESPACE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,62}")
+_MODAL_OPERATION_COHORT = re.compile(r"cohort-v1:[0-9a-f]{32}")
+
+# Epoch zero and operations without an epoch predate the persistent provider
+# barrier. They must never infer retry permission from a missing marker.
+MODAL_ACTIVITY_PROTOCOL_EPOCH = 1
 
 
 def _default_environment() -> str:
@@ -68,6 +79,12 @@ def _default_environment() -> str:
     return f"modal-agent://sha256:{hashlib.sha256(material.encode()).hexdigest()}"
 
 
+def _require_modal_namespace_name(value: str, *, label: str) -> str:
+    if not _MODAL_NAMESPACE_NAME.fullmatch(value):
+        raise ValueError(f"Modal {label} is invalid")
+    return value
+
+
 @dataclass(frozen=True)
 class ModalSandboxConfig:
     """Provider configuration; repository coordinates arrive in ``SandboxSpec``."""
@@ -80,6 +97,9 @@ class ModalSandboxConfig:
     checkpoint_ttl_seconds: int | None = 30 * 24 * 60 * 60
     heartbeat_seconds: int = 15
     login_timeout_seconds: int = 15 * 60
+    workspace_name: str | None = None
+    environment_name: str | None = None
+    operation_protocol_epoch: int | None = None
 
     def __post_init__(self) -> None:
         if not self.app_name.strip():
@@ -98,6 +118,74 @@ class ModalSandboxConfig:
             raise ValueError("heartbeat interval must be positive")
         if self.login_timeout_seconds < 1:
             raise ValueError("login timeout must be positive")
+        if self.operation_protocol_epoch is not None and self.operation_protocol_epoch < 0:
+            raise ValueError("Modal operation protocol epoch must not be negative")
+
+
+@dataclass(frozen=True, slots=True)
+class ModalSandboxOperationIdentity:
+    """Stable full provider identity known before any Modal effect."""
+
+    workspace_name: str
+    environment_name: str
+    app_name: str
+    operation_id: str
+    protocol_epoch: int
+
+    def __post_init__(self) -> None:
+        _require_modal_namespace_name(self.workspace_name, label="workspace_name")
+        _require_modal_namespace_name(self.environment_name, label="environment_name")
+        _require_modal_namespace_name(self.app_name, label="app_name")
+        if not self.operation_id.strip():
+            raise ValueError("Modal sandbox operation_id must not be empty")
+        if self.operation_id != self.operation_id.strip():
+            raise ValueError("Modal sandbox operation_id must not have surrounding whitespace")
+        if "\x00" in self.operation_id:
+            raise ValueError("Modal sandbox operation_id must not contain NUL")
+        if len(self.operation_id) > _MAX_PROVIDER_OPERATION_ID_LENGTH:
+            raise ValueError(
+                "Modal sandbox operation_id must not exceed "
+                f"{_MAX_PROVIDER_OPERATION_ID_LENGTH} characters"
+            )
+        if self.protocol_epoch < 0:
+            raise ValueError("Modal operation protocol epoch must not be negative")
+
+    @property
+    def digest(self) -> str:
+        """Return the complete namespaced content identity."""
+
+        payload = json.dumps(
+            {
+                "schema_version": 2,
+                "provider": "modal",
+                "workspace_name": self.workspace_name,
+                "environment_name": self.environment_name,
+                "app_name": self.app_name,
+                "protocol_epoch": self.protocol_epoch,
+                "operation_id": self.operation_id,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode()
+        return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+    @property
+    def mission_sandbox_name(self) -> str:
+        """Return a deterministic provider-safe name for the mission sandbox."""
+
+        return self._sandbox_name("m")
+
+    @property
+    def auth_sandbox_name(self) -> str:
+        """Return a deterministic provider-safe name for the isolated auth broker."""
+
+        return self._sandbox_name("a")
+
+    def _sandbox_name(self, role: str) -> str:
+        digest = bytes.fromhex(self.digest.removeprefix("sha256:"))
+        encoded = base64.b32encode(digest).decode().rstrip("=").lower()
+        return f"arc-{role}-{encoded}"
 
 
 class ModalSandboxSession:
@@ -114,6 +202,8 @@ class ModalSandboxSession:
         checkpoint_timeout_seconds: int,
         checkpoint_ttl_seconds: int | None,
         heartbeat_seconds: int,
+        operation_identity: ModalSandboxOperationIdentity | None = None,
+        operation_cohort_id: str | None = None,
     ) -> None:
         self._spec = spec
         self._sandbox = sandbox
@@ -123,6 +213,8 @@ class ModalSandboxSession:
         self._checkpoint_timeout_seconds = checkpoint_timeout_seconds
         self._checkpoint_ttl_seconds = checkpoint_ttl_seconds
         self._heartbeat_seconds = heartbeat_seconds
+        self._operation_identity = operation_identity
+        self._operation_cohort_id = operation_cohort_id
         self._lock = asyncio.Lock()
         self._event_lock = asyncio.Lock()
         self._event_sequence = 0
@@ -139,6 +231,18 @@ class ModalSandboxSession:
             sandbox_id=str(self._sandbox.object_id),
             environment=self._spec.environment,
         )
+
+    @property
+    def operation_identity(self) -> ModalSandboxOperationIdentity | None:
+        """Return the stable named-operation identity, when this session has one."""
+
+        return self._operation_identity
+
+    @property
+    def operation_cohort_id(self) -> str | None:
+        """Return the exact two-resource cohort created for this session."""
+
+        return self._operation_cohort_id
 
     @property
     def capabilities(self) -> SandboxCapabilities:
@@ -716,11 +820,16 @@ class ModalSandboxBackend:
             raise RuntimeError(
                 "Modal support is optional; install it with `uv sync --extra coding-agent`"
             ) from exc
-        app = await modal.App.lookup.aio(self.config.app_name, create_if_missing=True)
+        app = await modal.App.lookup.aio(
+            self.config.app_name,
+            create_if_missing=True,
+            environment_name=self.config.environment_name,
+        )
         volume = modal.Volume.from_name(
             self.config.auth_volume_name,
             create_if_missing=True,
             version=2,
+            environment_name=self.config.environment_name,
         )
         await volume.hydrate.aio()
         image = (
@@ -738,6 +847,7 @@ class ModalSandboxBackend:
             workdir=_AUTH_MOUNT,
             volumes={_AUTH_MOUNT: volume},
             tags={"kind": "archetype-agent-oauth-login"},
+            environment_name=self.config.environment_name,
         )
         try:
             process = await sandbox.exec.aio(
@@ -843,19 +953,51 @@ class ModalSandboxBackend:
             if writes:
                 await asyncio.gather(*writes, return_exceptions=True)
 
-    async def _start(self, modal: Any, spec: SandboxSpec, image: Any) -> SandboxSession:
-        app = await modal.App.lookup.aio(self.config.app_name, create_if_missing=True)
+    async def _start(
+        self,
+        modal: Any,
+        spec: SandboxSpec,
+        image: Any,
+        *,
+        operation_identity: ModalSandboxOperationIdentity | None = None,
+        client: Any | None = None,
+    ) -> SandboxSession:
+        if operation_identity is not None:
+            self._validate_operation_identity(operation_identity)
+        app = await modal.App.lookup.aio(
+            self.config.app_name,
+            create_if_missing=True,
+            environment_name=self.config.environment_name,
+            client=client,
+        )
         auth_volume = modal.Volume.from_name(
             self.config.auth_volume_name,
             create_if_missing=False,
             version=2,
+            environment_name=self.config.environment_name,
+            client=client,
         )
         await auth_volume.hydrate.aio()
         github_secret = modal.Secret.from_name(
             self.config.github_secret_name,
             required_keys=["GITHUB_TOKEN"],
+            environment_name=self.config.environment_name,
+            client=client,
         )
         metadata = spec.metadata_dict()
+        operation_cohort_id = f"cohort-v1:{uuid4().hex}" if operation_identity is not None else None
+        operation_tags = (
+            {
+                "operation_digest": operation_identity.digest,
+                "operation_cohort": str(operation_cohort_id),
+                "operation_protocol_epoch": str(operation_identity.protocol_epoch),
+            }
+            if operation_identity is not None
+            else {}
+        )
+        auth_name = (
+            {"name": operation_identity.auth_sandbox_name} if operation_identity is not None else {}
+        )
         auth_sandbox = await modal.Sandbox.create.aio(
             "sleep",
             "infinity",
@@ -865,9 +1007,17 @@ class ModalSandboxBackend:
             idle_timeout=spec.idle_timeout_seconds,
             workdir=_AUTH_MOUNT,
             volumes={_AUTH_MOUNT: auth_volume},
-            tags={"kind": "archetype-agent-auth", **metadata},
+            tags={**metadata, "kind": "archetype-agent-auth", **operation_tags},
+            environment_name=self.config.environment_name,
+            client=client,
+            **auth_name,
         )
         try:
+            mission_name = (
+                {"name": operation_identity.mission_sandbox_name}
+                if operation_identity is not None
+                else {}
+            )
             sandbox = await modal.Sandbox.create.aio(
                 "sleep",
                 "infinity",
@@ -876,7 +1026,10 @@ class ModalSandboxBackend:
                 timeout=spec.timeout_seconds,
                 idle_timeout=spec.idle_timeout_seconds,
                 workdir=str(PurePosixPath(spec.workdir).parent),
-                tags={"kind": "archetype-agent-mission", **metadata},
+                tags={**metadata, "kind": "archetype-agent-mission", **operation_tags},
+                environment_name=self.config.environment_name,
+                client=client,
+                **mission_name,
             )
         except BaseException:
             await ModalSandboxSession._terminate(auth_sandbox)
@@ -890,6 +1043,8 @@ class ModalSandboxBackend:
             checkpoint_timeout_seconds=self.config.checkpoint_timeout_seconds,
             checkpoint_ttl_seconds=self.config.checkpoint_ttl_seconds,
             heartbeat_seconds=self.config.heartbeat_seconds,
+            operation_identity=operation_identity,
+            operation_cohort_id=operation_cohort_id,
         )
         try:
             await verify_coding_agent_environment(
@@ -902,6 +1057,25 @@ class ModalSandboxBackend:
             await session.close()
             raise
         return session
+
+    def _validate_operation_identity(
+        self,
+        identity: ModalSandboxOperationIdentity,
+    ) -> None:
+        expected = (
+            self.config.workspace_name,
+            self.config.environment_name,
+            self.config.app_name,
+            self.config.operation_protocol_epoch,
+        )
+        observed = (
+            identity.workspace_name,
+            identity.environment_name,
+            identity.app_name,
+            identity.protocol_epoch,
+        )
+        if observed != expected:
+            raise ValueError("Modal operation identity does not match backend namespace")
 
     async def restore(
         self,
@@ -968,4 +1142,365 @@ class ModalSandboxBackend:
         )
 
 
-__all__ = ["ModalSandboxBackend", "ModalSandboxConfig", "ModalSandboxSession"]
+@dataclass(frozen=True, slots=True)
+class ModalSandboxOperationRunning:
+    """Bounded evidence that one coherent named cohort was running.
+
+    This value deliberately carries no executable session. Reconciliation
+    cannot grant a second worker access to the inner ``exec`` boundary.
+    """
+
+    identity: ModalSandboxOperationIdentity
+    mission_sandbox_id: str
+    auth_sandbox_id: str
+    cohort_id: str
+
+    def __post_init__(self) -> None:
+        if not self.mission_sandbox_id.strip() or not self.auth_sandbox_id.strip():
+            raise ValueError("running Modal operation requires both sandbox identities")
+        if (
+            len(self.mission_sandbox_id) > _MAX_PROVIDER_OBJECT_ID_LENGTH
+            or len(self.auth_sandbox_id) > _MAX_PROVIDER_OBJECT_ID_LENGTH
+        ):
+            raise ValueError("running Modal sandbox identity is too long")
+        if self.mission_sandbox_id == self.auth_sandbox_id:
+            raise ValueError("mission and auth sandbox identities must be distinct")
+        if (
+            not _MODAL_OPERATION_COHORT.fullmatch(self.cohort_id)
+            or len(self.cohort_id) > _MAX_PROVIDER_COHORT_ID_LENGTH
+        ):
+            raise ValueError("running Modal operation cohort identity is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class ModalSandboxOperationUnknown:
+    """Provider evidence cannot prove a complete live pair or safe absence."""
+
+    identity: ModalSandboxOperationIdentity
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not self.reason.strip():
+            raise ValueError("unknown Modal sandbox reconciliation requires a reason")
+        if len(self.reason) > 512:
+            raise ValueError("unknown Modal sandbox reconciliation reason is too long")
+
+
+type ModalSandboxOperationReconciliation = (
+    ModalSandboxOperationRunning | ModalSandboxOperationUnknown
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ModalSandboxLookupFailure:
+    reason: str
+
+
+_MODAL_SANDBOX_MISSING = object()
+
+
+class ModalSandboxOperationCapability:
+    """Start and observe one namespaced, cohort-tagged Modal sandbox pair.
+
+    Identity includes the authenticated workspace, explicit Environment, App,
+    protocol epoch, and logical operation. Epoch zero and any operation that
+    existed before the persistent barrier are legacy: missing barrier evidence
+    for them is always Unknown and must never authorize this endpoint.
+
+    ``start`` is an initial execution endpoint, not an idempotent retry
+    endpoint. A running provider name prevents a second ``start`` from
+    acquiring the same pair, but Modal releases names when sandboxes stop.
+    Consequently reconciliation never returns replay permission, a retry
+    guard, or an executable session. Public name-based cleanup is deliberately
+    absent because a late cleanup could terminate a newer name generation;
+    successful sessions close the exact handles they created.
+
+    This is provider-resource substrate, not full Activity parity. The current
+    multi-step author harness still invokes inner processes after pair
+    creation; those invocations are not one atomic named Modal operation. A
+    future Activity adapter must first acquire the persistent provider guard
+    and run marker from ``ModalProviderStartBarrier``. This low-level method
+    does not yet accept or verify that permit.
+    """
+
+    def __init__(self, backend: ModalSandboxBackend) -> None:
+        self._backend = backend
+        config = backend.config
+        if config.workspace_name is None:
+            raise ValueError("Modal named operations require an explicit workspace_name")
+        if config.environment_name is None:
+            raise ValueError("Modal named operations require an explicit environment_name")
+        _require_modal_namespace_name(config.workspace_name, label="workspace_name")
+        _require_modal_namespace_name(config.environment_name, label="environment_name")
+        _require_modal_namespace_name(config.app_name, label="app_name")
+        if config.operation_protocol_epoch != MODAL_ACTIVITY_PROTOCOL_EPOCH:
+            raise ValueError(
+                "Modal named operations require the barrier-aware protocol epoch "
+                f"{MODAL_ACTIVITY_PROTOCOL_EPOCH}"
+            )
+
+    def identity(self, operation_id: str) -> ModalSandboxOperationIdentity:
+        """Derive provider names without contacting Modal."""
+
+        config = self._backend.config
+        assert config.workspace_name is not None
+        assert config.environment_name is not None
+        assert config.operation_protocol_epoch is not None
+        return ModalSandboxOperationIdentity(
+            workspace_name=config.workspace_name,
+            environment_name=config.environment_name,
+            app_name=config.app_name,
+            operation_id=operation_id,
+            protocol_epoch=config.operation_protocol_epoch,
+        )
+
+    async def start(
+        self,
+        *,
+        operation_id: str,
+        spec: SandboxSpec,
+    ) -> ModalSandboxSession:
+        """Create a fresh named pair for one execution-authorized claim.
+
+        The first named create serializes live pair acquisition. It is not a
+        durable author-execution retry guard because Modal releases the name
+        when the sandbox stops. Callers that lose the live-name race must
+        reconcile; they must not attach and invoke ``exec`` through the
+        winning worker's sandbox.
+        """
+
+        identity = self.identity(operation_id)
+        self._validate_spec(spec)
+        modal = self._load_modal()
+        client = await self._verified_client(modal, phase="start")
+        if isinstance(client, _ModalSandboxLookupFailure):
+            raise RuntimeError(client.reason)
+        image = (
+            modal.Image.from_id(self._backend.config.image_id, client=client)
+            if self._backend.config.image_id
+            else self._backend._default_image(modal)
+        )
+        session = await self._backend._start(
+            modal,
+            spec,
+            image,
+            operation_identity=identity,
+            client=client,
+        )
+        if not isinstance(session, ModalSandboxSession):
+            raise TypeError("Modal named operation returned a non-Modal session")
+        return session
+
+    async def reconcile(
+        self,
+        *,
+        operation_id: str,
+        spec: SandboxSpec,
+    ) -> ModalSandboxOperationReconciliation:
+        """Observe a complete running pair without granting execution authority."""
+
+        identity = self.identity(operation_id)
+        self._validate_spec(spec)
+        modal = self._load_modal()
+        client = await self._verified_client(modal, phase="reconciliation")
+        if isinstance(client, _ModalSandboxLookupFailure):
+            return ModalSandboxOperationUnknown(identity, client.reason)
+        mission, auth = await asyncio.gather(
+            self._lookup(
+                modal,
+                client=client,
+                role="mission",
+                name=identity.mission_sandbox_name,
+            ),
+            self._lookup(
+                modal,
+                client=client,
+                role="auth",
+                name=identity.auth_sandbox_name,
+            ),
+        )
+        lookups = {"mission": mission, "auth": auth}
+        failures = [
+            value.reason
+            for value in lookups.values()
+            if isinstance(value, _ModalSandboxLookupFailure)
+        ]
+        if failures:
+            return ModalSandboxOperationUnknown(
+                identity,
+                "; ".join(sorted(failures)),
+            )
+        missing = [role for role, value in lookups.items() if value is _MODAL_SANDBOX_MISSING]
+        if len(missing) == len(lookups):
+            return ModalSandboxOperationUnknown(
+                identity,
+                "no running named Modal sandbox pair; absence is not retry authorization",
+            )
+        if missing:
+            return ModalSandboxOperationUnknown(
+                identity,
+                "named Modal sandbox pair is partial; absent=" + ",".join(sorted(missing)),
+            )
+
+        mission_tags, auth_tags, mission_poll, auth_poll = await asyncio.gather(
+            self._tags(mission, role="mission"),
+            self._tags(auth, role="auth"),
+            self._poll(mission, role="mission"),
+            self._poll(auth, role="auth"),
+        )
+        tags = {"mission": mission_tags, "auth": auth_tags}
+        polls = {"mission": mission_poll, "auth": auth_poll}
+        observation_failures = [
+            value.reason
+            for value in (*tags.values(), *polls.values())
+            if isinstance(value, _ModalSandboxLookupFailure)
+        ]
+        if observation_failures:
+            return ModalSandboxOperationUnknown(
+                identity,
+                "; ".join(sorted(observation_failures)),
+            )
+        stopped = [role for role, value in polls.items() if value is not None]
+        if stopped:
+            return ModalSandboxOperationUnknown(
+                identity,
+                "named Modal sandbox is not running; stopped=" + ",".join(sorted(stopped)),
+            )
+
+        expected_tags = {
+            "operation_digest": identity.digest,
+            "operation_protocol_epoch": str(identity.protocol_epoch),
+        }
+        for role, values in tags.items():
+            if not isinstance(values, dict):
+                return ModalSandboxOperationUnknown(
+                    identity,
+                    f"{role} sandbox returned invalid cohort evidence",
+                )
+            if any(values.get(key) != value for key, value in expected_tags.items()):
+                return ModalSandboxOperationUnknown(
+                    identity,
+                    f"{role} sandbox does not match the full provider operation identity",
+                )
+            if values.get("kind") != f"archetype-agent-{role}":
+                return ModalSandboxOperationUnknown(
+                    identity,
+                    f"{role} sandbox role evidence does not match",
+                )
+        mission_cohort = mission_tags.get("operation_cohort")
+        auth_cohort = auth_tags.get("operation_cohort")
+        if (
+            not isinstance(mission_cohort, str)
+            or not _MODAL_OPERATION_COHORT.fullmatch(mission_cohort)
+            or mission_cohort != auth_cohort
+        ):
+            return ModalSandboxOperationUnknown(
+                identity,
+                "named Modal sandbox pair has missing or mixed-generation cohort evidence",
+            )
+
+        return ModalSandboxOperationRunning(
+            identity=identity,
+            mission_sandbox_id=str(mission.object_id),
+            auth_sandbox_id=str(auth.object_id),
+            cohort_id=mission_cohort,
+        )
+
+    def _validate_spec(self, spec: SandboxSpec) -> None:
+        if spec.provider != self._backend.name:
+            raise ValueError("Modal operation capability received a non-Modal sandbox spec")
+        if spec.environment != self._backend.environment:
+            raise ValueError(
+                f"Modal environment must be {self._backend.environment!r}, got {spec.environment!r}"
+            )
+
+    @staticmethod
+    def _load_modal() -> Any:
+        try:
+            import modal
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "Modal support is optional; install it with `uv sync --extra coding-agent`"
+            ) from exc
+        return modal
+
+    async def _verified_client(
+        self,
+        modal: Any,
+        *,
+        phase: str,
+    ) -> Any | _ModalSandboxLookupFailure:
+        expected = self._backend.config.workspace_name
+        assert expected is not None
+        try:
+            workspace = modal.Workspace.from_context()
+            await workspace.hydrate.aio()
+            observed = str(workspace.name or "")
+            client = workspace.client
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return _ModalSandboxLookupFailure(
+                f"Modal {phase} workspace lookup failed ({type(exc).__name__[:128]})"
+            )
+        if observed != expected:
+            return _ModalSandboxLookupFailure(
+                f"Modal {phase} workspace identity does not match configured namespace"
+            )
+        return client
+
+    async def _lookup(
+        self,
+        modal: Any,
+        *,
+        client: Any,
+        role: str,
+        name: str,
+    ) -> Any:
+        try:
+            return await modal.Sandbox.from_name.aio(
+                self._backend.config.app_name,
+                name,
+                environment_name=self._backend.config.environment_name,
+                client=client,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            not_found = getattr(getattr(modal, "exception", None), "NotFoundError", None)
+            if isinstance(not_found, type) and isinstance(exc, not_found):
+                return _MODAL_SANDBOX_MISSING
+            return _ModalSandboxLookupFailure(f"{role} lookup failed ({type(exc).__name__[:128]})")
+
+    @staticmethod
+    async def _tags(sandbox: Any, *, role: str) -> Any:
+        try:
+            return await sandbox.get_tags.aio()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return _ModalSandboxLookupFailure(
+                f"{role} cohort lookup failed ({type(exc).__name__[:128]})"
+            )
+
+    @staticmethod
+    async def _poll(sandbox: Any, *, role: str) -> Any:
+        try:
+            return await sandbox.poll.aio()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return _ModalSandboxLookupFailure(f"{role} poll failed ({type(exc).__name__[:128]})")
+
+
+__all__ = [
+    "MODAL_ACTIVITY_PROTOCOL_EPOCH",
+    "ModalSandboxBackend",
+    "ModalSandboxConfig",
+    "ModalSandboxOperationCapability",
+    "ModalSandboxOperationIdentity",
+    "ModalSandboxOperationReconciliation",
+    "ModalSandboxOperationRunning",
+    "ModalSandboxOperationUnknown",
+    "ModalSandboxSession",
+]

--- a/src/archetype/missions/sandboxes/modal_barrier.py
+++ b/src/archetype/missions/sandboxes/modal_barrier.py
@@ -1,0 +1,583 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistent Modal provider barriers for one logical Mission author operation."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+from archetype.missions.sandboxes.modal import (
+    MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    ModalSandboxOperationIdentity,
+)
+
+_MAX_NAMESPACE_NAME_LENGTH = 63
+_MAX_MARKER_NAME_LENGTH = 63
+_MAX_OBJECT_ID_LENGTH = 256
+_MAX_REASON_LENGTH = 512
+_MARKER_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,62}")
+
+
+def _require_namespace_name(value: str, *, label: str) -> str:
+    if not _MARKER_NAME.fullmatch(value) or len(value) > _MAX_NAMESPACE_NAME_LENGTH:
+        raise ValueError(f"Modal barrier {label} name is invalid")
+    return value
+
+
+def _canonical_digest(value: dict[str, str | int]) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode()
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _operation_marker_name(identity: ModalSandboxOperationIdentity) -> str:
+    digest = bytes.fromhex(identity.digest.removeprefix("sha256:"))
+    encoded = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return f"op-v1-{encoded}"
+
+
+def _run_marker_name(guard_digest: str) -> str:
+    digest = hashlib.sha256(guard_digest.encode()).digest()
+    encoded = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return f"run-v1-{encoded}"
+
+
+@dataclass(frozen=True, slots=True)
+class ModalPersistentDictMarker:
+    """Bounded identity of one persistent named Modal Dict object."""
+
+    workspace_name: str
+    environment_name: str
+    app_name: str
+    protocol_epoch: int
+    name: str
+    object_id: str
+
+    def __post_init__(self) -> None:
+        _require_namespace_name(self.workspace_name, label="workspace")
+        _require_namespace_name(self.environment_name, label="environment")
+        _require_namespace_name(self.app_name, label="app")
+        if self.protocol_epoch != MODAL_ACTIVITY_PROTOCOL_EPOCH:
+            raise ValueError("Modal persistent marker protocol epoch is not barrier-aware")
+        if not _MARKER_NAME.fullmatch(self.name) or len(self.name) > _MAX_MARKER_NAME_LENGTH:
+            raise ValueError("Modal persistent marker name is invalid")
+        if (
+            not self.object_id.strip()
+            or self.object_id != self.object_id.strip()
+            or "\x00" in self.object_id
+            or len(self.object_id) > _MAX_OBJECT_ID_LENGTH
+        ):
+            raise ValueError("Modal persistent marker object identity is invalid")
+
+    @property
+    def reference(self) -> str:
+        """Return a bounded provider locator suitable for an Activity catalog."""
+
+        return (
+            "modal-dict://"
+            + quote(self.workspace_name, safe="")
+            + "/"
+            + quote(self.environment_name, safe="")
+            + "/"
+            + self.name
+            + "#"
+            + quote(self.object_id, safe="")
+        )
+
+    @property
+    def digest(self) -> str:
+        """Return the immutable digest of this exact provider object."""
+
+        return _canonical_digest(
+            {
+                "schema_version": 2,
+                "provider": "modal",
+                "workspace_name": self.workspace_name,
+                "environment_name": self.environment_name,
+                "app_name": self.app_name,
+                "protocol_epoch": self.protocol_epoch,
+                "name": self.name,
+                "object_id": self.object_id,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ModalProviderOperationGuard:
+    """Persistent one-winner barrier bound to one logical provider operation."""
+
+    identity: ModalSandboxOperationIdentity
+    marker: ModalPersistentDictMarker
+
+    def __post_init__(self) -> None:
+        if self.marker.name != _operation_marker_name(self.identity):
+            raise ValueError("Modal operation guard marker does not match its operation")
+        if self.marker.workspace_name != self.identity.workspace_name:
+            raise ValueError("Modal operation guard belongs to another workspace")
+        if self.marker.environment_name != self.identity.environment_name:
+            raise ValueError("Modal operation guard belongs to another environment")
+        if self.marker.app_name != self.identity.app_name:
+            raise ValueError("Modal operation guard belongs to another app")
+        if self.marker.protocol_epoch != self.identity.protocol_epoch:
+            raise ValueError("Modal operation guard belongs to another protocol epoch")
+
+    @property
+    def reference(self) -> str:
+        """Return the bounded provider retry-guard reference."""
+
+        return self.marker.reference
+
+    @property
+    def digest(self) -> str:
+        """Bind logical operation identity to the exact persistent marker."""
+
+        return _canonical_digest(
+            {
+                "schema_version": 2,
+                "kind": "modal_operation_guard",
+                "operation_digest": self.identity.digest,
+                "marker_digest": self.marker.digest,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ModalProviderRunPermit:
+    """One-winner evidence returned only by acknowledged run-marker creation.
+
+    The marker is permanent and must never be deleted. Losing this value after
+    marker creation leaves the operation Unknown forever; another claimant may
+    not reconstruct execution authority from provider lookup alone.
+    """
+
+    guard: ModalProviderOperationGuard
+    marker: ModalPersistentDictMarker
+
+    def __post_init__(self) -> None:
+        if self.marker.workspace_name != self.guard.marker.workspace_name:
+            raise ValueError("Modal run marker belongs to another workspace")
+        if self.marker.environment_name != self.guard.marker.environment_name:
+            raise ValueError("Modal run marker belongs to another environment")
+        if self.marker.app_name != self.guard.marker.app_name:
+            raise ValueError("Modal run marker belongs to another app")
+        if self.marker.protocol_epoch != self.guard.marker.protocol_epoch:
+            raise ValueError("Modal run marker belongs to another protocol epoch")
+        if self.marker.name != _run_marker_name(self.guard.digest):
+            raise ValueError("Modal run marker does not match its operation guard")
+
+    @property
+    def reference(self) -> str:
+        return self.marker.reference
+
+    @property
+    def digest(self) -> str:
+        return _canonical_digest(
+            {
+                "schema_version": 2,
+                "kind": "modal_run_permit",
+                "guard_digest": self.guard.digest,
+                "marker_digest": self.marker.digest,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ModalProviderMarkerExists:
+    """Another claimant already owns this permanent provider marker."""
+
+    identity: ModalSandboxOperationIdentity
+    phase: str
+    marker_name: str
+
+    def __post_init__(self) -> None:
+        if self.phase not in {"operation", "run"}:
+            raise ValueError("Modal provider marker phase is invalid")
+        if not _MARKER_NAME.fullmatch(self.marker_name):
+            raise ValueError("Modal provider marker name is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class ModalProviderBarrierUnknown:
+    """Provider evidence cannot grant guard or run authority."""
+
+    identity: ModalSandboxOperationIdentity
+    phase: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if self.phase not in {"operation", "run"}:
+            raise ValueError("Modal provider barrier phase is invalid")
+        if not self.reason.strip() or len(self.reason) > _MAX_REASON_LENGTH:
+            raise ValueError("Modal provider barrier unknown reason is invalid")
+
+
+type ModalOperationGuardAcquisition = (
+    ModalProviderOperationGuard | ModalProviderMarkerExists | ModalProviderBarrierUnknown
+)
+type ModalRunPermitAcquisition = (
+    ModalProviderRunPermit | ModalProviderMarkerExists | ModalProviderBarrierUnknown
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _MarkerLookupFailure:
+    reason: str
+
+
+_MARKER_MISSING = object()
+
+
+class ModalProviderStartBarrier:
+    """Atomically select one permanent operation owner and one run owner.
+
+    Both tiers use named Modal Dict object creation with
+    ``allow_existing=False``. Dict object names persist until explicitly
+    deleted; this capability deliberately exposes no deletion operation.
+    Its configured Modal workspace credentials, Environment, App, protocol
+    epoch, and both marker objects are durable provider identity and must never
+    be deleted or silently replaced. Only operations admitted into
+    ``MODAL_ACTIVITY_PROTOCOL_EPOCH`` from birth may use this barrier.
+    Pre-barrier and in-flight legacy operations remain Unknown even when no
+    marker exists.
+
+    Safety is fail-closed. An ambiguous create, a winner lost before effect,
+    or a winner lost between tiers remains Unknown forever. This capability
+    provides no lease, handoff, takeover, replay, or liveness promise.
+    """
+
+    def __init__(
+        self,
+        *,
+        workspace_name: str,
+        environment_name: str,
+        app_name: str,
+        protocol_epoch: int,
+    ) -> None:
+        self._workspace_name = _require_namespace_name(
+            workspace_name,
+            label="workspace",
+        )
+        self._environment_name = _require_namespace_name(
+            environment_name,
+            label="environment",
+        )
+        self._app_name = _require_namespace_name(app_name, label="app")
+        if protocol_epoch != MODAL_ACTIVITY_PROTOCOL_EPOCH:
+            raise ValueError(
+                "Modal provider barrier requires the barrier-aware protocol epoch "
+                f"{MODAL_ACTIVITY_PROTOCOL_EPOCH}"
+            )
+        self._protocol_epoch = protocol_epoch
+
+    @property
+    def workspace_name(self) -> str:
+        return self._workspace_name
+
+    @property
+    def environment_name(self) -> str:
+        return self._environment_name
+
+    @property
+    def app_name(self) -> str:
+        return self._app_name
+
+    @property
+    def protocol_epoch(self) -> int:
+        return self._protocol_epoch
+
+    def operation_marker_name(self, identity: ModalSandboxOperationIdentity) -> str:
+        """Derive the permanent first-tier marker name without provider I/O."""
+
+        failure = self._identity_failure(identity)
+        if failure is not None:
+            raise ValueError(failure)
+        return _operation_marker_name(identity)
+
+    @staticmethod
+    def run_marker_name(guard: ModalProviderOperationGuard) -> str:
+        """Derive the permanent second-tier marker name without provider I/O."""
+
+        return _run_marker_name(guard.digest)
+
+    async def acquire_initial(
+        self,
+        *,
+        identity: ModalSandboxOperationIdentity,
+    ) -> ModalOperationGuardAcquisition:
+        """Atomically acquire the permanent marker before an initial effect."""
+
+        failure = self._identity_failure(identity)
+        if failure is not None:
+            return ModalProviderBarrierUnknown(identity, "operation", failure)
+        return await self._create_operation_guard(identity)
+
+    async def acquire_retry_guard(
+        self,
+        *,
+        identity: ModalSandboxOperationIdentity,
+    ) -> ModalOperationGuardAcquisition:
+        """Acquire only for a barrier-born operation with no provider owner."""
+
+        failure = self._identity_failure(identity)
+        if failure is not None:
+            return ModalProviderBarrierUnknown(identity, "operation", failure)
+        marker_name = _operation_marker_name(identity)
+        observed = await self._lookup_marker(marker_name, phase="operation")
+        if isinstance(observed, ModalPersistentDictMarker):
+            return ModalProviderMarkerExists(identity, "operation", marker_name)
+        if isinstance(observed, _MarkerLookupFailure):
+            return ModalProviderBarrierUnknown(identity, "operation", observed.reason)
+        return await self._create_operation_guard(identity)
+
+    async def acquire_run(
+        self,
+        *,
+        guard: ModalProviderOperationGuard,
+    ) -> ModalRunPermitAcquisition:
+        """Verify the exact guard object, then atomically acquire run authority."""
+
+        identity = guard.identity
+        failure = self._identity_failure(identity)
+        if failure is not None:
+            return ModalProviderBarrierUnknown(identity, "run", failure)
+        if guard.marker.workspace_name != self._workspace_name:
+            return ModalProviderBarrierUnknown(
+                identity,
+                "run",
+                "operation guard belongs to another Modal workspace",
+            )
+        if guard.marker.environment_name != self._environment_name:
+            return ModalProviderBarrierUnknown(
+                identity,
+                "run",
+                "operation guard belongs to another Modal environment",
+            )
+        if guard.marker.app_name != self._app_name:
+            return ModalProviderBarrierUnknown(
+                identity,
+                "run",
+                "operation guard belongs to another Modal app",
+            )
+        if guard.marker.protocol_epoch != self._protocol_epoch:
+            return ModalProviderBarrierUnknown(
+                identity,
+                "run",
+                "operation guard belongs to another Modal protocol epoch",
+            )
+        expected_guard_name = _operation_marker_name(identity)
+        if guard.marker.name != expected_guard_name:
+            return ModalProviderBarrierUnknown(
+                identity,
+                "run",
+                "operation guard marker name does not match",
+            )
+        observed = await self._lookup_marker(expected_guard_name, phase="run")
+        if observed is _MARKER_MISSING:
+            return ModalProviderBarrierUnknown(
+                identity,
+                "run",
+                "persistent operation guard is missing",
+            )
+        if isinstance(observed, _MarkerLookupFailure):
+            return ModalProviderBarrierUnknown(identity, "run", observed.reason)
+        if not isinstance(observed, ModalPersistentDictMarker):
+            return ModalProviderBarrierUnknown(
+                identity,
+                "run",
+                "persistent operation guard lookup returned invalid evidence",
+            )
+        if observed.object_id != guard.marker.object_id:
+            return ModalProviderBarrierUnknown(
+                identity,
+                "run",
+                "persistent operation guard object identity changed",
+            )
+
+        marker_name = _run_marker_name(guard.digest)
+        created = await self._create_marker(
+            identity=identity,
+            phase="run",
+            marker_name=marker_name,
+        )
+        if isinstance(created, ModalPersistentDictMarker):
+            return ModalProviderRunPermit(guard, created)
+        return created
+
+    async def _create_operation_guard(
+        self,
+        identity: ModalSandboxOperationIdentity,
+    ) -> ModalOperationGuardAcquisition:
+        marker_name = _operation_marker_name(identity)
+        created = await self._create_marker(
+            identity=identity,
+            phase="operation",
+            marker_name=marker_name,
+        )
+        if isinstance(created, ModalPersistentDictMarker):
+            return ModalProviderOperationGuard(identity, created)
+        return created
+
+    async def _create_marker(
+        self,
+        *,
+        identity: ModalSandboxOperationIdentity,
+        phase: str,
+        marker_name: str,
+    ) -> ModalPersistentDictMarker | ModalProviderMarkerExists | ModalProviderBarrierUnknown:
+        modal = self._load_modal()
+        client = await self._verified_client(modal, phase=phase)
+        if isinstance(client, _MarkerLookupFailure):
+            return ModalProviderBarrierUnknown(identity, phase, client.reason)
+        try:
+            await modal.Dict.objects.create.aio(
+                marker_name,
+                allow_existing=False,
+                environment_name=self._environment_name,
+                client=client,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            already_exists = getattr(
+                getattr(modal, "exception", None),
+                "AlreadyExistsError",
+                None,
+            )
+            if isinstance(already_exists, type) and isinstance(exc, already_exists):
+                return ModalProviderMarkerExists(identity, phase, marker_name)
+            return ModalProviderBarrierUnknown(
+                identity,
+                phase,
+                f"persistent marker create failed ({type(exc).__name__[:128]})",
+            )
+
+        observed = await self._lookup_marker(
+            marker_name,
+            phase=phase,
+            verify_workspace=False,
+            client=client,
+        )
+        if isinstance(observed, ModalPersistentDictMarker):
+            return observed
+        if isinstance(observed, _MarkerLookupFailure):
+            reason = observed.reason
+        else:
+            reason = "acknowledged persistent marker is not visible"
+        return ModalProviderBarrierUnknown(identity, phase, reason)
+
+    async def _lookup_marker(
+        self,
+        marker_name: str,
+        *,
+        phase: str,
+        verify_workspace: bool = True,
+        client: Any | None = None,
+    ) -> ModalPersistentDictMarker | _MarkerLookupFailure | object:
+        modal = self._load_modal()
+        if verify_workspace:
+            client = await self._verified_client(modal, phase=phase)
+            if isinstance(client, _MarkerLookupFailure):
+                return client
+        if client is None:
+            return _MarkerLookupFailure(f"{phase} marker lookup has no verified provider client")
+        try:
+            marker = modal.Dict.from_name(
+                marker_name,
+                create_if_missing=False,
+                environment_name=self._environment_name,
+                client=client,
+            )
+            await marker.hydrate.aio()
+            return ModalPersistentDictMarker(
+                workspace_name=self._workspace_name,
+                environment_name=self._environment_name,
+                app_name=self._app_name,
+                protocol_epoch=self._protocol_epoch,
+                name=marker_name,
+                object_id=str(marker.object_id),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            not_found = getattr(getattr(modal, "exception", None), "NotFoundError", None)
+            if isinstance(not_found, type) and isinstance(exc, not_found):
+                return _MARKER_MISSING
+            return _MarkerLookupFailure(
+                f"{phase} marker lookup failed ({type(exc).__name__[:128]})"
+            )
+
+    async def _verified_client(
+        self,
+        modal: Any,
+        *,
+        phase: str,
+    ) -> Any | _MarkerLookupFailure:
+        try:
+            workspace = modal.Workspace.from_context()
+            await workspace.hydrate.aio()
+            observed = str(workspace.name or "")
+            client = workspace.client
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return _MarkerLookupFailure(
+                f"{phase} workspace lookup failed ({type(exc).__name__[:128]})"
+            )
+        if observed != self._workspace_name:
+            return _MarkerLookupFailure(
+                f"{phase} workspace identity does not match configured provider namespace"
+            )
+        return client
+
+    def _identity_failure(
+        self,
+        identity: ModalSandboxOperationIdentity,
+    ) -> str | None:
+        if identity.protocol_epoch != MODAL_ACTIVITY_PROTOCOL_EPOCH:
+            return (
+                "operation predates the barrier-aware protocol epoch; "
+                "legacy or in-flight absence remains Unknown"
+            )
+        if identity.protocol_epoch != self._protocol_epoch:
+            return "operation protocol epoch does not match provider barrier"
+        if identity.workspace_name != self._workspace_name:
+            return "operation belongs to another Modal workspace"
+        if identity.environment_name != self._environment_name:
+            return "operation belongs to another Modal environment"
+        if identity.app_name != self._app_name:
+            return "operation belongs to another Modal app"
+        return None
+
+    @staticmethod
+    def _load_modal() -> Any:
+        try:
+            import modal
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "Modal support is optional; install it with `uv sync --extra coding-agent`"
+            ) from exc
+        return modal
+
+
+__all__ = [
+    "ModalOperationGuardAcquisition",
+    "ModalPersistentDictMarker",
+    "ModalProviderBarrierUnknown",
+    "ModalProviderMarkerExists",
+    "ModalProviderOperationGuard",
+    "ModalProviderRunPermit",
+    "ModalProviderStartBarrier",
+    "ModalRunPermitAcquisition",
+]

--- a/tests/missions/test_modal_agent_sandbox.py
+++ b/tests/missions/test_modal_agent_sandbox.py
@@ -96,6 +96,14 @@ def test_modal_backend_has_no_task_outcome_or_commit_without_push_mode() -> None
         ModalSandboxConfig(image_id="floating-name")
 
 
+@pytest.mark.parametrize("app_name", ("_app", ".app", "a" * 64))
+def test_modal_config_preserves_existing_sdk_valid_app_names(app_name: str) -> None:
+    config = ModalSandboxConfig(app_name=app_name)
+
+    assert config.app_name == app_name
+    assert ModalSandboxBackend(config).config is config
+
+
 def test_modal_agent_process_is_wrapped_in_durable_live_output_files() -> None:
     session = ModalSandboxSession(
         spec=SandboxSpec("modal", "modal-codex-test", "/workspace/repo"),

--- a/tests/missions/test_modal_provider_barrier.py
+++ b/tests/missions/test_modal_provider_barrier.py
@@ -1,0 +1,534 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adversarial contracts for the persistent two-tier Modal start barrier."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from archetype.missions.sandboxes import (
+    MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    ModalPersistentDictMarker,
+    ModalProviderBarrierUnknown,
+    ModalProviderMarkerExists,
+    ModalProviderOperationGuard,
+    ModalProviderRunPermit,
+    ModalProviderStartBarrier,
+    ModalSandboxOperationIdentity,
+)
+
+
+class _NotFoundError(Exception):
+    pass
+
+
+class _AlreadyExistsError(Exception):
+    pass
+
+
+class _ConnectionError(Exception):
+    pass
+
+
+class _AsyncCall:
+    def __init__(self, callback) -> None:
+        self._callback = callback
+
+    async def aio(self, *args, **kwargs):
+        result = self._callback(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+
+class _DictObject:
+    def __init__(self, object_id: str) -> None:
+        self.object_id = object_id
+
+
+class _WorkspaceHandle:
+    def __init__(self, registry: _DictRegistry) -> None:
+        self._registry = registry
+        self.hydrate = _AsyncCall(lambda: self)
+
+    @property
+    def name(self) -> str:
+        return self._registry.workspace_name
+
+    @property
+    def client(self) -> object:
+        return self._registry.client
+
+
+class _DictHandle:
+    def __init__(
+        self,
+        registry: _DictRegistry,
+        *,
+        environment_name: str,
+        name: str,
+    ) -> None:
+        self._registry = registry
+        self._key = (environment_name, name)
+        self.object_id = ""
+        self.hydrate = _AsyncCall(self._hydrate)
+
+    def _hydrate(self) -> _DictHandle:
+        error = self._registry.lookup_errors.get(self._key)
+        if error is not None:
+            raise error
+        try:
+            value = self._registry.objects[self._key]
+        except KeyError as exc:
+            raise _NotFoundError(self._key) from exc
+        self.object_id = value.object_id
+        return self
+
+
+class _DictRegistry:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], _DictObject] = {}
+        self.create_calls: list[dict[str, Any]] = []
+        self.lookup_calls: list[dict[str, Any]] = []
+        self.raise_after_create: set[tuple[str, str]] = set()
+        self.create_errors: dict[tuple[str, str], Exception] = {}
+        self.lookup_errors: dict[tuple[str, str], Exception] = {}
+        self.workspace_name = "vangelis"
+        self.client = object()
+        self._sequence = 0
+        self._create_lock = asyncio.Lock()
+        self._create_barriers: dict[tuple[str, str], asyncio.Barrier] = {}
+
+    def race_creates(self, *, environment_name: str, name: str) -> None:
+        self._create_barriers[(environment_name, name)] = asyncio.Barrier(2)
+
+    async def create(
+        self,
+        name: str,
+        *,
+        allow_existing: bool,
+        environment_name: str,
+        client: object,
+    ) -> None:
+        assert allow_existing is False
+        assert client is self.client
+        key = (environment_name, name)
+        self.create_calls.append(
+            {
+                "name": name,
+                "allow_existing": allow_existing,
+                "environment_name": environment_name,
+                "client": client,
+            }
+        )
+        barrier = self._create_barriers.get(key)
+        if barrier is not None:
+            await barrier.wait()
+        async with self._create_lock:
+            self._create(key)
+
+    def _create(self, key: tuple[str, str]) -> None:
+        error = self.create_errors.get(key)
+        if error is not None:
+            raise error
+        if key in self.objects:
+            raise _AlreadyExistsError(key)
+        self._sequence += 1
+        self.objects[key] = _DictObject(f"di-{self._sequence}")
+        if key in self.raise_after_create:
+            raise _ConnectionError("provider response lost after persistent create")
+
+    def from_name(
+        self,
+        name: str,
+        *,
+        create_if_missing: bool,
+        environment_name: str,
+        client: object,
+    ) -> _DictHandle:
+        assert create_if_missing is False
+        assert client is self.client
+        self.lookup_calls.append(
+            {
+                "name": name,
+                "create_if_missing": create_if_missing,
+                "environment_name": environment_name,
+                "client": client,
+            }
+        )
+        return _DictHandle(
+            self,
+            environment_name=environment_name,
+            name=name,
+        )
+
+
+def _fake_modal(registry: _DictRegistry) -> object:
+    return SimpleNamespace(
+        exception=SimpleNamespace(
+            AlreadyExistsError=_AlreadyExistsError,
+            NotFoundError=_NotFoundError,
+        ),
+        Workspace=SimpleNamespace(
+            from_context=lambda: _WorkspaceHandle(registry),
+        ),
+        Dict=SimpleNamespace(
+            objects=SimpleNamespace(create=_AsyncCall(registry.create)),
+            from_name=registry.from_name,
+        ),
+    )
+
+
+@pytest.fixture
+def provider_barrier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[_DictRegistry, ModalProviderStartBarrier]:
+    registry = _DictRegistry()
+    monkeypatch.setitem(sys.modules, "modal", _fake_modal(registry))
+    return registry, ModalProviderStartBarrier(
+        workspace_name="vangelis",
+        environment_name="main",
+        app_name="archetype-agent-missions-test",
+        protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    )
+
+
+def _identity(
+    operation_id: str,
+    *,
+    workspace_name: str = "vangelis",
+    environment_name: str = "main",
+    app_name: str = "archetype-agent-missions-test",
+    protocol_epoch: int = MODAL_ACTIVITY_PROTOCOL_EPOCH,
+) -> ModalSandboxOperationIdentity:
+    return ModalSandboxOperationIdentity(
+        workspace_name=workspace_name,
+        environment_name=environment_name,
+        app_name=app_name,
+        operation_id=operation_id,
+        protocol_epoch=protocol_epoch,
+    )
+
+
+def test_provider_marker_names_bind_full_workspace_environment_and_app_namespace() -> None:
+    operation_id = "missions.author:world-a:dispatch-full-namespace"
+    namespaces = (
+        ("vangelis", "main", "archetype-agent-missions-test"),
+        ("another-workspace", "main", "archetype-agent-missions-test"),
+        ("vangelis", "staging", "archetype-agent-missions-test"),
+        ("vangelis", "main", "another-app"),
+    )
+    names = {
+        ModalProviderStartBarrier(
+            workspace_name=workspace_name,
+            environment_name=environment_name,
+            app_name=app_name,
+            protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+        ).operation_marker_name(
+            _identity(
+                operation_id,
+                workspace_name=workspace_name,
+                environment_name=environment_name,
+                app_name=app_name,
+            )
+        )
+        for workspace_name, environment_name, app_name in namespaces
+    }
+
+    assert len(names) == len(namespaces)
+
+
+@pytest.mark.asyncio
+async def test_two_tier_persistent_barrier_selects_one_owner_at_each_race(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    operation_id = "missions.author:world-a:dispatch-race"
+    identity = _identity(operation_id)
+    operation_marker_name = barrier.operation_marker_name(identity)
+    registry.race_creates(
+        environment_name="main",
+        name=operation_marker_name,
+    )
+
+    first, second = await asyncio.wait_for(
+        asyncio.gather(
+            barrier.acquire_initial(identity=identity),
+            barrier.acquire_initial(identity=identity),
+        ),
+        timeout=1,
+    )
+    guards = [
+        outcome for outcome in (first, second) if isinstance(outcome, ModalProviderOperationGuard)
+    ]
+    conflicts = [
+        outcome for outcome in (first, second) if isinstance(outcome, ModalProviderMarkerExists)
+    ]
+    assert len(guards) == len(conflicts) == 1
+    guard = guards[0]
+    assert guard.reference.startswith("modal-dict://vangelis/main/op-v1-")
+    assert guard.digest.startswith("sha256:")
+    assert len(registry.objects) == 1
+
+    run_marker_name = barrier.run_marker_name(guard)
+    registry.race_creates(
+        environment_name="main",
+        name=run_marker_name,
+    )
+    run_first, run_second = await asyncio.wait_for(
+        asyncio.gather(
+            barrier.acquire_run(guard=guard),
+            barrier.acquire_run(guard=guard),
+        ),
+        timeout=1,
+    )
+    permits = [
+        outcome
+        for outcome in (run_first, run_second)
+        if isinstance(outcome, ModalProviderRunPermit)
+    ]
+    run_conflicts = [
+        outcome
+        for outcome in (run_first, run_second)
+        if isinstance(outcome, ModalProviderMarkerExists)
+    ]
+    assert len(permits) == len(run_conflicts) == 1
+    assert permits[0].guard == guard
+    assert permits[0].reference.startswith("modal-dict://vangelis/main/run-v1-")
+    assert permits[0].digest.startswith("sha256:")
+    assert len(registry.objects) == 2
+    assert all(call["allow_existing"] is False for call in registry.create_calls)
+    assert all(call["client"] is registry.client for call in registry.create_calls)
+    assert all(call["client"] is registry.client for call in registry.lookup_calls)
+    assert not hasattr(barrier, "delete")
+
+
+@pytest.mark.asyncio
+async def test_retry_guard_winner_permanently_blocks_a_delayed_initial_worker(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    operation_id = "missions.author:world-a:dispatch-retry-wins"
+    identity = _identity(operation_id)
+
+    retry_guard = await barrier.acquire_retry_guard(identity=identity)
+    assert isinstance(retry_guard, ModalProviderOperationGuard)
+
+    stale_initial = await barrier.acquire_initial(identity=identity)
+    assert isinstance(stale_initial, ModalProviderMarkerExists)
+    assert stale_initial.phase == "operation"
+
+    run = await barrier.acquire_run(guard=retry_guard)
+    assert isinstance(run, ModalProviderRunPermit)
+    assert len(registry.objects) == 2
+
+
+@pytest.mark.asyncio
+async def test_stale_initial_winner_blocks_retry_without_handoff_or_replay(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    operation_id = "missions.author:world-a:dispatch-stale-wins"
+    identity = _identity(operation_id)
+
+    stale_guard = await barrier.acquire_initial(identity=identity)
+    assert isinstance(stale_guard, ModalProviderOperationGuard)
+
+    retry = await barrier.acquire_retry_guard(identity=identity)
+    repeated_retry = await barrier.acquire_retry_guard(identity=identity)
+    assert isinstance(retry, ModalProviderMarkerExists)
+    assert isinstance(repeated_retry, ModalProviderMarkerExists)
+    assert len(registry.objects) == 1
+    assert all(not name.startswith("run-v1-") for _environment, name in registry.objects)
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_operation_marker_create_is_unknown_forever(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    operation_id = "missions.author:world-a:dispatch-ambiguous-operation"
+    identity = _identity(operation_id)
+    marker_name = barrier.operation_marker_name(identity)
+    registry.raise_after_create.add(("main", marker_name))
+
+    ambiguous = await barrier.acquire_initial(identity=identity)
+    assert isinstance(ambiguous, ModalProviderBarrierUnknown)
+    assert ambiguous.phase == "operation"
+    assert "ConnectionError" in ambiguous.reason
+    assert "provider response lost" not in ambiguous.reason
+
+    retry = await barrier.acquire_retry_guard(identity=identity)
+    assert isinstance(retry, ModalProviderMarkerExists)
+    assert len(registry.objects) == 1
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_run_marker_never_reconstructs_a_permit(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    operation_id = "missions.author:world-a:dispatch-ambiguous-run"
+    identity = _identity(operation_id)
+    guard = await barrier.acquire_initial(identity=identity)
+    assert isinstance(guard, ModalProviderOperationGuard)
+    run_name = barrier.run_marker_name(guard)
+    registry.raise_after_create.add(("main", run_name))
+
+    ambiguous = await barrier.acquire_run(guard=guard)
+    assert isinstance(ambiguous, ModalProviderBarrierUnknown)
+    assert ambiguous.phase == "run"
+
+    repeated = await barrier.acquire_run(guard=guard)
+    assert isinstance(repeated, ModalProviderMarkerExists)
+    assert repeated.phase == "run"
+    assert len(registry.objects) == 2
+
+
+@pytest.mark.asyncio
+async def test_acknowledged_run_winner_loss_is_safe_but_permanently_stuck(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    operation_id = "missions.author:world-a:dispatch-run-winner-lost"
+    identity = _identity(operation_id)
+    guard = await barrier.acquire_initial(identity=identity)
+    assert isinstance(guard, ModalProviderOperationGuard)
+    permit = await barrier.acquire_run(guard=guard)
+    assert isinstance(permit, ModalProviderRunPermit)
+
+    # Simulate loss before the effect starts. Provider lookup can establish
+    # that a winner existed, but no later claimant reconstructs its permit.
+    repeated = await barrier.acquire_run(guard=guard)
+    assert isinstance(repeated, ModalProviderMarkerExists)
+    assert repeated.phase == "run"
+    assert len(registry.objects) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_requires_exact_guard_object_and_provider_environment(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    operation_id = "missions.author:world-a:dispatch-exact-guard"
+    identity = _identity(operation_id)
+    guard = await barrier.acquire_initial(identity=identity)
+    assert isinstance(guard, ModalProviderOperationGuard)
+
+    wrong_object = ModalProviderOperationGuard(
+        identity=guard.identity,
+        marker=ModalPersistentDictMarker(
+            workspace_name="vangelis",
+            environment_name="main",
+            app_name="archetype-agent-missions-test",
+            protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+            name=guard.marker.name,
+            object_id="di-another-object",
+        ),
+    )
+    rejected_object = await barrier.acquire_run(guard=wrong_object)
+    assert isinstance(rejected_object, ModalProviderBarrierUnknown)
+    assert "identity changed" in rejected_object.reason
+
+    other_environment = ModalProviderStartBarrier(
+        workspace_name="vangelis",
+        environment_name="staging",
+        app_name="archetype-agent-missions-test",
+        protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    )
+    rejected_environment = await other_environment.acquire_run(guard=guard)
+    assert isinstance(rejected_environment, ModalProviderBarrierUnknown)
+    assert "another Modal environment" in rejected_environment.reason
+    assert len(registry.objects) == 1
+
+    other_workspace = ModalProviderStartBarrier(
+        workspace_name="another-workspace",
+        environment_name="main",
+        app_name="archetype-agent-missions-test",
+        protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    )
+    rejected_workspace = await other_workspace.acquire_run(guard=guard)
+    assert isinstance(rejected_workspace, ModalProviderBarrierUnknown)
+    assert "another Modal workspace" in rejected_workspace.reason
+    assert len(registry.objects) == 1
+
+    other_app = ModalProviderStartBarrier(
+        workspace_name="vangelis",
+        environment_name="main",
+        app_name="another-app",
+        protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    )
+    rejected_app = await other_app.acquire_run(guard=guard)
+    assert isinstance(rejected_app, ModalProviderBarrierUnknown)
+    assert "another Modal app" in rejected_app.reason
+    assert len(registry.objects) == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_failures_are_bounded_unknowns_without_secret_text(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    operation_id = "missions.author:world-a:dispatch-provider-error"
+    identity = _identity(operation_id)
+    marker_name = barrier.operation_marker_name(identity)
+    registry.create_errors[("main", marker_name)] = _ConnectionError("credential-canary")
+
+    outcome = await barrier.acquire_initial(identity=identity)
+    assert isinstance(outcome, ModalProviderBarrierUnknown)
+    assert "ConnectionError" in outcome.reason
+    assert "credential-canary" not in outcome.reason
+    assert registry.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_authenticated_workspace_mismatch_fails_before_provider_create(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    registry.workspace_name = "unexpected-workspace"
+
+    outcome = await barrier.acquire_initial(
+        identity=_identity("missions.author:world-a:dispatch-wrong-workspace")
+    )
+
+    assert isinstance(outcome, ModalProviderBarrierUnknown)
+    assert "workspace identity" in outcome.reason
+    assert registry.create_calls == []
+    assert registry.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_pre_barrier_and_in_flight_legacy_operations_never_gain_retry_authority(
+    provider_barrier,
+) -> None:
+    registry, barrier = provider_barrier
+    legacy = _identity(
+        "missions.author:world-a:dispatch-pre-cutover",
+        protocol_epoch=0,
+    )
+
+    outcome = await barrier.acquire_retry_guard(identity=legacy)
+
+    assert isinstance(outcome, ModalProviderBarrierUnknown)
+    assert "predates the barrier-aware protocol epoch" in outcome.reason
+    assert "legacy or in-flight absence remains Unknown" in outcome.reason
+    assert registry.lookup_calls == []
+    assert registry.create_calls == []
+    assert registry.objects == {}
+    with pytest.raises(ValueError, match="predates"):
+        barrier.operation_marker_name(legacy)
+    with pytest.raises(ValueError, match="barrier-aware protocol epoch"):
+        ModalProviderStartBarrier(
+            workspace_name="vangelis",
+            environment_name="main",
+            app_name="archetype-agent-missions-test",
+            protocol_epoch=0,
+        )

--- a/tests/missions/test_modal_sandbox_operations.py
+++ b/tests/missions/test_modal_sandbox_operations.py
@@ -1,0 +1,808 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Crash contracts for stable named Modal mission sandbox operations."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from archetype.missions.sandboxes import (
+    MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    ModalSandboxBackend,
+    ModalSandboxConfig,
+    ModalSandboxOperationCapability,
+    ModalSandboxOperationIdentity,
+    ModalSandboxOperationRunning,
+    ModalSandboxOperationUnknown,
+    ModalSandboxSession,
+    SandboxSpec,
+)
+
+
+class _NotFoundError(Exception):
+    pass
+
+
+class _AlreadyExistsError(Exception):
+    pass
+
+
+class _ConnectionError(Exception):
+    pass
+
+
+class _AsyncCall:
+    def __init__(self, callback) -> None:
+        self._callback = callback
+
+    async def aio(self, *args, **kwargs):
+        return self._callback(*args, **kwargs)
+
+
+class _WorkspaceHandle:
+    def __init__(self, registry: _ModalRegistry) -> None:
+        self._registry = registry
+        self.hydrate = _AsyncCall(lambda: self)
+
+    @property
+    def name(self) -> str:
+        return self._registry.workspace_name
+
+    @property
+    def client(self) -> object:
+        return self._registry.client
+
+
+class _RemoteApp:
+    def __init__(
+        self,
+        *,
+        name: str,
+        environment_name: str,
+        client: object,
+    ) -> None:
+        self.name = name
+        self.environment_name = environment_name
+        self.client = client
+
+
+class _RemoteSandbox:
+    def __init__(
+        self,
+        registry: _ModalRegistry,
+        name: str,
+        object_id: str,
+        *,
+        app_name: str,
+        environment_name: str,
+        tags: dict[str, str],
+    ) -> None:
+        self._registry = registry
+        self.name = name
+        self.object_id = object_id
+        self.app_name = app_name
+        self.environment_name = environment_name
+        self.tags = dict(tags)
+        self.returncode: int | None = None
+        self.poll_error: Exception | None = None
+        self.tag_error: Exception | None = None
+        self.terminated = 0
+        self.detached = 0
+        self.poll = _AsyncCall(self._poll)
+        self.get_tags = _AsyncCall(self._get_tags)
+        self.terminate = _AsyncCall(self._terminate)
+        self.detach = _AsyncCall(self._detach)
+
+    def _poll(self) -> int | None:
+        if self.poll_error is not None:
+            raise self.poll_error
+        return self.returncode
+
+    def _get_tags(self) -> dict[str, str]:
+        if self.tag_error is not None:
+            raise self.tag_error
+        return dict(self.tags)
+
+    def _terminate(self, *, wait: bool) -> None:
+        assert wait is True
+        self.terminated += 1
+        self.returncode = 0
+        if self._registry.resources.get(self.name) is self:
+            self._registry.resources.pop(self.name)
+
+    def _detach(self) -> None:
+        self.detached += 1
+
+
+class _ModalRegistry:
+    def __init__(self) -> None:
+        self.resources: dict[str, _RemoteSandbox] = {}
+        self.create_calls: list[dict[str, Any]] = []
+        self.lookup_calls: list[dict[str, Any]] = []
+        self.app_calls: list[dict[str, Any]] = []
+        self.volume_calls: list[dict[str, Any]] = []
+        self.secret_calls: list[dict[str, Any]] = []
+        self.lookup_errors: dict[str, Exception] = {}
+        self.raise_after_create: set[str] = set()
+        self.workspace_name = "vangelis"
+        self.client = object()
+        self._sequence = 0
+
+    def app_lookup(
+        self,
+        app_name: str,
+        *,
+        create_if_missing: bool,
+        environment_name: str,
+        client: object,
+    ) -> _RemoteApp:
+        assert create_if_missing is True
+        assert client is self.client
+        self.app_calls.append(
+            {
+                "app_name": app_name,
+                "environment_name": environment_name,
+                "client": client,
+            }
+        )
+        return _RemoteApp(
+            name=app_name,
+            environment_name=environment_name,
+            client=client,
+        )
+
+    def create(self, *command: str, **kwargs: Any) -> _RemoteSandbox:
+        name = str(kwargs["name"])
+        app = kwargs["app"]
+        environment_name = str(kwargs["environment_name"])
+        assert isinstance(app, _RemoteApp)
+        assert app.environment_name == environment_name
+        assert kwargs["client"] is self.client
+        self.create_calls.append({"command": command, **kwargs})
+        if name in self.resources:
+            raise _AlreadyExistsError(name)
+        self._sequence += 1
+        sandbox = _RemoteSandbox(
+            self,
+            name,
+            f"sb-{self._sequence}",
+            app_name=app.name,
+            environment_name=environment_name,
+            tags=kwargs["tags"],
+        )
+        self.resources[name] = sandbox
+        if name in self.raise_after_create:
+            raise _ConnectionError("provider response lost after create")
+        return sandbox
+
+    def lookup(
+        self,
+        app_name: str,
+        name: str,
+        *,
+        environment_name: str,
+        client: object,
+    ) -> _RemoteSandbox:
+        assert client is self.client
+        self.lookup_calls.append(
+            {
+                "app_name": app_name,
+                "name": name,
+                "environment_name": environment_name,
+                "client": client,
+            }
+        )
+        error = self.lookup_errors.get(name)
+        if error is not None:
+            raise error
+        try:
+            sandbox = self.resources[name]
+        except KeyError as exc:
+            raise _NotFoundError(name) from exc
+        if sandbox.app_name != app_name or sandbox.environment_name != environment_name:
+            raise _NotFoundError(name)
+        return sandbox
+
+    def volume_from_name(self, name: str, **kwargs: Any) -> object:
+        assert kwargs["client"] is self.client
+        self.volume_calls.append({"name": name, **kwargs})
+        return SimpleNamespace(hydrate=_AsyncCall(lambda: None))
+
+    def secret_from_name(self, name: str, **kwargs: Any) -> object:
+        assert kwargs["client"] is self.client
+        self.secret_calls.append({"name": name, **kwargs})
+        return (name, kwargs)
+
+
+def _fake_modal(registry: _ModalRegistry) -> object:
+    return SimpleNamespace(
+        exception=SimpleNamespace(
+            NotFoundError=_NotFoundError,
+            AlreadyExistsError=_AlreadyExistsError,
+        ),
+        Workspace=SimpleNamespace(
+            from_context=lambda: _WorkspaceHandle(registry),
+        ),
+        App=SimpleNamespace(
+            lookup=_AsyncCall(registry.app_lookup),
+        ),
+        Volume=SimpleNamespace(
+            from_name=registry.volume_from_name,
+        ),
+        Secret=SimpleNamespace(
+            from_name=registry.secret_from_name,
+        ),
+        Image=SimpleNamespace(
+            from_id=lambda image_id, *, client: ("image", image_id, client),
+        ),
+        Sandbox=SimpleNamespace(
+            create=_AsyncCall(registry.create),
+            from_name=_AsyncCall(registry.lookup),
+        ),
+    )
+
+
+@pytest.fixture
+def modal_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[
+    _ModalRegistry,
+    ModalSandboxBackend,
+    ModalSandboxOperationCapability,
+    SandboxSpec,
+]:
+    registry = _ModalRegistry()
+    monkeypatch.setitem(sys.modules, "modal", _fake_modal(registry))
+
+    async def verified(*args, **kwargs) -> None:
+        del args, kwargs
+
+    monkeypatch.setattr(
+        "archetype.missions.sandboxes.modal.verify_coding_agent_environment",
+        verified,
+    )
+    backend = ModalSandboxBackend(
+        ModalSandboxConfig(
+            app_name="archetype-agent-missions-test",
+            image_id="im-reviewed",
+            workspace_name="vangelis",
+            environment_name="main",
+            operation_protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+        )
+    )
+    capability = ModalSandboxOperationCapability(backend)
+    spec = SandboxSpec(
+        "modal",
+        backend.environment,
+        "/workspace/repo",
+        metadata=(
+            ("mission", "mission-1"),
+            ("kind", "caller-cannot-replace-kind"),
+            ("operation_digest", "caller-cannot-replace-operation"),
+        ),
+    )
+    return registry, backend, capability, spec
+
+
+def _operation_identity(
+    operation_id: str,
+    *,
+    workspace_name: str = "vangelis",
+    environment_name: str = "main",
+    app_name: str = "archetype-agent-missions-test",
+    protocol_epoch: int = MODAL_ACTIVITY_PROTOCOL_EPOCH,
+) -> ModalSandboxOperationIdentity:
+    return ModalSandboxOperationIdentity(
+        workspace_name=workspace_name,
+        environment_name=environment_name,
+        app_name=app_name,
+        operation_id=operation_id,
+        protocol_epoch=protocol_epoch,
+    )
+
+
+def _remote_sandbox(
+    registry: _ModalRegistry,
+    identity: ModalSandboxOperationIdentity,
+    *,
+    role: str,
+    object_id: str,
+    cohort_id: str = "cohort-v1:00000000000000000000000000000001",
+) -> _RemoteSandbox:
+    return _RemoteSandbox(
+        registry,
+        (identity.mission_sandbox_name if role == "mission" else identity.auth_sandbox_name),
+        object_id,
+        app_name=identity.app_name,
+        environment_name=identity.environment_name,
+        tags={
+            "kind": f"archetype-agent-{role}",
+            "operation_digest": identity.digest,
+            "operation_cohort": cohort_id,
+            "operation_protocol_epoch": str(identity.protocol_epoch),
+        },
+    )
+
+
+def test_modal_operation_names_are_stable_safe_and_world_isolated() -> None:
+    operation_id = "missions.author:world-a:dispatch-1"
+    first = _operation_identity(operation_id)
+    repeated = _operation_identity(operation_id)
+    other_world = _operation_identity("missions.author:world-b:dispatch-1")
+    unusual = _operation_identity("missions.author:wørld:dispatch/with spaces")
+    other_workspace = _operation_identity(operation_id, workspace_name="another-workspace")
+    other_environment = _operation_identity(operation_id, environment_name="staging")
+    other_app = _operation_identity(operation_id, app_name="another-app")
+    legacy_epoch = _operation_identity(operation_id, protocol_epoch=0)
+
+    assert first == repeated
+    assert first.digest == repeated.digest
+    assert first.mission_sandbox_name == repeated.mission_sandbox_name
+    assert first.auth_sandbox_name == repeated.auth_sandbox_name
+    assert first.digest != other_world.digest
+    assert (
+        len(
+            {
+                first.digest,
+                other_workspace.digest,
+                other_environment.digest,
+                other_app.digest,
+                legacy_epoch.digest,
+            }
+        )
+        == 5
+    )
+    assert (
+        len(
+            {
+                first.mission_sandbox_name,
+                other_workspace.mission_sandbox_name,
+                other_environment.mission_sandbox_name,
+                other_app.mission_sandbox_name,
+                legacy_epoch.mission_sandbox_name,
+            }
+        )
+        == 5
+    )
+    assert (
+        len(
+            {
+                first.mission_sandbox_name,
+                first.auth_sandbox_name,
+                other_world.mission_sandbox_name,
+                other_world.auth_sandbox_name,
+            }
+        )
+        == 4
+    )
+    for name in (
+        first.mission_sandbox_name,
+        first.auth_sandbox_name,
+        other_world.mission_sandbox_name,
+        other_world.auth_sandbox_name,
+        unusual.mission_sandbox_name,
+        unusual.auth_sandbox_name,
+    ):
+        assert len(name) <= 63
+        assert re.fullmatch(r"[a-z0-9][a-z0-9-]*[a-z0-9]", name)
+
+    for invalid in ("", " ", " leading", "trailing ", "nul\x00value", "x" * 1025):
+        with pytest.raises(ValueError):
+            _operation_identity(invalid)
+
+    for field in ("workspace_name", "environment_name", "app_name"):
+        with pytest.raises(ValueError):
+            _operation_identity(operation_id, **{field: "invalid/name"})
+    with pytest.raises(ValueError, match="epoch"):
+        _operation_identity(operation_id, protocol_epoch=-1)
+
+
+@pytest.mark.asyncio
+async def test_named_modal_operation_reports_running_without_sharing_execution_handle(
+    modal_operation,
+) -> None:
+    registry, backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-1"
+    identity = capability.identity(operation_id)
+
+    created = await capability.start(operation_id=operation_id, spec=spec)
+    mission = registry.resources[identity.mission_sandbox_name]
+    auth = registry.resources[identity.auth_sandbox_name]
+
+    assert created.operation_identity == identity
+    assert created.identity.sandbox_id == mission.object_id
+    assert len(registry.create_calls) == 2
+    assert {call["name"] for call in registry.create_calls} == {
+        identity.mission_sandbox_name,
+        identity.auth_sandbox_name,
+    }
+    for call in registry.create_calls:
+        assert call["command"] == ("sleep", "infinity")
+        assert call["tags"]["operation_digest"] == identity.digest
+        assert call["tags"]["operation_cohort"] == created.operation_cohort_id
+        assert call["tags"]["operation_protocol_epoch"] == str(identity.protocol_epoch)
+        assert call["environment_name"] == identity.environment_name
+        assert call["client"] is registry.client
+        assert call["tags"]["kind"] in {
+            "archetype-agent-auth",
+            "archetype-agent-mission",
+        }
+    assert all(call["app_name"] == identity.app_name for call in registry.app_calls)
+    assert all(
+        call["environment_name"] == identity.environment_name and call["client"] is registry.client
+        for call in (*registry.app_calls, *registry.volume_calls, *registry.secret_calls)
+    )
+
+    # Simulate a process crash by discarding the local handle and rebuilding
+    # both the backend and capability over the same provider namespace.
+    restarted = ModalSandboxOperationCapability(ModalSandboxBackend(backend.config))
+    running = await restarted.reconcile(operation_id=operation_id, spec=spec)
+
+    assert isinstance(running, ModalSandboxOperationRunning)
+    assert running.identity == identity
+    assert running.mission_sandbox_id == mission.object_id
+    assert running.auth_sandbox_id == auth.object_id
+    assert running.cohort_id == created.operation_cohort_id
+    assert not hasattr(running, "session")
+    assert not hasattr(running, "retry_guard")
+    assert len(registry.create_calls) == 2
+
+    # A newer claimant cannot acquire the live provider name and reconcile
+    # does not hand it a session through which to invoke a second inner exec.
+    with pytest.raises(_AlreadyExistsError):
+        await restarted.start(operation_id=operation_id, spec=spec)
+    assert len(registry.resources) == 2
+    assert not hasattr(restarted, "cleanup")
+
+    await created.close()
+    assert registry.resources == {}
+    assert mission.terminated == auth.terminated == 1
+    assert mission.detached == auth.detached == 1
+
+
+@pytest.mark.asyncio
+async def test_modal_reconciliation_never_turns_missing_names_into_retry_permission(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-absent"
+    identity = capability.identity(operation_id)
+
+    missing = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(missing, ModalSandboxOperationUnknown)
+    assert missing.identity == identity
+    assert "not retry authorization" in missing.reason
+    assert not hasattr(missing, "retry_guard")
+    assert registry.create_calls == []
+
+    registry.resources[identity.auth_sandbox_name] = _remote_sandbox(
+        registry,
+        identity,
+        role="auth",
+        object_id="sb-partial-auth",
+    )
+    partial = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(partial, ModalSandboxOperationUnknown)
+    assert "partial" in partial.reason
+    assert "auth" not in partial.reason.partition("absent=")[2]
+    assert registry.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_modal_reconciliation_keeps_provider_and_poll_errors_unknown(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-unknown"
+    identity = capability.identity(operation_id)
+    registry.lookup_errors[identity.mission_sandbox_name] = _ConnectionError("credential-canary")
+
+    lookup_unknown = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(lookup_unknown, ModalSandboxOperationUnknown)
+    assert "ConnectionError" in lookup_unknown.reason
+    assert "credential-canary" not in lookup_unknown.reason
+    assert registry.create_calls == []
+
+    registry.lookup_errors.clear()
+    mission = _remote_sandbox(registry, identity, role="mission", object_id="sb-mission")
+    auth = _remote_sandbox(registry, identity, role="auth", object_id="sb-auth")
+    registry.resources[mission.name] = mission
+    registry.resources[auth.name] = auth
+    mission.poll_error = _ConnectionError("poll-credential-canary")
+
+    poll_unknown = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(poll_unknown, ModalSandboxOperationUnknown)
+    assert "poll failed" in poll_unknown.reason
+    assert "poll-credential-canary" not in poll_unknown.reason
+
+    mission.poll_error = None
+    mission.returncode = 0
+    stopped_unknown = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(stopped_unknown, ModalSandboxOperationUnknown)
+    assert "not running" in stopped_unknown.reason
+
+
+@pytest.mark.asyncio
+async def test_modal_reconciliation_rejects_mixed_or_unverifiable_cohorts(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-mixed-generation"
+    identity = capability.identity(operation_id)
+    mission = _remote_sandbox(
+        registry,
+        identity,
+        role="mission",
+        object_id="sb-old-mission",
+        cohort_id="cohort-v1:00000000000000000000000000000001",
+    )
+    auth = _remote_sandbox(
+        registry,
+        identity,
+        role="auth",
+        object_id="sb-new-auth",
+        cohort_id="cohort-v1:00000000000000000000000000000002",
+    )
+    registry.resources[mission.name] = mission
+    registry.resources[auth.name] = auth
+
+    mixed = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(mixed, ModalSandboxOperationUnknown)
+    assert "mixed-generation" in mixed.reason
+
+    auth.tags["operation_cohort"] = mission.tags["operation_cohort"]
+    auth.tags["operation_digest"] = "sha256:" + "0" * 64
+    wrong_identity = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(wrong_identity, ModalSandboxOperationUnknown)
+    assert "full provider operation identity" in wrong_identity.reason
+
+    auth.tags["operation_digest"] = identity.digest
+    auth.tag_error = _ConnectionError("tag-credential-canary")
+    unreadable = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(unreadable, ModalSandboxOperationUnknown)
+    assert "cohort lookup failed" in unreadable.reason
+    assert "tag-credential-canary" not in unreadable.reason
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_create_is_reconciled_as_partial_without_unsafe_name_cleanup(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-crash"
+    identity = capability.identity(operation_id)
+    registry.raise_after_create.add(identity.mission_sandbox_name)
+
+    with pytest.raises(_ConnectionError, match="response lost"):
+        await capability.start(operation_id=operation_id, spec=spec)
+
+    # The auth handle was known and compensated. The mission create response
+    # was lost, so its surviving name cannot be treated as safe absence.
+    assert set(registry.resources) == {identity.mission_sandbox_name}
+    calls_after_crash = len(registry.create_calls)
+    unknown = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(unknown, ModalSandboxOperationUnknown)
+    assert "partial" in unknown.reason
+    assert len(registry.create_calls) == calls_after_crash
+
+    mission = registry.resources[identity.mission_sandbox_name]
+    assert mission.terminated == mission.detached == 0
+    assert not hasattr(capability, "cleanup")
+
+
+@pytest.mark.asyncio
+async def test_atomic_live_name_allows_only_one_concurrent_pair_owner(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-race"
+
+    first, second = await asyncio.gather(
+        capability.start(operation_id=operation_id, spec=spec),
+        capability.start(operation_id=operation_id, spec=spec),
+        return_exceptions=True,
+    )
+
+    outcomes = (first, second)
+    winners = [outcome for outcome in outcomes if not isinstance(outcome, BaseException)]
+    losers = [outcome for outcome in outcomes if isinstance(outcome, BaseException)]
+    assert len(winners) == 1
+    assert len(losers) == 1
+    assert isinstance(losers[0], _AlreadyExistsError)
+    assert len(registry.resources) == 2
+
+    running = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(running, ModalSandboxOperationRunning)
+    assert not hasattr(running, "session")
+    assert isinstance(winners[0], ModalSandboxSession)
+    await winners[0].close()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_first_name_acquisition_never_authorizes_another_start(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-auth-crash"
+    identity = capability.identity(operation_id)
+    registry.raise_after_create.add(identity.auth_sandbox_name)
+
+    with pytest.raises(_ConnectionError, match="response lost"):
+        await capability.start(operation_id=operation_id, spec=spec)
+
+    assert set(registry.resources) == {identity.auth_sandbox_name}
+    unknown = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(unknown, ModalSandboxOperationUnknown)
+    assert "partial" in unknown.reason
+    calls_after_reconcile = len(registry.create_calls)
+
+    # The provider response was ambiguous, but its live name still fences a
+    # delayed claimant. Neither reconciliation nor the conflict yields a
+    # session or retry guard.
+    with pytest.raises(_AlreadyExistsError):
+        await capability.start(operation_id=operation_id, spec=spec)
+    assert len(registry.create_calls) == calls_after_reconcile + 1
+    assert not hasattr(unknown, "session")
+    assert not hasattr(unknown, "retry_guard")
+
+    assert not hasattr(capability, "cleanup")
+
+
+@pytest.mark.asyncio
+async def test_exact_session_close_cannot_terminate_a_reused_name_generation(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-late-close"
+    identity = capability.identity(operation_id)
+    session = await capability.start(operation_id=operation_id, spec=spec)
+    old_mission = registry.resources[identity.mission_sandbox_name]
+    old_auth = registry.resources[identity.auth_sandbox_name]
+
+    newer_mission = _remote_sandbox(
+        registry,
+        identity,
+        role="mission",
+        object_id="sb-newer-mission",
+        cohort_id="cohort-v1:00000000000000000000000000000002",
+    )
+    newer_auth = _remote_sandbox(
+        registry,
+        identity,
+        role="auth",
+        object_id="sb-newer-auth",
+        cohort_id="cohort-v1:00000000000000000000000000000002",
+    )
+    registry.resources[identity.mission_sandbox_name] = newer_mission
+    registry.resources[identity.auth_sandbox_name] = newer_auth
+
+    await session.close()
+
+    assert registry.resources[identity.mission_sandbox_name] is newer_mission
+    assert registry.resources[identity.auth_sandbox_name] is newer_auth
+    assert old_mission.terminated == old_auth.terminated == 1
+    assert newer_mission.terminated == newer_auth.terminated == 0
+    assert not hasattr(capability, "cleanup")
+
+
+@pytest.mark.asyncio
+async def test_named_modal_operations_isolate_same_dispatch_across_worlds(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    world_a = "missions.author:world-a:same-dispatch"
+    world_b = "missions.author:world-b:same-dispatch"
+
+    first = await capability.start(operation_id=world_a, spec=spec)
+    second = await capability.start(operation_id=world_b, spec=spec)
+    first_id = first.identity.sandbox_id
+    second_id = second.identity.sandbox_id
+
+    assert first_id != second_id
+    assert len(registry.resources) == 4
+    running_a = await capability.reconcile(operation_id=world_a, spec=spec)
+    running_b = await capability.reconcile(operation_id=world_b, spec=spec)
+    assert isinstance(running_a, ModalSandboxOperationRunning)
+    assert isinstance(running_b, ModalSandboxOperationRunning)
+    assert running_a.mission_sandbox_id == first_id
+    assert running_b.mission_sandbox_id == second_id
+
+    await first.close()
+    assert len(registry.resources) == 2
+    still_running = await capability.reconcile(operation_id=world_b, spec=spec)
+    assert isinstance(still_running, ModalSandboxOperationRunning)
+    await second.close()
+    assert registry.resources == {}
+
+
+@pytest.mark.asyncio
+async def test_modal_operation_namespace_is_explicit_and_ambient_mismatch_fails_closed(
+    modal_operation,
+) -> None:
+    registry, backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-namespace"
+    identity = capability.identity(operation_id)
+
+    for config in (
+        ModalSandboxConfig(
+            app_name=identity.app_name,
+            image_id="im-reviewed",
+            environment_name=identity.environment_name,
+            operation_protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+        ),
+        ModalSandboxConfig(
+            app_name=identity.app_name,
+            image_id="im-reviewed",
+            workspace_name=identity.workspace_name,
+            operation_protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+        ),
+        ModalSandboxConfig(
+            app_name=identity.app_name,
+            image_id="im-reviewed",
+            workspace_name=identity.workspace_name,
+            environment_name=identity.environment_name,
+            operation_protocol_epoch=0,
+        ),
+    ):
+        with pytest.raises(ValueError):
+            ModalSandboxOperationCapability(ModalSandboxBackend(config))
+
+    other_environment = ModalSandboxOperationCapability(
+        ModalSandboxBackend(
+            ModalSandboxConfig(
+                app_name=identity.app_name,
+                image_id="im-reviewed",
+                workspace_name=identity.workspace_name,
+                environment_name="staging",
+                operation_protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+            )
+        )
+    )
+    other_app = ModalSandboxOperationCapability(
+        ModalSandboxBackend(
+            ModalSandboxConfig(
+                app_name="another-app",
+                image_id="im-reviewed",
+                workspace_name=identity.workspace_name,
+                environment_name=identity.environment_name,
+                operation_protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+            )
+        )
+    )
+    assert other_environment.identity(operation_id).digest != identity.digest
+    assert other_app.identity(operation_id).digest != identity.digest
+
+    environment_absent = await other_environment.reconcile(
+        operation_id=operation_id,
+        spec=spec,
+    )
+    app_absent = await other_app.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(environment_absent, ModalSandboxOperationUnknown)
+    assert isinstance(app_absent, ModalSandboxOperationUnknown)
+    assert {call["environment_name"] for call in registry.lookup_calls[-4:]} == {
+        "main",
+        "staging",
+    }
+    assert {call["app_name"] for call in registry.lookup_calls[-4:]} == {
+        identity.app_name,
+        "another-app",
+    }
+
+    lookups_before_mismatch = len(registry.lookup_calls)
+    creates_before_mismatch = len(registry.create_calls)
+    registry.workspace_name = "unexpected-workspace"
+    mismatch = await capability.reconcile(operation_id=operation_id, spec=spec)
+    assert isinstance(mismatch, ModalSandboxOperationUnknown)
+    assert "workspace identity" in mismatch.reason
+    with pytest.raises(RuntimeError, match="workspace identity"):
+        await capability.start(operation_id=operation_id, spec=spec)
+    assert len(registry.lookup_calls) == lookups_before_mismatch
+    assert len(registry.create_calls) == creates_before_mismatch
+    assert registry.app_calls == []


### PR DESCRIPTION
## Outcome

Adds the Modal-side safety primitives needed before a Mission author Activity
can be allowed to start hosted work.

This is A4a, not Modal author parity. It does not consume the
generic Activity catalog, launch a coding-agent mission under an Activity
claim, accept a run permit in sandbox startup, or change the supported Mission
path.

Advances #671.

## What lands

- deterministic identities binding the exact Modal workspace, Environment,
  App, protocol epoch, and world-qualified logical operation
- bounded reconciliation of named sandbox pairs only when both live members
  carry the same full identity and provider-created cohort
- a persistent two-tier provider start barrier using Modal named Dict object
  creation with `allow_existing=False`
- an operation marker that atomically selects one initial/retry owner
- an exact-object retry guard bound to workspace, Environment, App, protocol
  epoch, marker name, and Modal object ID
- a second permanent run marker that atomically selects one fresh-execution
  winner
- fail-closed outcomes for ambiguous create, lookup failure, lost winner,
  namespace mismatch, missing/replaced marker, mixed sandbox generations,
  legacy epoch, and already-existing marker
- no marker deletion, takeover, or name-based sandbox cleanup API

Only operations durably admitted under protocol epoch 1 from birth may use this
barrier. Legacy or already-in-flight work cannot be relabeled. Both named Dict
marker objects must remain permanent and must never be deleted or recreated. If
a winner dies after either marker is created but before its effect/result
becomes durable, the logical operation remains `Unknown` forever. That is safe
but intentionally not live.

## What this proves

- two simultaneous initial claimants yield one operation-guard owner
- every stale initial claimant loses after the permanent operation marker
  exists
- two simultaneous fresh claimants using the exact retry guard yield one run
  permit
- a guard from another workspace, Environment, name, or object ID cannot
  authorize a run
- an ambiguous provider response never reconstructs execution authority from a
  later lookup
- a lost acknowledged winner never permits takeover
- mixed, stopped, or missing named sandboxes are `Unknown`, not proof that
  replay is safe
- the existing supported Modal configuration continues accepting every
  previously valid non-empty App name

## Real Modal proof

At 2026-07-26 01:46 PDT, Modal SDK 1.5.0 executed the persistent-barrier race
against `vangelis-tech/main` for:

`missions.author:a4a-live-proof:4370bce5-65ef-406e-9396-cf4f3fbfecae`

- initial race: one `ModalProviderOperationGuard`, one
  `ModalProviderMarkerExists`
- run race: one `ModalProviderRunPermit`, one `ModalProviderMarkerExists`
- every subsequent initial, retry, and run acquisition: conflict
- retained operation marker:
  `op-v1-7EZUuljOjtPIfzA8H9ZrvCIzFNQ8o3BhJR2e2Lg_qXE`
  (`di-2fOa72C4YRHLilPpgAP4uK`)
- retained run marker:
  `run-v1--NbSACbhK3noysRlFmEeJyzNvvTH3c8NCg4LqN0zufs`
  (`di-L4EdrESjB2Xeay2M1Fb84Z`)

The proof intentionally invoked only `ModalProviderStartBarrier`. It did not
start a sandbox or claim Activity parity.

## Remaining A4 gate

Full parity still requires the Mission author Activity adapter to:

1. durably bind protocol epoch 1 at Activity admission, never by relabeling
   legacy/in-flight work;
2. consume the exact run permit during sandbox start;
3. execute the complete author request under that permit;
4. persist/reconcile the exact result and Git head;
5. stage and commit the complete Mission observation;
6. settle the same generic Activity contract locally and on Modal; and
7. pass a real installed-artifact mission proof.

Production also needs an explicit quota/retention policy for the two permanent
Dict objects consumed per logical operation. No runtime cutover is authorized
until that gate is green.

## Validation

- `uv run pytest -q tests/missions/test_modal_provider_barrier.py tests/missions/test_modal_sandbox_operations.py`
  plus supported-path Modal contracts (`54 passed`)
- complete Mission suite (`202 passed`)
- `make static`
- real `vangelis-tech/main` two-tier race above
