### PR TITLE
EMERGENCY: kimi quota exhausted — move both opencode lens seats to claude-code

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -134,8 +134,8 @@ jobs:
         # key must exist as a repository secret).
         include:
           - lens: daft-shape
-            backend: opencode
-            model: kimi-for-coding/k3
+            backend: claude-code
+            model: ""
           - lens: state-lifecycle
             backend: claude-code
             model: ""
@@ -146,8 +146,8 @@ jobs:
             backend: claude-code
             model: ""
           - lens: observability
-            backend: opencode
-            model: kimi-for-coding/k3
+            backend: claude-code
+            model: ""
     permissions:
       contents: read
       pull-requests: read # Supply PR metadata to the read-only detector.

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -123,11 +123,11 @@ LENSES: dict[str, tuple[str, ...]] = {
 # The final receipt records who performed each validated lens without making
 # backend identity part of the model-authored result.
 LENS_BACKENDS: dict[str, str] = {
-    "daft-shape": "opencode",
+    "daft-shape": "claude-code",
     "state-lifecycle": "claude-code",
     "contracts": "claude-code",
     "authority": "claude-code",
-    "observability": "opencode",
+    "observability": "claude-code",
 }
 
 _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -469,7 +469,7 @@ def test_rendered_no_findings_evidence_is_specific_and_digest_bound():
 
     assert "no findings" in rendered
     assert "2 changed file(s), 24 detector categories, 5/5 lenses" in rendered
-    assert "| `daft-shape` | `opencode` | validated |" in rendered
+    assert "| `daft-shape` | `claude-code` | validated |" in rendered
     assert "| `authority` | `claude-code` | validated |" in rendered
     assert "The change replaces an unsafe call" not in rendered
     assert evidence_marker(HEAD_SHA, 0, digest) in rendered
@@ -1020,7 +1020,7 @@ def test_merge_packages_one_full_coverage_review_bundle(tmp_path):
     ("mutation", "message"),
     [
         (
-            lambda bundle: bundle["lenses"][0].update(backend="claude-code"),
+            lambda bundle: bundle["lenses"][0].update(backend="opencode"),
             "backend must be",
         ),
         (


### PR DESCRIPTION
**The merge pipeline is currently bricked for every open PR.** `KIMI_API_KEY` has exhausted its billing-cycle quota (`Error: You've reached your usage limit for this billing cycle` — from the lens logs). Both kimi lenses fail every attempt, so `review-complete` (required) fails on every head — verified on #690 (rerun reproduced it), #696, and the auditor's **docs-only** #692.

## What

- The two opencode matrix seats (daft-shape, observability) → `claude-code` backend on `CLAUDE_CODE_OAUTH_TOKEN` — the same subscription auth the other three lenses use. No third-party API key remains in the verdict path (per Everett's standing constraint).
- `LENS_BACKENDS` in the gate script and the two backend test literals move in lockstep (68/68 gate tests pass).
- The opencode step + key wiring remain intact for re-pointing after quota refresh, if cross-vendor diversity is still wanted.

## ⚠️ Everett action required — this PR cannot merge itself

`pull_request_target` runs the **base branch's** workflow, so this PR is reviewed by the broken gate it fixes. Two unblock paths, pick one:

1. **Bypass-merge this PR** (owner ruleset bypass). Fastest; unbricks every open PR (#688–#696 + the A7 implementer's) on their next gate run.
2. **Restore kimi quota instead** (top-up / new key in `KIMI_API_KEY`, or configure the empty `MOONSHOT_API_KEY` secret if that provider route is intended) — then close this PR unmerged.

Until one of these happens, no PR can merge and further gate runs only burn the three claude lens invocations to die on kimi. I've stopped pushing heads accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)