### PR TITLE
feat: add Modal hosted physical AI parity

### DIFF
--- a/docs/guide/activities.md
+++ b/docs/guide/activities.md
@@ -319,15 +319,22 @@ manifest, and exact completeness counts.
 The local provider proof uses an atomic permanent start marker and a
 provider-durable first-result index. It deliberately sacrifices liveness after
 an ambiguous start rather than assume a seeded GPU rerun is equivalent.
-Remote/Modal adapters implement the same `HostedEpisodeProvider` protocol but
-remain fail-closed until they can reuse the reviewed generic provider
-operation/start/result mechanics. Provider placement and recovery records never
-enter Components.
 
-The local value store and SQLite Activity catalog are executable proof
-substrates, not claims of remote storage parity. Production trajectory and
-frame publication still belongs in Iceberg or the artifact substrate, while a
-remote control-catalog implementation is its own parity slice.
+The Modal parity adapter preserves that contract under an exact workspace,
+Environment, App, Function, named Dict, named Volume, and protocol epoch. An
+atomic Dict `put(..., skip_if_exists=True)` selects one start winner. The remote
+function commits the four canonical Arrow payloads to the Volume before it
+atomically installs the bounded first-result index in the Dict. A lost function
+response is therefore recoverable; a permanent start without that index
+remains unknown and cannot be replayed. Provider placement diagnostics never
+enter canonical payloads or Components.
+
+The local family value store and SQLite Activity catalog remain executable
+proof substrates, not claims of remote storage parity. The Modal Volume and
+Dict prove provider-side start and first-result durability only. Production
+trajectory and frame publication still belongs in Iceberg or the artifact
+substrate, while a remote control-catalog implementation is its own parity
+slice.
 
 ## 8. Resource-spike disposition
 

--- a/docs/guide/physical-ai.md
+++ b/docs/guide/physical-ai.md
@@ -183,6 +183,7 @@ sequenceDiagram
 | `archetype.physical_ai.hosted_activities` | Exact-receipt projector, generic Activity adapter, fenced worker, result redelivery, and settlement choreography |
 | `archetype.physical_ai.hosted_activity_values` | Local content-addressed proof store, permanent-start seeded provider, and provider-durable first-result recovery |
 | `archetype.physical_ai.hosted_activity_world` | Exact storage reader, idempotent world stager, required-projector binding, and unsettled-work bridge |
+| `archetype.physical_ai.hosted_modal` | Exact Modal namespace, atomic hosted-start admission, Volume-first payload publication, and first-result reconciliation |
 | `CommandDispatcher` | Exact-operation admission and registered handler dispatch |
 | `RuntimeResources` | Process-scoped ownership and retryable close of live providers |
 | `ArchetypeRuntime` | Supported trusted Python entry point and sync parity |
@@ -234,7 +235,7 @@ publishes large results, stages factual observations, and binds settlement to
 the later committed receipt. It declares the lower-family ports that
 choreography needs; no parallel application-layer mirror is created.
 
-The implemented local path is:
+The provider-neutral path is:
 
 1. A tick commits `HostedEpisodeIntent`, which contains only the stable
    Activity/operation identity and a content-addressed canonical request.
@@ -255,6 +256,15 @@ a second episode. A crash after start but before a complete result remains
 permanently unknown: deterministic seeds and lease expiry are not replay
 authority. A partial trajectory cannot produce a manifest or Activity result.
 
+The Modal provider binds its identity to the exact workspace, Environment,
+App, Function, named Dict, named Volume, and protocol epoch. Its permanent
+start is an atomic Dict put-if-absent. The GPU function writes and commits the
+canonical request, trajectory, episode-results, and manifest blobs to the
+Volume before atomically publishing their bounded result index to the Dict.
+Cold reconstruction recovers that index when a completion response or worker
+process is lost, without another function spawn. A marker with no complete
+index remains reconciliation-required.
+
 `PhysicalHostedActivityBinding` exposes the required projector, worker, and
 world-scoped unsettled-work check without creating an
 `archetype.app.physical_ai` topology. The current direct per-step evaluation
@@ -269,11 +279,12 @@ world-qualified child Activity. The lifecycle unsettled-work gate is what makes
 that exact-world rule safe.
 
 The local filesystem value store and SQLite Activity catalog are restart
-oracles. They do not claim remote storage parity. Large production trajectories
-and frames belong in Iceberg/artifacts, and a Modal provider remains
-fail-closed behind the same `HostedEpisodeProvider` contract until the reviewed
-generic provider operation/start/result mechanics can be reused. No
-Mission-owned Modal barrier is imported or duplicated here.
+oracles. They do not claim remote catalog or application-publication parity.
+The Modal Dict and Volume are provider durability, not ECS state or a
+replacement for Iceberg/artifacts. No Mission-owned Modal barrier is imported:
+the Physical-AI family supplies the recovery meaning for its own provider,
+while the generic Activity catalog continues to own claims, fences, operation
+binding, result recording, and settlement.
 
 The family-owned hosted data contract is
 `archetype.physical_ai.hosted_episode`, version
@@ -488,5 +499,7 @@ The workflow enforces these contracts:
     constructor, limited to embedded-XML MuJoCo model/data scratch.
 
 The credential-free contracts live under `tests/physical_ai/`. Real LIBERO,
-VLA, GPU, and Modal adapters remain external provider implementations and paid
-dogfoods; the physical-AI family does not import them.
+VLA, and robot/simulator implementations remain external provider
+implementations and paid dogfoods. The family-owned Modal delivery adapter
+loads the optional SDK lazily and has a separate, user-triggered paid proof; it
+does not make Modal a requirement for local Physical-AI evaluation.

--- a/docs/planning/activity-boundary-refactor.md
+++ b/docs/planning/activity-boundary-refactor.md
@@ -46,7 +46,7 @@ shared substrate; they do not expand A2 speculatively.
 | A5 — Mission critic | Project and execute exact-candidate critic work through the proven Activity seam; remove only critic process-local delivery after parity | Existing exact-head, separate-sandbox, bounded-subject, and fail-closed critic oracles pass through restart |
 | A6 — Hosted Physical-AI contract | Reconcile one canonical whole-episode Arrow request/result schema and result publication contract before cutover | Robot adapter and simulator agree on episode/trial cardinality, transition budget, terminal meaning, and canonical digests |
 | A7 — Hosted Physical-AI Activity | Add provider-neutral family choreography under `archetype.physical_ai`, execute one seeded batch of whole episodes locally, publish the complete trajectory/results/manifest, and stage its factual observation | Cold reconstruction crosses provider publication, generic result recording, staging, and later settlement without a second episode; start-without-result remains unknown |
-| A7b — Hosted Physical-AI Modal parity | Bind the same family provider protocol to the reviewed generic operation/start/result mechanics after the Modal author safety dependency lands; do not copy Mission barriers | Real Modal/GPU execution recovers its first complete result by stable operation identity and uses the exact A6 request/result contract |
+| A7b — Hosted Physical-AI Modal parity | Bind the same family provider protocol to exact Modal namespace identity, atomic start admission, and provider-durable first-result publication without importing Mission barriers | Real Modal/GPU execution recovers its first complete result by stable operation identity and uses the exact A6 request/result contract |
 | A8 — Consolidation and refactor resume | Extract only mechanics shared by author, critic, and Physical AI; delete superseded outboxes and distributed per-step effect paths; reconcile broad docs and topology plan | No duplicate authority, no process-local durable queue, full release verification, and three end-to-end traces remain recognizable |
 
 ### A1 — Contract and plan
@@ -199,11 +199,30 @@ Activity result. The existing direct per-step path remains supported through
 this slice.
 
 A7 deliberately leaves the remote provider fail-closed behind the same family
-protocol. The safe operation/start/result barrier is genuinely shared
-mechanics, but its recovery meaning remains provider- and family-owned. A7b
-therefore reuses the reviewed generic extraction after the Modal author safety
-dependency rather than importing or duplicating Mission-owned barriers. Only
-A7b may claim real Modal/GPU parity.
+protocol. A7b supplies the Modal implementation under an exact workspace,
+Environment, App, Function, named Dict, named Volume, and protocol epoch. One
+atomic Dict put selects the start winner; canonical A6 payloads are committed
+to the Volume before the bounded first-result index is atomically installed in
+the Dict. Completion-response loss and worker reconstruction recover that
+first result without a second episode. Start-without-result remains unknown.
+
+The adapter does not import Mission-owned barriers or move Physical-AI
+recovery meaning into generic mechanics. A8 may extract only the identity,
+atomic-admission, and immutable-result mechanics that the completed Mission
+and Physical-AI implementations actually prove to be shared.
+
+Paid A7b evidence on 2026-07-26 used one L40S-backed function in stopped Modal
+App `ap-nXLKIwCqS18C4j6UuGFMSU`. The remote completion reported one visible GPU
+and first-result index digest
+`ad70beb7153d4b83cd0c12fb6218b1e312a265199e5013eae8d94f6f42327fb0`.
+After an injected worker failure before generic Activity result recording, a
+separate process recovered the exact two-episode result without another Modal
+call and staged result digest
+`784811d10f376faf3b45284c5f2b180ba179f4a35f9575b7af37444d08678cf9`.
+Provider evidence remains in named Dict
+`arch-a7b-results-20260726-185158-c3261f` and named Volume
+`arch-a7b-values-20260726-185158-c3261f` in workspace/environment
+`vangelis-tech/main`.
 
 ## Authority and dependency target
 

--- a/quality/observability/physical_ai.toml
+++ b/quality/observability/physical_ai.toml
@@ -67,6 +67,11 @@ operations = [
   "hosted_activity_contracts.HostedEpisodeProvider.provider",
   "hosted_activity_contracts.HostedEpisodeProvider.reconcile",
   "hosted_activity_values.HostedEpisodeRunner.run",
+  "hosted_modal.ModalHostedEpisodeRuntime.get",
+  "hosted_modal.ModalHostedEpisodeRuntime.put_if_absent",
+  "hosted_modal.ModalHostedEpisodeRuntime.read_blob",
+  "hosted_modal.ModalHostedEpisodeRuntime.spawn",
+  "hosted_modal.ModalHostedEpisodeRuntime.wait",
 ]
 signals = ["none"]
 outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
@@ -74,6 +79,7 @@ authority = "The provider's permanent operation-start evidence and first complet
 evidence = [
   "docs/guide/physical-ai.md",
   "tests/physical_ai/test_hosted_episode_activities.py",
+  "tests/physical_ai/test_hosted_modal_activity.py",
 ]
 rationale = "Provider execution and recovery are effect boundaries whose durable result or explicit unknown state is the authority; a second telemetry signal cannot make an episode complete or safe to repeat."
 

--- a/src/archetype/physical_ai/hosted_modal.py
+++ b/src/archetype/physical_ai/hosted_modal.py
@@ -1,0 +1,918 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Modal execution and first-result recovery for hosted Physical-AI Activities.
+
+The generic Activity catalog binds ``operation_id`` before this adapter is
+called.  This module then uses one permanent, atomic key in a named Modal Dict
+to select the only remote start.  Complete canonical payloads are committed to
+a named Modal Volume before a bounded result index is inserted into the Dict.
+
+The Dict and Volume are provider durability, not ECS state.  A permanent start
+without the complete result index is deliberately unknown and cannot be
+replayed, even when the request is seeded and the Activity lease has expired.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, cast, runtime_checkable
+from urllib.parse import quote
+
+from archetype.errors import AvailabilityError
+from archetype.physical_ai.hosted_activity_contracts import (
+    HostedEpisodeConfirmedAbsent,
+    HostedEpisodeProviderResult,
+    HostedEpisodeRecovered,
+    HostedEpisodeRecoveryUnknown,
+    HostedEpisodeRetryGuard,
+    validate_hosted_provider_result,
+)
+from archetype.physical_ai.hosted_activity_values import SeededHostedEpisodeRunner
+from archetype.physical_ai.hosted_episode import (
+    build_hosted_episode_manifest,
+    build_hosted_episode_results,
+    decode_hosted_episode_requests,
+    hosted_episode_manifest_digest,
+    hosted_episode_request_digest,
+    hosted_episode_results_digest,
+    hosted_episode_trajectory_digest,
+)
+
+MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH = 1
+MODAL_HOSTED_EPISODE_VOLUME_MOUNT = "/archetype-hosted-episodes"
+
+_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$")
+_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+_OPERATION = re.compile(r"^physical-episode:[0-9a-f]{64}$")
+_PAYLOAD_KINDS = ("request", "trajectory", "episode-results", "manifest")
+_RESULT_SCHEMA_VERSION = 1
+_START_SCHEMA_VERSION = 1
+_RESULT_ROOT = "archetype-physical-ai-hosted-v1"
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _bounded_name(value: str, field: str) -> str:
+    if not isinstance(value, str) or _NAME.fullmatch(value) is None:
+        raise ValueError(f"{field} must be a valid Modal name")
+    return value
+
+
+def _bounded_positive(value: int, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field} must be a positive integer")
+    return value
+
+
+def _operation_key(operation_id: str) -> str:
+    if _OPERATION.fullmatch(operation_id) is None:
+        raise ValueError("Modal hosted operation identity is invalid")
+    return hashlib.sha256(operation_id.encode()).hexdigest()
+
+
+def _start_key(operation_id: str) -> str:
+    return f"start:{_operation_key(operation_id)}"
+
+
+def _result_key(operation_id: str) -> str:
+    return f"result:{_operation_key(operation_id)}"
+
+
+def _blob_path(kind: str, digest: str) -> str:
+    if kind not in _PAYLOAD_KINDS:
+        raise ValueError("Modal hosted payload kind is invalid")
+    if _DIGEST.fullmatch(digest) is None:
+        raise ValueError("Modal hosted payload digest is invalid")
+    return f"{_RESULT_ROOT}/{kind}/{digest[:2]}/{digest}.arrow"
+
+
+def _payload_digest(kind: str, payload: bytes) -> str:
+    if kind == "request":
+        return hosted_episode_request_digest(payload)
+    if kind == "trajectory":
+        return hosted_episode_trajectory_digest(payload)
+    if kind == "episode-results":
+        return hosted_episode_results_digest(payload)
+    if kind == "manifest":
+        return hosted_episode_manifest_digest(payload)
+    raise ValueError("Modal hosted payload kind is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class ModalHostedEpisodeConfig:
+    """Exact persistent Modal namespace used by one hosted provider adapter."""
+
+    workspace_name: str
+    environment_name: str
+    app_name: str
+    function_name: str
+    result_dict_name: str
+    result_volume_name: str
+    protocol_epoch: int = MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH
+    call_timeout_seconds: int = 900
+    create_if_missing: bool = False
+
+    def __post_init__(self) -> None:
+        for field in (
+            "workspace_name",
+            "environment_name",
+            "app_name",
+            "function_name",
+            "result_dict_name",
+            "result_volume_name",
+        ):
+            _bounded_name(getattr(self, field), f"Modal hosted {field}")
+        if (
+            isinstance(self.protocol_epoch, bool)
+            or not isinstance(self.protocol_epoch, int)
+            or self.protocol_epoch != MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH
+        ):
+            raise ValueError("Modal hosted provider protocol epoch is unsupported")
+        _bounded_positive(self.call_timeout_seconds, "Modal hosted call timeout")
+        if not isinstance(self.create_if_missing, bool):
+            raise ValueError("Modal hosted create_if_missing must be a boolean")
+
+    @property
+    def namespace_digest(self) -> str:
+        """Bind workspace, environment, code entrypoint, and durable objects."""
+
+        return _sha256(
+            _canonical_json(
+                {
+                    "app_name": self.app_name,
+                    "environment_name": self.environment_name,
+                    "function_name": self.function_name,
+                    "protocol_epoch": self.protocol_epoch,
+                    "provider": "modal-hosted-episode",
+                    "result_dict_name": self.result_dict_name,
+                    "result_volume_name": self.result_volume_name,
+                    "schema_version": 1,
+                    "workspace_name": self.workspace_name,
+                }
+            )
+        )
+
+    @property
+    def provider_identity(self) -> str:
+        return f"modal-hosted-episode:{self.namespace_digest}"
+
+    def retry_guard(
+        self,
+        *,
+        operation_id: str,
+        request_digest: str,
+    ) -> HostedEpisodeRetryGuard:
+        """Describe the next atomic put-if-absent route, not transferable start authority."""
+
+        key = _operation_key(operation_id)
+        if _DIGEST.fullmatch(request_digest) is None:
+            raise ValueError("Modal hosted request digest is invalid")
+        payload = _canonical_json(
+            {
+                "barrier": "modal-dict-put-if-absent",
+                "namespace_digest": self.namespace_digest,
+                "operation_id": operation_id,
+                "protocol_epoch": self.protocol_epoch,
+                "request_digest": request_digest,
+                "schema_version": 1,
+            }
+        )
+        reference = (
+            "modal-hosted-start://"
+            + quote(self.workspace_name, safe="")
+            + "/"
+            + quote(self.environment_name, safe="")
+            + "/"
+            + quote(self.result_dict_name, safe="")
+            + "/"
+            + key
+        )
+        return HostedEpisodeRetryGuard(ref=reference, digest=_sha256(payload))
+
+
+@runtime_checkable
+class ModalHostedEpisodeRuntime(Protocol):
+    """Narrow Modal control/data operations used by the family adapter."""
+
+    async def get(self, key: str) -> object: ...
+
+    async def put_if_absent(self, key: str, value: Mapping[str, Any]) -> bool: ...
+
+    async def spawn(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        namespace_digest: str,
+    ) -> object: ...
+
+    async def wait(self, call: object) -> object: ...
+
+    async def read_blob(self, path: str) -> bytes: ...
+
+
+class ModalHostedEpisodeProviderUnknown(AvailabilityError):
+    """A permanent Modal start exists but no exact complete result is visible."""
+
+    public_detail = "Hosted episode provider state is temporarily unavailable"
+
+    def __init__(self, operation_id: str, reason: str) -> None:
+        self.operation_id = operation_id
+        self.reason = reason
+        super().__init__(f"Modal hosted operation {operation_id!r} is unknown: {reason}")
+
+
+class ModalHostedEpisodeProvider:
+    """Execute or recover one canonical episode batch through Modal."""
+
+    def __init__(
+        self,
+        config: ModalHostedEpisodeConfig,
+        *,
+        runtime: ModalHostedEpisodeRuntime | None = None,
+    ) -> None:
+        self._config = config
+        self._runtime = runtime or ModalNamedHostedEpisodeRuntime(config)
+
+    @property
+    def provider(self) -> str:
+        return self._config.provider_identity
+
+    async def execute(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        attempt: int,
+        fence: int,
+        retry_guard: HostedEpisodeRetryGuard | None,
+    ) -> HostedEpisodeProviderResult:
+        request_digest = self._validate_request(operation_id, request_ipc)
+        _bounded_positive(attempt, "Modal hosted Activity attempt")
+        _bounded_positive(fence, "Modal hosted Activity fence")
+        expected_guard = self._config.retry_guard(
+            operation_id=operation_id,
+            request_digest=request_digest,
+        )
+        if retry_guard is not None and retry_guard != expected_guard:
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                "retry guard does not bind this provider namespace and request",
+            )
+
+        recovered = await self._recover_if_complete(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+        )
+        if recovered is not None:
+            return recovered
+
+        marker = self._start_marker(
+            operation_id=operation_id,
+            request_digest=request_digest,
+            attempt=attempt,
+            fence=fence,
+        )
+        try:
+            acquired = await self._runtime.put_if_absent(
+                _start_key(operation_id),
+                marker,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            recovered = await self._recover_if_complete(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+            if recovered is not None:
+                return recovered
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                f"start admission was ambiguous ({type(exc).__name__[:128]})",
+            ) from exc
+
+        if not acquired:
+            recovered = await self._recover_if_complete(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+            if recovered is not None:
+                return recovered
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                "permanent start exists without a complete result index",
+            )
+
+        try:
+            call = await self._runtime.spawn(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+                namespace_digest=self._config.namespace_digest,
+            )
+            await self._runtime.wait(call)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            recovered = await self._recover_if_complete(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+            if recovered is not None:
+                return recovered
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                f"remote execution ended without provider result ({type(exc).__name__[:128]})",
+            ) from exc
+
+        recovered = await self._recover_if_complete(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+        )
+        if recovered is None:
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                "remote completion returned without a complete result index",
+            )
+        return recovered
+
+    async def reconcile(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeRecovered | HostedEpisodeConfirmedAbsent | HostedEpisodeRecoveryUnknown:
+        request_digest = self._validate_request(operation_id, request_ipc)
+        try:
+            raw_result = await self._runtime.get(_result_key(operation_id))
+            raw_start = await self._runtime.get(_start_key(operation_id))
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return HostedEpisodeRecoveryUnknown(
+                f"Modal provider lookup failed ({type(exc).__name__[:128]})"
+            )
+
+        if raw_result is not None:
+            if not self._start_matches(
+                raw_start,
+                operation_id=operation_id,
+                request_digest=request_digest,
+            ):
+                return HostedEpisodeRecoveryUnknown(
+                    "complete result exists without its exact permanent start"
+                )
+            result = await self._load_result(
+                raw_result,
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+            return HostedEpisodeRecovered(result)
+
+        if raw_start is not None:
+            if not self._start_matches(
+                raw_start,
+                operation_id=operation_id,
+                request_digest=request_digest,
+            ):
+                return HostedEpisodeRecoveryUnknown(
+                    "permanent start conflicts with this operation or request"
+                )
+            return HostedEpisodeRecoveryUnknown(
+                "permanent start exists without a complete result index"
+            )
+
+        return HostedEpisodeConfirmedAbsent(
+            self._config.retry_guard(
+                operation_id=operation_id,
+                request_digest=request_digest,
+            )
+        )
+
+    async def result_for(
+        self,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeProviderResult | None:
+        """Read the exact first result without creating retry evidence."""
+
+        self._validate_request(operation_id, request_ipc)
+        return await self._recover_if_complete(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+        )
+
+    async def _recover_if_complete(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeProviderResult | None:
+        try:
+            conclusion = await self.reconcile(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+        except asyncio.CancelledError:
+            raise
+        if isinstance(conclusion, HostedEpisodeRecovered):
+            return conclusion.result
+        return None
+
+    async def _load_result(
+        self,
+        raw: object,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeProviderResult:
+        records = self._parse_result_index(
+            raw,
+            operation_id=operation_id,
+            request_digest=hosted_episode_request_digest(request_ipc),
+        )
+        payloads: dict[str, bytes] = {}
+        for kind in _PAYLOAD_KINDS:
+            record = records[kind]
+            payload = await self._runtime.read_blob(str(record["path"]))
+            if (
+                len(payload) != int(record["size_bytes"])
+                or _payload_digest(kind, payload) != record["digest"]
+            ):
+                raise ValueError(f"Modal hosted {kind} bytes do not match result index")
+            payloads[kind] = payload
+        if payloads["request"] != request_ipc:
+            raise ValueError("Modal hosted result index binds another request")
+        result = HostedEpisodeProviderResult(
+            request_ipc=payloads["request"],
+            trajectory_ipc=payloads["trajectory"],
+            episode_results_ipc=payloads["episode-results"],
+            manifest_ipc=payloads["manifest"],
+        )
+        validate_hosted_provider_result(
+            result,
+            request_ipc=request_ipc,
+            operation_id=operation_id,
+        )
+        return result
+
+    def _parse_result_index(
+        self,
+        raw: object,
+        *,
+        operation_id: str,
+        request_digest: str,
+    ) -> dict[str, dict[str, str | int]]:
+        if not isinstance(raw, dict):
+            raise ValueError("Modal hosted result index is not an object")
+        index = cast(dict[str, object], raw)
+        expected_keys = {
+            "schema_version",
+            "protocol_epoch",
+            "namespace_digest",
+            "operation_id",
+            "request_digest",
+            "payloads",
+        }
+        if set(index) != expected_keys:
+            raise ValueError("Modal hosted result index fields are incompatible")
+        payloads = index["payloads"]
+        if (
+            index["schema_version"] != _RESULT_SCHEMA_VERSION
+            or index["protocol_epoch"] != self._config.protocol_epoch
+            or index["namespace_digest"] != self._config.namespace_digest
+            or index["operation_id"] != operation_id
+            or index["request_digest"] != request_digest
+            or not isinstance(payloads, dict)
+            or set(payloads) != set(_PAYLOAD_KINDS)
+        ):
+            raise ValueError("Modal hosted result index identity is incompatible")
+        payload_records = cast(dict[str, object], payloads)
+        parsed: dict[str, dict[str, str | int]] = {}
+        for kind in _PAYLOAD_KINDS:
+            record = payload_records[kind]
+            if not isinstance(record, dict) or set(record) != {
+                "digest",
+                "path",
+                "size_bytes",
+            }:
+                raise ValueError(f"Modal hosted {kind} index record is incompatible")
+            fields = cast(dict[str, object], record)
+            digest = fields["digest"]
+            path = fields["path"]
+            size_bytes = fields["size_bytes"]
+            if (
+                not isinstance(digest, str)
+                or _DIGEST.fullmatch(digest) is None
+                or path != _blob_path(kind, digest)
+                or isinstance(size_bytes, bool)
+                or not isinstance(size_bytes, int)
+                or size_bytes < 1
+            ):
+                raise ValueError(f"Modal hosted {kind} index record is invalid")
+            parsed[kind] = {
+                "digest": digest,
+                "path": cast(str, path),
+                "size_bytes": cast(int, size_bytes),
+            }
+        return parsed
+
+    def _start_matches(
+        self,
+        raw: object,
+        *,
+        operation_id: str,
+        request_digest: str,
+    ) -> bool:
+        if not isinstance(raw, dict):
+            return False
+        marker = cast(dict[str, object], raw)
+        return (
+            set(marker)
+            == {
+                "attempt",
+                "fence",
+                "namespace_digest",
+                "operation_id",
+                "protocol_epoch",
+                "request_digest",
+                "schema_version",
+            }
+            and marker["schema_version"] == _START_SCHEMA_VERSION
+            and marker["protocol_epoch"] == self._config.protocol_epoch
+            and marker["namespace_digest"] == self._config.namespace_digest
+            and marker["operation_id"] == operation_id
+            and marker["request_digest"] == request_digest
+            and isinstance(marker["attempt"], int)
+            and not isinstance(marker["attempt"], bool)
+            and marker["attempt"] > 0
+            and isinstance(marker["fence"], int)
+            and not isinstance(marker["fence"], bool)
+            and marker["fence"] > 0
+        )
+
+    def _start_marker(
+        self,
+        *,
+        operation_id: str,
+        request_digest: str,
+        attempt: int,
+        fence: int,
+    ) -> dict[str, str | int]:
+        return {
+            "attempt": attempt,
+            "fence": fence,
+            "namespace_digest": self._config.namespace_digest,
+            "operation_id": operation_id,
+            "protocol_epoch": self._config.protocol_epoch,
+            "request_digest": request_digest,
+            "schema_version": _START_SCHEMA_VERSION,
+        }
+
+    @staticmethod
+    def _validate_request(operation_id: str, request_ipc: bytes) -> str:
+        _operation_key(operation_id)
+        rows = decode_hosted_episode_requests(request_ipc)
+        if any(row["operation_id"] != operation_id for row in rows):
+            raise ValueError("Modal hosted provider operation does not match its request")
+        return hosted_episode_request_digest(request_ipc)
+
+
+class ModalNamedHostedEpisodeRuntime:
+    """Concrete named-Dict, named-Volume, named-Function Modal client."""
+
+    def __init__(
+        self,
+        config: ModalHostedEpisodeConfig,
+        *,
+        function: object | None = None,
+    ) -> None:
+        self._config = config
+        self._lock = asyncio.Lock()
+        self._client: Any | None = None
+        self._dictionary: Any | None = None
+        self._volume: Any | None = None
+        self._function: Any | None = function
+        self._last_completion: object | None = None
+
+    @property
+    def last_completion(self) -> object | None:
+        """Expose non-canonical placement diagnostics for a live proof only."""
+
+        return self._last_completion
+
+    async def get(self, key: str) -> object:
+        dictionary, _, _ = await self._objects()
+        return await dictionary.get.aio(key, None)
+
+    async def put_if_absent(self, key: str, value: Mapping[str, Any]) -> bool:
+        dictionary, _, _ = await self._objects()
+        return bool(await dictionary.put.aio(key, dict(value), skip_if_exists=True))
+
+    async def spawn(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        namespace_digest: str,
+    ) -> object:
+        _, _, function = await self._objects(require_function=True)
+        if function is None:
+            raise RuntimeError("Modal hosted execution function is unavailable")
+        return await function.spawn.aio(operation_id, request_ipc, namespace_digest)
+
+    async def wait(self, call: object) -> object:
+        get = getattr(call, "get", None)
+        if get is None or not hasattr(get, "aio"):
+            raise TypeError("Modal hosted function call has no async result boundary")
+        self._last_completion = await get.aio(timeout=float(self._config.call_timeout_seconds))
+        return self._last_completion
+
+    async def read_blob(self, path: str) -> bytes:
+        if not self._valid_blob_path(path):
+            raise ValueError("Modal hosted result index contains an unsafe blob path")
+        _, volume, _ = await self._objects()
+        chunks = [chunk async for chunk in volume.read_file.aio(path)]
+        return b"".join(chunks)
+
+    async def _objects(
+        self,
+        *,
+        require_function: bool = False,
+    ) -> tuple[Any, Any, Any | None]:
+        if (
+            self._dictionary is not None
+            and self._volume is not None
+            and (not require_function or self._function is not None)
+        ):
+            return self._dictionary, self._volume, self._function
+        async with self._lock:
+            if self._client is None:
+                modal = _load_modal()
+                workspace = modal.Workspace.from_context()
+                await workspace.hydrate.aio()
+                observed = str(workspace.name or "")
+                if observed != self._config.workspace_name:
+                    raise RuntimeError("Modal workspace does not match hosted provider namespace")
+                self._client = workspace.client
+            modal = _load_modal()
+            if self._dictionary is None:
+                self._dictionary = modal.Dict.from_name(
+                    self._config.result_dict_name,
+                    environment_name=self._config.environment_name,
+                    create_if_missing=self._config.create_if_missing,
+                    client=self._client,
+                )
+                await self._dictionary.hydrate.aio()
+            if self._volume is None:
+                self._volume = modal.Volume.from_name(
+                    self._config.result_volume_name,
+                    environment_name=self._config.environment_name,
+                    create_if_missing=self._config.create_if_missing,
+                    client=self._client,
+                )
+                await self._volume.hydrate.aio()
+            if require_function and self._function is None:
+                self._function = modal.Function.from_name(
+                    self._config.app_name,
+                    self._config.function_name,
+                    environment_name=self._config.environment_name,
+                    client=self._client,
+                )
+                await self._function.hydrate.aio()
+            return self._dictionary, self._volume, self._function
+
+    @staticmethod
+    def _valid_blob_path(path: str) -> bool:
+        parts = Path(path).parts
+        return (
+            len(parts) == 4
+            and parts[0] == _RESULT_ROOT
+            and parts[1] in _PAYLOAD_KINDS
+            and len(parts[2]) == 2
+            and parts[3].endswith(".arrow")
+            and _DIGEST.fullmatch(parts[3].removesuffix(".arrow")) is not None
+            and parts[2] == parts[3][:2]
+        )
+
+
+def build_seeded_modal_hosted_episode_app(
+    config: ModalHostedEpisodeConfig,
+    *,
+    gpu: str = "L40S",
+    image: object | None = None,
+) -> tuple[object, object]:
+    """Build the disposable seeded GPU app used by parity proofs.
+
+    Production robot or simulator deployments may register another named
+    function with the same three-argument entrypoint and publication order.
+    """
+
+    modal = _load_modal()
+    result_volume = modal.Volume.from_name(
+        config.result_volume_name,
+        environment_name=config.environment_name,
+        create_if_missing=True,
+    )
+    if image is None:
+        image = (
+            modal.Image.debian_slim(python_version="3.12")
+            .uv_pip_install("archetype-ecs==0.4.1")
+            .add_local_python_source("archetype", copy=True)
+        )
+    app = modal.App(config.app_name)
+    namespace_digest = config.namespace_digest
+    protocol_epoch = config.protocol_epoch
+    environment_name = config.environment_name
+    result_dict_name = config.result_dict_name
+    result_volume_name = config.result_volume_name
+
+    @app.function(
+        name=config.function_name,
+        image=image,
+        gpu=gpu,
+        serialized=True,
+        timeout=config.call_timeout_seconds,
+        volumes={MODAL_HOSTED_EPISODE_VOLUME_MOUNT: result_volume},
+    )
+    def seeded_hosted_episode(
+        operation_id: str,
+        request_ipc: bytes,
+        requested_namespace_digest: str,
+    ) -> dict[str, str | int]:
+        if requested_namespace_digest != namespace_digest:
+            raise ValueError("Modal hosted remote namespace does not match deployment")
+        modal = _load_modal()
+        remote_result_dict = modal.Dict.from_name(
+            result_dict_name,
+            environment_name=environment_name,
+            create_if_missing=False,
+        )
+        remote_result_volume = modal.Volume.from_name(
+            result_volume_name,
+            environment_name=environment_name,
+            create_if_missing=False,
+        )
+        result = _run_seeded_episode(request_ipc)
+        validate_hosted_provider_result(
+            result,
+            request_ipc=request_ipc,
+            operation_id=operation_id,
+        )
+        index = _publish_remote_result(
+            mount=Path(MODAL_HOSTED_EPISODE_VOLUME_MOUNT),
+            operation_id=operation_id,
+            namespace_digest=requested_namespace_digest,
+            protocol_epoch=protocol_epoch,
+            result=result,
+        )
+        remote_result_volume.commit()
+        key = _result_key(operation_id)
+        inserted = remote_result_dict.put(key, index, skip_if_exists=True)
+        if not inserted and remote_result_dict.get(key) != index:
+            raise RuntimeError("Modal hosted result index conflicts with first result")
+        return {
+            "gpu_count": _gpu_count(),
+            "index_digest": _sha256(_canonical_json(index)),
+            "schema_version": 1,
+        }
+
+    return app, seeded_hosted_episode
+
+
+def _run_seeded_episode(request_ipc: bytes) -> HostedEpisodeProviderResult:
+    trajectory_ipc = asyncio.run(SeededHostedEpisodeRunner().run(request_ipc))
+    episode_results_ipc = build_hosted_episode_results(request_ipc, trajectory_ipc)
+    manifest_ipc = build_hosted_episode_manifest(
+        request_ipc,
+        trajectory_ipc,
+        episode_results_ipc,
+    )
+    return HostedEpisodeProviderResult(
+        request_ipc=request_ipc,
+        trajectory_ipc=trajectory_ipc,
+        episode_results_ipc=episode_results_ipc,
+        manifest_ipc=manifest_ipc,
+    )
+
+
+def _publish_remote_result(
+    *,
+    mount: Path,
+    operation_id: str,
+    namespace_digest: str,
+    protocol_epoch: int,
+    result: HostedEpisodeProviderResult,
+) -> dict[str, Any]:
+    payloads = {
+        "request": result.request_ipc,
+        "trajectory": result.trajectory_ipc,
+        "episode-results": result.episode_results_ipc,
+        "manifest": result.manifest_ipc,
+    }
+    records: dict[str, dict[str, str | int]] = {}
+    for kind, payload in payloads.items():
+        digest = _payload_digest(kind, payload)
+        relative = _blob_path(kind, digest)
+        _write_remote_blob(mount / relative, payload)
+        records[kind] = {
+            "digest": digest,
+            "path": relative,
+            "size_bytes": len(payload),
+        }
+    return {
+        "namespace_digest": namespace_digest,
+        "operation_id": operation_id,
+        "payloads": records,
+        "protocol_epoch": protocol_epoch,
+        "request_digest": hosted_episode_request_digest(result.request_ipc),
+        "schema_version": _RESULT_SCHEMA_VERSION,
+    }
+
+
+def _write_remote_blob(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if path.read_bytes() != payload:
+            raise RuntimeError(f"Modal hosted immutable blob conflicts at {path.name}")
+        return
+    descriptor, temporary = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if path.exists():
+            if path.read_bytes() != payload:
+                raise RuntimeError(f"Modal hosted immutable blob conflicts at {path.name}")
+        else:
+            # Concurrent writers can only target the same digest. Replacing
+            # identical bytes is safe and leaves no partial durable payload.
+            os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _gpu_count() -> int:
+    """Return proof-only placement diagnostics; never enter canonical payloads."""
+
+    try:
+        completed = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    return len([line for line in completed.stdout.splitlines() if line.strip()])
+
+
+def _load_modal() -> Any:
+    try:
+        import modal
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "Modal support is optional; install it with `uv sync --extra coding-agent`"
+        ) from exc
+    return modal
+
+
+__all__ = [
+    "MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH",
+    "MODAL_HOSTED_EPISODE_VOLUME_MOUNT",
+    "ModalHostedEpisodeConfig",
+    "ModalHostedEpisodeProvider",
+    "ModalHostedEpisodeProviderUnknown",
+    "ModalHostedEpisodeRuntime",
+    "ModalNamedHostedEpisodeRuntime",
+    "build_seeded_modal_hosted_episode_app",
+]

--- a/src/archetype/physical_ai/hosted_modal.py
+++ b/src/archetype/physical_ai/hosted_modal.py
@@ -439,6 +439,11 @@ class ModalHostedEpisodeProvider:
             raise
         if isinstance(conclusion, HostedEpisodeRecovered):
             return conclusion.result
+        if isinstance(conclusion, HostedEpisodeRecoveryUnknown):
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                conclusion.reason or "provider reconciliation is unknown",
+            )
         return None
 
     async def _load_result(

--- a/tests/physical_ai/test_hosted_modal_activity.py
+++ b/tests/physical_ai/test_hosted_modal_activity.py
@@ -1,0 +1,573 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Modal admission and restart contracts for hosted Physical-AI Activities."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from archetype.activities import ActivityCoordinator
+from archetype.core.interfaces import CommittedTickReceipt
+from archetype.physical_ai import hosted_modal
+from archetype.physical_ai.hosted_activities import (
+    PhysicalHostedActivityCatalog,
+    PhysicalHostedActivityCoordinator,
+    PhysicalHostedActivityWorker,
+)
+from archetype.physical_ai.hosted_activity_contracts import (
+    HostedEpisodeConfirmedAbsent,
+    HostedEpisodeObservation,
+    HostedEpisodeProviderResult,
+    HostedEpisodeRecovered,
+    HostedEpisodeRecoveryUnknown,
+    HostedEpisodeRetryGuard,
+    hosted_episode_provider_operation_id,
+)
+from archetype.physical_ai.hosted_activity_values import (
+    LocalHostedEpisodeValueStore,
+    SeededHostedEpisodeRunner,
+)
+from archetype.physical_ai.hosted_episode import (
+    build_hosted_episode_manifest,
+    build_hosted_episode_results,
+    decode_hosted_episode_manifest,
+    encode_hosted_episode_requests,
+    validate_hosted_episode_result,
+)
+from archetype.physical_ai.hosted_modal import (
+    ModalHostedEpisodeConfig,
+    ModalHostedEpisodeProvider,
+    ModalHostedEpisodeProviderUnknown,
+)
+from archetype.storage.activity_catalog import SqliteActivityCatalog
+
+
+def _config(**changes: object) -> ModalHostedEpisodeConfig:
+    values: dict[str, Any] = {
+        "workspace_name": "test-workspace",
+        "environment_name": "test-environment",
+        "app_name": "physical-ai-proof",
+        "function_name": "seeded-hosted-episode",
+        "result_dict_name": "physical-ai-results",
+        "result_volume_name": "physical-ai-values",
+        "call_timeout_seconds": 60,
+    }
+    values.update(changes)
+    return ModalHostedEpisodeConfig(**values)
+
+
+def _request(world_id: str, activity_id: str) -> bytes:
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    return encode_hosted_episode_requests(
+        [
+            {
+                "operation_id": operation_id,
+                "trial_id": 1,
+                "suite": "seeded-reach",
+                "task_id": 7,
+                "seed": 101,
+                "instruction": "reach the target",
+                "max_transitions": 3,
+                "environment_id": "seeded-reach@v1",
+                "policy_id": "scripted-reach@v1",
+                "config_json": {
+                    "reward_per_transition": 0.25,
+                    "success_after_transitions": 2,
+                },
+            },
+            {
+                "operation_id": operation_id,
+                "trial_id": 0,
+                "suite": "seeded-reach",
+                "task_id": 7,
+                "seed": 100,
+                "instruction": "reach the target",
+                "max_transitions": 1,
+                "environment_id": "seeded-reach@v1",
+                "policy_id": "scripted-reach@v1",
+                "config_json": {"reward_per_transition": 0.25},
+            },
+        ]
+    )
+
+
+def _provider_operation_key(operation_id: str, prefix: str) -> str:
+    digest = hashlib.sha256(operation_id.encode()).hexdigest()
+    return f"{prefix}:{digest}"
+
+
+@dataclass
+class _FakeModalState:
+    root: Path
+    values: dict[str, object] = field(default_factory=dict)
+    blobs: dict[str, bytes] = field(default_factory=dict)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    wait_started: asyncio.Event = field(default_factory=asyncio.Event)
+    release_wait: asyncio.Event = field(default_factory=asyncio.Event)
+    spawn_attempts: int = 0
+    execution_count: int = 0
+
+
+class _FakeModalRuntime:
+    def __init__(
+        self,
+        state: _FakeModalState,
+        *,
+        block_before_result: bool = False,
+        fail_spawn: bool = False,
+        lose_response_after_result: bool = False,
+    ) -> None:
+        self.state = state
+        self.block_before_result = block_before_result
+        self.fail_spawn = fail_spawn
+        self.lose_response_after_result = lose_response_after_result
+
+    async def get(self, key: str) -> object:
+        async with self.state.lock:
+            return self.state.values.get(key)
+
+    async def put_if_absent(self, key: str, value: Mapping[str, Any]) -> bool:
+        async with self.state.lock:
+            if key in self.state.values:
+                return False
+            self.state.values[key] = dict(value)
+            return True
+
+    async def spawn(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        namespace_digest: str,
+    ) -> object:
+        self.state.spawn_attempts += 1
+        if self.fail_spawn:
+            raise RuntimeError("spawn response disappeared")
+        return operation_id, request_ipc, namespace_digest
+
+    async def wait(self, call: object) -> object:
+        operation_id, request_ipc, namespace_digest = cast(
+            tuple[str, bytes, str],
+            call,
+        )
+        self.state.execution_count += 1
+        self.state.wait_started.set()
+        if self.block_before_result:
+            await self.state.release_wait.wait()
+        trajectory_ipc = await SeededHostedEpisodeRunner().run(request_ipc)
+        episode_results_ipc = build_hosted_episode_results(
+            request_ipc,
+            trajectory_ipc,
+        )
+        manifest_ipc = build_hosted_episode_manifest(
+            request_ipc,
+            trajectory_ipc,
+            episode_results_ipc,
+        )
+        result = HostedEpisodeProviderResult(
+            request_ipc=request_ipc,
+            trajectory_ipc=trajectory_ipc,
+            episode_results_ipc=episode_results_ipc,
+            manifest_ipc=manifest_ipc,
+        )
+        index = hosted_modal._publish_remote_result(
+            mount=self.state.root,
+            operation_id=operation_id,
+            namespace_digest=namespace_digest,
+            protocol_epoch=hosted_modal.MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH,
+            result=result,
+        )
+        payloads = cast(dict[str, dict[str, object]], index["payloads"])
+        for record in payloads.values():
+            path = str(record["path"])
+            self.state.blobs[path] = (self.state.root / path).read_bytes()
+        key = _provider_operation_key(operation_id, "result")
+        async with self.state.lock:
+            existing = self.state.values.get(key)
+            if existing is not None and existing != index:
+                raise RuntimeError("first result index conflicts")
+            self.state.values.setdefault(key, index)
+        if self.lose_response_after_result:
+            self.lose_response_after_result = False
+            raise RuntimeError("completion response disappeared")
+        return {"gpu_count": 1, "schema_version": 1}
+
+    async def read_blob(self, path: str) -> bytes:
+        return self.state.blobs[path]
+
+
+class _ObservationStager:
+    def __init__(self) -> None:
+        self.observations: dict[tuple[str, str], HostedEpisodeObservation] = {}
+
+    async def stage_hosted_episode_observation(
+        self,
+        *,
+        world_id: str,
+        observation: HostedEpisodeObservation,
+    ) -> None:
+        key = world_id, observation.activity_id
+        existing = self.observations.get(key)
+        if existing is not None and existing != observation:
+            raise ValueError("conflicting hosted observation")
+        self.observations.setdefault(key, observation)
+
+
+class _CrashBeforeGenericRecord:
+    def __init__(self, catalog: PhysicalHostedActivityCoordinator) -> None:
+        self.catalog = catalog
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.catalog, name)
+
+    async def record_episode_result(self, claim: object, result: object) -> None:
+        raise RuntimeError("worker died before generic Activity result recording")
+
+
+def _open_catalog(
+    path: Path,
+    *,
+    lease_seconds: float = 0.01,
+) -> tuple[
+    SqliteActivityCatalog,
+    ActivityCoordinator,
+    PhysicalHostedActivityCoordinator,
+]:
+    physical = SqliteActivityCatalog(path)
+    generic = ActivityCoordinator(physical)
+    return (
+        physical,
+        generic,
+        PhysicalHostedActivityCoordinator(
+            generic,
+            lease_seconds=lease_seconds,
+        ),
+    )
+
+
+def test_modal_namespace_identity_binds_every_durable_and_execution_coordinate() -> None:
+    base = _config()
+    fields = (
+        "workspace_name",
+        "environment_name",
+        "app_name",
+        "function_name",
+        "result_dict_name",
+        "result_volume_name",
+    )
+    for field_name in fields:
+        changed = replace(base, **{field_name: f"{getattr(base, field_name)}-changed"})
+        assert changed.provider_identity != base.provider_identity
+        assert changed.namespace_digest != base.namespace_digest
+
+    with pytest.raises(ValueError, match="valid Modal name"):
+        _config(workspace_name=1)
+    with pytest.raises(ValueError, match="protocol epoch"):
+        _config(protocol_epoch=True)
+    with pytest.raises(ValueError, match="positive integer"):
+        _config(call_timeout_seconds=True)
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _config(create_if_missing=1)
+
+
+@pytest.mark.asyncio
+async def test_lost_modal_completion_response_recovers_provider_first_result(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "response-loss"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    provider = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state, lose_response_after_result=True),
+    )
+
+    result = await provider.execute(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+        attempt=1,
+        fence=1,
+        retry_guard=None,
+    )
+
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+    manifest = validate_hosted_episode_result(
+        result.request_ipc,
+        result.trajectory_ipc,
+        result.episode_results_ipc,
+        result.manifest_ipc,
+    )
+    assert decode_hosted_episode_manifest(result.manifest_ipc) == manifest
+
+    reconstructed = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+    recovery = await reconstructed.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeRecovered)
+    assert recovery.result == result
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+
+
+@pytest.mark.asyncio
+async def test_permanent_modal_start_without_result_never_replays(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "ambiguous-start"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    first = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state, fail_spawn=True),
+    )
+
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="without provider result"):
+        await first.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=1,
+            fence=1,
+            retry_guard=None,
+        )
+
+    reconstructed = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+    recovery = await reconstructed.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeRecoveryUnknown)
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="permanent start"):
+        await reconstructed.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=2,
+            fence=2,
+            retry_guard=None,
+        )
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 0
+
+
+@pytest.mark.asyncio
+async def test_modal_confirmed_absence_guard_cannot_bypass_atomic_start(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "guarded-start"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    provider = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+    recovery = await provider.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeConfirmedAbsent)
+
+    wrong_guard = HostedEpisodeRetryGuard(
+        ref=recovery.guard.ref,
+        digest="0" * 64,
+    )
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="retry guard"):
+        await provider.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=1,
+            fence=1,
+            retry_guard=wrong_guard,
+        )
+    assert state.values == {}
+
+    await provider.execute(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+        attempt=1,
+        fence=1,
+        retry_guard=recovery.guard,
+    )
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_modal_claimants_admit_only_one_remote_execution(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "concurrent-start"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    first = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state, block_before_result=True),
+    )
+    second = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+
+    first_task = asyncio.create_task(
+        first.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=1,
+            fence=1,
+            retry_guard=None,
+        )
+    )
+    await state.wait_started.wait()
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="permanent start"):
+        await second.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=2,
+            fence=2,
+            retry_guard=None,
+        )
+    state.release_wait.set()
+    await first_task
+
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+    recovered = await second.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovered, HostedEpisodeRecovered)
+
+
+@pytest.mark.asyncio
+async def test_modal_result_identity_corruption_fails_closed(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "corrupt-index"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    provider = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+    await provider.execute(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+        attempt=1,
+        fence=1,
+        retry_guard=None,
+    )
+    result_key = _provider_operation_key(operation_id, "result")
+    index = state.values[result_key]
+    assert isinstance(index, dict)
+    state.values[result_key] = {
+        **index,
+        "namespace_digest": "0" * 64,
+    }
+
+    with pytest.raises(ValueError, match="identity is incompatible"):
+        await provider.reconcile(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+        )
+
+    state.values[result_key] = index
+    del state.values[_provider_operation_key(operation_id, "start")]
+    recovery = await provider.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeRecoveryUnknown)
+
+
+@pytest.mark.asyncio
+async def test_activity_restart_recovers_modal_result_before_generic_record(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "activity-restart"
+    request_ipc = _request(world_id, activity_id)
+    catalog_path = tmp_path / "activities.db"
+    values_path = tmp_path / "values"
+    values = LocalHostedEpisodeValueStore(values_path)
+    request_ref = await values.put_request(request_ipc)
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+    physical, _generic, catalog = _open_catalog(catalog_path)
+    await catalog.admit_episode(
+        world_id=world_id,
+        receipt=receipt,
+        activity_id=activity_id,
+        request=request_ref,
+    )
+    state = _FakeModalState(tmp_path / "remote-volume")
+    first = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="before-crash",
+        catalog=cast(
+            PhysicalHostedActivityCatalog,
+            _CrashBeforeGenericRecord(catalog),
+        ),
+        values=values,
+        provider=ModalHostedEpisodeProvider(
+            _config(),
+            runtime=_FakeModalRuntime(state),
+        ),
+        stager=_ObservationStager(),
+    )
+
+    with pytest.raises(RuntimeError, match="before generic Activity result"):
+        await first.run_once()
+    assert state.execution_count == 1
+    await physical.close()
+    await asyncio.sleep(0.02)
+
+    recovered_physical, _recovered_generic, recovered_catalog = _open_catalog(
+        catalog_path,
+        lease_seconds=30,
+    )
+    stager = _ObservationStager()
+    reconstructed = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="after-restart",
+        catalog=recovered_catalog,
+        values=LocalHostedEpisodeValueStore(values_path),
+        provider=ModalHostedEpisodeProvider(
+            _config(),
+            runtime=_FakeModalRuntime(state),
+        ),
+        stager=stager,
+    )
+    assert await reconstructed.run_once()
+
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+    observation = stager.observations[(world_id, activity_id)]
+    assert observation.episode_count == 2
+    assert observation.trajectory_row_count == 5
+    assert observation.transition_count == 3
+    assert observation.success_count == 1
+    assert len(await recovered_catalog.pending_episode_results(world_id=world_id)) == 1
+    await recovered_physical.close()

--- a/tests/physical_ai/test_hosted_modal_activity.py
+++ b/tests/physical_ai/test_hosted_modal_activity.py
@@ -338,7 +338,7 @@ async def test_permanent_modal_start_without_result_never_replays(
         runtime=_FakeModalRuntime(state, fail_spawn=True),
     )
 
-    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="without provider result"):
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="permanent start"):
         await first.execute(
             operation_id=operation_id,
             request_ipc=request_ipc,
@@ -501,6 +501,18 @@ async def test_modal_result_identity_corruption_fails_closed(
         request_ipc=request_ipc,
     )
     assert isinstance(recovery, HostedEpisodeRecoveryUnknown)
+    with pytest.raises(
+        ModalHostedEpisodeProviderUnknown,
+        match="without its exact permanent start",
+    ):
+        await provider.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=2,
+            fence=2,
+            retry_guard=None,
+        )
+    assert state.spawn_attempts == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add the guarded Modal provider for hosted Physical-AI episode Activities
- preserve one provider-operation identity across admission, publication, settlement, and reconciliation
- recover a published provider result after a cold-process restart without launching a second GPU episode
- document the A7 provider contract and its executable oracles

## Real GPU proof

Executed against Modal workspace `vangelis-tech/main` with one real GPU:

- stopped App: `ap-nXLKIwCqS18C4j6UuGFMSU`
- provider operation: `modal-hosted-episode:791d846c879b97912b083ca08ac1941d80ed94c9c00a60f178c056073768f63a`
- provider index digest: `ad70beb7153d4b83cd0c12fb6218b1e312a265199e5013eae8d94f6f42327fb0`
- result digest: `784811d10f376faf3b45284c5f2b180ba179f4a35f9575b7af37444d08678cf9`
- provider reported `gpu_count=1`
- injected failure after provider publication and before the generic result record
- separate cold process recovered the first result with no second Modal call
- recovered evidence: 2 episodes, 5 rows, 3 transitions, 1 success

The retained reconciliation stores are `arch-a7b-results-20260726-185158-c3261f` and `arch-a7b-values-20260726-185158-c3261f`. The App is stopped; no release or RC was created.

## Validation

- `uv run pytest -q tests/physical_ai/test_hosted_episode_activities.py tests/physical_ai/test_hosted_episode_contract.py tests/physical_ai/test_hosted_modal_activity.py` (82 passed)
- `make static`
- `make docs-lint`
- pre-rebase full suite: 2683 passed, 6 skipped
