### PR TITLE
fix: make Activity lease authority lock-safe

### DIFF
--- a/src/archetype/storage/activity_catalog/sqlite.py
+++ b/src/archetype/storage/activity_catalog/sqlite.py
@@ -14,6 +14,7 @@ import asyncio
 import math
 import sqlite3
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -119,11 +120,18 @@ def activity_catalog_path_for(
 class SqliteActivityCatalog:
     """Single-host durable authority for activity claims and settlement."""
 
-    def __init__(self, path: Path, *, busy_timeout_ms: int = 5000) -> None:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        busy_timeout_ms: int = 5000,
+        now_seconds: Callable[[], float] = time.time,
+    ) -> None:
         if busy_timeout_ms < 0:
             raise ValueError("busy_timeout_ms must be non-negative")
         self.path = Path(path)
         self._busy_timeout_ms = busy_timeout_ms
+        self._now_seconds = now_seconds
         self._conn: sqlite3.Connection | None = None
         self._lock = asyncio.Lock()
 
@@ -311,9 +319,11 @@ class SqliteActivityCatalog:
 
         def _claim() -> ActivityClaimRecord:
             conn = self._connect_sync()
-            now_seconds = time.time()
             with conn:
                 conn.execute("BEGIN IMMEDIATE")
+                # BEGIN may wait behind another writer; lease decisions and
+                # newly minted expiry must use time observed after that wait.
+                now_seconds = self._now_seconds()
                 activity_row = _select_activity(conn, world_id, kind, activity_id)
                 if activity_row is None:
                     raise ActivityCatalogNotFoundError((world_id, kind, activity_id))
@@ -434,7 +444,11 @@ class SqliteActivityCatalog:
                     claim.activity.kind,
                     claim.activity.activity_id,
                 )
-                row = _require_live_claim(conn, claim)
+                row = _require_live_claim(
+                    conn,
+                    claim,
+                    now_seconds=self._now_seconds(),
+                )
                 if row["reconciles_attempt"] is not None:
                     raise ActivityCatalogClaimError(
                         "a reconciliation claim cannot invoke a new provider operation"
@@ -546,9 +560,11 @@ class SqliteActivityCatalog:
 
         def _confirm() -> ActivityClaimRecord:
             conn = self._connect_sync()
-            now_seconds = time.time()
             with conn:
                 conn.execute("BEGIN IMMEDIATE")
+                # Exact-retry liveness, renewal, and replay authorization all
+                # use one timestamp sampled after the write lock is held.
+                now_seconds = self._now_seconds()
                 activity = _require_activity(
                     conn,
                     claim.activity.source_world_id,
@@ -637,7 +653,11 @@ class SqliteActivityCatalog:
                         )
                     raise ActivityCatalogClaimError("provider-absence confirmation claim is stale")
 
-                reconciliation = _require_live_claim(conn, claim)
+                reconciliation = _require_live_claim(
+                    conn,
+                    claim,
+                    now_seconds=now_seconds,
+                )
                 reconciles_attempt = reconciliation["reconciles_attempt"]
                 if reconciles_attempt is None:
                     raise ActivityCatalogClaimError(
@@ -761,7 +781,11 @@ class SqliteActivityCatalog:
                         )
                     return activity
 
-                attempt_row = _require_live_claim(conn, claim)
+                attempt_row = _require_live_claim(
+                    conn,
+                    claim,
+                    now_seconds=self._now_seconds(),
+                )
                 if (
                     attempt_row["provider_operation_id"] is None
                     and attempt_row["reconciles_attempt"] is None
@@ -829,7 +853,11 @@ class SqliteActivityCatalog:
                 if row is not None and row["released_at"] is not None:
                     if int(row["fence"]) == claim.fence and row["owner"] == claim.owner:
                         return
-                row = _require_live_claim(conn, claim)
+                row = _require_live_claim(
+                    conn,
+                    claim,
+                    now_seconds=self._now_seconds(),
+                )
                 if (
                     row["provider_operation_id"] is not None
                     or row["reconciles_attempt"] is not None
@@ -1091,6 +1119,8 @@ def _attempt(
 def _require_live_claim(
     conn: sqlite3.Connection,
     claim: ActivityClaimRecord,
+    *,
+    now_seconds: float,
 ) -> sqlite3.Row:
     if not claim.acquired:
         raise ActivityCatalogClaimError("activity claim was not acquired")
@@ -1121,7 +1151,7 @@ def _require_live_claim(
     if row["released_at"] is not None:
         raise ActivityCatalogClaimError("activity claim was released")
     expires = row["lease_expires_at"]
-    if expires is None or float(expires) <= time.time():
+    if expires is None or float(expires) <= now_seconds:
         raise ActivityCatalogClaimError("activity claim lease expired")
     return row
 

--- a/tests/activities/test_activity_catalog_contracts.py
+++ b/tests/activities/test_activity_catalog_contracts.py
@@ -6,7 +6,12 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 import threading
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import cast
 
 import pytest
 
@@ -35,6 +40,77 @@ pytestmark = [
 
 _KIND = "missions.author"
 _OPERATION_ID = "missions.author:world-a:dispatch-1"
+
+
+@dataclass(slots=True)
+class _ManualClock:
+    value: float = 1_000_000.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class _BeginAdvancingConnection:
+    def __init__(
+        self,
+        connection: sqlite3.Connection,
+        clock: _ManualClock,
+        advance_seconds: float,
+    ) -> None:
+        self._connection = connection
+        self._clock = clock
+        self._advance_seconds = advance_seconds
+
+    def execute(
+        self,
+        statement: str,
+        parameters: tuple[object, ...] = (),
+    ) -> sqlite3.Cursor:
+        cursor = self._connection.execute(statement, parameters)
+        if statement == "BEGIN IMMEDIATE":
+            self._clock.advance(self._advance_seconds)
+        return cursor
+
+    def __enter__(self) -> _BeginAdvancingConnection:
+        self._connection.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        return self._connection.__exit__(exc_type, exc_value, traceback)
+
+
+class _BeginAdvancingCatalog(SqliteActivityCatalog):
+    def __init__(self, path: Path, *, clock: _ManualClock) -> None:
+        super().__init__(path, now_seconds=clock)
+        self._clock = clock
+        self._advance_after_begin: float | None = None
+
+    def advance_clock_after_next_begin(self, seconds: float) -> None:
+        assert self._advance_after_begin is None
+        self._advance_after_begin = seconds
+
+    def _connect_sync(self) -> sqlite3.Connection:
+        connection = super()._connect_sync()
+        advance_seconds = self._advance_after_begin
+        if advance_seconds is None:
+            return connection
+        self._advance_after_begin = None
+        return cast(
+            sqlite3.Connection,
+            _BeginAdvancingConnection(
+                connection,
+                self._clock,
+                advance_seconds,
+            ),
+        )
 
 
 def _receipt(
@@ -332,10 +408,46 @@ async def test_released_pre_provider_claim_is_safely_fenced_and_reclaimable(
         await catalog.close()
 
 
+async def test_claim_rechecks_expiry_after_write_lock(tmp_path) -> None:
+    clock = _ManualClock()
+    catalog = _BeginAdvancingCatalog(
+        tmp_path / "activities.db",
+        clock=clock,
+    )
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        await coordinator.admit(_admission())
+        initial = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-a",
+            lease_seconds=10,
+        )
+        assert initial.lease_expires_at == clock.value + 10
+
+        catalog.advance_clock_after_next_begin(10)
+        replacement = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-b",
+            lease_seconds=30,
+        )
+
+        assert replacement.acquired
+        assert replacement.attempt == replacement.fence == 2
+        assert replacement.lease_expires_at == clock.value + 30
+        assert not replacement.reconciliation_required
+    finally:
+        await catalog.close()
+
+
 async def test_expired_provider_bound_attempt_becomes_reconcile_only(tmp_path) -> None:
     path = tmp_path / "activities.db"
-    first_catalog = SqliteActivityCatalog(path)
-    second_catalog = SqliteActivityCatalog(path)
+    clock = _ManualClock()
+    first_catalog = SqliteActivityCatalog(path, now_seconds=clock)
+    second_catalog = SqliteActivityCatalog(path, now_seconds=clock)
     first = ActivityCoordinator(first_catalog)
     second = ActivityCoordinator(second_catalog)
     try:
@@ -345,7 +457,7 @@ async def test_expired_provider_bound_attempt_becomes_reconcile_only(tmp_path) -
             _KIND,
             "dispatch-1",
             "owner-a",
-            lease_seconds=0.01,
+            lease_seconds=10,
         )
         bound = await first.bind_provider_operation(
             initial,
@@ -364,7 +476,7 @@ async def test_expired_provider_bound_attempt_becomes_reconcile_only(tmp_path) -
         assert same_owner_after_restart.attempt == bound.attempt
         assert same_owner_after_restart.fence == bound.fence
         assert same_owner_after_restart.provider_operation_id == _OPERATION_ID
-        await asyncio.sleep(0.02)
+        clock.advance(10)
 
         recovery = await second.claim(
             "world-a",
@@ -400,9 +512,12 @@ async def test_expired_provider_bound_attempt_becomes_reconcile_only(tmp_path) -
         await first_catalog.close()
 
 
-async def test_confirmed_provider_absence_mints_fresh_execution_fence(tmp_path) -> None:
-    path = tmp_path / "activities.db"
-    catalog = SqliteActivityCatalog(path)
+async def test_absence_confirmation_rechecks_expiry_after_write_lock(tmp_path) -> None:
+    clock = _ManualClock()
+    catalog = _BeginAdvancingCatalog(
+        tmp_path / "activities.db",
+        clock=clock,
+    )
     coordinator = ActivityCoordinator(catalog)
     try:
         await coordinator.admit(_admission())
@@ -411,24 +526,140 @@ async def test_confirmed_provider_absence_mints_fresh_execution_fence(tmp_path) 
             _KIND,
             "dispatch-1",
             "owner-a",
-            lease_seconds=0.01,
+            lease_seconds=10,
+        )
+        await coordinator.bind_provider_operation(
+            initial,
+            "git",
+            _OPERATION_ID,
+        )
+        clock.advance(10)
+        recovery = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-b",
+            lease_seconds=10,
+        )
+        assert recovery.reconciliation_required
+        assert recovery.lease_expires_at is not None
+
+        catalog.advance_clock_after_next_begin(10)
+        with pytest.raises(ActivityClaimError, match="lease expired"):
+            await coordinator.confirm_provider_operation_absent(
+                recovery,
+                _guard(),
+            )
+
+        assert clock.value == recovery.lease_expires_at
+        replacement = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-c",
+            lease_seconds=30,
+        )
+        assert replacement.acquired
+        assert replacement.attempt == replacement.fence == 3
+        assert replacement.reconciliation_required
+        assert replacement.reconciles_attempt == 1
+    finally:
+        await catalog.close()
+
+
+async def test_absence_exact_retry_does_not_renew_after_write_lock_expiry(
+    tmp_path,
+) -> None:
+    clock = _ManualClock()
+    catalog = _BeginAdvancingCatalog(
+        tmp_path / "activities.db",
+        clock=clock,
+    )
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        await coordinator.admit(_admission())
+        initial = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-a",
+            lease_seconds=10,
+        )
+        await coordinator.bind_provider_operation(
+            initial,
+            "git",
+            _OPERATION_ID,
+        )
+        clock.advance(10)
+        recovery = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-b",
+            lease_seconds=10,
+        )
+        authorized = await coordinator.confirm_provider_operation_absent(
+            recovery,
+            _guard(),
+            lease_seconds=10,
+        )
+        assert authorized.lease_expires_at == clock.value + 10
+
+        catalog.advance_clock_after_next_begin(10)
+        with pytest.raises(ActivityClaimError, match="stale"):
+            await coordinator.confirm_provider_operation_absent(
+                recovery,
+                _guard(),
+                lease_seconds=30,
+            )
+
+        assert clock.value == authorized.lease_expires_at
+        replacement = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-c",
+            lease_seconds=30,
+        )
+        assert replacement.acquired
+        assert replacement.attempt == replacement.fence == 4
+        assert replacement.lease_expires_at == clock.value + 30
+        assert not replacement.reconciliation_required
+        assert replacement.retry_guard == _guard()
+    finally:
+        await catalog.close()
+
+
+async def test_confirmed_provider_absence_mints_fresh_execution_fence(tmp_path) -> None:
+    path = tmp_path / "activities.db"
+    clock = _ManualClock()
+    catalog = SqliteActivityCatalog(path, now_seconds=clock)
+    coordinator = ActivityCoordinator(catalog)
+    try:
+        await coordinator.admit(_admission())
+        initial = await coordinator.claim(
+            "world-a",
+            _KIND,
+            "dispatch-1",
+            "owner-a",
+            lease_seconds=10,
         )
         bound = await coordinator.bind_provider_operation(
             initial,
             "git",
             _OPERATION_ID,
         )
-        await asyncio.sleep(0.02)
+        clock.advance(10)
 
         unknown = await coordinator.claim(
             "world-a",
             _KIND,
             "dispatch-1",
             "owner-b",
-            lease_seconds=0.01,
+            lease_seconds=10,
         )
         assert unknown.reconciliation_required
-        await asyncio.sleep(0.02)
+        clock.advance(10)
 
         recovery = await coordinator.claim(
             "world-a",


### PR DESCRIPTION
## Outcome

Makes Activity lease authority deterministic and lock-safe. The original
symptom was a flaky crash/recovery contract built around a 10 ms wall-clock
lease. Replacing that sleep with a controllable clock exposed two real
pre-existing races: claim and absence-confirmation retry could decide
liveness from time sampled before waiting for SQLite's write lock.

## What changed

- give `SqliteActivityCatalog` an optional instance-owned epoch-seconds source
  that defaults to `time.time`
- sample lease time only after `BEGIN IMMEDIATE` has acquired the write lock
- use one post-lock transaction timestamp for liveness, renewal, and any lease
  minted by that claim/confirmation decision
- preserve the exact boundary: `lease_expires_at <= now` is expired
- replace wall-clock sleeps with a shared manual clock across restarted
  catalog instances

No durable schema or status transition changes.

## Lock-transition oracles

A one-shot test connection advances the manual clock immediately after
`BEGIN IMMEDIATE` succeeds. The contracts prove that:

1. a claim expiring while the write lock is acquired is reclaimed and its new
   lease is minted from post-lock time;
2. an absence-confirmation claim expiring there cannot authorize replay; and
3. an exact retry expiring there cannot renew its old lease.

These tests fail deterministically on the pre-fix sampling order.

## Validation

- original wall-clock test reproduced intermittently before the fix
- focused lock/expiry stress and complete Activity catalog suite
- `make static`
- exact-head CI runs on this PR

## Scope

This is an atomic Activity control-plane correctness fix. It does not change
the project version or perform any RC/release action.
