### PR TITLE
docs: stop advising gate re-runs for queue-ready re-evaluation

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -81,8 +81,11 @@ on:
   # entire workflow file invalid, so GitHub loads no jobs at all and every
   # push gets a bare "Invalid workflow file" run instead. Actions cannot
   # observe thread resolution at all; to re-evaluate arming after resolving
-  # the last thread, re-run Deterministic Review Gate (that fires the
-  # workflow_run trigger below) or push.
+  # the last thread, SUBMIT A REVIEW (see the header above). Re-running
+  # Deterministic Review Gate also re-evaluates, but on a head whose
+  # findings were all advisory the gate succeeds and republishes those
+  # findings as fresh unresolved threads — straight back to
+  # not-queue-ready. Pushing is fine: a new head earns a fresh review.
   pull_request_review:
     types: [submitted, edited, dismissed]
   # The review gate's completion is the first arming signal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ For the three Python rulebooks, `paths` frontmatter additionally limits that
 model invocation to Python under `src/`, `tests/`, or `examples/`; it is an
 eligibility fence, not a path-only trigger or a guarantee of invocation.
 Before editing those files, load the relevant skill — the deterministic
-footgun gate in CI reviews every PR against the same rules, so skipping them
-locally just moves the failure to review.
+footgun gate in CI reviews every maintainer PR against the same rules, so
+skipping them locally just moves the failure to review.
 
 ## Skills index
 
@@ -23,7 +23,7 @@ locally just moves the failure to review.
 | `daft-antipatterns` | `/daft-antipatterns` | Diff review for wrong-shape Daft (UDF theater, premature materialization, multimodal/lakehouse/PAI antipatterns) — complementary to footgun |
 | `archetype-components` | `/archetype-components`, or model-invoked for Component/schema code within its configured paths | Component definitions, Arrow serialization, field conventions |
 | `archetype-processors` | `/archetype-processors`, or model-invoked for processor/pipeline code within its configured paths | AsyncProcessor patterns, priority ordering, resource access |
-| `footgun-detector` | `/footgun-detector`; CI runs the same rulebook on every PR head as a five-lens matrix (authority, contracts, state-lifecycle, observability, daft-shape) | Archetype-specific runtime bugs in the current diff, graded `blocking` (fails the gate) or `advisory` (resolvable review thread) |
+| `footgun-detector` | `/footgun-detector`; CI runs the same rulebook on each maintainer-authored PR head as a five-lens matrix (authority, contracts, state-lifecycle, observability, daft-shape); other authors fail closed, unreviewed | Archetype-specific runtime bugs in the current diff, graded `blocking` (fails the gate) or `advisory` (resolvable review thread) |
 
 ## Agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ locally just moves the failure to review.
 | `daft-antipatterns` | `/daft-antipatterns` | Diff review for wrong-shape Daft (UDF theater, premature materialization, multimodal/lakehouse/PAI antipatterns) — complementary to footgun |
 | `archetype-components` | `/archetype-components`, or model-invoked for Component/schema code within its configured paths | Component definitions, Arrow serialization, field conventions |
 | `archetype-processors` | `/archetype-processors`, or model-invoked for processor/pipeline code within its configured paths | AsyncProcessor patterns, priority ordering, resource access |
-| `footgun-detector` | `/footgun-detector` | Scans the current diff for archetype-specific runtime bugs across three perspectives: actor (code), observed (data), observer (review) |
+| `footgun-detector` | `/footgun-detector`; CI runs the same rulebook on every PR head as a five-lens matrix (authority, contracts, state-lifecycle, observability, daft-shape) | Archetype-specific runtime bugs in the current diff, graded `blocking` (fails the gate) or `advisory` (resolvable review thread) |
 
 ## Agents
 
@@ -71,8 +71,12 @@ workflow arms auto-merge only once your head is queue-ready: the latest
 review thread is resolved. Arming earlier does not merge sooner, it only
 lets the PR enter the merge queue before its review verdict (premature
 arms are auto-reverted). Reply to footgun review threads with what you
-changed, then resolve them — then re-run **Deterministic Review Gate**,
-because GitHub Actions cannot observe thread resolution and nothing
-re-evaluates arming on its own. A review submitted on an armed PR that is
-no longer queue-ready disarms it, best-effort. Full mechanism in
-`AGENTS.md`.
+changed, then resolve them. GitHub Actions cannot observe thread
+resolution, so after resolving the last thread submit a PR review —
+`gh pr review <n> --comment --body "Queue-readiness re-evaluation on
+exact head <sha>"` — the only signal that re-evaluates arming without
+re-reviewing the head. Do NOT re-run **Deterministic Review Gate** for
+this: the head already passed, and a re-run republishes its advisory
+findings as fresh unresolved threads, undoing the resolutions. A review
+submitted on an armed PR that is no longer queue-ready disarms it,
+best-effort. Full mechanism in `AGENTS.md`.


### PR DESCRIPTION
## What

Docs/comment-only fixes to stop distributing harmful PR-flow instructions (PR-H0 of the 2026-07-26 harness audit).

1. **CLAUDE.md, PR flow** — it instructed "resolve threads, then re-run Deterministic Review Gate". Since #662 that is the harmful path: on a head whose findings were all advisory, a gate re-run succeeds and republishes those findings as fresh unresolved threads, undoing the resolutions. Replaced with the correct mechanism, which AGENTS.md and automerge.yml's header already describe: after resolving the last thread, submit a PR review (`gh pr review <n> --comment --body "Queue-readiness re-evaluation on exact head <sha>"`) — the only signal that re-evaluates arming without re-reviewing the head — plus an explicit warning against gate re-runs for this purpose.
2. **automerge.yml, `pull_request_review` trigger comment** — it repeated the stale "re-run Deterministic Review Gate ... or push" half and contradicted the same file's header. Aligned with the header. Comment-only; no job logic touched.
3. **CLAUDE.md, skills-index row for `footgun-detector`** — still described the #191-era "three perspectives" gate. Rewritten to the current reality: a five-lens matrix (authority, contracts, state-lifecycle, observability, daft-shape) with a blocking/advisory severity tier, run by CI on every PR head.

## Verification

`make ci` green (PR verification profile passed; 12/12 operational scenarios). One unrelated flake observed on the first run: `tests/idempotency/test_idempotency_evals.py::test_process_writer_fence_race_classifies_reconciled_loser_as_stale` failed once under full-suite load, passed 3/3 in isolation and passed on the clean re-run.

Companion PR (independent): detector-anchor fixes land separately as PR-H0b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)