### PR TITLE
fix(review): design-brief prompt gets the literal scope manifest

### DIFF
--- a/.github/review/prompts/design-brief.md
+++ b/.github/review/prompts/design-brief.md
@@ -9,8 +9,9 @@ change. The finalized bundle is the finding authority: preserve its cluster
 states, adjudications, design notes, and human-decision dispositions.
 
 The scope manifest is exactly these changed files, and every
-`change_cohorts[].files` entry must come from this list — never the review
-bundle, scope file, diff file, or anything else you merely opened:
+`change_cohorts[].files` entry must come from this list. The review bundle,
+scope file, diff file, and anything else you merely opened belong in a
+cohort only when they appear in this manifest:
 
 $scoped_files
 

--- a/.github/review/prompts/design-brief.md
+++ b/.github/review/prompts/design-brief.md
@@ -8,6 +8,12 @@ repository guidance, and only the protected-base context needed to explain the
 change. The finalized bundle is the finding authority: preserve its cluster
 states, adjudications, design notes, and human-decision dispositions.
 
+The scope manifest is exactly these changed files, and every
+`change_cohorts[].files` entry must come from this list — never the review
+bundle, scope file, diff file, or anything else you merely opened:
+
+$scoped_files
+
 Organize the diff into logical change cohorts in the order a human should read
 them, not alphabetical file order. Explain intent and behavioral delta, design
 choices and alternatives, affected invariants, validation evidence, and the

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -837,6 +837,7 @@ jobs:
             --input "${REVIEW_DIR}/validated/review-bundle.json")"
           python3 scripts/footgun_review_gate.py prompt \
             --kind design-brief \
+            --scope "${SCOPE_FILE}" \
             --pr-number "${PR_NUMBER}" \
             --head "${HEAD_SHA}" \
             --bundle-digest "${BUNDLE_DIGEST}" \

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -1116,7 +1116,7 @@ def _extract_command(args: argparse.Namespace) -> None:
 
 def _prompt_command(args: argparse.Namespace) -> None:
     lens_scope: list[str] = []
-    if args.kind in ("lens-review", "lens-retry"):
+    if args.kind in ("lens-review", "lens-retry", "design-brief"):
         if args.scope is None:
             raise GateError("lens prompts require --scope for the file manifest")
         _, lens_scope = _scope_values(_load_json(args.scope))
@@ -1147,6 +1147,7 @@ def _prompt_command(args: argparse.Namespace) -> None:
             pr_number=args.pr_number,
             head_sha=args.head,
             bundle_digest=args.bundle_digest,
+            scoped_files=lens_scope,
         )
     if args.output is None:
         print(prompt, end="")

--- a/scripts/review_contracts.py
+++ b/scripts/review_contracts.py
@@ -1342,6 +1342,7 @@ def render_design_brief_prompt(
     pr_number: int,
     head_sha: str,
     bundle_digest: str,
+    scoped_files: Sequence[str] = (),
 ) -> str:
     return _render_template(
         "design-brief.md",
@@ -1349,6 +1350,7 @@ def render_design_brief_prompt(
             "pr_number": str(pr_number),
             "head_sha": head_sha,
             "bundle_digest": bundle_digest,
+            "scoped_files": "\n".join(f"- `{path}`" for path in scoped_files),
             "output_schema": json.dumps(human_design_brief_schema(), indent=2),
         },
     )


### PR DESCRIPTION
The last model stage without #700's manifest lesson: the codex brief author listed harness working files (`.footgun-review-output/validated/review-bundle.json`, the scope file) in `change_cohorts[].files`, failing brief validation on #688/#694's fresh runs. Template inlines the changed-file manifest with an explicit must-come-from-this-list rule; renderer + prompt CLI thread `scoped_files`; workflow passes `--scope`. Toggle-merge on green CI — the gate cannot pass its own brief step until this lands (same catch-22 as #699/#700/#701).

🤖 Generated with [Claude Code](https://claude.com/claude-code)