### PR TITLE
fix: recover concurrent ECS table registration

### DIFF
--- a/src/archetype/core/aio/async_store.py
+++ b/src/archetype/core/aio/async_store.py
@@ -22,6 +22,7 @@ from daft import DataFrame, Schema, lit, read_iceberg
 from daft.catalog import Table
 from daft.io import IOConfig
 from daft.session import Session
+from pyiceberg.exceptions import TableAlreadyExistsError
 
 # Internals
 from archetype.core.archetype import Archetype
@@ -72,6 +73,10 @@ class AsyncStore(iAsyncStore):
         daft_schema = Schema.from_pyarrow_schema(pyarrow_schema)
         try:
             table = self.session.create_table_if_not_exists(hash_val, source=daft_schema)
+        except TableAlreadyExistsError:
+            # Another catalog client won first registration after both
+            # create-if-absent checks. The catalog winner is authoritative.
+            table = self.session.get_table(hash_val)
         except Exception as e:
             raise RuntimeError(f"Error creating table {hash_val}: {e}") from e
 

--- a/src/archetype/core/sync/store.py
+++ b/src/archetype/core/sync/store.py
@@ -20,6 +20,7 @@ from daft import DataFrame, Schema, read_iceberg
 from daft.catalog import Table
 from daft.io import IOConfig
 from daft.session import Session
+from pyiceberg.exceptions import TableAlreadyExistsError
 
 from archetype.core.archetype import Archetype
 
@@ -68,6 +69,10 @@ class SyncStore(iStore):
         daft_schema = Schema.from_pyarrow_schema(pyarrow_schema)
         try:
             table = self.sess.create_table_if_not_exists(hash_val, source=daft_schema)
+        except TableAlreadyExistsError:
+            # Another catalog client won first registration after both
+            # create-if-absent checks. The catalog winner is authoritative.
+            table = self.sess.get_table(hash_val)
         except Exception as e:
             raise RuntimeError(f"Error creating table {hash_val}: {e}") from e
 

--- a/tests/core/test_store_table_registration_race.py
+++ b/tests/core/test_store_table_registration_race.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from archetype.core.aio.async_store import AsyncStore
+from archetype.core.archetype import Archetype
+from archetype.core.component import Component
+from archetype.core.config import StorageConfig
+from archetype.core.sync.store import SyncStore
+from archetype.storage.session import configure_session
+
+
+class RegistrationProbe(Component):
+    value: int
+
+
+def _stores(tmp_path):
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="registration_race")
+    first_session = configure_session(storage)
+    second_session = configure_session(storage)
+    sig = Archetype.sig_from_components([RegistrationProbe(value=1)])
+    return storage, first_session, second_session, sig
+
+
+def _synchronize_first_absence(monkeypatch, *sessions) -> None:
+    """Force independent catalogs to decide absence before either creates."""
+    barrier = threading.Barrier(len(sessions))
+    for session in sessions:
+        catalog = session.current_catalog()
+        assert catalog is not None
+        original_has_table = catalog.has_table
+
+        def synchronized_has_table(identifier, *, _has_table=original_has_table):
+            exists = _has_table(identifier)
+            assert not exists
+            barrier.wait(timeout=10)
+            return exists
+
+        monkeypatch.setattr(catalog, "has_table", synchronized_has_table)
+
+
+@pytest.mark.asyncio
+async def test_async_store_recovers_concurrent_table_registration_loser(tmp_path, monkeypatch):
+    storage, first_session, second_session, sig = _stores(tmp_path)
+    first = AsyncStore(first_session, io_config=storage.io_config)
+    second = AsyncStore(second_session, io_config=storage.io_config)
+    _synchronize_first_absence(monkeypatch, first.session, second.session)
+
+    tables = await asyncio.wait_for(
+        asyncio.gather(
+            asyncio.to_thread(first._ensure_table, sig),
+            asyncio.to_thread(second._ensure_table, sig),
+        ),
+        timeout=20,
+    )
+
+    table_name = Archetype.get_name(sig)
+    assert [table.name for table in tables] == [table_name, table_name]
+    assert await first.list_signatures() == [sig]
+    assert await second.list_signatures() == [sig]
+
+
+def test_sync_store_recovers_concurrent_table_registration_loser(tmp_path, monkeypatch):
+    storage, first_session, second_session, sig = _stores(tmp_path)
+    first = SyncStore(uri=str(storage.uri), session=first_session, io_config=storage.io_config)
+    second = SyncStore(uri=str(storage.uri), session=second_session, io_config=storage.io_config)
+    _synchronize_first_absence(monkeypatch, first.sess, second.sess)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(first._ensure_table, sig),
+            executor.submit(second._ensure_table, sig),
+        ]
+        tables = [future.result(timeout=20) for future in futures]
+
+    table_name = Archetype.get_name(sig)
+    assert [table.name for table in tables] == [table_name, table_name]
+    assert first.list_signatures() == [sig]
+    assert second.list_signatures() == [sig]


### PR DESCRIPTION
Closes #679.

## Summary

- recover the exact `TableAlreadyExistsError` raised when another Iceberg catalog client wins first ECS table registration
- resolve the authoritative winning table and register the archetype signature normally
- keep async and compatibility sync store behavior aligned
- preserve existing wrapping for every unrelated table-creation error

## Contract

Two real Daft/PyIceberg sessions are forced through a barrier so both observe
the same table as absent before either creates it. One wins catalog
registration; the loser resolves that table. The oracle covers both
`AsyncStore` and `SyncStore` and verifies both signature caches.

This intentionally does not add Iceberg append-conflict retry. A simultaneous
append can still lose optimistic commit and remains a separate durability
decision.

## Validation

- `uv run pytest -q tests/aio/test_async_store.py tests/core/test_async_store_ensure_table_error.py tests/core/test_async_store_updater_failures.py tests/core/test_store_table_registration_race.py tests/sync/test_sync_stack_contracts.py` — 44 passed
- `make static`
