### PR TITLE
fix(security): fail-closed auth boundary, generic public errors, proven lockfile audit (R1)

### DIFF
--- a/.github/workflows/daily-security-audit.yml
+++ b/.github/workflows/daily-security-audit.yml
@@ -36,7 +36,7 @@ jobs:
           version: "latest"
 
       - name: Install dependency audit tooling
-        run: python -m pip install --disable-pip-version-check pip-audit==2.7.3
+        run: python -m pip install --disable-pip-version-check pip-audit==2.10.1
 
       - name: Prepare dependency audit artifacts
         shell: bash
@@ -48,9 +48,9 @@ jobs:
           python --version > .github/security-artifacts/python-version.txt
           uv --version > .github/security-artifacts/uv-version.txt
 
-          if uv export --all-extras --format requirements-txt > .github/security-artifacts/requirements.txt 2> .github/security-artifacts/uv-export.stderr; then
+          if uv export --locked --all-extras --all-groups --no-emit-project --format requirements-txt > .github/security-artifacts/requirements.txt 2> .github/security-artifacts/uv-export.stderr; then
             printf "uv export succeeded\n" > .github/security-artifacts/dependency-audit-status.txt
-            if pip-audit -r .github/security-artifacts/requirements.txt --format json -o .github/security-artifacts/pip-audit.json > .github/security-artifacts/pip-audit.stdout 2> .github/security-artifacts/pip-audit.stderr; then
+            if pip-audit -r .github/security-artifacts/requirements.txt --no-deps --disable-pip --format json -o .github/security-artifacts/pip-audit.json > .github/security-artifacts/pip-audit.stdout 2> .github/security-artifacts/pip-audit.stderr; then
               printf "pip-audit succeeded\n" >> .github/security-artifacts/dependency-audit-status.txt
             else
               printf "pip-audit reported findings or failed; inspect pip-audit.json and stderr\n" >> .github/security-artifacts/dependency-audit-status.txt

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ help:
 	@echo "  make operational-audit Validate operational scenario ownership and policies"
 	@echo "  make architecture-audit  Enforce dependency and encapsulation policy"
 	@echo "  make observability-audit Enforce signal safety and family dispositions"
+	@echo "  make lockfile-audit  Scan the locked dependency graph for known vulnerabilities"
 	@echo "  make version-inventory-audit  Validate pinned execution-environment inventory"
 	@echo "  make python-api-audit  Validate committed generated Python reference"
 	@echo "  make lint-fix       Lint and auto-fix"
@@ -107,7 +108,7 @@ format:
 	@uv run ruff format $(RUFF_PATHS)
 
 .PHONY: lint
-lint: lazy-audit architecture-audit observability-audit version-inventory-audit python-api-audit api-boundary-audit idempotency-audit gate-coverage-audit operational-audit
+lint: lazy-audit architecture-audit observability-audit lockfile-audit version-inventory-audit python-api-audit api-boundary-audit idempotency-audit gate-coverage-audit operational-audit
 	@uv run ruff check $(RUFF_PATHS)
 
 .PHONY: lint-fix
@@ -141,6 +142,10 @@ operational-audit:
 .PHONY: static
 static: format-check lint typecheck lock-check contract-audit benchmark-audit
 	@echo "Static validation passed"
+
+.PHONY: lockfile-audit
+lockfile-audit:
+	@uv run python scripts/audit_lockfile.py
 
 # Lazy-evaluation audit: gate .collect()/.to_pylist() call sites against
 # lazy_audit.toml. Every premature materialization is a contract exception

--- a/README.md
+++ b/README.md
@@ -171,9 +171,10 @@ normative contracts are under [`docs/guide/`](docs/guide/specification.md).
 ## Status
 
 Archetype is alpha software. The append-only world, history, and fork paths
-are the most mature parts of the project. The HTTP layer uses development-mode
-authentication by default; supply your own authentication before exposing it
-to untrusted users.
+are the most mature parts of the project. Protected HTTP routes reject requests
+unless the application factory receives an authenticator. The built-in
+role-based development shortcut requires `archetype serve --dev-auth` and a
+loopback bind; it is not credential verification.
 
 ## License
 

--- a/docs/guide/api-layer.md
+++ b/docs/guide/api-layer.md
@@ -10,7 +10,9 @@ runtime calls construct the same models and use actor-free dispatcher entry.
 
 ## Application Factory
 
-`create_app()` builds the FastAPI app with routers for worlds, commands, simulation, and queries:
+`create_app()` builds the FastAPI app with routers for worlds, commands,
+simulation, and queries. The host injects an authenticator into this factory;
+omitting it leaves protected routes fail closed:
 
 ```python
 @asynccontextmanager
@@ -60,10 +62,18 @@ async def run_world(
 ## Authentication context
 
 Production ingress authenticates a stable principal and fails closed when
-credentials are absent or invalid. A development-only anonymous-admin mode, if
-enabled explicitly, uses one stable process principal so quotas and audit
-identity do not reset on every request. The trusted runtime has no actor
-context. See [Command Gate](command-gate.md).
+credentials are absent or invalid. The factory accepts a callback that receives
+the bearer token and returns `ActorCtx`; Archetype does not ship an IdP or token
+service. If no callback is injected, protected requests receive a generic 401.
+
+The built-in development mode is disabled by default. `archetype serve
+--dev-auth` enables the role-bearing shortcut only when the server binds to
+`localhost`, an address in `127.0.0.0/8`, or `::1`; any other bind is rejected
+before Uvicorn starts. In that mode, an omitted header selects the stable
+development admin identity and `Bearer admin|operator|player|viewer` selects a
+stable development role identity. These values are role shortcuts, not
+credentials. The trusted runtime has no actor context. See [Command
+Gate](command-gate.md).
 
 ## Route Structure
 
@@ -164,7 +174,7 @@ starting Uvicorn. Every other CLI command remains an HTTP client and performs
 no local provider or handler setup.
 
 ```text
-archetype serve              Starts uvicorn with the FastAPI app
+archetype serve --dev-auth   Starts the loopback development server
 archetype world create       POST /worlds
 archetype world list         GET /worlds
 archetype world inspect      GET /worlds/{id}
@@ -182,9 +192,11 @@ archetype hooks list         GET /worlds/{id}/hooks
 archetype resources list     GET /worlds/{id}/resources
 ```
 
-The server URL defaults to `http://localhost:8000` and can be overridden with
-`ARCHETYPE_URL` or per command with `--url`. HTTP commands accept the developer
-auth shortcut `--role` / `-r` and the bearer-token option `--token`.
+The server binds to `127.0.0.1:8000` by default. The client URL defaults to
+`http://localhost:8000` and can be overridden with `ARCHETYPE_URL` or per
+command with `--url`. HTTP commands accept `--role` / `-r` only for a server
+started with `--dev-auth`; `--token` sends a bearer token to a host-injected
+authenticator.
 
 Without component types, `query` returns the world-state projection. Pass comma-separated
 component types positionally to use the lazy component-query path:

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -270,6 +270,7 @@ make test-contract    # tests carrying approved contract IDs
 make test-integration # multi-layer tests
 make test-process     # subprocess/crash/independent-writer tests
 make observability-audit # signal safety and exact family dispositions
+make lockfile-audit   # scan every locked dependency for known vulnerabilities
 make static           # format, lint, types, lock, contracts, benchmarks
 make eval-conformance # blocking regression + specification evidence
 make eval-reliability # blocking retry/replay/crash/recovery evidence
@@ -280,6 +281,11 @@ make bench            # record one local ECS microbenchmark report
 make bench-query      # record materialized durable-world read latency
 make docs
 ```
+
+`make lockfile-audit` exports all extras and dependency groups from the exact
+`uv.lock`, excludes the editable project entry, and runs the pinned
+`pip-audit`. A vulnerability finding, stale lock, export failure, or audit-tool
+failure makes the quality gate fail.
 
 Test directories identify the owning subsystem. Orthogonal markers identify
 evidence type and cost: `unit`, `contract(<id>)`, `integration`, `race`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,8 +72,9 @@ multi-user host.
 ## Project status
 
 Archetype is alpha software. The core world, append-only history, and fork
-paths are the best-tested parts. The built-in HTTP server has development-mode
-authentication; add real authentication before exposing it to untrusted users.
+paths are the best-tested parts. Protected HTTP routes fail closed without an
+injected authenticator. The built-in role shortcut is available only through
+explicit loopback development auth.
 
 ## Development and design notes
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,7 +29,7 @@ archetype episode <WORLD_ID> [OPTIONS]
 | `--max-steps` / `-n` | integer | `1000` | Maximum episode steps |
 | `--terminal-component` | text | — | Terminal component type name |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -59,7 +59,7 @@ archetype history <WORLD_ID> [OPTIONS]
 | `--tick-from` | integer | — | Reserved for API v2 |
 | `--tick-to` | integer | — | Reserved for API v2 |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -92,7 +92,7 @@ archetype query <WORLD_ID> [COMPONENT_TYPES] [OPTIONS]
 | `--count` / `-c` | boolean | `False` | Return the row count only |
 | `--where` / `-w` | text | — | Filter with one comparison, for example "score__value > 0.5" |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -122,7 +122,7 @@ archetype rollout <WORLD_ID> [OPTIONS]
 | `--parallel` | boolean | `False` | Run episodes concurrently |
 | `--destroy-forks-on-complete` | boolean | `False` | Destroy forked worlds after each episode; storage retained |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -148,7 +148,7 @@ archetype run <WORLD_ID> [OPTIONS]
 |------|------|---------|-------------|
 | `--steps` / `-n` | integer | `1` | Number of steps |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -165,9 +165,10 @@ archetype serve [OPTIONS]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--host` | text | `0.0.0.0` | Bind host |
+| `--host` | text | `127.0.0.1` | Bind host |
 | `--port` | integer | `8000` | Bind port |
 | `--reload` / `--no-reload` | boolean | `False` | Enable auto-reload |
+| `--dev-auth` | boolean | `False` | Enable role-based development auth (loopback only) |
 
 ---
 
@@ -184,7 +185,7 @@ archetype status [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -209,7 +210,7 @@ archetype step <WORLD_ID> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -239,7 +240,7 @@ archetype entity add-components <WORLD_ID> <ENTITY_ID> [OPTIONS]
 |------|------|---------|-------------|
 | `--components` | text | — | JSON array of component payloads |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -264,7 +265,7 @@ archetype entity despawn <WORLD_ID> <ENTITY_ID> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -290,7 +291,7 @@ archetype entity remove-components <WORLD_ID> <ENTITY_ID> [OPTIONS]
 |------|------|---------|-------------|
 | `--types` / `--typ` | text | — | Comma-separated component type names |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -315,7 +316,7 @@ archetype entity spawn <WORLD_ID> [OPTIONS]
 |------|------|---------|-------------|
 | `--components` | text | — | JSON array of component payloads |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -341,7 +342,7 @@ archetype entity update <WORLD_ID> <ENTITY_ID> [OPTIONS]
 |------|------|---------|-------------|
 | `--components` | text | — | JSON array of component payloads |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -369,7 +370,7 @@ archetype hooks list <WORLD_ID> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -398,7 +399,7 @@ archetype processors list <WORLD_ID> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -427,7 +428,7 @@ archetype resources list <WORLD_ID> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -439,7 +440,7 @@ World management commands
 
 ### `archetype world create`
 
-Create a world. Defaults to API admin mode when auth is omitted.
+Create a world.
 
 ```bash
 archetype world create <NAME> [OPTIONS]
@@ -459,7 +460,7 @@ archetype world create <NAME> [OPTIONS]
 | `--namespace` | text | `archetypes` | Storage namespace |
 | `--cache` | boolean | `False` | Use default cache config |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -483,7 +484,7 @@ archetype world destroy <WORLD_ID> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -511,7 +512,7 @@ archetype world fork <WORLD_ID> [OPTIONS]
 | `--namespace` | text | `archetypes` | Storage namespace |
 | `--cache` | boolean | `False` | Use default cache config |
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 
 ---
@@ -535,7 +536,7 @@ archetype world inspect <WORLD_ID> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 
@@ -554,7 +555,7 @@ archetype world list [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--url` | text | — | Override ARCHETYPE_URL for this command |
-| `--role` / `-r` | choice | — | Developer role shortcut; production callers should use --token |
+| `--role` / `-r` | choice | — | Role shortcut for a server started with --dev-auth |
 | `--token` | text | — | Bearer token to send verbatim |
 | `--json` | boolean | `False` | Emit raw JSON |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "fastapi>=0.110",
     "uvicorn[standard]>=0.29",
     "typer>=0.9",
+    # Keep Typer's runtime Click resolution past PYSEC-2026-2132.
+    "click>=8.3.3",
     "httpx>=0.27",
     # Observability is vendor-neutral: archetype emits through the OTel API
     # only (archetype._obs). The SDK ships so ARCHETYPE_LOG=debug works out
@@ -67,11 +69,11 @@ docs       = [
     "mkdocs-material>=9.6,<10",
     "mkdocs-mermaid2-plugin",
     "mkdocstrings[python]>=0.27",
-    "pymdown-extensions",
+    "pymdown-extensions>=11.0",
 ]
 
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=83.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -142,6 +144,9 @@ dev = [
     # explicit host adapter; the published base package remains vendor-neutral.
     "logfire[fastapi]>=4.32.0",
     "python-dotenv>=1.2.2",
+    "setuptools>=83.0.0",
+    # Blocking quality gate for the complete uv lock projection.
+    "pip-audit==2.10.1",
 ]
 
 # Mutation testing. Scoped narrowly: mutmut runs each mutation as a full
@@ -188,6 +193,10 @@ starlette = "2026-06-13T00:00:00Z"
 # Dependabot alerts #116-117 (pypdf), #112 (msgpack), and #98-110 (Pillow).
 pypdf = "2026-06-24T00:00:00Z"
 msgpack = "2026-06-19T00:00:00Z"
+# Security releases admitted for the blocking lockfile audit:
+# GHSA-9xwg-3r6f-jcx2 and PYSEC-2026-3447.
+pymdown-extensions = "2026-06-24T00:00:00Z"
+setuptools = "2026-07-05T00:00:00Z"
 pillow = "2026-07-02T00:00:00Z"
 
 [tool.ruff]

--- a/scripts/audit_lockfile.py
+++ b/scripts/audit_lockfile.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Audit every locked dependency with pip-audit."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+Run = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _emit(process: subprocess.CompletedProcess[str]) -> None:
+    if process.stdout:
+        print(process.stdout, end="")
+    if process.stderr:
+        print(process.stderr, end="", file=sys.stderr)
+
+
+def audit_lockfile(
+    *,
+    root: Path = ROOT,
+    run: Run = subprocess.run,
+) -> int:
+    """Export the exact lock and return pip-audit's blocking status."""
+    with TemporaryDirectory(prefix="archetype-lockfile-audit-") as temporary:
+        requirements = Path(temporary) / "requirements.txt"
+        exported = run(
+            [
+                "uv",
+                "export",
+                "--locked",
+                "--all-extras",
+                "--all-groups",
+                "--no-emit-project",
+                "--format",
+                "requirements-txt",
+                "--output-file",
+                str(requirements),
+            ],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if exported.returncode != 0:
+            _emit(exported)
+            return exported.returncode
+
+        contents = requirements.read_text(encoding="utf-8")
+        if any(line.lstrip().startswith(("-e ", "--editable ")) for line in contents.splitlines()):
+            print(
+                "Lockfile audit refused an editable project requirement",
+                file=sys.stderr,
+            )
+            return 1
+
+        audited = run(
+            [
+                sys.executable,
+                "-m",
+                "pip_audit",
+                "--requirement",
+                str(requirements),
+                "--no-deps",
+                "--disable-pip",
+            ],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        _emit(audited)
+        return audited.returncode
+
+
+def main(_argv: Sequence[str] | None = None) -> int:
+    return audit_lockfile()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_runtime_loopback.py
+++ b/scripts/run_runtime_loopback.py
@@ -273,6 +273,7 @@ def run_runtime_loopback(workspace: Path) -> dict[str, object]:
                         "serve",
                         "--host",
                         "127.0.0.1",
+                        "--dev-auth",
                         "--port",
                         "0",
                     ],

--- a/src/archetype/api/app.py
+++ b/src/archetype/api/app.py
@@ -14,13 +14,19 @@
 
 """FastAPI application factory."""
 
+import ipaddress
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
 from archetype import __version__
 from archetype._logging import configure_host_observability
+from archetype.api.deps import Authenticator
 from archetype.api.routes import commands, entities, missions, query, simulation, worlds
+
+_SERVE_HOST_ENV = "ARCHETYPE_SERVE_HOST"
+_SERVE_DEV_AUTH_ENV = "ARCHETYPE_SERVE_DEV_AUTH"
 
 
 @asynccontextmanager
@@ -45,14 +51,36 @@ async def lifespan(app: FastAPI):
         del app.state.resources
 
 
-def create_app() -> FastAPI:
-    """Create and configure the FastAPI application."""
+def _is_loopback_host(host: str) -> bool:
+    candidate = host.strip().strip("[]")
+    if candidate.casefold() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return False
+
+
+def create_app(
+    *,
+    authenticator: Authenticator | None = None,
+    dev_auth: bool = False,
+    bind_host: str | None = None,
+) -> FastAPI:
+    """Create the FastAPI application with explicit authentication."""
+    if dev_auth and authenticator is not None:
+        raise ValueError("development auth and an injected authenticator are mutually exclusive")
+    if dev_auth and (bind_host is None or not _is_loopback_host(bind_host)):
+        raise ValueError("development auth requires an explicit loopback bind host")
+
     app = FastAPI(
         title="Archetype ECS",
         description="Dataframe-first ECS runtime for simulations and AI agents.",
         version=__version__,
         lifespan=lifespan,
     )
+    app.state.authenticator = authenticator
+    app.state.development_auth = dev_auth
     app.include_router(worlds.router)
     app.include_router(entities.router)
     app.include_router(commands.router)
@@ -69,3 +97,10 @@ def create_app() -> FastAPI:
         return {"status": "ok"}
 
     return app
+
+
+def _create_cli_app() -> FastAPI:
+    """Rebuild the CLI-selected app inside Uvicorn reload/worker processes."""
+    host = os.environ.get(_SERVE_HOST_ENV)
+    dev_auth = os.environ.get(_SERVE_DEV_AUTH_ENV) == "1"
+    return create_app(dev_auth=dev_auth, bind_host=host)

--- a/src/archetype/api/deps.py
+++ b/src/archetype/api/deps.py
@@ -16,11 +16,22 @@
 
 from __future__ import annotations
 
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+
 from fastapi import Header, HTTPException, Request
 from uuid_utils import NAMESPACE_URL, uuid5
 
 from archetype.commands.dispatch import CommandDispatcher
 from archetype.commands.models import ActorCtx
+
+Authenticator = Callable[[str], ActorCtx | Awaitable[ActorCtx]]
+
+logger = logging.getLogger(__name__)
+
+_DEVELOPMENT_ROLES = frozenset({"admin", "operator", "player", "viewer"})
+_PUBLIC_AUTH_DETAIL = "Authentication failed"
 
 
 async def get_dispatcher(request: Request) -> CommandDispatcher:
@@ -28,29 +39,78 @@ async def get_dispatcher(request: Request) -> CommandDispatcher:
     return request.app.state.resources.dispatcher
 
 
-async def get_actor_ctx(authorization: str | None = Header(None)) -> ActorCtx:
-    """Build the request actor context.
+def _reject_authentication(reason: str) -> HTTPException:
+    """Return one generic public rejection while retaining a fixed diagnostic."""
+    logger.info("API authentication rejected: %s", reason)
+    return HTTPException(
+        status_code=401,
+        detail=_PUBLIC_AUTH_DETAIL,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
-    v1 developer mode:
-    - no Authorization header means default single-tenant admin
-    - "Bearer <role>" accepts admin/operator/player/viewer
-    """
+
+def _bearer_token(authorization: str | None) -> str:
     if authorization is None:
-        role = "admin"
-        return ActorCtx(
-            id=uuid5(NAMESPACE_URL, f"archetype:development-principal:{role}"),
-            roles={role},
-        )
+        raise _reject_authentication("credentials are absent")
 
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not token:
-        raise HTTPException(status_code=401, detail="Invalid Authorization header")
+        raise _reject_authentication("the authorization header is malformed")
+    token = token.strip()
+    if not token:
+        raise _reject_authentication("the authorization header is malformed")
+    return token
 
-    role = token.strip().lower()
-    if role not in {"admin", "operator", "player", "viewer"}:
-        raise HTTPException(status_code=401, detail="Unknown bearer role")
+
+def _development_actor(token: str) -> ActorCtx:
+    role = token.lower()
+    if role not in _DEVELOPMENT_ROLES:
+        raise _reject_authentication("the development role is not supported")
 
     return ActorCtx(
         id=uuid5(NAMESPACE_URL, f"archetype:development-principal:{role}"),
         roles={role},
     )
+
+
+async def get_actor_ctx(
+    request: Request,
+    authorization: str | None = Header(None),
+) -> ActorCtx:
+    """Authenticate one untrusted request into a commands-owned actor context."""
+    development_auth = bool(getattr(request.app.state, "development_auth", False))
+    authenticator: Authenticator | None = getattr(request.app.state, "authenticator", None)
+
+    if authorization is None and development_auth:
+        return _development_actor("admin")
+
+    token = _bearer_token(authorization)
+    if development_auth:
+        return _development_actor(token)
+
+    if authenticator is None:
+        raise _reject_authentication("no authenticator is configured")
+
+    try:
+        actor = authenticator(token)
+        if inspect.isawaitable(actor):
+            actor = await actor
+    except Exception as exc:
+        # Authentication callbacks receive credentials. Log only the exception
+        # class, never its message, arguments, or the supplied token.
+        logger.info(
+            "API authentication callback rejected credentials (%s)",
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=401,
+            detail=_PUBLIC_AUTH_DETAIL,
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from None
+
+    if not isinstance(actor, ActorCtx):
+        raise _reject_authentication("the authenticator returned an invalid actor context")
+    return actor
+
+
+__all__ = ["Authenticator", "get_actor_ctx", "get_dispatcher"]

--- a/src/archetype/api/errors.py
+++ b/src/archetype/api/errors.py
@@ -35,7 +35,10 @@ logger = logging.getLogger(__name__)
 def raise_api_error(exc: Exception, *, conflict: bool = False) -> NoReturn:
     """Map service-layer exceptions to stable REST errors."""
     if isinstance(exc, PermissionError):
-        logger.info("API authorization rejected: %s", exc)
+        # The denial message can embed request-derived values (roles parsed
+        # from the Authorization header), so log only the exception class:
+        # CodeQL py/clear-text-logging-sensitive-data gates this call site.
+        logger.info("API authorization rejected (%s)", type(exc).__name__)
         raise HTTPException(status_code=403, detail="Forbidden") from None
     # WorldNotFoundError extends LookupError, not KeyError; without the
     # explicit branch it fell through to the 500 fallback (issue #180).

--- a/src/archetype/api/errors.py
+++ b/src/archetype/api/errors.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 def raise_api_error(exc: Exception, *, conflict: bool = False) -> NoReturn:
     """Map service-layer exceptions to stable REST errors."""
     if isinstance(exc, PermissionError):
-        raise HTTPException(status_code=403, detail=str(exc)) from None
+        logger.info("API authorization rejected: %s", exc)
+        raise HTTPException(status_code=403, detail="Forbidden") from None
     # WorldNotFoundError extends LookupError, not KeyError; without the
     # explicit branch it fell through to the 500 fallback (issue #180).
     if isinstance(exc, WorldNotFoundError | KeyError):

--- a/src/archetype/cli/main.py
+++ b/src/archetype/cli/main.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 import os
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
 import typer
@@ -67,7 +67,7 @@ ROLE_OPTION = typer.Option(
     None,
     "--role",
     "-r",
-    help="Developer role shortcut; production callers should use --token",
+    help="Role shortcut for a server started with --dev-auth",
 )
 
 
@@ -241,15 +241,40 @@ def _common_request_kwargs(
 
 @app.command()
 def serve(
-    host: str = typer.Option("0.0.0.0", help="Bind host"),
+    host: str = typer.Option("127.0.0.1", help="Bind host"),
     port: int = typer.Option(8000, help="Bind port"),
     reload: bool = typer.Option(False, help="Enable auto-reload"),
+    dev_auth: Annotated[
+        bool,
+        typer.Option(
+            "--dev-auth",
+            help="Enable role-based development auth (loopback only)",
+        ),
+    ] = False,
 ):
     """Start the FastAPI server."""
+    from archetype.api.app import (
+        _SERVE_DEV_AUTH_ENV,
+        _SERVE_HOST_ENV,
+        _is_loopback_host,
+    )
+
+    if dev_auth and not _is_loopback_host(host):
+        typer.echo("Error: --dev-auth requires a loopback --host", err=True)
+        raise typer.Exit(code=2)
+
     import uvicorn
 
     configure_host_observability(service_name="archetype-api")
-    uvicorn.run("archetype.api.app:create_app", host=host, port=port, reload=reload, factory=True)
+    os.environ[_SERVE_HOST_ENV] = host
+    os.environ[_SERVE_DEV_AUTH_ENV] = "1" if dev_auth else "0"
+    uvicorn.run(
+        "archetype.api.app:_create_cli_app",
+        host=host,
+        port=port,
+        reload=reload,
+        factory=True,
+    )
 
 
 # ── Status ───────────────────────────────────────────────────────────────
@@ -283,7 +308,7 @@ def world_create(
     role: Role | None = ROLE_OPTION,
     token: str | None = typer.Option(None, "--token", help="Bearer token to send verbatim"),
 ):
-    """Create a world. Defaults to API admin mode when auth is omitted."""
+    """Create a world."""
     body: dict[str, Any] = {
         "config": {"name": name},
         "storage_config": {"uri": storage, "namespace": namespace},

--- a/tests/api/test_auth_contracts.py
+++ b/tests/api/test_auth_contracts.py
@@ -107,4 +107,7 @@ def test_authentication_and_authorization_errors_are_generic_publicly(
 
     assert raised.value.status_code == 403
     assert raised.value.detail == "Forbidden"
-    assert internal_detail in caplog.text
+    # The server-side record names the rejection without echoing the
+    # request-derived denial message (see errors.py: CodeQL-gated call site).
+    assert "API authorization rejected (PermissionError)" in caplog.text
+    assert internal_detail not in caplog.text

--- a/tests/api/test_auth_contracts.py
+++ b/tests/api/test_auth_contracts.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed HTTP authentication contracts."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from uuid_utils import uuid7
+
+from archetype.api.app import create_app
+from archetype.api.deps import get_dispatcher
+from archetype.api.errors import raise_api_error
+from archetype.commands.models import ActorCtx
+
+
+class _ListDispatcher:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def apply_as(self, _actor: ActorCtx, _operation: object) -> list[object]:
+        self.calls += 1
+        return []
+
+
+def _client(app, dispatcher: _ListDispatcher) -> TestClient:
+    app.dependency_overrides[get_dispatcher] = lambda: dispatcher
+    return TestClient(app)
+
+
+def test_development_auth_is_explicit_and_loopback_only() -> None:
+    with pytest.raises(ValueError, match="explicit loopback"):
+        create_app(dev_auth=True)
+    with pytest.raises(ValueError, match="explicit loopback"):
+        create_app(dev_auth=True, bind_host="0.0.0.0")
+
+    dispatcher = _ListDispatcher()
+    app = create_app(dev_auth=True, bind_host="127.0.0.1")
+    response = _client(app, dispatcher).get(
+        "/worlds",
+        headers={"Authorization": "Bearer admin"},
+    )
+
+    assert response.status_code == 200
+    assert dispatcher.calls == 1
+
+
+@pytest.mark.parametrize(
+    "headers",
+    ({}, {"Authorization": "Bearer admin"}),
+)
+def test_absent_injected_authenticator_fails_closed(headers: dict[str, str]) -> None:
+    dispatcher = _ListDispatcher()
+    response = _client(create_app(), dispatcher).get("/worlds", headers=headers)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication failed"}
+    assert response.headers["www-authenticate"] == "Bearer"
+    assert dispatcher.calls == 0
+
+
+def test_injected_authenticator_is_the_only_non_development_auth_path() -> None:
+    calls: list[str] = []
+    actor = ActorCtx(id=uuid7(), roles={"viewer"})
+
+    async def authenticate(token: str) -> ActorCtx:
+        calls.append(token)
+        return actor
+
+    dispatcher = _ListDispatcher()
+    response = _client(create_app(authenticator=authenticate), dispatcher).get(
+        "/worlds",
+        headers={"Authorization": "Bearer opaque-token"},
+    )
+
+    assert response.status_code == 200
+    assert calls == ["opaque-token"]
+    assert dispatcher.calls == 1
+
+
+def test_authentication_and_authorization_errors_are_generic_publicly(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    secret = "opaque-secret-never-log"
+    dispatcher = _ListDispatcher()
+    app = create_app(dev_auth=True, bind_host="localhost")
+
+    with caplog.at_level(logging.INFO, logger="archetype.api.deps"):
+        response = _client(app, dispatcher).get(
+            "/worlds",
+            headers={"Authorization": f"Bearer {secret}"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication failed"}
+    assert secret not in caplog.text
+    assert dispatcher.calls == 0
+
+    internal_detail = "actor private-principal expected role admin"
+    with caplog.at_level(logging.INFO, logger="archetype.api.errors"):
+        with pytest.raises(HTTPException) as raised:
+            raise_api_error(PermissionError(internal_detail))
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail == "Forbidden"
+    assert internal_detail in caplog.text

--- a/tests/api/test_missions_routes.py
+++ b/tests/api/test_missions_routes.py
@@ -24,7 +24,7 @@ from archetype.missions.relations import DependsOn, Guards, PartOfMission
 @pytest.fixture
 def client(tmp_path, monkeypatch):
     monkeypatch.setenv("ARCHETYPE_CATALOG_DIR", str(tmp_path / "catalogs"))
-    app = create_app()
+    app = create_app(dev_auth=True, bind_host="127.0.0.1")
     with TestClient(app) as c:
         yield c
 

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -32,7 +32,7 @@ class QueryRouteMetric104(Component):
 @pytest.fixture
 def client(tmp_path, monkeypatch):
     monkeypatch.setenv("ARCHETYPE_CATALOG_DIR", str(tmp_path / "catalogs"))
-    app = create_app()
+    app = create_app(dev_auth=True, bind_host="127.0.0.1")
     with TestClient(app) as c:
         yield c
 
@@ -737,8 +737,10 @@ def test_route_modules_do_not_import_forbidden_services():
 
 @pytest.mark.asyncio
 async def test_development_principal_identity_is_stable_across_requests():
-    first = await get_actor_ctx("Bearer player")
-    second = await get_actor_ctx("Bearer player")
+    app = create_app(dev_auth=True, bind_host="127.0.0.1")
+    request = type("_Request", (), {"app": app})()
+    first = await get_actor_ctx(request, "Bearer player")
+    second = await get_actor_ctx(request, "Bearer player")
     policy = Policy(max_commands_per_tick=1)
 
     assert first.id == second.id

--- a/tests/app/test_logging_contracts.py
+++ b/tests/app/test_logging_contracts.py
@@ -534,14 +534,14 @@ def test_cli_serve_configures_the_server_host_before_uvicorn(monkeypatch) -> Non
         types.SimpleNamespace(run=lambda *args, **kwargs: events.append(("run", (args, kwargs)))),
     )
 
-    cli.serve(host="127.0.0.1", port=8123, reload=False)
+    cli.serve(host="127.0.0.1", port=8123, reload=False, dev_auth=False)
 
     assert events == [
         ("configure", {"service_name": "archetype-api"}),
         (
             "run",
             (
-                ("archetype.api.app:create_app",),
+                ("archetype.api.app:_create_cli_app",),
                 {"host": "127.0.0.1", "port": 8123, "reload": False, "factory": True},
             ),
         ),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -32,7 +32,7 @@ runner = CliRunner()
 def api_client(tmp_path, monkeypatch):
     """Yield a TestClient wired to a fresh runtime resource owner."""
     monkeypatch.setenv("ARCHETYPE_CATALOG_DIR", str(tmp_path / "catalogs"))
-    fastapi_app = create_app()
+    fastapi_app = create_app(dev_auth=True, bind_host="127.0.0.1")
     with TestClient(fastapi_app) as tc:
         yield tc
 
@@ -70,6 +70,21 @@ class TestCLI:
         assert result.exit_code == 0
         assert "host" in result.output.lower()
         assert "port" in result.output.lower()
+        assert "dev-auth" in result.output.lower()
+
+    def test_serve_dev_auth_refuses_non_loopback_bind(self, monkeypatch):
+        started = False
+
+        def unexpected_run(*_args, **_kwargs):
+            nonlocal started
+            started = True
+
+        monkeypatch.setattr("uvicorn.run", unexpected_run)
+        result = runner.invoke(app, ["serve", "--dev-auth", "--host", "0.0.0.0"])
+
+        assert result.exit_code == 2
+        assert "requires a loopback" in result.output
+        assert started is False
 
     def test_world_help(self):
         result = runner.invoke(app, ["world", "--help"])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -70,9 +70,9 @@ class TestCLI:
         assert result.exit_code == 0
         assert "host" in result.output.lower()
         assert "port" in result.output.lower()
-        # Rich wraps help text at the terminal width and may split the flag
-        # name across lines; compare against whitespace-free output.
-        assert "--dev-auth" in "".join(result.output.lower().split())
+        # Rich wraps help text at the terminal width and may interleave ANSI
+        # style codes; strip both before asserting on the flag name.
+        assert "--dev-auth" in "".join(unstyle(result.output).lower().split())
 
     def test_serve_dev_auth_refuses_non_loopback_bind(self, monkeypatch):
         started = False

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -70,7 +70,9 @@ class TestCLI:
         assert result.exit_code == 0
         assert "host" in result.output.lower()
         assert "port" in result.output.lower()
-        assert "dev-auth" in result.output.lower()
+        # Rich wraps help text at the terminal width and may split the flag
+        # name across lines; compare against whitespace-free output.
+        assert "--dev-auth" in "".join(result.output.lower().split())
 
     def test_serve_dev_auth_refuses_non_loopback_bind(self, monkeypatch):
         started = False

--- a/tests/scripts/test_audit_lockfile.py
+++ b/tests/scripts/test_audit_lockfile.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the blocking lockfile dependency audit."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.audit_lockfile import audit_lockfile
+
+
+def test_lockfile_audit_fails_on_known_bad_injection(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    calls: list[list[str]] = []
+
+    def run(
+        command: list[str],
+        **_kwargs,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:2] == ["uv", "export"]:
+            output = Path(command[command.index("--output-file") + 1])
+            output.write_text("known-bad-package==0\n", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, "", "")
+        assert command[1:3] == ["-m", "pip_audit"]
+        assert "known-bad-package==0" in Path(
+            command[command.index("--requirement") + 1]
+        ).read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            "Found 1 known vulnerability in 1 package\n",
+            "",
+        )
+
+    status = audit_lockfile(root=tmp_path, run=run)
+
+    assert status == 1
+    assert len(calls) == 2
+    assert "--locked" in calls[0]
+    assert "--no-emit-project" in calls[0]
+    assert "--no-deps" in calls[1]
+    assert "Found 1 known vulnerability" in capsys.readouterr().out

--- a/tests/storage/test_path_safety.py
+++ b/tests/storage/test_path_safety.py
@@ -241,7 +241,7 @@ class TestApiSurface:
         from archetype.api.app import create_app
 
         monkeypatch.setenv("ARCHETYPE_CATALOG_DIR", str(tmp_path / "control"))
-        with TestClient(create_app()) as client:
+        with TestClient(create_app(dev_auth=True, bind_host="127.0.0.1")) as client:
             resp = client.post(
                 "/worlds",
                 json={

--- a/uv.lock
+++ b/uv.lock
@@ -14,8 +14,10 @@ exclude-newer = "2026-06-12T00:00:00Z"
 starlette = "2026-06-13T00:00:00Z"
 msgpack = "2026-06-19T00:00:00Z"
 daft = "2026-07-11T00:00:00Z"
+setuptools = "2026-07-05T00:00:00Z"
 pillow = "2026-07-02T00:00:00Z"
 pypdf = "2026-06-24T00:00:00Z"
+pymdown-extensions = "2026-06-24T00:00:00Z"
 
 [[package]]
 name = "absl-py"
@@ -194,6 +196,7 @@ version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "av" },
+    { name = "click" },
     { name = "daft", extra = ["audio", "iceberg", "lance"] },
     { name = "fastapi" },
     { name = "httpx" },
@@ -255,6 +258,7 @@ dev = [
     { name = "logfire", extra = ["fastapi"] },
     { name = "mujoco" },
     { name = "mutmut" },
+    { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -262,11 +266,13 @@ dev = [
     { name = "pytest-xdist" },
     { name = "python-dotenv" },
     { name = "ruff" },
+    { name = "setuptools" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "av", specifier = ">=15.0.0,<17.1.0" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "daft", extras = ["lance", "iceberg", "audio"], specifier = ">=0.7.19" },
     { name = "esper", marker = "extra == 'benchmark'", specifier = ">=2.45" },
     { name = "fastapi", specifier = ">=0.110" },
@@ -293,7 +299,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=5.9" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyiceberg", extras = ["daft", "sql-sqlite"] },
-    { name = "pymdown-extensions", marker = "extra == 'docs'" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0" },
     { name = "pypdf", specifier = ">=6.14.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26" },
@@ -313,6 +319,7 @@ dev = [
     { name = "logfire", extras = ["fastapi"], specifier = ">=4.32.0" },
     { name = "mujoco", specifier = ">=3.2" },
     { name = "mutmut", specifier = ">=3.5" },
+    { name = "pip-audit", specifier = "==2.10.1" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26" },
@@ -320,6 +327,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "ruff", specifier = ">=0.15,<0.16" },
+    { name = "setuptools", specifier = ">=83.0.0" },
 ]
 
 [[package]]
@@ -475,6 +483,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -676,14 +711,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -864,6 +899,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/54/40d741cb605229cddcf9ec689b0fd401e39e2e70c2fe9cc728923b983b8e/cyclonedx_python_lib-11.10.0.tar.gz", hash = "sha256:d03d6ea271e26feaf123b8b1b34468a305f33a338c5763f56e397a8408f9b290", size = 1429036, upload-time = "2026-06-11T10:36:27.633Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/21/01c9b957ec3a778de86e010c1b54ea433ebf2fc50b810a3ca0ce8000782f/cyclonedx_python_lib-11.10.0-py3-none-any.whl", hash = "sha256:ffb9510b8d00a0896cfbe0a78b97c545d28f7d2a54e9d9dd5e5dc6e91ca9b375", size = 527798, upload-time = "2026-06-11T10:36:25.985Z" },
+]
+
+[[package]]
 name = "daft"
 version = "0.7.19"
 source = { registry = "https://pypi.org/simple" }
@@ -935,6 +986,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -1863,6 +1923,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/64/36/360b5aafa0238e29758729e9486c6ed92a6f37fa403b7875e06c115cdf4a/librosa-0.11.0.tar.gz", hash = "sha256:f5ed951ca189b375bbe2e33b2abd7e040ceeee302b9bbaeeffdfddb8d0ace908", size = 327001, upload-time = "2025-03-11T15:09:54.884Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/ba/c63c5786dfee4c3417094c4b00966e61e4a63efecee22cb7b4c0387dda83/librosa-0.11.0-py3-none-any.whl", hash = "sha256:0b6415c4fd68bff4c29288abe67c6d80b587e0e1e2cfb0aad23e4559504a7fa1", size = 260749, upload-time = "2025-03-11T15:09:52.982Z" },
+]
+
+[[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
 ]
 
 [[package]]
@@ -2829,6 +2901,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2945,6 +3026,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
     { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
     { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
 ]
 
 [[package]]
@@ -3163,6 +3299,18 @@ wheels = [
 ]
 
 [[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3377,15 +3525,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
 ]
 
 [[package]]
@@ -3899,11 +4047,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]
@@ -3931,6 +4079,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -4155,6 +4312,60 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
R1 slice of the v0.5.0 parallel correctness lane (#704).

- Dev auth is explicit opt-in and refuses any non-loopback bind (serve refuses to start; no warning-only path).
- Absent injected auth fails closed: requests are rejected, no anonymous default.
- Auth failures return generic public messages; server logs record the rejection class without request-derived detail (CodeQL py/clear-text-logging).
- Lockfile audit (scripts/audit_lockfile.py) wired into the quality gate and proven by a known-bad injection test.

Cut per packet: no IdP, no token service, no distributed quotas.

Validation: tests/api + tests/cli 152 passed; make ci green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)