### PR TITLE
fix(ci): R2 lane — diagnosable flakes, named stalls, non-evicting retry (H4)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -145,19 +145,37 @@ jobs:
         run: >-
           PYTHONPATH="${PYTHONPATH:-}:."
           uv run pytest -q tests/infrastructure/test_r2_idempotency.py
+      # One in-job retry, with the first attempt's receipt retained as
+      # evidence. The lane's measured flake rate is ~1 failure in 60 runs
+      # against external object storage, and a merge-group flake evicts the
+      # whole queue entry (#678: a 600s silent stall cost ~28 minutes of
+      # queue latency plus an hour of forensics). A real regression fails
+      # both attempts; a flake costs one extra scenario run instead of an
+      # eviction. This codifies the sanctioned one-classified-rerun policy
+      # (AGENTS.md) inside the job, and the retained attempt-1 receipt IS
+      # the classification record.
       - name: Run public-runtime R2 scenario
         if: always()
         run: |
-          PYTHONPATH="${PYTHONPATH:-}:." uv run python scripts/run_operational_scenarios.py \
-            --mode source \
-            --cadence pr \
-            --min-tier 5 \
-            --max-tier 5 \
-            --scenario dogfood.storage.r2 \
-            --require-run \
-            --expected-revision "$GITHUB_SHA" \
-            --require-clean \
-            --out r2-operational-results.json
+          run_r2_scenario() {
+            PYTHONPATH="${PYTHONPATH:-}:." uv run python scripts/run_operational_scenarios.py \
+              --mode source \
+              --cadence pr \
+              --min-tier 5 \
+              --max-tier 5 \
+              --scenario dogfood.storage.r2 \
+              --require-run \
+              --expected-revision "$GITHUB_SHA" \
+              --require-clean \
+              --out r2-operational-results.json
+          }
+          if run_r2_scenario; then
+            exit 0
+          fi
+          [ -f r2-operational-results.json ] && mv r2-operational-results.json r2-operational-results.attempt1.json
+          [ -d r2-operational-results.d ] && mv r2-operational-results.d r2-operational-results.attempt1.d
+          echo "::warning::R2 scenario failed once; retrying. Attempt 1's receipt is retained in the artifact."
+          run_r2_scenario
       - name: Require R2 operational receipt
         if: always()
         run: test -f r2-operational-results.json
@@ -168,6 +186,8 @@ jobs:
           path: |
             r2-operational-results.json
             r2-operational-results.d/
+            r2-operational-results.attempt1.json
+            r2-operational-results.attempt1.d/
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -115,7 +115,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Budget covers BOTH scenario attempts at their full 600s
+    # timeout_seconds plus setup and the idempotency test (~4 min): a
+    # 10-minute budget made the retry unreachable exactly when the first
+    # attempt was the 600s stall the retry exists to absorb — GitHub
+    # cancelled the job mid-timeout and the queue entry was still evicted.
+    timeout-minutes: 30
     env:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -172,7 +177,17 @@ jobs:
           if run_r2_scenario; then
             exit 0
           fi
-          [ -f r2-operational-results.json ] && mv r2-operational-results.json r2-operational-results.attempt1.json
+          # Rename attempt 1's evidence AND rewrite the log paths inside its
+          # receipt: the JSON references logs under r2-operational-results.d/,
+          # which the retry recreates — without the rewrite the retained
+          # receipt would resolve to attempt 2's logs. Only path strings
+          # change; the log files move with the directory, so their recorded
+          # digests still match their contents.
+          if [ -f r2-operational-results.json ]; then
+            jq '(.. | strings) |= gsub("r2-operational-results\\.d"; "r2-operational-results.attempt1.d")' \
+              r2-operational-results.json > r2-operational-results.attempt1.json
+            rm r2-operational-results.json
+          fi
           [ -d r2-operational-results.d ] && mv r2-operational-results.d r2-operational-results.attempt1.d
           echo "::warning::R2 scenario failed once; retrying. Attempt 1's receipt is retained in the artifact."
           run_r2_scenario

--- a/scripts/run_operational_scenarios.py
+++ b/scripts/run_operational_scenarios.py
@@ -292,14 +292,80 @@ def _stop_timed_out_process(process: subprocess.Popen[bytes]) -> tuple[int | Non
     return returncode, group_closed
 
 
+def _process_group_snapshot(process_group: int) -> str:
+    """One line per still-running group member: pid, age, command.
+
+    Best-effort diagnostics only — a snapshot failure must never mask the
+    timeout it is trying to explain.
+    """
+    try:
+        listing = subprocess.run(
+            ["ps", "-eo", "pid=,pgid=,etime=,command="],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"(snapshot unavailable: {type(exc).__name__}: {exc})"
+    members = []
+    for line in listing.splitlines():
+        fields = line.split(maxsplit=3)
+        if len(fields) == 4 and fields[1] == str(process_group):
+            pid, _, etime, command = fields
+            members.append(f"  pid={pid} age={etime} cmd={command}")
+    return "\n".join(members) if members else "(no group members visible)"
+
+
+_FAILURE_TAIL_BYTES = 16_384
+_SECRET_ENV_NAME = re.compile(r"KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL")
+_SECRET_MIN_LENGTH = 8
+
+
+def _secret_environment_values(env: dict[str, str]) -> list[tuple[str, str]]:
+    """Env values that must never appear in retained output, longest first.
+
+    Longest-first so a value that contains another (a token embedding a key
+    id) is masked before its substring turns the remainder unrecognizable.
+    Short values are excluded: masking every 3-character string would
+    destroy the log, and no real credential is that short.
+    """
+    values = [
+        (name, value)
+        for name, value in env.items()
+        if _SECRET_ENV_NAME.search(name) and len(value) >= _SECRET_MIN_LENGTH
+    ]
+    return sorted(values, key=lambda item: len(item[1]), reverse=True)
+
+
 def _write_captured_log(
     *,
     raw: bytes,
     destination: Path,
     redacted: bool,
+    failed: bool = False,
+    secret_values: list[tuple[str, str]] | None = None,
 ) -> dict[str, object]:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    if redacted:
+    failure_tail_retained = False
+    if redacted and failed and raw:
+        # Redact secrets, not the assertion: a redacted receipt on a FAILED
+        # run previously discarded the entire output, which made the two R2
+        # incidents on #675/#678 undiagnosable ("exact assertion is
+        # unrecoverable"). Retain a bounded tail with credential values
+        # masked; digest and byte count still describe the full raw output.
+        tail = raw[-_FAILURE_TAIL_BYTES:]
+        text = tail.decode("utf-8", errors="replace")
+        for name, value in secret_values or ():
+            text = text.replace(value, f"***{name}***")
+        destination.write_text(
+            "Redacted receipt: run FAILED, so the output tail is retained "
+            "with credential values masked.\n"
+            f"(last {len(tail)} of {len(raw)} bytes)\n---\n" + text,
+            encoding="utf-8",
+        )
+        failure_tail_retained = True
+    elif redacted:
         destination.write_text(
             "Output omitted by redacted_receipt policy.\n",
             encoding="utf-8",
@@ -311,6 +377,7 @@ def _write_captured_log(
         "bytes": len(raw),
         "digest": _sha256_bytes(raw),
         "redacted": redacted,
+        "failure_tail_retained": failure_tail_retained,
     }
 
 
@@ -349,6 +416,11 @@ def _run_process(
                     returncode = process.wait(timeout=timeout_seconds)
                 except subprocess.TimeoutExpired:
                     timed_out = True
+                    # Photograph the group BEFORE killing it: a scenario that
+                    # hangs silently for its whole budget (#678's 600s R2
+                    # stall) otherwise leaves a receipt naming nothing. The
+                    # snapshot names the processes that were still running.
+                    timeout_snapshot = _process_group_snapshot(process.pid)
                     returncode, group_closed = _stop_timed_out_process(process)
                     process_group_leaked = not group_closed
 
@@ -356,6 +428,11 @@ def _run_process(
         stderr_raw = stderr_path.read_bytes()
         if launch_error is not None:
             stderr_raw += f"\noperational launch error: {launch_error}\n".encode()
+        if timed_out:
+            stderr_raw += (
+                f"\noperational timeout: no exit within {timeout_seconds}s; "
+                f"process-group snapshot at SIGTERM:\n{timeout_snapshot}\n"
+            ).encode()
         if process is not None and not timed_out:
             # Give well-behaved children a short exit window. Anything retaining
             # the scenario's process group afterward is owned cleanup debt even
@@ -370,6 +447,8 @@ def _run_process(
                 if not cleanup_succeeded:
                     launch_error = "process group survived SIGTERM and SIGKILL"
 
+    failed = timed_out or launch_error is not None or returncode != 0
+    secret_values = _secret_environment_values(env)
     return {
         "command": command,
         "returncode": returncode,
@@ -380,11 +459,15 @@ def _run_process(
             raw=stdout_raw,
             destination=log_prefix.with_suffix(".stdout.log"),
             redacted=redacted,
+            failed=failed,
+            secret_values=secret_values,
         ),
         "stderr": _write_captured_log(
             raw=stderr_raw,
             destination=log_prefix.with_suffix(".stderr.log"),
             redacted=redacted,
+            failed=failed,
+            secret_values=secret_values,
         ),
         "stdout_text": stdout_raw.decode("utf-8", errors="replace"),
         "process_group_leaked": process_group_leaked,

--- a/tests/scripts/test_operational_capture.py
+++ b/tests/scripts/test_operational_capture.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for operational-scenario output capture.
+
+Two incidents motivated these: the #675 R2 flake and the #678 merge-group
+stall were both undiagnosable because the ``redacted_receipt`` policy
+discarded the entire output of FAILED runs, and the stall additionally
+produced no output at all until the runner's timeout killed it. The
+contracts:
+
+1. A redacted receipt on a failed run retains a bounded output tail with
+   credential values masked — redact secrets, not the assertion.
+2. A redacted receipt on a successful run still discards everything.
+3. A timed-out run's stderr names the processes that were still running
+   (the group snapshot taken before SIGTERM).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from scripts.run_operational_scenarios import (
+    _run_process,
+    _secret_environment_values,
+    _write_captured_log,
+)
+
+
+def test_redacted_failure_retains_masked_tail(tmp_path: Path) -> None:
+    secret = "AKIA-example-secret-value-1234"
+    raw = (
+        b"collected 2 items\n"
+        b"FAILED test_r2_artifact_context.py::test_roundtrip - "
+        b"AssertionError: manifest missing\n"
+        b"credential leaked into output: " + secret.encode() + b"\n"
+    )
+    destination = tmp_path / "stderr.log"
+
+    entry = _write_captured_log(
+        raw=raw,
+        destination=destination,
+        redacted=True,
+        failed=True,
+        secret_values=[("R2_SECRET_ACCESS_KEY", secret)],
+    )
+
+    written = destination.read_text(encoding="utf-8")
+    assert "AssertionError: manifest missing" in written, "the assertion is the diagnosis"
+    assert secret not in written, "credential values must never survive into the receipt"
+    assert "***R2_SECRET_ACCESS_KEY***" in written
+    assert entry["failure_tail_retained"] is True
+    assert entry["redacted"] is True
+    # Digest and byte count still describe the full raw output, not the tail.
+    assert entry["bytes"] == len(raw)
+
+
+def test_redacted_success_still_discards_output(tmp_path: Path) -> None:
+    destination = tmp_path / "stdout.log"
+
+    entry = _write_captured_log(
+        raw=b"2 passed in 97.9s\npresigned url: https://bucket/...\n",
+        destination=destination,
+        redacted=True,
+        failed=False,
+    )
+
+    assert destination.read_text(encoding="utf-8") == (
+        "Output omitted by redacted_receipt policy.\n"
+    )
+    assert entry["failure_tail_retained"] is False
+
+
+def test_secret_values_filter_names_and_lengths() -> None:
+    env = {
+        "R2_ACCESS_KEY_ID": "key-value-long-enough",
+        "R2_SECRET_ACCESS_KEY": "an-even-longer-secret-value",
+        "LOGFIRE_TOKEN": "tokenvalue",
+        "HOME": "/home/runner",
+        "SHORT_KEY": "abc",
+    }
+
+    values = _secret_environment_values(env)
+
+    names = [name for name, _ in values]
+    assert set(names) == {"R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "LOGFIRE_TOKEN"}
+    # Longest value first, so embedded substrings are masked after their
+    # containers.
+    lengths = [len(value) for _, value in values]
+    assert lengths == sorted(lengths, reverse=True)
+
+
+def test_timed_out_run_records_a_process_group_snapshot(tmp_path: Path) -> None:
+    result = _run_process(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        cwd=tmp_path,
+        env={"PATH": "/usr/bin:/bin"},
+        timeout_seconds=1,
+        log_prefix=tmp_path / "capture",
+        redacted=False,
+    )
+
+    assert result["timed_out"] is True
+    stderr_text = (tmp_path / "capture.stderr.log").read_text(encoding="utf-8")
+    assert "operational timeout: no exit within 1s" in stderr_text
+    assert "process-group snapshot at SIGTERM" in stderr_text
+    # The stalled interpreter itself should be visible in the snapshot.
+    assert "time.sleep(60)" in stderr_text or "pid=" in stderr_text
+
+
+def test_timed_out_redacted_run_still_explains_itself(tmp_path: Path) -> None:
+    """The #678 shape exactly: silent hang + redacted receipt."""
+    result = _run_process(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        cwd=tmp_path,
+        env={"PATH": "/usr/bin:/bin", "FAKE_SECRET_KEY": "irrelevant-but-long"},
+        timeout_seconds=1,
+        log_prefix=tmp_path / "capture",
+        redacted=True,
+    )
+
+    assert result["timed_out"] is True
+    stderr_text = (tmp_path / "capture.stderr.log").read_text(encoding="utf-8")
+    assert "run FAILED, so the output tail is retained" in stderr_text
+    assert "process-group snapshot at SIGTERM" in stderr_text

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -189,8 +189,25 @@ def test_r2_job_runs_each_oracle_once_and_retains_the_redacted_receipt() -> None
         "the scenario must be invoked exactly twice: first attempt and one retry"
     )
     assert "r2-operational-results.attempt1.json" in code
-    assert re.search(r"mv r2-operational-results\.json r2-operational-results\.attempt1\.json", code)
+    # Attempt 1's receipt must reference its OWN logs after the rename: the
+    # retry recreates r2-operational-results.d, so without the path rewrite
+    # the retained receipt resolves to attempt 2's logs.
+    assert re.search(
+        r"jq .+gsub\(\"r2-operational-results\\\\\.d\"; "
+        r"\"r2-operational-results\.attempt1\.d\"\)",
+        code,
+    ), "the retained attempt-1 receipt must have its log paths rewritten"
     assert "::warning::" in infrastructure, "a silent retry hides the flake it absorbed"
+
+    # The job budget must cover BOTH attempts at the scenario's full
+    # timeout plus setup overhead, or the retry is unreachable exactly when
+    # the first attempt is the stall it exists to absorb.
+    timeout_match = re.search(r"timeout-minutes: (\d+)", infrastructure)
+    assert timeout_match is not None, "the R2 job lost its timeout"
+    scenario_seconds = scenario["timeout_seconds"]
+    assert int(timeout_match.group(1)) * 60 >= 2 * scenario_seconds + 240, (
+        "job timeout must cover two scenario attempts plus ~4 min overhead"
+    )
 
 
 def test_observability_audit_uses_the_existing_required_format_context() -> None:

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -172,9 +172,25 @@ def test_r2_job_runs_each_oracle_once_and_retains_the_redacted_receipt() -> None
         r"\s+path: \|\n"
         r"\s+r2-operational-results\.json\n"
         r"\s+r2-operational-results\.d/\n"
+        r"\s+r2-operational-results\.attempt1\.json\n"
+        r"\s+r2-operational-results\.attempt1\.d/\n"
         r"\s+if-no-files-found: error",
         infrastructure,
     )
+
+    # One sanctioned in-job retry: the scenario command is defined once
+    # (count above), invoked through a function, and a failed first attempt
+    # keeps its receipt as the classification record before the single
+    # retry. Nothing may retry more than once, and the retry must not
+    # discard attempt 1's evidence.
+    code = _code_only(infrastructure)
+    assert code.count("run_r2_scenario()") == 1, "scenario command must be defined exactly once"
+    assert code.count("run_r2_scenario\n") + code.count("run_r2_scenario;") == 2, (
+        "the scenario must be invoked exactly twice: first attempt and one retry"
+    )
+    assert "r2-operational-results.attempt1.json" in code
+    assert re.search(r"mv r2-operational-results\.json r2-operational-results\.attempt1\.json", code)
+    assert "::warning::" in infrastructure, "a silent retry hides the flake it absorbed"
 
 
 def test_observability_audit_uses_the_existing_required_format_context() -> None:


### PR DESCRIPTION
H4 of the harness-robustness track. The R2 lane caused two of the costliest incidents in the A1–A7 window; this makes that class diagnosable and absorbs single flakes before they evict queue entries.

## The incidents

- **#675**: single R2 flake on a diff that cannot touch R2 — held the Mission draft red for much of a session because the redacted receipt discarded the failing assertion ("exact assertion is unrecoverable").
- **#678**: merge-group R2 test produced zero output until the runner's 600s timeout SIGTERM'd it → queue eviction, ~28 min extra latency, ~1 hour of artifact forensics — and the receipt named nothing.

## What

1. **Redact secrets, not the assertion** (`scripts/run_operational_scenarios.py`): a `redacted_receipt` scenario that FAILS now retains a bounded output tail (16 KiB) with credential values masked (env values matching KEY/TOKEN/SECRET/PASSWORD/CREDENTIAL, longest-first so embedded substrings can't survive). Successful runs still discard everything; `stdout_text` remains internal (popped before receipts serialize, verified). Digest/byte counts still describe the full raw stream.
2. **Timeouts name the stalled processes**: on `TimeoutExpired` the runner photographs the process group (`ps` pid/age/command, filtered to the group) *before* SIGTERM and appends it to stderr — which the failure tail then retains even under redaction. The #678 shape (silent hang + redacted receipt) is covered by an explicit test.
3. **One sanctioned in-job retry** in the Quality R2 step: first attempt's receipt is renamed `attempt1` and retained in the artifact as the classification record, a `::warning::` annotates the absorbed flake, then exactly one retry. A real regression fails both attempts. This codifies the one-classified-rerun policy inside the job so a flake costs one extra scenario run instead of a queue eviction.

## What deliberately did NOT change

The `evals` job's "Require applicable infrastructure evidence" coupling stays. Its comment documents why it exists: an infra failure must *fail* a required context rather than skip-satisfy it (the R2 job itself is not a required check). Decoupling it would be fail-open. My original track plan called for decoupling; reading the code reversed that — the right fix is fewer, better-explained R2 failures, which is this PR.

## Verification

27/27 tests pass: 5 new capture contracts (masked failure tail, success still redacted, secret filter ordering, live timed-out subprocess with snapshot, the exact #678 shape) plus the updated workflow contract (scenario command defined once, invoked exactly twice, attempt-1 evidence retained, warning required). ruff + YAML + license headers clean.

Part of the harness track: H1 #688 → H2 #689 → H3 #690 → **H4 (this)** → H5 (review topology) → H6 (policy tunes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)