### PR TITLE
fix(core): ban row-count admission preflights at every core append boundary (C2/#538)

### DIFF
--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -11,6 +11,13 @@
 # Generic reasons ("needed", "for the test", "convenience") are
 # rejected automatically by scripts/check_lazy_audit.py.
 #
+# Zero-exception ban (issue #538): `.count_rows()` under
+# `src/archetype/core/` cannot be allowlisted at all — core submits frames
+# to their owning append/write boundary instead of counting rows to decide
+# whether work exists; an unknown receipt count is None, not a preflight.
+# scripts/check_lazy_audit.py rejects both the call site and any entry
+# that tries to admit one.
+#
 # Entries are keyed by (path, symbol, expr, method) — never by line
 # number. `symbol` is the dotted path of the enclosing def/class (or
 # "<module>"); `expr` is the normalized source of the audited attribute
@@ -75,13 +82,6 @@ symbol = "read_head"
 expr = "materialized.to_pylist"
 method = "to_pylist"
 reason = "Single-row loop-state extract: StorageService has already admitted and materialized the query; the latest BranchHead then enters Python control flow for incumbent comparison and entity-id routing."
-
-[[entries]]
-path = "src/archetype/core/aio/async_store.py"
-symbol = "AsyncStore.append"
-expr = "df.collect"
-method = "collect"
-reason = "Storage write boundary: materialize the incoming frame once for the empty-row guard and reuse that same materialized frame for the backing-table append."
 
 [[entries]]
 path = "src/archetype/core/aio/async_world.py"
@@ -432,13 +432,6 @@ symbol = "AsyncStore._append_table"
 expr = "df.write_iceberg"
 method = "write_iceberg"
 reason = "Iceberg storage sink: explicit IO configuration requires the native Daft write at the store-owned append boundary."
-
-[[entries]]
-path = "src/archetype/core/aio/async_store.py"
-symbol = "AsyncStore.append"
-expr = "materialized.count_rows"
-method = "count_rows"
-reason = "Owned store boundary: the input is already collected once; this count reads the concrete result to preserve empty-append and committed-signature behavior without replaying the upstream plan."
 
 [[entries]]
 path = "src/archetype/core/sync/store.py"

--- a/quality/observability/core.toml
+++ b/quality/observability/core.toml
@@ -73,49 +73,9 @@ expiry_condition = "Remove when #530 migrates this call to parameterized stdlib 
 
 [[legacy]]
 rule = "eager_log_interpolation"
-path = "src/archetype/core/aio/async_lancedb_store.py"
-qualified_scope = "archetype.core.aio.async_lancedb_store.AsyncLancedbStore.append"
-target = "log:info:f'Append skipped (lancedb): archetype={table_id} rows=0':interpolation"
-owner = "core"
-issue = 530
-reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
-expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
-
-[[legacy]]
-rule = "eager_log_interpolation"
 path = "src/archetype/core/aio/async_store.py"
 qualified_scope = "archetype.core.aio.async_store.AsyncStore.append"
 target = "log:info:f'Append skipped (store): archetype={table_id} empty schema':interpolation"
-owner = "core"
-issue = 530
-reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
-expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
-
-[[legacy]]
-rule = "eager_log_interpolation"
-path = "src/archetype/core/aio/async_store.py"
-qualified_scope = "archetype.core.aio.async_store.AsyncStore.append"
-target = "log:error:f'Append collect failed for {table_id}: {e}':interpolation"
-owner = "core"
-issue = 530
-reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."
-expiry_condition = "Remove when #530 migrates this call to parameterized stdlib logging."
-
-[[legacy]]
-rule = "raw_exception_logging"
-path = "src/archetype/core/aio/async_store.py"
-qualified_scope = "archetype.core.aio.async_store.AsyncStore.append"
-target = "log:error:f'Append collect failed for {table_id}: {e}':exception"
-owner = "core"
-issue = 530
-reason = "This existing core diagnostic exports raw exception text or stack details."
-expiry_condition = "Remove when #530 replaces exception content with a bounded error classification."
-
-[[legacy]]
-rule = "eager_log_interpolation"
-path = "src/archetype/core/aio/async_store.py"
-qualified_scope = "archetype.core.aio.async_store.AsyncStore.append"
-target = "log:info:f'Append skipped (store): archetype={table_id} rows=0':interpolation"
 owner = "core"
 issue = 530
 reason = "This existing core diagnostic eagerly renders values before stdlib logging handles the record."

--- a/scripts/check_lazy_audit.py
+++ b/scripts/check_lazy_audit.py
@@ -61,6 +61,15 @@ The checker detects this pattern via AST analysis:
 Every other execution-capable terminal, plus ``Series.to_pylist()`` *outside*
 batch-UDF scope, still requires an entry.
 
+**Zero-exception ban — core row counting (issue #538)**
+
+``.count_rows()`` under ``src/archetype/core/`` has no diagnostic or
+empty-check exception and cannot be allowlisted. Core submits a lazy frame to
+its owning terminal append/write boundary; it never runs a count first to
+decide whether the work exists, and a receipt whose count the write did not
+naturally produce reports ``None``. The checker fails both the call site and
+any ``lazy_audit.toml`` entry that tries to admit one.
+
 Tests are intentionally out of scope: terminal materialization at the
 assertion boundary is expected. The contract being audited is the
 production execution model, not test ergonomics.
@@ -117,6 +126,21 @@ _MATERIALIZATION_METHODS = frozenset(
         "write_turbopuffer",
     }
 )
+
+
+# Maintainer decision (issue #538): core does not count rows to decide
+# whether work exists. Each pair is (path prefix, method); a matching site
+# fails the audit even with an allowlist entry, and a matching entry is
+# itself rejected.
+_BANNED_TERMINALS: tuple[tuple[str, str], ...] = (("src/archetype/core/", "count_rows"),)
+
+
+def is_banned(path: str, method: str) -> bool:
+    """True when (path, method) falls under a zero-exception terminal ban."""
+    return any(
+        path.startswith(prefix) and method == banned_method
+        for prefix, banned_method in _BANNED_TERMINALS
+    )
 
 
 MODULE_SCOPE = "<module>"
@@ -451,16 +475,27 @@ def main() -> int:
     audited_sites = [s for s in sites if not s.sanctioned]
     sanctioned_sites = [s for s in sites if s.sanctioned]
 
-    site_keys = {s.key: s for s in audited_sites}
-    allow_keys = {e.key: e for e in allow}
+    # Zero-exception terminal bans (issue #538): a banned site fails outright
+    # — no allowlist entry can admit it, so it is excluded from the entry
+    # matching below (which would otherwise print an entry template for it),
+    # and any entry that targets a banned (path, method) is itself rejected.
+    banned_sites = [s for s in audited_sites if is_banned(s.path, s.method)]
+    banned_entries = [e for e in allow if is_banned(e.path, e.method)]
+    gated_sites = [s for s in audited_sites if not is_banned(s.path, s.method)]
+    gated_allow = [e for e in allow if not is_banned(e.path, e.method)]
+
+    site_keys = {s.key: s for s in gated_sites}
+    allow_keys = {e.key: e for e in gated_allow}
 
     new_sites = [site_keys[k] for k in site_keys.keys() - allow_keys.keys()]
     stale_entries = [allow_keys[k] for k in allow_keys.keys() - site_keys.keys()]
-    weak_reasons = [e for e in allow if not _reason_is_substantive(e.reason)]
+    weak_reasons = [e for e in gated_allow if not _reason_is_substantive(e.reason)]
 
     new_sites.sort(key=lambda s: (s.path, s.line))
     stale_entries.sort(key=lambda e: (e.path, e.symbol, e.expr))
     weak_reasons.sort(key=lambda e: (e.path, e.symbol, e.expr))
+    banned_sites.sort(key=lambda s: (s.path, s.line))
+    banned_entries.sort(key=lambda e: (e.path, e.symbol, e.expr))
 
     # Always print sanctioned summary for visibility.
     if sanctioned_sites:
@@ -469,11 +504,32 @@ def main() -> int:
             f"(sanctioned @daft.method.batch / @daft.func.batch parameter access)."
         )
 
-    if not (new_sites or stale_entries or weak_reasons):
+    if not (banned_sites or banned_entries or new_sites or stale_entries or weak_reasons):
         print(f"lazy audit: {len(audited_sites)} audited site(s), all accounted for.")
         return 0
 
     print(STERN_HEADER, file=sys.stderr)
+
+    if banned_sites:
+        rendered = [f"{s.path}:{s.line}  {s.symbol}  .{s.method}()  {s.expr}" for s in banned_sites]
+        sys.stderr.write(
+            _format_section(
+                "Banned terminals (issue #538 — zero exceptions, not allowlistable):",
+                rendered,
+            )
+        )
+
+    if banned_entries:
+        rendered = [
+            f"{e.path}  {e.symbol}  .{e.method}()  {e.expr}  reason={e.reason!r}"
+            for e in banned_entries
+        ]
+        sys.stderr.write(
+            _format_section(
+                "Allowlist entries targeting banned terminals (remove them; the ban has no exceptions):",
+                rendered,
+            )
+        )
 
     if new_sites:
         rendered = [

--- a/src/archetype/core/aio/async_cached_store.py
+++ b/src/archetype/core/aio/async_cached_store.py
@@ -54,9 +54,11 @@ class MemTable:
         self.last_mut = time.time()
 
     def extend(self, other: "MemTable") -> None:
-        """Append another memtable without rebuilding its Arrow batches."""
-        if not other.rows:
-            return
+        """Append another memtable without rebuilding its Arrow batches.
+
+        An empty ``other`` is a natural no-op of the extend itself — no
+        row-count admission guard (issue #538).
+        """
         self.batches.extend(other.batches)
         self.rows += other.rows
         self.bytes += other.bytes
@@ -295,13 +297,12 @@ class AsyncCachedStore(iAsyncStore):
         commit coordinator must call flush() before publishing a manifest
         head — a head must never claim RAM-only rows are durable.
         """
-        # 1) convert the tiny incoming Daft DataFrame slice → RecordBatch
+        # 1) convert the tiny incoming Daft DataFrame slice → RecordBatch.
+        # No row-count admission guard (issue #538): an empty slice buffers
+        # nothing and the staging path below is its natural no-op.
         pending = MemTable()
         for batch in df.to_arrow_iter():
             pending.append(batch)
-
-        if pending.rows == 0:
-            return AppendReceipt(table_id=Archetype.get_name(sig), rows=0, durable=True)
 
         async with self._state_lock:
             if not self._accepting_appends:

--- a/src/archetype/core/aio/async_lancedb_store.py
+++ b/src/archetype/core/aio/async_lancedb_store.py
@@ -347,19 +347,20 @@ class AsyncLancedbStore(iAsyncStore):
         return [sig for key, sig in self._known_sigs.items() if key in self._committed_sigs]
 
     async def append(self, sig, df: DataFrame) -> AppendReceipt:
-        # ONE materialization. Lance rejects zero-row / schemaless frames, so the
-        # empty guard stays — but the row count comes free from the Arrow table we
-        # must build anyway. A separate df.collect() + df.count_rows() re-ran the
-        # Daft plan twice for nothing; this redundancy is a recurring rewrite
-        # regression (perf-fixed before in the predecessor stores) — keep it lean.
+        # ONE materialization: to_arrow() is the conversion the backend add()
+        # requires, and the receipt's row count is metadata that conversion
+        # already produced. Core never asks whether the frame is empty before
+        # the write (issue #538) — a zero-row add() is LanceDB's own
+        # successful no-op. A separate df.collect() + df.count_rows() re-ran
+        # the Daft plan twice for nothing; this redundancy is a recurring
+        # rewrite regression (perf-fixed before in the predecessor stores).
         table_id = Archetype.get_name(sig)
         if not df.column_names:
+            # Schema availability, not row cardinality: a schemaless frame
+            # cannot even name a backing table.
             logger.info(f"Append skipped (lancedb): archetype={table_id} empty schema")
             return AppendReceipt(table_id=table_id, rows=0, durable=True)
         arrow_table = df.to_arrow()
-        if arrow_table.num_rows == 0:
-            logger.info(f"Append skipped (lancedb): archetype={table_id} rows=0")
-            return AppendReceipt(table_id=table_id, rows=0, durable=True)
 
         async_table = await self._ensure_table(sig)
         result = await async_table.add(arrow_table, mode="append")

--- a/src/archetype/core/aio/async_store.py
+++ b/src/archetype/core/aio/async_store.py
@@ -269,26 +269,25 @@ class AsyncStore(iAsyncStore):
     async def append(self, sig: ArchetypeSignature, df: DataFrame) -> AppendReceipt:
         """
         Append a table with a new dataframe. Returns the durable batch receipt.
+
+        The backing-table write is the only executor of the incoming plan.
+        Core never runs a count first to decide whether the append is worth
+        attempting (issue #538): a zero-row frame is the backend's own
+        successful no-op. Iceberg's append produces no natural row count, so
+        the receipt reports ``rows=None`` — unknown is None, not a preflight.
         """
         table_id = Archetype.get_name(sig)
         if not df.column_names:
+            # Schema availability, not row cardinality: a schemaless frame
+            # cannot even name a backing table.
             logger.info(f"Append skipped (store): archetype={table_id} empty schema")
-            return AppendReceipt(table_id=table_id, rows=0, durable=True)
-        try:
-            materialized = df.collect(num_preview_rows=0)
-            rows = materialized.count_rows()
-        except Exception as e:
-            logger.error(f"Append collect failed for {table_id}: {e}")
-            raise
-        if rows == 0:
-            logger.info(f"Append skipped (store): archetype={table_id} rows=0")
             return AppendReceipt(table_id=table_id, rows=0, durable=True)
 
         table = self._ensure_table(sig)
-        self._append_table(table, materialized)
+        self._append_table(table, df)
         self._committed_sigs.add(table_id)
         return AppendReceipt(
-            table_id=table_id, rows=rows, durable=True, backend_ref=self._snapshot_ref(table)
+            table_id=table_id, rows=None, durable=True, backend_ref=self._snapshot_ref(table)
         )
 
     @staticmethod

--- a/tests/core/test_async_store_updater_failures.py
+++ b/tests/core/test_async_store_updater_failures.py
@@ -69,12 +69,13 @@ async def test_async_store_append_skips_on_empty_df(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_async_store_append_raises_on_collect_failure(tmp_path, caplog):
+async def test_async_store_append_raises_on_write_failure(tmp_path):
     """A frame that cannot materialize must fail the append, not no-op.
 
     Persistence failure is observable to callers (specification.md, updater
-    contracts): a swallowed collect failure would let a tick 'succeed' while
-    persisting nothing.
+    contracts). The write boundary is the only executor of the plan (issue
+    #538 — no collect/count preflight), so the failure surfaces from the
+    write itself.
     """
     session, cfg = _build_session_and_config(tmp_path)
     store = AsyncStore(session, io_config=cfg.io_config)
@@ -83,13 +84,11 @@ async def test_async_store_append_raises_on_collect_failure(tmp_path, caplog):
     class BadDf:
         column_names = ["broken"]
 
-        def collect(self, **_kwargs):
+        def write_iceberg(self, *_args, **_kwargs):
             raise RuntimeError("boom")
 
-    with caplog.at_level("ERROR"):
-        with pytest.raises(RuntimeError, match="boom"):
-            await store.append(sig, BadDf())
-    assert any("Append collect failed" in rec.message for rec in caplog.records)
+    with pytest.raises(RuntimeError, match="boom"):
+        await store.append(sig, BadDf())
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/test_check_lazy_audit.py
+++ b/tests/scripts/test_check_lazy_audit.py
@@ -533,3 +533,25 @@ def test_unreadable_module_is_not_silently_clean(tmp_path):
 
     with pytest.raises(OSError):
         _scan_file(missing, "gone.py")
+
+
+# ---------------------------------------------------------------------------
+# Unit: is_banned (issue #538 zero-exception terminal ban)
+# ---------------------------------------------------------------------------
+
+
+def test_core_count_rows_is_banned():
+    """count_rows under src/archetype/core/ has no allowlist path at all."""
+    from check_lazy_audit import is_banned
+
+    assert is_banned("src/archetype/core/aio/async_store.py", "count_rows")
+    assert is_banned("src/archetype/core/sync/store.py", "count_rows")
+
+
+def test_ban_is_scoped_to_core_and_count_rows():
+    """The ban covers exactly (core path, count_rows) — not other layers or methods."""
+    from check_lazy_audit import is_banned
+
+    assert not is_banned("src/archetype/evaluation/views.py", "count_rows")
+    assert not is_banned("src/archetype/core/aio/async_store.py", "collect")
+    assert not is_banned("tests/aio/test_store.py", "count_rows")


### PR DESCRIPTION
C2 slice of the v0.5.0 parallel correctness lane (#704), completing #538 after #708 fixed the debug seam.

- AsyncStore.append: no collect()+count_rows() preflight — the Iceberg write is the only executor of the plan; receipt reports rows=None (unknown is None, not a preflight).
- AsyncLancedbStore.append: zero-row add() is LanceDB's own successful no-op; schema guard retained (schema availability ≠ row cardinality).
- AsyncCachedStore: MemTable.extend and append drop row-count admission branches; empty input is the natural no-op of the staging path.
- Lazy audit: zero-exception ban — .count_rows() under src/archetype/core/ fails the checker even with an allowlist entry, and entries targeting it are rejected. Unit-tested.
- Stale observability legacy exceptions for the deleted diagnostics removed.

Validation: tests/core + tests/aio + tests/scripts 628 passed post-rebase; make ci green.

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)