### PR TITLE
feat(physical-ai): hosted Physical-AI Activity choreography + Modal parity (A7/A7b)

### DIFF
--- a/docs/guide/activities.md
+++ b/docs/guide/activities.md
@@ -3,10 +3,11 @@
 **Document type:** Normative accepted-target contract.
 
 **Status:** The boundary and migration order are ratified. The generic local
-catalog, canonical hosted Physical-AI data contract, and opt-in Mission
-author/critic integrations are implemented. Hosted Physical-AI execution and
-final topology consolidation remain separate slices. Each implementation
-slice must land its executable oracle with the behavior it enables.
+catalog, canonical hosted Physical-AI data contract, opt-in Mission
+author/critic integrations, and family-owned local hosted Activity
+choreography are implemented. Remote hosted-provider parity and final
+topology consolidation remain separate slices. Each implementation slice
+must land its executable oracle with the behavior it enables.
 
 **Scope:** Durable work admitted after one committed tick and observed by a
 later committed tick. This specification refines the required-projector rule
@@ -72,7 +73,7 @@ family adapter executes or reconciles provider work
 bounded result reference and digest become durable
         |
         v
-application workflow stages factual observations
+owning family stages factual observations
         |
         v
 tick U commits those observations
@@ -375,7 +376,40 @@ projector settles only against the exact receipt of the tick that committed
 that bundle. Processors alone decide acceptance, repair, failure, or another
 review.
 
-## 7. Resource-spike disposition
+## 7. Hosted Physical-AI crash matrix
+
+The hosted Physical-AI consumer uses
+`kind="physical_ai.hosted_episode"`. Its committed `HostedEpisodeIntent`
+contains only a family-local Activity identity, the world-scoped stable
+provider operation identity, and the exact content-addressed request identity.
+Its later `HostedEpisodeObservation` binds the bounded Activity result
+descriptor to the request, complete trajectory, derived episode results,
+manifest, and exact completeness counts.
+
+| Crash window | Durable evidence after restart | Required behavior |
+|---|---|---|
+| After intent commit, before projection | Exact receipt and request reference | Retry required projection; admit the same immutable Activity. |
+| After provider result publication, before generic result recording | Permanent operation start plus complete provider result index | Reconcile by operation identity, publish the same family payloads, and do not execute another episode. |
+| After generic result recording, before observation staging | Bounded descriptor plus complete content-addressed payloads | Reconstruct and restage the exact marker without provider work. |
+| After staging, before observation commit | Result remains unobserved; staged mutation may be lost | Restage the same marker idempotently until a tick commits it. |
+| After observation commit, before settlement | Exact later receipt contains the complete marker | Settle against that receipt without provider work or another tick. |
+| Permanent provider start exists without a complete result | Stable operation identity but ambiguous external truth | Remain unknown. Lease expiry and deterministic seeds do not authorize replay. |
+| Provider returns a partial trajectory | No valid complete manifest can be built | Publish no Activity result; remain unknown after the permanent start. |
+
+The local provider proof uses an atomic permanent start marker and a
+provider-durable first-result index. It deliberately sacrifices liveness after
+an ambiguous start rather than assume a seeded GPU rerun is equivalent.
+Remote/Modal adapters implement the same `HostedEpisodeProvider` protocol but
+remain fail-closed until they can reuse the reviewed generic provider
+operation/start/result mechanics. Provider placement and recovery records never
+enter Components.
+
+The local value store and SQLite Activity catalog are executable proof
+substrates, not claims of remote storage parity. Production trajectory and
+frame publication still belongs in Iceberg or the artifact substrate, while a
+remote control-catalog implementation is its own parity slice.
+
+## 8. Resource-spike disposition
 
 The `AsyncResources`/WorldHost prototype is retained as architecture evidence
 and is frozen. It is not the implementation path for Agent Missions or
@@ -392,7 +426,7 @@ handled as read-only, reconstructible, safely idempotent access or as an
 Activity. Evidence from the frozen spike should inform that proposal rather
 than silently entering the current refactor.
 
-## 8. Verification gates
+## 9. Verification gates
 
 The Activity migration is conforming only when focused contracts prove:
 

--- a/docs/guide/activities.md
+++ b/docs/guide/activities.md
@@ -453,6 +453,9 @@ The Activity migration is conforming only when focused contracts prove:
   a fresh execution-authorized attempt;
 - a complete result becomes durable before ECS staging;
 - restart repeatedly restages completed-but-unobserved results;
+- claim and result-delivery scans page the pending set to exhaustion, so a
+  leased prefix cannot strand a claimable Activity or skip an unobserved
+  durable result — a larger finite prefix is not conforming;
 - settlement binds the exact observation receipt and matching result
   reference/digest completeness evidence;
 - equal world-local Activity IDs in two worlds remain isolated in both control

--- a/docs/guide/activities.md
+++ b/docs/guide/activities.md
@@ -399,15 +399,22 @@ manifest, and exact completeness counts.
 The local provider proof uses an atomic permanent start marker and a
 provider-durable first-result index. It deliberately sacrifices liveness after
 an ambiguous start rather than assume a seeded GPU rerun is equivalent.
-Remote/Modal adapters implement the same `HostedEpisodeProvider` protocol but
-remain fail-closed until they can reuse the reviewed generic provider
-operation/start/result mechanics. Provider placement and recovery records never
-enter Components.
 
-The local value store and SQLite Activity catalog are executable proof
-substrates, not claims of remote storage parity. Production trajectory and
-frame publication still belongs in Iceberg or the artifact substrate, while a
-remote control-catalog implementation is its own parity slice.
+The Modal parity adapter preserves that contract under an exact workspace,
+Environment, App, Function, named Dict, named Volume, and protocol epoch. An
+atomic Dict `put(..., skip_if_exists=True)` selects one start winner. The remote
+function commits the four canonical Arrow payloads to the Volume before it
+atomically installs the bounded first-result index in the Dict. A lost function
+response is therefore recoverable; a permanent start without that index
+remains unknown and cannot be replayed. Provider placement diagnostics never
+enter canonical payloads or Components.
+
+The local family value store and SQLite Activity catalog remain executable
+proof substrates, not claims of remote storage parity. The Modal Volume and
+Dict prove provider-side start and first-result durability only. Production
+trajectory and frame publication still belongs in Iceberg or the artifact
+substrate, while a remote control-catalog implementation is its own parity
+slice.
 
 ## 8. Resource-spike disposition
 

--- a/docs/guide/physical-ai.md
+++ b/docs/guide/physical-ai.md
@@ -183,6 +183,7 @@ sequenceDiagram
 | `archetype.physical_ai.hosted_activities` | Exact-receipt projector, generic Activity adapter, fenced worker, result redelivery, and settlement choreography |
 | `archetype.physical_ai.hosted_activity_values` | Local content-addressed proof store, permanent-start seeded provider, and provider-durable first-result recovery |
 | `archetype.physical_ai.hosted_activity_world` | Exact storage reader, idempotent world stager, required-projector binding, and unsettled-work bridge |
+| `archetype.physical_ai.hosted_modal` | Exact Modal namespace, atomic hosted-start admission, Volume-first payload publication, and first-result reconciliation |
 | `CommandDispatcher` | Exact-operation admission and registered handler dispatch |
 | `RuntimeResources` | Process-scoped ownership and retryable close of live providers |
 | `ArchetypeRuntime` | Supported trusted Python entry point and sync parity |
@@ -234,7 +235,7 @@ publishes large results, stages factual observations, and binds settlement to
 the later committed receipt. It declares the lower-family ports that
 choreography needs; no parallel application-layer mirror is created.
 
-The implemented local path is:
+The provider-neutral path is:
 
 1. A tick commits `HostedEpisodeIntent`, which contains only the stable
    Activity/operation identity and a content-addressed canonical request.
@@ -255,6 +256,15 @@ a second episode. A crash after start but before a complete result remains
 permanently unknown: deterministic seeds and lease expiry are not replay
 authority. A partial trajectory cannot produce a manifest or Activity result.
 
+The Modal provider binds its identity to the exact workspace, Environment,
+App, Function, named Dict, named Volume, and protocol epoch. Its permanent
+start is an atomic Dict put-if-absent. The GPU function writes and commits the
+canonical request, trajectory, episode-results, and manifest blobs to the
+Volume before atomically publishing their bounded result index to the Dict.
+Cold reconstruction recovers that index when a completion response or worker
+process is lost, without another function spawn. A marker with no complete
+index remains reconciliation-required.
+
 `PhysicalHostedActivityBinding` exposes the required projector, worker, and
 world-scoped unsettled-work check without creating an
 `archetype.app.physical_ai` topology. The current direct per-step evaluation
@@ -269,11 +279,12 @@ world-qualified child Activity. The lifecycle unsettled-work gate is what makes
 that exact-world rule safe.
 
 The local filesystem value store and SQLite Activity catalog are restart
-oracles. They do not claim remote storage parity. Large production trajectories
-and frames belong in Iceberg/artifacts, and a Modal provider remains
-fail-closed behind the same `HostedEpisodeProvider` contract until the reviewed
-generic provider operation/start/result mechanics can be reused. No
-Mission-owned Modal barrier is imported or duplicated here.
+oracles. They do not claim remote catalog or application-publication parity.
+The Modal Dict and Volume are provider durability, not ECS state or a
+replacement for Iceberg/artifacts. No Mission-owned Modal barrier is imported:
+the Physical-AI family supplies the recovery meaning for its own provider,
+while the generic Activity catalog continues to own claims, fences, operation
+binding, result recording, and settlement.
 
 The family-owned hosted data contract is
 `archetype.physical_ai.hosted_episode`, version
@@ -488,5 +499,7 @@ The workflow enforces these contracts:
     constructor, limited to embedded-XML MuJoCo model/data scratch.
 
 The credential-free contracts live under `tests/physical_ai/`. Real LIBERO,
-VLA, GPU, and Modal adapters remain external provider implementations and paid
-dogfoods; the physical-AI family does not import them.
+VLA, and robot/simulator implementations remain external provider
+implementations and paid dogfoods. The family-owned Modal delivery adapter
+loads the optional SDK lazily and has a separate, user-triggered paid proof; it
+does not make Modal a requirement for local Physical-AI evaluation.

--- a/docs/guide/physical-ai.md
+++ b/docs/guide/physical-ai.md
@@ -178,7 +178,11 @@ sequenceDiagram
 | `archetype.physical_ai.optimization` | Pure, callback-driven instruction search |
 | `archetype.physical_ai.views` | Storage-backed terminal report projection |
 | `archetype.physical_ai.handlers` | Free world/processor/episode/query workflows over declared storage and world ports |
-| `archetype.physical_ai.hosted_episode` | Canonical whole-episode Arrow schemas, codecs, identities, digests, completeness validation, and the family-owned hosted choreography target |
+| `archetype.physical_ai.hosted_episode` | Canonical whole-episode Arrow schemas, codecs, identities, digests, and completeness validation |
+| `archetype.physical_ai.hosted_activity_contracts` | Family Components, stable operation identity, bounded content references, provider protocol, and reconciliation facts |
+| `archetype.physical_ai.hosted_activities` | Exact-receipt projector, generic Activity adapter, fenced worker, result redelivery, and settlement choreography |
+| `archetype.physical_ai.hosted_activity_values` | Local content-addressed proof store, permanent-start seeded provider, and provider-durable first-result recovery |
+| `archetype.physical_ai.hosted_activity_world` | Exact storage reader, idempotent world stager, required-projector binding, and unsettled-work bridge |
 | `CommandDispatcher` | Exact-operation admission and registered handler dispatch |
 | `RuntimeResources` | Process-scoped ownership and retryable close of live providers |
 | `ArchetypeRuntime` | Supported trusted Python entry point and sync parity |
@@ -197,7 +201,7 @@ The separation is intentional:
 - The runtime exposes the capability without exposing a concrete service or
   live `AsyncWorld`.
 
-### Accepted hosted-episode Activity target
+### Hosted-episode Activity boundary
 
 The current direct path above remains supported until its owning cutover
 passes. It supplies environment and policy clients to internal per-step
@@ -229,6 +233,40 @@ choreography that projects committed intent, invokes the Activity coordinator,
 publishes large results, stages factual observations, and binds settlement to
 the later committed receipt. It declares the lower-family ports that
 choreography needs; no parallel application-layer mirror is created.
+
+The implemented local path is:
+
+1. A tick commits `HostedEpisodeIntent`, which contains only the stable
+   Activity/operation identity and a content-addressed canonical request.
+2. `PhysicalHostedActivityProjector` reads that receipt's singleton manifest
+   head and idempotently admits the generic Activity.
+3. `PhysicalHostedActivityWorker`, outside the world lock, binds the stable
+   provider operation before asking the family provider to execute or
+   reconcile.
+4. The provider publishes a complete request/trajectory/results/manifest set
+   under a permanent operation index before the generic catalog records its
+   bounded descriptor.
+5. The worker repeatedly stages the exact `HostedEpisodeObservation`; a later
+   tick commits it, and only that exact receipt can settle the Activity.
+
+The local seeded provider acquires one permanent atomic start marker. A crash
+after complete provider publication is recovered from the first result without
+a second episode. A crash after start but before a complete result remains
+permanently unknown: deterministic seeds and lease expiry are not replay
+authority. A partial trajectory cannot produce a manifest or Activity result.
+
+`PhysicalHostedActivityBinding` exposes the required projector, worker, and
+world-scoped unsettled-work check without creating an
+`archetype.app.physical_ai` topology. The current direct per-step evaluation
+path remains supported and unchanged until consolidation; this Activity slice
+does not silently cut over runtime operations.
+
+The local filesystem value store and SQLite Activity catalog are restart
+oracles. They do not claim remote storage parity. Large production trajectories
+and frames belong in Iceberg/artifacts, and a Modal provider remains
+fail-closed behind the same `HostedEpisodeProvider` contract until the reviewed
+generic provider operation/start/result mechanics can be reused. No
+Mission-owned Modal barrier is imported or duplicated here.
 
 The family-owned hosted data contract is
 `archetype.physical_ai.hosted_episode`, version
@@ -270,9 +308,10 @@ appears exactly once, its rows are contiguous from reset through exactly one
 terminal row, no row exceeds its transition budget, every echoed request field
 and digest agrees, the per-episode results are the exact trajectory derivation,
 and the one manifest binds the other three payloads and their counts. The
-validator then requires that exact canonical manifest as the fourth payload. A7
-must publish the complete trajectory and manifest before recording a bounded
-Activity result reference; a partial trajectory is never a settleable result.
+validator then requires that exact canonical manifest as the fourth payload.
+The Activity worker publishes the complete trajectory and manifest before
+recording a bounded Activity result reference; a partial trajectory is never a
+settleable result.
 
 External simulator and robot adapters should migrate to this module rather than
 copying its schemas. The proof-era names map as follows:

--- a/docs/guide/physical-ai.md
+++ b/docs/guide/physical-ai.md
@@ -261,6 +261,13 @@ world-scoped unsettled-work check without creating an
 path remains supported and unchanged until consolidation; this Activity slice
 does not silently cut over runtime operations.
 
+Both Activity admission reads and observation-idempotency reads intentionally
+use only the current world's coordinated segment. Settled parent observations
+remain visible through ordinary lineage queries, but a fork neither re-admits
+the parent's intent nor treats a parent observation as settlement for a
+world-qualified child Activity. The lifecycle unsettled-work gate is what makes
+that exact-world rule safe.
+
 The local filesystem value store and SQLite Activity catalog are restart
 oracles. They do not claim remote storage parity. Large production trajectories
 and frames belong in Iceberg/artifacts, and a Modal provider remains

--- a/docs/planning/activity-boundary-refactor.md
+++ b/docs/planning/activity-boundary-refactor.md
@@ -46,7 +46,8 @@ shared substrate; they do not expand A2 speculatively.
 | A5a — Mission critic value contract | Family-owned `missions.critic` request/result/receipt values, deterministic bounded redacted codecs, explicit domain-review attempt identity, and a digest-bound byte-budgeted subject transport contract | Canonical round trips preserve exact base/head/diff/policy/validator and separate-sandbox identity; diff bytes never enter the command line; over-budget subjects fail closed before inference |
 | A5b — Mission critic Activity integration | Purely project exact-current-candidate intent, execute/reconcile it through generic Activities, stage a complete result-bound critic fact bundle, and settle its exact later receipt; retain legacy delivery until A8 | Real Git and managed-world crash/restart oracles prove one provider execution, exact file-bound subject identity, fresh critic sandbox, marker-last atomic staging, idempotent redelivery, and exact-receipt settlement without `CriticReviewOutbox` |
 | A6 — Hosted Physical-AI contract | Reconcile one canonical whole-episode Arrow request/result schema and result publication contract before cutover | Robot adapter and simulator agree on episode/trial cardinality, transition budget, terminal meaning, and canonical digests |
-| A7 — Hosted Physical-AI Activity | Add family-owned choreography under `archetype.physical_ai`, execute a whole seeded episode locally and on Modal, publish the full trajectory, and stage its factual observation | First result is recovered by operation identity; correctness does not depend on byte-identical GPU replay |
+| A7 — Hosted Physical-AI Activity | Add provider-neutral family choreography under `archetype.physical_ai`, execute one seeded batch of whole episodes locally, publish the complete trajectory/results/manifest, and stage its factual observation | Cold reconstruction crosses provider publication, generic result recording, staging, and later settlement without a second episode; start-without-result remains unknown |
+| A7b — Hosted Physical-AI Modal parity | Bind the same family provider protocol to the reviewed generic operation/start/result mechanics after the Modal author safety dependency lands; do not copy Mission barriers | Real Modal/GPU execution recovers its first complete result by stable operation identity and uses the exact A6 request/result contract |
 | A8 — Consolidation and refactor resume | Extract only mechanics shared by author, critic, and Physical AI; delete superseded outboxes and distributed per-step effect paths; reconcile broad docs and topology plan | No duplicate authority, no process-local durable queue, full release verification, and three end-to-end traces remain recognizable |
 
 ### A1 — Contract and plan
@@ -256,6 +257,41 @@ built for a partial trajectory. Replay configuration recursively rejects
 activation, placement, timing, credential, and host-path facts, and frame
 evidence crosses the boundary only as content-addressed references. A7 may
 execute this contract but may not redefine it.
+
+### A7 and A7b — Hosted Physical-AI execution
+
+A7 creates the hosted choreography directly in `archetype.physical_ai`; it
+does not create an `archetype.app.physical_ai` mirror. A committed
+`HostedEpisodeIntent` references the canonical A6 request. The required
+projector admits `kind="physical_ai.hosted_episode"`, and the out-of-lock
+worker binds the world-scoped stable provider operation before execution or
+reconciliation. Complete request, trajectory, derived episode results, and
+manifest bytes are content-addressed before the generic catalog records one
+bounded descriptor. `HostedEpisodeObservation` binds all four payloads and
+their exact completeness counts, and only a later matching committed receipt
+settles the Activity.
+
+The local restart oracle destroys and reconstructs the SQLite catalog,
+coordinator, value store, worker, and provider adapter across four separate
+windows:
+
+1. provider result published before generic result recording;
+2. generic result recorded before observation staging;
+3. observation staged before its tick commits; and
+4. provider start present without a complete result.
+
+The first three redeliver without a second episode. The fourth remains
+permanently unknown; lease expiry and deterministic seeds are not replay
+authority. Partial trajectory publication cannot produce a manifest or
+Activity result. The existing direct per-step path remains supported through
+this slice.
+
+A7 deliberately leaves the remote provider fail-closed behind the same family
+protocol. The safe operation/start/result barrier is genuinely shared
+mechanics, but its recovery meaning remains provider- and family-owned. A7b
+therefore reuses the reviewed generic extraction after the Modal author safety
+dependency rather than importing or duplicating Mission-owned barriers. Only
+A7b may claim real Modal/GPU parity.
 
 ## Authority and dependency target
 

--- a/docs/planning/activity-boundary-refactor.md
+++ b/docs/planning/activity-boundary-refactor.md
@@ -47,7 +47,7 @@ shared substrate; they do not expand A2 speculatively.
 | A5b — Mission critic Activity integration | Purely project exact-current-candidate intent, execute/reconcile it through generic Activities, stage a complete result-bound critic fact bundle, and settle its exact later receipt; retain legacy delivery until A8 | Real Git and managed-world crash/restart oracles prove one provider execution, exact file-bound subject identity, fresh critic sandbox, marker-last atomic staging, idempotent redelivery, and exact-receipt settlement without `CriticReviewOutbox` |
 | A6 — Hosted Physical-AI contract | Reconcile one canonical whole-episode Arrow request/result schema and result publication contract before cutover | Robot adapter and simulator agree on episode/trial cardinality, transition budget, terminal meaning, and canonical digests |
 | A7 — Hosted Physical-AI Activity | Add provider-neutral family choreography under `archetype.physical_ai`, execute one seeded batch of whole episodes locally, publish the complete trajectory/results/manifest, and stage its factual observation | Cold reconstruction crosses provider publication, generic result recording, staging, and later settlement without a second episode; start-without-result remains unknown |
-| A7b — Hosted Physical-AI Modal parity | Bind the same family provider protocol to the reviewed generic operation/start/result mechanics after the Modal author safety dependency lands; do not copy Mission barriers | Real Modal/GPU execution recovers its first complete result by stable operation identity and uses the exact A6 request/result contract |
+| A7b — Hosted Physical-AI Modal parity | Bind the same family provider protocol to exact Modal namespace identity, atomic start admission, and provider-durable first-result publication without importing Mission barriers | Real Modal/GPU execution recovers its first complete result by stable operation identity and uses the exact A6 request/result contract |
 | A8 — Consolidation and refactor resume | Extract only mechanics shared by author, critic, and Physical AI; delete superseded outboxes and distributed per-step effect paths; reconcile broad docs and topology plan | No duplicate authority, no process-local durable queue, full release verification, and three end-to-end traces remain recognizable |
 
 ### A1 — Contract and plan
@@ -287,11 +287,30 @@ Activity result. The existing direct per-step path remains supported through
 this slice.
 
 A7 deliberately leaves the remote provider fail-closed behind the same family
-protocol. The safe operation/start/result barrier is genuinely shared
-mechanics, but its recovery meaning remains provider- and family-owned. A7b
-therefore reuses the reviewed generic extraction after the Modal author safety
-dependency rather than importing or duplicating Mission-owned barriers. Only
-A7b may claim real Modal/GPU parity.
+protocol. A7b supplies the Modal implementation under an exact workspace,
+Environment, App, Function, named Dict, named Volume, and protocol epoch. One
+atomic Dict put selects the start winner; canonical A6 payloads are committed
+to the Volume before the bounded first-result index is atomically installed in
+the Dict. Completion-response loss and worker reconstruction recover that
+first result without a second episode. Start-without-result remains unknown.
+
+The adapter does not import Mission-owned barriers or move Physical-AI
+recovery meaning into generic mechanics. A8 may extract only the identity,
+atomic-admission, and immutable-result mechanics that the completed Mission
+and Physical-AI implementations actually prove to be shared.
+
+Paid A7b evidence on 2026-07-26 used one L40S-backed function in stopped Modal
+App `ap-nXLKIwCqS18C4j6UuGFMSU`. The remote completion reported one visible GPU
+and first-result index digest
+`ad70beb7153d4b83cd0c12fb6218b1e312a265199e5013eae8d94f6f42327fb0`.
+After an injected worker failure before generic Activity result recording, a
+separate process recovered the exact two-episode result without another Modal
+call and staged result digest
+`784811d10f376faf3b45284c5f2b180ba179f4a35f9575b7af37444d08678cf9`.
+Provider evidence remains in named Dict
+`arch-a7b-results-20260726-185158-c3261f` and named Volume
+`arch-a7b-values-20260726-185158-c3261f` in workspace/environment
+`vangelis-tech/main`.
 
 ## Authority and dependency target
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -315,6 +315,20 @@ method = "to_pylist"
 reason = "Canonical Arrow IPC codec boundary: the input is already one validated in-memory PyArrow RecordBatch, not a lazy Daft DataFrame, and exact Python values are required to validate cross-payload identities, terminal completeness, and canonical byte re-encoding before any Activity result reference can be recorded."
 
 [[entries]]
+path = "src/archetype/physical_ai/hosted_activities.py"
+symbol = "_component_rows"
+expr = "selected.select(*columns).to_pylist"
+method = "to_pylist"
+reason = "Exact post-commit Activity boundary: the receipt-pinned reader has already admitted and materialized the committed snapshot, and only bounded HostedEpisodeIntent or HostedEpisodeObservation scalar fields cross into generic Activity admission or exact-digest settlement."
+
+[[entries]]
+path = "src/archetype/physical_ai/hosted_activity_world.py"
+symbol = "WorldHostedEpisodeObservationStager._committed_observations"
+expr = "materialized.to_pylist"
+method = "to_pylist"
+reason = "Idempotent world-mutation boundary: StorageService has already admitted and materialized only HostedEpisodeObservation columns, whose bounded Activity identity and digest fields must enter Python to reject conflicts before staging one imperative world mutation."
+
+[[entries]]
 path = "src/archetype/storage/service.py"
 symbol = "StorageService.append_missing"
 expr = "aligned.collect"

--- a/quality/architecture.d/activities.toml
+++ b/quality/architecture.d/activities.toml
@@ -10,6 +10,7 @@ allowed_families = ["archetype.storage"]
 [[module_rule]]
 module = "archetype.activities.service"
 allowed_interfaces = [
+  "archetype.activities.interfaces.iActivityCoordinator",
   "archetype.core.interfaces.CommittedTickReceipt",
   "archetype.storage.activity_catalog.interfaces.ActivityCatalog",
 ]

--- a/quality/architecture.d/physical_ai.toml
+++ b/quality/architecture.d/physical_ai.toml
@@ -6,6 +6,7 @@
 name = "physical-ai-domain-family"
 consumer = "archetype.physical_ai"
 allowed_families = [
+  "archetype.activities",
   "archetype.storage",
   "archetype.world",
 ]

--- a/quality/observability/physical_ai.toml
+++ b/quality/observability/physical_ai.toml
@@ -67,6 +67,11 @@ operations = [
   "hosted_activity_contracts.HostedEpisodeProvider.provider",
   "hosted_activity_contracts.HostedEpisodeProvider.reconcile",
   "hosted_activity_values.HostedEpisodeRunner.run",
+  "hosted_modal.ModalHostedEpisodeRuntime.get",
+  "hosted_modal.ModalHostedEpisodeRuntime.put_if_absent",
+  "hosted_modal.ModalHostedEpisodeRuntime.read_blob",
+  "hosted_modal.ModalHostedEpisodeRuntime.spawn",
+  "hosted_modal.ModalHostedEpisodeRuntime.wait",
 ]
 signals = ["none"]
 outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
@@ -74,6 +79,7 @@ authority = "The provider's permanent operation-start evidence and first complet
 evidence = [
   "docs/guide/physical-ai.md",
   "tests/physical_ai/test_hosted_episode_activities.py",
+  "tests/physical_ai/test_hosted_modal_activity.py",
 ]
 rationale = "Provider execution and recovery are effect boundaries whose durable result or explicit unknown state is the authority; a second telemetry signal cannot make an episode complete or safe to repeat."
 

--- a/quality/observability/physical_ai.toml
+++ b/quality/observability/physical_ai.toml
@@ -60,3 +60,46 @@ evidence = [
   "tests/physical_ai/test_instruction_sweep.py",
 ]
 rationale = "Instruction perturbation is a pure strategy call and has no independently approved signal."
+
+[[disposition]]
+operations = [
+  "hosted_activity_contracts.HostedEpisodeProvider.execute",
+  "hosted_activity_contracts.HostedEpisodeProvider.provider",
+  "hosted_activity_contracts.HostedEpisodeProvider.reconcile",
+  "hosted_activity_values.HostedEpisodeRunner.run",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The provider's permanent operation-start evidence and first complete request/trajectory/result/manifest publication remain authoritative; returned typed recovery evidence reports that truth without authorizing replay from lease expiry."
+evidence = [
+  "docs/guide/physical-ai.md",
+  "tests/physical_ai/test_hosted_episode_activities.py",
+]
+rationale = "Provider execution and recovery are effect boundaries whose durable result or explicit unknown state is the authority; a second telemetry signal cannot make an episode complete or safe to repeat."
+
+[[disposition]]
+operations = [
+  "hosted_activities.PhysicalCommittedIntentReader.read",
+  "hosted_activities.PhysicalHostedActivityCatalog.admit_episode",
+  "hosted_activities.PhysicalHostedActivityCatalog.bind_provider_operation",
+  "hosted_activities.PhysicalHostedActivityCatalog.claim_episode",
+  "hosted_activities.PhysicalHostedActivityCatalog.confirm_provider_operation_absent",
+  "hosted_activities.PhysicalHostedActivityCatalog.has_unsettled_work",
+  "hosted_activities.PhysicalHostedActivityCatalog.pending_episode_results",
+  "hosted_activities.PhysicalHostedActivityCatalog.record_episode_result",
+  "hosted_activities.PhysicalHostedActivityCatalog.settle_episode_observation",
+  "hosted_activities.PhysicalHostedObservationStager.stage_hosted_episode_observation",
+  "hosted_activities.PhysicalHostedValueStore.get_request",
+  "hosted_activities.PhysicalHostedValueStore.get_result",
+  "hosted_activities.PhysicalHostedValueStore.publish_result",
+  "hosted_activities.PhysicalHostedValueStore.put_request",
+]
+signals = ["none"]
+outcomes = ["propagated_failure", "handled_outcome", "retryable_attempt"]
+authority = "The exact committed receipt, generic Activity catalog facts, content-addressed hosted payloads, and later committed HostedEpisodeObservation remain authoritative."
+evidence = [
+  "docs/guide/activities.md",
+  "docs/guide/physical-ai.md",
+  "tests/physical_ai/test_hosted_episode_activities.py",
+]
+rationale = "Family choreography translates between existing durable authorities; logging cannot acknowledge admission, publication, staging, or exact-receipt settlement."

--- a/src/archetype/activities/__init__.py
+++ b/src/archetype/activities/__init__.py
@@ -15,7 +15,11 @@ from archetype.activities.contracts import (
     ActivitySnapshot,
 )
 from archetype.activities.interfaces import iActivityCoordinator
-from archetype.activities.service import ActivityCoordinator
+from archetype.activities.service import (
+    ActivityCoordinator,
+    claim_next_pending,
+    collect_pending_results,
+)
 
 __all__ = [
     "ActivityAdmission",
@@ -28,5 +32,7 @@ __all__ = [
     "ActivityRetryGuard",
     "ActivitySettlement",
     "ActivitySnapshot",
+    "claim_next_pending",
+    "collect_pending_results",
     "iActivityCoordinator",
 ]

--- a/src/archetype/activities/contracts.py
+++ b/src/archetype/activities/contracts.py
@@ -149,15 +149,23 @@ class ActivitySettlement:
 
 @dataclass(frozen=True, slots=True)
 class ActivitySnapshot:
-    """Current durable facts for one logical activity, without a status enum."""
+    """Current durable facts for one logical activity, without a status enum.
+
+    ``sequence`` is the catalog-assigned admission order: immutable,
+    strictly monotonic across admissions, and never reassigned.  Pending
+    and result scans use it as their keyset cursor.
+    """
 
     admission: ActivityAdmission
     result: ActivityResultRef | None = None
     settlement: ActivitySettlement | None = None
     result_attempt: int | None = None
     result_fence: int | None = None
+    sequence: int | None = None
 
     def __post_init__(self) -> None:
+        if self.sequence is not None and self.sequence < 1:
+            raise ValueError("activity sequence must be positive")
         result_identity = (self.result_attempt, self.result_fence)
         if self.result is None and any(value is not None for value in result_identity):
             raise ValueError("activity result identity cannot exist without a result")

--- a/src/archetype/activities/interfaces.py
+++ b/src/archetype/activities/interfaces.py
@@ -71,6 +71,7 @@ class iActivityCoordinator(Protocol):
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> tuple[ActivitySnapshot, ...]: ...
 
     async def pending_results(

--- a/src/archetype/activities/interfaces.py
+++ b/src/archetype/activities/interfaces.py
@@ -80,6 +80,7 @@ class iActivityCoordinator(Protocol):
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> tuple[ActivitySnapshot, ...]: ...
 
     async def settle_observation(

--- a/src/archetype/activities/interfaces.py
+++ b/src/archetype/activities/interfaces.py
@@ -19,7 +19,14 @@ from archetype.activities.contracts import (
 
 @runtime_checkable
 class iActivityCoordinator(Protocol):
-    """Coordinate durable work between two exact committed world states."""
+    """Coordinate durable work between two exact committed world states.
+
+    ``pending`` and ``pending_results`` return snapshots in ascending
+    catalog admission ``sequence`` order and honor ``after_sequence`` as a
+    keyset cursor: only rows whose ``sequence`` is strictly greater are
+    returned.  Every returned snapshot must carry its ``sequence`` so scans
+    can page without an absolute offset.
+    """
 
     async def admit(self, admission: ActivityAdmission) -> ActivitySnapshot: ...
 
@@ -71,7 +78,7 @@ class iActivityCoordinator(Protocol):
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> tuple[ActivitySnapshot, ...]: ...
 
     async def pending_results(
@@ -80,7 +87,7 @@ class iActivityCoordinator(Protocol):
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> tuple[ActivitySnapshot, ...]: ...
 
     async def settle_observation(

--- a/src/archetype/activities/service.py
+++ b/src/archetype/activities/service.py
@@ -18,6 +18,7 @@ from archetype.activities.contracts import (
     ActivitySettlement,
     ActivitySnapshot,
 )
+from archetype.activities.interfaces import iActivityCoordinator
 from archetype.core.interfaces import CommittedTickReceipt
 from archetype.storage.activity_catalog.interfaces import ActivityCatalog
 from archetype.storage.activity_catalog.records import (
@@ -191,6 +192,87 @@ class ActivityCoordinator:
             )
         )
         return _snapshot(record)
+
+
+async def claim_next_pending(
+    coordinator: iActivityCoordinator,
+    *,
+    kind: str,
+    world_id: str,
+    owner: str,
+    lease_seconds: float,
+    page_size: int = 1_000,
+) -> ActivityClaim | None:
+    """Claim the first claimable pending Activity, paging until exhaustion.
+
+    A finite prefix scan strands claimable work: when other workers hold
+    leases on every row the scan can see, it reports no work even though a
+    claimable Activity sits just beyond the prefix, and that Activity stays
+    pending until an unrelated change reshuffles the prefix.  Every
+    coordinator claim scan must page to the end of the pending set before
+    concluding there is nothing to claim; a larger prefix is not a fix.
+
+    Offset paging over a mutating set can skip or repeat entries within one
+    pass; a repeat is one failed claim attempt and a skipped entry remains
+    pending for the caller's next scan, so no Activity is permanently
+    stranded.
+    """
+
+    if page_size < 1:
+        raise ValueError("claim scan page size must be positive")
+    offset = 0
+    while True:
+        page = await coordinator.pending(
+            kind=kind,
+            world_id=world_id,
+            limit=page_size,
+            offset=offset,
+        )
+        for snapshot in page:
+            claim = await coordinator.claim(
+                world_id=world_id,
+                kind=kind,
+                activity_id=snapshot.admission.activity_id,
+                owner=owner,
+                lease_seconds=lease_seconds,
+            )
+            if claim.acquired:
+                return claim
+        if len(page) < page_size:
+            return None
+        offset += page_size
+
+
+async def collect_pending_results(
+    coordinator: iActivityCoordinator,
+    *,
+    kind: str,
+    world_id: str,
+    page_size: int = 1_000,
+) -> tuple[ActivitySnapshot, ...]:
+    """Collect every unobserved durable result, paging until exhaustion.
+
+    The results-side twin of :func:`claim_next_pending`: a finite prefix
+    silently drops durable results beyond it, so an observation committed
+    on the current receipt could miss deliveries whenever a world holds
+    more than one page of unobserved results.
+    """
+
+    if page_size < 1:
+        raise ValueError("result scan page size must be positive")
+    snapshots: list[ActivitySnapshot] = []
+    offset = 0
+    while True:
+        page = await coordinator.pending_results(
+            kind=kind,
+            world_id=world_id,
+            limit=page_size,
+            offset=offset,
+        )
+        snapshots.extend(page)
+        if len(page) < page_size:
+            return tuple(snapshots)
+        offset += page_size
 
 
 def _admission_record(admission: ActivityAdmission) -> ActivityAdmissionRecord:
@@ -372,4 +454,8 @@ async def _translate_catalog_errors[T](awaitable: Awaitable[T]) -> T:
         raise ActivityConflictError(str(exc)) from exc
 
 
-__all__ = ["ActivityCoordinator"]
+__all__ = [
+    "ActivityCoordinator",
+    "claim_next_pending",
+    "collect_pending_results",
+]

--- a/src/archetype/activities/service.py
+++ b/src/archetype/activities/service.py
@@ -141,14 +141,14 @@ class ActivityCoordinator:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> tuple[ActivitySnapshot, ...]:
         records = await _translate_catalog_errors(
             self._catalog.list_incomplete_activities(
                 kind=kind,
                 world_id=world_id,
                 limit=limit,
-                offset=offset,
+                after_sequence=after_sequence,
             )
         )
         return tuple(_snapshot(record) for record in records)
@@ -159,14 +159,14 @@ class ActivityCoordinator:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> tuple[ActivitySnapshot, ...]:
         records = await _translate_catalog_errors(
             self._catalog.list_unobserved_results(
                 kind=kind,
                 world_id=world_id,
                 limit=limit,
-                offset=offset,
+                after_sequence=after_sequence,
             )
         )
         return tuple(_snapshot(record) for record in records)
@@ -212,21 +212,25 @@ async def claim_next_pending(
     coordinator claim scan must page to the end of the pending set before
     concluding there is nothing to claim; a larger prefix is not a fix.
 
-    Offset paging over a mutating set can skip or repeat entries within one
-    pass; a repeat is one failed claim attempt and a skipped entry remains
-    pending for the caller's next scan, so no Activity is permanently
-    stranded.
+    Pages advance by keyset over the catalog-assigned admission sequence:
+    each page requests rows whose ``sequence`` is strictly greater than the
+    last row of the previous page.  The cursor key is immutable and
+    monotonic, so rows that other workers complete mid-scan leave the
+    pending set without shifting the rows behind them — one pass visits
+    every Activity that stays pending throughout the scan.  A row leased
+    mid-scan is one failed claim attempt, and ``None`` means the scan
+    reached the end of the pending set, not a shifted page boundary.
     """
 
     if page_size < 1:
         raise ValueError("claim scan page size must be positive")
-    offset = 0
+    after_sequence = 0
     while True:
         page = await coordinator.pending(
             kind=kind,
             world_id=world_id,
             limit=page_size,
-            offset=offset,
+            after_sequence=after_sequence,
         )
         for snapshot in page:
             claim = await coordinator.claim(
@@ -240,7 +244,7 @@ async def claim_next_pending(
                 return claim
         if len(page) < page_size:
             return None
-        offset += page_size
+        after_sequence = _scan_cursor(page[-1])
 
 
 async def collect_pending_results(
@@ -255,24 +259,36 @@ async def collect_pending_results(
     The results-side twin of :func:`claim_next_pending`: a finite prefix
     silently drops durable results beyond it, so an observation committed
     on the current receipt could miss deliveries whenever a world holds
-    more than one page of unobserved results.
+    more than one page of unobserved results.  Pages advance by the same
+    admission-sequence keyset cursor, so results observed by other workers
+    mid-scan leave the set without shifting later rows out of the pass —
+    every result that stays unobserved throughout the scan is collected.
     """
 
     if page_size < 1:
         raise ValueError("result scan page size must be positive")
     snapshots: list[ActivitySnapshot] = []
-    offset = 0
+    after_sequence = 0
     while True:
         page = await coordinator.pending_results(
             kind=kind,
             world_id=world_id,
             limit=page_size,
-            offset=offset,
+            after_sequence=after_sequence,
         )
         snapshots.extend(page)
         if len(page) < page_size:
             return tuple(snapshots)
-        offset += page_size
+        after_sequence = _scan_cursor(page[-1])
+
+
+def _scan_cursor(snapshot: ActivitySnapshot) -> int:
+    if snapshot.sequence is None:
+        raise RuntimeError(
+            "activity scan paging requires the catalog-assigned admission "
+            "sequence on every returned snapshot"
+        )
+    return snapshot.sequence
 
 
 def _admission_record(admission: ActivityAdmission) -> ActivityAdmissionRecord:
@@ -311,6 +327,7 @@ def _activity_record(snapshot: ActivitySnapshot) -> ActivityRecord:
     result = snapshot.result
     settlement = snapshot.settlement
     return ActivityRecord(
+        sequence=snapshot.sequence,
         activity_id=admission.activity_id,
         kind=admission.kind,
         source_world_id=admission.source.world_id,
@@ -440,6 +457,7 @@ def _snapshot(record: ActivityRecord) -> ActivitySnapshot:
         settlement=settlement,
         result_attempt=record.result_attempt,
         result_fence=record.result_fence,
+        sequence=record.sequence,
     )
 
 

--- a/src/archetype/activities/service.py
+++ b/src/archetype/activities/service.py
@@ -158,12 +158,14 @@ class ActivityCoordinator:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> tuple[ActivitySnapshot, ...]:
         records = await _translate_catalog_errors(
             self._catalog.list_unobserved_results(
                 kind=kind,
                 world_id=world_id,
                 limit=limit,
+                offset=offset,
             )
         )
         return tuple(_snapshot(record) for record in records)

--- a/src/archetype/activities/service.py
+++ b/src/archetype/activities/service.py
@@ -140,12 +140,14 @@ class ActivityCoordinator:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> tuple[ActivitySnapshot, ...]:
         records = await _translate_catalog_errors(
             self._catalog.list_incomplete_activities(
                 kind=kind,
                 world_id=world_id,
                 limit=limit,
+                offset=offset,
             )
         )
         return tuple(_snapshot(record) for record in records)

--- a/src/archetype/app/missions/activity_coordinator.py
+++ b/src/archetype/app/missions/activity_coordinator.py
@@ -12,6 +12,8 @@ from archetype.activities import (
     ActivityResultRef,
     ActivityRetryGuard,
     ActivitySettlement,
+    claim_next_pending,
+    collect_pending_results,
     iActivityCoordinator,
 )
 from archetype.app.missions.activities import (
@@ -25,6 +27,11 @@ from archetype.missions.activities import (
     AuthorActivityResultRef,
     AuthorActivityRetryGuard,
 )
+
+# Pending-scan page size, not a scan bound: claim and result scans page
+# until the catalog is exhausted.  A module constant so tests can shrink
+# it and prove the pagination property with few rows.
+_CLAIM_SCAN_PAGE = 1_000
 
 
 class MissionAuthorActivityCoordinator:
@@ -85,23 +92,19 @@ class MissionAuthorActivityCoordinator:
         world_id: str,
         owner: str,
     ) -> AuthorActivityClaim | None:
-        pending = await self._coordinator.pending(
+        # Page until the catalog is exhausted: the old finite 10,000-row
+        # prefix stranded claimable author work behind leased rows.
+        generic = await claim_next_pending(
+            self._coordinator,
             kind=AUTHOR_ACTIVITY_KIND,
             world_id=world_id,
-            limit=10_000,
+            owner=owner,
+            lease_seconds=self._lease_seconds,
+            page_size=_CLAIM_SCAN_PAGE,
         )
-        for snapshot in pending:
-            generic = await self._coordinator.claim(
-                kind=AUTHOR_ACTIVITY_KIND,
-                world_id=world_id,
-                activity_id=snapshot.admission.activity_id,
-                owner=owner,
-                lease_seconds=self._lease_seconds,
-            )
-            if not generic.acquired:
-                continue
-            return self._remember(generic)
-        return None
+        if generic is None:
+            return None
+        return self._remember(generic)
 
     async def bind_provider_operation(
         self,
@@ -149,9 +152,13 @@ class MissionAuthorActivityCoordinator:
         *,
         world_id: str,
     ) -> tuple[AuthorActivityResultDelivery, ...]:
-        snapshots = await self._coordinator.pending_results(
+        # Results-side twin of the claim scan: page to exhaustion so a
+        # durable result beyond the first page still reaches observation.
+        snapshots = await collect_pending_results(
+            self._coordinator,
             kind=AUTHOR_ACTIVITY_KIND,
             world_id=world_id,
+            page_size=_CLAIM_SCAN_PAGE,
         )
         deliveries: list[AuthorActivityResultDelivery] = []
         for snapshot in snapshots:

--- a/src/archetype/app/missions/critic_activity_coordinator.py
+++ b/src/archetype/app/missions/critic_activity_coordinator.py
@@ -12,6 +12,8 @@ from archetype.activities import (
     ActivityResultRef,
     ActivityRetryGuard,
     ActivitySettlement,
+    claim_next_pending,
+    collect_pending_results,
     iActivityCoordinator,
 )
 from archetype.core.interfaces import CommittedTickReceipt
@@ -26,6 +28,11 @@ from .critic_activities import (
     CriticActivityClaim,
     CriticActivityResultDelivery,
 )
+
+# Pending-scan page size, not a scan bound: claim and result scans page
+# until the catalog is exhausted.  A module constant so tests can shrink
+# it and prove the pagination property with few rows.
+_CLAIM_SCAN_PAGE = 1_000
 
 
 class MissionCriticActivityCoordinator:
@@ -86,22 +93,19 @@ class MissionCriticActivityCoordinator:
         world_id: str,
         owner: str,
     ) -> CriticActivityClaim | None:
-        pending = await self._coordinator.pending(
+        # Page until the catalog is exhausted: the old single default-sized
+        # prefix (100 rows) stranded claimable critic work behind leased rows.
+        generic = await claim_next_pending(
+            self._coordinator,
             kind=CRITIC_ACTIVITY_KIND,
             world_id=world_id,
+            owner=owner,
+            lease_seconds=self._lease_seconds,
+            page_size=_CLAIM_SCAN_PAGE,
         )
-        for snapshot in pending:
-            generic = await self._coordinator.claim(
-                kind=CRITIC_ACTIVITY_KIND,
-                world_id=world_id,
-                activity_id=snapshot.admission.activity_id,
-                owner=owner,
-                lease_seconds=self._lease_seconds,
-            )
-            if not generic.acquired:
-                continue
-            return self._remember(generic)
-        return None
+        if generic is None:
+            return None
+        return self._remember(generic)
 
     async def bind_provider_operation(
         self,
@@ -149,9 +153,13 @@ class MissionCriticActivityCoordinator:
         *,
         world_id: str,
     ) -> tuple[CriticActivityResultDelivery, ...]:
-        snapshots = await self._coordinator.pending_results(
+        # Results-side twin of the claim scan: page to exhaustion so a
+        # durable result beyond the first page still reaches observation.
+        snapshots = await collect_pending_results(
+            self._coordinator,
             kind=CRITIC_ACTIVITY_KIND,
             world_id=world_id,
+            page_size=_CLAIM_SCAN_PAGE,
         )
         deliveries: list[CriticActivityResultDelivery] = []
         for snapshot in snapshots:

--- a/src/archetype/physical_ai/hosted_activities.py
+++ b/src/archetype/physical_ai/hosted_activities.py
@@ -13,12 +13,12 @@ from daft import DataFrame, col
 
 from archetype.activities import (
     ActivityAdmission,
-    ActivitySnapshot,
     ActivityClaim,
     ActivityConflictError,
     ActivityResultRef,
     ActivityRetryGuard,
     ActivitySettlement,
+    ActivitySnapshot,
     iActivityCoordinator,
 )
 from archetype.core.hooks import PostTick

--- a/src/archetype/physical_ai/hosted_activities.py
+++ b/src/archetype/physical_ai/hosted_activities.py
@@ -18,7 +18,8 @@ from archetype.activities import (
     ActivityResultRef,
     ActivityRetryGuard,
     ActivitySettlement,
-    ActivitySnapshot,
+    claim_next_pending,
+    collect_pending_results,
     iActivityCoordinator,
 )
 from archetype.core.hooks import PostTick
@@ -46,9 +47,10 @@ from archetype.physical_ai.hosted_episode import (
     hosted_episode_request_digest,
 )
 
-# Pending-scan page size for claim_episode; a module constant so tests can
-# shrink it and prove the pagination property without 10,000 rows.
-_CLAIM_SCAN_BATCH = 10_000
+# Pending-scan page size, not a scan bound: claim and result scans page
+# until the catalog is exhausted.  A module constant so tests can shrink
+# it and prove the pagination property with few rows.
+_CLAIM_SCAN_PAGE = 1_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -457,33 +459,19 @@ class PhysicalHostedActivityCoordinator:
     ) -> HostedEpisodeActivityClaim | None:
         # Page until the catalog is exhausted: a finite prefix scan stranded
         # claimable Activities beyond the batch when the head of the pending
-        # set was leased by other workers — they stayed pending until an
-        # unrelated change reshuffled the prefix. Offset paging over a
-        # mutating set can skip or repeat entries within one pass; a repeat
-        # is a failed claim attempt and a skipped entry remains incomplete
-        # for the next pass, so no Activity is permanently stranded.
-        offset = 0
-        batch = _CLAIM_SCAN_BATCH
-        while True:
-            pending = await self._coordinator.pending(
-                kind=HOSTED_EPISODE_ACTIVITY_KIND,
-                world_id=world_id,
-                limit=batch,
-                offset=offset,
-            )
-            for snapshot in pending:
-                generic = await self._coordinator.claim(
-                    world_id,
-                    HOSTED_EPISODE_ACTIVITY_KIND,
-                    snapshot.admission.activity_id,
-                    owner,
-                    lease_seconds=self._lease_seconds,
-                )
-                if generic.acquired:
-                    return self._remember(generic)
-            if len(pending) < batch:
-                return None
-            offset += batch
+        # set was leased by other workers.  claim_next_pending carries this
+        # invariant for the author, critic, and hosted coordinators alike.
+        generic = await claim_next_pending(
+            self._coordinator,
+            kind=HOSTED_EPISODE_ACTIVITY_KIND,
+            world_id=world_id,
+            owner=owner,
+            lease_seconds=self._lease_seconds,
+            page_size=_CLAIM_SCAN_PAGE,
+        )
+        if generic is None:
+            return None
+        return self._remember(generic)
 
     async def bind_provider_operation(
         self,
@@ -536,19 +524,12 @@ class PhysicalHostedActivityCoordinator:
         # receipt could miss its delivery when a world held more than one
         # page of unobserved results — the results-side twin of the
         # claim_episode stranding fix.
-        snapshots: list[ActivitySnapshot] = []
-        offset = 0
-        while True:
-            page = await self._coordinator.pending_results(
-                kind=HOSTED_EPISODE_ACTIVITY_KIND,
-                world_id=world_id,
-                limit=_CLAIM_SCAN_BATCH,
-                offset=offset,
-            )
-            snapshots.extend(page)
-            if len(page) < _CLAIM_SCAN_BATCH:
-                break
-            offset += _CLAIM_SCAN_BATCH
+        snapshots = await collect_pending_results(
+            self._coordinator,
+            kind=HOSTED_EPISODE_ACTIVITY_KIND,
+            world_id=world_id,
+            page_size=_CLAIM_SCAN_PAGE,
+        )
         deliveries: list[HostedEpisodeResultDelivery] = []
         for snapshot in snapshots:
             result = snapshot.result

--- a/src/archetype/physical_ai/hosted_activities.py
+++ b/src/archetype/physical_ai/hosted_activities.py
@@ -45,6 +45,10 @@ from archetype.physical_ai.hosted_episode import (
     hosted_episode_request_digest,
 )
 
+# Pending-scan page size for claim_episode; a module constant so tests can
+# shrink it and prove the pagination property without 10,000 rows.
+_CLAIM_SCAN_BATCH = 10_000
+
 
 @dataclass(frozen=True, slots=True)
 class HostedEpisodeActivityClaim:
@@ -450,22 +454,35 @@ class PhysicalHostedActivityCoordinator:
         world_id: str,
         owner: str,
     ) -> HostedEpisodeActivityClaim | None:
-        pending = await self._coordinator.pending(
-            kind=HOSTED_EPISODE_ACTIVITY_KIND,
-            world_id=world_id,
-            limit=10_000,
-        )
-        for snapshot in pending:
-            generic = await self._coordinator.claim(
-                world_id,
-                HOSTED_EPISODE_ACTIVITY_KIND,
-                snapshot.admission.activity_id,
-                owner,
-                lease_seconds=self._lease_seconds,
+        # Page until the catalog is exhausted: a finite prefix scan stranded
+        # claimable Activities beyond the batch when the head of the pending
+        # set was leased by other workers — they stayed pending until an
+        # unrelated change reshuffled the prefix. Offset paging over a
+        # mutating set can skip or repeat entries within one pass; a repeat
+        # is a failed claim attempt and a skipped entry remains incomplete
+        # for the next pass, so no Activity is permanently stranded.
+        offset = 0
+        batch = _CLAIM_SCAN_BATCH
+        while True:
+            pending = await self._coordinator.pending(
+                kind=HOSTED_EPISODE_ACTIVITY_KIND,
+                world_id=world_id,
+                limit=batch,
+                offset=offset,
             )
-            if generic.acquired:
-                return self._remember(generic)
-        return None
+            for snapshot in pending:
+                generic = await self._coordinator.claim(
+                    world_id,
+                    HOSTED_EPISODE_ACTIVITY_KIND,
+                    snapshot.admission.activity_id,
+                    owner,
+                    lease_seconds=self._lease_seconds,
+                )
+                if generic.acquired:
+                    return self._remember(generic)
+            if len(pending) < batch:
+                return None
+            offset += batch
 
     async def bind_provider_operation(
         self,

--- a/src/archetype/physical_ai/hosted_activities.py
+++ b/src/archetype/physical_ai/hosted_activities.py
@@ -13,6 +13,7 @@ from daft import DataFrame, col
 
 from archetype.activities import (
     ActivityAdmission,
+    ActivitySnapshot,
     ActivityClaim,
     ActivityConflictError,
     ActivityResultRef,
@@ -530,10 +531,24 @@ class PhysicalHostedActivityCoordinator:
         *,
         world_id: str,
     ) -> tuple[HostedEpisodeResultDelivery, ...]:
-        snapshots = await self._coordinator.pending_results(
-            kind=HOSTED_EPISODE_ACTIVITY_KIND,
-            world_id=world_id,
-        )
+        # Page to exhaustion: the default 100-row prefix skipped durable
+        # results beyond it, so an observation committed on the current
+        # receipt could miss its delivery when a world held more than one
+        # page of unobserved results — the results-side twin of the
+        # claim_episode stranding fix.
+        snapshots: list[ActivitySnapshot] = []
+        offset = 0
+        while True:
+            page = await self._coordinator.pending_results(
+                kind=HOSTED_EPISODE_ACTIVITY_KIND,
+                world_id=world_id,
+                limit=_CLAIM_SCAN_BATCH,
+                offset=offset,
+            )
+            snapshots.extend(page)
+            if len(page) < _CLAIM_SCAN_BATCH:
+                break
+            offset += _CLAIM_SCAN_BATCH
         deliveries: list[HostedEpisodeResultDelivery] = []
         for snapshot in snapshots:
             result = snapshot.result

--- a/src/archetype/physical_ai/hosted_activities.py
+++ b/src/archetype/physical_ai/hosted_activities.py
@@ -221,12 +221,13 @@ class HostedEpisodeReconciliationRequired(AvailabilityError):
 
     public_detail = "Hosted episode provider state is temporarily unavailable"
 
-    def __init__(self, activity_id: str, operation_id: str) -> None:
+    def __init__(self, activity_id: str, operation_id: str, reason: str) -> None:
         self.activity_id = activity_id
         self.operation_id = operation_id
+        self.reason = reason
         super().__init__(
             f"hosted episode {activity_id!r} requires provider reconciliation "
-            f"for operation {operation_id!r}"
+            f"for operation {operation_id!r}: {reason}"
         )
 
 
@@ -698,6 +699,7 @@ class PhysicalHostedActivityWorker:
                 raise HostedEpisodeReconciliationRequired(
                     claim.activity_id,
                     claim.provider_operation_id,
+                    reconciliation.reason,
                 )
             raise TypeError("hosted provider returned invalid reconciliation evidence")
 

--- a/src/archetype/physical_ai/hosted_activities.py
+++ b/src/archetype/physical_ai/hosted_activities.py
@@ -453,6 +453,7 @@ class PhysicalHostedActivityCoordinator:
         pending = await self._coordinator.pending(
             kind=HOSTED_EPISODE_ACTIVITY_KIND,
             world_id=world_id,
+            limit=10_000,
         )
         for snapshot in pending:
             generic = await self._coordinator.claim(

--- a/src/archetype/physical_ai/hosted_activities.py
+++ b/src/archetype/physical_ai/hosted_activities.py
@@ -1,0 +1,809 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Intent-to-Activity-to-observation choreography for hosted Physical AI."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from daft import DataFrame, col
+
+from archetype.activities import (
+    ActivityAdmission,
+    ActivityClaim,
+    ActivityConflictError,
+    ActivityResultRef,
+    ActivityRetryGuard,
+    ActivitySettlement,
+    iActivityCoordinator,
+)
+from archetype.core.hooks import PostTick
+from archetype.core.interfaces import ArchetypeSignature, CommittedTickReceipt
+from archetype.errors import AvailabilityError
+from archetype.physical_ai.hosted_activity_contracts import (
+    HOSTED_EPISODE_ACTIVITY_KIND,
+    HostedEpisodeActivityResultRef,
+    HostedEpisodeConfirmedAbsent,
+    HostedEpisodeIntent,
+    HostedEpisodeObservation,
+    HostedEpisodeProvider,
+    HostedEpisodeProviderResult,
+    HostedEpisodePublishedResult,
+    HostedEpisodeRecovered,
+    HostedEpisodeRecoveryUnknown,
+    HostedEpisodeRequestIdentity,
+    HostedEpisodeRequestRef,
+    HostedEpisodeRetryGuard,
+    hosted_episode_provider_operation_id,
+    validate_hosted_provider_result,
+)
+from archetype.physical_ai.hosted_episode import (
+    decode_hosted_episode_requests,
+    hosted_episode_request_digest,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeActivityClaim:
+    """One fenced delivery of a logical whole-episode Activity."""
+
+    world_id: str
+    activity_id: str
+    attempt: int
+    fence: int
+    request: HostedEpisodeRequestIdentity
+    provider: str = ""
+    provider_operation_id: str = ""
+    reconciliation_required: bool = False
+    retry_guard: HostedEpisodeRetryGuard | None = None
+
+    def __post_init__(self) -> None:
+        if not self.world_id.strip() or not self.activity_id.strip():
+            raise ValueError("hosted claim requires world and activity identities")
+        if self.attempt < 1 or self.fence < 1:
+            raise ValueError("hosted claim requires positive attempt and fence values")
+        if bool(self.provider) != bool(self.provider_operation_id):
+            raise ValueError("hosted claim provider identity must be complete")
+        if self.reconciliation_required and not self.provider_operation_id:
+            raise ValueError("hosted reconciliation claim requires provider identity")
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeResultDelivery:
+    """One complete result awaiting a committed factual observation."""
+
+    world_id: str
+    activity_id: str
+    request: HostedEpisodeRequestIdentity
+    result: HostedEpisodeActivityResultRef
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedPhysicalSnapshot:
+    """Physical-AI view read from one exact committed receipt."""
+
+    world_id: str
+    run_id: str
+    committed_tick: int
+    visibility_token: str
+    results: Mapping[ArchetypeSignature, DataFrame]
+
+    def __post_init__(self) -> None:
+        if not self.world_id.strip() or not self.run_id.strip():
+            raise ValueError("committed physical snapshot requires world and run identities")
+        if self.committed_tick < 0:
+            raise ValueError("committed physical snapshot tick cannot be negative")
+        if not self.visibility_token.strip():
+            raise ValueError("committed physical snapshot requires a visibility token")
+
+    @property
+    def receipt_identity(self) -> tuple[str, str, int, str]:
+        return (
+            self.world_id,
+            self.run_id,
+            self.committed_tick,
+            self.visibility_token,
+        )
+
+    def as_post_tick(self) -> PostTick:
+        return PostTick(
+            world_id=self.world_id,
+            tick=self.committed_tick + 1,
+            results=dict(self.results),
+        )
+
+
+@runtime_checkable
+class PhysicalCommittedIntentReader(Protocol):
+    """Read only the exact physical snapshot named by a committed receipt."""
+
+    async def read(self, receipt: CommittedTickReceipt) -> CommittedPhysicalSnapshot: ...
+
+
+@runtime_checkable
+class PhysicalHostedActivityCatalog(Protocol):
+    """Physical-AI view over generic Activity coordination mechanics."""
+
+    async def admit_episode(
+        self,
+        *,
+        world_id: str,
+        receipt: CommittedTickReceipt,
+        activity_id: str,
+        request: HostedEpisodeRequestRef,
+    ) -> None: ...
+
+    async def claim_episode(
+        self,
+        *,
+        world_id: str,
+        owner: str,
+    ) -> HostedEpisodeActivityClaim | None: ...
+
+    async def bind_provider_operation(
+        self,
+        claim: HostedEpisodeActivityClaim,
+        *,
+        provider: str,
+        operation_id: str,
+    ) -> HostedEpisodeActivityClaim: ...
+
+    async def confirm_provider_operation_absent(
+        self,
+        claim: HostedEpisodeActivityClaim,
+        guard: HostedEpisodeRetryGuard,
+    ) -> HostedEpisodeActivityClaim: ...
+
+    async def record_episode_result(
+        self,
+        claim: HostedEpisodeActivityClaim,
+        result: HostedEpisodeActivityResultRef,
+    ) -> None: ...
+
+    async def pending_episode_results(
+        self,
+        *,
+        world_id: str,
+    ) -> tuple[HostedEpisodeResultDelivery, ...]: ...
+
+    async def settle_episode_observation(
+        self,
+        *,
+        world_id: str,
+        activity_id: str,
+        result_digest: str,
+        receipt: CommittedTickReceipt,
+    ) -> None: ...
+
+    async def has_unsettled_work(self, world_id: str) -> bool: ...
+
+
+@runtime_checkable
+class PhysicalHostedValueStore(Protocol):
+    """Durable request, trajectory, result, and manifest publication."""
+
+    async def put_request(self, request_ipc: bytes) -> HostedEpisodeRequestRef: ...
+
+    async def get_request(
+        self,
+        value: HostedEpisodeRequestRef | HostedEpisodeRequestIdentity,
+    ) -> bytes: ...
+
+    async def publish_result(
+        self,
+        request: HostedEpisodeRequestRef,
+        result: HostedEpisodeProviderResult,
+    ) -> HostedEpisodePublishedResult: ...
+
+    async def get_result(
+        self,
+        value: HostedEpisodeActivityResultRef,
+    ) -> HostedEpisodePublishedResult: ...
+
+
+@runtime_checkable
+class PhysicalHostedObservationStager(Protocol):
+    """Idempotently stage one factual completion marker for a later tick."""
+
+    async def stage_hosted_episode_observation(
+        self,
+        *,
+        world_id: str,
+        observation: HostedEpisodeObservation,
+    ) -> None: ...
+
+
+class HostedEpisodeReconciliationRequired(AvailabilityError):
+    """A provider-bound episode cannot safely be replayed."""
+
+    public_detail = "Hosted episode provider state is temporarily unavailable"
+
+    def __init__(self, activity_id: str, operation_id: str) -> None:
+        self.activity_id = activity_id
+        self.operation_id = operation_id
+        super().__init__(
+            f"hosted episode {activity_id!r} requires provider reconciliation "
+            f"for operation {operation_id!r}"
+        )
+
+
+def _component_rows(
+    event: PostTick,
+    component_type: type[HostedEpisodeIntent] | type[HostedEpisodeObservation],
+) -> tuple[HostedEpisodeIntent | HostedEpisodeObservation, ...]:
+    prefix = component_type.get_prefix()
+    columns = [f"{prefix}{field}" for field in component_type.model_fields]
+    values: list[HostedEpisodeIntent | HostedEpisodeObservation] = []
+    for signature, frame in event.results.items():
+        if component_type not in signature:
+            continue
+        selected = frame
+        if "is_active" in frame.column_names:
+            selected = selected.where(col("is_active"))
+        for row in selected.select(*columns).to_pylist():
+            values.append(
+                component_type(
+                    **{field: row[f"{prefix}{field}"] for field in component_type.model_fields}
+                )
+            )
+    return tuple(values)
+
+
+class PhysicalHostedActivityProjector:
+    """Admit committed intents and settle exact later observation markers."""
+
+    consumer_name = "physical-ai.hosted-episodes"
+
+    def __init__(
+        self,
+        *,
+        reader: PhysicalCommittedIntentReader,
+        catalog: PhysicalHostedActivityCatalog,
+        values: PhysicalHostedValueStore,
+    ) -> None:
+        self._reader = reader
+        self._catalog = catalog
+        self._values = values
+
+    async def project(self, receipt: CommittedTickReceipt) -> None:
+        if receipt.visibility_token is None:
+            raise ValueError("hosted episode projection requires a visibility token")
+        snapshot = await self._reader.read(receipt)
+        if snapshot.receipt_identity != receipt.identity:
+            raise ValueError("physical snapshot does not match the exact committed receipt")
+        event = snapshot.as_post_tick()
+
+        intents = self._unique_intents(_component_rows(event, HostedEpisodeIntent))
+        for intent in intents.values():
+            request_ref = HostedEpisodeRequestRef(
+                ref=intent.request_ref,
+                digest=intent.request_digest,
+                size_bytes=intent.request_size_bytes,
+            )
+            request_ipc = await self._values.get_request(request_ref)
+            self._validate_intent(receipt.world_id, intent, request_ipc)
+            await self._catalog.admit_episode(
+                world_id=receipt.world_id,
+                receipt=receipt,
+                activity_id=intent.activity_id,
+                request=request_ref,
+            )
+
+        pending = {
+            delivery.activity_id: delivery
+            for delivery in await self._catalog.pending_episode_results(
+                world_id=receipt.world_id,
+            )
+        }
+        observations = self._unique_observations(_component_rows(event, HostedEpisodeObservation))
+        for observation in observations.values():
+            delivery = pending.get(observation.activity_id)
+            if delivery is None:
+                continue
+            published = await self._values.get_result(delivery.result)
+            expected = published.observation(observation.activity_id)
+            if observation != expected:
+                continue
+            await self._catalog.settle_episode_observation(
+                world_id=receipt.world_id,
+                activity_id=observation.activity_id,
+                result_digest=observation.result_digest,
+                receipt=receipt,
+            )
+
+    @staticmethod
+    def _unique_intents(
+        intents: tuple[HostedEpisodeIntent | HostedEpisodeObservation, ...],
+    ) -> dict[str, HostedEpisodeIntent]:
+        unique: dict[str, HostedEpisodeIntent] = {}
+        for value in intents:
+            if not isinstance(value, HostedEpisodeIntent):
+                raise TypeError("hosted intent projection returned another component")
+            existing = unique.get(value.activity_id)
+            if existing is not None and existing != value:
+                raise ValueError("one hosted activity has conflicting committed intents")
+            unique[value.activity_id] = value
+        return unique
+
+    @staticmethod
+    def _unique_observations(
+        observations: tuple[HostedEpisodeIntent | HostedEpisodeObservation, ...],
+    ) -> dict[str, HostedEpisodeObservation]:
+        unique: dict[str, HostedEpisodeObservation] = {}
+        for value in observations:
+            if not isinstance(value, HostedEpisodeObservation):
+                raise TypeError("hosted observation projection returned another component")
+            if value.activity_id in unique:
+                raise ValueError("one hosted Activity has multiple committed observation markers")
+            unique[value.activity_id] = value
+        return unique
+
+    @staticmethod
+    def _validate_intent(
+        world_id: str,
+        intent: HostedEpisodeIntent,
+        request_ipc: bytes,
+    ) -> None:
+        digest = hosted_episode_request_digest(request_ipc)
+        rows = decode_hosted_episode_requests(request_ipc)
+        expected_operation = hosted_episode_provider_operation_id(
+            world_id,
+            intent.activity_id,
+        )
+        if (
+            intent.request_digest != digest
+            or intent.request_size_bytes != len(request_ipc)
+            or intent.operation_id != expected_operation
+            or any(row["operation_id"] != expected_operation for row in rows)
+            or intent.episode_count != len(rows)
+        ):
+            raise ValueError("committed hosted intent does not match its durable request")
+
+
+async def prepare_hosted_episode_intent(
+    values: PhysicalHostedValueStore,
+    *,
+    world_id: str,
+    activity_id: str,
+    request_ipc: bytes,
+) -> HostedEpisodeIntent:
+    """Publish an immutable request and return the Component to commit."""
+
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    rows = decode_hosted_episode_requests(request_ipc)
+    if any(row["operation_id"] != operation_id for row in rows):
+        raise ValueError("hosted request operation does not match its world Activity")
+    request = await values.put_request(request_ipc)
+    if request.digest != hosted_episode_request_digest(request_ipc) or request.size_bytes != len(
+        request_ipc
+    ):
+        raise ValueError("hosted value store returned another request identity")
+    return HostedEpisodeIntent(
+        activity_id=activity_id,
+        operation_id=operation_id,
+        request_ref=request.ref,
+        request_digest=request.digest,
+        request_size_bytes=request.size_bytes,
+        episode_count=len(rows),
+    )
+
+
+class PhysicalHostedActivityCoordinator:
+    """Translate generic mechanics into the Physical-AI family port."""
+
+    def __init__(
+        self,
+        coordinator: iActivityCoordinator,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> None:
+        if lease_seconds <= 0:
+            raise ValueError("hosted episode Activity lease must be positive")
+        self._coordinator = coordinator
+        self._lease_seconds = lease_seconds
+        self._claims: dict[tuple[str, str, int], ActivityClaim] = {}
+
+    async def admit_episode(
+        self,
+        *,
+        world_id: str,
+        receipt: CommittedTickReceipt,
+        activity_id: str,
+        request: HostedEpisodeRequestRef,
+    ) -> None:
+        if world_id != receipt.world_id:
+            raise ValueError("hosted episode admission belongs to another world")
+        admission = ActivityAdmission(
+            activity_id=activity_id,
+            kind=HOSTED_EPISODE_ACTIVITY_KIND,
+            source=receipt,
+            input_ref=request.ref,
+            input_digest=request.digest,
+        )
+        existing = await self._coordinator.get(
+            world_id,
+            HOSTED_EPISODE_ACTIVITY_KIND,
+            activity_id,
+        )
+        if existing is not None:
+            self._validate_existing(existing.admission, admission)
+            return
+        try:
+            await self._coordinator.admit(admission)
+        except ActivityConflictError:
+            existing = await self._coordinator.get(
+                world_id,
+                HOSTED_EPISODE_ACTIVITY_KIND,
+                activity_id,
+            )
+            if existing is None:
+                raise
+            self._validate_existing(existing.admission, admission)
+
+    async def claim_episode(
+        self,
+        *,
+        world_id: str,
+        owner: str,
+    ) -> HostedEpisodeActivityClaim | None:
+        pending = await self._coordinator.pending(
+            kind=HOSTED_EPISODE_ACTIVITY_KIND,
+            world_id=world_id,
+        )
+        for snapshot in pending:
+            generic = await self._coordinator.claim(
+                world_id,
+                HOSTED_EPISODE_ACTIVITY_KIND,
+                snapshot.admission.activity_id,
+                owner,
+                lease_seconds=self._lease_seconds,
+            )
+            if generic.acquired:
+                return self._remember(generic)
+        return None
+
+    async def bind_provider_operation(
+        self,
+        claim: HostedEpisodeActivityClaim,
+        *,
+        provider: str,
+        operation_id: str,
+    ) -> HostedEpisodeActivityClaim:
+        generic = await self._coordinator.bind_provider_operation(
+            self._resolve(claim),
+            provider,
+            operation_id,
+        )
+        return self._remember(generic)
+
+    async def confirm_provider_operation_absent(
+        self,
+        claim: HostedEpisodeActivityClaim,
+        guard: HostedEpisodeRetryGuard,
+    ) -> HostedEpisodeActivityClaim:
+        generic = await self._coordinator.confirm_provider_operation_absent(
+            self._resolve(claim),
+            ActivityRetryGuard(ref=guard.ref, digest=guard.digest),
+            lease_seconds=self._lease_seconds,
+        )
+        return self._remember(generic)
+
+    async def record_episode_result(
+        self,
+        claim: HostedEpisodeActivityClaim,
+        result: HostedEpisodeActivityResultRef,
+    ) -> None:
+        await self._coordinator.record_result(
+            self._resolve(claim),
+            ActivityResultRef(
+                ref=result.ref,
+                digest=result.digest,
+                media_type=result.media_type,
+                size_bytes=result.size_bytes,
+            ),
+        )
+
+    async def pending_episode_results(
+        self,
+        *,
+        world_id: str,
+    ) -> tuple[HostedEpisodeResultDelivery, ...]:
+        snapshots = await self._coordinator.pending_results(
+            kind=HOSTED_EPISODE_ACTIVITY_KIND,
+            world_id=world_id,
+        )
+        deliveries: list[HostedEpisodeResultDelivery] = []
+        for snapshot in snapshots:
+            result = snapshot.result
+            if result is None:
+                raise AssertionError("pending hosted Activity has no result")
+            admission = snapshot.admission
+            deliveries.append(
+                HostedEpisodeResultDelivery(
+                    world_id=admission.source.world_id,
+                    activity_id=admission.activity_id,
+                    request=HostedEpisodeRequestIdentity(
+                        ref=admission.input_ref,
+                        digest=admission.input_digest,
+                    ),
+                    result=HostedEpisodeActivityResultRef(
+                        ref=result.ref,
+                        digest=result.digest,
+                        media_type=result.media_type,
+                        size_bytes=result.size_bytes,
+                    ),
+                )
+            )
+        return tuple(deliveries)
+
+    async def settle_episode_observation(
+        self,
+        *,
+        world_id: str,
+        activity_id: str,
+        result_digest: str,
+        receipt: CommittedTickReceipt,
+    ) -> None:
+        await self._coordinator.settle_observation(
+            world_id,
+            HOSTED_EPISODE_ACTIVITY_KIND,
+            activity_id,
+            ActivitySettlement(receipt=receipt, result_digest=result_digest),
+        )
+
+    async def has_unsettled_work(self, world_id: str) -> bool:
+        return await self._coordinator.has_unsettled(world_id)
+
+    def _remember(self, claim: ActivityClaim) -> HostedEpisodeActivityClaim:
+        if not claim.acquired or claim.attempt is None or claim.fence is None:
+            raise ValueError("hosted adapter requires an acquired generic claim")
+        operation_id = (
+            claim.reconciles_provider_operation_id
+            if claim.reconciliation_required
+            else claim.provider_operation_id
+        )
+        provider = claim.reconciles_provider if claim.reconciliation_required else claim.provider
+        semantic = HostedEpisodeActivityClaim(
+            world_id=claim.world_id,
+            activity_id=claim.activity_id,
+            attempt=claim.attempt,
+            fence=claim.fence,
+            request=HostedEpisodeRequestIdentity(
+                ref=claim.snapshot.admission.input_ref,
+                digest=claim.snapshot.admission.input_digest,
+            ),
+            provider=provider or "",
+            provider_operation_id=operation_id or "",
+            reconciliation_required=claim.reconciliation_required,
+            retry_guard=(
+                HostedEpisodeRetryGuard(
+                    ref=claim.retry_guard.ref,
+                    digest=claim.retry_guard.digest,
+                )
+                if claim.retry_guard is not None
+                else None
+            ),
+        )
+        self._claims[(claim.world_id, claim.activity_id, claim.fence)] = claim
+        return semantic
+
+    def _resolve(self, claim: HostedEpisodeActivityClaim) -> ActivityClaim:
+        try:
+            return self._claims[(claim.world_id, claim.activity_id, claim.fence)]
+        except KeyError:
+            raise ValueError("hosted Activity claim was not issued by this adapter") from None
+
+    @staticmethod
+    def _validate_existing(
+        existing: ActivityAdmission,
+        candidate: ActivityAdmission,
+    ) -> None:
+        if (
+            existing.kind != candidate.kind
+            or existing.input_ref != candidate.input_ref
+            or existing.input_digest != candidate.input_digest
+        ):
+            raise ActivityConflictError(
+                "hosted Activity identity has different immutable request content"
+            )
+
+
+class PhysicalHostedActivityWorker:
+    """Execute/reconcile one episode and redeliver its factual observation."""
+
+    def __init__(
+        self,
+        *,
+        world_id: str,
+        owner: str,
+        catalog: PhysicalHostedActivityCatalog,
+        values: PhysicalHostedValueStore,
+        provider: HostedEpisodeProvider,
+        stager: PhysicalHostedObservationStager,
+    ) -> None:
+        if not world_id.strip() or not owner.strip():
+            raise ValueError("hosted worker world and owner cannot be empty")
+        if not provider.provider.strip():
+            raise ValueError("hosted provider identity cannot be empty")
+        self._world_id = world_id
+        self._owner = owner
+        self._catalog = catalog
+        self._values = values
+        self._provider = provider
+        self._stager = stager
+
+    async def run_once(self) -> bool:
+        progressed = await self._deliver_pending_results()
+        claim = await self._catalog.claim_episode(
+            world_id=self._world_id,
+            owner=self._owner,
+        )
+        if claim is None:
+            return progressed
+        if claim.world_id != self._world_id:
+            raise ValueError("hosted catalog returned another world's claim")
+        request = await self._load_claim_request(claim)
+        result_claim, provider_result = await self._execute_or_reconcile(
+            claim,
+            request,
+        )
+        validate_hosted_provider_result(
+            provider_result,
+            request_ipc=request,
+            operation_id=result_claim.provider_operation_id,
+        )
+        published = await self._values.publish_result(
+            self._request_ref(claim.request, request),
+            provider_result,
+        )
+        await self._catalog.record_episode_result(
+            result_claim,
+            published.activity_result,
+        )
+        await self._deliver_pending_results()
+        return True
+
+    async def _execute_or_reconcile(
+        self,
+        claim: HostedEpisodeActivityClaim,
+        request_ipc: bytes,
+    ) -> tuple[HostedEpisodeActivityClaim, HostedEpisodeProviderResult]:
+        if claim.provider_operation_id:
+            if claim.provider != self._provider.provider:
+                raise ValueError("hosted claim belongs to another provider adapter")
+            reconciliation = await self._provider.reconcile(
+                operation_id=claim.provider_operation_id,
+                request_ipc=request_ipc,
+            )
+            if isinstance(reconciliation, HostedEpisodeRecovered):
+                return claim, reconciliation.result
+            if isinstance(reconciliation, HostedEpisodeConfirmedAbsent):
+                fresh = await self._catalog.confirm_provider_operation_absent(
+                    claim,
+                    reconciliation.guard,
+                )
+                if fresh.provider_operation_id or fresh.reconciliation_required:
+                    raise RuntimeError("confirmed absence did not produce an unbound fresh claim")
+                if fresh.retry_guard != reconciliation.guard:
+                    raise RuntimeError("catalog returned another hosted retry guard")
+                return await self._bind_and_execute(
+                    fresh,
+                    request_ipc,
+                    operation_id=claim.provider_operation_id,
+                )
+            if isinstance(reconciliation, HostedEpisodeRecoveryUnknown):
+                raise HostedEpisodeReconciliationRequired(
+                    claim.activity_id,
+                    claim.provider_operation_id,
+                )
+            raise TypeError("hosted provider returned invalid reconciliation evidence")
+
+        if claim.reconciliation_required:
+            raise AssertionError("hosted reconciliation claim lacks provider identity")
+        operation_id = hosted_episode_provider_operation_id(
+            claim.world_id,
+            claim.activity_id,
+        )
+        return await self._bind_and_execute(
+            claim,
+            request_ipc,
+            operation_id=operation_id,
+        )
+
+    async def _bind_and_execute(
+        self,
+        claim: HostedEpisodeActivityClaim,
+        request_ipc: bytes,
+        *,
+        operation_id: str,
+    ) -> tuple[HostedEpisodeActivityClaim, HostedEpisodeProviderResult]:
+        bound = await self._catalog.bind_provider_operation(
+            claim,
+            provider=self._provider.provider,
+            operation_id=operation_id,
+        )
+        if bound.provider != self._provider.provider or bound.provider_operation_id != operation_id:
+            raise RuntimeError("catalog returned another hosted provider identity")
+        result = await self._provider.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=bound.attempt,
+            fence=bound.fence,
+            retry_guard=bound.retry_guard,
+        )
+        return bound, result
+
+    async def _deliver_pending_results(self) -> bool:
+        progressed = False
+        for delivery in await self._catalog.pending_episode_results(
+            world_id=self._world_id,
+        ):
+            if delivery.world_id != self._world_id:
+                raise ValueError("hosted catalog returned another world's result")
+            published = await self._values.get_result(delivery.result)
+            expected_operation = hosted_episode_provider_operation_id(
+                delivery.world_id,
+                delivery.activity_id,
+            )
+            if (
+                published.operation_id != expected_operation
+                or published.request.ref != delivery.request.ref
+                or published.request.digest != delivery.request.digest
+            ):
+                raise ValueError("hosted result delivery does not match its Activity")
+            await self._stager.stage_hosted_episode_observation(
+                world_id=delivery.world_id,
+                observation=published.observation(delivery.activity_id),
+            )
+            progressed = True
+        return progressed
+
+    async def _load_claim_request(self, claim: HostedEpisodeActivityClaim) -> bytes:
+        request = await self._values.get_request(claim.request)
+        self._validate_claim_request(claim, request)
+        return request
+
+    @staticmethod
+    def _request_ref(
+        value: HostedEpisodeRequestIdentity,
+        request_ipc: bytes,
+    ) -> HostedEpisodeRequestRef:
+        return HostedEpisodeRequestRef(
+            ref=value.ref,
+            digest=value.digest,
+            size_bytes=len(request_ipc),
+        )
+
+    @staticmethod
+    def _validate_claim_request(
+        claim: HostedEpisodeActivityClaim,
+        request_ipc: bytes,
+    ) -> None:
+        operation_id = hosted_episode_provider_operation_id(
+            claim.world_id,
+            claim.activity_id,
+        )
+        if hosted_episode_request_digest(request_ipc) != claim.request.digest or any(
+            row["operation_id"] != operation_id
+            for row in decode_hosted_episode_requests(request_ipc)
+        ):
+            raise ValueError("claimed hosted Activity does not match its request")
+
+
+__all__ = [
+    "CommittedPhysicalSnapshot",
+    "HostedEpisodeActivityClaim",
+    "HostedEpisodeReconciliationRequired",
+    "HostedEpisodeResultDelivery",
+    "PhysicalCommittedIntentReader",
+    "PhysicalHostedActivityCatalog",
+    "PhysicalHostedActivityCoordinator",
+    "PhysicalHostedActivityProjector",
+    "PhysicalHostedActivityWorker",
+    "PhysicalHostedObservationStager",
+    "PhysicalHostedValueStore",
+    "prepare_hosted_episode_intent",
+]

--- a/src/archetype/physical_ai/hosted_activity_contracts.py
+++ b/src/archetype/physical_ai/hosted_activity_contracts.py
@@ -1,0 +1,430 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Physical-AI meaning around the generic hosted-episode Activity boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Literal, Protocol, TypedDict, cast, runtime_checkable
+
+from archetype.core.component import Component
+from archetype.physical_ai.hosted_episode import (
+    decode_hosted_episode_manifest,
+    decode_hosted_episode_requests,
+    hosted_episode_request_digest,
+    hosted_episode_results_digest,
+    hosted_episode_trajectory_digest,
+    validate_hosted_episode_result,
+)
+
+HOSTED_EPISODE_ACTIVITY_KIND = "physical_ai.hosted_episode"
+HOSTED_EPISODE_RESULT_MEDIA_TYPE = (
+    "application/vnd.archetype.physical-ai.hosted-episode-result+json"
+)
+HOSTED_EPISODE_ARROW_MEDIA_TYPE = "application/vnd.apache.arrow.stream"
+HOSTED_EPISODE_REQUEST_REF_PREFIX = "physical-episode-request+arrow:sha256:"
+HOSTED_EPISODE_TRAJECTORY_REF_PREFIX = "physical-episode-trajectory+arrow:sha256:"
+HOSTED_EPISODE_RESULTS_REF_PREFIX = "physical-episode-results+arrow:sha256:"
+HOSTED_EPISODE_MANIFEST_REF_PREFIX = "physical-episode-manifest+arrow:sha256:"
+HOSTED_EPISODE_RESULT_REF_PREFIX = "physical-episode-result+json:sha256:"
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+type HostedEpisodePayloadKind = Literal["trajectory", "episode-results", "manifest"]
+_PAYLOAD_PREFIX = {
+    "trajectory": HOSTED_EPISODE_TRAJECTORY_REF_PREFIX,
+    "episode-results": HOSTED_EPISODE_RESULTS_REF_PREFIX,
+    "manifest": HOSTED_EPISODE_MANIFEST_REF_PREFIX,
+}
+
+
+def _bounded(value: str, field: str, *, maximum: int = 4096) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    if len(value) > maximum:
+        raise ValueError(f"{field} must be at most {maximum} characters")
+    return value
+
+
+def _digest(value: str, field: str) -> str:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _content_ref(ref: str, digest: str, field: str, prefixes: frozenset[str]) -> None:
+    _bounded(ref, f"{field} ref")
+    _digest(digest, f"{field} digest")
+    matching = tuple(prefix for prefix in prefixes if ref.startswith(prefix))
+    if len(matching) != 1 or ref.removeprefix(matching[0]) != digest:
+        raise ValueError(f"{field} ref must embed its exact lowercase SHA-256 digest")
+
+
+def hosted_episode_provider_operation_id(world_id: str, activity_id: str) -> str:
+    """Derive one stable, world-scoped provider operation identity."""
+
+    _bounded(world_id, "world_id", maximum=512)
+    _bounded(activity_id, "activity_id", maximum=512)
+    encoded = json.dumps(
+        {
+            "activity_id": activity_id,
+            "contract": HOSTED_EPISODE_ACTIVITY_KIND,
+            "world_id": world_id,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return f"physical-episode:{hashlib.sha256(encoded).hexdigest()}"
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeRequestRef:
+    """Content identity for one canonical hosted-episode request."""
+
+    ref: str
+    digest: str
+    size_bytes: int
+    media_type: str = HOSTED_EPISODE_ARROW_MEDIA_TYPE
+
+    def __post_init__(self) -> None:
+        _content_ref(
+            self.ref,
+            self.digest,
+            "hosted request",
+            frozenset({HOSTED_EPISODE_REQUEST_REF_PREFIX}),
+        )
+        if self.media_type != HOSTED_EPISODE_ARROW_MEDIA_TYPE:
+            raise ValueError("hosted request must use canonical Arrow stream media type")
+        if self.size_bytes < 1:
+            raise ValueError("hosted request size must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeRequestIdentity:
+    """Bounded request identity retained by the generic control catalog."""
+
+    ref: str
+    digest: str
+
+    def __post_init__(self) -> None:
+        _content_ref(
+            self.ref,
+            self.digest,
+            "hosted request identity",
+            frozenset({HOSTED_EPISODE_REQUEST_REF_PREFIX}),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodePayloadRef:
+    """Content identity for one canonical hosted result payload."""
+
+    kind: HostedEpisodePayloadKind
+    ref: str
+    digest: str
+    size_bytes: int
+    media_type: str = HOSTED_EPISODE_ARROW_MEDIA_TYPE
+
+    def __post_init__(self) -> None:
+        try:
+            prefix = _PAYLOAD_PREFIX[self.kind]
+        except KeyError:
+            raise ValueError("hosted payload kind is not supported") from None
+        _content_ref(
+            self.ref,
+            self.digest,
+            f"hosted {self.kind} payload",
+            frozenset({prefix}),
+        )
+        if self.media_type != HOSTED_EPISODE_ARROW_MEDIA_TYPE:
+            raise ValueError("hosted payload must use canonical Arrow stream media type")
+        if self.size_bytes < 1:
+            raise ValueError("hosted payload size must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeActivityResultRef:
+    """Bounded descriptor retained by the generic Activity catalog."""
+
+    ref: str
+    digest: str
+    size_bytes: int
+    media_type: str = HOSTED_EPISODE_RESULT_MEDIA_TYPE
+
+    def __post_init__(self) -> None:
+        _content_ref(
+            self.ref,
+            self.digest,
+            "hosted result",
+            frozenset({HOSTED_EPISODE_RESULT_REF_PREFIX}),
+        )
+        if self.media_type != HOSTED_EPISODE_RESULT_MEDIA_TYPE:
+            raise ValueError("hosted result has a non-canonical media type")
+        if self.size_bytes < 1:
+            raise ValueError("hosted result size must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeRetryGuard:
+    """Provider-side atomic-start evidence for one safe fresh claim."""
+
+    ref: str
+    digest: str
+
+    def __post_init__(self) -> None:
+        _bounded(self.ref, "hosted retry guard ref")
+        _digest(self.digest, "hosted retry guard digest")
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeProviderResult:
+    """Complete provider-durable bytes, recovered before Activity recording."""
+
+    request_ipc: bytes
+    trajectory_ipc: bytes
+    episode_results_ipc: bytes
+    manifest_ipc: bytes
+
+    def __post_init__(self) -> None:
+        validate_hosted_episode_result(
+            self.request_ipc,
+            self.trajectory_ipc,
+            self.episode_results_ipc,
+            self.manifest_ipc,
+        )
+
+    @property
+    def operation_id(self) -> str:
+        return str(decode_hosted_episode_manifest(self.manifest_ipc)["operation_id"])
+
+    @property
+    def request_digest(self) -> str:
+        return hosted_episode_request_digest(self.request_ipc)
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodePublishedResult:
+    """Complete family publication plus its bounded Activity descriptor."""
+
+    operation_id: str
+    request: HostedEpisodeRequestRef
+    trajectory: HostedEpisodePayloadRef
+    episode_results: HostedEpisodePayloadRef
+    manifest: HostedEpisodePayloadRef
+    activity_result: HostedEpisodeActivityResultRef
+    episode_count: int
+    trajectory_row_count: int
+    transition_count: int
+    success_count: int
+
+    def __post_init__(self) -> None:
+        _bounded(self.operation_id, "hosted result operation_id", maximum=256)
+        if (
+            min(
+                self.episode_count,
+                self.trajectory_row_count,
+                self.transition_count,
+                self.success_count,
+            )
+            < 0
+        ):
+            raise ValueError("hosted result completeness counts cannot be negative")
+        if self.episode_count < 1:
+            raise ValueError("hosted result must contain at least one episode")
+        if self.success_count > self.episode_count:
+            raise ValueError("hosted success count exceeds episode count")
+        if self.trajectory_row_count != self.episode_count + self.transition_count:
+            raise ValueError("hosted trajectory count is not reset rows plus transitions")
+        if (
+            self.trajectory.kind,
+            self.episode_results.kind,
+            self.manifest.kind,
+        ) != ("trajectory", "episode-results", "manifest"):
+            raise ValueError("hosted result payload references have incorrect kinds")
+
+    def observation(self, activity_id: str) -> HostedEpisodeObservation:
+        """Return the exact factual marker to commit in a later tick."""
+
+        return HostedEpisodeObservation(
+            activity_id=activity_id,
+            operation_id=self.operation_id,
+            request_ref=self.request.ref,
+            request_digest=self.request.digest,
+            result_ref=self.activity_result.ref,
+            result_digest=self.activity_result.digest,
+            trajectory_ref=self.trajectory.ref,
+            trajectory_digest=self.trajectory.digest,
+            episode_results_ref=self.episode_results.ref,
+            episode_results_digest=self.episode_results.digest,
+            manifest_ref=self.manifest.ref,
+            manifest_digest=self.manifest.digest,
+            episode_count=self.episode_count,
+            trajectory_row_count=self.trajectory_row_count,
+            transition_count=self.transition_count,
+            success_count=self.success_count,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeRecovered:
+    """Provider evidence proves the exact prior operation completed."""
+
+    result: HostedEpisodeProviderResult
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeConfirmedAbsent:
+    """Provider evidence proves atomic-start absence behind a retry guard."""
+
+    guard: HostedEpisodeRetryGuard
+
+
+@dataclass(frozen=True, slots=True)
+class HostedEpisodeRecoveryUnknown:
+    """Provider truth cannot establish completion or safe absence."""
+
+    reason: str = ""
+
+
+type HostedEpisodeReconciliation = (
+    HostedEpisodeRecovered | HostedEpisodeConfirmedAbsent | HostedEpisodeRecoveryUnknown
+)
+
+
+class HostedEpisodeManifestFacts(TypedDict):
+    """Typed canonical manifest row returned after full validation."""
+
+    contract_version: str
+    operation_id: str
+    manifest_id: str
+    request_digest: str
+    trajectory_digest: str
+    episode_results_digest: str
+    episode_count: int
+    trajectory_row_count: int
+    transition_count: int
+    success_count: int
+
+
+@runtime_checkable
+class HostedEpisodeProvider(Protocol):
+    """Execute or reconcile a whole episode under provider-owned semantics."""
+
+    @property
+    def provider(self) -> str: ...
+
+    async def execute(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        attempt: int,
+        fence: int,
+        retry_guard: HostedEpisodeRetryGuard | None,
+    ) -> HostedEpisodeProviderResult: ...
+
+    async def reconcile(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeReconciliation: ...
+
+
+class HostedEpisodeIntent(Component):
+    """Committed decision to execute one immutable whole-episode request."""
+
+    activity_id: str
+    operation_id: str
+    request_ref: str
+    request_digest: str
+    request_size_bytes: int
+    episode_count: int
+
+
+class HostedEpisodeObservation(Component):
+    """Committed factual binding to one complete, durable hosted result."""
+
+    activity_id: str
+    operation_id: str
+    request_ref: str
+    request_digest: str
+    result_ref: str
+    result_digest: str
+    trajectory_ref: str
+    trajectory_digest: str
+    episode_results_ref: str
+    episode_results_digest: str
+    manifest_ref: str
+    manifest_digest: str
+    episode_count: int
+    trajectory_row_count: int
+    transition_count: int
+    success_count: int
+
+
+def validate_hosted_provider_result(
+    result: HostedEpisodeProviderResult,
+    *,
+    request_ipc: bytes,
+    operation_id: str,
+) -> HostedEpisodeManifestFacts:
+    """Validate exact request identity and return the canonical manifest."""
+
+    if result.request_ipc != request_ipc:
+        raise ValueError("provider result does not bind the exact admitted request bytes")
+    manifest = validate_hosted_episode_result(
+        request_ipc,
+        result.trajectory_ipc,
+        result.episode_results_ipc,
+        result.manifest_ipc,
+    )
+    request_rows = decode_hosted_episode_requests(request_ipc)
+    if (
+        result.operation_id != operation_id
+        or manifest["operation_id"] != operation_id
+        or any(row["operation_id"] != operation_id for row in request_rows)
+    ):
+        raise ValueError("provider result belongs to another operation")
+    if manifest["request_digest"] != hosted_episode_request_digest(request_ipc):
+        raise ValueError("provider manifest has another request digest")
+    if manifest["trajectory_digest"] != hosted_episode_trajectory_digest(result.trajectory_ipc):
+        raise ValueError("provider manifest has another trajectory digest")
+    if manifest["episode_results_digest"] != hosted_episode_results_digest(
+        result.episode_results_ipc
+    ):
+        raise ValueError("provider manifest has another episode-results digest")
+    return cast(HostedEpisodeManifestFacts, manifest)
+
+
+__all__ = [
+    "HOSTED_EPISODE_ACTIVITY_KIND",
+    "HOSTED_EPISODE_ARROW_MEDIA_TYPE",
+    "HOSTED_EPISODE_MANIFEST_REF_PREFIX",
+    "HOSTED_EPISODE_REQUEST_REF_PREFIX",
+    "HOSTED_EPISODE_RESULT_MEDIA_TYPE",
+    "HOSTED_EPISODE_RESULT_REF_PREFIX",
+    "HOSTED_EPISODE_RESULTS_REF_PREFIX",
+    "HOSTED_EPISODE_TRAJECTORY_REF_PREFIX",
+    "HostedEpisodeActivityResultRef",
+    "HostedEpisodeConfirmedAbsent",
+    "HostedEpisodeIntent",
+    "HostedEpisodeManifestFacts",
+    "HostedEpisodeObservation",
+    "HostedEpisodePayloadKind",
+    "HostedEpisodePayloadRef",
+    "HostedEpisodeProvider",
+    "HostedEpisodeProviderResult",
+    "HostedEpisodePublishedResult",
+    "HostedEpisodeReconciliation",
+    "HostedEpisodeRecovered",
+    "HostedEpisodeRecoveryUnknown",
+    "HostedEpisodeRequestIdentity",
+    "HostedEpisodeRequestRef",
+    "HostedEpisodeRetryGuard",
+    "hosted_episode_provider_operation_id",
+    "validate_hosted_provider_result",
+]

--- a/src/archetype/physical_ai/hosted_activity_values.py
+++ b/src/archetype/physical_ai/hosted_activity_values.py
@@ -1,0 +1,825 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local durable values and seeded provider for hosted Physical-AI Activities."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Protocol
+
+from archetype.errors import AvailabilityError
+from archetype.physical_ai.hosted_activity_contracts import (
+    HOSTED_EPISODE_MANIFEST_REF_PREFIX,
+    HOSTED_EPISODE_REQUEST_REF_PREFIX,
+    HOSTED_EPISODE_RESULT_MEDIA_TYPE,
+    HOSTED_EPISODE_RESULT_REF_PREFIX,
+    HOSTED_EPISODE_RESULTS_REF_PREFIX,
+    HOSTED_EPISODE_TRAJECTORY_REF_PREFIX,
+    HostedEpisodeActivityResultRef,
+    HostedEpisodeConfirmedAbsent,
+    HostedEpisodePayloadKind,
+    HostedEpisodePayloadRef,
+    HostedEpisodeProviderResult,
+    HostedEpisodePublishedResult,
+    HostedEpisodeRecovered,
+    HostedEpisodeRecoveryUnknown,
+    HostedEpisodeRequestIdentity,
+    HostedEpisodeRequestRef,
+    HostedEpisodeRetryGuard,
+    validate_hosted_provider_result,
+)
+from archetype.physical_ai.hosted_episode import (
+    build_hosted_episode_manifest,
+    build_hosted_episode_results,
+    decode_hosted_episode_requests,
+    encode_hosted_episode_trajectory,
+    hosted_episode_manifest_digest,
+    hosted_episode_request_digest,
+    hosted_episode_result_id,
+    hosted_episode_results_digest,
+    hosted_episode_step_id,
+    hosted_episode_trajectory_digest,
+)
+
+_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+_BUNDLE_DOMAIN = "archetype.physical-ai.hosted-activity-result/v1"
+_PROVIDER_RECORD_VERSION = 1
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _bundle_digest(payload: bytes) -> str:
+    digest = hashlib.sha256()
+    digest.update(_BUNDLE_DOMAIN.encode())
+    digest.update(b"\0")
+    digest.update(payload)
+    return digest.hexdigest()
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_once(path: Path, payload: bytes) -> None:
+    """Publish immutable bytes atomically and accept only exact duplicates."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if path.read_bytes() != payload:
+            raise RuntimeError(f"immutable hosted value conflicts at {path.name}")
+        return
+    handle, temporary = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(handle, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            if path.read_bytes() != payload:
+                raise RuntimeError(f"immutable hosted value conflicts at {path.name}") from None
+        _fsync_directory(path.parent)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _create_once(path: Path, payload: bytes) -> bool:
+    """Create one durable provider marker without replacing another claimant."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return False
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+    _fsync_directory(path.parent)
+    return True
+
+
+class LocalHostedEpisodeValueStore:
+    """Content-address canonical IPC and one bounded completeness descriptor."""
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root)
+
+    async def put_request(self, request_ipc: bytes) -> HostedEpisodeRequestRef:
+        return await asyncio.to_thread(self._put_request, request_ipc)
+
+    async def get_request(
+        self,
+        value: HostedEpisodeRequestRef | HostedEpisodeRequestIdentity,
+    ) -> bytes:
+        return await asyncio.to_thread(self._get_request, value)
+
+    async def publish_result(
+        self,
+        request: HostedEpisodeRequestRef,
+        result: HostedEpisodeProviderResult,
+    ) -> HostedEpisodePublishedResult:
+        return await asyncio.to_thread(self._publish_result, request, result)
+
+    async def get_result(
+        self,
+        value: HostedEpisodeActivityResultRef,
+    ) -> HostedEpisodePublishedResult:
+        return await asyncio.to_thread(self._get_result, value)
+
+    def _put_request(self, request_ipc: bytes) -> HostedEpisodeRequestRef:
+        digest = hosted_episode_request_digest(request_ipc)
+        path = self._payload_path("request", digest)
+        _write_once(path, request_ipc)
+        return HostedEpisodeRequestRef(
+            ref=f"{HOSTED_EPISODE_REQUEST_REF_PREFIX}{digest}",
+            digest=digest,
+            size_bytes=len(request_ipc),
+        )
+
+    def _get_request(
+        self,
+        value: HostedEpisodeRequestRef | HostedEpisodeRequestIdentity,
+    ) -> bytes:
+        digest = self._ref_digest(value.ref, HOSTED_EPISODE_REQUEST_REF_PREFIX)
+        if digest != value.digest:
+            raise ValueError("hosted request reference and digest disagree")
+        payload = self._payload_path("request", digest).read_bytes()
+        if isinstance(value, HostedEpisodeRequestRef) and len(payload) != value.size_bytes:
+            raise ValueError("hosted request size does not match durable bytes")
+        if hosted_episode_request_digest(payload) != digest:
+            raise ValueError("hosted request digest does not match durable bytes")
+        return payload
+
+    def _publish_result(
+        self,
+        request: HostedEpisodeRequestRef,
+        result: HostedEpisodeProviderResult,
+    ) -> HostedEpisodePublishedResult:
+        request_ipc = self._get_request(request)
+        manifest = validate_hosted_provider_result(
+            result,
+            request_ipc=request_ipc,
+            operation_id=result.operation_id,
+        )
+        trajectory = self._put_payload(
+            "trajectory",
+            result.trajectory_ipc,
+            hosted_episode_trajectory_digest(result.trajectory_ipc),
+            HOSTED_EPISODE_TRAJECTORY_REF_PREFIX,
+        )
+        episode_results = self._put_payload(
+            "episode-results",
+            result.episode_results_ipc,
+            hosted_episode_results_digest(result.episode_results_ipc),
+            HOSTED_EPISODE_RESULTS_REF_PREFIX,
+        )
+        manifest_ref = self._put_payload(
+            "manifest",
+            result.manifest_ipc,
+            hosted_episode_manifest_digest(result.manifest_ipc),
+            HOSTED_EPISODE_MANIFEST_REF_PREFIX,
+        )
+        descriptor_value: dict[str, Any] = {
+            "schema_version": 1,
+            "operation_id": result.operation_id,
+            "request": asdict(request),
+            "trajectory": asdict(trajectory),
+            "episode_results": asdict(episode_results),
+            "manifest": asdict(manifest_ref),
+            "episode_count": int(manifest["episode_count"]),
+            "trajectory_row_count": int(manifest["trajectory_row_count"]),
+            "transition_count": int(manifest["transition_count"]),
+            "success_count": int(manifest["success_count"]),
+        }
+        descriptor = _canonical_json(descriptor_value)
+        descriptor_digest = _bundle_digest(descriptor)
+        descriptor_path = self._descriptor_path(descriptor_digest)
+        _write_once(descriptor_path, descriptor)
+        published = HostedEpisodePublishedResult(
+            operation_id=result.operation_id,
+            request=request,
+            trajectory=trajectory,
+            episode_results=episode_results,
+            manifest=manifest_ref,
+            activity_result=HostedEpisodeActivityResultRef(
+                ref=f"{HOSTED_EPISODE_RESULT_REF_PREFIX}{descriptor_digest}",
+                digest=descriptor_digest,
+                size_bytes=len(descriptor),
+            ),
+            episode_count=int(manifest["episode_count"]),
+            trajectory_row_count=int(manifest["trajectory_row_count"]),
+            transition_count=int(manifest["transition_count"]),
+            success_count=int(manifest["success_count"]),
+        )
+        return published
+
+    def _get_result(
+        self,
+        value: HostedEpisodeActivityResultRef,
+    ) -> HostedEpisodePublishedResult:
+        if value.media_type != HOSTED_EPISODE_RESULT_MEDIA_TYPE:
+            raise ValueError("hosted result descriptor has an unsupported media type")
+        digest = self._ref_digest(value.ref, HOSTED_EPISODE_RESULT_REF_PREFIX)
+        if digest != value.digest:
+            raise ValueError("hosted result reference and digest disagree")
+        descriptor = self._descriptor_path(digest).read_bytes()
+        if len(descriptor) != value.size_bytes or _bundle_digest(descriptor) != digest:
+            raise ValueError("hosted result descriptor does not match its reference")
+        envelope = json.loads(descriptor)
+        if not isinstance(envelope, dict) or envelope.get("schema_version") != 1:
+            raise ValueError("hosted result descriptor has an incompatible schema")
+        request = HostedEpisodeRequestRef(**envelope["request"])
+        trajectory = HostedEpisodePayloadRef(**envelope["trajectory"])
+        episode_results = HostedEpisodePayloadRef(**envelope["episode_results"])
+        manifest = HostedEpisodePayloadRef(**envelope["manifest"])
+        request_ipc = self._get_request(request)
+        provider_result = HostedEpisodeProviderResult(
+            request_ipc=request_ipc,
+            trajectory_ipc=self._get_payload(
+                "trajectory",
+                trajectory,
+                HOSTED_EPISODE_TRAJECTORY_REF_PREFIX,
+                hosted_episode_trajectory_digest,
+            ),
+            episode_results_ipc=self._get_payload(
+                "episode-results",
+                episode_results,
+                HOSTED_EPISODE_RESULTS_REF_PREFIX,
+                hosted_episode_results_digest,
+            ),
+            manifest_ipc=self._get_payload(
+                "manifest",
+                manifest,
+                HOSTED_EPISODE_MANIFEST_REF_PREFIX,
+                hosted_episode_manifest_digest,
+            ),
+        )
+        operation_id = str(envelope["operation_id"])
+        validated = validate_hosted_provider_result(
+            provider_result,
+            request_ipc=request_ipc,
+            operation_id=operation_id,
+        )
+        counts = (
+            int(envelope["episode_count"]),
+            int(envelope["trajectory_row_count"]),
+            int(envelope["transition_count"]),
+            int(envelope["success_count"]),
+        )
+        expected_counts = (
+            int(validated["episode_count"]),
+            int(validated["trajectory_row_count"]),
+            int(validated["transition_count"]),
+            int(validated["success_count"]),
+        )
+        if counts != expected_counts:
+            raise ValueError("hosted result descriptor completeness counts are false")
+        return HostedEpisodePublishedResult(
+            operation_id=operation_id,
+            request=request,
+            trajectory=trajectory,
+            episode_results=episode_results,
+            manifest=manifest,
+            activity_result=value,
+            episode_count=counts[0],
+            trajectory_row_count=counts[1],
+            transition_count=counts[2],
+            success_count=counts[3],
+        )
+
+    def _put_payload(
+        self,
+        kind: HostedEpisodePayloadKind,
+        payload: bytes,
+        digest: str,
+        prefix: str,
+    ) -> HostedEpisodePayloadRef:
+        _write_once(self._payload_path(kind, digest), payload)
+        return HostedEpisodePayloadRef(
+            kind=kind,
+            ref=f"{prefix}{digest}",
+            digest=digest,
+            size_bytes=len(payload),
+        )
+
+    def _get_payload(
+        self,
+        kind: HostedEpisodePayloadKind,
+        value: HostedEpisodePayloadRef,
+        prefix: str,
+        digest_fn: Callable[[bytes], str],
+    ) -> bytes:
+        if value.kind != kind:
+            raise ValueError(f"hosted {kind} descriptor contains another payload kind")
+        digest = self._ref_digest(value.ref, prefix)
+        if digest != value.digest:
+            raise ValueError(f"hosted {kind} reference and digest disagree")
+        payload = self._payload_path(kind, digest).read_bytes()
+        if len(payload) != value.size_bytes or digest_fn(payload) != digest:
+            raise ValueError(f"hosted {kind} bytes do not match their reference")
+        return payload
+
+    @staticmethod
+    def _ref_digest(ref: str, prefix: str) -> str:
+        if not ref.startswith(prefix):
+            raise ValueError("unsupported hosted value reference")
+        digest = ref.removeprefix(prefix)
+        if _DIGEST.fullmatch(digest) is None:
+            raise ValueError("hosted value reference has an invalid digest")
+        return digest
+
+    def _payload_path(self, kind: str, digest: str) -> Path:
+        if _DIGEST.fullmatch(digest) is None:
+            raise ValueError("invalid hosted payload digest")
+        return self._root / kind / digest[:2] / f"{digest}.arrow"
+
+    def _descriptor_path(self, digest: str) -> Path:
+        if _DIGEST.fullmatch(digest) is None:
+            raise ValueError("invalid hosted descriptor digest")
+        return self._root / "descriptor" / digest[:2] / f"{digest}.json"
+
+
+class SeededHostedEpisodeRunner:
+    """Small deterministic simulator that exercises the exact hosted contract."""
+
+    def __init__(self, counter_path: str | Path | None = None) -> None:
+        self._counter_path = Path(counter_path) if counter_path is not None else None
+        self._memory_count = 0
+
+    @property
+    def execution_count(self) -> int:
+        if self._counter_path is None:
+            return self._memory_count
+        if not self._counter_path.exists():
+            return 0
+        return int(json.loads(self._counter_path.read_text())["execution_count"])
+
+    async def run(self, request_ipc: bytes) -> bytes:
+        await asyncio.to_thread(self._increment)
+        return encode_hosted_episode_trajectory(self._trajectory_rows(request_ipc))
+
+    def _increment(self) -> None:
+        if self._counter_path is None:
+            self._memory_count += 1
+            return
+        count = self.execution_count + 1
+        _write_replace(
+            self._counter_path,
+            _canonical_json({"execution_count": count}),
+        )
+
+    @staticmethod
+    def _trajectory_rows(request_ipc: bytes) -> list[dict[str, Any]]:
+        requests = decode_hosted_episode_requests(request_ipc)
+        request_digest = hosted_episode_request_digest(request_ipc)
+        rows: list[dict[str, Any]] = []
+        for request in requests:
+            config = json.loads(str(request["config_json"]))
+            max_transitions = int(request["max_transitions"])
+            success_after = int(config.get("success_after_transitions", max_transitions + 1))
+            done_after = int(config.get("environment_done_after_transitions", max_transitions + 1))
+            reward_per_transition = float(config.get("reward_per_transition", 0.0))
+            terminal_step = min(max_transitions, success_after, done_after)
+            if terminal_step < 0:
+                raise ValueError("seeded hosted terminal step cannot be negative")
+            for step_index in range(terminal_step + 1):
+                is_final = step_index == terminal_step
+                success = is_final and step_index > 0 and success_after == step_index
+                environment_done = (
+                    is_final and not success and step_index > 0 and done_after == step_index
+                )
+                terminal = is_final
+                reason: str | None = None
+                if terminal:
+                    if success:
+                        reason = "success"
+                    elif environment_done:
+                        reason = "environment_done"
+                    else:
+                        reason = "transition_budget"
+                seed = int(request["seed"])
+                scalar = ((seed % 997) / 997.0) + (step_index / 100.0)
+                rows.append(
+                    {
+                        **{
+                            field: request[field]
+                            for field in (
+                                "operation_id",
+                                "episode_id",
+                                "trial_id",
+                                "suite",
+                                "task_id",
+                                "seed",
+                                "instruction",
+                                "max_transitions",
+                                "environment_id",
+                                "policy_id",
+                                "config_digest",
+                            )
+                        },
+                        "episode_result_id": hosted_episode_result_id(
+                            str(request["operation_id"]),
+                            str(request["episode_id"]),
+                        ),
+                        "step_id": hosted_episode_step_id(
+                            str(request["operation_id"]),
+                            str(request["episode_id"]),
+                            step_index,
+                        ),
+                        "request_digest": request_digest,
+                        "step_index": step_index,
+                        "action": None if step_index == 0 else [scalar / 10.0] * 7,
+                        "proprio": {
+                            "eef_pos": [scalar, 0.0, 0.5],
+                            "eef_quat": [1.0, 0.0, 0.0, 0.0],
+                            "gripper": 0.0,
+                            "gripper_qpos": [0.0, 0.0],
+                        },
+                        "reward": 0.0 if step_index == 0 else reward_per_transition,
+                        "environment_done": environment_done,
+                        "success": success,
+                        "terminal": terminal,
+                        "termination_reason": reason,
+                        "agentview_frame": None,
+                        "wrist_frame": None,
+                    }
+                )
+        return rows
+
+
+class HostedEpisodeRunner(Protocol):
+    """Produce one complete trajectory from the canonical request bytes."""
+
+    async def run(self, request_ipc: bytes) -> bytes: ...
+
+
+class HostedEpisodeProviderStartBlocked(AvailabilityError):
+    """Another provider claimant owns the permanent operation start marker."""
+
+    public_detail = "Hosted episode provider start is temporarily unavailable"
+
+
+class LocalDurableHostedEpisodeProvider:
+    """At-most-one local seeded start with provider-durable first-result lookup.
+
+    A permanent start marker is acquired with ``O_EXCL`` before invoking the
+    runner. If the process dies before a complete result index is published,
+    reconciliation remains unknown; neither lease expiry nor deterministic
+    seeds authorize a replay.
+    """
+
+    provider = "local-seeded-hosted-episode"
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        runner: HostedEpisodeRunner,
+        crash_after_publish: bool = False,
+    ) -> None:
+        self._root = Path(root)
+        self._runner = runner
+        self._crash_after_publish = crash_after_publish
+
+    async def execute(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        attempt: int,
+        fence: int,
+        retry_guard: HostedEpisodeRetryGuard | None,
+    ) -> HostedEpisodeProviderResult:
+        self._validate_request(operation_id, request_ipc)
+        recovered = await asyncio.to_thread(
+            self._load_result,
+            operation_id,
+            request_ipc,
+        )
+        if recovered is not None:
+            return recovered
+        await asyncio.to_thread(
+            self._begin,
+            operation_id,
+            request_ipc,
+            attempt,
+            fence,
+            retry_guard,
+        )
+        trajectory_ipc = await self._run(request_ipc)
+        episode_results_ipc = build_hosted_episode_results(
+            request_ipc,
+            trajectory_ipc,
+        )
+        manifest_ipc = build_hosted_episode_manifest(
+            request_ipc,
+            trajectory_ipc,
+            episode_results_ipc,
+        )
+        result = HostedEpisodeProviderResult(
+            request_ipc=request_ipc,
+            trajectory_ipc=trajectory_ipc,
+            episode_results_ipc=episode_results_ipc,
+            manifest_ipc=manifest_ipc,
+        )
+        validate_hosted_provider_result(
+            result,
+            request_ipc=request_ipc,
+            operation_id=operation_id,
+        )
+        await asyncio.to_thread(self._publish_result, operation_id, result)
+        if self._crash_after_publish:
+            self._crash_after_publish = False
+            raise RuntimeError("worker died after provider result publication")
+        return result
+
+    async def reconcile(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeRecovered | HostedEpisodeConfirmedAbsent | HostedEpisodeRecoveryUnknown:
+        self._validate_request(operation_id, request_ipc)
+        recovered = await asyncio.to_thread(
+            self._load_result,
+            operation_id,
+            request_ipc,
+        )
+        if recovered is not None:
+            return HostedEpisodeRecovered(recovered)
+        if self._start_path(operation_id).exists():
+            return HostedEpisodeRecoveryUnknown(
+                "provider start exists without a complete result index"
+            )
+        guard = await asyncio.to_thread(self._install_guard, operation_id, request_ipc)
+        recovered = await asyncio.to_thread(
+            self._load_result,
+            operation_id,
+            request_ipc,
+        )
+        if recovered is not None:
+            return HostedEpisodeRecovered(recovered)
+        if self._start_path(operation_id).exists():
+            return HostedEpisodeRecoveryUnknown(
+                "provider start raced confirmed-absence reconciliation"
+            )
+        return HostedEpisodeConfirmedAbsent(guard)
+
+    async def _run(self, request_ipc: bytes) -> bytes:
+        trajectory = await self._runner.run(request_ipc)
+        if not isinstance(trajectory, bytes):
+            raise TypeError("hosted episode runner must return Arrow IPC bytes")
+        return trajectory
+
+    def _begin(
+        self,
+        operation_id: str,
+        request_ipc: bytes,
+        attempt: int,
+        fence: int,
+        retry_guard: HostedEpisodeRetryGuard | None,
+    ) -> None:
+        if attempt < 1 or fence < 1:
+            raise ValueError("hosted provider attempt and fence must be positive")
+        if retry_guard is not None:
+            expected = self._guard(operation_id, request_ipc)
+            if retry_guard != expected:
+                raise HostedEpisodeProviderStartBlocked(
+                    "hosted retry guard does not bind this operation and request"
+                )
+            guard_path = self._guard_path(operation_id)
+            if not guard_path.exists() or _sha256(guard_path.read_bytes()) != retry_guard.digest:
+                raise HostedEpisodeProviderStartBlocked("hosted retry guard is absent or changed")
+        marker = _canonical_json(
+            {
+                "attempt": attempt,
+                "fence": fence,
+                "operation_id": operation_id,
+                "request_digest": hosted_episode_request_digest(request_ipc),
+            }
+        )
+        if not _create_once(self._start_path(operation_id), marker):
+            raise HostedEpisodeProviderStartBlocked(
+                "provider operation already has a permanent start marker"
+            )
+
+    def _install_guard(
+        self,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeRetryGuard:
+        guard = self._guard(operation_id, request_ipc)
+        payload = self._guard_payload(operation_id, request_ipc)
+        path = self._guard_path(operation_id)
+        if not _create_once(path, payload) and path.read_bytes() != payload:
+            raise RuntimeError("hosted provider retry guard conflicts")
+        return guard
+
+    def _guard(
+        self,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeRetryGuard:
+        payload = self._guard_payload(operation_id, request_ipc)
+        return HostedEpisodeRetryGuard(
+            ref=f"local-hosted-start://{self._operation_key(operation_id)}",
+            digest=_sha256(payload),
+        )
+
+    @staticmethod
+    def _guard_payload(operation_id: str, request_ipc: bytes) -> bytes:
+        return _canonical_json(
+            {
+                "barrier": "atomic-create-if-absent",
+                "operation_id": operation_id,
+                "request_digest": hosted_episode_request_digest(request_ipc),
+                "version": 1,
+            }
+        )
+
+    def _publish_result(
+        self,
+        operation_id: str,
+        result: HostedEpisodeProviderResult,
+    ) -> None:
+        payloads = {
+            "request": (
+                result.request_ipc,
+                hosted_episode_request_digest(result.request_ipc),
+            ),
+            "trajectory": (
+                result.trajectory_ipc,
+                hosted_episode_trajectory_digest(result.trajectory_ipc),
+            ),
+            "episode-results": (
+                result.episode_results_ipc,
+                hosted_episode_results_digest(result.episode_results_ipc),
+            ),
+            "manifest": (
+                result.manifest_ipc,
+                hosted_episode_manifest_digest(result.manifest_ipc),
+            ),
+        }
+        records: dict[str, dict[str, Any]] = {}
+        for kind, (payload, digest) in payloads.items():
+            path = self._provider_blob_path(kind, digest)
+            _write_once(path, payload)
+            records[kind] = {
+                "digest": digest,
+                "size_bytes": len(payload),
+            }
+        index = _canonical_json(
+            {
+                "schema_version": _PROVIDER_RECORD_VERSION,
+                "operation_id": operation_id,
+                "payloads": records,
+            }
+        )
+        _write_once(self._result_path(operation_id), index)
+
+    def _load_result(
+        self,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeProviderResult | None:
+        index_path = self._result_path(operation_id)
+        if not index_path.exists():
+            return None
+        envelope = json.loads(index_path.read_bytes())
+        if (
+            not isinstance(envelope, dict)
+            or envelope.get("schema_version") != _PROVIDER_RECORD_VERSION
+            or envelope.get("operation_id") != operation_id
+            or not isinstance(envelope.get("payloads"), dict)
+        ):
+            raise ValueError("hosted provider result index is incompatible")
+        payloads = envelope["payloads"]
+
+        def read(kind: str, digest_fn: Callable[[bytes], str]) -> bytes:
+            record = payloads.get(kind)
+            if not isinstance(record, dict):
+                raise ValueError(f"hosted provider index omits {kind}")
+            digest = str(record.get("digest", ""))
+            size = int(record.get("size_bytes", -1))
+            if _DIGEST.fullmatch(digest) is None or size < 1:
+                raise ValueError(f"hosted provider index has invalid {kind} metadata")
+            payload = self._provider_blob_path(kind, digest).read_bytes()
+            if len(payload) != size or digest_fn(payload) != digest:
+                raise ValueError(f"hosted provider {kind} bytes do not match their index")
+            return payload
+
+        durable_request = read("request", hosted_episode_request_digest)
+        if durable_request != request_ipc:
+            raise ValueError("provider result index binds another request")
+        result = HostedEpisodeProviderResult(
+            request_ipc=durable_request,
+            trajectory_ipc=read("trajectory", hosted_episode_trajectory_digest),
+            episode_results_ipc=read("episode-results", hosted_episode_results_digest),
+            manifest_ipc=read("manifest", hosted_episode_manifest_digest),
+        )
+        validate_hosted_provider_result(
+            result,
+            request_ipc=request_ipc,
+            operation_id=operation_id,
+        )
+        return result
+
+    @staticmethod
+    def _validate_request(operation_id: str, request_ipc: bytes) -> None:
+        requests = decode_hosted_episode_requests(request_ipc)
+        if any(row["operation_id"] != operation_id for row in requests):
+            raise ValueError("hosted provider operation does not match its request")
+
+    async def result_for(
+        self,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeProviderResult | None:
+        """Read provider truth without creating a retry guard."""
+
+        self._validate_request(operation_id, request_ipc)
+        return await asyncio.to_thread(self._load_result, operation_id, request_ipc)
+
+    @staticmethod
+    def _operation_key(operation_id: str) -> str:
+        return hashlib.sha256(operation_id.encode()).hexdigest()
+
+    def _operation_dir(self, operation_id: str) -> Path:
+        return self._root / "operations" / self._operation_key(operation_id)[:2]
+
+    def _start_path(self, operation_id: str) -> Path:
+        return self._operation_dir(operation_id) / f"{self._operation_key(operation_id)}.start.json"
+
+    def _guard_path(self, operation_id: str) -> Path:
+        return self._operation_dir(operation_id) / f"{self._operation_key(operation_id)}.guard.json"
+
+    def _result_path(self, operation_id: str) -> Path:
+        return (
+            self._operation_dir(operation_id) / f"{self._operation_key(operation_id)}.result.json"
+        )
+
+    def _provider_blob_path(self, kind: str, digest: str) -> Path:
+        if _DIGEST.fullmatch(digest) is None:
+            raise ValueError("invalid hosted provider payload digest")
+        return self._root / "blobs" / kind / digest[:2] / f"{digest}.arrow"
+
+
+def _write_replace(path: Path, payload: bytes) -> None:
+    """Atomically replace mutable local diagnostics; never used as authority."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, temporary = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(handle, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+__all__ = [
+    "HostedEpisodeRunner",
+    "HostedEpisodeProviderStartBlocked",
+    "LocalDurableHostedEpisodeProvider",
+    "LocalHostedEpisodeValueStore",
+    "SeededHostedEpisodeRunner",
+]

--- a/src/archetype/physical_ai/hosted_activity_values.py
+++ b/src/archetype/physical_ai/hosted_activity_values.py
@@ -499,8 +499,6 @@ class LocalDurableHostedEpisodeProvider:
     seeds authorize a replay.
     """
 
-    provider = "local-seeded-hosted-episode"
-
     def __init__(
         self,
         root: str | Path,
@@ -508,9 +506,18 @@ class LocalDurableHostedEpisodeProvider:
         runner: HostedEpisodeRunner,
         crash_after_publish: bool = False,
     ) -> None:
-        self._root = Path(root)
+        self._root = Path(root).resolve()
+        self._provider = (
+            "local-seeded-hosted-episode:" + hashlib.sha256(str(self._root).encode()).hexdigest()
+        )
         self._runner = runner
         self._crash_after_publish = crash_after_publish
+
+    @property
+    def provider(self) -> str:
+        """Bind generic Activity ownership to this exact durable namespace."""
+
+        return self._provider
 
     async def execute(
         self,

--- a/src/archetype/physical_ai/hosted_activity_world.py
+++ b/src/archetype/physical_ai/hosted_activity_world.py
@@ -57,6 +57,9 @@ async def _query_groups(
     snapshot: PinnedWorldQuerySnapshot,
     groups: tuple[tuple[type[Component], ...], ...],
 ) -> Mapping[ArchetypeSignature, DataFrame]:
+    # Activity delivery control is exact-world state. A child may observe a
+    # settled parent fact through ordinary lineage queries, but it must never
+    # read and re-admit the parent's intent as a child-world Activity.
     visibility = snapshot.current.visibility_tokens
     if visibility is None:
         raise ValueError("physical Activity reads require coordinated visibility")
@@ -204,6 +207,9 @@ class WorldHostedEpisodeObservationStager:
             str(world.run_id),
             storage_config,
         )
+        # Idempotency is scoped to the world-qualified Activity key. An
+        # inherited parent observation is an ordinary fact, not settlement for
+        # a child-world Activity with the same family-local activity_id.
         visibility = snapshot.current.visibility_tokens
         if visibility is None:
             raise ValueError("hosted observation staging requires coordinated visibility")

--- a/src/archetype/physical_ai/hosted_activity_world.py
+++ b/src/archetype/physical_ai/hosted_activity_world.py
@@ -1,0 +1,286 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact world adapters for hosted Physical-AI Activity choreography."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+from daft import DataFrame, Expression, col
+
+from archetype.core.component import Component
+from archetype.core.config import StorageConfig
+from archetype.core.interfaces import ArchetypeSignature, CommittedTickReceipt
+from archetype.physical_ai.hosted_activities import (
+    CommittedPhysicalSnapshot,
+    PhysicalHostedActivityCatalog,
+    PhysicalHostedActivityProjector,
+    PhysicalHostedActivityWorker,
+    PhysicalHostedValueStore,
+)
+from archetype.physical_ai.hosted_activity_contracts import (
+    HostedEpisodeIntent,
+    HostedEpisodeObservation,
+    HostedEpisodeProvider,
+)
+from archetype.storage.catalog import SignatureRecord
+from archetype.storage.interfaces import iStorageService
+from archetype.world.interfaces import iWorldRegistry
+from archetype.world.query import (
+    PinnedWorldQuerySnapshot,
+    pin_query_snapshot,
+    query_components,
+)
+from archetype.world.simulation import RequiredProjector
+
+_PHYSICAL_ACTIVITY_QUERY_GROUPS: tuple[tuple[type[Component], ...], ...] = (
+    # Keep intent/observation separate so either can exist without requiring
+    # an archetype that contains both.
+    (HostedEpisodeIntent,),
+    (HostedEpisodeObservation,),
+)
+
+
+def _has_recorded_group(
+    records: list[SignatureRecord],
+    group: tuple[type[Component], ...],
+) -> bool:
+    requested = {component.__name__ for component in group}
+    return any(requested.issubset(record.component_names) for record in records)
+
+
+async def _query_groups(
+    storage: iStorageService,
+    storage_config: StorageConfig,
+    snapshot: PinnedWorldQuerySnapshot,
+    groups: tuple[tuple[type[Component], ...], ...],
+) -> Mapping[ArchetypeSignature, DataFrame]:
+    visibility = snapshot.current.visibility_tokens
+    if visibility is None:
+        raise ValueError("physical Activity reads require coordinated visibility")
+    records = await storage.get_control_catalog(storage_config).list_signatures()
+    results: dict[ArchetypeSignature, DataFrame] = {}
+    for group in groups:
+        if not _has_recorded_group(records, group):
+            continue
+        frame = await query_components(
+            storage,
+            list(group),
+            snapshot.world_id,
+            snapshot.run_id,
+            storage_config,
+            visibility_tokens=list(visibility),
+        )
+        results[group] = await storage.materialize(frame)
+    return results
+
+
+class StoragePhysicalCommittedIntentReader:
+    """Read the exact singleton manifest head named by a required receipt."""
+
+    def __init__(
+        self,
+        storage: iStorageService,
+        storage_config: StorageConfig | None = None,
+    ) -> None:
+        self._storage = storage
+        self._storage_config = storage_config or StorageConfig()
+
+    async def read(self, receipt: CommittedTickReceipt) -> CommittedPhysicalSnapshot:
+        if receipt.visibility_token is None:
+            raise ValueError("physical Activity reader requires a visibility token")
+        snapshot = await pin_query_snapshot(
+            self._storage,
+            receipt.world_id,
+            receipt.run_id,
+            self._storage_config,
+        )
+        if (
+            snapshot.world_id != receipt.world_id
+            or snapshot.run_id != receipt.run_id
+            or snapshot.head_tick != receipt.committed_tick
+            or snapshot.head_tokens != (receipt.visibility_token,)
+        ):
+            raise ValueError("physical Activity read is not the exact committed receipt")
+        return CommittedPhysicalSnapshot(
+            world_id=snapshot.world_id,
+            run_id=snapshot.run_id,
+            committed_tick=receipt.committed_tick,
+            visibility_token=receipt.visibility_token,
+            results=await _query_groups(
+                self._storage,
+                self._storage_config,
+                snapshot,
+                _PHYSICAL_ACTIVITY_QUERY_GROUPS,
+            ),
+        )
+
+
+def _component_from_row(
+    component_type: type[HostedEpisodeObservation],
+    row: dict[str, object],
+) -> HostedEpisodeObservation:
+    prefix = component_type.get_prefix()
+    return component_type.model_validate(
+        {field: row[f"{prefix}{field}"] for field in component_type.model_fields}
+    )
+
+
+def _pending_observations(world: Any) -> tuple[HostedEpisodeObservation, ...]:
+    spawn_cache = world.spawn_cache
+    entity2sig = world.entity2sig
+    prefix = HostedEpisodeObservation.get_prefix()
+    required = {f"{prefix}{field}" for field in HostedEpisodeObservation.model_fields}
+    observations: list[HostedEpisodeObservation] = []
+    for signature, rows in spawn_cache.items():
+        for row in rows:
+            if not required.issubset(row):
+                continue
+            if entity2sig.get(int(row["entity_id"])) != signature:
+                continue
+            observations.append(_component_from_row(HostedEpisodeObservation, row))
+    return tuple(observations)
+
+
+class WorldHostedEpisodeObservationStager:
+    """Stage one complete marker idempotently under the exact world lock."""
+
+    def __init__(
+        self,
+        *,
+        storage: iStorageService,
+        registry: iWorldRegistry,
+    ) -> None:
+        self._storage = storage
+        self._registry = registry
+
+    async def stage_hosted_episode_observation(
+        self,
+        *,
+        world_id: str,
+        observation: HostedEpisodeObservation,
+    ) -> None:
+        if not world_id.strip() or not observation.activity_id.strip():
+            raise ValueError("hosted observation requires world and Activity identities")
+        async with self._registry.operation(world_id) as world:
+            committed = tuple(
+                item
+                for item in await self._committed_observations(
+                    world_id,
+                    world,
+                    observation.activity_id,
+                )
+                if item.activity_id == observation.activity_id
+            )
+            self._accept_existing(committed, observation)
+            if committed:
+                return
+            pending = tuple(
+                item
+                for item in _pending_observations(world)
+                if item.activity_id == observation.activity_id
+            )
+            self._accept_existing(pending, observation)
+            if pending:
+                return
+            await world.create_entity([observation])
+
+    async def _committed_observations(
+        self,
+        world_id: str,
+        world: Any,
+        activity_id: str,
+    ) -> tuple[HostedEpisodeObservation, ...]:
+        storage_record = await self._registry.storage_record(world_id)
+        storage_config = storage_record[0] if storage_record is not None else StorageConfig()
+        records = await self._storage.get_control_catalog(storage_config).list_signatures()
+        if not _has_recorded_group(records, (HostedEpisodeObservation,)):
+            return ()
+        snapshot = await pin_query_snapshot(
+            self._storage,
+            world_id,
+            str(world.run_id),
+            storage_config,
+        )
+        visibility = snapshot.current.visibility_tokens
+        if visibility is None:
+            raise ValueError("hosted observation staging requires coordinated visibility")
+        frame = await query_components(
+            self._storage,
+            [HostedEpisodeObservation],
+            snapshot.world_id,
+            snapshot.run_id,
+            storage_config,
+            visibility_tokens=list(visibility),
+        )
+        prefix = HostedEpisodeObservation.get_prefix()
+        matching = frame.where(cast(Expression, col(f"{prefix}activity_id") == activity_id))
+        materialized = await self._storage.materialize(matching)
+        return tuple(
+            _component_from_row(HostedEpisodeObservation, row) for row in materialized.to_pylist()
+        )
+
+    @staticmethod
+    def _accept_existing(
+        existing: tuple[HostedEpisodeObservation, ...],
+        candidate: HostedEpisodeObservation,
+    ) -> None:
+        matching = tuple(value for value in existing if value.activity_id == candidate.activity_id)
+        if not matching:
+            return
+        if len(matching) != 1 or matching[0] != candidate:
+            raise ValueError("hosted Activity has conflicting or duplicate observation markers")
+
+
+class PhysicalHostedActivityBinding:
+    """Bind one world to required projection and an out-of-lock worker."""
+
+    def __init__(
+        self,
+        *,
+        world_id: str,
+        owner: str,
+        reader: StoragePhysicalCommittedIntentReader,
+        catalog: PhysicalHostedActivityCatalog,
+        values: PhysicalHostedValueStore,
+        provider: HostedEpisodeProvider,
+        stager: WorldHostedEpisodeObservationStager,
+    ) -> None:
+        if not world_id.strip():
+            raise ValueError("hosted Physical-AI binding requires a world identity")
+        self.world_id = world_id
+        self.projector = PhysicalHostedActivityProjector(
+            reader=reader,
+            catalog=catalog,
+            values=values,
+        )
+        self.required_projector = RequiredProjector(
+            consumer_name=self.projector.consumer_name,
+            project=self.projector.project,
+        )
+        self.worker = PhysicalHostedActivityWorker(
+            world_id=world_id,
+            owner=owner,
+            catalog=catalog,
+            values=values,
+            provider=provider,
+            stager=stager,
+        )
+        self._catalog = catalog
+
+    def required_projector_for(self, world_id: str) -> RequiredProjector | None:
+        return self.required_projector if str(world_id) == self.world_id else None
+
+    async def has_unsettled_work(self, world_id: str) -> bool:
+        if str(world_id) != self.world_id:
+            return False
+        return await self._catalog.has_unsettled_work(self.world_id)
+
+
+__all__ = [
+    "PhysicalHostedActivityBinding",
+    "StoragePhysicalCommittedIntentReader",
+    "WorldHostedEpisodeObservationStager",
+]

--- a/src/archetype/physical_ai/hosted_modal.py
+++ b/src/archetype/physical_ai/hosted_modal.py
@@ -1,0 +1,923 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Modal execution and first-result recovery for hosted Physical-AI Activities.
+
+The generic Activity catalog binds ``operation_id`` before this adapter is
+called.  This module then uses one permanent, atomic key in a named Modal Dict
+to select the only remote start.  Complete canonical payloads are committed to
+a named Modal Volume before a bounded result index is inserted into the Dict.
+
+The Dict and Volume are provider durability, not ECS state.  A permanent start
+without the complete result index is deliberately unknown and cannot be
+replayed, even when the request is seeded and the Activity lease has expired.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, cast, runtime_checkable
+from urllib.parse import quote
+
+from archetype.errors import AvailabilityError
+from archetype.physical_ai.hosted_activity_contracts import (
+    HostedEpisodeConfirmedAbsent,
+    HostedEpisodeProviderResult,
+    HostedEpisodeRecovered,
+    HostedEpisodeRecoveryUnknown,
+    HostedEpisodeRetryGuard,
+    validate_hosted_provider_result,
+)
+from archetype.physical_ai.hosted_activity_values import SeededHostedEpisodeRunner
+from archetype.physical_ai.hosted_episode import (
+    build_hosted_episode_manifest,
+    build_hosted_episode_results,
+    decode_hosted_episode_requests,
+    hosted_episode_manifest_digest,
+    hosted_episode_request_digest,
+    hosted_episode_results_digest,
+    hosted_episode_trajectory_digest,
+)
+
+MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH = 1
+MODAL_HOSTED_EPISODE_VOLUME_MOUNT = "/archetype-hosted-episodes"
+
+_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$")
+_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+_OPERATION = re.compile(r"^physical-episode:[0-9a-f]{64}$")
+_PAYLOAD_KINDS = ("request", "trajectory", "episode-results", "manifest")
+_RESULT_SCHEMA_VERSION = 1
+_START_SCHEMA_VERSION = 1
+_RESULT_ROOT = "archetype-physical-ai-hosted-v1"
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _bounded_name(value: str, field: str) -> str:
+    if not isinstance(value, str) or _NAME.fullmatch(value) is None:
+        raise ValueError(f"{field} must be a valid Modal name")
+    return value
+
+
+def _bounded_positive(value: int, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field} must be a positive integer")
+    return value
+
+
+def _operation_key(operation_id: str) -> str:
+    if _OPERATION.fullmatch(operation_id) is None:
+        raise ValueError("Modal hosted operation identity is invalid")
+    return hashlib.sha256(operation_id.encode()).hexdigest()
+
+
+def _start_key(operation_id: str) -> str:
+    return f"start:{_operation_key(operation_id)}"
+
+
+def _result_key(operation_id: str) -> str:
+    return f"result:{_operation_key(operation_id)}"
+
+
+def _blob_path(kind: str, digest: str) -> str:
+    if kind not in _PAYLOAD_KINDS:
+        raise ValueError("Modal hosted payload kind is invalid")
+    if _DIGEST.fullmatch(digest) is None:
+        raise ValueError("Modal hosted payload digest is invalid")
+    return f"{_RESULT_ROOT}/{kind}/{digest[:2]}/{digest}.arrow"
+
+
+def _payload_digest(kind: str, payload: bytes) -> str:
+    if kind == "request":
+        return hosted_episode_request_digest(payload)
+    if kind == "trajectory":
+        return hosted_episode_trajectory_digest(payload)
+    if kind == "episode-results":
+        return hosted_episode_results_digest(payload)
+    if kind == "manifest":
+        return hosted_episode_manifest_digest(payload)
+    raise ValueError("Modal hosted payload kind is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class ModalHostedEpisodeConfig:
+    """Exact persistent Modal namespace used by one hosted provider adapter."""
+
+    workspace_name: str
+    environment_name: str
+    app_name: str
+    function_name: str
+    result_dict_name: str
+    result_volume_name: str
+    protocol_epoch: int = MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH
+    call_timeout_seconds: int = 900
+    create_if_missing: bool = False
+
+    def __post_init__(self) -> None:
+        for field in (
+            "workspace_name",
+            "environment_name",
+            "app_name",
+            "function_name",
+            "result_dict_name",
+            "result_volume_name",
+        ):
+            _bounded_name(getattr(self, field), f"Modal hosted {field}")
+        if (
+            isinstance(self.protocol_epoch, bool)
+            or not isinstance(self.protocol_epoch, int)
+            or self.protocol_epoch != MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH
+        ):
+            raise ValueError("Modal hosted provider protocol epoch is unsupported")
+        _bounded_positive(self.call_timeout_seconds, "Modal hosted call timeout")
+        if not isinstance(self.create_if_missing, bool):
+            raise ValueError("Modal hosted create_if_missing must be a boolean")
+
+    @property
+    def namespace_digest(self) -> str:
+        """Bind workspace, environment, code entrypoint, and durable objects."""
+
+        return _sha256(
+            _canonical_json(
+                {
+                    "app_name": self.app_name,
+                    "environment_name": self.environment_name,
+                    "function_name": self.function_name,
+                    "protocol_epoch": self.protocol_epoch,
+                    "provider": "modal-hosted-episode",
+                    "result_dict_name": self.result_dict_name,
+                    "result_volume_name": self.result_volume_name,
+                    "schema_version": 1,
+                    "workspace_name": self.workspace_name,
+                }
+            )
+        )
+
+    @property
+    def provider_identity(self) -> str:
+        return f"modal-hosted-episode:{self.namespace_digest}"
+
+    def retry_guard(
+        self,
+        *,
+        operation_id: str,
+        request_digest: str,
+    ) -> HostedEpisodeRetryGuard:
+        """Describe the next atomic put-if-absent route, not transferable start authority."""
+
+        key = _operation_key(operation_id)
+        if _DIGEST.fullmatch(request_digest) is None:
+            raise ValueError("Modal hosted request digest is invalid")
+        payload = _canonical_json(
+            {
+                "barrier": "modal-dict-put-if-absent",
+                "namespace_digest": self.namespace_digest,
+                "operation_id": operation_id,
+                "protocol_epoch": self.protocol_epoch,
+                "request_digest": request_digest,
+                "schema_version": 1,
+            }
+        )
+        reference = (
+            "modal-hosted-start://"
+            + quote(self.workspace_name, safe="")
+            + "/"
+            + quote(self.environment_name, safe="")
+            + "/"
+            + quote(self.result_dict_name, safe="")
+            + "/"
+            + key
+        )
+        return HostedEpisodeRetryGuard(ref=reference, digest=_sha256(payload))
+
+
+@runtime_checkable
+class ModalHostedEpisodeRuntime(Protocol):
+    """Narrow Modal control/data operations used by the family adapter."""
+
+    async def get(self, key: str) -> object: ...
+
+    async def put_if_absent(self, key: str, value: Mapping[str, Any]) -> bool: ...
+
+    async def spawn(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        namespace_digest: str,
+    ) -> object: ...
+
+    async def wait(self, call: object) -> object: ...
+
+    async def read_blob(self, path: str) -> bytes: ...
+
+
+class ModalHostedEpisodeProviderUnknown(AvailabilityError):
+    """A permanent Modal start exists but no exact complete result is visible."""
+
+    public_detail = "Hosted episode provider state is temporarily unavailable"
+
+    def __init__(self, operation_id: str, reason: str) -> None:
+        self.operation_id = operation_id
+        self.reason = reason
+        super().__init__(f"Modal hosted operation {operation_id!r} is unknown: {reason}")
+
+
+class ModalHostedEpisodeProvider:
+    """Execute or recover one canonical episode batch through Modal."""
+
+    def __init__(
+        self,
+        config: ModalHostedEpisodeConfig,
+        *,
+        runtime: ModalHostedEpisodeRuntime | None = None,
+    ) -> None:
+        self._config = config
+        self._runtime = runtime or ModalNamedHostedEpisodeRuntime(config)
+
+    @property
+    def provider(self) -> str:
+        return self._config.provider_identity
+
+    async def execute(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        attempt: int,
+        fence: int,
+        retry_guard: HostedEpisodeRetryGuard | None,
+    ) -> HostedEpisodeProviderResult:
+        request_digest = self._validate_request(operation_id, request_ipc)
+        _bounded_positive(attempt, "Modal hosted Activity attempt")
+        _bounded_positive(fence, "Modal hosted Activity fence")
+        expected_guard = self._config.retry_guard(
+            operation_id=operation_id,
+            request_digest=request_digest,
+        )
+        if retry_guard is not None and retry_guard != expected_guard:
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                "retry guard does not bind this provider namespace and request",
+            )
+
+        recovered = await self._recover_if_complete(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+        )
+        if recovered is not None:
+            return recovered
+
+        marker = self._start_marker(
+            operation_id=operation_id,
+            request_digest=request_digest,
+            attempt=attempt,
+            fence=fence,
+        )
+        try:
+            acquired = await self._runtime.put_if_absent(
+                _start_key(operation_id),
+                marker,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            recovered = await self._recover_if_complete(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+            if recovered is not None:
+                return recovered
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                f"start admission was ambiguous ({type(exc).__name__[:128]})",
+            ) from exc
+
+        if not acquired:
+            recovered = await self._recover_if_complete(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+            if recovered is not None:
+                return recovered
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                "permanent start exists without a complete result index",
+            )
+
+        try:
+            call = await self._runtime.spawn(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+                namespace_digest=self._config.namespace_digest,
+            )
+            await self._runtime.wait(call)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            recovered = await self._recover_if_complete(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+            if recovered is not None:
+                return recovered
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                f"remote execution ended without provider result ({type(exc).__name__[:128]})",
+            ) from exc
+
+        recovered = await self._recover_if_complete(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+        )
+        if recovered is None:
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                "remote completion returned without a complete result index",
+            )
+        return recovered
+
+    async def reconcile(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeRecovered | HostedEpisodeConfirmedAbsent | HostedEpisodeRecoveryUnknown:
+        request_digest = self._validate_request(operation_id, request_ipc)
+        try:
+            raw_result = await self._runtime.get(_result_key(operation_id))
+            raw_start = await self._runtime.get(_start_key(operation_id))
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return HostedEpisodeRecoveryUnknown(
+                f"Modal provider lookup failed ({type(exc).__name__[:128]})"
+            )
+
+        if raw_result is not None:
+            if not self._start_matches(
+                raw_start,
+                operation_id=operation_id,
+                request_digest=request_digest,
+            ):
+                return HostedEpisodeRecoveryUnknown(
+                    "complete result exists without its exact permanent start"
+                )
+            result = await self._load_result(
+                raw_result,
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+            return HostedEpisodeRecovered(result)
+
+        if raw_start is not None:
+            if not self._start_matches(
+                raw_start,
+                operation_id=operation_id,
+                request_digest=request_digest,
+            ):
+                return HostedEpisodeRecoveryUnknown(
+                    "permanent start conflicts with this operation or request"
+                )
+            return HostedEpisodeRecoveryUnknown(
+                "permanent start exists without a complete result index"
+            )
+
+        return HostedEpisodeConfirmedAbsent(
+            self._config.retry_guard(
+                operation_id=operation_id,
+                request_digest=request_digest,
+            )
+        )
+
+    async def result_for(
+        self,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeProviderResult | None:
+        """Read the exact first result without creating retry evidence."""
+
+        self._validate_request(operation_id, request_ipc)
+        return await self._recover_if_complete(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+        )
+
+    async def _recover_if_complete(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeProviderResult | None:
+        try:
+            conclusion = await self.reconcile(
+                operation_id=operation_id,
+                request_ipc=request_ipc,
+            )
+        except asyncio.CancelledError:
+            raise
+        if isinstance(conclusion, HostedEpisodeRecovered):
+            return conclusion.result
+        if isinstance(conclusion, HostedEpisodeRecoveryUnknown):
+            raise ModalHostedEpisodeProviderUnknown(
+                operation_id,
+                conclusion.reason or "provider reconciliation is unknown",
+            )
+        return None
+
+    async def _load_result(
+        self,
+        raw: object,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+    ) -> HostedEpisodeProviderResult:
+        records = self._parse_result_index(
+            raw,
+            operation_id=operation_id,
+            request_digest=hosted_episode_request_digest(request_ipc),
+        )
+        payloads: dict[str, bytes] = {}
+        for kind in _PAYLOAD_KINDS:
+            record = records[kind]
+            payload = await self._runtime.read_blob(str(record["path"]))
+            if (
+                len(payload) != int(record["size_bytes"])
+                or _payload_digest(kind, payload) != record["digest"]
+            ):
+                raise ValueError(f"Modal hosted {kind} bytes do not match result index")
+            payloads[kind] = payload
+        if payloads["request"] != request_ipc:
+            raise ValueError("Modal hosted result index binds another request")
+        result = HostedEpisodeProviderResult(
+            request_ipc=payloads["request"],
+            trajectory_ipc=payloads["trajectory"],
+            episode_results_ipc=payloads["episode-results"],
+            manifest_ipc=payloads["manifest"],
+        )
+        validate_hosted_provider_result(
+            result,
+            request_ipc=request_ipc,
+            operation_id=operation_id,
+        )
+        return result
+
+    def _parse_result_index(
+        self,
+        raw: object,
+        *,
+        operation_id: str,
+        request_digest: str,
+    ) -> dict[str, dict[str, str | int]]:
+        if not isinstance(raw, dict):
+            raise ValueError("Modal hosted result index is not an object")
+        index = cast(dict[str, object], raw)
+        expected_keys = {
+            "schema_version",
+            "protocol_epoch",
+            "namespace_digest",
+            "operation_id",
+            "request_digest",
+            "payloads",
+        }
+        if set(index) != expected_keys:
+            raise ValueError("Modal hosted result index fields are incompatible")
+        payloads = index["payloads"]
+        if (
+            index["schema_version"] != _RESULT_SCHEMA_VERSION
+            or index["protocol_epoch"] != self._config.protocol_epoch
+            or index["namespace_digest"] != self._config.namespace_digest
+            or index["operation_id"] != operation_id
+            or index["request_digest"] != request_digest
+            or not isinstance(payloads, dict)
+            or set(payloads) != set(_PAYLOAD_KINDS)
+        ):
+            raise ValueError("Modal hosted result index identity is incompatible")
+        payload_records = cast(dict[str, object], payloads)
+        parsed: dict[str, dict[str, str | int]] = {}
+        for kind in _PAYLOAD_KINDS:
+            record = payload_records[kind]
+            if not isinstance(record, dict) or set(record) != {
+                "digest",
+                "path",
+                "size_bytes",
+            }:
+                raise ValueError(f"Modal hosted {kind} index record is incompatible")
+            fields = cast(dict[str, object], record)
+            digest = fields["digest"]
+            path = fields["path"]
+            size_bytes = fields["size_bytes"]
+            if (
+                not isinstance(digest, str)
+                or _DIGEST.fullmatch(digest) is None
+                or path != _blob_path(kind, digest)
+                or isinstance(size_bytes, bool)
+                or not isinstance(size_bytes, int)
+                or size_bytes < 1
+            ):
+                raise ValueError(f"Modal hosted {kind} index record is invalid")
+            parsed[kind] = {
+                "digest": digest,
+                "path": cast(str, path),
+                "size_bytes": cast(int, size_bytes),
+            }
+        return parsed
+
+    def _start_matches(
+        self,
+        raw: object,
+        *,
+        operation_id: str,
+        request_digest: str,
+    ) -> bool:
+        if not isinstance(raw, dict):
+            return False
+        marker = cast(dict[str, object], raw)
+        return (
+            set(marker)
+            == {
+                "attempt",
+                "fence",
+                "namespace_digest",
+                "operation_id",
+                "protocol_epoch",
+                "request_digest",
+                "schema_version",
+            }
+            and marker["schema_version"] == _START_SCHEMA_VERSION
+            and marker["protocol_epoch"] == self._config.protocol_epoch
+            and marker["namespace_digest"] == self._config.namespace_digest
+            and marker["operation_id"] == operation_id
+            and marker["request_digest"] == request_digest
+            and isinstance(marker["attempt"], int)
+            and not isinstance(marker["attempt"], bool)
+            and marker["attempt"] > 0
+            and isinstance(marker["fence"], int)
+            and not isinstance(marker["fence"], bool)
+            and marker["fence"] > 0
+        )
+
+    def _start_marker(
+        self,
+        *,
+        operation_id: str,
+        request_digest: str,
+        attempt: int,
+        fence: int,
+    ) -> dict[str, str | int]:
+        return {
+            "attempt": attempt,
+            "fence": fence,
+            "namespace_digest": self._config.namespace_digest,
+            "operation_id": operation_id,
+            "protocol_epoch": self._config.protocol_epoch,
+            "request_digest": request_digest,
+            "schema_version": _START_SCHEMA_VERSION,
+        }
+
+    @staticmethod
+    def _validate_request(operation_id: str, request_ipc: bytes) -> str:
+        _operation_key(operation_id)
+        rows = decode_hosted_episode_requests(request_ipc)
+        if any(row["operation_id"] != operation_id for row in rows):
+            raise ValueError("Modal hosted provider operation does not match its request")
+        return hosted_episode_request_digest(request_ipc)
+
+
+class ModalNamedHostedEpisodeRuntime:
+    """Concrete named-Dict, named-Volume, named-Function Modal client."""
+
+    def __init__(
+        self,
+        config: ModalHostedEpisodeConfig,
+        *,
+        function: object | None = None,
+    ) -> None:
+        self._config = config
+        self._lock = asyncio.Lock()
+        self._client: Any | None = None
+        self._dictionary: Any | None = None
+        self._volume: Any | None = None
+        self._function: Any | None = function
+        self._last_completion: object | None = None
+
+    @property
+    def last_completion(self) -> object | None:
+        """Expose non-canonical placement diagnostics for a live proof only."""
+
+        return self._last_completion
+
+    async def get(self, key: str) -> object:
+        dictionary, _, _ = await self._objects()
+        return await dictionary.get.aio(key, None)
+
+    async def put_if_absent(self, key: str, value: Mapping[str, Any]) -> bool:
+        dictionary, _, _ = await self._objects()
+        return bool(await dictionary.put.aio(key, dict(value), skip_if_exists=True))
+
+    async def spawn(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        namespace_digest: str,
+    ) -> object:
+        _, _, function = await self._objects(require_function=True)
+        if function is None:
+            raise RuntimeError("Modal hosted execution function is unavailable")
+        return await function.spawn.aio(operation_id, request_ipc, namespace_digest)
+
+    async def wait(self, call: object) -> object:
+        get = getattr(call, "get", None)
+        if get is None or not hasattr(get, "aio"):
+            raise TypeError("Modal hosted function call has no async result boundary")
+        self._last_completion = await get.aio(timeout=float(self._config.call_timeout_seconds))
+        return self._last_completion
+
+    async def read_blob(self, path: str) -> bytes:
+        if not self._valid_blob_path(path):
+            raise ValueError("Modal hosted result index contains an unsafe blob path")
+        _, volume, _ = await self._objects()
+        chunks = [chunk async for chunk in volume.read_file.aio(path)]
+        return b"".join(chunks)
+
+    async def _objects(
+        self,
+        *,
+        require_function: bool = False,
+    ) -> tuple[Any, Any, Any | None]:
+        if (
+            self._dictionary is not None
+            and self._volume is not None
+            and (not require_function or self._function is not None)
+        ):
+            return self._dictionary, self._volume, self._function
+        async with self._lock:
+            if self._client is None:
+                modal = _load_modal()
+                workspace = modal.Workspace.from_context()
+                await workspace.hydrate.aio()
+                observed = str(workspace.name or "")
+                if observed != self._config.workspace_name:
+                    raise RuntimeError("Modal workspace does not match hosted provider namespace")
+                self._client = workspace.client
+            modal = _load_modal()
+            if self._dictionary is None:
+                self._dictionary = modal.Dict.from_name(
+                    self._config.result_dict_name,
+                    environment_name=self._config.environment_name,
+                    create_if_missing=self._config.create_if_missing,
+                    client=self._client,
+                )
+                await self._dictionary.hydrate.aio()
+            if self._volume is None:
+                self._volume = modal.Volume.from_name(
+                    self._config.result_volume_name,
+                    environment_name=self._config.environment_name,
+                    create_if_missing=self._config.create_if_missing,
+                    client=self._client,
+                )
+                await self._volume.hydrate.aio()
+            if require_function and self._function is None:
+                self._function = modal.Function.from_name(
+                    self._config.app_name,
+                    self._config.function_name,
+                    environment_name=self._config.environment_name,
+                    client=self._client,
+                )
+                await self._function.hydrate.aio()
+            return self._dictionary, self._volume, self._function
+
+    @staticmethod
+    def _valid_blob_path(path: str) -> bool:
+        parts = Path(path).parts
+        return (
+            len(parts) == 4
+            and parts[0] == _RESULT_ROOT
+            and parts[1] in _PAYLOAD_KINDS
+            and len(parts[2]) == 2
+            and parts[3].endswith(".arrow")
+            and _DIGEST.fullmatch(parts[3].removesuffix(".arrow")) is not None
+            and parts[2] == parts[3][:2]
+        )
+
+
+def build_seeded_modal_hosted_episode_app(
+    config: ModalHostedEpisodeConfig,
+    *,
+    gpu: str = "L40S",
+    image: object | None = None,
+) -> tuple[object, object]:
+    """Build the disposable seeded GPU app used by parity proofs.
+
+    Production robot or simulator deployments may register another named
+    function with the same three-argument entrypoint and publication order.
+    """
+
+    modal = _load_modal()
+    result_volume = modal.Volume.from_name(
+        config.result_volume_name,
+        environment_name=config.environment_name,
+        create_if_missing=True,
+    )
+    if image is None:
+        image = (
+            modal.Image.debian_slim(python_version="3.12")
+            .uv_pip_install("archetype-ecs==0.4.1")
+            .add_local_python_source("archetype", copy=True)
+        )
+    app = modal.App(config.app_name)
+    namespace_digest = config.namespace_digest
+    protocol_epoch = config.protocol_epoch
+    environment_name = config.environment_name
+    result_dict_name = config.result_dict_name
+    result_volume_name = config.result_volume_name
+
+    @app.function(
+        name=config.function_name,
+        image=image,
+        gpu=gpu,
+        serialized=True,
+        timeout=config.call_timeout_seconds,
+        volumes={MODAL_HOSTED_EPISODE_VOLUME_MOUNT: result_volume},
+    )
+    def seeded_hosted_episode(
+        operation_id: str,
+        request_ipc: bytes,
+        requested_namespace_digest: str,
+    ) -> dict[str, str | int]:
+        if requested_namespace_digest != namespace_digest:
+            raise ValueError("Modal hosted remote namespace does not match deployment")
+        modal = _load_modal()
+        remote_result_dict = modal.Dict.from_name(
+            result_dict_name,
+            environment_name=environment_name,
+            create_if_missing=False,
+        )
+        remote_result_volume = modal.Volume.from_name(
+            result_volume_name,
+            environment_name=environment_name,
+            create_if_missing=False,
+        )
+        result = _run_seeded_episode(request_ipc)
+        validate_hosted_provider_result(
+            result,
+            request_ipc=request_ipc,
+            operation_id=operation_id,
+        )
+        index = _publish_remote_result(
+            mount=Path(MODAL_HOSTED_EPISODE_VOLUME_MOUNT),
+            operation_id=operation_id,
+            namespace_digest=requested_namespace_digest,
+            protocol_epoch=protocol_epoch,
+            result=result,
+        )
+        remote_result_volume.commit()
+        key = _result_key(operation_id)
+        inserted = remote_result_dict.put(key, index, skip_if_exists=True)
+        if not inserted and remote_result_dict.get(key) != index:
+            raise RuntimeError("Modal hosted result index conflicts with first result")
+        return {
+            "gpu_count": _gpu_count(),
+            "index_digest": _sha256(_canonical_json(index)),
+            "schema_version": 1,
+        }
+
+    return app, seeded_hosted_episode
+
+
+def _run_seeded_episode(request_ipc: bytes) -> HostedEpisodeProviderResult:
+    trajectory_ipc = asyncio.run(SeededHostedEpisodeRunner().run(request_ipc))
+    episode_results_ipc = build_hosted_episode_results(request_ipc, trajectory_ipc)
+    manifest_ipc = build_hosted_episode_manifest(
+        request_ipc,
+        trajectory_ipc,
+        episode_results_ipc,
+    )
+    return HostedEpisodeProviderResult(
+        request_ipc=request_ipc,
+        trajectory_ipc=trajectory_ipc,
+        episode_results_ipc=episode_results_ipc,
+        manifest_ipc=manifest_ipc,
+    )
+
+
+def _publish_remote_result(
+    *,
+    mount: Path,
+    operation_id: str,
+    namespace_digest: str,
+    protocol_epoch: int,
+    result: HostedEpisodeProviderResult,
+) -> dict[str, Any]:
+    payloads = {
+        "request": result.request_ipc,
+        "trajectory": result.trajectory_ipc,
+        "episode-results": result.episode_results_ipc,
+        "manifest": result.manifest_ipc,
+    }
+    records: dict[str, dict[str, str | int]] = {}
+    for kind, payload in payloads.items():
+        digest = _payload_digest(kind, payload)
+        relative = _blob_path(kind, digest)
+        _write_remote_blob(mount / relative, payload)
+        records[kind] = {
+            "digest": digest,
+            "path": relative,
+            "size_bytes": len(payload),
+        }
+    return {
+        "namespace_digest": namespace_digest,
+        "operation_id": operation_id,
+        "payloads": records,
+        "protocol_epoch": protocol_epoch,
+        "request_digest": hosted_episode_request_digest(result.request_ipc),
+        "schema_version": _RESULT_SCHEMA_VERSION,
+    }
+
+
+def _write_remote_blob(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if path.read_bytes() != payload:
+            raise RuntimeError(f"Modal hosted immutable blob conflicts at {path.name}")
+        return
+    descriptor, temporary = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if path.exists():
+            if path.read_bytes() != payload:
+                raise RuntimeError(f"Modal hosted immutable blob conflicts at {path.name}")
+        else:
+            # Concurrent writers can only target the same digest. Replacing
+            # identical bytes is safe and leaves no partial durable payload.
+            os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _gpu_count() -> int:
+    """Return proof-only placement diagnostics; never enter canonical payloads."""
+
+    try:
+        completed = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    return len([line for line in completed.stdout.splitlines() if line.strip()])
+
+
+def _load_modal() -> Any:
+    try:
+        import modal
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "Modal support is optional; install it with `uv sync --extra coding-agent`"
+        ) from exc
+    return modal
+
+
+__all__ = [
+    "MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH",
+    "MODAL_HOSTED_EPISODE_VOLUME_MOUNT",
+    "ModalHostedEpisodeConfig",
+    "ModalHostedEpisodeProvider",
+    "ModalHostedEpisodeProviderUnknown",
+    "ModalHostedEpisodeRuntime",
+    "ModalNamedHostedEpisodeRuntime",
+    "build_seeded_modal_hosted_episode_app",
+]

--- a/src/archetype/storage/activity_catalog/interfaces.py
+++ b/src/archetype/storage/activity_catalog/interfaces.py
@@ -82,6 +82,7 @@ class ActivityCatalog(Protocol):
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[ActivityRecord]: ...
 
     async def settle_activity_observation(

--- a/src/archetype/storage/activity_catalog/interfaces.py
+++ b/src/archetype/storage/activity_catalog/interfaces.py
@@ -73,7 +73,7 @@ class ActivityCatalog(Protocol):
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> list[ActivityRecord]: ...
 
     async def list_unobserved_results(
@@ -82,7 +82,7 @@ class ActivityCatalog(Protocol):
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> list[ActivityRecord]: ...
 
     async def settle_activity_observation(

--- a/src/archetype/storage/activity_catalog/interfaces.py
+++ b/src/archetype/storage/activity_catalog/interfaces.py
@@ -73,6 +73,7 @@ class ActivityCatalog(Protocol):
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[ActivityRecord]: ...
 
     async def list_unobserved_results(

--- a/src/archetype/storage/activity_catalog/records.py
+++ b/src/archetype/storage/activity_catalog/records.py
@@ -36,6 +36,7 @@ class ActivityAdmissionRecord:
 
 @dataclass(frozen=True, slots=True)
 class ActivityRecord:
+    sequence: int | None
     activity_id: str
     kind: str
     source_world_id: str

--- a/src/archetype/storage/activity_catalog/sqlite.py
+++ b/src/archetype/storage/activity_catalog/sqlite.py
@@ -888,6 +888,7 @@ class SqliteActivityCatalog:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[ActivityRecord]:
         """Discover admitted work without relying on a process-local queue."""
 
@@ -896,6 +897,7 @@ class SqliteActivityCatalog:
             kind=kind,
             world_id=world_id,
             limit=limit,
+            offset=offset,
         )
 
     async def list_unobserved_results(
@@ -938,9 +940,12 @@ class SqliteActivityCatalog:
         kind: str | None,
         world_id: str | None,
         limit: int,
+        offset: int = 0,
     ) -> list[ActivityRecord]:
         if limit < 1:
             raise ValueError("limit must be positive")
+        if offset < 0:
+            raise ValueError("offset must be non-negative")
 
         def _list() -> list[ActivityRecord]:
             conditions = (
@@ -956,12 +961,13 @@ class SqliteActivityCatalog:
                 conditions.append("source_world_id=?")
                 parameters.append(world_id)
             parameters.append(limit)
+            parameters.append(offset)
             rows = (
                 self._connect_sync()
                 .execute(
                     "SELECT * FROM activities WHERE "
                     + " AND ".join(conditions)
-                    + " ORDER BY sequence LIMIT ?",
+                    + " ORDER BY sequence LIMIT ? OFFSET ?",
                     parameters,
                 )
                 .fetchall()

--- a/src/archetype/storage/activity_catalog/sqlite.py
+++ b/src/archetype/storage/activity_catalog/sqlite.py
@@ -888,7 +888,7 @@ class SqliteActivityCatalog:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> list[ActivityRecord]:
         """Discover admitted work without relying on a process-local queue."""
 
@@ -897,7 +897,7 @@ class SqliteActivityCatalog:
             kind=kind,
             world_id=world_id,
             limit=limit,
-            offset=offset,
+            after_sequence=after_sequence,
         )
 
     async def list_unobserved_results(
@@ -906,7 +906,7 @@ class SqliteActivityCatalog:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> list[ActivityRecord]:
         """Discover durable results that a later world tick has not observed."""
 
@@ -915,7 +915,7 @@ class SqliteActivityCatalog:
             kind=kind,
             world_id=world_id,
             limit=limit,
-            offset=offset,
+            after_sequence=after_sequence,
         )
 
     async def has_unsettled_activities(self, world_id: str) -> bool:
@@ -942,12 +942,12 @@ class SqliteActivityCatalog:
         kind: str | None,
         world_id: str | None,
         limit: int,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> list[ActivityRecord]:
         if limit < 1:
             raise ValueError("limit must be positive")
-        if offset < 0:
-            raise ValueError("offset must be non-negative")
+        if after_sequence < 0:
+            raise ValueError("after_sequence must be non-negative")
 
         def _list() -> list[ActivityRecord]:
             conditions = (
@@ -962,14 +962,15 @@ class SqliteActivityCatalog:
             if world_id is not None:
                 conditions.append("source_world_id=?")
                 parameters.append(world_id)
+            conditions.append("sequence>?")
+            parameters.append(after_sequence)
             parameters.append(limit)
-            parameters.append(offset)
             rows = (
                 self._connect_sync()
                 .execute(
                     "SELECT * FROM activities WHERE "
                     + " AND ".join(conditions)
-                    + " ORDER BY sequence LIMIT ? OFFSET ?",
+                    + " ORDER BY sequence LIMIT ?",
                     parameters,
                 )
                 .fetchall()
@@ -1242,6 +1243,7 @@ def _claim_from_row(
 
 def _activity_from_row(row: sqlite3.Row) -> ActivityRecord:
     return ActivityRecord(
+        sequence=int(row["sequence"]),
         activity_id=str(row["activity_id"]),
         kind=str(row["kind"]),
         source_world_id=str(row["source_world_id"]),

--- a/src/archetype/storage/activity_catalog/sqlite.py
+++ b/src/archetype/storage/activity_catalog/sqlite.py
@@ -906,6 +906,7 @@ class SqliteActivityCatalog:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[ActivityRecord]:
         """Discover durable results that a later world tick has not observed."""
 
@@ -914,6 +915,7 @@ class SqliteActivityCatalog:
             kind=kind,
             world_id=world_id,
             limit=limit,
+            offset=offset,
         )
 
     async def has_unsettled_activities(self, world_id: str) -> bool:

--- a/tests/activities/test_claim_scan_contract.py
+++ b/tests/activities/test_claim_scan_contract.py
@@ -14,6 +14,8 @@ prefix.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
 from archetype.activities import (
@@ -30,7 +32,7 @@ _WORLD_ID = "world-a"
 _KIND = "contract.kind"
 
 
-def _snapshot(activity_id: str) -> ActivitySnapshot:
+def _snapshot(activity_id: str, sequence: int | None = None) -> ActivitySnapshot:
     return ActivitySnapshot(
         admission=ActivityAdmission(
             activity_id=activity_id,
@@ -38,11 +40,12 @@ def _snapshot(activity_id: str) -> ActivitySnapshot:
             source=CommittedTickReceipt(_WORLD_ID, "run-a", 1, "token-1", 0),
             input_ref=f"contract-input:{activity_id}",
             input_digest="0" * 64,
-        )
+        ),
+        sequence=sequence,
     )
 
 
-def _result_snapshot(activity_id: str) -> ActivitySnapshot:
+def _result_snapshot(activity_id: str, sequence: int | None = None) -> ActivitySnapshot:
     base = _snapshot(activity_id)
     return ActivitySnapshot(
         admission=base.admission,
@@ -54,15 +57,18 @@ def _result_snapshot(activity_id: str) -> ActivitySnapshot:
         ),
         result_attempt=1,
         result_fence=1,
+        sequence=sequence,
     )
 
 
 class _ScanCoordinator:
-    """In-memory pending/claim surface honoring limit and offset.
+    """In-memory pending/claim surface honoring limit and the keyset cursor.
 
-    ``pending`` and ``pending_results`` slice a stable admission order the
-    way the catalog's ``ORDER BY sequence LIMIT ? OFFSET ?`` queries do;
-    ``claim`` acquires only rows no other worker holds a lease on.
+    ``pending`` and ``pending_results`` filter the current mutable set the
+    way the catalog's ``WHERE sequence > ? ORDER BY sequence LIMIT ?``
+    queries do; ``claim`` acquires only rows no other worker holds a lease
+    on.  ``complete_pending`` and ``observe_result`` remove rows the way a
+    concurrent worker's completion or observation does.
     """
 
     def __init__(
@@ -72,11 +78,31 @@ class _ScanCoordinator:
         claimable_ids: list[str],
         result_ids: list[str] | None = None,
     ) -> None:
-        self._order = [*leased_ids, *claimable_ids]
+        self._pending = {
+            sequence: activity_id
+            for sequence, activity_id in enumerate([*leased_ids, *claimable_ids], start=1)
+        }
         self._leased = set(leased_ids)
-        self._results = [_result_snapshot(rid) for rid in result_ids or []]
-        self.pending_offsets: list[int] = []
-        self.result_offsets: list[int] = []
+        self._results = {
+            sequence: _result_snapshot(rid, sequence)
+            for sequence, rid in enumerate(result_ids or [], start=1)
+        }
+        self.pending_cursors: list[int] = []
+        self.result_cursors: list[int] = []
+        self.after_pending_page: Callable[[], None] | None = None
+        self.after_result_page: Callable[[], None] | None = None
+
+    def complete_pending(self, activity_id: str) -> None:
+        self._pending = {
+            sequence: aid for sequence, aid in self._pending.items() if aid != activity_id
+        }
+
+    def observe_result(self, activity_id: str) -> None:
+        self._results = {
+            sequence: snapshot
+            for sequence, snapshot in self._results.items()
+            if snapshot.admission.activity_id != activity_id
+        }
 
     async def pending(
         self,
@@ -84,11 +110,18 @@ class _ScanCoordinator:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> tuple[ActivitySnapshot, ...]:
         assert kind == _KIND and world_id == _WORLD_ID
-        self.pending_offsets.append(offset)
-        return tuple(_snapshot(aid) for aid in self._order[offset : offset + limit])
+        self.pending_cursors.append(after_sequence)
+        page = tuple(
+            _snapshot(aid, sequence)
+            for sequence, aid in sorted(self._pending.items())
+            if sequence > after_sequence
+        )[:limit]
+        if self.after_pending_page is not None:
+            self.after_pending_page()
+        return page
 
     async def claim(
         self,
@@ -117,11 +150,18 @@ class _ScanCoordinator:
         kind: str | None = None,
         world_id: str | None = None,
         limit: int = 100,
-        offset: int = 0,
+        after_sequence: int = 0,
     ) -> tuple[ActivitySnapshot, ...]:
         assert kind == _KIND and world_id == _WORLD_ID
-        self.result_offsets.append(offset)
-        return tuple(self._results[offset : offset + limit])
+        self.result_cursors.append(after_sequence)
+        page = tuple(
+            snapshot
+            for sequence, snapshot in sorted(self._results.items())
+            if sequence > after_sequence
+        )[:limit]
+        if self.after_result_page is not None:
+            self.after_result_page()
+        return page
 
 
 @pytest.mark.asyncio
@@ -170,7 +210,7 @@ async def test_claim_scan_reports_none_only_after_exhaustion() -> None:
     )
 
     assert claim is None
-    assert coordinator.pending_offsets == [0, 1_000, 2_000]
+    assert coordinator.pending_cursors == [0, 1_000, 2_000]
 
 
 @pytest.mark.asyncio
@@ -191,8 +231,78 @@ async def test_result_scan_collects_beyond_one_page() -> None:
     )
 
     assert len(snapshots) == 2_050
-    assert coordinator.result_offsets == [0, 1_000, 2_000]
+    assert coordinator.result_cursors == [0, 1_000, 2_000]
     assert snapshots[-1].admission.activity_id == "result-2049"
+
+
+@pytest.mark.asyncio
+async def test_claim_scan_survives_mid_scan_completions() -> None:
+    """Rows completed by other workers mid-scan cannot hide claimable work.
+
+    The retired offset paging sliced the *current* pending set at an
+    absolute position: when concurrent completions shrank the set between
+    pages, the slice shifted past the still-claimable tail and the scan
+    returned ``None`` to a drain loop that treats ``None`` as exhaustion.
+    The keyset cursor keys pages by admission sequence, so removed rows
+    never shift the rows behind them.
+    """
+
+    leased_ids = [f"leased-{index:02d}" for index in range(10)]
+    coordinator = _ScanCoordinator(
+        leased_ids=leased_ids,
+        claimable_ids=["claimable-tail"],
+    )
+
+    def _complete_first_five() -> None:
+        coordinator.after_pending_page = None
+        for activity_id in leased_ids[:5]:
+            coordinator.complete_pending(activity_id)
+
+    coordinator.after_pending_page = _complete_first_five
+
+    claim = await claim_next_pending(
+        coordinator,
+        kind=_KIND,
+        world_id=_WORLD_ID,
+        owner="draining-worker",
+        lease_seconds=300.0,
+        page_size=10,
+    )
+
+    assert claim is not None
+    assert claim.acquired
+    assert claim.activity_id == "claimable-tail"
+    assert coordinator.pending_cursors == [0, 10]
+
+
+@pytest.mark.asyncio
+async def test_result_scan_survives_mid_scan_observations() -> None:
+    """Results observed by other workers mid-scan cannot drop later results."""
+
+    result_ids = [f"result-{index:02d}" for index in range(15)]
+    coordinator = _ScanCoordinator(
+        leased_ids=[],
+        claimable_ids=[],
+        result_ids=result_ids,
+    )
+
+    def _observe_first_five() -> None:
+        coordinator.after_result_page = None
+        for activity_id in result_ids[:5]:
+            coordinator.observe_result(activity_id)
+
+    coordinator.after_result_page = _observe_first_five
+
+    snapshots = await collect_pending_results(
+        coordinator,
+        kind=_KIND,
+        world_id=_WORLD_ID,
+        page_size=10,
+    )
+
+    collected = [snapshot.admission.activity_id for snapshot in snapshots]
+    assert collected == result_ids
+    assert coordinator.result_cursors == [0, 10]
 
 
 @pytest.mark.asyncio

--- a/tests/activities/test_claim_scan_contract.py
+++ b/tests/activities/test_claim_scan_contract.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Claim-scan starvation contract for coordinator claim and result scans.
+
+The retired implementations scanned one finite prefix of the pending set
+(10,000 rows for the author and hosted coordinators, the 100-row default
+for the critic coordinator).  When other workers held leases on the whole
+prefix, a claimable Activity beyond it was stranded: the scan reported no
+work until an unrelated change reshuffled the prefix.  These contracts pin
+the shared replacement: page until exhaustion, never conclude from a
+prefix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from archetype.activities import (
+    ActivityAdmission,
+    ActivityClaim,
+    ActivityResultRef,
+    ActivitySnapshot,
+    claim_next_pending,
+    collect_pending_results,
+)
+from archetype.core.interfaces import CommittedTickReceipt
+
+_WORLD_ID = "world-a"
+_KIND = "contract.kind"
+
+
+def _snapshot(activity_id: str) -> ActivitySnapshot:
+    return ActivitySnapshot(
+        admission=ActivityAdmission(
+            activity_id=activity_id,
+            kind=_KIND,
+            source=CommittedTickReceipt(_WORLD_ID, "run-a", 1, "token-1", 0),
+            input_ref=f"contract-input:{activity_id}",
+            input_digest="0" * 64,
+        )
+    )
+
+
+def _result_snapshot(activity_id: str) -> ActivitySnapshot:
+    base = _snapshot(activity_id)
+    return ActivitySnapshot(
+        admission=base.admission,
+        result=ActivityResultRef(
+            ref=f"contract-result:{activity_id}",
+            digest="1" * 64,
+            media_type="application/json",
+            size_bytes=1,
+        ),
+        result_attempt=1,
+        result_fence=1,
+    )
+
+
+class _ScanCoordinator:
+    """In-memory pending/claim surface honoring limit and offset.
+
+    ``pending`` and ``pending_results`` slice a stable admission order the
+    way the catalog's ``ORDER BY sequence LIMIT ? OFFSET ?`` queries do;
+    ``claim`` acquires only rows no other worker holds a lease on.
+    """
+
+    def __init__(
+        self,
+        *,
+        leased_ids: list[str],
+        claimable_ids: list[str],
+        result_ids: list[str] | None = None,
+    ) -> None:
+        self._order = [*leased_ids, *claimable_ids]
+        self._leased = set(leased_ids)
+        self._results = [_result_snapshot(rid) for rid in result_ids or []]
+        self.pending_offsets: list[int] = []
+        self.result_offsets: list[int] = []
+
+    async def pending(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[ActivitySnapshot, ...]:
+        assert kind == _KIND and world_id == _WORLD_ID
+        self.pending_offsets.append(offset)
+        return tuple(_snapshot(aid) for aid in self._order[offset : offset + limit])
+
+    async def claim(
+        self,
+        world_id: str,
+        kind: str,
+        activity_id: str,
+        owner: str,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> ActivityClaim:
+        assert kind == _KIND and world_id == _WORLD_ID
+        if activity_id in self._leased:
+            return ActivityClaim(snapshot=_snapshot(activity_id), acquired=False)
+        return ActivityClaim(
+            snapshot=_snapshot(activity_id),
+            acquired=True,
+            attempt=1,
+            fence=1,
+            owner=owner,
+            lease_expires_at=lease_seconds,
+        )
+
+    async def pending_results(
+        self,
+        *,
+        kind: str | None = None,
+        world_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[ActivitySnapshot, ...]:
+        assert kind == _KIND and world_id == _WORLD_ID
+        self.result_offsets.append(offset)
+        return tuple(self._results[offset : offset + limit])
+
+
+@pytest.mark.asyncio
+async def test_claim_scan_claims_beyond_the_retired_finite_prefix() -> None:
+    """More leased rows than the old 10,000-row scan bound cannot strand work.
+
+    Every row the retired prefix could see is leased by other workers; the
+    single claimable Activity sits just beyond row 10,000 and must still be
+    claimed.
+    """
+
+    coordinator = _ScanCoordinator(
+        leased_ids=[f"leased-{index:05d}" for index in range(10_001)],
+        claimable_ids=["claimable-beyond-the-prefix"],
+    )
+
+    claim = await claim_next_pending(
+        coordinator,
+        kind=_KIND,
+        world_id=_WORLD_ID,
+        owner="available-worker",
+        lease_seconds=300.0,
+    )
+
+    assert claim is not None
+    assert claim.acquired
+    assert claim.activity_id == "claimable-beyond-the-prefix"
+
+
+@pytest.mark.asyncio
+async def test_claim_scan_reports_none_only_after_exhaustion() -> None:
+    """No-work is honest only once every page of the pending set was scanned."""
+
+    coordinator = _ScanCoordinator(
+        leased_ids=[f"leased-{index:04d}" for index in range(2_500)],
+        claimable_ids=[],
+    )
+
+    claim = await claim_next_pending(
+        coordinator,
+        kind=_KIND,
+        world_id=_WORLD_ID,
+        owner="available-worker",
+        lease_seconds=300.0,
+        page_size=1_000,
+    )
+
+    assert claim is None
+    assert coordinator.pending_offsets == [0, 1_000, 2_000]
+
+
+@pytest.mark.asyncio
+async def test_result_scan_collects_beyond_one_page() -> None:
+    """Durable results beyond the first page still reach delivery."""
+
+    coordinator = _ScanCoordinator(
+        leased_ids=[],
+        claimable_ids=[],
+        result_ids=[f"result-{index:04d}" for index in range(2_050)],
+    )
+
+    snapshots = await collect_pending_results(
+        coordinator,
+        kind=_KIND,
+        world_id=_WORLD_ID,
+        page_size=1_000,
+    )
+
+    assert len(snapshots) == 2_050
+    assert coordinator.result_offsets == [0, 1_000, 2_000]
+    assert snapshots[-1].admission.activity_id == "result-2049"
+
+
+@pytest.mark.asyncio
+async def test_scan_page_size_must_be_positive() -> None:
+    coordinator = _ScanCoordinator(leased_ids=[], claimable_ids=[])
+
+    with pytest.raises(ValueError, match="page size must be positive"):
+        await claim_next_pending(
+            coordinator,
+            kind=_KIND,
+            world_id=_WORLD_ID,
+            owner="worker",
+            lease_seconds=300.0,
+            page_size=0,
+        )
+    with pytest.raises(ValueError, match="page size must be positive"):
+        await collect_pending_results(
+            coordinator,
+            kind=_KIND,
+            world_id=_WORLD_ID,
+            page_size=0,
+        )

--- a/tests/app/test_mission_author_activities.py
+++ b/tests/app/test_mission_author_activities.py
@@ -1861,3 +1861,59 @@ async def test_world_identity_scopes_equal_dispatch_ids(tmp_path: Path) -> None:
     assert first_bound.provider_operation_id == first_operation
     assert second_bound.provider_operation_id == second_operation
     await physical.close()
+
+
+@pytest.mark.asyncio
+async def test_author_claim_pages_past_a_full_page_of_live_claims(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A claimable author Activity beyond the scan page must not be stranded.
+
+    The retired scan read one finite 10,000-row prefix of the pending set;
+    a prefix of foreign leases made claim_author report no work, leaving
+    later claimable Activities pending until an unrelated prefix change.
+    """
+
+    import archetype.app.missions.activity_coordinator as author_coordinator_module
+
+    monkeypatch.setattr(author_coordinator_module, "_CLAIM_SCAN_PAGE", 3)
+    world_id = "mission-world"
+    physical, generic, catalog = _open_catalog(
+        tmp_path / "activities.db",
+        lease_seconds=300,
+    )
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+
+    activity_ids = [f"dispatch-{position:03d}" for position in range(7)]
+    for activity_id in activity_ids:
+        digest = hashlib.sha256(activity_id.encode()).hexdigest()
+        await catalog.admit_author(
+            world_id=world_id,
+            receipt=receipt,
+            activity_id=activity_id,
+            request=AuthorActivityRequestRef(
+                ref=f"mission-author+json:sha256:{digest}",
+                digest=digest,
+            ),
+        )
+    # Lease two full pages' worth so the claimable Activity sits on page 3.
+    for activity_id in activity_ids[:6]:
+        claim = await generic.claim(
+            world_id,
+            AUTHOR_ACTIVITY_KIND,
+            activity_id,
+            f"busy-{activity_id}",
+            lease_seconds=300,
+        )
+        assert claim.acquired
+
+    claim = await catalog.claim_author(world_id=world_id, owner="available-worker")
+
+    assert claim is not None
+    assert claim.activity_id == activity_ids[-1]
+
+    # Every Activity now leased: an honest None, reached only by paging to
+    # the catalog's end rather than stopping at page one.
+    assert await catalog.claim_author(world_id=world_id, owner="late-worker") is None
+    await physical.close()

--- a/tests/app/test_mission_critic_activities.py
+++ b/tests/app/test_mission_critic_activities.py
@@ -31,9 +31,11 @@ from archetype.app.missions.local_critic_activity_values import (
 from archetype.core.interfaces import CommittedTickReceipt
 from archetype.missions import CriticPolicy
 from archetype.missions.critics import (
+    CRITIC_ACTIVITY_KIND,
     CandidateReviewRequest,
     CriticActivityCodec,
     CriticActivityRequest,
+    CriticActivityRequestRef,
     CriticActivityResult,
     CriticActivityResultRef,
     CriticActivityRetryGuard,
@@ -613,3 +615,56 @@ async def test_confirmed_absence_rebinds_and_executes_with_exact_retry_guard(
     assert provider._state()["retry_guard_ref"] == f"critic-retry://{operation_id}"
     assert (world_id, raw_request.review_id) in stager.staged
     await recovered_physical.close()
+
+
+@pytest.mark.asyncio
+async def test_critic_claim_claims_beyond_the_retired_default_prefix(
+    tmp_path: Path,
+) -> None:
+    """More leased rows than the old scan bound cannot strand critic work.
+
+    The retired claim scan read one default-sized page (100 rows) of the
+    pending set.  Lease more rows than that bound with foreign owners and
+    prove the claimable Activity beyond the prefix is still claimed — at
+    the real page size, with no page shrinking.
+    """
+
+    world_id = "critic-world"
+    physical, generic, catalog = _open_catalog(
+        tmp_path / "activities.db",
+        lease_seconds=300,
+    )
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+
+    total = 131  # 130 leased rows, one claimable row beyond the old bound.
+    activity_ids = [f"review-{position:03d}" for position in range(total)]
+    for activity_id in activity_ids:
+        digest = hashlib.sha256(activity_id.encode()).hexdigest()
+        await catalog.admit_critic(
+            world_id=world_id,
+            receipt=receipt,
+            activity_id=activity_id,
+            request=CriticActivityRequestRef(
+                ref=f"mission-critic+json:sha256:{digest}",
+                digest=digest,
+            ),
+        )
+    for activity_id in activity_ids[:-1]:
+        claim = await generic.claim(
+            world_id,
+            CRITIC_ACTIVITY_KIND,
+            activity_id,
+            f"busy-{activity_id}",
+            lease_seconds=300,
+        )
+        assert claim.acquired
+
+    claim = await catalog.claim_critic(world_id=world_id, owner="available-worker")
+
+    assert claim is not None
+    assert claim.activity_id == activity_ids[-1]
+
+    # Every Activity now leased: an honest None, reached only by paging to
+    # the catalog's end rather than stopping at the first prefix.
+    assert await catalog.claim_critic(world_id=world_id, owner="late-worker") is None
+    await physical.close()

--- a/tests/physical_ai/test_hosted_episode_activities.py
+++ b/tests/physical_ai/test_hosted_episode_activities.py
@@ -958,7 +958,7 @@ async def test_hosted_claim_pages_past_a_full_batch_of_live_claims(
     """
     import archetype.physical_ai.hosted_activities as hosted_module
 
-    monkeypatch.setattr(hosted_module, "_CLAIM_SCAN_BATCH", 3)
+    monkeypatch.setattr(hosted_module, "_CLAIM_SCAN_PAGE", 3)
     world_id = "physical-world"
     values = LocalHostedEpisodeValueStore(tmp_path / "values")
     physical, generic, catalog = _open_catalog(
@@ -1006,7 +1006,7 @@ async def test_pending_results_page_past_a_full_batch(
     """A durable result beyond the first page must still be delivered."""
     import archetype.physical_ai.hosted_activities as hosted_module
 
-    monkeypatch.setattr(hosted_module, "_CLAIM_SCAN_BATCH", 2)
+    monkeypatch.setattr(hosted_module, "_CLAIM_SCAN_PAGE", 2)
     world_id = "physical-world"
     values = LocalHostedEpisodeValueStore(tmp_path / "values")
     physical, generic, catalog = _open_catalog(

--- a/tests/physical_ai/test_hosted_episode_activities.py
+++ b/tests/physical_ai/test_hosted_episode_activities.py
@@ -996,3 +996,51 @@ async def test_hosted_claim_pages_past_a_full_batch_of_live_claims(
     # the catalog's end rather than stopping at page one.
     assert await catalog.claim_episode(world_id=world_id, owner="late-worker") is None
     await physical.close()
+
+
+@pytest.mark.asyncio
+async def test_pending_results_page_past_a_full_batch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A durable result beyond the first page must still be delivered."""
+    import archetype.physical_ai.hosted_activities as hosted_module
+
+    monkeypatch.setattr(hosted_module, "_CLAIM_SCAN_BATCH", 2)
+    world_id = "physical-world"
+    values = LocalHostedEpisodeValueStore(tmp_path / "values")
+    physical, generic, catalog = _open_catalog(
+        tmp_path / "activities.db",
+        lease_seconds=300,
+    )
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+
+    activity_ids = [f"episode-{position:03d}" for position in range(5)]
+    for activity_id in activity_ids:
+        request = await values.put_request(_request(world_id, activity_id))
+        await catalog.admit_episode(
+            world_id=world_id,
+            receipt=receipt,
+            activity_id=activity_id,
+            request=request,
+        )
+        claim = await catalog.claim_episode(world_id=world_id, owner="worker")
+        assert claim is not None
+        claim = await catalog.bind_provider_operation(
+            claim,
+            provider="local",
+            operation_id=hosted_episode_provider_operation_id(world_id, claim.activity_id),
+        )
+        digest = "a" * 64
+        await catalog.record_episode_result(
+            claim,
+            HostedEpisodeActivityResultRef(
+                ref=f"physical-episode-result+json:sha256:{digest}",
+                digest=digest,
+                size_bytes=10,
+            ),
+        )
+
+    deliveries = await catalog.pending_episode_results(world_id=world_id)
+
+    assert sorted(delivery.activity_id for delivery in deliveries) == activity_ids

--- a/tests/physical_ai/test_hosted_episode_activities.py
+++ b/tests/physical_ai/test_hosted_episode_activities.py
@@ -557,8 +557,10 @@ async def test_lease_expiry_does_not_replay_an_ambiguous_provider_start(
         ),
         stager=_ObservationStager(),
     )
-    with pytest.raises(HostedEpisodeReconciliationRequired):
+    with pytest.raises(HostedEpisodeReconciliationRequired) as exc_info:
         await recovered.run_once()
+    assert exc_info.value.reason == "provider start exists without a complete result index"
+    assert exc_info.value.reason in str(exc_info.value)
     assert healthy_runner.execution_count == 1
     await recovered_physical.close()
 
@@ -676,6 +678,122 @@ async def test_committed_reader_excludes_inherited_intent_from_child_projection(
     assert query_calls == [(world_id, run_id, ("child-token",))]
     assert result.visibility_token == "child-token"
     assert set(result.results) == {(HostedEpisodeIntent,)}
+
+
+@pytest.mark.asyncio
+async def test_world_stager_scopes_idempotency_to_child_activity_control(
+    monkeypatch,
+) -> None:
+    digest = "0" * 64
+    observation = HostedEpisodeObservation(
+        activity_id="reused-family-id",
+        operation_id="physical-episode:" + digest,
+        request_ref=f"{HOSTED_EPISODE_REQUEST_REF_PREFIX}{digest}",
+        request_digest=digest,
+        result_ref=f"physical-episode-result+json:sha256:{digest}",
+        result_digest=digest,
+        trajectory_ref=f"physical-episode-trajectory+arrow:sha256:{digest}",
+        trajectory_digest=digest,
+        episode_results_ref=f"physical-episode-results+arrow:sha256:{digest}",
+        episode_results_digest=digest,
+        manifest_ref=f"physical-episode-manifest+arrow:sha256:{digest}",
+        manifest_digest=digest,
+        episode_count=1,
+        trajectory_row_count=2,
+        transition_count=1,
+        success_count=1,
+    )
+    snapshot = PinnedWorldQuerySnapshot(
+        world_id="physical-world",
+        run_id="run-a",
+        head_tick=7,
+        head_tokens=("child-token",),
+        current=PinnedQuerySegment(
+            world_id="physical-world",
+            run_id="run-a",
+            up_to_tick=None,
+            head_tick=7,
+            head_tokens=("child-token",),
+            visibility_tokens=("child-token",),
+        ),
+        lineage=(
+            PinnedQuerySegment(
+                world_id="parent-world",
+                run_id="parent-run",
+                up_to_tick=6,
+                head_tick=6,
+                head_tokens=("parent-token",),
+                visibility_tokens=("parent-token",),
+            ),
+        ),
+    )
+    query_calls: list[tuple[str, str, tuple[str, ...]]] = []
+
+    class ObservationControlCatalog:
+        async def list_signatures(self):
+            return [
+                SignatureRecord(
+                    table_id="hosted-observation",
+                    component_names=("HostedEpisodeObservation",),
+                    schema_json="{}",
+                    fingerprint="hosted-observation",
+                )
+            ]
+
+    class ObservationStorage:
+        def get_control_catalog(self, storage_config):
+            return ObservationControlCatalog()
+
+        async def materialize(self, frame):
+            return frame
+
+    async def pinned(*_args, **_kwargs):
+        return snapshot
+
+    async def queried(
+        _storage,
+        _components,
+        queried_world_id,
+        queried_run_id,
+        _storage_config,
+        *,
+        visibility_tokens,
+    ):
+        tokens = tuple(visibility_tokens)
+        query_calls.append((queried_world_id, queried_run_id, tokens))
+        if tokens == ("parent-token",):
+            return _frame(
+                1,
+                6,
+                observation.model_copy(update={"success_count": 0}),
+            )
+        return _frame(
+            2,
+            7,
+            observation.model_copy(update={"activity_id": "unrelated"}),
+        )
+
+    monkeypatch.setattr(
+        "archetype.physical_ai.hosted_activity_world.pin_query_snapshot",
+        pinned,
+    )
+    monkeypatch.setattr(
+        "archetype.physical_ai.hosted_activity_world.query_components",
+        queried,
+    )
+    world = _PendingWorld()
+    stager = WorldHostedEpisodeObservationStager(
+        storage=ObservationStorage(),  # type: ignore[arg-type]
+        registry=_PendingRegistry(world),  # type: ignore[arg-type]
+    )
+
+    await stager.stage_hosted_episode_observation(
+        world_id="physical-world",
+        observation=observation,
+    )
+
+    assert query_calls == [("physical-world", "run-a", ("child-token",))]
+    assert sum(len(rows) for rows in world.spawn_cache.values()) == 1
 
 
 def test_provider_operation_identity_is_world_scoped_and_matches_request() -> None:

--- a/tests/physical_ai/test_hosted_episode_activities.py
+++ b/tests/physical_ai/test_hosted_episode_activities.py
@@ -1,0 +1,780 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restart and completeness contracts for hosted Physical-AI Activities."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import daft
+import pytest
+
+from archetype.activities import ActivityCoordinator
+from archetype.core.component import Component
+from archetype.core.interfaces import CommittedTickReceipt
+from archetype.physical_ai.hosted_activities import (
+    CommittedPhysicalSnapshot,
+    HostedEpisodeReconciliationRequired,
+    PhysicalHostedActivityCoordinator,
+    PhysicalHostedActivityProjector,
+    PhysicalHostedActivityWorker,
+    prepare_hosted_episode_intent,
+)
+from archetype.physical_ai.hosted_activity_contracts import (
+    HOSTED_EPISODE_ACTIVITY_KIND,
+    HOSTED_EPISODE_REQUEST_REF_PREFIX,
+    HostedEpisodeActivityResultRef,
+    HostedEpisodeIntent,
+    HostedEpisodeObservation,
+    HostedEpisodePayloadRef,
+    HostedEpisodeRecoveryUnknown,
+    HostedEpisodeRequestRef,
+    hosted_episode_provider_operation_id,
+)
+from archetype.physical_ai.hosted_activity_values import (
+    LocalDurableHostedEpisodeProvider,
+    LocalHostedEpisodeValueStore,
+    SeededHostedEpisodeRunner,
+)
+from archetype.physical_ai.hosted_activity_world import (
+    StoragePhysicalCommittedIntentReader,
+    WorldHostedEpisodeObservationStager,
+)
+from archetype.physical_ai.hosted_episode import (
+    decode_hosted_episode_manifest,
+    decode_hosted_episode_requests,
+    decode_hosted_episode_trajectory,
+    encode_hosted_episode_requests,
+    encode_hosted_episode_trajectory,
+    hosted_episode_request_digest,
+    validate_hosted_episode_result,
+)
+from archetype.storage.activity_catalog import SqliteActivityCatalog
+from archetype.storage.catalog import SignatureRecord
+from archetype.world.query import PinnedQuerySegment, PinnedWorldQuerySnapshot
+
+
+class _Reader:
+    def __init__(self, snapshot: CommittedPhysicalSnapshot) -> None:
+        self.snapshot = snapshot
+
+    async def read(self, receipt: CommittedTickReceipt) -> CommittedPhysicalSnapshot:
+        return self.snapshot
+
+
+class _ObservationStager:
+    def __init__(self, *, crash_once: bool = False) -> None:
+        self.crash_once = crash_once
+        self.observations: dict[tuple[str, str], HostedEpisodeObservation] = {}
+
+    async def stage_hosted_episode_observation(
+        self,
+        *,
+        world_id: str,
+        observation: HostedEpisodeObservation,
+    ) -> None:
+        if self.crash_once:
+            self.crash_once = False
+            raise RuntimeError("worker died before observation staging")
+        key = (world_id, observation.activity_id)
+        existing = self.observations.get(key)
+        if existing is not None and existing != observation:
+            raise ValueError("conflicting hosted observation")
+        self.observations.setdefault(key, observation)
+
+
+class _CrashDuringRunner:
+    def __init__(self, seeded: SeededHostedEpisodeRunner) -> None:
+        self.seeded = seeded
+
+    async def run(self, request_ipc: bytes) -> bytes:
+        await self.seeded.run(request_ipc)
+        raise RuntimeError("GPU process disappeared before result publication")
+
+
+class _PartialRunner:
+    async def run(self, request_ipc: bytes) -> bytes:
+        full = await SeededHostedEpisodeRunner().run(request_ipc)
+        rows = decode_hosted_episode_trajectory(full)
+        first_episode = rows[0]["episode_id"]
+        return encode_hosted_episode_trajectory(
+            [row for row in rows if row["episode_id"] == first_episode]
+        )
+
+
+class _PendingWorld:
+    def __init__(self) -> None:
+        self.run_id = "run-a"
+        self.tick = 2
+        self.next_entity_id = 1
+        self.spawn_cache: dict[tuple[type[Component], ...], list[dict[str, Any]]] = {}
+        self.entity2sig: dict[int, tuple[type[Component], ...]] = {}
+
+    async def create_entity(self, components: list[Component]) -> int:
+        entity_id = self.next_entity_id
+        self.next_entity_id += 1
+        signature = tuple(type(component) for component in components)
+        row: dict[str, Any] = {
+            "entity_id": entity_id,
+            "tick": self.tick,
+            "is_active": True,
+        }
+        for component in components:
+            row.update(component.to_row_dict())
+        self.spawn_cache.setdefault(signature, []).append(row)
+        self.entity2sig[entity_id] = signature
+        return entity_id
+
+
+class _EmptyControlCatalog:
+    async def list_signatures(self):
+        return []
+
+
+class _EmptyStorage:
+    def get_control_catalog(self, storage_config):
+        return _EmptyControlCatalog()
+
+
+class _ReaderControlCatalog:
+    async def list_signatures(self):
+        return [
+            SignatureRecord(
+                table_id="hosted-intent",
+                component_names=("HostedEpisodeIntent",),
+                schema_json="{}",
+                fingerprint="hosted-intent",
+            )
+        ]
+
+
+class _ReaderStorage:
+    def get_control_catalog(self, storage_config):
+        return _ReaderControlCatalog()
+
+    async def materialize(self, frame):
+        return frame
+
+
+class _PendingRegistry:
+    def __init__(self, world: _PendingWorld) -> None:
+        self.world = world
+
+    @asynccontextmanager
+    async def operation(self, world_id: str):
+        assert world_id == "physical-world"
+        yield self.world
+
+    async def storage_record(self, world_id: str):
+        assert world_id == "physical-world"
+        return None
+
+
+def _frame(entity_id: int, tick: int, *components: Component):
+    values: dict[str, list[Any]] = {"entity_id": [entity_id], "tick": [tick]}
+    for component in components:
+        prefix = type(component).get_prefix()
+        for field, value in component.model_dump().items():
+            values[f"{prefix}{field}"] = [value]
+    return daft.from_pydict(values)
+
+
+def _request(world_id: str, activity_id: str) -> bytes:
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    return encode_hosted_episode_requests(
+        [
+            {
+                "operation_id": operation_id,
+                "trial_id": 1,
+                "suite": "seeded-reach",
+                "task_id": 7,
+                "seed": 101,
+                "instruction": "reach the target",
+                "max_transitions": 3,
+                "environment_id": "seeded-reach@v1",
+                "policy_id": "scripted-reach@v1",
+                "config_json": {
+                    "reward_per_transition": 0.25,
+                    "success_after_transitions": 2,
+                },
+            },
+            {
+                "operation_id": operation_id,
+                "trial_id": 0,
+                "suite": "seeded-reach",
+                "task_id": 7,
+                "seed": 100,
+                "instruction": "reach the target",
+                "max_transitions": 1,
+                "environment_id": "seeded-reach@v1",
+                "policy_id": "scripted-reach@v1",
+                "config_json": {"reward_per_transition": 0.25},
+            },
+        ]
+    )
+
+
+async def _intent(
+    values: LocalHostedEpisodeValueStore,
+    *,
+    world_id: str,
+    activity_id: str,
+) -> tuple[HostedEpisodeIntent, bytes]:
+    request_ipc = _request(world_id, activity_id)
+    return (
+        await prepare_hosted_episode_intent(
+            values,
+            world_id=world_id,
+            activity_id=activity_id,
+            request_ipc=request_ipc,
+        ),
+        request_ipc,
+    )
+
+
+def _snapshot(
+    *,
+    world_id: str,
+    run_id: str,
+    tick: int,
+    intent: HostedEpisodeIntent,
+    observation: HostedEpisodeObservation | None = None,
+    visibility_token: str | None = None,
+) -> CommittedPhysicalSnapshot:
+    results = {
+        (HostedEpisodeIntent,): _frame(1, tick, intent),
+    }
+    if observation is not None:
+        results[(HostedEpisodeObservation,)] = _frame(2, tick, observation)
+    return CommittedPhysicalSnapshot(
+        world_id=world_id,
+        run_id=run_id,
+        committed_tick=tick,
+        visibility_token=visibility_token or f"token-{tick}",
+        results=results,
+    )
+
+
+def _open_catalog(
+    path: Path,
+    *,
+    lease_seconds: float = 0.01,
+) -> tuple[
+    SqliteActivityCatalog,
+    ActivityCoordinator,
+    PhysicalHostedActivityCoordinator,
+]:
+    physical = SqliteActivityCatalog(path)
+    generic = ActivityCoordinator(physical)
+    return (
+        physical,
+        generic,
+        PhysicalHostedActivityCoordinator(
+            generic,
+            lease_seconds=lease_seconds,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cold_restart_recovers_first_provider_result_without_second_episode(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    run_id = "run-a"
+    activity_id = "eval-batch-7"
+    catalog_path = tmp_path / "activities.db"
+    values_path = tmp_path / "values"
+    provider_path = tmp_path / "provider"
+    counter_path = tmp_path / "provider-executions.json"
+    values = LocalHostedEpisodeValueStore(values_path)
+    intent, request_ipc = await _intent(
+        values,
+        world_id=world_id,
+        activity_id=activity_id,
+    )
+    receipt = CommittedTickReceipt(world_id, run_id, 1, "token-1", 0)
+    reader = _Reader(
+        _snapshot(
+            world_id=world_id,
+            run_id=run_id,
+            tick=1,
+            intent=intent,
+        )
+    )
+    physical, generic, catalog = _open_catalog(catalog_path)
+    projector = PhysicalHostedActivityProjector(
+        reader=reader,
+        catalog=catalog,
+        values=values,
+    )
+    await projector.project(receipt)
+    await projector.project(receipt)
+    assert (
+        len(
+            await generic.pending(
+                kind=HOSTED_EPISODE_ACTIVITY_KIND,
+                world_id=world_id,
+            )
+        )
+        == 1
+    )
+
+    first_runner = SeededHostedEpisodeRunner(counter_path)
+    first_worker = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="worker-before-crash",
+        catalog=catalog,
+        values=values,
+        provider=LocalDurableHostedEpisodeProvider(
+            provider_path,
+            runner=first_runner,
+            crash_after_publish=True,
+        ),
+        stager=_ObservationStager(),
+    )
+    with pytest.raises(RuntimeError, match="after provider result publication"):
+        await first_worker.run_once()
+    assert first_runner.execution_count == 1
+    await physical.close()
+    await asyncio.sleep(0.02)
+
+    # Reconstruct every Archetype-side object. The provider index is the first
+    # durable result, so generic catalog recording cannot trigger another run.
+    recovered_values = LocalHostedEpisodeValueStore(values_path)
+    recovered_physical, recovered_generic, recovered_catalog = _open_catalog(
+        catalog_path,
+        lease_seconds=30,
+    )
+    recovered_runner = SeededHostedEpisodeRunner(counter_path)
+    crash_before_stage = _ObservationStager(crash_once=True)
+    recovered_worker = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="worker-after-provider-crash",
+        catalog=recovered_catalog,
+        values=recovered_values,
+        provider=LocalDurableHostedEpisodeProvider(
+            provider_path,
+            runner=recovered_runner,
+        ),
+        stager=crash_before_stage,
+    )
+    with pytest.raises(RuntimeError, match="before observation staging"):
+        await recovered_worker.run_once()
+    assert recovered_runner.execution_count == 1
+    pending_results = await recovered_catalog.pending_episode_results(world_id=world_id)
+    assert len(pending_results) == 1
+    await recovered_physical.close()
+
+    # A third process redelivers the bounded result and stages the same marker.
+    final_physical, _final_generic, final_catalog = _open_catalog(catalog_path)
+    final_stager = _ObservationStager()
+    final_runner = SeededHostedEpisodeRunner(counter_path)
+    final_worker = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="worker-before-observation-commit",
+        catalog=final_catalog,
+        values=LocalHostedEpisodeValueStore(values_path),
+        provider=LocalDurableHostedEpisodeProvider(
+            provider_path,
+            runner=final_runner,
+        ),
+        stager=final_stager,
+    )
+    assert await final_worker.run_once()
+    assert final_runner.execution_count == 1
+    observation = final_stager.observations[(world_id, activity_id)]
+    assert observation.episode_count == 2
+    assert observation.trajectory_row_count == 5
+    assert observation.transition_count == 3
+    assert observation.success_count == 1
+    await final_physical.close()
+
+    # The worker dies after staging but before a tick commits. A new process has
+    # no staged mutation, so it redelivers the same immutable marker and still
+    # does not touch the provider.
+    restage_physical, restage_generic, restage_catalog = _open_catalog(catalog_path)
+    restage_stager = _ObservationStager()
+    restage_worker = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="worker-after-staging-crash",
+        catalog=restage_catalog,
+        values=LocalHostedEpisodeValueStore(values_path),
+        provider=LocalDurableHostedEpisodeProvider(
+            provider_path,
+            runner=final_runner,
+        ),
+        stager=restage_stager,
+    )
+    assert await restage_worker.run_once()
+    assert restage_stager.observations[(world_id, activity_id)] == observation
+    assert final_runner.execution_count == 1
+
+    provider_result = await LocalDurableHostedEpisodeProvider(
+        provider_path,
+        runner=final_runner,
+    ).result_for(
+        hosted_episode_provider_operation_id(world_id, activity_id),
+        request_ipc,
+    )
+    assert provider_result is not None
+    manifest = validate_hosted_episode_result(
+        provider_result.request_ipc,
+        provider_result.trajectory_ipc,
+        provider_result.episode_results_ipc,
+        provider_result.manifest_ipc,
+    )
+    assert manifest == decode_hosted_episode_manifest(provider_result.manifest_ipc)
+
+    # Only the exact later committed marker settles the Activity.
+    reader.snapshot = _snapshot(
+        world_id=world_id,
+        run_id=run_id,
+        tick=2,
+        intent=intent,
+        observation=observation.model_copy(update={"success_count": 0}),
+    )
+    await PhysicalHostedActivityProjector(
+        reader=reader,
+        catalog=restage_catalog,
+        values=LocalHostedEpisodeValueStore(values_path),
+    ).project(CommittedTickReceipt(world_id, run_id, 2, "token-2", 0))
+    assert len(await restage_catalog.pending_episode_results(world_id=world_id)) == 1
+
+    reader.snapshot = _snapshot(
+        world_id=world_id,
+        run_id=run_id,
+        tick=3,
+        intent=intent,
+        observation=observation,
+    )
+    await PhysicalHostedActivityProjector(
+        reader=reader,
+        catalog=restage_catalog,
+        values=LocalHostedEpisodeValueStore(values_path),
+    ).project(CommittedTickReceipt(world_id, run_id, 3, "token-3", 0))
+    settled = await restage_generic.get(
+        world_id,
+        HOSTED_EPISODE_ACTIVITY_KIND,
+        activity_id,
+    )
+    assert settled is not None and settled.settlement is not None
+    assert settled.settlement.receipt.committed_tick == 3
+    assert not await restage_catalog.has_unsettled_work(world_id)
+    await restage_physical.close()
+
+
+@pytest.mark.asyncio
+async def test_partial_provider_trajectory_never_publishes_a_result(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "partial-batch"
+    request_ipc = _request(world_id, activity_id)
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    provider = LocalDurableHostedEpisodeProvider(
+        tmp_path / "provider",
+        runner=_PartialRunner(),
+    )
+
+    with pytest.raises(ValueError, match="exactly every admitted episode"):
+        await provider.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=1,
+            fence=1,
+            retry_guard=None,
+        )
+
+    assert await provider.result_for(operation_id, request_ipc) is None
+    recovery = await provider.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeRecoveryUnknown)
+
+
+@pytest.mark.asyncio
+async def test_lease_expiry_does_not_replay_an_ambiguous_provider_start(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    run_id = "run-a"
+    activity_id = "ambiguous-batch"
+    values_path = tmp_path / "values"
+    catalog_path = tmp_path / "activities.db"
+    provider_path = tmp_path / "provider"
+    counter_path = tmp_path / "counter.json"
+    values = LocalHostedEpisodeValueStore(values_path)
+    intent, _ = await _intent(values, world_id=world_id, activity_id=activity_id)
+    receipt = CommittedTickReceipt(world_id, run_id, 1, "token-1", 0)
+    reader = _Reader(
+        _snapshot(
+            world_id=world_id,
+            run_id=run_id,
+            tick=1,
+            intent=intent,
+        )
+    )
+    physical, _generic, catalog = _open_catalog(catalog_path)
+    await PhysicalHostedActivityProjector(
+        reader=reader,
+        catalog=catalog,
+        values=values,
+    ).project(receipt)
+    seeded = SeededHostedEpisodeRunner(counter_path)
+    first = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="first",
+        catalog=catalog,
+        values=values,
+        provider=LocalDurableHostedEpisodeProvider(
+            provider_path,
+            runner=_CrashDuringRunner(seeded),
+        ),
+        stager=_ObservationStager(),
+    )
+    with pytest.raises(RuntimeError, match="GPU process disappeared"):
+        await first.run_once()
+    assert seeded.execution_count == 1
+    await physical.close()
+    await asyncio.sleep(0.02)
+
+    recovered_physical, _generic, recovered_catalog = _open_catalog(catalog_path)
+    healthy_runner = SeededHostedEpisodeRunner(counter_path)
+    recovered = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="after-expiry",
+        catalog=recovered_catalog,
+        values=LocalHostedEpisodeValueStore(values_path),
+        provider=LocalDurableHostedEpisodeProvider(
+            provider_path,
+            runner=healthy_runner,
+        ),
+        stager=_ObservationStager(),
+    )
+    with pytest.raises(HostedEpisodeReconciliationRequired):
+        await recovered.run_once()
+    assert healthy_runner.execution_count == 1
+    await recovered_physical.close()
+
+
+@pytest.mark.asyncio
+async def test_projector_rejects_another_visibility_token_before_admission(
+    tmp_path: Path,
+) -> None:
+    values = LocalHostedEpisodeValueStore(tmp_path / "values")
+    intent, _ = await _intent(
+        values,
+        world_id="physical-world",
+        activity_id="visibility-batch",
+    )
+    physical, generic, catalog = _open_catalog(tmp_path / "activities.db")
+    projector = PhysicalHostedActivityProjector(
+        reader=_Reader(
+            _snapshot(
+                world_id="physical-world",
+                run_id="run-a",
+                tick=1,
+                intent=intent,
+                visibility_token="other-token",
+            )
+        ),
+        catalog=catalog,
+        values=values,
+    )
+
+    with pytest.raises(ValueError, match="exact committed receipt"):
+        await projector.project(
+            CommittedTickReceipt(
+                "physical-world",
+                "run-a",
+                1,
+                "authoritative-token",
+                0,
+            )
+        )
+
+    assert (
+        await generic.pending(
+            kind=HOSTED_EPISODE_ACTIVITY_KIND,
+            world_id="physical-world",
+        )
+        == ()
+    )
+    await physical.close()
+
+
+@pytest.mark.asyncio
+async def test_committed_reader_excludes_inherited_intent_from_child_projection(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    world_id = "child-world"
+    run_id = "child-run"
+    activity_id = "child-batch"
+    values = LocalHostedEpisodeValueStore(tmp_path / "values")
+    intent, _ = await _intent(values, world_id=world_id, activity_id=activity_id)
+    snapshot = PinnedWorldQuerySnapshot(
+        world_id=world_id,
+        run_id=run_id,
+        head_tick=7,
+        head_tokens=("child-token",),
+        current=PinnedQuerySegment(
+            world_id=world_id,
+            run_id=run_id,
+            up_to_tick=None,
+            head_tick=7,
+            head_tokens=("child-token",),
+            visibility_tokens=("child-token",),
+        ),
+        lineage=(
+            PinnedQuerySegment(
+                world_id="parent-world",
+                run_id="parent-run",
+                up_to_tick=6,
+                head_tick=6,
+                head_tokens=("parent-token",),
+                visibility_tokens=("parent-token",),
+            ),
+        ),
+    )
+    query_calls: list[tuple[str, str, tuple[str, ...]]] = []
+
+    async def pinned(*_args, **_kwargs):
+        return snapshot
+
+    async def queried(
+        _storage,
+        _components,
+        queried_world_id,
+        queried_run_id,
+        _storage_config,
+        *,
+        visibility_tokens,
+    ):
+        query_calls.append((queried_world_id, queried_run_id, tuple(visibility_tokens)))
+        return _frame(1, 7, intent)
+
+    monkeypatch.setattr(
+        "archetype.physical_ai.hosted_activity_world.pin_query_snapshot",
+        pinned,
+    )
+    monkeypatch.setattr(
+        "archetype.physical_ai.hosted_activity_world.query_components",
+        queried,
+    )
+
+    result = await StoragePhysicalCommittedIntentReader(
+        _ReaderStorage(),  # type: ignore[arg-type]
+    ).read(CommittedTickReceipt(world_id, run_id, 7, "child-token", 0))
+
+    assert query_calls == [(world_id, run_id, ("child-token",))]
+    assert result.visibility_token == "child-token"
+    assert set(result.results) == {(HostedEpisodeIntent,)}
+
+
+def test_provider_operation_identity_is_world_scoped_and_matches_request() -> None:
+    first = hosted_episode_provider_operation_id("world-a", "batch")
+    second = hosted_episode_provider_operation_id("world-b", "batch")
+
+    assert first != second
+    assert first == decode_hosted_episode_requests(_request("world-a", "batch"))[0]["operation_id"]
+    assert hosted_episode_request_digest(_request("world-a", "batch"))
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda digest: HostedEpisodeRequestRef(
+            ref=f"{HOSTED_EPISODE_REQUEST_REF_PREFIX}{'0' * 64}",
+            digest=digest,
+            size_bytes=10,
+        ),
+        lambda digest: HostedEpisodePayloadRef(
+            kind="trajectory",
+            ref=f"physical-episode-trajectory+arrow:sha256:{'0' * 64}",
+            digest=digest,
+            size_bytes=10,
+        ),
+        lambda digest: HostedEpisodeActivityResultRef(
+            ref=f"physical-episode-result+json:sha256:{'0' * 64}",
+            digest=digest,
+            size_bytes=10,
+        ),
+    ],
+)
+def test_content_references_reject_digest_mismatch_at_construction(factory) -> None:
+    with pytest.raises(ValueError, match="embed its exact"):
+        factory("1" * 64)
+
+
+@pytest.mark.parametrize("size", [-1, 0])
+def test_sized_content_references_reject_nonpositive_bytes(size: int) -> None:
+    digest = "0" * 64
+    with pytest.raises(ValueError, match="positive"):
+        HostedEpisodeRequestRef(
+            ref=f"{HOSTED_EPISODE_REQUEST_REF_PREFIX}{digest}",
+            digest=digest,
+            size_bytes=size,
+        )
+
+
+def test_payload_reference_kind_requires_its_exact_prefix() -> None:
+    digest = "0" * 64
+    with pytest.raises(ValueError, match="embed its exact"):
+        HostedEpisodePayloadRef(
+            kind="trajectory",
+            ref=f"physical-episode-results+arrow:sha256:{digest}",
+            digest=digest,
+            size_bytes=10,
+        )
+
+
+@pytest.mark.asyncio
+async def test_world_stager_is_idempotent_and_rejects_pending_conflict() -> None:
+    digest = "0" * 64
+    observation = HostedEpisodeObservation(
+        activity_id="batch",
+        operation_id="physical-episode:" + digest,
+        request_ref=f"{HOSTED_EPISODE_REQUEST_REF_PREFIX}{digest}",
+        request_digest=digest,
+        result_ref=f"physical-episode-result+json:sha256:{digest}",
+        result_digest=digest,
+        trajectory_ref=f"physical-episode-trajectory+arrow:sha256:{digest}",
+        trajectory_digest=digest,
+        episode_results_ref=f"physical-episode-results+arrow:sha256:{digest}",
+        episode_results_digest=digest,
+        manifest_ref=f"physical-episode-manifest+arrow:sha256:{digest}",
+        manifest_digest=digest,
+        episode_count=1,
+        trajectory_row_count=2,
+        transition_count=1,
+        success_count=1,
+    )
+    world = _PendingWorld()
+    stager = WorldHostedEpisodeObservationStager(
+        storage=_EmptyStorage(),  # type: ignore[arg-type]
+        registry=_PendingRegistry(world),  # type: ignore[arg-type]
+    )
+
+    await stager.stage_hosted_episode_observation(
+        world_id="physical-world",
+        observation=observation,
+    )
+    await stager.stage_hosted_episode_observation(
+        world_id="physical-world",
+        observation=observation,
+    )
+
+    assert world.next_entity_id == 2
+    assert sum(len(rows) for rows in world.spawn_cache.values()) == 1
+    with pytest.raises(ValueError, match="conflicting"):
+        await stager.stage_hosted_episode_observation(
+            world_id="physical-world",
+            observation=observation.model_copy(update={"success_count": 0}),
+        )

--- a/tests/physical_ai/test_hosted_episode_activities.py
+++ b/tests/physical_ai/test_hosted_episode_activities.py
@@ -280,6 +280,53 @@ def _open_catalog(
     )
 
 
+def test_local_provider_identity_binds_its_exact_durable_root(tmp_path: Path) -> None:
+    runner = SeededHostedEpisodeRunner(tmp_path / "counter.json")
+    first = LocalDurableHostedEpisodeProvider(tmp_path / "provider-a", runner=runner)
+    same = LocalDurableHostedEpisodeProvider(tmp_path / "provider-a", runner=runner)
+    other = LocalDurableHostedEpisodeProvider(tmp_path / "provider-b", runner=runner)
+
+    assert first.provider == same.provider
+    assert first.provider != other.provider
+    assert first.provider.startswith("local-seeded-hosted-episode:")
+
+
+@pytest.mark.asyncio
+async def test_hosted_claim_searches_beyond_one_hundred_live_claims(tmp_path: Path) -> None:
+    world_id = "physical-world"
+    values = LocalHostedEpisodeValueStore(tmp_path / "values")
+    physical, generic, catalog = _open_catalog(
+        tmp_path / "activities.db",
+        lease_seconds=300,
+    )
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+
+    activity_ids = [f"episode-{position:03d}" for position in range(101)]
+    for activity_id in activity_ids:
+        request = await values.put_request(_request(world_id, activity_id))
+        await catalog.admit_episode(
+            world_id=world_id,
+            receipt=receipt,
+            activity_id=activity_id,
+            request=request,
+        )
+    for activity_id in activity_ids[:100]:
+        claim = await generic.claim(
+            world_id,
+            HOSTED_EPISODE_ACTIVITY_KIND,
+            activity_id,
+            f"busy-{activity_id}",
+            lease_seconds=300,
+        )
+        assert claim.acquired
+
+    claim = await catalog.claim_episode(world_id=world_id, owner="available-worker")
+
+    assert claim is not None
+    assert claim.activity_id == activity_ids[-1]
+    await physical.close()
+
+
 @pytest.mark.asyncio
 async def test_cold_restart_recovers_first_provider_result_without_second_episode(
     tmp_path: Path,

--- a/tests/physical_ai/test_hosted_episode_activities.py
+++ b/tests/physical_ai/test_hosted_episode_activities.py
@@ -943,3 +943,56 @@ async def test_world_stager_is_idempotent_and_rejects_pending_conflict() -> None
             world_id="physical-world",
             observation=observation.model_copy(update={"success_count": 0}),
         )
+
+
+@pytest.mark.asyncio
+async def test_hosted_claim_pages_past_a_full_batch_of_live_claims(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A claimable Activity beyond the scan page must not be stranded.
+
+    With more admitted Activities than one pending page, a page-sized prefix
+    of foreign leases previously made claim_episode report no work, leaving
+    later claimable Activities pending until an unrelated prefix change.
+    """
+    import archetype.physical_ai.hosted_activities as hosted_module
+
+    monkeypatch.setattr(hosted_module, "_CLAIM_SCAN_BATCH", 3)
+    world_id = "physical-world"
+    values = LocalHostedEpisodeValueStore(tmp_path / "values")
+    physical, generic, catalog = _open_catalog(
+        tmp_path / "activities.db",
+        lease_seconds=300,
+    )
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+
+    activity_ids = [f"episode-{position:03d}" for position in range(7)]
+    for activity_id in activity_ids:
+        request = await values.put_request(_request(world_id, activity_id))
+        await catalog.admit_episode(
+            world_id=world_id,
+            receipt=receipt,
+            activity_id=activity_id,
+            request=request,
+        )
+    # Lease two full pages' worth so the claimable Activity sits on page 3.
+    for activity_id in activity_ids[:6]:
+        claim = await generic.claim(
+            world_id,
+            HOSTED_EPISODE_ACTIVITY_KIND,
+            activity_id,
+            f"busy-{activity_id}",
+            lease_seconds=300,
+        )
+        assert claim.acquired
+
+    claim = await catalog.claim_episode(world_id=world_id, owner="available-worker")
+
+    assert claim is not None
+    assert claim.activity_id == activity_ids[-1]
+
+    # Every Activity now leased: an honest None, reached only by paging to
+    # the catalog's end rather than stopping at page one.
+    assert await catalog.claim_episode(world_id=world_id, owner="late-worker") is None
+    await physical.close()

--- a/tests/physical_ai/test_hosted_modal_activity.py
+++ b/tests/physical_ai/test_hosted_modal_activity.py
@@ -1,0 +1,585 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Modal admission and restart contracts for hosted Physical-AI Activities."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from archetype.activities import ActivityCoordinator
+from archetype.core.interfaces import CommittedTickReceipt
+from archetype.physical_ai import hosted_modal
+from archetype.physical_ai.hosted_activities import (
+    PhysicalHostedActivityCatalog,
+    PhysicalHostedActivityCoordinator,
+    PhysicalHostedActivityWorker,
+)
+from archetype.physical_ai.hosted_activity_contracts import (
+    HostedEpisodeConfirmedAbsent,
+    HostedEpisodeObservation,
+    HostedEpisodeProviderResult,
+    HostedEpisodeRecovered,
+    HostedEpisodeRecoveryUnknown,
+    HostedEpisodeRetryGuard,
+    hosted_episode_provider_operation_id,
+)
+from archetype.physical_ai.hosted_activity_values import (
+    LocalHostedEpisodeValueStore,
+    SeededHostedEpisodeRunner,
+)
+from archetype.physical_ai.hosted_episode import (
+    build_hosted_episode_manifest,
+    build_hosted_episode_results,
+    decode_hosted_episode_manifest,
+    encode_hosted_episode_requests,
+    validate_hosted_episode_result,
+)
+from archetype.physical_ai.hosted_modal import (
+    ModalHostedEpisodeConfig,
+    ModalHostedEpisodeProvider,
+    ModalHostedEpisodeProviderUnknown,
+)
+from archetype.storage.activity_catalog import SqliteActivityCatalog
+
+
+def _config(**changes: object) -> ModalHostedEpisodeConfig:
+    values: dict[str, Any] = {
+        "workspace_name": "test-workspace",
+        "environment_name": "test-environment",
+        "app_name": "physical-ai-proof",
+        "function_name": "seeded-hosted-episode",
+        "result_dict_name": "physical-ai-results",
+        "result_volume_name": "physical-ai-values",
+        "call_timeout_seconds": 60,
+    }
+    values.update(changes)
+    return ModalHostedEpisodeConfig(**values)
+
+
+def _request(world_id: str, activity_id: str) -> bytes:
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    return encode_hosted_episode_requests(
+        [
+            {
+                "operation_id": operation_id,
+                "trial_id": 1,
+                "suite": "seeded-reach",
+                "task_id": 7,
+                "seed": 101,
+                "instruction": "reach the target",
+                "max_transitions": 3,
+                "environment_id": "seeded-reach@v1",
+                "policy_id": "scripted-reach@v1",
+                "config_json": {
+                    "reward_per_transition": 0.25,
+                    "success_after_transitions": 2,
+                },
+            },
+            {
+                "operation_id": operation_id,
+                "trial_id": 0,
+                "suite": "seeded-reach",
+                "task_id": 7,
+                "seed": 100,
+                "instruction": "reach the target",
+                "max_transitions": 1,
+                "environment_id": "seeded-reach@v1",
+                "policy_id": "scripted-reach@v1",
+                "config_json": {"reward_per_transition": 0.25},
+            },
+        ]
+    )
+
+
+def _provider_operation_key(operation_id: str, prefix: str) -> str:
+    digest = hashlib.sha256(operation_id.encode()).hexdigest()
+    return f"{prefix}:{digest}"
+
+
+@dataclass
+class _FakeModalState:
+    root: Path
+    values: dict[str, object] = field(default_factory=dict)
+    blobs: dict[str, bytes] = field(default_factory=dict)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    wait_started: asyncio.Event = field(default_factory=asyncio.Event)
+    release_wait: asyncio.Event = field(default_factory=asyncio.Event)
+    spawn_attempts: int = 0
+    execution_count: int = 0
+
+
+class _FakeModalRuntime:
+    def __init__(
+        self,
+        state: _FakeModalState,
+        *,
+        block_before_result: bool = False,
+        fail_spawn: bool = False,
+        lose_response_after_result: bool = False,
+    ) -> None:
+        self.state = state
+        self.block_before_result = block_before_result
+        self.fail_spawn = fail_spawn
+        self.lose_response_after_result = lose_response_after_result
+
+    async def get(self, key: str) -> object:
+        async with self.state.lock:
+            return self.state.values.get(key)
+
+    async def put_if_absent(self, key: str, value: Mapping[str, Any]) -> bool:
+        async with self.state.lock:
+            if key in self.state.values:
+                return False
+            self.state.values[key] = dict(value)
+            return True
+
+    async def spawn(
+        self,
+        *,
+        operation_id: str,
+        request_ipc: bytes,
+        namespace_digest: str,
+    ) -> object:
+        self.state.spawn_attempts += 1
+        if self.fail_spawn:
+            raise RuntimeError("spawn response disappeared")
+        return operation_id, request_ipc, namespace_digest
+
+    async def wait(self, call: object) -> object:
+        operation_id, request_ipc, namespace_digest = cast(
+            tuple[str, bytes, str],
+            call,
+        )
+        self.state.execution_count += 1
+        self.state.wait_started.set()
+        if self.block_before_result:
+            await self.state.release_wait.wait()
+        trajectory_ipc = await SeededHostedEpisodeRunner().run(request_ipc)
+        episode_results_ipc = build_hosted_episode_results(
+            request_ipc,
+            trajectory_ipc,
+        )
+        manifest_ipc = build_hosted_episode_manifest(
+            request_ipc,
+            trajectory_ipc,
+            episode_results_ipc,
+        )
+        result = HostedEpisodeProviderResult(
+            request_ipc=request_ipc,
+            trajectory_ipc=trajectory_ipc,
+            episode_results_ipc=episode_results_ipc,
+            manifest_ipc=manifest_ipc,
+        )
+        index = hosted_modal._publish_remote_result(
+            mount=self.state.root,
+            operation_id=operation_id,
+            namespace_digest=namespace_digest,
+            protocol_epoch=hosted_modal.MODAL_HOSTED_EPISODE_PROTOCOL_EPOCH,
+            result=result,
+        )
+        payloads = cast(dict[str, dict[str, object]], index["payloads"])
+        for record in payloads.values():
+            path = str(record["path"])
+            self.state.blobs[path] = (self.state.root / path).read_bytes()
+        key = _provider_operation_key(operation_id, "result")
+        async with self.state.lock:
+            existing = self.state.values.get(key)
+            if existing is not None and existing != index:
+                raise RuntimeError("first result index conflicts")
+            self.state.values.setdefault(key, index)
+        if self.lose_response_after_result:
+            self.lose_response_after_result = False
+            raise RuntimeError("completion response disappeared")
+        return {"gpu_count": 1, "schema_version": 1}
+
+    async def read_blob(self, path: str) -> bytes:
+        return self.state.blobs[path]
+
+
+class _ObservationStager:
+    def __init__(self) -> None:
+        self.observations: dict[tuple[str, str], HostedEpisodeObservation] = {}
+
+    async def stage_hosted_episode_observation(
+        self,
+        *,
+        world_id: str,
+        observation: HostedEpisodeObservation,
+    ) -> None:
+        key = world_id, observation.activity_id
+        existing = self.observations.get(key)
+        if existing is not None and existing != observation:
+            raise ValueError("conflicting hosted observation")
+        self.observations.setdefault(key, observation)
+
+
+class _CrashBeforeGenericRecord:
+    def __init__(self, catalog: PhysicalHostedActivityCoordinator) -> None:
+        self.catalog = catalog
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.catalog, name)
+
+    async def record_episode_result(self, claim: object, result: object) -> None:
+        raise RuntimeError("worker died before generic Activity result recording")
+
+
+def _open_catalog(
+    path: Path,
+    *,
+    lease_seconds: float = 0.01,
+) -> tuple[
+    SqliteActivityCatalog,
+    ActivityCoordinator,
+    PhysicalHostedActivityCoordinator,
+]:
+    physical = SqliteActivityCatalog(path)
+    generic = ActivityCoordinator(physical)
+    return (
+        physical,
+        generic,
+        PhysicalHostedActivityCoordinator(
+            generic,
+            lease_seconds=lease_seconds,
+        ),
+    )
+
+
+def test_modal_namespace_identity_binds_every_durable_and_execution_coordinate() -> None:
+    base = _config()
+    fields = (
+        "workspace_name",
+        "environment_name",
+        "app_name",
+        "function_name",
+        "result_dict_name",
+        "result_volume_name",
+    )
+    for field_name in fields:
+        changed = replace(base, **{field_name: f"{getattr(base, field_name)}-changed"})
+        assert changed.provider_identity != base.provider_identity
+        assert changed.namespace_digest != base.namespace_digest
+
+    with pytest.raises(ValueError, match="valid Modal name"):
+        _config(workspace_name=1)
+    with pytest.raises(ValueError, match="protocol epoch"):
+        _config(protocol_epoch=True)
+    with pytest.raises(ValueError, match="positive integer"):
+        _config(call_timeout_seconds=True)
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _config(create_if_missing=1)
+
+
+@pytest.mark.asyncio
+async def test_lost_modal_completion_response_recovers_provider_first_result(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "response-loss"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    provider = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state, lose_response_after_result=True),
+    )
+
+    result = await provider.execute(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+        attempt=1,
+        fence=1,
+        retry_guard=None,
+    )
+
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+    manifest = validate_hosted_episode_result(
+        result.request_ipc,
+        result.trajectory_ipc,
+        result.episode_results_ipc,
+        result.manifest_ipc,
+    )
+    assert decode_hosted_episode_manifest(result.manifest_ipc) == manifest
+
+    reconstructed = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+    recovery = await reconstructed.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeRecovered)
+    assert recovery.result == result
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+
+
+@pytest.mark.asyncio
+async def test_permanent_modal_start_without_result_never_replays(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "ambiguous-start"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    first = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state, fail_spawn=True),
+    )
+
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="permanent start"):
+        await first.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=1,
+            fence=1,
+            retry_guard=None,
+        )
+
+    reconstructed = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+    recovery = await reconstructed.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeRecoveryUnknown)
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="permanent start"):
+        await reconstructed.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=2,
+            fence=2,
+            retry_guard=None,
+        )
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 0
+
+
+@pytest.mark.asyncio
+async def test_modal_confirmed_absence_guard_cannot_bypass_atomic_start(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "guarded-start"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    provider = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+    recovery = await provider.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeConfirmedAbsent)
+
+    wrong_guard = HostedEpisodeRetryGuard(
+        ref=recovery.guard.ref,
+        digest="0" * 64,
+    )
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="retry guard"):
+        await provider.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=1,
+            fence=1,
+            retry_guard=wrong_guard,
+        )
+    assert state.values == {}
+
+    await provider.execute(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+        attempt=1,
+        fence=1,
+        retry_guard=recovery.guard,
+    )
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_modal_claimants_admit_only_one_remote_execution(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "concurrent-start"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    first = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state, block_before_result=True),
+    )
+    second = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+
+    first_task = asyncio.create_task(
+        first.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=1,
+            fence=1,
+            retry_guard=None,
+        )
+    )
+    await state.wait_started.wait()
+    with pytest.raises(ModalHostedEpisodeProviderUnknown, match="permanent start"):
+        await second.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=2,
+            fence=2,
+            retry_guard=None,
+        )
+    state.release_wait.set()
+    await first_task
+
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+    recovered = await second.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovered, HostedEpisodeRecovered)
+
+
+@pytest.mark.asyncio
+async def test_modal_result_identity_corruption_fails_closed(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "corrupt-index"
+    operation_id = hosted_episode_provider_operation_id(world_id, activity_id)
+    request_ipc = _request(world_id, activity_id)
+    state = _FakeModalState(tmp_path / "remote-volume")
+    provider = ModalHostedEpisodeProvider(
+        _config(),
+        runtime=_FakeModalRuntime(state),
+    )
+    await provider.execute(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+        attempt=1,
+        fence=1,
+        retry_guard=None,
+    )
+    result_key = _provider_operation_key(operation_id, "result")
+    index = state.values[result_key]
+    assert isinstance(index, dict)
+    state.values[result_key] = {
+        **index,
+        "namespace_digest": "0" * 64,
+    }
+
+    with pytest.raises(ValueError, match="identity is incompatible"):
+        await provider.reconcile(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+        )
+
+    state.values[result_key] = index
+    del state.values[_provider_operation_key(operation_id, "start")]
+    recovery = await provider.reconcile(
+        operation_id=operation_id,
+        request_ipc=request_ipc,
+    )
+    assert isinstance(recovery, HostedEpisodeRecoveryUnknown)
+    with pytest.raises(
+        ModalHostedEpisodeProviderUnknown,
+        match="without its exact permanent start",
+    ):
+        await provider.execute(
+            operation_id=operation_id,
+            request_ipc=request_ipc,
+            attempt=2,
+            fence=2,
+            retry_guard=None,
+        )
+    assert state.spawn_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_activity_restart_recovers_modal_result_before_generic_record(
+    tmp_path: Path,
+) -> None:
+    world_id = "physical-world"
+    activity_id = "activity-restart"
+    request_ipc = _request(world_id, activity_id)
+    catalog_path = tmp_path / "activities.db"
+    values_path = tmp_path / "values"
+    values = LocalHostedEpisodeValueStore(values_path)
+    request_ref = await values.put_request(request_ipc)
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+    physical, _generic, catalog = _open_catalog(catalog_path)
+    await catalog.admit_episode(
+        world_id=world_id,
+        receipt=receipt,
+        activity_id=activity_id,
+        request=request_ref,
+    )
+    state = _FakeModalState(tmp_path / "remote-volume")
+    first = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="before-crash",
+        catalog=cast(
+            PhysicalHostedActivityCatalog,
+            _CrashBeforeGenericRecord(catalog),
+        ),
+        values=values,
+        provider=ModalHostedEpisodeProvider(
+            _config(),
+            runtime=_FakeModalRuntime(state),
+        ),
+        stager=_ObservationStager(),
+    )
+
+    with pytest.raises(RuntimeError, match="before generic Activity result"):
+        await first.run_once()
+    assert state.execution_count == 1
+    await physical.close()
+    await asyncio.sleep(0.02)
+
+    recovered_physical, _recovered_generic, recovered_catalog = _open_catalog(
+        catalog_path,
+        lease_seconds=30,
+    )
+    stager = _ObservationStager()
+    reconstructed = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="after-restart",
+        catalog=recovered_catalog,
+        values=LocalHostedEpisodeValueStore(values_path),
+        provider=ModalHostedEpisodeProvider(
+            _config(),
+            runtime=_FakeModalRuntime(state),
+        ),
+        stager=stager,
+    )
+    assert await reconstructed.run_once()
+
+    assert state.spawn_attempts == 1
+    assert state.execution_count == 1
+    observation = stager.observations[(world_id, activity_id)]
+    assert observation.episode_count == 2
+    assert observation.trajectory_row_count == 5
+    assert observation.transition_count == 3
+    assert observation.success_count == 1
+    assert len(await recovered_catalog.pending_episode_results(world_id=world_id)) == 1
+    await recovered_physical.close()


### PR DESCRIPTION
Part of #704 (Gate 0 of the v0.5.0 cut order). Supersedes #687.

## Issue

Hosted Physical AI has a canonical whole-episode Arrow contract, but it did not yet have the durable boundary between a committed evaluation decision and consequential episode execution. Keeping provider work inside a retryable tick would make lease expiry or process loss look like replay authority, even when a simulator or robot may already have started.

#687 carried this work (A7, plus A7b Modal parity merged into the same branch via #693) but is agent-authored, so the deterministic review gate fails closed on its head by design. This is the maintainer-owned re-cut over current main, and it fixes the one named bug found in review: a finite-prefix claim scan that can strand claimable work.

## User effect and root cause

Without this slice, a hosted evaluation cannot honestly recover across provider publication, control-catalog recording, observation staging, and the later world commit. The missing piece was family-owned choreography around the generic Activity mechanics: exact committed intent admission, stable provider operation identity, provider-specific reconciliation, complete result publication, idempotent factual observation staging, and exact-receipt settlement.

Separately, every coordinator claim scan read one finite prefix of the pending set (10,000 rows for the Mission author and hosted coordinators, the 100-row default for the Mission critic). When other workers held leases on the whole prefix, a claimable Activity beyond it was stranded until an unrelated change reshuffled the prefix.

## Change

- Add `HostedEpisodeIntent` and `HostedEpisodeObservation`, strict content-reference values, stable world-scoped provider operation identity, and the provider recovery protocol under `archetype.physical_ai`.
- Add an exact-receipt required projector, a Physical-AI adapter over the generic Activity coordinator, and an out-of-lock worker that binds provider identity before execution or reconciliation.
- Add a local content-addressed value store and seeded durable provider proof. A permanent atomic start marker prevents duplicate starts; a provider-durable first-result index recovers a complete result after process loss; start-without-result remains unknown.
- A7b: add the Modal provider under an exact workspace, Environment, App, Function, named Dict, named Volume, and protocol epoch (`archetype.physical_ai.hosted_modal`). One atomic Dict put selects the start winner; canonical payloads are committed to the Volume before the bounded first-result index is installed. It does not import Mission-owned barriers.
- Publish request, trajectory, derived episode results, manifest, and one bounded descriptor before staging a later factual observation.
- Add concrete storage/world adapters. Forked worlds project only the current run's pinned visibility, and observation staging is idempotent under the world lock.
- **Fix the claim-starvation bug** across all three coordinators: `archetype.activities` gains one shared page-until-exhaustion implementation (`claim_next_pending`, `collect_pending_results`), and the Mission author, Mission critic, and hosted Physical-AI coordinators all claim and deliver through it. No scan concludes no-work from a finite prefix; a larger constant is explicitly not the fix, and the page size is now only a fetch size. The verification gates in `docs/guide/activities.md` pin the property.
- Update the normative Activity/Physical AI docs, the refactor plan, and architecture/lazy/observability manifests.

The existing direct per-step Physical AI path remains supported and unchanged; this slice does not cut over any runtime operation (the hosted binding is not wired into `archetype.wiring`/`archetype.runtime`).

## Validation

- `uv run pytest -q tests/activities tests/physical_ai` — 178 passed (includes the new claim-scan contract: with more leased rows than the retired 10,000-row scan bound, a claimable Activity beyond the prefix is still claimed; plus paging-to-exhaustion and results-side twins)
- `uv run pytest -q tests/app/test_mission_author_activities.py::test_author_claim_pages_past_a_full_page_of_live_claims tests/app/test_mission_critic_activities.py::test_critic_claim_claims_beyond_the_retired_default_prefix` — 2 passed (author pages past a fully leased prefix on the real SQLite catalog; critic claims beyond its retired 100-row default bound with no page shrinking)
- `make ci` — passed (lint including architecture, lazy-boundary, observability, API, idempotency, gate-coverage, and scenario audits; lock check; full test suite with coverage)

## Deliberate stop line

This PR proves the provider-neutral local A7 choreography with filesystem/SQLite restart oracles, plus one seeded A7b Modal first-result recovery proof (2026-07-26, paid, recorded with its digests in `docs/planning/activity-boundary-refactor.md`). It does **not** claim byte-identical GPU replay — correctness depends on recovery by stable operation identity, not replay — and the seeded Modal proof is not a universal provider bridge: the Modal Dict and Volume prove provider-side start and first-result durability only, not remote storage or control-catalog parity, which remain separate slices. No runtime path is cut over; consolidation and the direct per-step path's disposition belong to A8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
