### PR TITLE
fix(ci): codex lenses need the literal scope manifest

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -429,7 +429,12 @@ jobs:
           npm install -g "@openai/codex@${CODEX_VERSION}"
           printf '%s' "${SCHEMA}" > "${RUNNER_TEMP}/lens-schema.json"
           python3 - <<'EOF'
+          import json
           import os
+
+          scoped_files = json.dumps(
+              json.load(open(os.environ["SCOPE_FILE"]))["files"]
+          )
 
           prompt = f"""Review PR #{os.environ["PR_NUMBER"]} at exact head
           {os.environ["HEAD_SHA"]} for archetype-specific footguns through the
@@ -444,6 +449,12 @@ jobs:
           `.footgun-review-scope.json` and `.footgun-review.diff` are the
           authoritative scope and diff. Inspect every change plus relevant
           protected-base context through your lens.
+
+          The scope manifest for this review is exactly these changed files:
+          {scoped_files}
+          Your `reviewed_files` array must equal exactly that list — NOT the
+          skill file, the diff file, or anything else you merely opened while
+          reviewing.
 
           The gate rejects the result unless it binds to the exact head, lists
           every scoped file exactly once, lists exactly your lens's categories as
@@ -664,7 +675,12 @@ jobs:
           npm install -g "@openai/codex@${CODEX_VERSION}"
           printf '%s' "${SCHEMA}" > "${RUNNER_TEMP}/lens-schema.json"
           python3 - <<'EOF'
+          import json
           import os
+
+          scoped_files = json.dumps(
+              json.load(open(os.environ["SCOPE_FILE"]))["files"]
+          )
 
           prompt = f"""Correct or replace the first structured review response
           for PR #{os.environ["PR_NUMBER"]} at exact head
@@ -681,7 +697,12 @@ jobs:
 
           Follow the trusted `.claude/skills/footgun-detector/SKILL.md` from the
           protected base, restricted to exactly these detector categories:
-          {os.environ["CATEGORIES"]}. The corrected result must bind to the
+          {os.environ["CATEGORIES"]}. The scope manifest for this review is
+          exactly these changed files:
+          {scoped_files}
+          Your `reviewed_files` array must equal exactly that list — NOT the
+          skill file, the diff file, or anything else you merely opened.
+          The corrected result must bind to the
           exact head, list every scoped file exactly once, list exactly your
           lens's categories as `reviewed_categories`, cover every changed file
           in `review_context`, anchor findings to changed lines, and give every


### PR DESCRIPTION
Follow-up to #699, from the first all-codex probe on #692: 4/5 lenses returned schema-valid JSON whose `reviewed_files` listed the files the model *opened* (SKILL.md, the diff) rather than the scoped changed files — the validator rejected them, correctly, on both attempts. daft-shape's seat guessed the intended meaning and passed, proving the seat works when the interpretation lands.

Fix: stop asking Luna to infer — both codex prompt generators read `.footgun-review-scope.json` and inject the exact file list with an explicit "`reviewed_files` must equal exactly that list — NOT … anything you merely opened." claude-code/opencode prompts untouched; guarded replacement verified to touch only heredocs that define `scoped_files`.

Merge path: same toggle procedure as #697/#699 once its own CI is green (the gate reviewing this PR runs main's prompts, which are the broken ones). Probe #692 re-runs immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)