### PR TITLE
feat(ci): merge-group queue-readiness recheck (H2)

### DIFF
--- a/.github/workflows/merge-group-recheck.yml
+++ b/.github/workflows/merge-group-recheck.yml
@@ -17,10 +17,12 @@
 # merge-group run.
 #
 # Two event legs:
-# - merge_group: the real re-check. The PR number is parsed from the queue
-#   ref (gh-readonly-queue/<base>/pr-N-<base-sha> — the trailing sha is the
-#   BASE main was at, NOT the PR head, so the live head is fetched from the
-#   API; pushes are blocked while queued, so the live head is the queued
+# - merge_group: the real re-check, for EVERY member of the group. The queue
+#   can batch several PRs into one group and the ref names only the last
+#   member (gh-readonly-queue/<base>/pr-N-<base-sha> — the trailing sha is
+#   the BASE main was at, NOT the PR head), so members are enumerated from
+#   the group's own commits and each one is re-checked; live heads come from
+#   the API (pushes are blocked while queued, so the live head is the queued
 #   head). Readiness is judged by scripts/gh_pr_queue_ready.sh — the same
 #   oracle the arm/guard/dequeue jobs use. One oracle, no drift.
 # - pull_request_target: a trivial pass so the required context exists on PR
@@ -74,38 +76,65 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           QUEUE_REF: ${{ github.event.merge_group.head_ref }}
+          GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           chmod +x scripts/gh_pr_queue_ready.sh
 
-          pr=$(printf '%s\n' "$QUEUE_REF" | sed -nE 's|.*/pr-([0-9]+)-[0-9a-f]{40}$|\1|p')
-          if [ -z "$pr" ]; then
+          # The queue can BATCH several PRs into one merge group; the ref
+          # names only the last member. Enumerate every member by walking the
+          # group's commits (base..head) and parsing the squash subjects the
+          # queue writes ("<PR title> (#N)"), then union with the ref-named
+          # PR. A group member that cannot be enumerated would silently skip
+          # its re-check, so enumeration failure is a hard failure.
+          ref_pr=$(printf '%s\n' "$QUEUE_REF" | sed -nE 's|.*/pr-([0-9]+)-[0-9a-f]{40}$|\1|p')
+          if [ -z "$ref_pr" ]; then
             echo "::error::could not parse a PR number from merge-group ref '${QUEUE_REF}'." \
                  "The queue ref naming convention may have changed; failing closed."
             exit 1
           fi
 
-          head_sha=$(gh pr view "$pr" --repo "${GITHUB_REPOSITORY}" \
-            --json headRefOid --jq '.headRefOid')
-          if [ -z "$head_sha" ]; then
-            echo "::error::could not resolve the live head of PR #${pr}; failing closed."
+          if ! commits=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/compare/${GROUP_BASE_SHA}...${GROUP_HEAD_SHA}" \
+              --jq '.commits[].commit.message | split("\n")[0]'); then
+            echo "::error::could not enumerate the merge group's commits; failing closed."
             exit 1
           fi
+          batch_prs=$(printf '%s\n' "$commits" | sed -nE 's|.*\(#([0-9]+)\)$|\1|p')
+          prs=$(printf '%s\n%s\n' "$batch_prs" "$ref_pr" | sort -un)
+          echo "merge group contains PR(s): $(echo $prs | tr '\n' ' ')"
 
-          set +e
-          reason=$(scripts/gh_pr_queue_ready.sh "${GITHUB_REPOSITORY}" "$pr" "$head_sha")
-          status=$?
-          set -e
-          if [ "$status" -eq 0 ]; then
-            echo "PR #${pr} is still queue-ready on ${head_sha}; merge may proceed."
-            exit 0
-          fi
-          if [ "$status" -ne 1 ]; then
-            echo "::error::queue-ready helper failed (exit ${status}): ${reason}"
+          failed=0
+          for pr in $prs; do
+            head_sha=$(gh pr view "$pr" --repo "${GITHUB_REPOSITORY}" \
+              --json headRefOid --jq '.headRefOid')
+            if [ -z "$head_sha" ]; then
+              echo "::error::could not resolve the live head of PR #${pr}; failing closed."
+              failed=$((failed + 1))
+              continue
+            fi
+
+            set +e
+            reason=$(scripts/gh_pr_queue_ready.sh "${GITHUB_REPOSITORY}" "$pr" "$head_sha")
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then
+              echo "PR #${pr} is still queue-ready on ${head_sha}."
+              continue
+            fi
+            if [ "$rc" -ne 1 ]; then
+              echo "::error::queue-ready helper failed for PR #${pr} (exit ${rc}): ${reason}"
+              failed=$((failed + 1))
+              continue
+            fi
+            echo "::error::PR #${pr} is no longer queue-ready (${reason})." \
+                 "This eviction is intentional: findings arrived after queue entry." \
+                 "Resolve the threads, run scripts/gh_dispose_thread.sh ${GITHUB_REPOSITORY} ${pr} --signal," \
+                 "and let automerge re-arm — do NOT rerun this merge-group run."
+            failed=$((failed + 1))
+          done
+
+          if [ "$failed" -gt 0 ]; then
             exit 1
           fi
-
-          echo "::error::PR #${pr} is no longer queue-ready (${reason})." \
-               "This eviction is intentional: findings arrived after queue entry." \
-               "Resolve the threads, run scripts/gh_dispose_thread.sh ${GITHUB_REPOSITORY} ${pr} --signal," \
-               "and let automerge re-arm — do NOT rerun this merge-group run."
-          exit 1
+          echo "every PR in the merge group is queue-ready; merge may proceed."

--- a/.github/workflows/merge-group-recheck.yml
+++ b/.github/workflows/merge-group-recheck.yml
@@ -1,0 +1,111 @@
+# Re-verify queue-readiness INSIDE the merge group.
+#
+# Why this exists: arming covers the path into the queue, and the automerge
+# dequeue job covers the path back out — but the dequeue is best-effort and
+# can lose the race (#646 merged known defects; #683 was queue-locked against
+# its own fix push with GH006 while new review threads sat unresolved). Once
+# GitHub's queue holds a PR, nothing re-checks whether the review verdict the
+# arm was based on still stands. This workflow is that re-check, running as a
+# required merge-group context: if review threads arrived after queue entry
+# (or review-complete lapsed), the group fails, GitHub evicts the PR, and the
+# branch unlocks for the fix push — automatically, instead of via hand-crafted
+# dequeue mutations.
+#
+# An eviction by this check is INTENTIONAL, not a flake: resolve the threads,
+# submit the re-evaluation review (scripts/gh_dispose_thread.sh --signal),
+# and let the automerge workflow re-arm and requeue. Do not rerun the failed
+# merge-group run.
+#
+# Two event legs:
+# - merge_group: the real re-check. The PR number is parsed from the queue
+#   ref (gh-readonly-queue/<base>/pr-N-<base-sha> — the trailing sha is the
+#   BASE main was at, NOT the PR head, so the live head is fetched from the
+#   API; pushes are blocked while queued, so the live head is the queued
+#   head). Readiness is judged by scripts/gh_pr_queue_ready.sh — the same
+#   oracle the arm/guard/dequeue jobs use. One oracle, no drift.
+# - pull_request_target: a trivial pass so the required context exists on PR
+#   heads without requiring every in-flight branch to rebase for the workflow
+#   file (pull_request_target resolves this file from the base branch).
+#   zizmor: ignore[dangerous-triggers] — this leg runs no PR code: no
+#   checkout, no secrets, permissions {} at the workflow level.
+#
+# Trusted-checkout rule (same as automerge.yml): the merge-group tree is the
+# PR's code merged with main, so an unpinned checkout would execute the PR's
+# own copy of gh_pr_queue_ready.sh — which the PR could have edited into
+# printing "queue-ready". The helper is always taken from the default branch.
+
+name: Merge Group Recheck
+
+on:
+  merge_group:
+  # zizmor: ignore[dangerous-triggers] Trivial-pass leg only; no PR code runs.
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  queue-ready-recheck:
+    name: queue-ready-recheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      checks: read # gh_pr_queue_ready.sh reads review-complete check runs.
+      pull-requests: read # ...and enumerates review threads.
+      contents: read # Checkout of the default-branch helper.
+    steps:
+      - name: Trivially satisfy the context on PR heads
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "queue-ready-recheck applies only inside merge groups;" \
+               "nothing to verify on a PR head."
+
+      - name: Checkout queue-ready helper
+        if: github.event_name == 'merge_group'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Trusted ref, NOT the merge-group sha: the group tree contains the
+          # PR's copy of the helper (see header).
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Re-verify queue-readiness for the queued PR
+        if: github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          QUEUE_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          chmod +x scripts/gh_pr_queue_ready.sh
+
+          pr=$(printf '%s\n' "$QUEUE_REF" | sed -nE 's|.*/pr-([0-9]+)-[0-9a-f]{40}$|\1|p')
+          if [ -z "$pr" ]; then
+            echo "::error::could not parse a PR number from merge-group ref '${QUEUE_REF}'." \
+                 "The queue ref naming convention may have changed; failing closed."
+            exit 1
+          fi
+
+          head_sha=$(gh pr view "$pr" --repo "${GITHUB_REPOSITORY}" \
+            --json headRefOid --jq '.headRefOid')
+          if [ -z "$head_sha" ]; then
+            echo "::error::could not resolve the live head of PR #${pr}; failing closed."
+            exit 1
+          fi
+
+          set +e
+          reason=$(scripts/gh_pr_queue_ready.sh "${GITHUB_REPOSITORY}" "$pr" "$head_sha")
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "PR #${pr} is still queue-ready on ${head_sha}; merge may proceed."
+            exit 0
+          fi
+          if [ "$status" -ne 1 ]; then
+            echo "::error::queue-ready helper failed (exit ${status}): ${reason}"
+            exit 1
+          fi
+
+          echo "::error::PR #${pr} is no longer queue-ready (${reason})." \
+               "This eviction is intentional: findings arrived after queue entry." \
+               "Resolve the threads, run scripts/gh_dispose_thread.sh ${GITHUB_REPOSITORY} ${pr} --signal," \
+               "and let automerge re-arm — do NOT rerun this merge-group run."
+          exit 1


### PR DESCRIPTION
H2 of the harness-robustness track (H0–H6). Closes the merge-queue race class where a PR is captured by the queue before late review findings land, then locks its branch against the fix push.

## The race this kills

- #646: findings arrived after review-complete passed; the PR was queue-locked, the repair push was rejected GH006, both manual dequeues failed, and known defects merged (hotfix #647).
- #683 (yesterday): queued just before new threads arrived; the safety-fix push hit GH006; recovery required hand-crafting a GraphQL `dequeuePullRequest` mutation.

The automerge `dequeue` job is explicitly best-effort — once the queue holds the PR, nothing re-checks the verdict the arm was based on. This adds that re-check *inside* the merge group: not-queue-ready → group fails → GitHub evicts → branch unlocks for the fix. Eviction becomes the automatic, correct outcome.

## Design notes

- **One oracle**: readiness is judged by `scripts/gh_pr_queue_ready.sh`, the same script the arm/guard/dequeue jobs use. No second definition of queue-ready.
- **Ref parsing verified**: the trailing sha in `gh-readonly-queue/<base>/pr-N-<sha>` refs is the **base** sha, not the PR head (verified against live queue refs), so the live head is fetched from the API — pushes are blocked while queued, so live head == queued head.
- **Trusted checkout**: the helper is pinned to the default branch; the merge-group tree contains the PR's own copy and must not be executed (same rule as automerge.yml).
- **`pull_request_target` trivial-pass leg** so the required context exists on PR heads without in-flight branches rebasing for the workflow file. That leg runs no PR code: no checkout, no secrets, workflow-level `permissions: {}`.
- **Failure text teaches the recovery**: resolve threads → `scripts/gh_dispose_thread.sh --signal` (from #688) → automerge requeues. Never rerun the failed group.

## Verification

The merge-group step body was executed locally against live queued PR #683: parsed `pr=683` from the real queue ref, resolved live head `1ed778a8`, oracle returned `queue-ready`/exit 0. The failure path is the oracle's own (battle-tested by arm/guard/dequeue). YAML validated.

## Action needed after merge (Everett)

Add `queue-ready-recheck` to the required status checks in the main ruleset. Until then the check runs but does not gate.

Part of the harness track: H0/H0b (docs + detector anchors) → H1 #688 (state/disposition scripts) → **H2 (this)** → H3 (scheduled re-evaluator) → H4 (R2 hardening) → H5 (review topology) → H6 (policy tunes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)