### PR TITLE
fix(review): drop uniqueItems from model-facing schemas

### DIFF
--- a/scripts/review_contracts.py
+++ b/scripts/review_contracts.py
@@ -479,7 +479,6 @@ def _review_context_schema() -> dict[str, Any]:
                     "type": "array",
                     "items": _text_schema(),
                     "minItems": 1,
-                    "uniqueItems": True,
                 },
                 "assessment": _text_schema(30),
             },
@@ -627,7 +626,6 @@ def human_design_brief_schema() -> dict[str, Any]:
                 "type": "array",
                 "items": _text_schema(),
                 "minItems": 1,
-                "uniqueItems": True,
             },
             "summary": _text_schema(30),
             "reading_order": {"type": "integer", "minimum": 1},
@@ -659,7 +657,6 @@ def human_design_brief_schema() -> dict[str, Any]:
             "related_cluster_ids": {
                 "type": "array",
                 "items": {"type": "string", "pattern": _DIGEST_RE},
-                "uniqueItems": True,
             },
         },
         ("question", "why_now", "options", "related_cluster_ids"),


### PR DESCRIPTION
OpenAI structured-output rejects `uniqueItems` (400 pre-call), failing the codex design-brief step on every post-#698 run — reproduced locally with the exact schema and error. All three occurrences have deterministic normalizer backstops (explicit duplicate rejection for both `files` arrays; `dict.fromkeys` dedupe for `related_cluster_ids`), so uniqueness enforcement is unchanged where it actually runs. Toggle-merge once CI is green — the gate cannot pass its own brief step until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)