### PR TITLE
fix(storage): retry managed Iceberg conflicts

### DIFF
--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -457,6 +457,17 @@ conflict, storage refreshes the table and recomputes the anti-join before
 retrying so stale pending rows cannot duplicate an already-committed logical
 key.
 
+Managed ECS appends follow the same storage authority without changing core:
+the private Iceberg adapter materializes one Arrow payload, retains its commit
+token and physical table identity, and refreshes/retries only an exact catalog
+compare-and-swap conflict. Retry is bounded and uses full jitter. A
+commit-state-unknown response cannot prove absence, so v0.5 does not retry it
+or claim exact reconciliation. Storage raises `AmbiguousCommitError` with the
+exact table/world/run/tick identity and commit token, then rejects later
+non-empty appends to that table for the managed store's remaining lifetime.
+This also prevents a restored cached batch from replaying. The manifest-last
+protocol keeps any unconfirmed rows invisible (issue #704).
+
 The durable control plane is separate from that data plane. The local SQLite
 `ControlCatalog`, or its remote Durable Object implementation, owns world
 identity, writer fences, visibility manifests, deferred commands, and narrow

--- a/docs/guide/specification.md
+++ b/docs/guide/specification.md
@@ -548,6 +548,22 @@ boundary.
   read/write operations.
 - Per-store credentials MUST NOT rely solely on process-global Daft planning
   config.
+- A `StorageService`-managed ECS append MUST materialize its producer into
+  Arrow exactly once. A retry MUST reuse that payload, commit token, and
+  physical table identity; it MUST NOT collect, plan, or execute the producer
+  again.
+- Only an exact Iceberg `CommitFailedException`, which proves the catalog
+  compare-and-swap did not land, MAY be retried. Retry MUST refresh table
+  metadata and stop after a bounded number of full-jitter attempts.
+- An exact Iceberg `CommitStateUnknownException` MUST NOT authorize replay.
+  The v0.5 contract freezes it as `AmbiguousCommitError`, preserving the
+  table, world, run, tick, commit token, and writer epoch for the caller.
+  The managed store MUST reject later non-empty appends to that physical table
+  for its remaining lifetime before materialization, including a restored
+  cached batch. Exact snapshot reconciliation and restart-persistent freeze
+  state are not shipped in v0.5; the physical append may be durable, but it
+  remains logically invisible unless its tick manifest is later published
+  (issue #704).
 - Control-catalog bootstrap MUST be captured once in an immutable
   `ControlCatalogConfig`. `RuntimeBootstrapConfig.from_env()` may resolve it
   once at the host boundary; ordinary storage/catalog operations MUST NOT

--- a/docs/guide/stores.md
+++ b/docs/guide/stores.md
@@ -333,6 +333,22 @@ recomputes its anti-join against the new snapshot before retrying. That
 distinction prevents a stale retry from publishing a logical key that another
 writer committed first.
 
+The managed ECS Iceberg adapter also freezes one Arrow payload and retries only
+PyIceberg's exact catalog compare-and-swap conflict, for at most 16 attempts
+with full jitter. Every attempt retains the same physical table identity and
+commit token; processor work is never planned or materialized again.
+
+The deliberate v0.5 ambiguity posture is fail-closed rather than
+reconciliation: PyIceberg's exact commit-state-unknown signal becomes
+`AmbiguousCommitError`, whose fields preserve the table, world, run, tick,
+commit token, and writer epoch. Storage does not replay that append because it
+cannot prove absence, and the managed store rejects later non-empty appends to
+that physical table before materialization. This includes a cached batch
+restored after the typed error. The physical rows may already exist, while
+manifest-last visibility keeps them hidden. Exact snapshot readback,
+reconciliation, and restart-persistent freeze state remain future work
+(issue #704).
+
 Application families may construct lazy DataFrame transforms. They request
 materialization or table persistence from `iStorageService`; they do not call
 Daft collection, Iceberg read/write, or catalog table-creation primitives

--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -330,6 +330,13 @@ reason = "Idempotent world-mutation boundary: StorageService has already admitte
 
 [[entries]]
 path = "src/archetype/storage/service.py"
+symbol = "_AdmittedAsyncStore.append"
+expr = "df.to_arrow"
+method = "to_arrow"
+reason = "Managed-write boundary: the admitted world append materializes its plan exactly once so bounded Iceberg CAS retries resubmit the same physical Arrow payload via daft.from_arrow instead of re-executing the upstream DAG."
+
+[[entries]]
+path = "src/archetype/storage/service.py"
 symbol = "StorageService.append_missing"
 expr = "aligned.collect"
 method = "collect"

--- a/src/archetype/storage/__init__.py
+++ b/src/archetype/storage/__init__.py
@@ -5,6 +5,7 @@
 
 from archetype.storage.config import ControlCatalogConfig
 from archetype.storage.service import (
+    AmbiguousCommitError,
     PinnedVisibility,
     StorageService,
     VisibleTableRows,
@@ -13,6 +14,7 @@ from archetype.storage.service import (
 )
 
 __all__ = [
+    "AmbiguousCommitError",
     "ControlCatalogConfig",
     "PinnedVisibility",
     "StorageService",

--- a/src/archetype/storage/service.py
+++ b/src/archetype/storage/service.py
@@ -18,20 +18,27 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeVar
 
+import daft
 import pyarrow as pa
 from daft import DataFrame, DataType, col, lit, read_iceberg
 from daft.catalog import Catalog, Table
 from daft.io import IOConfig
 from daft.session import Session
-from pyiceberg.exceptions import CommitFailedException, TableAlreadyExistsError
+from pyiceberg.exceptions import (
+    CommitFailedException,
+    CommitStateUnknownException,
+    TableAlreadyExistsError,
+)
 
 from archetype.core.aio import AsyncCachedStore, AsyncLancedbStore, AsyncStore
+from archetype.core.archetype import Archetype
 from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
 from archetype.core.interfaces import AppendReceipt, ArchetypeSignature, iAsyncStore
 from archetype.core.paths import (
@@ -40,6 +47,7 @@ from archetype.core.paths import (
     require_safe_namespace,
     resolve_local_root,
 )
+from archetype.errors import AvailabilityError
 from archetype.storage.catalog import (
     ControlCatalog,
     RemoteControlCatalog,
@@ -57,6 +65,44 @@ logger = logging.getLogger(__name__)
 _MAX_COMMIT_ATTEMPTS = 16
 _T = TypeVar("_T")
 _WORLD_ENVELOPE_COLUMNS = ("world_id", "run_id")
+
+
+class AmbiguousCommitError(AvailabilityError):
+    """An Iceberg table commit may have landed and must not be replayed.
+
+    The exact physical table and managed tick identity remain inspectable so
+    callers can fail closed without parsing a backend exception. v0.5 freezes
+    this outcome rather than retrying an append whose absence is unproven
+    (issue #704).
+    """
+
+    public_detail = "Storage commit status is temporarily unavailable; retry is not authorized"
+
+    def __init__(
+        self,
+        *,
+        table_id: str,
+        world_id: str,
+        run_id: str,
+        tick: int,
+        commit_token: str,
+        writer_epoch: int,
+    ) -> None:
+        self.table_id = table_id
+        self.world_id = world_id
+        self.run_id = run_id
+        self.tick = tick
+        self.commit_token = commit_token
+        self.writer_epoch = writer_epoch
+        super().__init__(
+            f"Iceberg commit outcome for table {table_id!r}, world {world_id!r}, "
+            f"run {run_id!r}, tick {tick} is ambiguous; replay is not authorized"
+        )
+
+    @property
+    def physical_identity(self) -> tuple[str, str, str, int]:
+        """The exact table/world/run/tick destination of the frozen append."""
+        return (self.table_id, self.world_id, self.run_id, self.tick)
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,7 +173,7 @@ class _DaftExecutionGate:
 
 
 class _AdmittedAsyncStore(AsyncStore):
-    """Iceberg ECS store whose terminal append shares StorageService admission."""
+    """Managed Iceberg ECS writes owned by the StorageService execution lane."""
 
     def __init__(
         self,
@@ -137,10 +183,109 @@ class _AdmittedAsyncStore(AsyncStore):
     ) -> None:
         super().__init__(session, io_config=io_config)
         self._execution_gate = execution_gate
+        self._ambiguous_commits: dict[str, tuple[str, str, int, str, int]] = {}
 
     async def append(self, sig: ArchetypeSignature, df: DataFrame) -> AppendReceipt:
-        async with self._execution_gate.admit():
-            return await super().append(sig, df)
+        """Materialize once and retry only proven Iceberg CAS losers.
+
+        The one Arrow payload is retained across bounded attempts, so retry
+        cannot re-plan or re-execute processors. A commit-state-unknown signal
+        is never retried; it becomes the typed v0.5 frozen outcome ruled in
+        issue #704.
+        """
+        table_id = Archetype.get_name(sig)
+        if not df.column_names:
+            logger.info("Append skipped (store): archetype=%s empty schema", table_id)
+            return AppendReceipt(table_id=table_id, rows=0, durable=True)
+
+        payload: pa.Table | None = None
+        table: Table | None = None
+        identity: tuple[str, str, int, str, int] | None = None
+
+        for attempt in range(_MAX_COMMIT_ATTEMPTS):
+            try:
+                async with self._execution_gate.admit():
+                    self._raise_if_ambiguous(sig)
+                    if payload is None:
+                        payload = await asyncio.to_thread(df.to_arrow)
+                        rows = payload.num_rows
+                        if rows == 0:
+                            logger.info("Append skipped (store): archetype=%s rows=0", table_id)
+                            return AppendReceipt(table_id=table_id, rows=0, durable=True)
+                        identity = self._managed_identity(payload, table_id)
+                        table = self._ensure_table(sig)
+                    else:
+                        assert table is not None
+                        native = getattr(table, "_inner", None)
+                        if native is None:
+                            raise RuntimeError("Daft table does not expose an Iceberg handle")
+                        native.refresh()
+
+                    assert table is not None
+                    await asyncio.to_thread(
+                        self._append_table,
+                        table,
+                        daft.from_arrow(payload),
+                    )
+                    self._committed_sigs.add(table_id)
+                    return AppendReceipt(
+                        table_id=table_id,
+                        rows=payload.num_rows,
+                        durable=True,
+                        backend_ref=self._snapshot_ref(table),
+                    )
+            except CommitFailedException:
+                if attempt + 1 == _MAX_COMMIT_ATTEMPTS:
+                    raise
+                ceiling = min(0.005 * (2**attempt), 0.1)
+                await asyncio.sleep(random.uniform(0.0, ceiling))
+            except CommitStateUnknownException as exc:
+                assert identity is not None
+                self._ambiguous_commits[table_id] = identity
+                raise self._ambiguous_error(table_id, identity) from exc
+
+        raise AssertionError("unreachable managed Iceberg append retry state")
+
+    @staticmethod
+    def _managed_identity(
+        payload: pa.Table,
+        table_id: str,
+    ) -> tuple[str, str, int, str, int]:
+        required = ("world_id", "run_id", "tick", "commit_token", "writer_epoch")
+        missing = [name for name in required if name not in payload.column_names]
+        if missing:
+            raise ValueError(
+                f"managed Iceberg payload for table {table_id!r} is missing identity "
+                f"column(s): {', '.join(missing)}"
+            )
+        return (
+            str(payload["world_id"][0].as_py()),
+            str(payload["run_id"][0].as_py()),
+            int(payload["tick"][0].as_py()),
+            str(payload["commit_token"][0].as_py()),
+            int(payload["writer_epoch"][0].as_py()),
+        )
+
+    @staticmethod
+    def _ambiguous_error(
+        table_id: str,
+        identity: tuple[str, str, int, str, int],
+    ) -> AmbiguousCommitError:
+        world_id, run_id, tick, commit_token, writer_epoch = identity
+        return AmbiguousCommitError(
+            table_id=table_id,
+            world_id=world_id,
+            run_id=run_id,
+            tick=tick,
+            commit_token=commit_token,
+            writer_epoch=writer_epoch,
+        )
+
+    def _raise_if_ambiguous(self, sig: ArchetypeSignature) -> None:
+        """Reject work for a table frozen by an earlier ambiguous commit."""
+        table_id = Archetype.get_name(sig)
+        if identity := self._ambiguous_commits.get(table_id):
+            raise self._ambiguous_error(table_id, identity)
 
 
 class _AdmittedAsyncLancedbStore(AsyncLancedbStore):
@@ -174,6 +319,8 @@ class _AdmittedAsyncCachedStore(AsyncCachedStore):
 
     async def append(self, sig: ArchetypeSignature, df: DataFrame) -> AppendReceipt:
         async with self._execution_gate.admit():
+            if isinstance(self._inner, _AdmittedAsyncStore):
+                self._inner._raise_if_ambiguous(sig)
             return await super().append(sig, df)
 
     async def flush(self) -> None:

--- a/tests/infrastructure/test_r2_idempotency.py
+++ b/tests/infrastructure/test_r2_idempotency.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import threading
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -18,9 +20,12 @@ from pyarrow.fs import S3FileSystem
 from pyiceberg.catalog.sql import SqlCatalog
 from uuid_utils import uuid7
 
-from archetype.core.aio import AsyncStore, AsyncUpdateManager
+from archetype.core.aio import AsyncUpdateManager
+from archetype.core.archetype import Archetype
 from archetype.core.component import Component
+from archetype.core.config import StorageBackend, StorageConfig
 from archetype.core.interfaces import CommitContext
+from archetype.storage.service import StorageService
 
 ACCESS_KEY_ID = os.environ.get("R2_ACCESS_KEY_ID")
 SECRET_ACCESS_KEY = os.environ.get("R2_SECRET_ACCESS_KEY")
@@ -40,7 +45,7 @@ class R2Reading(Component):
 
 
 async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
-    """Exercise Archetype's real Iceberg store in one disposable R2 prefix."""
+    """Exercise managed concurrent Iceberg writes in one disposable R2 prefix."""
     assert ACCESS_KEY_ID is not None
     assert SECRET_ACCESS_KEY is not None
     assert API_ENDPOINT is not None
@@ -52,19 +57,18 @@ async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
     warehouse = f"s3://{BUCKET}/{prefix}"
     namespace = "archetype_ci"
     endpoint = urlparse(API_ENDPOINT)
-    catalog = SqlCatalog(
-        "archetype_r2_ci",
-        uri=f"sqlite:///{tmp_path / 'catalog.db'}",
-        warehouse=warehouse,
-        **{
-            # PyIceberg documents a full URL; direct PyArrow cleanup below uses host[:port].
-            "s3.endpoint": API_ENDPOINT,
-            "s3.access-key-id": ACCESS_KEY_ID,
-            "s3.secret-access-key": SECRET_ACCESS_KEY,
-            "s3.region": "auto",
-            "s3.force-virtual-addressing": "false",
-        },
-    )
+    catalog_properties = {
+        "uri": f"sqlite:///{tmp_path / 'catalog.db'}",
+        "warehouse": warehouse,
+        # PyIceberg documents a full URL; direct PyArrow cleanup below uses host[:port].
+        "s3.endpoint": API_ENDPOINT,
+        "s3.access-key-id": ACCESS_KEY_ID,
+        "s3.secret-access-key": SECRET_ACCESS_KEY,
+        "s3.region": "auto",
+        "s3.force-virtual-addressing": "false",
+    }
+    catalog = SqlCatalog("archetype_r2_ci", **catalog_properties)
+    second_catalog = SqlCatalog("archetype_r2_ci", **catalog_properties)
     catalog.create_namespace(namespace)
     io_config = IOConfig(
         s3=S3Config(
@@ -76,13 +80,28 @@ async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
             force_virtual_addressing=False,
         )
     )
+    storage = StorageConfig(
+        uri=warehouse,
+        namespace=namespace,
+        backend=StorageBackend.ICEBERG,
+        io_config=io_config,
+    )
+
+    first_session = Session()
+    first_session.attach_catalog(Catalog.from_iceberg(catalog))
+    first_session.set_namespace(namespace)
+    second_session = Session()
+    second_session.attach_catalog(Catalog.from_iceberg(second_catalog))
+    second_session.set_namespace(namespace)
+    first = StorageService(session=first_session)
+    second = StorageService(session=second_session)
 
     try:
-        session = Session()
-        session.attach_catalog(Catalog.from_iceberg(catalog))
-        session.set_namespace(namespace)
-        store = AsyncStore(session, io_config=io_config)
-        updater = AsyncUpdateManager(store)
+        first_store, second_store = await asyncio.gather(
+            first.get_or_create_store(storage),
+            second.get_or_create_store(storage),
+        )
+        updater = AsyncUpdateManager(first_store)
         signature = (R2Reading,)
         world_id = f"r2-world-{uuid7().hex}"
         archetype_run_id = f"r2-run-{uuid7().hex}"
@@ -90,14 +109,16 @@ async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
         abandoned = CommitContext(commit_token=uuid7().hex, writer_epoch=1)
         published = CommitContext(commit_token=uuid7().hex, writer_epoch=2)
 
-        # Both attempts physically reach R2. Core append is intentionally
-        # non-idempotent; the published-token allowlist supplies visibility.
+        # Distinct tick identities both physically reach R2; the published-token
+        # allowlist still supplies logical visibility.
         await updater.update(raw, signature, 0, world_id, archetype_run_id, commit=abandoned)
         await updater.update(raw, signature, 0, world_id, archetype_run_id, commit=published)
 
-        physical = (await store.get_archetype_df(signature, world_id, archetype_run_id)).to_pylist()
+        physical = (
+            await first_store.get_archetype_df(signature, world_id, archetype_run_id)
+        ).to_pylist()
         visible_a = (
-            await store.get_archetype_df(
+            await first_store.get_archetype_df(
                 signature,
                 world_id,
                 archetype_run_id,
@@ -105,7 +126,7 @@ async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
             )
         ).to_pylist()
         visible_b = (
-            await store.get_archetype_df(
+            await first_store.get_archetype_df(
                 signature,
                 world_id,
                 archetype_run_id,
@@ -117,7 +138,74 @@ async def test_r2_iceberg_commit_visibility(tmp_path: Path) -> None:
         assert len(visible_a) == 1, "only the published retry token may be visible"
         assert visible_b == visible_a, "replaying a fixed-snapshot read must be stable"
         assert visible_a[0]["commit_token"] == published.commit_token
+
+        barrier = threading.Barrier(2)
+
+        def arm(catalog_client):
+            original = catalog_client._write_metadata
+            armed = True
+
+            def synchronized_metadata(*args, **kwargs):
+                nonlocal armed
+                result = original(*args, **kwargs)
+                if armed:
+                    armed = False
+                    barrier.wait(timeout=30)
+                return result
+
+            catalog_client._write_metadata = synchronized_metadata
+
+        table_id = Archetype.get_name(signature)
+        for managed_store in (first_store, second_store):
+            native = (
+                managed_store.session.current_catalog().get_table(f"{namespace}.{table_id}")._inner
+            )
+            arm(native.catalog)
+
+        first_world = f"r2-race-first-{uuid7().hex}"
+        second_world = f"r2-race-second-{uuid7().hex}"
+        first_token = uuid7().hex
+        second_token = uuid7().hex
+        await asyncio.wait_for(
+            asyncio.gather(
+                AsyncUpdateManager(first_store).update(
+                    daft.from_pylist(
+                        [{"entity_id": 2, "is_active": True, "r2reading__value": 5.0}]
+                    ),
+                    signature,
+                    1,
+                    first_world,
+                    archetype_run_id,
+                    commit=CommitContext(commit_token=first_token, writer_epoch=3),
+                ),
+                AsyncUpdateManager(second_store).update(
+                    daft.from_pylist(
+                        [{"entity_id": 3, "is_active": True, "r2reading__value": 6.0}]
+                    ),
+                    signature,
+                    1,
+                    second_world,
+                    archetype_run_id,
+                    commit=CommitContext(commit_token=second_token, writer_epoch=4),
+                ),
+            ),
+            timeout=120,
+        )
+        first_committed = (
+            await first_store.get_archetype_df(signature, first_world, archetype_run_id)
+        ).to_pylist()
+        second_committed = (
+            await first_store.get_archetype_df(signature, second_world, archetype_run_id)
+        ).to_pylist()
+        assert [(row["r2reading__value"], row["commit_token"]) for row in first_committed] == [
+            (5.0, first_token)
+        ]
+        assert [(row["r2reading__value"], row["commit_token"]) for row in second_committed] == [
+            (6.0, second_token)
+        ]
     finally:
+        await first.shutdown()
+        await second.shutdown()
         for table in catalog.list_tables(namespace):
             catalog.drop_table(table)
         catalog.drop_namespace(namespace)

--- a/tests/storage/test_storage_execution.py
+++ b/tests/storage/test_storage_execution.py
@@ -9,10 +9,14 @@ import time
 
 import daft
 import pytest
+from pyiceberg.exceptions import CommitFailedException, CommitStateUnknownException
 
+from archetype.core.aio import AsyncUpdateManager
+from archetype.core.archetype import Archetype
 from archetype.core.component import Component
 from archetype.core.config import CacheConfig, RunConfig, StorageBackend, StorageConfig, WorldConfig
-from archetype.storage.service import StorageService
+from archetype.core.interfaces import CommitContext
+from archetype.storage.service import AmbiguousCommitError, StorageService
 from archetype.storage.session import configure_session
 from archetype.world.lifecycle import WorldLifecycle
 from archetype.world.registry import WorldRegistry
@@ -22,11 +26,25 @@ class Position(Component):
     x: int = 0
 
 
+class ManagedWriteProbe(Component):
+    value: int = 0
+
+
 def _storage(tmp_path) -> StorageConfig:
     return StorageConfig(
         uri=str(tmp_path / "store"),
         namespace="ns",
         backend=StorageBackend.ICEBERG,
+    )
+
+
+def _managed_rows(value: int) -> daft.DataFrame:
+    return daft.from_pydict(
+        {
+            "entity_id": [value],
+            "is_active": [True],
+            "managedwriteprobe__value": [value],
+        }
     )
 
 
@@ -244,6 +262,263 @@ async def test_concurrent_first_table_registration_recovers_losing_creator(tmp_p
     finally:
         await first.shutdown()
         await second.shutdown()
+
+
+@pytest.mark.contract("storage.execution.single_authority")
+@pytest.mark.asyncio
+async def test_managed_iceberg_conflict_retries_frozen_payload_once_per_writer(
+    tmp_path,
+    monkeypatch,
+):
+    """Two catalog clients commit one copy each after a real Iceberg CAS race."""
+    storage = _storage(tmp_path)
+    first = StorageService(session=configure_session(storage))
+    second = StorageService(session=configure_session(storage))
+    signature = Archetype.sig_from_components([ManagedWriteProbe()])
+    barrier = threading.Barrier(2)
+    try:
+        first_store, second_store = await asyncio.gather(
+            first.get_or_create_store(storage),
+            second.get_or_create_store(storage),
+        )
+        first_updater = AsyncUpdateManager(first_store)
+        second_updater = AsyncUpdateManager(second_store)
+        await first_updater.update(
+            _managed_rows(0),
+            signature,
+            0,
+            "seed-world",
+            "seed-run",
+            commit=CommitContext(commit_token="seed-token", writer_epoch=1),
+        )
+
+        def arm(catalog):
+            original = catalog._write_metadata
+            armed = True
+
+            def synchronized_metadata(*args, **kwargs):
+                nonlocal armed
+                result = original(*args, **kwargs)
+                if armed:
+                    armed = False
+                    barrier.wait(timeout=10)
+                return result
+
+            catalog._write_metadata = synchronized_metadata
+
+        table_id = Archetype.get_name(signature)
+        for store in (first_store, second_store):
+            native = store.session.current_catalog().get_table(f"ns.{table_id}")._inner
+            arm(native.catalog)
+
+        original_to_arrow = daft.DataFrame.to_arrow
+        materializations = 0
+
+        def counted_to_arrow(frame):
+            nonlocal materializations
+            materializations += 1
+            return original_to_arrow(frame)
+
+        monkeypatch.setattr(daft.DataFrame, "to_arrow", counted_to_arrow)
+        await asyncio.wait_for(
+            asyncio.gather(
+                first_updater.update(
+                    _managed_rows(1),
+                    signature,
+                    1,
+                    "first-world",
+                    "first-run",
+                    commit=CommitContext(commit_token="first-token", writer_epoch=2),
+                ),
+                second_updater.update(
+                    _managed_rows(2),
+                    signature,
+                    1,
+                    "second-world",
+                    "second-run",
+                    commit=CommitContext(commit_token="second-token", writer_epoch=3),
+                ),
+            ),
+            timeout=20,
+        )
+
+        assert materializations == 2
+        first_rows = (
+            await first_store.get_archetype_df(signature, "first-world", "first-run")
+        ).to_pylist()
+        second_rows = (
+            await first_store.get_archetype_df(signature, "second-world", "second-run")
+        ).to_pylist()
+        assert [(row["managedwriteprobe__value"], row["commit_token"]) for row in first_rows] == [
+            (1, "first-token")
+        ]
+        assert [(row["managedwriteprobe__value"], row["commit_token"]) for row in second_rows] == [
+            (2, "second-token")
+        ]
+    finally:
+        await first.shutdown()
+        await second.shutdown()
+
+
+@pytest.mark.contract("storage.execution.single_authority")
+@pytest.mark.asyncio
+async def test_managed_iceberg_conflict_retry_is_bounded_without_rematerializing(
+    tmp_path,
+    monkeypatch,
+):
+    storage = _storage(tmp_path)
+    service = StorageService(session=configure_session(storage))
+    signature = Archetype.sig_from_components([ManagedWriteProbe()])
+    attempts = 0
+    materializations = 0
+    try:
+        store = await service.get_or_create_store(storage)
+        original_to_arrow = daft.DataFrame.to_arrow
+
+        def counted_to_arrow(frame):
+            nonlocal materializations
+            materializations += 1
+            return original_to_arrow(frame)
+
+        def conflict(*args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            raise CommitFailedException("induced definite conflict")
+
+        async def no_wait(_delay):
+            return None
+
+        monkeypatch.setattr(daft.DataFrame, "to_arrow", counted_to_arrow)
+        monkeypatch.setattr(store, "_append_table", conflict)
+        monkeypatch.setattr(asyncio, "sleep", no_wait)
+
+        with pytest.raises(CommitFailedException, match="induced definite conflict"):
+            await AsyncUpdateManager(store).update(
+                _managed_rows(1),
+                signature,
+                1,
+                "world",
+                "run",
+                commit=CommitContext(commit_token="bounded-token", writer_epoch=4),
+            )
+
+        assert attempts == 16
+        assert materializations == 1
+    finally:
+        await service.shutdown()
+
+
+@pytest.mark.contract("storage.execution.single_authority")
+@pytest.mark.asyncio
+async def test_managed_iceberg_ambiguous_commit_is_typed_and_never_replayed(
+    tmp_path,
+    monkeypatch,
+):
+    storage = _storage(tmp_path)
+    service = StorageService(session=configure_session(storage))
+    observer = StorageService(session=configure_session(storage))
+    signature = Archetype.sig_from_components([ManagedWriteProbe()])
+    token = "ambiguous-token"
+    commit_calls = 0
+    materializations = 0
+    arrow_iterations = 0
+    try:
+        store = await service.get_or_create_store(
+            storage,
+            CacheConfig(flush_rows=1, flush_mb=1, global_mb=1, idle_sec=999),
+        )
+        await AsyncUpdateManager(store).update(
+            _managed_rows(0),
+            signature,
+            0,
+            "seed-world",
+            "seed-run",
+            commit=CommitContext(commit_token="seed-token", writer_epoch=1),
+        )
+        table_id = Archetype.get_name(signature)
+        inner_store = store._inner
+        native = inner_store.session.current_catalog().get_table(f"ns.{table_id}")._inner
+        original_commit = native.catalog.commit_table
+        original_to_arrow = daft.DataFrame.to_arrow
+        original_to_arrow_iter = daft.DataFrame.to_arrow_iter
+
+        def commit_then_lose_response(*args, **kwargs):
+            nonlocal commit_calls
+            commit_calls += 1
+            original_commit(*args, **kwargs)
+            raise CommitStateUnknownException("induced lost commit response")
+
+        def counted_to_arrow(frame):
+            nonlocal materializations
+            materializations += 1
+            return original_to_arrow(frame)
+
+        def counted_to_arrow_iter(frame, *args, **kwargs):
+            nonlocal arrow_iterations
+            arrow_iterations += 1
+            return original_to_arrow_iter(frame, *args, **kwargs)
+
+        monkeypatch.setattr(native.catalog, "commit_table", commit_then_lose_response)
+        monkeypatch.setattr(daft.DataFrame, "to_arrow", counted_to_arrow)
+        monkeypatch.setattr(daft.DataFrame, "to_arrow_iter", counted_to_arrow_iter)
+
+        with pytest.raises(AmbiguousCommitError) as raised:
+            await AsyncUpdateManager(store).update(
+                _managed_rows(7),
+                signature,
+                7,
+                "ambiguous-world",
+                "ambiguous-run",
+                commit=CommitContext(commit_token=token, writer_epoch=9),
+            )
+
+        outcome = raised.value
+        assert outcome.table_id == table_id
+        assert outcome.physical_identity == (
+            table_id,
+            "ambiguous-world",
+            "ambiguous-run",
+            7,
+        )
+        assert outcome.commit_token == token
+        assert outcome.writer_epoch == 9
+        assert isinstance(outcome.__cause__, CommitStateUnknownException)
+        assert materializations == 1
+        assert commit_calls == 1
+        iterations_after_ambiguity = arrow_iterations
+
+        with pytest.raises(AmbiguousCommitError) as frozen:
+            await AsyncUpdateManager(store).update(
+                _managed_rows(8),
+                signature,
+                8,
+                "later-world",
+                "later-run",
+                commit=CommitContext(commit_token="later-token", writer_epoch=10),
+            )
+        assert frozen.value.commit_token == token
+        assert frozen.value.physical_identity == outcome.physical_identity
+        assert materializations == 1
+        assert commit_calls == 1
+        assert arrow_iterations == iterations_after_ambiguity
+
+        observer_store = await observer.get_or_create_store(storage)
+        physical = (
+            await observer_store.get_archetype_df(
+                signature,
+                "ambiguous-world",
+                "ambiguous-run",
+            )
+        ).to_pylist()
+        assert [(row["managedwriteprobe__value"], row["commit_token"]) for row in physical] == [
+            (7, token)
+        ]
+    finally:
+        try:
+            await service.shutdown()
+        except RuntimeError as exc:
+            assert isinstance(exc.__cause__, AmbiguousCommitError)
+        await observer.shutdown()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

#677 repaired concurrent first-table registration but explicitly left optimistic append-conflict retry to the separate C1 slice tracked by #704. This change follows the storage authority ruling in #704: Iceberg catalog CAS owns one table, the control manifest owns one world's logical multi-table visibility, and `StorageService` owns operation-aware retry and ambiguous-outcome handling. The vocabulary and citation fence follows #703.

## What

- Materialize each managed ECS append into Arrow once inside `StorageService`, then reuse that payload, commit token, and table/world/run/tick identity across bounded attempts.
- Retry only PyIceberg's exact `CommitFailedException`, refreshing table metadata between attempts and using capped full jitter.
- Convert an exact `CommitStateUnknownException` into a typed, caller-observable frozen outcome and reject later non-empty appends to that table for the managed store's remaining lifetime, including restored cached batches.
- Add a real two-client Iceberg CAS race contract proving both definite contenders commit exactly one copy while each original DataFrame materializes once.
- Add bounded-exhaustion and induced post-commit ambiguity contracts proving there is no blind replay or duplicate.
- Extend the credential-gated R2 contract to run the same managed contention path using independent catalog clients and real R2 objects.

PROPOSED TERM: `AmbiguousCommitError` is the plain typed error name for the v0.5 frozen commit outcome required by #704. It preserves the existing table, world, run, tick, commit token, and writer epoch; it does not introduce a new domain identity.

## Deliberate v0.5 limitation

As required by condition 4 in #704, the specifications now match the shipped posture: exact snapshot readback reconciliation and restart-persistent freeze state are not included. A commit-state-unknown response freezes the table only for that managed store lifetime. Physical rows may already exist, while manifest-last publication keeps them logically invisible unless the tick manifest is later published.

The R2 check uses a shared runner-local SQLite metadata catalog with two independent clients and real R2 data objects. It exercises the managed conflict path but does not claim multi-host managed-catalog parity.

## Validation

- `uv run pytest -q tests/storage/test_storage_execution.py` — 13 passed
- Focused storage/application contracts — 41 passed
- `uv run pytest -q tests/infrastructure/test_r2_idempotency.py` — skipped locally because R2 credentials are absent; remains credential-gated in CI
- `make typecheck` — passed
- `make static` — passed
- `make ci` — 2777 passed, 6 skipped; regression 15/15, specification 8/8, capability 7/7; source and installed-wheel scenarios passed

Refs #704