### PR TITLE
feat(storage): bounded CAS retry + typed ambiguous-commit freeze (C1)

### DIFF
--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -457,6 +457,17 @@ conflict, storage refreshes the table and recomputes the anti-join before
 retrying so stale pending rows cannot duplicate an already-committed logical
 key.
 
+Commit outcomes are classified, and the classification is a deliberate v0.5
+posture. A definite commit conflict (`CommitFailedException` — the catalog
+proved the commit did not land) retries a bounded number of times, reusing the
+payload the first attempt already materialized; the upstream Daft plan is never
+re-executed. An ambiguous outcome (`CommitStateUnknownException` — the commit
+may or may not have landed) freezes as a typed `AmbiguousCommitError` instead
+of retrying or leaking the raw provider exception: a blind retry could
+double-append, and v0.5 does not attempt automatic reconciliation. The caller
+or operator inspects the table before resubmitting. There is no global storage
+lock, write broker, or general transaction layer behind this contract.
+
 The durable control plane is separate from that data plane. The local SQLite
 `ControlCatalog`, or its remote Durable Object implementation, owns world
 identity, writer fences, visibility manifests, deferred commands, and narrow

--- a/scripts/check_gate_coverage.py
+++ b/scripts/check_gate_coverage.py
@@ -227,6 +227,12 @@ INTENTIONAL_UNMAPPED = {
     "archetype.storage.catalog.records.CatalogSchemaMismatchError": (
         "integrity violation intentionally surfaces as 500; decision recorded in #413"
     ),
+    "archetype.storage.service.AmbiguousCommitError": (
+        "frozen ambiguous Iceberg commit intentionally surfaces as 500: the "
+        "append may or may not have landed, no HTTP status invites a safe "
+        "client retry, and the operator reconciles server-side; C1 posture "
+        "recorded in #704"
+    ),
 }
 
 # Private control-flow exceptions proven not to cross a registered handler

--- a/src/archetype/storage/service.py
+++ b/src/archetype/storage/service.py
@@ -29,7 +29,11 @@ from daft import DataFrame, DataType, col, lit, read_iceberg
 from daft.catalog import Catalog, Table
 from daft.io import IOConfig
 from daft.session import Session
-from pyiceberg.exceptions import CommitFailedException, TableAlreadyExistsError
+from pyiceberg.exceptions import (
+    CommitFailedException,
+    CommitStateUnknownException,
+    TableAlreadyExistsError,
+)
 
 from archetype.core.aio import AsyncCachedStore, AsyncLancedbStore, AsyncStore
 from archetype.core.config import CacheConfig, StorageBackend, StorageConfig
@@ -57,6 +61,28 @@ logger = logging.getLogger(__name__)
 _MAX_COMMIT_ATTEMPTS = 16
 _T = TypeVar("_T")
 _WORLD_ENVELOPE_COLUMNS = ("world_id", "run_id")
+
+
+class AmbiguousCommitError(RuntimeError):
+    """An Iceberg commit whose outcome cannot be proven either way.
+
+    Raised when the catalog reports an unknown commit state
+    (``CommitStateUnknownException``): the append may or may not have become
+    part of the table. Retrying could double-append and swallowing could drop
+    a durable write, so the operation freezes as this typed outcome — the
+    deliberate v0.5 posture. The caller (or operator) reconciles by inspecting
+    the table before resubmitting.
+    """
+
+    def __init__(self, table_name: str, attempt: int) -> None:
+        super().__init__(
+            f"Iceberg commit outcome unknown for table {table_name!r} "
+            f"(attempt {attempt + 1}): the append may or may not have "
+            "committed; not retrying (a retry could double-append). "
+            "Inspect the table before resubmitting."
+        )
+        self.table_name = table_name
+        self.attempt = attempt
 
 
 @dataclass(frozen=True, slots=True)
@@ -725,6 +751,10 @@ class StorageService:
                             io_config=store.io_config,
                         )
                     return rows_written
+            except CommitStateUnknownException as exc:
+                # Ambiguous: the commit may have landed. A definite-conflict
+                # retry would risk a double-append; freeze as a typed outcome.
+                raise AmbiguousCommitError(table_name, attempt) from exc
             except CommitFailedException:
                 if attempt + 1 == _MAX_COMMIT_ATTEMPTS:
                     raise
@@ -810,6 +840,10 @@ class StorageService:
                         io_config=store.io_config,
                     )
                     return rows_written
+            except CommitStateUnknownException as exc:
+                # Same freeze as append_table: an anti-join retry against a
+                # table whose commit state is unknown could double-append.
+                raise AmbiguousCommitError(table_name, attempt) from exc
             except CommitFailedException:
                 if attempt + 1 == _MAX_COMMIT_ATTEMPTS:
                     raise

--- a/tests/storage/test_storage_execution.py
+++ b/tests/storage/test_storage_execution.py
@@ -9,10 +9,11 @@ import time
 
 import daft
 import pytest
+from pyiceberg.exceptions import CommitStateUnknownException
 
 from archetype.core.component import Component
 from archetype.core.config import CacheConfig, RunConfig, StorageBackend, StorageConfig, WorldConfig
-from archetype.storage.service import StorageService
+from archetype.storage.service import AmbiguousCommitError, StorageService
 from archetype.storage.session import configure_session
 from archetype.world.lifecycle import WorldLifecycle
 from archetype.world.registry import WorldRegistry
@@ -303,3 +304,101 @@ async def test_real_iceberg_conflict_recomputes_conditional_append(tmp_path):
     finally:
         await first.shutdown()
         await second.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_definite_conflict_losers_retry_append_to_success(tmp_path):
+    """Racing appends: the CAS loser retries the same frozen payload to success.
+
+    C1 managed-write contract (#704): definite Iceberg commit conflicts retry
+    boundedly with the already-materialized payload; each payload commits
+    exactly once.
+    """
+    storage = _storage(tmp_path)
+    first = StorageService(session=configure_session(storage))
+    second = StorageService(session=configure_session(storage))
+    barrier = threading.Barrier(2)
+    try:
+        await first.append_table(
+            storage,
+            "events",
+            daft.from_pydict({"event_id": ["seed"], "writer": ["seed"]}),
+        )
+
+        def arm(catalog):
+            original = catalog._write_metadata
+            armed = True
+
+            def synchronized_metadata(*args, **kwargs):
+                nonlocal armed
+                result = original(*args, **kwargs)
+                if armed:
+                    armed = False
+                    barrier.wait(timeout=10)
+                return result
+
+            catalog._write_metadata = synchronized_metadata
+
+        for service in (first, second):
+            store = await service.get_or_create_store(storage)
+            native = store.session.current_catalog().get_table("ns.events")._inner
+            arm(native.catalog)
+
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                first.append_table(
+                    storage,
+                    "events",
+                    daft.from_pydict({"event_id": ["a"], "writer": ["first"]}),
+                ),
+                second.append_table(
+                    storage,
+                    "events",
+                    daft.from_pydict({"event_id": ["b"], "writer": ["second"]}),
+                ),
+            ),
+            timeout=20,
+        )
+
+        assert results == [1, 1]
+        rows = (await first.read_table(storage, "events")).sort("event_id").to_pylist()
+        assert [row["event_id"] for row in rows] == ["a", "b", "seed"]
+    finally:
+        await first.shutdown()
+        await second.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_commit_freezes_as_typed_outcome(tmp_path):
+    """An unknown commit state freezes: typed error, no retry, no duplicate.
+
+    C1 managed-write contract (#704): ambiguity must not silently retry (a
+    retry could double-append) and must not leak a raw provider exception.
+    """
+    storage = _storage(tmp_path)
+    service = StorageService(session=configure_session(storage))
+    try:
+        await service.append_table(storage, "events", daft.from_pydict({"event_id": ["seed"]}))
+        store = await service.get_or_create_store(storage)
+        native = store.session.current_catalog().get_table("ns.events")._inner
+        calls = 0
+
+        def unknown_commit(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            raise CommitStateUnknownException("catalog response lost")
+
+        original = native.catalog.commit_table
+        native.catalog.commit_table = unknown_commit
+        try:
+            with pytest.raises(AmbiguousCommitError) as raised:
+                await service.append_table(storage, "events", daft.from_pydict({"event_id": ["x"]}))
+        finally:
+            native.catalog.commit_table = original
+
+        assert calls == 1, "an ambiguous commit must freeze, not retry"
+        assert raised.value.table_name == "events"
+        rows = (await service.read_table(storage, "events")).to_pylist()
+        assert [row["event_id"] for row in rows] == ["seed"]
+    finally:
+        await service.shutdown()


### PR DESCRIPTION
C1 slice of the v0.5.0 parallel correctness lane (#704).

- Definite Iceberg commit conflicts (CommitFailedException) retry boundedly reusing the already-materialized payload — never re-planning or re-executing the Daft DAG (this part existed; now proven under real concurrency).
- Ambiguous outcomes (CommitStateUnknownException) freeze as typed `AmbiguousCommitError` — no silent retry that could double-append, no raw exception leak. PROPOSED TERM: AmbiguousCommitError.
- Proof: two-writer sqlite-catalog race where the CAS loser retries the same frozen payload to success with exactly one committed copy per payload; induced-ambiguity case lands in the typed outcome, never a duplicate (tests/storage/test_storage_execution.py).
- Freeze posture documented as the deliberate v0.5 limitation in docs/guide/application-architecture.md; gate-coverage manifest records the intentional 500.

Cut per packet: no global lock, broker, schema/layout work, or transaction layer.

Validation: tests/storage 12 passed; make ci green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)