### PR TITLE
fix: couple Modal provider admission and start

### DIFF
--- a/docs/planning/activity-boundary-refactor.md
+++ b/docs/planning/activity-boundary-refactor.md
@@ -132,7 +132,11 @@ authority only for Activities admitted under that barrier-aware epoch from
 birth. Missing markers for legacy or already-in-flight Missions are unknown,
 never confirmed absence. Marker objects must not be deleted or recreated.
 Ambiguous creation and lost winners deliberately sacrifice liveness rather
-than permit duplicate starts.
+than permit duplicate starts. The public initial and retry paths each couple
+acknowledged operation-marker creation, run-marker creation, and the single
+named-sandbox start in one coroutine. No structural guard or permit is accepted
+as execution authority, and reconstruction after either success or ambiguity
+cannot replay the start—even after the live sandbox names have been released.
 
 Modal supplies placement, sandbox lifetime, and process execution behind the
 same Activity request/result contract. It does not become workflow authority.

--- a/src/archetype/missions/sandboxes/__init__.py
+++ b/src/archetype/missions/sandboxes/__init__.py
@@ -52,6 +52,8 @@ from archetype.missions.sandboxes.modal_barrier import (
     ModalProviderOperationGuard,
     ModalProviderRunPermit,
     ModalProviderStartBarrier,
+    ModalProviderStarted,
+    ModalProviderStartOutcome,
     ModalRunPermitAcquisition,
 )
 from archetype.missions.sandboxes.service import SandboxService
@@ -80,6 +82,8 @@ __all__ = [
     "ModalProviderMarkerExists",
     "ModalProviderOperationGuard",
     "ModalProviderRunPermit",
+    "ModalProviderStartOutcome",
+    "ModalProviderStarted",
     "ModalProviderStartBarrier",
     "ModalRunPermitAcquisition",
     "ProcessRequest",

--- a/src/archetype/missions/sandboxes/modal.py
+++ b/src/archetype/missions/sandboxes/modal.py
@@ -1217,10 +1217,11 @@ class ModalSandboxOperationCapability:
 
     This is provider-resource substrate, not full Activity parity. The current
     multi-step author harness still invokes inner processes after pair
-    creation; those invocations are not one atomic named Modal operation. A
-    future Activity adapter must first acquire the persistent provider guard
-    and run marker from ``ModalProviderStartBarrier``. This low-level method
-    does not yet accept or verify that permit.
+    creation; those invocations are not one atomic named Modal operation. An
+    Activity adapter must use ``ModalProviderStartBarrier.start_initial`` or
+    ``start_retry``. The barrier owns both acknowledged marker acquisitions and
+    the one allowed call into this capability; no structural value is accepted
+    as start authority.
     """
 
     def __init__(self, backend: ModalSandboxBackend) -> None:
@@ -1254,22 +1255,23 @@ class ModalSandboxOperationCapability:
             protocol_epoch=config.operation_protocol_epoch,
         )
 
-    async def start(
+    async def _start_after_provider_barrier(
         self,
         *,
-        operation_id: str,
+        identity: ModalSandboxOperationIdentity,
         spec: SandboxSpec,
     ) -> ModalSandboxSession:
-        """Create a fresh named pair for one execution-authorized claim.
+        """Create the pair after the barrier acknowledged its permanent marker.
 
-        The first named create serializes live pair acquisition. It is not a
-        durable author-execution retry guard because Modal releases the name
-        when the sandbox stops. Callers that lose the live-name race must
-        reconcile; they must not attach and invoke ``exec`` through the
-        winning worker's sandbox.
+        This is deliberately private. The ``ModalProviderStartBarrier`` start
+        methods are the public family contract and never release transferable
+        start authority. The first named sandbox create additionally
+        serializes the live provider cohort, but it is not a retry guard
+        because Modal releases sandbox names when they stop.
         """
 
-        identity = self.identity(operation_id)
+        if self.identity(identity.operation_id) != identity:
+            raise ValueError("Modal provider barrier belongs to another operation capability")
         self._validate_spec(spec)
         modal = self._load_modal()
         client = await self._verified_client(modal, phase="start")

--- a/src/archetype/missions/sandboxes/modal_barrier.py
+++ b/src/archetype/missions/sandboxes/modal_barrier.py
@@ -14,9 +14,12 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
 
+from archetype.missions.sandboxes.contracts import SandboxSpec
 from archetype.missions.sandboxes.modal import (
     MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    ModalSandboxOperationCapability,
     ModalSandboxOperationIdentity,
+    ModalSandboxSession,
 )
 
 _MAX_NAMESPACE_NAME_LENGTH = 63
@@ -155,11 +158,16 @@ class ModalProviderOperationGuard:
 
 @dataclass(frozen=True, slots=True)
 class ModalProviderRunPermit:
-    """One-winner evidence returned only by acknowledged run-marker creation.
+    """Evidence created inside the acknowledged run-marker/start transaction.
 
     The marker is permanent and must never be deleted. Losing this value after
     marker creation leaves the operation Unknown forever; another claimant may
     not reconstruct execution authority from provider lookup alone.
+
+    This frozen value is evidence, not transferable authority. Public provider
+    execution accepts no run-permit argument. Only
+    ``ModalProviderStartBarrier`` may interpret the instance it receives
+    directly from its own acknowledged marker create.
     """
 
     guard: ModalProviderOperationGuard
@@ -232,6 +240,35 @@ type ModalRunPermitAcquisition = (
 
 
 @dataclass(frozen=True, slots=True)
+class ModalProviderStarted:
+    """Exact acknowledged run-marker evidence paired with its live session."""
+
+    permit: ModalProviderRunPermit
+    session: ModalSandboxSession
+
+    def __post_init__(self) -> None:
+        if self.session.operation_identity != self.permit.guard.identity:
+            raise ValueError("Modal provider session does not match its run marker")
+
+    @property
+    def identity(self) -> ModalSandboxOperationIdentity:
+        return self.permit.guard.identity
+
+    @property
+    def run_marker_reference(self) -> str:
+        return self.permit.reference
+
+    @property
+    def run_marker_digest(self) -> str:
+        return self.permit.digest
+
+
+type ModalProviderStartOutcome = (
+    ModalProviderStarted | ModalProviderMarkerExists | ModalProviderBarrierUnknown
+)
+
+
+@dataclass(frozen=True, slots=True)
 class _MarkerLookupFailure:
     reason: str
 
@@ -253,8 +290,11 @@ class ModalProviderStartBarrier:
     marker exists.
 
     Safety is fail-closed. An ambiguous create, a winner lost before effect,
-    or a winner lost between tiers remains Unknown forever. This capability
-    provides no lease, handoff, takeover, replay, or liveness promise.
+    or a winner lost between tiers remains Unknown forever. The public start
+    path couples acknowledged operation-marker creation, run-marker creation,
+    and exactly one provider start in this same coroutine; it never releases
+    transferable execution authority. This capability provides no lease,
+    handoff, takeover, replay, or liveness promise.
     """
 
     def __init__(
@@ -311,7 +351,7 @@ class ModalProviderStartBarrier:
 
         return _run_marker_name(guard.digest)
 
-    async def acquire_initial(
+    async def _acquire_initial(
         self,
         *,
         identity: ModalSandboxOperationIdentity,
@@ -323,7 +363,7 @@ class ModalProviderStartBarrier:
             return ModalProviderBarrierUnknown(identity, "operation", failure)
         return await self._create_operation_guard(identity)
 
-    async def acquire_retry_guard(
+    async def _acquire_retry_guard(
         self,
         *,
         identity: ModalSandboxOperationIdentity,
@@ -341,7 +381,103 @@ class ModalProviderStartBarrier:
             return ModalProviderBarrierUnknown(identity, "operation", observed.reason)
         return await self._create_operation_guard(identity)
 
-    async def acquire_run(
+    async def start_initial(
+        self,
+        *,
+        identity: ModalSandboxOperationIdentity,
+        capability: ModalSandboxOperationCapability,
+        spec: SandboxSpec,
+    ) -> ModalProviderStartOutcome:
+        """Acquire both permanent markers and immediately start one pair.
+
+        No operation guard or run permit crosses this public boundary.
+        Cancellation, local failure, or an ambiguous provider response after
+        either acknowledged marker permanently sacrifices replay.
+        """
+
+        invalid = self._validate_start_request(
+            identity=identity,
+            capability=capability,
+            spec=spec,
+        )
+        if invalid is not None:
+            return invalid
+        guard = await self._acquire_initial(identity=identity)
+        if not isinstance(guard, ModalProviderOperationGuard):
+            return guard
+        return await self._start_after_guard(
+            guard=guard,
+            capability=capability,
+            spec=spec,
+        )
+
+    async def start_retry(
+        self,
+        *,
+        identity: ModalSandboxOperationIdentity,
+        capability: ModalSandboxOperationCapability,
+        spec: SandboxSpec,
+    ) -> ModalProviderStartOutcome:
+        """Start only when retry atomically creates the still-missing guard.
+
+        Exact persistent operation-marker existence never reconstructs
+        authority. A retry claimant must be the acknowledged creator returned
+        in this coroutine, after a provider lookup established safe absence.
+        """
+
+        invalid = self._validate_start_request(
+            identity=identity,
+            capability=capability,
+            spec=spec,
+        )
+        if invalid is not None:
+            return invalid
+        guard = await self._acquire_retry_guard(identity=identity)
+        if not isinstance(guard, ModalProviderOperationGuard):
+            return guard
+        return await self._start_after_guard(
+            guard=guard,
+            capability=capability,
+            spec=spec,
+        )
+
+    async def _start_after_guard(
+        self,
+        *,
+        guard: ModalProviderOperationGuard,
+        capability: ModalSandboxOperationCapability,
+        spec: SandboxSpec,
+    ) -> ModalProviderStartOutcome:
+        permit = await self._acquire_run(guard=guard)
+        if not isinstance(permit, ModalProviderRunPermit):
+            return permit
+        session = await capability._start_after_provider_barrier(
+            identity=guard.identity,
+            spec=spec,
+        )
+        return ModalProviderStarted(permit, session)
+
+    def _validate_start_request(
+        self,
+        *,
+        identity: ModalSandboxOperationIdentity,
+        capability: ModalSandboxOperationCapability,
+        spec: SandboxSpec,
+    ) -> ModalProviderBarrierUnknown | None:
+        failure = self._identity_failure(identity)
+        if failure is not None:
+            return ModalProviderBarrierUnknown(identity, "operation", failure)
+        capability_identity = capability.identity(identity.operation_id)
+        if capability_identity != identity:
+            return ModalProviderBarrierUnknown(
+                identity,
+                "operation",
+                "operation capability belongs to another Modal provider namespace",
+            )
+        capability._validate_spec(spec)
+        return None
+
+    async def _acquire_run(
         self,
         *,
         guard: ModalProviderOperationGuard,
@@ -578,6 +714,8 @@ __all__ = [
     "ModalProviderMarkerExists",
     "ModalProviderOperationGuard",
     "ModalProviderRunPermit",
+    "ModalProviderStartOutcome",
+    "ModalProviderStarted",
     "ModalProviderStartBarrier",
     "ModalRunPermitAcquisition",
 ]

--- a/tests/missions/test_modal_provider_barrier.py
+++ b/tests/missions/test_modal_provider_barrier.py
@@ -260,8 +260,8 @@ async def test_two_tier_persistent_barrier_selects_one_owner_at_each_race(
 
     first, second = await asyncio.wait_for(
         asyncio.gather(
-            barrier.acquire_initial(identity=identity),
-            barrier.acquire_initial(identity=identity),
+            barrier._acquire_initial(identity=identity),
+            barrier._acquire_initial(identity=identity),
         ),
         timeout=1,
     )
@@ -284,8 +284,8 @@ async def test_two_tier_persistent_barrier_selects_one_owner_at_each_race(
     )
     run_first, run_second = await asyncio.wait_for(
         asyncio.gather(
-            barrier.acquire_run(guard=guard),
-            barrier.acquire_run(guard=guard),
+            barrier._acquire_run(guard=guard),
+            barrier._acquire_run(guard=guard),
         ),
         timeout=1,
     )
@@ -318,14 +318,14 @@ async def test_retry_guard_winner_permanently_blocks_a_delayed_initial_worker(
     operation_id = "missions.author:world-a:dispatch-retry-wins"
     identity = _identity(operation_id)
 
-    retry_guard = await barrier.acquire_retry_guard(identity=identity)
+    retry_guard = await barrier._acquire_retry_guard(identity=identity)
     assert isinstance(retry_guard, ModalProviderOperationGuard)
 
-    stale_initial = await barrier.acquire_initial(identity=identity)
+    stale_initial = await barrier._acquire_initial(identity=identity)
     assert isinstance(stale_initial, ModalProviderMarkerExists)
     assert stale_initial.phase == "operation"
 
-    run = await barrier.acquire_run(guard=retry_guard)
+    run = await barrier._acquire_run(guard=retry_guard)
     assert isinstance(run, ModalProviderRunPermit)
     assert len(registry.objects) == 2
 
@@ -338,11 +338,11 @@ async def test_stale_initial_winner_blocks_retry_without_handoff_or_replay(
     operation_id = "missions.author:world-a:dispatch-stale-wins"
     identity = _identity(operation_id)
 
-    stale_guard = await barrier.acquire_initial(identity=identity)
+    stale_guard = await barrier._acquire_initial(identity=identity)
     assert isinstance(stale_guard, ModalProviderOperationGuard)
 
-    retry = await barrier.acquire_retry_guard(identity=identity)
-    repeated_retry = await barrier.acquire_retry_guard(identity=identity)
+    retry = await barrier._acquire_retry_guard(identity=identity)
+    repeated_retry = await barrier._acquire_retry_guard(identity=identity)
     assert isinstance(retry, ModalProviderMarkerExists)
     assert isinstance(repeated_retry, ModalProviderMarkerExists)
     assert len(registry.objects) == 1
@@ -359,13 +359,13 @@ async def test_ambiguous_operation_marker_create_is_unknown_forever(
     marker_name = barrier.operation_marker_name(identity)
     registry.raise_after_create.add(("main", marker_name))
 
-    ambiguous = await barrier.acquire_initial(identity=identity)
+    ambiguous = await barrier._acquire_initial(identity=identity)
     assert isinstance(ambiguous, ModalProviderBarrierUnknown)
     assert ambiguous.phase == "operation"
     assert "ConnectionError" in ambiguous.reason
     assert "provider response lost" not in ambiguous.reason
 
-    retry = await barrier.acquire_retry_guard(identity=identity)
+    retry = await barrier._acquire_retry_guard(identity=identity)
     assert isinstance(retry, ModalProviderMarkerExists)
     assert len(registry.objects) == 1
 
@@ -377,16 +377,16 @@ async def test_ambiguous_run_marker_never_reconstructs_a_permit(
     registry, barrier = provider_barrier
     operation_id = "missions.author:world-a:dispatch-ambiguous-run"
     identity = _identity(operation_id)
-    guard = await barrier.acquire_initial(identity=identity)
+    guard = await barrier._acquire_initial(identity=identity)
     assert isinstance(guard, ModalProviderOperationGuard)
     run_name = barrier.run_marker_name(guard)
     registry.raise_after_create.add(("main", run_name))
 
-    ambiguous = await barrier.acquire_run(guard=guard)
+    ambiguous = await barrier._acquire_run(guard=guard)
     assert isinstance(ambiguous, ModalProviderBarrierUnknown)
     assert ambiguous.phase == "run"
 
-    repeated = await barrier.acquire_run(guard=guard)
+    repeated = await barrier._acquire_run(guard=guard)
     assert isinstance(repeated, ModalProviderMarkerExists)
     assert repeated.phase == "run"
     assert len(registry.objects) == 2
@@ -399,14 +399,14 @@ async def test_acknowledged_run_winner_loss_is_safe_but_permanently_stuck(
     registry, barrier = provider_barrier
     operation_id = "missions.author:world-a:dispatch-run-winner-lost"
     identity = _identity(operation_id)
-    guard = await barrier.acquire_initial(identity=identity)
+    guard = await barrier._acquire_initial(identity=identity)
     assert isinstance(guard, ModalProviderOperationGuard)
-    permit = await barrier.acquire_run(guard=guard)
+    permit = await barrier._acquire_run(guard=guard)
     assert isinstance(permit, ModalProviderRunPermit)
 
     # Simulate loss before the effect starts. Provider lookup can establish
     # that a winner existed, but no later claimant reconstructs its permit.
-    repeated = await barrier.acquire_run(guard=guard)
+    repeated = await barrier._acquire_run(guard=guard)
     assert isinstance(repeated, ModalProviderMarkerExists)
     assert repeated.phase == "run"
     assert len(registry.objects) == 2
@@ -419,7 +419,7 @@ async def test_run_requires_exact_guard_object_and_provider_environment(
     registry, barrier = provider_barrier
     operation_id = "missions.author:world-a:dispatch-exact-guard"
     identity = _identity(operation_id)
-    guard = await barrier.acquire_initial(identity=identity)
+    guard = await barrier._acquire_initial(identity=identity)
     assert isinstance(guard, ModalProviderOperationGuard)
 
     wrong_object = ModalProviderOperationGuard(
@@ -433,7 +433,7 @@ async def test_run_requires_exact_guard_object_and_provider_environment(
             object_id="di-another-object",
         ),
     )
-    rejected_object = await barrier.acquire_run(guard=wrong_object)
+    rejected_object = await barrier._acquire_run(guard=wrong_object)
     assert isinstance(rejected_object, ModalProviderBarrierUnknown)
     assert "identity changed" in rejected_object.reason
 
@@ -443,7 +443,7 @@ async def test_run_requires_exact_guard_object_and_provider_environment(
         app_name="archetype-agent-missions-test",
         protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
     )
-    rejected_environment = await other_environment.acquire_run(guard=guard)
+    rejected_environment = await other_environment._acquire_run(guard=guard)
     assert isinstance(rejected_environment, ModalProviderBarrierUnknown)
     assert "another Modal environment" in rejected_environment.reason
     assert len(registry.objects) == 1
@@ -454,7 +454,7 @@ async def test_run_requires_exact_guard_object_and_provider_environment(
         app_name="archetype-agent-missions-test",
         protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
     )
-    rejected_workspace = await other_workspace.acquire_run(guard=guard)
+    rejected_workspace = await other_workspace._acquire_run(guard=guard)
     assert isinstance(rejected_workspace, ModalProviderBarrierUnknown)
     assert "another Modal workspace" in rejected_workspace.reason
     assert len(registry.objects) == 1
@@ -465,7 +465,7 @@ async def test_run_requires_exact_guard_object_and_provider_environment(
         app_name="another-app",
         protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
     )
-    rejected_app = await other_app.acquire_run(guard=guard)
+    rejected_app = await other_app._acquire_run(guard=guard)
     assert isinstance(rejected_app, ModalProviderBarrierUnknown)
     assert "another Modal app" in rejected_app.reason
     assert len(registry.objects) == 1
@@ -481,7 +481,7 @@ async def test_provider_failures_are_bounded_unknowns_without_secret_text(
     marker_name = barrier.operation_marker_name(identity)
     registry.create_errors[("main", marker_name)] = _ConnectionError("credential-canary")
 
-    outcome = await barrier.acquire_initial(identity=identity)
+    outcome = await barrier._acquire_initial(identity=identity)
     assert isinstance(outcome, ModalProviderBarrierUnknown)
     assert "ConnectionError" in outcome.reason
     assert "credential-canary" not in outcome.reason
@@ -495,7 +495,7 @@ async def test_authenticated_workspace_mismatch_fails_before_provider_create(
     registry, barrier = provider_barrier
     registry.workspace_name = "unexpected-workspace"
 
-    outcome = await barrier.acquire_initial(
+    outcome = await barrier._acquire_initial(
         identity=_identity("missions.author:world-a:dispatch-wrong-workspace")
     )
 
@@ -515,7 +515,7 @@ async def test_pre_barrier_and_in_flight_legacy_operations_never_gain_retry_auth
         protocol_epoch=0,
     )
 
-    outcome = await barrier.acquire_retry_guard(identity=legacy)
+    outcome = await barrier._acquire_retry_guard(identity=legacy)
 
     assert isinstance(outcome, ModalProviderBarrierUnknown)
     assert "predates the barrier-aware protocol epoch" in outcome.reason

--- a/tests/missions/test_modal_sandbox_operations.py
+++ b/tests/missions/test_modal_sandbox_operations.py
@@ -15,6 +15,12 @@ import pytest
 
 from archetype.missions.sandboxes import (
     MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    ModalPersistentDictMarker,
+    ModalProviderBarrierUnknown,
+    ModalProviderMarkerExists,
+    ModalProviderOperationGuard,
+    ModalProviderStartBarrier,
+    ModalProviderStarted,
     ModalSandboxBackend,
     ModalSandboxConfig,
     ModalSandboxOperationCapability,
@@ -58,6 +64,33 @@ class _WorkspaceHandle:
     @property
     def client(self) -> object:
         return self._registry.client
+
+
+class _PersistentDictObject:
+    def __init__(self, object_id: str) -> None:
+        self.object_id = object_id
+
+
+class _PersistentDictHandle:
+    def __init__(
+        self,
+        registry: _ModalRegistry,
+        *,
+        environment_name: str,
+        name: str,
+    ) -> None:
+        self._registry = registry
+        self._key = (environment_name, name)
+        self.object_id = ""
+        self.hydrate = _AsyncCall(self._hydrate)
+
+    def _hydrate(self) -> _PersistentDictHandle:
+        try:
+            value = self._registry.persistent_objects[self._key]
+        except KeyError as exc:
+            raise _NotFoundError(self._key) from exc
+        self.object_id = value.object_id
+        return self
 
 
 class _RemoteApp:
@@ -129,11 +162,63 @@ class _ModalRegistry:
         self.app_calls: list[dict[str, Any]] = []
         self.volume_calls: list[dict[str, Any]] = []
         self.secret_calls: list[dict[str, Any]] = []
+        self.persistent_objects: dict[tuple[str, str], _PersistentDictObject] = {}
+        self.dict_create_calls: list[dict[str, Any]] = []
+        self.dict_lookup_calls: list[dict[str, Any]] = []
         self.lookup_errors: dict[str, Exception] = {}
         self.raise_after_create: set[str] = set()
         self.workspace_name = "vangelis"
         self.client = object()
         self._sequence = 0
+        self._dict_sequence = 0
+
+    def create_dict(
+        self,
+        name: str,
+        *,
+        allow_existing: bool,
+        environment_name: str,
+        client: object,
+    ) -> None:
+        assert allow_existing is False
+        assert client is self.client
+        key = (environment_name, name)
+        self.dict_create_calls.append(
+            {
+                "name": name,
+                "allow_existing": allow_existing,
+                "environment_name": environment_name,
+                "client": client,
+            }
+        )
+        if key in self.persistent_objects:
+            raise _AlreadyExistsError(key)
+        self._dict_sequence += 1
+        self.persistent_objects[key] = _PersistentDictObject(f"di-{self._dict_sequence}")
+
+    def dict_from_name(
+        self,
+        name: str,
+        *,
+        create_if_missing: bool,
+        environment_name: str,
+        client: object,
+    ) -> _PersistentDictHandle:
+        assert create_if_missing is False
+        assert client is self.client
+        self.dict_lookup_calls.append(
+            {
+                "name": name,
+                "create_if_missing": create_if_missing,
+                "environment_name": environment_name,
+                "client": client,
+            }
+        )
+        return _PersistentDictHandle(
+            self,
+            environment_name=environment_name,
+            name=name,
+        )
 
     def app_lookup(
         self,
@@ -246,6 +331,10 @@ def _fake_modal(registry: _ModalRegistry) -> object:
             create=_AsyncCall(registry.create),
             from_name=_AsyncCall(registry.lookup),
         ),
+        Dict=SimpleNamespace(
+            objects=SimpleNamespace(create=_AsyncCall(registry.create_dict)),
+            from_name=registry.dict_from_name,
+        ),
     )
 
 
@@ -306,6 +395,33 @@ def _operation_identity(
         operation_id=operation_id,
         protocol_epoch=protocol_epoch,
     )
+
+
+def _provider_barrier(
+    identity: ModalSandboxOperationIdentity,
+) -> ModalProviderStartBarrier:
+    return ModalProviderStartBarrier(
+        workspace_name=identity.workspace_name,
+        environment_name=identity.environment_name,
+        app_name=identity.app_name,
+        protocol_epoch=identity.protocol_epoch,
+    )
+
+
+async def _start_once(
+    capability: ModalSandboxOperationCapability,
+    spec: SandboxSpec,
+    operation_id: str,
+) -> tuple[ModalProviderStartBarrier, ModalProviderStarted]:
+    identity = capability.identity(operation_id)
+    barrier = _provider_barrier(identity)
+    started = await barrier.start_initial(
+        identity=identity,
+        capability=capability,
+        spec=spec,
+    )
+    assert isinstance(started, ModalProviderStarted)
+    return barrier, started
 
 
 def _remote_sandbox(
@@ -405,6 +521,79 @@ def test_modal_operation_names_are_stable_safe_and_world_isolated() -> None:
 
 
 @pytest.mark.asyncio
+async def test_lost_operation_guard_cannot_be_reconstructed_into_start_authority(
+    modal_operation,
+) -> None:
+    registry, _backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-permit"
+    identity = capability.identity(operation_id)
+    barrier = _provider_barrier(identity)
+    issued = await barrier._acquire_initial(identity=identity)
+    assert isinstance(issued, ModalProviderOperationGuard)
+    reconstructed = ModalProviderOperationGuard(
+        identity,
+        ModalPersistentDictMarker(
+            workspace_name=issued.marker.workspace_name,
+            environment_name=issued.marker.environment_name,
+            app_name=issued.marker.app_name,
+            protocol_epoch=issued.marker.protocol_epoch,
+            name=issued.marker.name,
+            object_id=issued.marker.object_id,
+        ),
+    )
+
+    assert not hasattr(capability, "start")
+    assert not hasattr(barrier, "start_once")
+    assert not hasattr(barrier, "acquire_initial")
+    assert reconstructed == issued
+    assert reconstructed is not issued
+    rejected = await _provider_barrier(identity).start_retry(
+        identity=identity,
+        capability=capability,
+        spec=spec,
+    )
+
+    assert isinstance(rejected, ModalProviderMarkerExists)
+    assert rejected.phase == "operation"
+    assert len(registry.persistent_objects) == 1
+    assert registry.lookup_calls == []
+    assert registry.create_calls == []
+    assert registry.app_calls == []
+    assert registry.volume_calls == []
+    assert registry.secret_calls == []
+
+
+@pytest.mark.asyncio
+async def test_retry_start_wins_only_by_creating_both_markers_in_one_coroutine(
+    modal_operation,
+) -> None:
+    registry, backend, capability, spec = modal_operation
+    operation_id = "missions.author:world-a:dispatch-safe-retry"
+    identity = capability.identity(operation_id)
+
+    started = await _provider_barrier(identity).start_retry(
+        identity=identity,
+        capability=capability,
+        spec=spec,
+    )
+
+    assert isinstance(started, ModalProviderStarted)
+    assert len(registry.persistent_objects) == 2
+    assert len(registry.create_calls) == 2
+    await started.session.close()
+
+    creates_before_reconstruction = len(registry.create_calls)
+    reconstructed = await _provider_barrier(identity).start_retry(
+        identity=identity,
+        capability=ModalSandboxOperationCapability(ModalSandboxBackend(backend.config)),
+        spec=spec,
+    )
+    assert isinstance(reconstructed, ModalProviderMarkerExists)
+    assert reconstructed.phase == "operation"
+    assert len(registry.create_calls) == creates_before_reconstruction
+
+
+@pytest.mark.asyncio
 async def test_named_modal_operation_reports_running_without_sharing_execution_handle(
     modal_operation,
 ) -> None:
@@ -412,10 +601,14 @@ async def test_named_modal_operation_reports_running_without_sharing_execution_h
     operation_id = "missions.author:world-a:dispatch-1"
     identity = capability.identity(operation_id)
 
-    created = await capability.start(operation_id=operation_id, spec=spec)
+    _barrier, started = await _start_once(capability, spec, operation_id)
+    created = started.session
     mission = registry.resources[identity.mission_sandbox_name]
     auth = registry.resources[identity.auth_sandbox_name]
 
+    assert started.identity == identity
+    assert started.run_marker_reference.startswith("modal-dict://")
+    assert started.run_marker_digest.startswith("sha256:")
     assert created.operation_identity == identity
     assert created.identity.sandbox_id == mission.object_id
     assert len(registry.create_calls) == 2
@@ -454,10 +647,15 @@ async def test_named_modal_operation_reports_running_without_sharing_execution_h
     assert not hasattr(running, "retry_guard")
     assert len(registry.create_calls) == 2
 
-    # A newer claimant cannot acquire the live provider name and reconcile
-    # does not hand it a session through which to invoke a second inner exec.
-    with pytest.raises(_AlreadyExistsError):
-        await restarted.start(operation_id=operation_id, spec=spec)
+    # Reconstructing both substrate objects cannot replay the acknowledged
+    # marker, even after the process-local objects that created it are gone.
+    restarted_barrier = _provider_barrier(identity)
+    blocked_live = await restarted_barrier.start_retry(
+        identity=identity,
+        capability=restarted,
+        spec=spec,
+    )
+    assert isinstance(blocked_live, ModalProviderMarkerExists)
     assert len(registry.resources) == 2
     assert not hasattr(restarted, "cleanup")
 
@@ -465,6 +663,16 @@ async def test_named_modal_operation_reports_running_without_sharing_execution_h
     assert registry.resources == {}
     assert mission.terminated == auth.terminated == 1
     assert mission.detached == auth.detached == 1
+
+    creates_before_delayed_replay = len(registry.create_calls)
+    blocked_after_close = await _provider_barrier(identity).start_retry(
+        identity=identity,
+        capability=ModalSandboxOperationCapability(ModalSandboxBackend(backend.config)),
+        spec=spec,
+    )
+    assert isinstance(blocked_after_close, ModalProviderMarkerExists)
+    assert len(registry.create_calls) == creates_before_delayed_replay
+    assert len(registry.persistent_objects) == 2
 
 
 @pytest.mark.asyncio
@@ -579,9 +787,14 @@ async def test_ambiguous_create_is_reconciled_as_partial_without_unsafe_name_cle
     operation_id = "missions.author:world-a:dispatch-crash"
     identity = capability.identity(operation_id)
     registry.raise_after_create.add(identity.mission_sandbox_name)
+    barrier = _provider_barrier(identity)
 
     with pytest.raises(_ConnectionError, match="response lost"):
-        await capability.start(operation_id=operation_id, spec=spec)
+        await barrier.start_initial(
+            identity=identity,
+            capability=capability,
+            spec=spec,
+        )
 
     # The auth handle was known and compensated. The mission create response
     # was lost, so its surviving name cannot be treated as safe absence.
@@ -603,26 +816,34 @@ async def test_atomic_live_name_allows_only_one_concurrent_pair_owner(
 ) -> None:
     registry, _backend, capability, spec = modal_operation
     operation_id = "missions.author:world-a:dispatch-race"
+    identity = capability.identity(operation_id)
+    barrier = _provider_barrier(identity)
 
     first, second = await asyncio.gather(
-        capability.start(operation_id=operation_id, spec=spec),
-        capability.start(operation_id=operation_id, spec=spec),
-        return_exceptions=True,
+        barrier.start_initial(
+            identity=identity,
+            capability=capability,
+            spec=spec,
+        ),
+        barrier.start_initial(
+            identity=identity,
+            capability=capability,
+            spec=spec,
+        ),
     )
 
     outcomes = (first, second)
-    winners = [outcome for outcome in outcomes if not isinstance(outcome, BaseException)]
-    losers = [outcome for outcome in outcomes if isinstance(outcome, BaseException)]
+    winners = [outcome for outcome in outcomes if isinstance(outcome, ModalProviderStarted)]
+    losers = [outcome for outcome in outcomes if isinstance(outcome, ModalProviderMarkerExists)]
     assert len(winners) == 1
     assert len(losers) == 1
-    assert isinstance(losers[0], _AlreadyExistsError)
     assert len(registry.resources) == 2
 
     running = await capability.reconcile(operation_id=operation_id, spec=spec)
     assert isinstance(running, ModalSandboxOperationRunning)
     assert not hasattr(running, "session")
-    assert isinstance(winners[0], ModalSandboxSession)
-    await winners[0].close()
+    assert isinstance(winners[0].session, ModalSandboxSession)
+    await winners[0].session.close()
 
 
 @pytest.mark.asyncio
@@ -632,10 +853,15 @@ async def test_ambiguous_first_name_acquisition_never_authorizes_another_start(
     registry, _backend, capability, spec = modal_operation
     operation_id = "missions.author:world-a:dispatch-auth-crash"
     identity = capability.identity(operation_id)
+    barrier = _provider_barrier(identity)
     registry.raise_after_create.add(identity.auth_sandbox_name)
 
     with pytest.raises(_ConnectionError, match="response lost"):
-        await capability.start(operation_id=operation_id, spec=spec)
+        await barrier.start_initial(
+            identity=identity,
+            capability=capability,
+            spec=spec,
+        )
 
     assert set(registry.resources) == {identity.auth_sandbox_name}
     unknown = await capability.reconcile(operation_id=operation_id, spec=spec)
@@ -646,9 +872,13 @@ async def test_ambiguous_first_name_acquisition_never_authorizes_another_start(
     # The provider response was ambiguous, but its live name still fences a
     # delayed claimant. Neither reconciliation nor the conflict yields a
     # session or retry guard.
-    with pytest.raises(_AlreadyExistsError):
-        await capability.start(operation_id=operation_id, spec=spec)
-    assert len(registry.create_calls) == calls_after_reconcile + 1
+    blocked = await _provider_barrier(identity).start_retry(
+        identity=identity,
+        capability=ModalSandboxOperationCapability(ModalSandboxBackend(_backend.config)),
+        spec=spec,
+    )
+    assert isinstance(blocked, ModalProviderMarkerExists)
+    assert len(registry.create_calls) == calls_after_reconcile
     assert not hasattr(unknown, "session")
     assert not hasattr(unknown, "retry_guard")
 
@@ -662,7 +892,8 @@ async def test_exact_session_close_cannot_terminate_a_reused_name_generation(
     registry, _backend, capability, spec = modal_operation
     operation_id = "missions.author:world-a:dispatch-late-close"
     identity = capability.identity(operation_id)
-    session = await capability.start(operation_id=operation_id, spec=spec)
+    _barrier, started = await _start_once(capability, spec, operation_id)
+    session = started.session
     old_mission = registry.resources[identity.mission_sandbox_name]
     old_auth = registry.resources[identity.auth_sandbox_name]
 
@@ -700,8 +931,18 @@ async def test_named_modal_operations_isolate_same_dispatch_across_worlds(
     world_a = "missions.author:world-a:same-dispatch"
     world_b = "missions.author:world-b:same-dispatch"
 
-    first = await capability.start(operation_id=world_a, spec=spec)
-    second = await capability.start(operation_id=world_b, spec=spec)
+    _first_barrier, first_started = await _start_once(
+        capability,
+        spec,
+        world_a,
+    )
+    _second_barrier, second_started = await _start_once(
+        capability,
+        spec,
+        world_b,
+    )
+    first = first_started.session
+    second = second_started.session
     first_id = first.identity.sandbox_id
     second_id = second.identity.sandbox_id
 
@@ -797,12 +1038,18 @@ async def test_modal_operation_namespace_is_explicit_and_ambient_mismatch_fails_
 
     lookups_before_mismatch = len(registry.lookup_calls)
     creates_before_mismatch = len(registry.create_calls)
+    barrier = _provider_barrier(identity)
     registry.workspace_name = "unexpected-workspace"
     mismatch = await capability.reconcile(operation_id=operation_id, spec=spec)
     assert isinstance(mismatch, ModalSandboxOperationUnknown)
     assert "workspace identity" in mismatch.reason
-    with pytest.raises(RuntimeError, match="workspace identity"):
-        await capability.start(operation_id=operation_id, spec=spec)
+    start_mismatch = await barrier.start_initial(
+        identity=identity,
+        capability=capability,
+        spec=spec,
+    )
+    assert isinstance(start_mismatch, ModalProviderBarrierUnknown)
+    assert "workspace" in start_mismatch.reason
     assert len(registry.lookup_calls) == lookups_before_mismatch
     assert len(registry.create_calls) == creates_before_mismatch
     assert registry.app_calls == []


### PR DESCRIPTION
## Summary
- couple permanent operation-marker and run-marker acquisition with the single named sandbox start
- remove public structural guard/permit start authority so reconstruction cannot replay provider work
- prove lost-winner, ambiguous-create, concurrent-winner, namespace, restart, and post-close replay schedules

## Validation
- uv run pytest -q tests/missions/test_modal_sandbox_operations.py tests/missions/test_modal_provider_barrier.py (24 passed)
- make static
- independent adversarial review: no blocking safety hole