### PR TITLE
fix(core): keep debug diagnostics lazy

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -464,9 +464,11 @@ df = df.with_column("agent__normalized", normalizer.normalize(col("agent__name")
 
 ## Lazy-Audit UDF-Boundary Exemption (Jun 2026)
 
-``scripts/check_lazy_audit.py`` gates every ``.collect`` reference (including a
-bound callable) and ``.to_pylist()`` call in ``src/`` against
-``lazy_audit.toml``. There is
+``scripts/check_lazy_audit.py`` gates execution-capable DataFrame terminals in
+``src/`` against ``lazy_audit.toml``. This includes conversions, iterators,
+diagnostics, and writes such as ``.collect``, ``.count_rows()``, ``.show()``,
+``.to_arrow()``, ``.to_arrow_iter()``, ``.to_pydict()``, and ``.write_*()``.
+There is
 **one sanctioned exception** that does not require an allowlist entry:
 
 > ``Series.to_pylist()`` called on a *parameter* of a function decorated
@@ -499,6 +501,7 @@ Rules:
 - ``Series.to_pylist()`` on a **batch-UDF parameter** → exempt, no entry.
 - ``DataFrame.to_pylist()`` anywhere → requires entry.
 - ``DataFrame.collect()`` anywhere → requires entry.
+- DataFrame diagnostics, conversions, iterators, and writes → require entries.
 - ``Series.to_pylist()`` **outside** a batch-UDF → requires entry.
 - ``collect()`` inside a batch-UDF on a DataFrame (not a parameter) → requires entry.
 
@@ -594,8 +597,12 @@ Enable with `run_config.debug = True`:
 ```text
 [archetype] {"event": "tick_start", "world_id": "...", "tick": 0}
 [archetype] processor_start: PhysicsProcessor (priority=10)
-[archetype] processor_end: PhysicsProcessor (rows_out=100)
+[archetype] processor_end: PhysicsProcessor (archetype=a_2c_s...)
 ```
+
+Debug diagnostics describe orchestration and lazy plan shape. They do not
+execute a DataFrame to manufacture row counts or previews; execution remains
+at the owning terminal boundary.
 
 ---
 

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -1,11 +1,12 @@
 # Lazy-evaluation audit allowlist.
 #
 # Each entry documents an exception to Archetype's lazy execution
-# contract. .collect() and .to_pylist() force a Daft DataFrame through
-# Python memory and defeat query planning. Adding an entry here is
-# auditable: PR reviewers will challenge any new entry whose reason
-# does not name a specific technical boundary (storage write, single-row
-# migration extract, debug logging).
+# contract. Execution-capable terminals run a Daft DataFrame plan;
+# conversion terminals may also force it through Python memory and
+# defeat query planning. Adding an entry here is auditable: PR reviewers
+# will challenge any new entry whose reason does not name a specific
+# technical boundary (storage write, transport conversion, single-row
+# migration extract).
 #
 # Generic reasons ("needed", "for the test", "convenience") are
 # rejected automatically by scripts/check_lazy_audit.py.
@@ -95,13 +96,6 @@ symbol = "load_lineage"
 expr = "df.to_pylist"
 method = "to_pylist"
 reason = "Lineage metadata extract: a fork's ancestor segments (bounded by fork depth, typically 1-3 rows) must become Python (world_id, run_id, up_to_tick) tuples because they route subsequent per-tick store queries; the routing decision cannot be expressed inside a single Daft plan."
-
-[[entries]]
-path = "src/archetype/core/sync/store.py"
-symbol = "SyncStore.append"
-expr = "df.collect"
-method = "collect"
-reason = "Debug-mode-only logging: materialise so count_rows and df.show emit diagnostics; gated on self.debug and never reached in production execution paths."
 
 [[entries]]
 path = "src/archetype/core/sync/world.py"
@@ -361,3 +355,143 @@ symbol = "_entities_terminal"
 expr = "materialized.to_pylist"
 method = "to_pylist"
 reason = "Episode-termination boundary: StorageService admits and materializes the one-row (n_done, n_total) reduction before its all/any values enter Python control flow to stop the episode loop."
+
+[[entries]]
+path = "src/archetype/api/routes/query.py"
+symbol = "get_components"
+expr = "frame.count_rows"
+method = "count_rows"
+reason = "Explicit HTTP count operation: the caller requested a scalar count instead of row output, so the API route owns this terminal query boundary."
+
+[[entries]]
+path = "src/archetype/artifacts/handlers.py"
+symbol = "ingest_artifacts"
+expr = "discovered.to_pydict"
+method = "to_pydict"
+reason = "Artifact discovery validation boundary: StorageService has already materialized the occurrence frame once; bounded source identities enter Python validation before any durable publication."
+
+[[entries]]
+path = "src/archetype/artifacts/handlers.py"
+symbol = "ingest_artifacts"
+expr = "stored.to_pydict"
+method = "to_pydict"
+reason = "Artifact index-routing boundary: StorageService has already materialized the persisted occurrence frame once; bounded media families and logical paths select the required typed indexes."
+
+[[entries]]
+path = "src/archetype/core/aio/async_cached_store.py"
+symbol = "AsyncCachedStore.append"
+expr = "df.to_arrow_iter"
+method = "to_arrow_iter"
+reason = "Cached-store append boundary: stream the incoming Daft plan once into bounded Arrow record batches retained until the owning durable flush."
+
+[[entries]]
+path = "src/archetype/core/aio/async_lancedb_store.py"
+symbol = "AsyncLancedbStore.get_existing_table_df"
+expr = "table.query().where(where_str).to_arrow"
+method = "to_arrow"
+reason = "LanceDB SDK query boundary: the async SDK returns an Arrow table for the exact durable table identity; the receiver is not a lazy Daft DataFrame."
+
+[[entries]]
+path = "src/archetype/core/aio/async_lancedb_store.py"
+symbol = "AsyncLancedbStore.get_archetype_df"
+expr = "async_table.query().where(where_str).to_arrow"
+method = "to_arrow"
+reason = "LanceDB SDK query boundary: execute the backend-filtered async query once and convert its Arrow result into the lazy Daft frame returned to core."
+
+[[entries]]
+path = "src/archetype/core/aio/async_lancedb_store.py"
+symbol = "AsyncLancedbStore._legacy_df"
+expr = "table.query().where(where_str).to_arrow"
+method = "to_arrow"
+reason = "LanceDB SDK legacy-read boundary: execute the backend-filtered frozen-history query once before aligning its Arrow result to the current lazy Daft schema."
+
+[[entries]]
+path = "src/archetype/core/aio/async_lancedb_store.py"
+symbol = "AsyncLancedbStore.append"
+expr = "df.to_arrow"
+method = "to_arrow"
+reason = "LanceDB append boundary: materialize the incoming Daft plan exactly once as the Arrow table required by the backend add operation and its returned row metadata."
+
+[[entries]]
+path = "src/archetype/core/aio/async_store.py"
+symbol = "AsyncStore._append_table"
+expr = "df.write_iceberg"
+method = "write_iceberg"
+reason = "Iceberg storage sink: explicit IO configuration requires the native Daft write at the store-owned append boundary."
+
+[[entries]]
+path = "src/archetype/core/aio/async_store.py"
+symbol = "AsyncStore.append"
+expr = "materialized.count_rows"
+method = "count_rows"
+reason = "Owned store boundary: the input is already collected once; this count reads the concrete result to preserve empty-append and committed-signature behavior without replaying the upstream plan."
+
+[[entries]]
+path = "src/archetype/core/sync/store.py"
+symbol = "SyncStore._append_table"
+expr = "df.write_iceberg"
+method = "write_iceberg"
+reason = "Synchronous Iceberg storage sink: explicit IO configuration requires the native Daft write at the store-owned append boundary."
+
+[[entries]]
+path = "src/archetype/evaluation/views.py"
+symbol = "read_result"
+expr = "(await storage.materialize(matched)).to_pydict"
+method = "to_pydict"
+reason = "Single-row evaluation receipt boundary: StorageService admits and materializes the exact identity match before its bounded scalar values become the typed return value."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.scan_visible_world_rows"
+expr = "tick_frame.to_pydict"
+method = "to_pydict"
+reason = "Single-row physical tick reduction: StorageService has already materialized the aggregate, whose bounded maximum tick routes visibility metadata for the returned table frame."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_table"
+expr = "frozen.count_rows"
+method = "count_rows"
+reason = "Owned append receipt boundary: the producer plan is already collected exactly once, and the concrete row count controls the write no-op and returned scalar without replay."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_table"
+expr = "frozen.write_iceberg"
+method = "write_iceberg"
+reason = "StorageService-owned Iceberg sink: write the single frozen producer result while retaining it across bounded optimistic commit retries."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_missing"
+expr = "candidates.count_rows"
+method = "count_rows"
+reason = "Conditional-write validation boundary: the candidate plan is already collected once, and its concrete row count is compared with the key projection before persistence."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_missing"
+expr = "candidates.where(null_key_filter).limit(1).count_rows"
+method = "count_rows"
+reason = "Conditional-write validation boundary: execute a bounded one-row null-key probe over frozen candidates before admitting them to the Iceberg sink."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_missing"
+expr = "candidates.distinct(*key_columns).count_rows"
+method = "count_rows"
+reason = "Conditional-write validation boundary: count distinct keys over frozen candidates to reject ambiguous same-batch identities before persistence."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_missing"
+expr = "pending.count_rows"
+method = "count_rows"
+reason = "Owned append receipt boundary: the anti-joined pending frame is already collected once, and its concrete row count controls the write no-op and returned scalar."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
+symbol = "StorageService.append_missing"
+expr = "pending.write_iceberg"
+method = "write_iceberg"
+reason = "StorageService-owned conditional Iceberg sink: write the frozen anti-joined rows under the execution gate and bounded optimistic commit retry."

--- a/quality/observability/core.toml
+++ b/quality/observability/core.toml
@@ -135,16 +135,6 @@ expiry_condition = "Remove when #530 migrates this call to parameterized stdlib 
 rule = "eager_log_interpolation"
 path = "src/archetype/core/aio/async_system.py"
 qualified_scope = "archetype.core.aio.async_system.AsyncSystem.execute"
-target = "log:debug:f'[archetype] processor_end: {proc_name} (rows_out={row_count})':interpolation"
-owner = "core"
-issue = 530
-reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
-expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
-
-[[legacy]]
-rule = "eager_log_interpolation"
-path = "src/archetype/core/aio/async_system.py"
-qualified_scope = "archetype.core.aio.async_system.AsyncSystem.execute"
 target = "log:error:f'Error processing archetype {sig}: {e} with processor {proc_instance} of type {type(proc_instance)}':interpolation"
 owner = "core"
 issue = 530
@@ -260,16 +250,6 @@ owner = "core"
 issue = 530
 reason = "This existing core diagnostic exports raw exception text or stack details."
 expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
-
-[[legacy]]
-rule = "eager_log_interpolation"
-path = "src/archetype/core/sync/querier.py"
-qualified_scope = "archetype.core.sync.querier.QueryManager.query_archetype"
-target = "log:info:f'Querying {Archetype.get_name(sig)} with {df.count_rows()} rows':interpolation"
-owner = "core"
-issue = 530
-reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
-expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
 
 [[legacy]]
 rule = "eager_log_interpolation"

--- a/scripts/check_lazy_audit.py
+++ b/scripts/check_lazy_audit.py
@@ -15,8 +15,10 @@
 """Lazy-evaluation audit.
 
 Daft is lazily evaluated. DataFrames represent computations, not results.
-Calling ``.collect()`` or ``.to_pylist()`` forces the frame through Python
-memory, defeats query planning, and stops scaling at in-memory size.
+Execution-capable terminals such as ``.collect()``, ``.count_rows()``,
+``.show()``, ``.to_arrow()``, ``.to_pylist()``, and ``.write_*()`` execute
+the lazy plan. Conversion terminals may also force the frame through Python
+memory and stop scaling at in-memory size.
 
 Every such reference inside ``src/`` is a contract exception against
 Archetype's lazy execution model. This includes bound callables such as
@@ -56,8 +58,8 @@ The checker detects this pattern via AST analysis:
   classified as **udf-boundary (sanctioned)** and reported separately.  It
   does not need an entry in ``lazy_audit.toml``.
 
-``DataFrame.collect()`` and ``DataFrame.to_pylist()`` anywhere, and
-``Series.to_pylist()`` *outside* batch-UDF scope, still require entries.
+Every other execution-capable terminal, plus ``Series.to_pylist()`` *outside*
+batch-UDF scope, still requires an entry.
 
 Tests are intentionally out of scope: terminal materialization at the
 assertion boundary is expected. The contract being audited is the
@@ -79,7 +81,42 @@ ROOTS: tuple[str, ...] = ("src",)
 ALLOWLIST_FILENAME = "lazy_audit.toml"
 SELF_RELATIVE = "scripts/check_lazy_audit.py"
 
-_MATERIALIZATION_METHODS = frozenset({"collect", "to_pylist"})
+# Daft 0.7.19 DataFrame methods that execute a plan, create an execution-backed
+# iterator/dataset, or write a sink. Keep this as the single source of truth;
+# tests exercise representative conversion, diagnostic, iterator, and sink
+# terminals without carrying a second full inventory.
+_MATERIALIZATION_METHODS = frozenset(
+    {
+        "collect",
+        "count_rows",
+        "iter_partitions",
+        "iter_rows",
+        "show",
+        "to_arrow",
+        "to_arrow_iter",
+        "to_dask_dataframe",
+        "to_pandas",
+        "to_pydict",
+        "to_pylist",
+        "to_ray_dataset",
+        "to_torch_dataloader",
+        "to_torch_iter_dataset",
+        "to_torch_map_dataset",
+        "write_bigtable",
+        "write_clickhouse",
+        "write_csv",
+        "write_deltalake",
+        "write_huggingface",
+        "write_iceberg",
+        "write_json",
+        "write_lance",
+        "write_paimon",
+        "write_parquet",
+        "write_sink",
+        "write_sql",
+        "write_turbopuffer",
+    }
+)
 
 
 MODULE_SCOPE = "<module>"
@@ -338,18 +375,19 @@ STERN_HEADER = (
 
 STERN_BODY = """\
 Daft is lazily evaluated. DataFrames represent computations, not results.
-.collect() and .to_pylist() force the frame through Python memory, defeat
-query planning, and stop scaling at in-memory dataset sizes. Every such
-call is a contract exception against Archetype's lazy execution model.
+Execution-capable terminals run the lazy plan. Conversion terminals may also
+force the frame through Python memory, defeat query planning, and stop scaling
+at in-memory dataset sizes. Every such call is a contract exception against
+Archetype's lazy execution model.
 
 If you are reading this, the most likely answer is to rewrite the
 expression in Daft. Reach for where, select, with_column, agg, join,
-sort, distinct, count_rows before pulling rows into Python. See
-LEARNINGS.md and docs/guide/specification.md for the lazy contract.
+sort, and distinct, or use explain for plan diagnostics. See LEARNINGS.md
+and docs/guide/specification.md for the lazy contract.
 
 If the materialization is genuinely unavoidable (storage write boundary,
-single-row migration extract, debug logging, terminal test assertion),
-the exception must be documented in writing and visible in code review:
+single-row migration extract, terminal transport conversion), the exception
+must be documented in writing and visible in code review:
 
   * The reason field in lazy_audit.toml must state the technical reason
     the boundary cannot be expressed lazily. Generic phrases ("needed",
@@ -383,7 +421,7 @@ def main() -> int:
     parser.add_argument(
         "--list",
         action="store_true",
-        help="Print every detected materialization site and exit 0 (no gating).",
+        help="Print every detected execution-capable terminal and exit 0 (no gating).",
     )
     parser.add_argument(
         "files",
@@ -444,7 +482,7 @@ def main() -> int:
             f'    expr = "{s.expr}"\n    method = "{s.method}"\n    reason = "..."'
             for s in new_sites
         ]
-        sys.stderr.write(_format_section("New, undocumented materialization points:", rendered))
+        sys.stderr.write(_format_section("New, undocumented execution points:", rendered))
 
     if stale_entries:
         rendered = [

--- a/src/archetype/core/aio/async_system.py
+++ b/src/archetype/core/aio/async_system.py
@@ -103,9 +103,10 @@ class AsyncSystem(iAsyncSystem):
                     df = await proc_instance.process(df, **filtered_input_kwargs)
 
                     if debug:
-                        row_count = df.count_rows() if hasattr(df, "count_rows") else "?"
                         logger.debug(
-                            f"[archetype] processor_end: {proc_name} (rows_out={row_count})"
+                            "[archetype] processor_end: %s (archetype=%s)",
+                            proc_name,
+                            archetype_name,
                         )
                 except Exception as e:
                     logger.error(

--- a/src/archetype/core/aio/async_world.py
+++ b/src/archetype/core/aio/async_world.py
@@ -1150,10 +1150,7 @@ class AsyncWorld(iAsyncWorld):
             )
 
         async def log_tick_end(event: PostTick) -> None:
-            total_live = sum(
-                df.count_rows() if hasattr(df, "count_rows") else 0 for df in event.results.values()
-            )
-            self._debug_log("tick_end", tick=event.tick, live_entities=total_live)
+            self._debug_log("tick_end", tick=event.tick)
 
         return (
             self.add_hook(PreTick, log_tick_start),

--- a/src/archetype/core/sync/querier.py
+++ b/src/archetype/core/sync/querier.py
@@ -69,9 +69,8 @@ class QueryManager(iQueryManager):
             df = df.select(*Archetype.projection_columns(components))
 
         if run_config and run_config.debug:
-            logger.info(f"Querying {Archetype.get_name(sig)} with {df.count_rows()} rows")
+            logger.info("Querying %s", Archetype.get_name(sig))
             df.explain()
-            df.show()
 
         return df
 

--- a/src/archetype/core/sync/store.py
+++ b/src/archetype/core/sync/store.py
@@ -118,7 +118,6 @@ class SyncStore(iStore):
 
         if self.debug:
             logger.debug("Reading table %s", table.name)
-            df.limit(5).show()
 
         # stored as strings; ensure filter values are strings
         # (Daft stubs type Expression.__eq__ as bool; these are Expressions.)
@@ -134,9 +133,7 @@ class SyncStore(iStore):
         table_name = table.name
 
         if self.debug:
-            df.collect()
-            logger.debug("Appending %s rows to table %s", df.count_rows(), table_name)
-            df.show()
+            logger.debug("Appending to table %s", table_name)
 
         self._append_table(table, df)
 

--- a/tests/aio/test_async_world_execution.py
+++ b/tests/aio/test_async_world_execution.py
@@ -2,9 +2,10 @@ import asyncio
 import json
 import logging
 
+import daft
 import pytest
 import pytest_asyncio
-from daft import col, from_pylist, lit
+from daft import DataFrame, DataType, col, from_pylist, lit
 
 from archetype.core.aio.async_cached_store import AsyncCachedStore
 from archetype.core.aio.async_processor import AsyncProcessor
@@ -28,6 +29,28 @@ class Position(Component):
 
 class ResourceProbeMarker(Component):
     value: int
+
+
+class LazyExecutionMarker(Component):
+    value: int
+
+
+_LAZY_EXECUTION_CALLS: list[int] = []
+
+
+@daft.func(return_dtype=DataType.int64(), use_process=False)
+def _observe_lazy_execution(value: int) -> int:
+    _LAZY_EXECUTION_CALLS.append(value)
+    return value
+
+
+class FilteredSideEffectProbe(AsyncProcessor):
+    components = (LazyExecutionMarker,)
+
+    async def process(self, df: DataFrame, **kwargs: object) -> DataFrame:
+        return df.with_column(
+            "observed", _observe_lazy_execution(col("lazyexecutionmarker__value"))
+        ).where(col("observed") > 0)
 
 
 class SharedCounter:
@@ -231,6 +254,30 @@ async def test_concurrent_archetype_executions_share_resources():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.asyncio
+async def test_async_system_debug_does_not_execute_lazy_udfs(caplog):
+    async def calls_for(debug: bool) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        _LAZY_EXECUTION_CALLS.clear()
+        system = AsyncSystem()
+        await system.add_processor(FilteredSideEffectProbe())
+        source = daft.from_pydict({"lazyexecutionmarker__value": [1, 2, 3]})
+
+        planned = await system.execute(source, (LazyExecutionMarker,), debug=debug)
+        after_execute = tuple(_LAZY_EXECUTION_CALLS)
+        planned.collect()
+        return after_execute, tuple(_LAZY_EXECUTION_CALLS)
+
+    caplog.set_level(logging.DEBUG, logger="archetype.core.aio.async_system")
+    traces = {debug: await calls_for(debug) for debug in (False, True)}
+
+    assert traces[False] == traces[True] == ((), (1, 2, 3))
+    processor_end = [
+        record.message for record in caplog.records if "processor_end" in record.message
+    ]
+    assert processor_end
+    assert all("rows_out" not in message for message in processor_end)
+
+
 class CatchAllKwargsProbe(AsyncProcessor):
     """Processor using the documented catch-all signature. Captures the full
     kwargs dict it receives for assertions."""
@@ -350,7 +397,7 @@ async def test_run_config_debug_logs_step_lifecycle_via_hooks(store_backend, cap
     assert payloads[0]["spawn_pending"] == 1
     assert payloads[1]["count"] == 1
     assert payloads[2]["tick"] == 1
-    assert payloads[2]["live_entities"] == 1
+    assert "live_entities" not in payloads[2]
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/test_check_lazy_audit.py
+++ b/tests/scripts/test_check_lazy_audit.py
@@ -3,7 +3,7 @@
 
 """Tests for scripts/check_lazy_audit.py — AST scope detection.
 
-Covers the two key policy assertions:
+Covers the key policy assertions:
 
 1. **Positive (sanctioned):** ``Series.to_pylist()`` on a parameter of a
    ``@daft.method.batch`` / ``@daft.func.batch`` decorated function is
@@ -12,6 +12,9 @@ Covers the two key policy assertions:
 2. **Negative (gated):** A plain ``df.to_pylist()`` at module scope (or
    outside a batch-UDF) is still flagged as an audited site that requires
    an allowlist entry.
+
+3. **Execution coverage:** diagnostic, Arrow, iterator, conversion, and sink
+   terminals are all audited.
 """
 
 from __future__ import annotations
@@ -214,6 +217,26 @@ def test_collect_call_reports_one_attribute_site(tmp_path):
     sites = _scan_file(py, "one_collect.py")
 
     assert [(site.line, site.method) for site in sites] == [(1, "collect")]
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "count_rows",
+        "show",
+        "to_arrow",
+        "to_arrow_iter",
+        "to_pydict",
+        "iter_rows",
+        "write_parquet",
+    ],
+)
+def test_execution_capable_terminals_are_gated(tmp_path, method):
+    py = _write_py(tmp_path, "terminal.py", f"result = frame.{method}()\n")
+
+    sites = _scan_file(py, "terminal.py")
+
+    assert [(site.method, site.sanctioned) for site in sites] == [(method, False)]
 
 
 def test_non_call_text_is_ignored(tmp_path):


### PR DESCRIPTION
## Summary

- remove debug-only Daft execution from async processor/tick diagnostics and sync query/store diagnostics while retaining bounded orchestration logs
- expand the lazy audit from `collect`/`to_pylist` to Daft 0.7.19 execution-capable diagnostics, conversions, iterators, datasets, and sinks
- add #538's filtered side-effect UDF regression so debug and non-debug traces must match
- remove the two now-stale #530 observability legacy entries and document the lazy diagnostic contract

## Root cause

`AsyncSystem.execute(debug=True)` called `count_rows()` after processor planning. Because Daft frames are lazy, that diagnostic executed the accumulated processor plan before the owning terminal boundary and the later collection replayed the UDF. The audit could not detect it because its method inventory contained only `collect` and `to_pylist` and recommended `count_rows` as a rewrite.

## Scope and rulings

This is the focused C2 implementation from #704 for #538: remove diagnostic execution without redesigning processors, hooks, or the store boundary. The wider audit gives every pre-existing owned terminal an exact stable-key disposition; debug logging receives no exception. Vocabulary follows the canon fence in #703.

Refs #538. Coordinated under #704.

## Validation

- pre-fix #538 MRE: debug false `[] -> [1, 2, 3]`; debug true `[1, 2, 3] -> [1, 2, 3, 1, 2, 3]`
- post-fix #538 MRE: both modes `[] -> [1, 2, 3]`
- `uv run python scripts/check_lazy_audit.py` — 66 audited sites, all accounted for
- focused audit/aio/sync tests — 42 passed
- `make ci` — 2,782 passed, 6 skipped, 87.71% coverage; all regression/spec/capability and source/wheel operational scenarios passed