### PR TITLE
fix: recover concurrent Iceberg table registration

### DIFF
--- a/src/archetype/core/aio/async_store.py
+++ b/src/archetype/core/aio/async_store.py
@@ -22,6 +22,7 @@ from daft import DataFrame, Schema, lit, read_iceberg
 from daft.catalog import Table
 from daft.io import IOConfig
 from daft.session import Session
+from pyiceberg.exceptions import TableAlreadyExistsError
 
 # Internals
 from archetype.core.archetype import Archetype
@@ -72,6 +73,10 @@ class AsyncStore(iAsyncStore):
         daft_schema = Schema.from_pyarrow_schema(pyarrow_schema)
         try:
             table = self.session.create_table_if_not_exists(hash_val, source=daft_schema)
+        except TableAlreadyExistsError:
+            # Another catalog client won first registration after both
+            # create-if-absent checks. The catalog winner is authoritative.
+            table = self.session.get_table(hash_val)
         except Exception as e:
             raise RuntimeError(f"Error creating table {hash_val}: {e}") from e
 

--- a/src/archetype/core/sync/store.py
+++ b/src/archetype/core/sync/store.py
@@ -20,6 +20,7 @@ from daft import DataFrame, Schema, read_iceberg
 from daft.catalog import Table
 from daft.io import IOConfig
 from daft.session import Session
+from pyiceberg.exceptions import TableAlreadyExistsError
 
 from archetype.core.archetype import Archetype
 
@@ -68,6 +69,10 @@ class SyncStore(iStore):
         daft_schema = Schema.from_pyarrow_schema(pyarrow_schema)
         try:
             table = self.sess.create_table_if_not_exists(hash_val, source=daft_schema)
+        except TableAlreadyExistsError:
+            # Another catalog client won first registration after both
+            # create-if-absent checks. The catalog winner is authoritative.
+            table = self.sess.get_table(hash_val)
         except Exception as e:
             raise RuntimeError(f"Error creating table {hash_val}: {e}") from e
 

--- a/src/archetype/storage/service.py
+++ b/src/archetype/storage/service.py
@@ -29,7 +29,7 @@ from daft import DataFrame, DataType, col, lit, read_iceberg
 from daft.catalog import Catalog, Table
 from daft.io import IOConfig
 from daft.session import Session
-from pyiceberg.exceptions import CommitFailedException
+from pyiceberg.exceptions import CommitFailedException, TableAlreadyExistsError
 
 from archetype.core.aio import AsyncCachedStore, AsyncLancedbStore, AsyncStore
 from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
@@ -843,7 +843,15 @@ class StorageService:
         schema,
     ) -> Table:
         catalog, identifier = cls._catalog_identity(store, table_name)
-        return catalog.create_table_if_not_exists(identifier, schema)
+        try:
+            return catalog.create_table_if_not_exists(identifier, schema)
+        except TableAlreadyExistsError:
+            # Daft's helper checks for existence before creating, so a
+            # concurrent first-use creator can win between those operations.
+            # The winning catalog row is authoritative; resolve it and let the
+            # caller's normal schema-alignment check reject any incompatible
+            # concurrent definition before writing.
+            return catalog.get_table(identifier)
 
     @staticmethod
     def _read_table(table: Table, io_config: IOConfig | None) -> DataFrame:

--- a/tests/core/test_store_table_registration_race.py
+++ b/tests/core/test_store_table_registration_race.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from archetype.core.aio.async_store import AsyncStore
+from archetype.core.archetype import Archetype
+from archetype.core.component import Component
+from archetype.core.config import StorageConfig
+from archetype.core.sync.store import SyncStore
+from archetype.storage.session import configure_session
+
+
+class RegistrationProbe(Component):
+    value: int
+
+
+def _stores(tmp_path):
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="registration_race")
+    first_session = configure_session(storage)
+    second_session = configure_session(storage)
+    sig = Archetype.sig_from_components([RegistrationProbe(value=1)])
+    return storage, first_session, second_session, sig
+
+
+def _synchronize_first_absence(monkeypatch, *sessions) -> None:
+    """Force independent catalogs to decide absence before either creates."""
+    barrier = threading.Barrier(len(sessions))
+    for session in sessions:
+        catalog = session.current_catalog()
+        assert catalog is not None
+        original_has_table = catalog.has_table
+
+        def synchronized_has_table(identifier, *, _has_table=original_has_table):
+            exists = _has_table(identifier)
+            assert not exists
+            barrier.wait(timeout=10)
+            return exists
+
+        monkeypatch.setattr(catalog, "has_table", synchronized_has_table)
+
+
+@pytest.mark.asyncio
+async def test_async_store_recovers_concurrent_table_registration_loser(tmp_path, monkeypatch):
+    storage, first_session, second_session, sig = _stores(tmp_path)
+    first = AsyncStore(first_session, io_config=storage.io_config)
+    second = AsyncStore(second_session, io_config=storage.io_config)
+    _synchronize_first_absence(monkeypatch, first.session, second.session)
+
+    tables = await asyncio.wait_for(
+        asyncio.gather(
+            asyncio.to_thread(first._ensure_table, sig),
+            asyncio.to_thread(second._ensure_table, sig),
+        ),
+        timeout=20,
+    )
+
+    table_name = Archetype.get_name(sig)
+    assert [table.name for table in tables] == [table_name, table_name]
+    assert await first.list_signatures() == [sig]
+    assert await second.list_signatures() == [sig]
+
+
+def test_sync_store_recovers_concurrent_table_registration_loser(tmp_path, monkeypatch):
+    storage, first_session, second_session, sig = _stores(tmp_path)
+    first = SyncStore(uri=str(storage.uri), session=first_session, io_config=storage.io_config)
+    second = SyncStore(uri=str(storage.uri), session=second_session, io_config=storage.io_config)
+    _synchronize_first_absence(monkeypatch, first.sess, second.sess)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(first._ensure_table, sig),
+            executor.submit(second._ensure_table, sig),
+        ]
+        tables = [future.result(timeout=20) for future in futures]
+
+    table_name = Archetype.get_name(sig)
+    assert [table.name for table in tables] == [table_name, table_name]
+    assert first.list_signatures() == [sig]
+    assert second.list_signatures() == [sig]

--- a/tests/storage/test_storage_execution.py
+++ b/tests/storage/test_storage_execution.py
@@ -208,6 +208,45 @@ async def test_app_table_schema_drift_fails_before_write(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_concurrent_first_table_registration_recovers_losing_creator(tmp_path, monkeypatch):
+    """A first-use creator that loses the catalog race resolves the winning table."""
+    storage = _storage(tmp_path)
+    first = StorageService(session=configure_session(storage))
+    second = StorageService(session=configure_session(storage))
+    rows = daft.from_pydict({"event_id": ["e1"]})
+    barrier = threading.Barrier(2)
+    try:
+        first_store, second_store = await asyncio.gather(
+            first.get_or_create_store(storage),
+            second.get_or_create_store(storage),
+        )
+        for store in (first_store, second_store):
+            catalog = store.session.current_catalog()
+            original_has_table = catalog.has_table
+
+            def synchronized_has_table(identifier, *, _has_table=original_has_table):
+                exists = _has_table(identifier)
+                assert not exists
+                barrier.wait(timeout=10)
+                return exists
+
+            monkeypatch.setattr(catalog, "has_table", synchronized_has_table)
+
+        tables = await asyncio.wait_for(
+            asyncio.gather(
+                asyncio.to_thread(first._ensure_table, first_store, "events", rows.schema()),
+                asyncio.to_thread(second._ensure_table, second_store, "events", rows.schema()),
+            ),
+            timeout=20,
+        )
+
+        assert all(table.name == "events" for table in tables)
+    finally:
+        await first.shutdown()
+        await second.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_real_iceberg_conflict_recomputes_conditional_append(tmp_path):
     """A losing writer refreshes and anti-joins again instead of duplicating a key."""
     storage = _storage(tmp_path)


### PR DESCRIPTION
## Outcome

Two independent catalog clients can race on first use of the same absent Iceberg table. Daft's `create_table_if_not_exists` performs a check followed by creation: both clients may observe absence, then PyIceberg admits one catalog row and raises `TableAlreadyExistsError` in the loser.

This PR now restores the same invariant across every known Archetype registration path:

- `StorageService` application tables;
- core `AsyncStore` ECS signature tables; and
- compatibility `SyncStore` ECS signature tables.

The two originally separate PRs could not safely land independently: deterministic review correctly found that either one would leave the parallel path known-broken. The fixes remain separate commits in this PR.

## Contract

Each path catches only PyIceberg's exact `TableAlreadyExistsError`, resolves the authoritative winning table from the catalog, and continues through its existing validation/cache path. `StorageService` still performs schema alignment before writing; ECS table identity already incorporates the complete storage schema.

Two real Daft/PyIceberg sessions are synchronized so both observe the same table as absent before either creates it. One wins catalog registration; the loser must resolve that table. The regression covers application tables plus both async and sync ECS stores.

## Non-goals

This does **not** add Iceberg append-conflict retry, change lazy execution, swallow generic provider errors, or claim exactly-once writes. A simultaneous append can still lose optimistic snapshot commit; that remains a separate storage durability and throughput decision.

PyIceberg may leave an unreferenced candidate metadata JSON after a lost catalog insertion. Unsafe cleanup is deliberately out of scope.

## Validation

- combined focused contracts: 79 passed
- process profile: 27 passed
- prior deterministic race repetitions: 20/20 on each race oracle
- `make static`

Closes #679.