### PR TITLE
feat(ci): scheduled queue-readiness re-evaluator (H3)

### DIFF
--- a/.github/workflows/queue-reevaluator.yml
+++ b/.github/workflows/queue-reevaluator.yml
@@ -1,0 +1,82 @@
+# Periodically reconcile auto-merge arming with actual queue-readiness.
+#
+# Why: the automerge workflow is event-driven, but GitHub Actions delivers no
+# event for the state change that most often completes queue-readiness —
+# resolving the last review thread (`pull_request_review_thread` is an Apps
+# webhook, not an Actions trigger; naming it in `on:` invalidates the
+# workflow file). Until now the workaround was to submit a synthetic review
+# comment purely to emit a `pull_request_review` event. This cron closes the
+# gap without the ritual: every few minutes, each open maintainer PR has its
+# arm reconciled against what is true right now.
+#
+# Division of labor:
+#   automerge.yml        event-driven fast path (push, review, gate runs)
+#   this workflow        event-free slow path (bounded staleness ~5 min)
+#   merge-group recheck  final verification inside the queue itself
+#
+# All three delegate the decision to scripts/gh_pr_queue_ready.sh. This
+# workflow adds no second definition of queue-ready.
+#
+# Token: arming uses AUTOMERGE_PAT for the same reason automerge.yml's arm
+# job does — the eventual merge commit must trigger `on: push` workflows
+# (docs deploy), and pushes from the default GITHUB_TOKEN do not. Scheduled
+# workflows run the default-branch workflow file with a default-branch
+# checkout, so the PAT is never exposed to PR-authored code.
+
+name: Queue Re-evaluator
+
+on:
+  schedule:
+    # Every 5 minutes (GitHub's minimum; delivery may lag under load). The
+    # bound on staleness after resolving the last thread is one period.
+    - cron: "*/5 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  checks: read # queue-ready helper reads review-complete check runs
+  contents: write # arming (via the reconcile script)
+  pull-requests: write # arm/disarm
+
+concurrency:
+  group: queue-reevaluator
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Reconcile arming for open maintainer PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout helpers
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # The PR list is filtered here only to bound the loop; the authoritative
+      # eligibility filter (open, non-draft, author) lives inside the
+      # reconcile script and mirrors automerge.yml's arm job. A PR slipping
+      # through this list is re-filtered there — fail closed, not fail open.
+      - name: Reconcile each open PR
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || github.token }}
+        run: |
+          chmod +x scripts/gh_pr_arm_reconcile.sh scripts/gh_pr_queue_ready.sh
+
+          prs=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --limit 100 \
+            --json number --jq '.[].number')
+          if [ -z "$prs" ]; then
+            echo "no open PRs; nothing to reconcile."
+            exit 0
+          fi
+
+          failed=0
+          for pr in $prs; do
+            if ! scripts/gh_pr_arm_reconcile.sh "${GITHUB_REPOSITORY}" "$pr"; then
+              echo "::warning::reconcile failed for PR #${pr}"
+              failed=$((failed + 1))
+            fi
+          done
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::${failed} PR(s) failed to reconcile; see warnings above."
+            exit 1
+          fi

--- a/scripts/gh_pr_arm_reconcile.sh
+++ b/scripts/gh_pr_arm_reconcile.sh
@@ -127,7 +127,11 @@ reconcile() {
 }
 
 if [[ "$ready" -eq 0 && "$armed" != "true" ]]; then
-  if reconcile true --auto --squash; then
+  # --match-head-commit closes the read-arm race: if a push lands after the
+  # readiness read, the arm applies to a head the oracle never judged. With
+  # the pin, GitHub rejects the arm for any head other than the reviewed
+  # one; the retry re-fails and the next cron cycle judges the new head.
+  if reconcile true --auto --squash --match-head-commit "$head_sha"; then
     echo "PR #${PR} is queue-ready on ${head_sha}; armed auto-merge."
     exit 0
   fi

--- a/scripts/gh_pr_arm_reconcile.sh
+++ b/scripts/gh_pr_arm_reconcile.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Copyright 2025 Vangelis Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reconcile one PR's auto-merge arm with its actual queue-readiness.
+#
+# The automerge workflow is event-driven, and GitHub Actions delivers no
+# event for the state change that most often completes queue-readiness:
+# resolving the last review thread (`pull_request_review_thread` is an Apps
+# webhook, not an Actions trigger). This script is the event-free half of the
+# arming contract: given a PR, read what is true NOW and make the arm match.
+#
+#   eligible + queue-ready + unarmed          -> arm (squash), verify
+#   armed + no longer queue-ready             -> disarm, verify
+#   already held by the merge queue           -> no-op (the merge-group
+#                                                recheck owns that phase)
+#   ineligible (closed, draft, wrong author)  -> no-op
+#   state already correct                     -> no-op
+#
+# Queue-readiness is decided ONLY by scripts/gh_pr_queue_ready.sh — the same
+# oracle the automerge arm/guard/dequeue jobs run. This script adds no second
+# definition of ready; it only acts on the answer.
+#
+# MIRROR NOTE: the eligibility filter (open, non-draft, author) restates the
+# filter inside automerge.yml's arm job. tests/scripts/test_queue_reevaluator.py
+# holds the two literals together; change them together or not at all.
+#
+# Usage:
+#   gh_pr_arm_reconcile.sh <owner/repo> <pr-number>
+#
+# Exit codes:
+#   0 — reconciled or nothing to do (stdout says which)
+#   1 — arm/disarm postcondition failed after retries
+#   2 — usage / tool failure
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <owner/repo> <pr-number>" >&2
+  exit 2
+fi
+
+REPO="$1"
+PR="$2"
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+# Mirrors automerge.yml's arm-job filter (see MIRROR NOTE above).
+MAINTAINER="everettVT"
+
+if [[ ! "$PR" =~ ^[0-9]+$ ]]; then
+  echo "invalid PR number: ${PR}" >&2
+  exit 2
+fi
+
+meta="$(
+  gh api graphql \
+    -f query='query($owner:String!, $name:String!, $number:Int!) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$number) {
+          state
+          isDraft
+          author { login }
+          headRefOid
+          autoMergeRequest { enabledAt }
+          mergeQueueEntry { position }
+        }
+      }
+    }' \
+    -f owner="$OWNER" -f name="$NAME" -F number="$PR" \
+    --jq '.data.repository.pullRequest
+          | "\(.state) \(.isDraft) \(.author.login) \(.headRefOid) \(.autoMergeRequest != null) \(.mergeQueueEntry != null)"' \
+    2>/dev/null || true
+)"
+if [[ -z "$meta" ]]; then
+  echo "could not read PR #${PR}; leaving arm state untouched" >&2
+  exit 2
+fi
+read -r state draft author head_sha armed queued <<<"$meta"
+
+if [[ "$state" != "OPEN" || "$draft" != "false" || "$author" != "$MAINTAINER" ]]; then
+  echo "PR #${PR} is not eligible (state=${state} draft=${draft} author=${author}); nothing to reconcile."
+  exit 0
+fi
+
+if [[ "$queued" == "true" ]]; then
+  echo "PR #${PR} is already held by the merge queue; the merge-group recheck owns this phase."
+  exit 0
+fi
+
+set +e
+reason=$(scripts/gh_pr_queue_ready.sh "$REPO" "$PR" "$head_sha")
+ready=$?
+set -e
+if [[ "$ready" -ne 0 && "$ready" -ne 1 ]]; then
+  echo "queue-ready helper failed (exit ${ready}): ${reason}" >&2
+  exit 2
+fi
+
+# Postcondition over exit code, in both directions: `gh pr merge` exits
+# nonzero on benign no-ops, and a transient API failure must not be mistaken
+# for success. Read the arm state back and require it to match.
+reconcile() {
+  local want="$1"
+  shift
+  local attempt observed
+  for attempt in 1 2 3; do
+    gh pr merge "$@" --repo "$REPO" "$PR" 2>/dev/null || true
+    observed=$(gh pr view "$PR" --repo "$REPO" \
+      --json autoMergeRequest --jq '.autoMergeRequest != null')
+    if [[ "$observed" == "$want" ]]; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+if [[ "$ready" -eq 0 && "$armed" != "true" ]]; then
+  if reconcile true --auto --squash; then
+    echo "PR #${PR} is queue-ready on ${head_sha}; armed auto-merge."
+    exit 0
+  fi
+  echo "could not arm queue-ready PR #${PR} after 3 attempts" >&2
+  exit 1
+fi
+
+if [[ "$ready" -eq 1 && "$armed" == "true" ]]; then
+  if reconcile false --disable-auto; then
+    echo "PR #${PR} is no longer queue-ready (${reason}); disarmed auto-merge."
+    exit 0
+  fi
+  echo "could not disarm PR #${PR} (${reason}); a stale arm may enter the queue" >&2
+  exit 1
+fi
+
+if [[ "$ready" -eq 0 ]]; then
+  echo "PR #${PR} is queue-ready and already armed; nothing to do."
+else
+  echo "PR #${PR} is not queue-ready (${reason}) and not armed; nothing to do."
+fi
+exit 0

--- a/tests/scripts/test_queue_reevaluator.py
+++ b/tests/scripts/test_queue_reevaluator.py
@@ -81,7 +81,10 @@ def test_reconcile_script_delegates_to_the_one_queue_ready_oracle() -> None:
     # Postcondition over exit code, both directions.
     assert "autoMergeRequest != null" in script
     assert "--disable-auto" in script
-    assert "--auto --squash" in script
+    # Arming is pinned to the head the oracle judged: without
+    # --match-head-commit, a push racing the readiness read would arm the
+    # new, unreviewed head on a stale verdict.
+    assert '--auto --squash --match-head-commit "$head_sha"' in _code_only(script)
 
 
 def test_eligibility_filter_mirrors_the_automerge_arm_job() -> None:
@@ -256,7 +259,10 @@ def test_ready_and_unarmed_arms_with_postcondition(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "armed auto-merge" in result.stdout
-    assert any("--auto" in call and "--squash" in call for call in calls)
+    assert any(
+        "--auto" in call and "--squash" in call and f"--match-head-commit {_STUB_HEAD}" in call
+        for call in calls
+    ), f"arming must be pinned to the judged head; calls: {calls}"
 
 
 def test_not_ready_and_armed_disarms(tmp_path: Path) -> None:

--- a/tests/scripts/test_queue_reevaluator.py
+++ b/tests/scripts/test_queue_reevaluator.py
@@ -1,0 +1,300 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the scheduled queue-readiness re-evaluator.
+
+The automerge workflow is event-driven; the re-evaluator is the event-free
+half of the same arming contract (thread resolution emits no Actions event).
+These tests hold three promises:
+
+1. The reconcile script delegates the readiness decision to the one oracle
+   (``gh_pr_queue_ready.sh``) and acts only on its answer.
+2. The eligibility filter mirrors automerge.yml's arm job — the two literals
+   are held together here so they change together or not at all.
+3. Each reconcile outcome is verified by postcondition (arm state read back),
+   never inferred from ``gh pr merge``'s exit code.
+
+Behavior tests run the real script against a stubbed ``gh`` (the idiom
+established in test_quality_workflow.py) and assert the decision reached.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+RECONCILE_SCRIPT = ROOT / "scripts" / "gh_pr_arm_reconcile.sh"
+REEVALUATOR_WORKFLOW = ROOT / ".github" / "workflows" / "queue-reevaluator.yml"
+AUTOMERGE_WORKFLOW = ROOT / ".github" / "workflows" / "automerge.yml"
+
+_STUB_REPO = "VangelisTech/archetype"
+_STUB_PR = "654"
+_STUB_HEAD = "1" * 40
+
+
+def _code_only(text: str) -> str:
+    """Drop whole-line comments so assertions bind to code, not prose."""
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+
+
+def test_reevaluator_workflow_runs_the_reconcile_script_on_a_schedule() -> None:
+    workflow = REEVALUATOR_WORKFLOW.read_text(encoding="utf-8")
+    code = _code_only(workflow)
+
+    # Scheduled plus manually dispatchable; no PR-triggered path exists, so
+    # the workflow file and both helpers always come from the default branch.
+    assert "schedule:" in code
+    assert re.search(r'cron:\s*"\*/\d+ \* \* \* \*"', code)
+    assert "workflow_dispatch:" in code
+    assert "pull_request" not in code
+
+    # The decision belongs to the reconcile script, which owns the oracle
+    # delegation; the workflow only enumerates PRs.
+    assert "scripts/gh_pr_arm_reconcile.sh" in code
+    assert "gh pr merge" not in code, (
+        "the workflow must not arm PRs directly; arming lives in the "
+        "reconcile script behind its postcondition check"
+    )
+
+    # Arming must use the PAT so the merge commit triggers on:push workflows
+    # (same reasoning as automerge.yml's arm job).
+    assert "AUTOMERGE_PAT" in code
+
+
+def test_reconcile_script_delegates_to_the_one_queue_ready_oracle() -> None:
+    script = _code_only(RECONCILE_SCRIPT.read_text(encoding="utf-8"))
+
+    # One oracle: the readiness decision is the helper's exit code, and no
+    # local re-derivation of "ready" exists (no review-complete query here).
+    assert "scripts/gh_pr_queue_ready.sh" in script
+    assert "check_name=review-complete" not in script, (
+        "the reconcile script re-derives readiness instead of delegating"
+    )
+
+    # Postcondition over exit code, both directions.
+    assert "autoMergeRequest != null" in script
+    assert "--disable-auto" in script
+    assert "--auto --squash" in script
+
+
+def test_eligibility_filter_mirrors_the_automerge_arm_job() -> None:
+    """automerge.yml and the reconcile script restate one maintainer literal."""
+    script = RECONCILE_SCRIPT.read_text(encoding="utf-8")
+    automerge = AUTOMERGE_WORKFLOW.read_text(encoding="utf-8")
+
+    script_maintainer = re.search(r'^MAINTAINER="(\w+)"$', script, re.MULTILINE)
+    assert script_maintainer is not None, "reconcile script lost its MAINTAINER literal"
+
+    automerge_maintainers = set(re.findall(r"author\.login == .{1,2}?(\w+)", automerge))
+    assert automerge_maintainers, "automerge.yml lost its author filter"
+    assert automerge_maintainers == {script_maintainer.group(1)}, (
+        "the reconcile script and automerge.yml disagree on the maintainer "
+        "eligibility literal; change them together or not at all"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavior: run the real script against a stubbed `gh`.
+#
+# The stub dispatches on argv: PR metadata GraphQL (mergeQueueEntry in the
+# query), review-thread GraphQL (the oracle's query), review-complete
+# check-runs, `pr merge` (records the call, flips an arm marker file), and
+# `pr view --json autoMergeRequest` (reads the marker) — so the script's
+# postcondition read-back observes the effect of its own arm/disarm.
+# ---------------------------------------------------------------------------
+
+_GH_STUB = """#!/bin/sh
+filter='.'
+query=''
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = "--jq" ]; then filter="$arg"; fi
+  case "$arg" in query=*) query="$arg" ;; esac
+  prev="$arg"
+done
+
+case "$1" in
+  pr)
+    case "$2" in
+      merge)
+        echo "merge $*" >> "$STUB_DIR/merge_calls.log"
+        case " $* " in
+          *" --auto "*) touch "$STUB_DIR/armed" ;;
+          *" --disable-auto "*) rm -f "$STUB_DIR/armed" ;;
+        esac
+        exit 0
+        ;;
+      view)
+        if [ -e "$STUB_DIR/armed" ]; then
+          echo '{"autoMergeRequest":{"enabledAt":"now"}}' | jq -r "$filter"
+        else
+          echo '{"autoMergeRequest":null}' | jq -r "$filter"
+        fi
+        exit 0
+        ;;
+    esac
+    ;;
+  api)
+    case " $* " in
+      *" graphql "*)
+        case "$query" in
+          *mergeQueueEntry*) exec jq -r "$filter" "$STUB_DIR/pr_meta.json" ;;
+          *reviewThreads*) exec jq -r "$filter" "$STUB_DIR/threads.json" ;;
+        esac
+        ;;
+      *check-runs*) exec jq -r "$filter" "$STUB_DIR/check_runs.json" ;;
+    esac
+    ;;
+esac
+echo "gh stub: unhandled call: $*" >&2
+exit 64
+"""
+
+
+def _run_reconcile(
+    tmp_path: Path,
+    *,
+    armed: bool,
+    queued: bool = False,
+    draft: bool = False,
+    author: str = "everettVT",
+    review_conclusion: str = "success",
+    unresolved_threads: int = 0,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    if shutil.which("jq") is None:
+        pytest.skip("jq is required to evaluate the scripts' --jq filters")
+
+    stub_dir = tmp_path / "stubs"
+    bin_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    bin_dir.mkdir()
+
+    (stub_dir / "pr_meta.json").write_text(
+        json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "state": "OPEN",
+                            "isDraft": draft,
+                            "author": {"login": author},
+                            "headRefOid": _STUB_HEAD,
+                            "autoMergeRequest": {"enabledAt": "now"} if armed else None,
+                            "mergeQueueEntry": {"position": 1} if queued else None,
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (stub_dir / "check_runs.json").write_text(
+        json.dumps(
+            {
+                "check_runs": [
+                    {"started_at": "2026-07-26T10:00:00Z", "conclusion": review_conclusion}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    threads = [{"isResolved": False, "isOutdated": False}] * unresolved_threads
+    (stub_dir / "threads.json").write_text(
+        json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": threads,
+                            }
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    if armed:
+        (stub_dir / "armed").touch()
+
+    gh = bin_dir / "gh"
+    gh.write_text(_GH_STUB, encoding="utf-8")
+    gh.chmod(0o755)
+    # `sleep` between postcondition retries would slow a failing test; stub it.
+    sleep = bin_dir / "sleep"
+    sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    sleep.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["STUB_DIR"] = str(stub_dir)
+    env["QUEUE_READY_STUB_DIR"] = str(stub_dir)
+    result = subprocess.run(
+        [str(RECONCILE_SCRIPT), _STUB_REPO, _STUB_PR],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        cwd=ROOT,
+    )
+    merge_log = stub_dir / "merge_calls.log"
+    calls = merge_log.read_text(encoding="utf-8").splitlines() if merge_log.exists() else []
+    return result, calls
+
+
+def test_ready_and_unarmed_arms_with_postcondition(tmp_path: Path) -> None:
+    result, calls = _run_reconcile(tmp_path, armed=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "armed auto-merge" in result.stdout
+    assert any("--auto" in call and "--squash" in call for call in calls)
+
+
+def test_not_ready_and_armed_disarms(tmp_path: Path) -> None:
+    result, calls = _run_reconcile(tmp_path, armed=True, unresolved_threads=2)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "disarmed auto-merge" in result.stdout
+    assert any("--disable-auto" in call for call in calls)
+
+
+def test_queued_pr_is_left_alone(tmp_path: Path) -> None:
+    """The merge-group recheck owns the queue phase; the cron must not act."""
+    result, calls = _run_reconcile(tmp_path, armed=True, queued=True, unresolved_threads=2)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "merge queue" in result.stdout
+    assert calls == []
+
+
+def test_draft_pr_is_left_alone(tmp_path: Path) -> None:
+    result, calls = _run_reconcile(tmp_path, armed=False, draft=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "not eligible" in result.stdout
+    assert calls == []
+
+
+def test_failed_review_never_arms(tmp_path: Path) -> None:
+    result, calls = _run_reconcile(tmp_path, armed=False, review_conclusion="failure")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "not queue-ready" in result.stdout
+    assert calls == []
+
+
+def test_ready_and_armed_is_a_no_op(tmp_path: Path) -> None:
+    result, calls = _run_reconcile(tmp_path, armed=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "nothing to do" in result.stdout
+    assert calls == []


### PR DESCRIPTION
H3 of the harness-robustness track. Closes the thread-resolution observability gap: GitHub Actions has no trigger for resolving a review thread, so today the only way to get armed after resolving the last thread is the synthetic-review-comment ritual (or a push). This cron reconciles arming with reality every 5 minutes instead.

## What

- **`scripts/gh_pr_arm_reconcile.sh <repo> <pr>`** — reconcile one PR's arm state: eligible + queue-ready + unarmed → arm (squash); armed + no-longer-ready → disarm; queued/draft/ineligible/already-correct → no-op. Every transition verified by postcondition (arm state read back), never inferred from `gh pr merge`'s exit code — same idiom as automerge.yml's disarm loops.
- **`.github/workflows/queue-reevaluator.yml`** — runs it over open PRs on `*/5` cron + `workflow_dispatch`. Arming uses `AUTOMERGE_PAT` for the same reason automerge.yml's arm job does (merge commit must fire `on: push` workflows). No PR-triggered path exists, so file and helpers always execute from the default branch.
- **`tests/scripts/test_queue_reevaluator.py`** — real script against a stubbed `gh` (the `test_quality_workflow.py` idiom): arms when ready+unarmed, disarms when stale+armed, leaves queued/draft/failed-review PRs untouched; plus text contracts holding the workflow to the reconcile script and the eligibility literal to automerge.yml's arm job (mirror drift test).

## Design constraints honored

- **One oracle**: readiness is decided only by `scripts/gh_pr_queue_ready.sh` — the same script the arm/guard/dequeue jobs run. This PR adds no second definition of queue-ready.
- **Queue phase untouched**: a PR already held by the merge queue is a no-op here; that phase belongs to the merge-group recheck (#689).
- **Division of labor**: automerge.yml = event-driven fast path; this cron = event-free slow path (staleness bounded to one period); #689 = final verification inside the queue.

## Verification

9/9 tests pass; ruff + license headers clean. The reconcile script's behavior matrix is exercised end-to-end against the stub (including postcondition read-back via a marker file the stub's `pr merge` flips).

After this lands, the reply→resolve→signal ritual becomes optional: resolve threads and the cron arms within 5 minutes. `scripts/gh_dispose_thread.sh --signal` (#688) remains the zero-latency path.

Part of the harness track: H0/H0b (docs + detector anchors) → H1 #688 → H2 #689 → **H3 (this)** → H4 (R2 hardening) → H5 (review topology) → H6 (policy tunes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)