### PR TITLE
feat(missions): A8.1 — canonical episode contract; trajectory becomes a derived view

### DIFF
--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -820,13 +820,12 @@ are first-class recovery/evidence references, but their existence has no
 implicit acceptance authority. Only an explicit typed policy may require
 their publication for a transition.
 
-Remaining target after PR4: persistent behavioral evidence converges on
-`episode_id`. A trajectory becomes a derived learning-facing DataFrame
-selected from episode evidence and has no persistent identity. Until its
-owning migration lands, the persistent trajectory contract in
-[Mission Trajectories](trajectories.md) remains current. The episode-schema
-change is an intentional pre-1.0 v0.5 migration rather than a silent
-compatibility alias.
+Persistent behavioral evidence converges on `episode_id`: evidence rows are
+keyed by `episode_id` and `seq`, and a trajectory is a derived learning-facing
+DataFrame selected from episode evidence with no persistent identity. The
+contract is documented in [Mission Trajectories](trajectories.md). The
+episode-schema change was an intentional pre-1.0 v0.5 migration — no 0.4
+backfill, dual reads, or compatibility aliases.
 
 ### v0.5 migration oracle status
 
@@ -840,7 +839,7 @@ boundary rather than relying on a pre-refactor baseline.
 | command materialization and manifest-coupled settlement | command-flow and durable-command integration contracts | Landed in world/commands |
 | lock and shutdown admission | runtime lifecycle and admitted-work race contracts | Landed in world/runtime resources |
 | UUIDv7 run identity and fork/resume continuity | command-flow, fork-storage, and world-resume contracts | Landed in world |
-| episode identity and trajectory derivation | episode-rollout and trajectory-domain contracts | Remaining episodes migration |
+| episode identity and trajectory derivation | trajectory-domain, trajectory-service, and episode-join contracts | Landed: evidence keyed by `episode_id`, trajectory is a derived view |
 | stable task base, immutable candidate, exact-head critic | coding-agent, critic, mission-service, and capability-eval contracts | Current preservation baseline; author and critic Activity cutovers must preserve it |
 | sandbox cleanup and retryable phased teardown | sandbox-service, runtime-contract, and mission-service race contracts | Process lifetime landed; Activity worker ownership remains |
 | committed required projection and provider reconciliation | generic seam and mission-consumer failpoint contracts | Generic world seam landed; Activity catalog and Mission consumers are A2–A5 |

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -167,9 +167,9 @@ Requires an OpenAI API key (or any provider via `daft.set_provider()`).
 
 ## 6. Mission Trajectory Analysis
 
-Persist normalized trajectory headers, turns, and rewards, then select and
-grade one trajectory through the runtime-owned application service. The example
-is deterministic and requires no model credentials.
+Persist normalized turn and reward rows keyed by `episode_id`, then select
+and grade one episode's evidence through the runtime-owned application
+service. The example is deterministic and requires no model credentials.
 
 ```bash
 uv run python examples/06_trajectory_analysis.py
@@ -179,8 +179,9 @@ Source: [`examples/06_trajectory_analysis.py`](https://github.com/VangelisTech/a
 
 **What it demonstrates:**
 
-- **Normalized evidence**: header, turn, and reward rows remain independently queryable.
-- **Typed selection**: `TrajectorySelection` applies only fields stored by the requested table.
+- **Normalized evidence**: turn and reward rows remain independently queryable per episode.
+- **Typed selection**: `TrajectorySelection` filters one evidence table by `episode_id`.
+- **Derived view**: `trajectory(...)` reconstructs one episode's seq-ordered evidence lazily.
 - **Application composition**: `query_trajectory()` uses persisted query access; `grade_trajectory()` delegates graders to evaluation.
 - **No duplicate trajectory model**: the example consumes `archetype.missions.trajectories` directly.
 

--- a/docs/guide/trajectories.md
+++ b/docs/guide/trajectories.md
@@ -1,103 +1,86 @@
 ---
 title: Mission Trajectories
-description: Persist, select, and grade lightweight mission evidence
+description: Persist, select, and grade lightweight episode evidence
 ---
 
 **Document type:** Contract and user guide.
 
-**Migration status:** The persistent `trajectory_id` Component schema and
-runtime methods documented here are the implemented current, pre-PR-9
-contract. The [accepted v0.5 target](application-architecture.md#lifetime-and-workflow-ownership)
-replaces persistent trajectory identity with authoritative episode evidence:
-`episode_id` persists, while a trajectory becomes a derived learning-facing
-DataFrame. Until that owning migration lands, the current API below remains
-the executable contract; the target is not a compatibility alias or a second
-simultaneous persistence model.
+`episode_id` is the one persistent identity of a bounded Mission or hosted
+Physical-AI execution. Evidence rows are stored per episode; a trajectory is a
+derived, learning-facing DataFrame view over that evidence and has no
+persistent identity of its own. There is no persistent `trajectory_id`.
 
-A trajectory is a lightweight, typed index over what happened during a mission
-or rollout. It is evidence: it can be queried and graded, but it never decides
-whether a task advances.
+Evidence can be queried and graded, but it never decides whether a task
+advances.
 
-Archetype provides separate schemas for headers, turns, commands, observations,
-actions, and rewards; it does not hide trajectory evidence in one JSON
-document. Small, already-safe evidence may be authored as Component rows. Raw
-coding-agent transcripts use the artifact boundary described below: only a
-sanitized file enters the common artifact index, while normalized narrative
-lives in a typed ingestion table. Transcript ingestion does not silently add
-entities to the mission graph.
+Archetype provides separate typed schemas for turns, commands, observations,
+actions, and rewards; it does not hide evidence in one JSON document. Small,
+already-safe evidence may be authored as Component rows. Raw coding-agent
+transcripts use the artifact boundary described below: only a sanitized file
+enters the common artifact index, while normalized narrative lives in a typed
+ingestion table. Transcript ingestion does not silently add entities to the
+mission graph.
 
 ## Ownership
 
 | File | Responsibility |
 |---|---|
-| `archetype.missions.trajectories.components` | Persistent Arrow-safe schemas. |
+| `archetype.missions.trajectories.components` | Persistent Arrow-safe evidence schemas keyed by `episode_id` and `seq`. |
 | `archetype.missions.trajectories.contracts` | In-memory authoring values, structural inputs, and typed selection. |
 | `archetype.missions.trajectories.claude` | Claude source configuration and pure parsing of already-sanitized text. No file I/O or durability. |
-| `archetype.missions.trajectories.transforms` | Pure row and lazy DataFrame transforms; no service access. |
+| `archetype.missions.trajectories.transforms` | Pure row transforms and the derived `trajectory(...)` view; no service access. |
 | `archetype.app.missions.trajectory_service` | Internal composition of persisted query access and evaluation graders. |
 | `archetype.app.missions.transcript_service` | Internal snapshot, redaction, sanitized-file ingestion, and normalized-row workflow. |
 | `RuntimeWorld.query_trajectory()` | Recommended filtered read path. |
 | `RuntimeWorld.grade_trajectory()` | Recommended query-then-grade path. |
 | `RuntimeWorld.ingest_claude_transcript()` | Recommended source-to-artifact workflow. |
 
-The app service owns no trajectory truth. Query storage remains authoritative
+The app service owns no evidence truth. Query storage remains authoritative
 for rows, evaluation remains authoritative for grader execution and receipts,
 and mission processors remain authoritative for task transitions.
 
-## Current pre-PR-9 persistent rows
+## Persistent evidence rows
 
 | Component | One row represents |
 |---|---|
-| `Trajectory` | Header and coordinates for one trajectory. |
-| `TrajectoryTurn` | One historical or explicitly authored conversational/tool-use turn. New raw-transcript ingestion does not write it. |
+| `TrajectoryTurn` | One explicitly authored conversational/tool-use turn. Raw-transcript ingestion does not write it. |
 | `TranscriptArtifactRef` | Optional explicitly authored Component link to a sanitized transcript artifact. Raw-transcript ingestion does not write it. |
 | `TrajectoryCommandEvent` | One command or audit event. |
 | `TrajectoryObservation` | One observed tick or external event. |
-| `TrajectoryAction` | One action aligned to the trajectory sequence. |
+| `TrajectoryAction` | One action aligned to the evidence sequence. |
 | `TrajectoryReward` | One reward observation. |
 
-Under the current pre-PR-9 schema, every child row carries `trajectory_id` and
-`seq`. This normalization keeps the tables independently queryable and avoids
-rewriting a large payload whenever one observation changes. It describes the
-preservation baseline, not the accepted v0.5 episode-owned replacement.
+Every row carries `episode_id` and `seq`. This normalization keeps the tables
+independently queryable and avoids rewriting a large payload whenever one
+observation changes.
 
-`Trajectory.episode_id` is retained as string-valued runtime metadata for
-historical rows. It is not the integer dataset-episode identity in the
-evaluation ontology.
+The world runtime's `EpisodeResult.episode_id` is a runtime lifecycle
+identifier (a string). It is not the integer dataset-episode index in the
+[evaluation ontology](dataset-eval-ontology.md); the two stay type-distinct.
 
 ## Author small, already-safe evidence
 
 ```python
 from archetype import ArchetypeRuntime
 from archetype.missions.trajectories import (
-    Trajectory,
     TrajectoryReward,
     Turn,
     turns_to_components,
 )
 
+episode_id = "episode-auth-1"
 turns = [
     Turn(role="user", content="Fix the login regression", tokens=6),
     Turn(role="assistant", content="Patched and validated", tokens=18),
 ]
-header = Trajectory.from_turns(
-    "mission-42:task-auth:attempt-1",
-    turns,
-    run_id="run-42",
-    task_id="auth",
-    source="coding-agent",
-    terminal=True,
-    outcome="accepted",
-)
 
 async with ArchetypeRuntime() as runtime:
     world = runtime.world("mission-evidence", storage="./data")
-    await world.spawn(header)
     await world.spawn_many(
-        [[row] for row in turns_to_components(header.trajectory_id, turns)]
+        [[row] for row in turns_to_components(episode_id, turns)]
     )
     await world.spawn(
-        TrajectoryReward(trajectory_id=header.trajectory_id, reward=1.0)
+        TrajectoryReward(episode_id=episode_id, reward=1.0)
     )
     await world.run(steps=1)
 ```
@@ -106,10 +89,10 @@ The spawned values become visible together at the tick commit boundary. This
 is an authoring path, not a transcript loader. Use artifact ingestion for
 large, externally sourced, or potentially secret-bearing material.
 
-## Select one trajectory table
+## Select one evidence table
 
-`TrajectorySelection` is explicit and table-local. A filter must name a field
-stored by the requested Component; Archetype does not perform an implicit join.
+`TrajectorySelection` is explicit and table-local: it filters one typed
+evidence table by `episode_id`. Archetype does not perform an implicit join.
 
 ```python
 from archetype.missions.trajectories import (
@@ -117,9 +100,7 @@ from archetype.missions.trajectories import (
     TrajectorySelection,
 )
 
-selection = TrajectorySelection(
-    trajectory_ids=("mission-42:task-auth:attempt-1",),
-)
+selection = TrajectorySelection(episode_ids=("episode-auth-1",))
 rewards = await world.query_trajectory(
     TrajectoryReward,
     selection=selection,
@@ -128,12 +109,22 @@ rewards = await world.query_trajectory(
 
 The result is a lazy Daft DataFrame. The application service asks the query
 service for persisted rows, then applies selection as DataFrame expressions;
-it does not collect the frame.
+it does not collect the frame. A filter against a Component that does not
+store `episode_id` fails with a precise error.
 
-For example, `TrajectoryReward` stores `trajectory_id` but not `task_id`.
-Selecting rewards by `task_ids` therefore fails with a precise error. Query the
-`Trajectory` header by task first, then carry the selected trajectory IDs into
-the reward query.
+## Derive one trajectory
+
+`trajectory(...)` is the derived view: one episode's seq-ordered evidence,
+reconstructed lazily from a persisted evidence table.
+
+```python
+from archetype.missions.trajectories import TrajectoryTurn, trajectory
+
+turns = await world.query_trajectory(TrajectoryTurn)
+ordered = trajectory(turns, TrajectoryTurn, episode_id="episode-auth-1")
+```
+
+The view is a lazy DataFrame; nothing runs until the caller materializes it.
 
 ## Grade a selection
 
@@ -159,18 +150,14 @@ Sync scripts use the same names through `ArchetypeRuntime.sync()`.
 
 ## Pure transforms
 
-The family provides structural transforms for existing command, audit,
-episode, tick, action, and reward values. They accept only the fields they need
-and do not import application DTOs:
+The family provides structural transforms for existing command, audit, tick,
+action, and reward values. They accept only the fields they need and do not
+import application DTOs:
 
 ```python
-from archetype.missions.trajectories import (
-    audit_rows_to_events,
-    trajectory_from_episode_result,
-)
+from archetype.missions.trajectories import audit_rows_to_events
 
-header = trajectory_from_episode_result(episode, rollout_id="rollout-7")
-events = audit_rows_to_events(audit_rows, trajectory_id=header.trajectory_id)
+events = audit_rows_to_events(audit_rows, episode_id="episode-auth-1")
 ```
 
 This keeps reusable evidence construction below the application layer while
@@ -202,15 +189,19 @@ turns the session into spawnable entities. The mission-owned application
 workflow performs the stable snapshot, quarantine/redaction, complete parse,
 sanitized artifact ingestion, and typed Iceberg append.
 
+One ingested Claude session is one bounded execution; its stable
+`episode_id` is the canonical `claude-session://` source URI
+(`ClaudeTranscriptSource.episode_id`).
+
 The common artifact index stores the sanitized file occurrence and its
 content-addressed object URI. The `coding_agent_transcript_rows` table stores
 one session row plus ordered turn rows linked by the same canonical
-`trajectory_id` and `source_artifact_id`. The submitted local path is absent
+`episode_id` and `source_artifact_id`. The submitted local path is absent
 from both durable tables. `TranscriptIngestionResult` returns the portable
 `ArtifactRef`, linkage, row count, and redaction outcome;
 `world.transcript_rows()` reads the normalized rows for analysis.
 
-`TrajectoryTurn` remains the one class identity for historical Component rows
-and deliberate safe authoring. Compatibility does not authorize a new raw
-transcript writer. See [Transcript ingestion](artifacts.md#8-transcript-ingestion)
+`TrajectoryTurn` remains the one class identity for deliberate safe authoring;
+transcript ingestion does not write it. See
+[Transcript ingestion](artifacts.md#8-transcript-ingestion)
 for ordering, redaction, occurrence identity, and failure semantics.

--- a/docs/planning/activity-boundary-refactor.md
+++ b/docs/planning/activity-boundary-refactor.md
@@ -349,6 +349,28 @@ evidence. Neither is a merge dependency. `WorldHost` may later describe an
 executor implementation detail, but it is not the durable semantic owner of
 Mission or whole-episode work.
 
+## Rulings closed (2026-07-26)
+
+These questions are decided; execution slices implement them and do not
+re-open them.
+
+1. **Episode identity (A8.1).** `episode_id` is the canonical persistent
+   identity of one bounded domain execution (a Mission or a hosted
+   Physical-AI execution). A trajectory is a derived DataFrame view
+   (`trajectory(...)`) over persisted episode evidence; persistent
+   `trajectory_id` is removed. Hosted Physical-AI results use the same
+   persistent episode identity. Evaluation's dataset-local integer episode
+   index and the world runtime's lifecycle episode identifier stay
+   type-distinct; unrelated identifiers are not falsely unified. Any
+   contingency branch that re-opened this contract is void — A8.1 executes
+   the ruling, it does not debate it.
+2. **A8 ships in v0.5.0.** Correctness and cleanup are the release together,
+   including "`archetype.app` is gone." There is no pre-authorized
+   "v0.5.0 without A8" contingency; if the chain misses the wall-clock, the
+   tag moves unless Everett explicitly redefines the release. v0.5 is a
+   clean pre-1.0 contract epoch: no 0.4 backfill, dual reads, schema
+   evolution, or compatibility aliases in the release window.
+
 ## Release cut lines
 
 The release consumes only the highest contiguous green slice:

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -48,7 +48,7 @@ machine authority; this page is its review surface.
 | `core.ecs.data_model` | `core` | high | [docs/guide/specification.md](../guide/specification.md) — Data Model Contracts | pytest: 2; eval: 2; benchmark: 1 | `pr`, `main`, `release` |
 | `core.processors.execution` | `core` | high | [docs/guide/specification.md](../guide/specification.md) — System and Processor Contracts | pytest: 3; eval: 1 | `pr`, `main`, `release` |
 | `core.hooks.lifecycle` | `core` | medium | [docs/guide/specification.md](../guide/specification.md) — Lifecycle Hook Contracts | pytest: 3 | `pr`, `main`, `release` |
-| `missions.trajectory.runtime_service` | `missions` | medium | [docs/guide/trajectories.md](../guide/trajectories.md) — Select one trajectory table | pytest: 3 | `pr`, `main`, `release` |
+| `missions.trajectory.runtime_service` | `missions` | medium | [docs/guide/trajectories.md](../guide/trajectories.md) — Select one evidence table | pytest: 3 | `pr`, `main`, `release` |
 | `research.autoresearch.ledger` | `research` | high | [docs/guide/autoresearch.md](../guide/autoresearch.md) — The Loop | pytest: 9 | `pr`, `main`, `release` |
 | `graph.relations.temporal` | `graph` | medium | [docs/guide/prefab-libraries.md](../guide/prefab-libraries.md) — Current relation and temporal-view contract | pytest: 4 | `pr`, `main`, `release` |
 | `graph.prefabs.copy_on_instantiate` | `graph` | medium | [docs/guide/prefab-libraries.md](../guide/prefab-libraries.md) — Instantiation is a ledger operation | pytest: 3 | `pr`, `main`, `release` |

--- a/docs/reference/python/transcripts.md
+++ b/docs/reference/python/transcripts.md
@@ -25,7 +25,7 @@
 | --- | --- | --- |
 | `world_id` | `str` | `required` |
 | `run_id` | `str` | `required` |
-| `trajectory_id` | `str` | `required` |
+| `episode_id` | `str` | `required` |
 | `mission_id` | `str` | `required` |
 | `source_uri` | `str` | `required` |
 | `artifact` | `ArtifactRef` | `required` |

--- a/examples/06_trajectory_analysis.py
+++ b/examples/06_trajectory_analysis.py
@@ -1,11 +1,11 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Query and grade normalized mission trajectory evidence.
+"""Query and grade normalized episode evidence.
 
-The example is deterministic and credential-free. It writes two trajectory
-headers plus separate turn and reward rows, selects one failed trial, and asks
-the trajectory application service to grade that trial's rewards.
+The example is deterministic and credential-free. It writes turn and reward
+rows for two episodes keyed by ``episode_id``, selects one failed episode,
+and asks the trajectory application service to grade that episode's rewards.
 
 Usage:
     uv run python examples/06_trajectory_analysis.py
@@ -21,80 +21,60 @@ from daft import DataFrame
 from archetype import ArchetypeRuntime
 from archetype.core.config import StorageConfig
 from archetype.missions.trajectories import (
-    Trajectory,
     TrajectoryReward,
     TrajectorySelection,
+    TrajectoryTurn,
     Turn,
+    trajectory,
     turns_to_components,
 )
 
 
 @dataclass(frozen=True)
-class ExampleTrajectory:
-    """One header and its normalized child values before spawning."""
+class ExampleEpisode:
+    """One episode's normalized evidence values before spawning."""
 
-    header: Trajectory
+    episode_id: str
     turns: tuple[Turn, ...]
     rewards: tuple[float, ...]
 
 
-def make_trajectories() -> tuple[ExampleTrajectory, ...]:
+def make_episodes() -> tuple[ExampleEpisode, ...]:
     """Build two small synthetic mission attempts."""
-    accepted_turns = (
-        Turn(role="user", content="Fix the login regression", tokens=6),
-        Turn(role="assistant", content="Patched and validated", tokens=18),
-    )
-    rejected_turns = (
-        Turn(role="user", content="Fix the cache regression", tokens=6),
-        Turn(role="assistant", content="Validator still fails", tokens=14),
-    )
     return (
-        ExampleTrajectory(
-            header=Trajectory.from_turns(
-                "mission-42:auth:attempt-1",
-                list(accepted_turns),
-                run_id="mission-42",
-                task_id="auth",
-                trial_idx=0,
-                source="coding-agent",
-                terminal=True,
-                outcome="accepted",
+        ExampleEpisode(
+            episode_id="episode-auth-1",
+            turns=(
+                Turn(role="user", content="Fix the login regression", tokens=6),
+                Turn(role="assistant", content="Patched and validated", tokens=18),
             ),
-            turns=accepted_turns,
             rewards=(0.25, 1.0),
         ),
-        ExampleTrajectory(
-            header=Trajectory.from_turns(
-                "mission-42:cache:attempt-1",
-                list(rejected_turns),
-                run_id="mission-42",
-                task_id="cache",
-                trial_idx=1,
-                source="coding-agent",
-                terminal=True,
-                outcome="rejected",
+        ExampleEpisode(
+            episode_id="episode-cache-1",
+            turns=(
+                Turn(role="user", content="Fix the cache regression", tokens=6),
+                Turn(role="assistant", content="Validator still fails", tokens=14),
             ),
-            turns=rejected_turns,
             rewards=(-1.0,),
         ),
     )
 
 
 async def run_demo(storage_uri: str = "./archetype_data") -> dict[str, object]:
-    """Persist, select, and grade the synthetic trajectory evidence."""
+    """Persist, select, and grade the synthetic episode evidence."""
     async with ArchetypeRuntime() as runtime:
         world = runtime.world(
             "trajectory-analysis",
             storage=StorageConfig(uri=storage_uri, namespace="trajectory_example"),
         )
-        for authored in make_trajectories():
-            await world.spawn(authored.header)
+        for episode in make_episodes():
             await world.spawn_many(
                 [
                     [turn]
                     for turn in turns_to_components(
-                        authored.header.trajectory_id,
-                        list(authored.turns),
+                        episode.episode_id,
+                        list(episode.turns),
                     )
                 ]
             )
@@ -102,22 +82,20 @@ async def run_demo(storage_uri: str = "./archetype_data") -> dict[str, object]:
                 [
                     [
                         TrajectoryReward(
-                            trajectory_id=authored.header.trajectory_id,
+                            episode_id=episode.episode_id,
                             seq=seq,
                             reward=reward,
                         )
                     ]
-                    for seq, reward in enumerate(authored.rewards)
+                    for seq, reward in enumerate(episode.rewards)
                 ]
             )
         await world.run(steps=1)
 
-        rejected = await world.query_trajectory(
-            Trajectory,
-            selection=TrajectorySelection(task_ids=("cache",), trial_idxs=(1,)),
-        )
-        rejected_rows = rejected.collect().to_pylist()
-        trajectory_id = str(rejected_rows[0]["trajectory__trajectory_id"])
+        failed_episode_id = "episode-cache-1"
+        turns_frame = await world.query_trajectory(TrajectoryTurn)
+        ordered = trajectory(turns_frame, TrajectoryTurn, episode_id=failed_episode_id)
+        roles = [row["trajectoryturn__role"] for row in ordered.collect().to_pylist()]
 
         def reward_summary(frame: DataFrame) -> dict[str, object]:
             rows = frame.collect().to_pylist()
@@ -128,19 +106,19 @@ async def run_demo(storage_uri: str = "./archetype_data") -> dict[str, object]:
 
         outputs = await world.grade_trajectory(
             TrajectoryReward,
-            selection=TrajectorySelection(trajectory_ids=(trajectory_id,)),
+            selection=TrajectorySelection(episode_ids=(failed_episode_id,)),
             graders=[reward_summary],
         )
         return {
-            "trajectory_id": trajectory_id,
-            "outcome": rejected_rows[0]["trajectory__outcome"],
+            "episode_id": failed_episode_id,
+            "roles": roles,
             "grade": outputs[0],
         }
 
 
 async def main() -> None:
     result = await run_demo()
-    print(f"Selected: {result['trajectory_id']} ({result['outcome']})")
+    print(f"Selected: {result['episode_id']} (roles: {result['roles']})")
     print(f"Grade:    {result['grade']}")
 
 

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -622,7 +622,7 @@ profiles = ["pr", "main", "release"]
 [[contract]]
 id = "missions.trajectory.runtime_service"
 source = "docs/guide/trajectories.md"
-section = "Select one trajectory table"
+section = "Select one evidence table"
 owner = "missions"
 risk = "medium"
 pytest = [

--- a/src/archetype/app/missions/transcript_service.py
+++ b/src/archetype/app/missions/transcript_service.py
@@ -111,7 +111,7 @@ def _normalize_session(
     header_value = header.value
     models = header_value.get("models") or []
     common = {
-        "trajectory_id": session.trajectory.trajectory_id,
+        "episode_id": session.episode_id,
         "mission_id": session.mission_id,
         "project": str(header_value.get("project") or ""),
         "session_id": str(header_value.get("session_id") or ""),
@@ -122,9 +122,9 @@ def _normalize_session(
         "started_at": str(header_value.get("started_at") or ""),
         "ended_at": str(header_value.get("ended_at") or ""),
         "sidechain_turns_skipped": session.sidechain_turns_skipped,
-        "total_turns": session.trajectory.total_turns,
-        "total_tokens": session.trajectory.total_tokens,
-        "duration_seconds": session.trajectory.duration_seconds,
+        "total_turns": session.total_turns,
+        "total_tokens": session.total_tokens,
+        "duration_seconds": session.duration_seconds,
     }
     rows: list[dict[str, Any]] = [
         {
@@ -278,12 +278,6 @@ class TranscriptIngestionService:
                 row_receipts,
             )
             safe_project = str(normalized[0]["project"])
-            trajectory = session.trajectory.model_copy(
-                update={
-                    "task_id": safe_project,
-                    "model": str(normalized[0]["model"]),
-                }
-            )
             logical_path = f"claude/{safe_project}/{source.session_id}.jsonl"
             sanitized_digest = _file_digest(sanitized.path)
             (artifact,) = await artifact_handlers.ingest_artifacts(
@@ -319,7 +313,7 @@ class TranscriptIngestionService:
         return TranscriptIngestionResult(
             world_id=wid,
             run_id=run_id,
-            trajectory_id=trajectory.trajectory_id,
+            episode_id=session.episode_id,
             mission_id=source.mission_id,
             source_uri=source.source_uri,
             artifact=artifact,

--- a/src/archetype/episodes/contracts.py
+++ b/src/archetype/episodes/contracts.py
@@ -44,36 +44,22 @@ class ClaudeTranscriptSource:
         return f"claude-session://{quote(self.project, safe='')}/{quote(self.session_id, safe='')}"
 
     @property
-    def trajectory_id(self) -> str:
-        """Stable trajectory linkage for normalized rows and the lightweight index."""
+    def episode_id(self) -> str:
+        """Stable episode identity for normalized rows and the lightweight index."""
 
         return self.source_uri
 
 
 @dataclass(frozen=True)
 class TrajectorySelection:
-    """Typed filters applied to one trajectory component table."""
+    """Typed episode filter applied to one evidence component table."""
 
-    trajectory_ids: tuple[str, ...] = ()
     episode_ids: tuple[str, ...] = ()
-    rollout_ids: tuple[str, ...] = ()
-    task_ids: tuple[str, ...] = ()
-    trial_idxs: tuple[int, ...] = ()
 
-    def requested(self) -> dict[str, tuple[str, ...] | tuple[int, ...]]:
+    def requested(self) -> dict[str, tuple[str, ...]]:
         """Return only active field filters."""
 
-        return {
-            name: values
-            for name, values in (
-                ("trajectory_id", self.trajectory_ids),
-                ("episode_id", self.episode_ids),
-                ("rollout_id", self.rollout_ids),
-                ("task_id", self.task_ids),
-                ("trial_idx", self.trial_idxs),
-            )
-            if values
-        }
+        return {"episode_id": self.episode_ids} if self.episode_ids else {}
 
 
 @dataclass(frozen=True)
@@ -82,7 +68,7 @@ class TranscriptIngestionResult:
 
     world_id: str
     run_id: str
-    trajectory_id: str
+    episode_id: str
     mission_id: str
     source_uri: str
     artifact: ArtifactRef

--- a/src/archetype/missions/trajectories/__init__.py
+++ b/src/archetype/missions/trajectories/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Mission trajectory schemas, authoring contracts, and pure transforms."""
+"""Episode-evidence schemas, authoring contracts, and derived trajectory views."""
 
 from archetype.missions.trajectories.claude import (
     ClaudeTranscriptSource,
@@ -10,7 +10,6 @@ from archetype.missions.trajectories.claude import (
 )
 from archetype.missions.trajectories.components import (
     CLAUDE_TRANSCRIPT_TABLE,
-    Trajectory,
     TrajectoryAction,
     TrajectoryCommandEvent,
     TrajectoryObservation,
@@ -32,12 +31,11 @@ from archetype.missions.trajectories.transforms import (
     filter_trajectory_rows,
     observations_from_post_tick_events,
     reward_row,
-    trajectory_from_episode_result,
+    trajectory,
     turns_to_components,
 )
 
 __all__ = [
-    "Trajectory",
     "TrajectoryAction",
     "TrajectoryCommandEvent",
     "TrajectoryObservation",
@@ -58,7 +56,7 @@ __all__ = [
     "filter_trajectory_rows",
     "observations_from_post_tick_events",
     "reward_row",
-    "trajectory_from_episode_result",
+    "trajectory",
     "turns_to_components",
     "parse_claude_transcript",
 ]

--- a/src/archetype/missions/trajectories/claude.py
+++ b/src/archetype/missions/trajectories/claude.py
@@ -16,20 +16,16 @@ from datetime import datetime
 from typing import Any
 
 from archetype.episodes.contracts import ClaudeTranscriptSource
-from archetype.missions.trajectories.components import Trajectory
 from archetype.missions.trajectories.contracts import Turn
 
 _TRUNCATION_MARK = "…[truncated]"
-
-
-# PR-9 deletes this compatibility import after episode consumers repoint.
 
 
 @dataclass(frozen=True)
 class LoadedSession:
     """One parsed session held in memory until an artifact adapter publishes it."""
 
-    trajectory: Trajectory
+    episode_id: str
     turns: tuple[Turn, ...]
     source_uri: str
     mission_id: str = ""
@@ -42,6 +38,22 @@ class LoadedSession:
     started_at: str = ""
     ended_at: str = ""
     sidechain_turns_skipped: int = 0
+
+    @property
+    def model(self) -> str:
+        return self.models[0] if self.models else ""
+
+    @property
+    def total_turns(self) -> int:
+        return len(self.turns)
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(turn.tokens for turn in self.turns)
+
+    @property
+    def duration_seconds(self) -> float:
+        return sum(turn.duration_ms for turn in self.turns) / 1000.0
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -224,16 +236,8 @@ def parse_claude_transcript(
         return None
 
     ordered_models = tuple(sorted(models))
-    trajectory = Trajectory.from_turns(
-        source.trajectory_id,
-        turns,
-        source="claude-code",
-        model=ordered_models[0] if ordered_models else "",
-        task_id=source.project,
-        terminal=True,
-    )
     return LoadedSession(
-        trajectory=trajectory,
+        episode_id=source.episode_id,
         turns=tuple(turns),
         source_uri=source.source_uri,
         mission_id=source.mission_id,

--- a/src/archetype/missions/trajectories/components.py
+++ b/src/archetype/missions/trajectories/components.py
@@ -12,86 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Persistent trajectory schemas for mission and rollout evidence.
+"""Persistent episode-evidence schemas for mission and rollout evidence.
 
-Trajectory data is stored as normalized, Arrow-friendly component rows. The
-header row identifies the trajectory; turns, commands, observations, actions,
-and rewards are separate typed rows keyed by ``trajectory_id`` and ``seq``.
+Evidence is stored as normalized, Arrow-friendly component rows keyed by
+``episode_id`` and ``seq``. ``episode_id`` is the one persistent identity of a
+bounded execution; a trajectory is a derived DataFrame view over these rows
+(see :func:`archetype.missions.trajectories.transforms.trajectory`), never a
+second persistent identity.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from archetype.core.component import Component
-
-if TYPE_CHECKING:
-    from archetype.missions.trajectories.contracts import Turn
 
 CLAUDE_TRANSCRIPT_TABLE = "coding_agent_transcript_rows"
 
 
-class Trajectory(Component):
-    """One durable trajectory header row."""
-
-    trajectory_id: str = ""
-    run_id: str = ""
-    episode_id: str = ""
-    rollout_id: str = ""
-    task_id: str = ""
-    trial_idx: int = 0
-
-    source: str = ""
-    model: str = ""
-    policy_version: str = ""
-
-    terminal: bool = False
-    total_steps: int = 0
-    total_turns: int = 0
-    total_tokens: int = 0
-    duration_seconds: float = 0.0
-    outcome: str = ""
-
-    @classmethod
-    def from_turns(
-        cls,
-        trajectory_id: str,
-        turns: list[Turn],
-        *,
-        run_id: str = "",
-        episode_id: str = "",
-        rollout_id: str = "",
-        task_id: str = "",
-        trial_idx: int = 0,
-        source: str = "",
-        model: str = "",
-        policy_version: str = "",
-        terminal: bool = False,
-        outcome: str = "",
-    ) -> Trajectory:
-        return cls(
-            trajectory_id=trajectory_id,
-            run_id=run_id,
-            episode_id=episode_id,
-            rollout_id=rollout_id,
-            task_id=task_id,
-            trial_idx=trial_idx,
-            source=source,
-            model=model,
-            policy_version=policy_version,
-            terminal=terminal,
-            total_steps=0,
-            total_turns=len(turns),
-            total_tokens=sum(turn.tokens for turn in turns),
-            duration_seconds=sum(turn.duration_ms for turn in turns) / 1000.0,
-            outcome=outcome,
-        )
-
-
 class TrajectoryTurn(Component):
-    """One typed turn row belonging to a trajectory."""
+    """One typed conversational or tool-use turn row of episode evidence."""
 
-    trajectory_id: str = ""
+    episode_id: str = ""
     seq: int = 0
     role: str = ""
     content: str = ""
@@ -104,14 +44,13 @@ class TrajectoryTurn(Component):
 
 
 class TranscriptArtifactRef(Component):
-    """Lightweight link from a trajectory to redacted transcript artifacts.
+    """Lightweight link from episode evidence to redacted transcript artifacts.
 
-    Narrative content never belongs in this Component. Historical
-    ``TrajectoryTurn`` rows remain readable, while new transcript ingestion
+    Narrative content never belongs in this Component. Transcript ingestion
     writes normalized narrative rows only through the artifact table boundary.
     """
 
-    trajectory_id: str = ""
+    episode_id: str = ""
     mission_id: str = ""
     source_uri: str = ""
     source_content_hash: str = ""
@@ -123,9 +62,9 @@ class TranscriptArtifactRef(Component):
 
 
 class TrajectoryCommandEvent(Component):
-    """One typed command/audit event row belonging to a trajectory."""
+    """One typed command/audit event row of episode evidence."""
 
-    trajectory_id: str = ""
+    episode_id: str = ""
     seq: int = 0
     audit_id: str = ""
     command_id: str = ""
@@ -141,9 +80,9 @@ class TrajectoryCommandEvent(Component):
 
 
 class TrajectoryObservation(Component):
-    """One typed observation/event row belonging to a trajectory."""
+    """One typed observation/event row of episode evidence."""
 
-    trajectory_id: str = ""
+    episode_id: str = ""
     seq: int = 0
     world_id: str = ""
     tick: int = 0
@@ -153,17 +92,17 @@ class TrajectoryObservation(Component):
 
 
 class TrajectoryAction(Component):
-    """One typed action row belonging to a trajectory."""
+    """One typed action row of episode evidence."""
 
-    trajectory_id: str = ""
+    episode_id: str = ""
     seq: int = 0
     tick: int = 0
     action_type: str = ""
 
 
 class TrajectoryReward(Component):
-    """One typed reward row belonging to a trajectory."""
+    """One typed reward row of episode evidence."""
 
-    trajectory_id: str = ""
+    episode_id: str = ""
     seq: int = 0
     reward: float = 0.0

--- a/src/archetype/missions/trajectories/contracts.py
+++ b/src/archetype/missions/trajectories/contracts.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Non-persistent authoring and structural input contracts for trajectories."""
+"""Non-persistent authoring and structural input contracts for episode evidence."""
 
 from __future__ import annotations
 
@@ -67,12 +67,12 @@ class Turn:
             metadata=dict(data.get("metadata") or {}),
         )
 
-    def to_component(self, trajectory_id: str, seq: int) -> TrajectoryTurn:
-        """Materialize the historical typed turn row without storing metadata."""
+    def to_component(self, episode_id: str, seq: int) -> TrajectoryTurn:
+        """Materialize the typed turn row without storing metadata."""
         from archetype.missions.trajectories.components import TrajectoryTurn
 
         return TrajectoryTurn(
-            trajectory_id=trajectory_id,
+            episode_id=episode_id,
             seq=seq,
             role=self.role,
             content=self.content,
@@ -86,22 +86,10 @@ class Turn:
 
 
 class CommandRecord(Protocol):
-    """Structural command fields required by trajectory transforms."""
+    """Structural command fields required by evidence transforms."""
 
     id: object
     tick: int
     type: object
     priority: int
     version: int
-
-
-class EpisodeRecord(Protocol):
-    """Structural episode fields required by trajectory transforms."""
-
-    episode_id: object
-    terminated: bool
-    duration_steps: int
-
-
-# PR-9 deletes these identity-preserving compatibility imports after episode
-# consumers repoint.  The persistent trajectory Components are unchanged.

--- a/src/archetype/missions/trajectories/transforms.py
+++ b/src/archetype/missions/trajectories/transforms.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pure structural transforms into typed trajectory rows and filtered frames."""
+"""Pure structural transforms into typed evidence rows and derived views."""
 
 from __future__ import annotations
 
@@ -23,7 +23,6 @@ from daft import DataFrame, col
 
 from archetype.core.component import Component
 from archetype.missions.trajectories.components import (
-    Trajectory,
     TrajectoryAction,
     TrajectoryCommandEvent,
     TrajectoryObservation,
@@ -32,26 +31,25 @@ from archetype.missions.trajectories.components import (
 )
 from archetype.missions.trajectories.contracts import (
     CommandRecord,
-    EpisodeRecord,
     TrajectorySelection,
     Turn,
 )
 
 
-def turns_to_components(trajectory_id: str, turns: list[Turn]) -> list[TrajectoryTurn]:
+def turns_to_components(episode_id: str, turns: list[Turn]) -> list[TrajectoryTurn]:
     """Materialize typed rows for an authored turn sequence."""
-    return [turn.to_component(trajectory_id, seq) for seq, turn in enumerate(turns)]
+    return [turn.to_component(episode_id, seq) for seq, turn in enumerate(turns)]
 
 
 def command_to_event(
     command: CommandRecord,
     *,
-    trajectory_id: str,
+    episode_id: str,
     seq: int,
 ) -> TrajectoryCommandEvent:
-    """Serialize a queued command into a typed trajectory event."""
+    """Serialize a queued command into a typed evidence event."""
     return TrajectoryCommandEvent(
-        trajectory_id=trajectory_id,
+        episode_id=episode_id,
         seq=seq,
         command_id=str(command.id),
         tick=command.tick,
@@ -64,12 +62,12 @@ def command_to_event(
 def audit_row_to_event(
     row: Mapping[str, Any],
     *,
-    trajectory_id: str,
+    episode_id: str,
     seq: int,
 ) -> TrajectoryCommandEvent:
-    """Serialize an audit row dict into a typed trajectory event."""
+    """Serialize an audit row dict into a typed evidence event."""
     return TrajectoryCommandEvent(
-        trajectory_id=trajectory_id,
+        episode_id=episode_id,
         seq=seq,
         audit_id=str(row.get("audit_id") or ""),
         command_id=str(row.get("command_id") or ""),
@@ -85,10 +83,10 @@ def audit_row_to_event(
 def commands_to_events(
     commands: Iterable[CommandRecord],
     *,
-    trajectory_id: str,
+    episode_id: str,
 ) -> list[TrajectoryCommandEvent]:
     return [
-        command_to_event(command, trajectory_id=trajectory_id, seq=seq)
+        command_to_event(command, episode_id=episode_id, seq=seq)
         for seq, command in enumerate(commands)
     ]
 
@@ -96,50 +94,19 @@ def commands_to_events(
 def audit_rows_to_events(
     rows: Iterable[Mapping[str, Any]],
     *,
-    trajectory_id: str,
+    episode_id: str,
 ) -> list[TrajectoryCommandEvent]:
-    return [
-        audit_row_to_event(row, trajectory_id=trajectory_id, seq=seq)
-        for seq, row in enumerate(rows)
-    ]
-
-
-def trajectory_from_episode_result(
-    episode: EpisodeRecord,
-    *,
-    rollout_id: str = "",
-    run_id: str = "",
-    task_id: str = "",
-    trial_idx: int = 0,
-    source: str = "archetype.rollout",
-) -> Trajectory:
-    """Build a durable trajectory header row from one episode result."""
-    trajectory_id = (
-        f"{rollout_id}:trial-{trial_idx}:{episode.episode_id}"
-        if rollout_id
-        else str(episode.episode_id)
-    )
-    return Trajectory(
-        trajectory_id=trajectory_id,
-        run_id=run_id,
-        episode_id=str(episode.episode_id),
-        rollout_id=rollout_id,
-        task_id=task_id,
-        trial_idx=trial_idx,
-        source=source,
-        terminal=episode.terminated,
-        total_steps=episode.duration_steps,
-    )
+    return [audit_row_to_event(row, episode_id=episode_id, seq=seq) for seq, row in enumerate(rows)]
 
 
 def observations_from_post_tick_events(
     events: Iterable[Mapping[str, Any]],
     *,
-    trajectory_id: str,
+    episode_id: str,
 ) -> list[TrajectoryObservation]:
     return [
         TrajectoryObservation(
-            trajectory_id=trajectory_id,
+            episode_id=episode_id,
             seq=seq,
             world_id=str(event.get("world_id") or ""),
             tick=int(event.get("tick") or 0),
@@ -158,7 +125,7 @@ def actions_from_observations(
 ) -> list[TrajectoryAction]:
     return [
         TrajectoryAction(
-            trajectory_id=observation.trajectory_id,
+            episode_id=observation.episode_id,
             seq=seq,
             tick=observation.tick,
             action_type=action_type,
@@ -169,11 +136,11 @@ def actions_from_observations(
 
 def reward_row(
     *,
-    trajectory_id: str,
+    episode_id: str,
     reward: float,
     seq: int = 0,
 ) -> TrajectoryReward:
-    return TrajectoryReward(trajectory_id=trajectory_id, seq=seq, reward=reward)
+    return TrajectoryReward(episode_id=episode_id, seq=seq, reward=reward)
 
 
 def filter_trajectory_rows(
@@ -181,16 +148,37 @@ def filter_trajectory_rows(
     component: type[Component],
     selection: TrajectorySelection,
 ) -> DataFrame:
-    """Lazily filter one typed trajectory table by fields it actually stores."""
+    """Lazily filter one typed evidence table by fields it actually stores."""
     requested = selection.requested()
     unsupported = sorted(set(requested) - set(component.model_fields))
     if unsupported:
         names = ", ".join(unsupported)
         raise ValueError(
             f"{component.__name__} does not store requested trajectory filter field(s): "
-            f"{names}; filter the Trajectory header or use fields stored on this component"
+            f"{names}; use fields stored on this component"
         )
     prefix = component.get_prefix()
     for field_name, values in requested.items():
         df = df.where(col(f"{prefix}{field_name}").is_in(list(values)))
     return df
+
+
+def trajectory(
+    df: DataFrame,
+    component: type[Component],
+    *,
+    episode_id: str,
+) -> DataFrame:
+    """Derive one episode's ordered evidence view as a lazy DataFrame.
+
+    A trajectory has no persistent identity: it is this seq-ordered selection
+    of one episode's persisted evidence rows.
+    """
+    missing = sorted({"episode_id", "seq"} - set(component.model_fields))
+    if missing:
+        names = ", ".join(missing)
+        raise ValueError(
+            f"{component.__name__} is not seq-ordered episode evidence; missing field(s): {names}"
+        )
+    prefix = component.get_prefix()
+    return df.where(col(f"{prefix}episode_id").is_in([episode_id])).sort(col(f"{prefix}seq"))

--- a/tests/app/test_trajectory_service.py
+++ b/tests/app/test_trajectory_service.py
@@ -11,7 +11,12 @@ from daft import DataFrame
 from archetype import ArchetypeRuntime
 from archetype.core.config import RunConfig, StorageConfig, WorldConfig
 from archetype.episodes.models import GradeTrajectory, QueryTrajectory
-from archetype.missions.trajectories import Trajectory, TrajectoryReward, TrajectorySelection
+from archetype.missions.trajectories import (
+    TrajectoryReward,
+    TrajectorySelection,
+    TrajectoryTurn,
+    trajectory,
+)
 from archetype.world.models import CreateWorld, Run, Spawn
 from evals.graders import exact_match, state_check
 from evals.types import GraderResult
@@ -23,7 +28,7 @@ def _rows(frame: DataFrame) -> list[dict]:
 
 
 @pytest.mark.asyncio
-async def test_service_filters_one_persisted_trajectory_table(tmp_path) -> None:
+async def test_service_filters_one_persisted_evidence_table(tmp_path) -> None:
     resources = build_test_runtime(tmp_path)
     dispatcher = resources.dispatcher
     try:
@@ -34,53 +39,31 @@ async def test_service_filters_one_persisted_trajectory_table(tmp_path) -> None:
                 storage_config=storage,
             )
         )
-        await dispatcher.apply(
-            Spawn.from_components(
-                world_id=world.world_id,
-                components=[
-                    Trajectory(
-                        trajectory_id="traj-a",
-                        run_id="run-a",
-                        episode_id="episode-a",
-                        task_id="reach",
-                        trial_idx=0,
-                        terminal=True,
-                        outcome="success",
-                    ),
-                ],
+        for turn in (
+            TrajectoryTurn(episode_id="episode-a", seq=0, role="user", content="reach"),
+            TrajectoryTurn(episode_id="episode-b", seq=0, role="user", content="retry"),
+        ):
+            await dispatcher.apply(
+                Spawn.from_components(
+                    world_id=world.world_id,
+                    components=[turn],
+                )
             )
-        )
-        await dispatcher.apply(
-            Spawn.from_components(
-                world_id=world.world_id,
-                components=[
-                    Trajectory(
-                        trajectory_id="traj-b",
-                        run_id="run-a",
-                        episode_id="episode-b",
-                        task_id="reach",
-                        trial_idx=1,
-                        terminal=True,
-                        outcome="failure",
-                    ),
-                ],
-            )
-        )
 
         run = await dispatcher.apply(
             Run(world_id=world.world_id, run_config=RunConfig(num_steps=1))
         )
         frame = await dispatcher.apply(
             QueryTrajectory(
-                component=Trajectory,
+                component=TrajectoryTurn,
                 world_id=world.world_id,
                 run_id=run.run_id,
-                selection=TrajectorySelection(task_ids=("reach",), trial_idxs=(1,)),
+                selection=TrajectorySelection(episode_ids=("episode-b",)),
                 storage_config=storage,
             )
         )
 
-        assert [row["trajectory__trajectory_id"] for row in _rows(frame)] == ["traj-b"]
+        assert [row["trajectoryturn__episode_id"] for row in _rows(frame)] == ["episode-b"]
     finally:
         await resources.aclose()
 
@@ -98,9 +81,9 @@ async def test_service_composes_query_with_evaluation_graders(tmp_path) -> None:
             )
         )
         for reward in (
-            TrajectoryReward(trajectory_id="traj-a", seq=0, reward=0.25),
-            TrajectoryReward(trajectory_id="traj-a", seq=1, reward=1.0),
-            TrajectoryReward(trajectory_id="traj-b", seq=0, reward=-1.0),
+            TrajectoryReward(episode_id="episode-a", seq=0, reward=0.25),
+            TrajectoryReward(episode_id="episode-a", seq=1, reward=1.0),
+            TrajectoryReward(episode_id="episode-b", seq=0, reward=-1.0),
         ):
             await dispatcher.apply(
                 Spawn.from_components(
@@ -125,7 +108,7 @@ async def test_service_composes_query_with_evaluation_graders(tmp_path) -> None:
                 component=TrajectoryReward,
                 world_id=world.world_id,
                 run_id=run.run_id,
-                selection=TrajectorySelection(trajectory_ids=("traj-a",)),
+                selection=TrajectorySelection(episode_ids=("episode-a",)),
                 graders=(grade_total_reward,),
                 storage_config=storage,
             )
@@ -133,20 +116,6 @@ async def test_service_composes_query_with_evaluation_graders(tmp_path) -> None:
 
         assert [result.passed for result in results] == [True, True]
         assert [result.grader_name for result in results] == ["sample_count", "total_reward"]
-
-        with pytest.raises(
-            ValueError,
-            match=r"TrajectoryReward does not store requested trajectory filter field\(s\): task_id",
-        ):
-            await dispatcher.apply(
-                QueryTrajectory(
-                    component=TrajectoryReward,
-                    world_id=world.world_id,
-                    run_id=run.run_id,
-                    selection=TrajectorySelection(task_ids=("reach",)),
-                    storage_config=storage,
-                )
-            )
     finally:
         await resources.aclose()
 
@@ -156,11 +125,11 @@ async def test_runtime_world_exposes_trajectory_query_and_grading(tmp_path) -> N
     storage = StorageConfig(uri=str(tmp_path / "store"), namespace="runtime_trajectory")
     async with ArchetypeRuntime() as runtime:
         world = runtime.world("runtime-trajectory", storage=storage)
-        await world.spawn(TrajectoryReward(trajectory_id="traj-a", seq=0, reward=0.25))
-        await world.spawn(TrajectoryReward(trajectory_id="traj-a", seq=1, reward=1.0))
-        await world.spawn(TrajectoryReward(trajectory_id="traj-b", seq=0, reward=-1.0))
+        await world.spawn(TrajectoryReward(episode_id="episode-a", seq=0, reward=0.25))
+        await world.spawn(TrajectoryReward(episode_id="episode-a", seq=1, reward=1.0))
+        await world.spawn(TrajectoryReward(episode_id="episode-b", seq=0, reward=-1.0))
         await world.run(steps=1)
-        selection = TrajectorySelection(trajectory_ids=("traj-a",))
+        selection = TrajectorySelection(episode_ids=("episode-a",))
 
         frame = await world.query_trajectory(TrajectoryReward, selection=selection)
 
@@ -183,16 +152,35 @@ async def test_runtime_world_exposes_trajectory_query_and_grading(tmp_path) -> N
         assert results[0].passed is True
 
 
+@pytest.mark.asyncio
+async def test_derived_trajectory_view_orders_persisted_evidence(tmp_path) -> None:
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="derived_view")
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("derived-view", storage=storage)
+        # Spawn out of seq order; the derived view must restore evidence order.
+        await world.spawn(TrajectoryTurn(episode_id="episode-a", seq=1, role="assistant"))
+        await world.spawn(TrajectoryTurn(episode_id="episode-a", seq=0, role="user"))
+        await world.spawn(TrajectoryTurn(episode_id="episode-b", seq=0, role="user"))
+        await world.run(steps=1)
+
+        frame = await world.query_trajectory(TrajectoryTurn)
+        view = trajectory(frame, TrajectoryTurn, episode_id="episode-a")
+        rows = _rows(view)
+
+        assert [row["trajectoryturn__seq"] for row in rows] == [0, 1]
+        assert [row["trajectoryturn__role"] for row in rows] == ["user", "assistant"]
+
+
 def test_sync_runtime_world_mirrors_trajectory_query(tmp_path) -> None:
     storage = StorageConfig(uri=str(tmp_path / "store"), namespace="sync_trajectory")
     with ArchetypeRuntime.sync() as runtime:
         world = runtime.world("sync-trajectory", storage=storage)
-        world.spawn(TrajectoryReward(trajectory_id="traj-a", seq=0, reward=2.0))
+        world.spawn(TrajectoryReward(episode_id="episode-a", seq=0, reward=2.0))
         world.run(steps=1)
 
         frame = world.query_trajectory(
             TrajectoryReward,
-            selection=TrajectorySelection(trajectory_ids=("traj-a",)),
+            selection=TrajectorySelection(episode_ids=("episode-a",)),
         )
 
         assert _rows(frame)[0]["trajectoryreward__reward"] == 2.0

--- a/tests/app/test_transcript_ingestion.py
+++ b/tests/app/test_transcript_ingestion.py
@@ -268,7 +268,7 @@ async def test_transcript_persists_sanitized_artifact_and_normalized_rows(
 
         assert [row["row_kind"] for row in rows] == ["session", "turn", "turn"]
         assert [row["seq"] for row in rows] == [-1, 0, 1]
-        assert {row["trajectory_id"] for row in rows} == {source.source_uri}
+        assert {row["episode_id"] for row in rows} == {source.source_uri}
         assert {row["mission_id"] for row in rows} == {"mission-7"}
         assert {row["project"] for row in rows} == {"project-a"}
         assert {row["session_id"] for row in rows} == {"session-1"}

--- a/tests/integration/test_domain_example_receipts.py
+++ b/tests/integration/test_domain_example_receipts.py
@@ -52,8 +52,8 @@ async def test_trajectory_receipt_is_semantic_and_stable(tmp_path: Path) -> None
     )
 
     assert result == {
-        "trajectory_id": "mission-42:cache:attempt-1",
-        "outcome": "rejected",
+        "episode_id": "episode-cache-1",
+        "roles": ["user", "assistant"],
         "grade": {"samples": 1, "total_reward": -1.0},
     }
 

--- a/tests/integration/test_runtime_loopback_operational.py
+++ b/tests/integration/test_runtime_loopback_operational.py
@@ -272,7 +272,7 @@ async def test_trusted_runtime_reaches_all_fourteen_models_and_reserved_spawn(
             max_steps=1,
             storage=storage,
         )
-        selection = TrajectorySelection(task_ids=("task-1",))
+        selection = TrajectorySelection(episode_ids=("episode-1",))
         env_client = object()
         policy_client = object()
 

--- a/tests/integration/test_trajectory_analysis.py
+++ b/tests/integration/test_trajectory_analysis.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Executable contract for the normalized trajectory example."""
+"""Executable contract for the normalized episode-evidence example."""
 
 from __future__ import annotations
 
@@ -9,9 +9,14 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import daft
 import pytest
+from daft import col
 
-from archetype.missions.trajectories import Trajectory
+from archetype import ArchetypeRuntime
+from archetype.core.config import StorageConfig
+from archetype.missions.trajectories import TrajectoryTurn, turns_to_components
+from archetype.physical_ai.hosted_episode import hosted_episode_id
 
 _EXAMPLE = Path(__file__).resolve().parents[2] / "examples" / "06_trajectory_analysis.py"
 _SPEC = importlib.util.spec_from_file_location("trajectory_example", _EXAMPLE)
@@ -21,14 +26,14 @@ sys.modules[_SPEC.name] = trajectory_example
 _SPEC.loader.exec_module(trajectory_example)
 
 
-def test_example_authors_normalized_trajectory_headers() -> None:
-    authored = trajectory_example.make_trajectories()
+def test_example_authors_normalized_episode_evidence() -> None:
+    authored = trajectory_example.make_episodes()
 
     assert len(authored) == 2
-    assert all(isinstance(item.header, Trajectory) for item in authored)
-    assert [item.header.outcome for item in authored] == ["accepted", "rejected"]
-    assert [item.header.total_turns for item in authored] == [2, 2]
-    assert all(not hasattr(item.header, "turns_json") for item in authored)
+    assert [item.episode_id for item in authored] == ["episode-auth-1", "episode-cache-1"]
+    rows = turns_to_components(authored[0].episode_id, list(authored[0].turns))
+    assert all(isinstance(row, TrajectoryTurn) for row in rows)
+    assert {row.episode_id for row in rows} == {"episode-auth-1"}
 
 
 @pytest.mark.asyncio
@@ -36,7 +41,40 @@ async def test_example_runs_through_runtime_trajectory_service(tmp_path) -> None
     result = await trajectory_example.run_demo(str(tmp_path / "store"))
 
     assert result == {
-        "trajectory_id": "mission-42:cache:attempt-1",
-        "outcome": "rejected",
+        "episode_id": "episode-cache-1",
+        "roles": ["user", "assistant"],
         "grade": {"samples": 1, "total_reward": -1.0},
     }
+
+
+@pytest.mark.asyncio
+async def test_fresh_world_mission_and_hosted_evidence_join_on_episode_id(tmp_path) -> None:
+    """Mission evidence and hosted Physical-AI evidence share one persistent key."""
+    episode_id = hosted_episode_id("op-join-1", 0)
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="episode_join")
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("episode-join", storage=storage)
+        await world.spawn(TrajectoryTurn(episode_id=episode_id, seq=0, role="user", content="pick"))
+        await world.run(steps=1)
+        mission_frame = await world.query_trajectory(TrajectoryTurn)
+
+        hosted_frame = daft.from_pylist(
+            [
+                {
+                    "episode_id": episode_id,
+                    "operation_id": "op-join-1",
+                    "trial_id": 0,
+                    "terminal_reason": "success",
+                }
+            ]
+        )
+        joined = mission_frame.join(
+            hosted_frame,
+            left_on=col("trajectoryturn__episode_id"),
+            right_on=col("episode_id"),
+        )
+        rows = joined.collect().to_pylist()
+
+    assert len(rows) == 1
+    assert rows[0]["trajectoryturn__episode_id"] == episode_id
+    assert rows[0]["terminal_reason"] == "success"

--- a/tests/missions/trajectories/test_claude_parser.py
+++ b/tests/missions/trajectories/test_claude_parser.py
@@ -51,7 +51,7 @@ def _parse(lines: list[str], source: ClaudeTranscriptSource | None = None):
     return parse_claude_transcript("\n".join(lines), source or _source())
 
 
-def test_session_parses_to_in_memory_trajectory_and_turns() -> None:
+def test_session_parses_to_in_memory_episode_evidence_turns() -> None:
     loaded = _parse(
         [
             json.dumps({"type": "queue-operation", "operation": "enqueue"}),
@@ -100,10 +100,8 @@ def test_session_parses_to_in_memory_trajectory_and_turns() -> None:
 
     assert loaded is not None
     assert loaded.source_uri == "claude-session://proj-a/abc123"
-    assert loaded.trajectory.trajectory_id == loaded.source_uri
-    assert loaded.trajectory.source == "claude-code"
-    assert loaded.trajectory.model == "claude-fable-5"
-    assert loaded.trajectory.task_id == "proj-a"
+    assert loaded.episode_id == loaded.source_uri
+    assert loaded.model == "claude-fable-5"
     assert loaded.project == "proj-a"
     assert loaded.session_id == "abc123"
     assert loaded.git_branch == "main"
@@ -124,8 +122,8 @@ def test_session_parses_to_in_memory_trajectory_and_turns() -> None:
     assert loaded.turns[3].error == ""
     assert loaded.turns[4].error == "tool_error"
     assert loaded.turns[1].duration_ms == 5000.0
-    assert loaded.trajectory.total_turns == 5
-    assert loaded.trajectory.total_tokens == 42
+    assert loaded.total_turns == 5
+    assert loaded.total_tokens == 42
 
 
 def test_parser_cannot_materialize_new_component_rows() -> None:
@@ -134,11 +132,12 @@ def test_parser_cannot_materialize_new_component_rows() -> None:
     assert loaded is not None
     assert not hasattr(loaded, "components")
 
-    # Historical TrajectoryTurn rows remain a readable authoring contract;
-    # transcript ingestion simply stops writing new ones.
-    historical = loaded.turns[0].to_component(loaded.trajectory.trajectory_id, 0)
-    assert isinstance(historical, TrajectoryTurn)
-    assert historical.content == "hello"
+    # TrajectoryTurn rows remain a deliberate authoring contract;
+    # transcript ingestion does not write them.
+    authored = loaded.turns[0].to_component(loaded.episode_id, 0)
+    assert isinstance(authored, TrajectoryTurn)
+    assert authored.episode_id == loaded.episode_id
+    assert authored.content == "hello"
 
 
 def test_sidechain_and_meta_lines_are_skipped() -> None:
@@ -187,7 +186,7 @@ def test_noise_only_input_returns_none_without_touching_the_source_path() -> Non
 def test_source_identity_is_canonical_and_validated() -> None:
     source = _source(project="repo/name", session_id="session one")
     assert source.source_uri == "claude-session://repo%2Fname/session%20one"
-    assert source.trajectory_id == source.source_uri
+    assert source.episode_id == source.source_uri
 
     with pytest.raises(ValueError, match=".jsonl suffix"):
         ClaudeTranscriptSource(path=Path("proj/session.txt"))

--- a/tests/missions/trajectories/test_domain.py
+++ b/tests/missions/trajectories/test_domain.py
@@ -1,31 +1,33 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for typed mission trajectory schemas and pure transforms."""
+"""Tests for typed episode-evidence schemas, transforms, and derived views."""
 
 from types import SimpleNamespace
 
+import daft
 import pyarrow as pa
+import pytest
 from uuid_utils import uuid7
 
 from archetype.core.component import Component
 from archetype.missions.trajectories import (
-    Trajectory,
     TrajectoryAction,
     TrajectoryCommandEvent,
     TrajectoryObservation,
     TrajectoryReward,
+    TrajectorySelection,
     TrajectoryTurn,
     Turn,
     actions_from_observations,
     audit_rows_to_events,
     commands_to_events,
+    filter_trajectory_rows,
     observations_from_post_tick_events,
     reward_row,
-    trajectory_from_episode_result,
+    trajectory,
     turns_to_components,
 )
-from archetype.world.models import EpisodeResult
 
 
 def test_turn_authoring_helper_round_trips_optional_fields() -> None:
@@ -46,28 +48,9 @@ def test_turn_authoring_helper_round_trips_optional_fields() -> None:
     assert restored.metadata == {"phase": "inspect"}
 
 
-def test_trajectory_from_turns_is_header_only() -> None:
-    trajectory = Trajectory.from_turns(
-        "traj-1",
-        [
-            Turn(role="user", content="go", tokens=2, duration_ms=10),
-            Turn(role="assistant", content="done", tokens=3, duration_ms=20),
-        ],
-        source="unit",
-        outcome="success",
-    )
-
-    assert issubclass(Trajectory, Component)
-    assert trajectory.trajectory_id == "traj-1"
-    assert trajectory.total_turns == 2
-    assert trajectory.total_tokens == 5
-    assert trajectory.duration_seconds == 0.03
-    assert trajectory.outcome == "success"
-
-
 def test_turns_materialize_as_typed_rows() -> None:
     rows = turns_to_components(
-        "traj-1",
+        "episode-1",
         [
             Turn(role="user", content="go", tokens=2),
             Turn(role="assistant", content="done", tokens=3, duration_ms=25),
@@ -75,9 +58,9 @@ def test_turns_materialize_as_typed_rows() -> None:
     )
 
     assert rows == [
-        TrajectoryTurn(trajectory_id="traj-1", seq=0, role="user", content="go", tokens=2),
+        TrajectoryTurn(episode_id="episode-1", seq=0, role="user", content="go", tokens=2),
         TrajectoryTurn(
-            trajectory_id="traj-1",
+            episode_id="episode-1",
             seq=1,
             role="assistant",
             content="done",
@@ -87,9 +70,8 @@ def test_turns_materialize_as_typed_rows() -> None:
     ]
 
 
-def test_typed_trajectory_schemas_are_arrow_materializable() -> None:
+def test_typed_evidence_schemas_are_arrow_materializable() -> None:
     for component in (
-        Trajectory,
         TrajectoryTurn,
         TrajectoryCommandEvent,
         TrajectoryObservation,
@@ -98,35 +80,9 @@ def test_typed_trajectory_schemas_are_arrow_materializable() -> None:
     ):
         schema = component.to_pyarrow_schema()
         assert isinstance(schema, pa.Schema)
-        assert "trajectory_id" in schema.names
+        assert "episode_id" in schema.names
+        assert "trajectory_id" not in schema.names
         assert not any(name.endswith("_json") for name in schema.names)
-
-
-def test_trajectory_from_episode_result_records_header_fields() -> None:
-    episode = EpisodeResult(
-        episode_id="episode-1",
-        world_id="world-1",
-        run_id="run-1",
-        final_tick=3,
-        terminated=True,
-        duration_steps=3,
-    )
-
-    trajectory = trajectory_from_episode_result(
-        episode,
-        rollout_id="rollout-1",
-        run_id="run-1",
-        task_id="task-1",
-        trial_idx=7,
-    )
-
-    assert trajectory.trajectory_id == "rollout-1:trial-7:episode-1"
-    assert trajectory.episode_id == "episode-1"
-    assert trajectory.rollout_id == "rollout-1"
-    assert trajectory.task_id == "task-1"
-    assert trajectory.trial_idx == 7
-    assert trajectory.terminal is True
-    assert trajectory.total_steps == 3
 
 
 def test_commands_and_audit_rows_materialize_as_typed_events() -> None:
@@ -137,7 +93,7 @@ def test_commands_and_audit_rows_materialize_as_typed_events() -> None:
         priority=5,
         version=3,
     )
-    command_events = commands_to_events([command], trajectory_id="traj-1")
+    command_events = commands_to_events([command], episode_id="episode-1")
     audit_events = audit_rows_to_events(
         [
             {
@@ -149,12 +105,12 @@ def test_commands_and_audit_rows_materialize_as_typed_events() -> None:
                 "status": "applied",
             }
         ],
-        trajectory_id="traj-1",
+        episode_id="episode-1",
     )
 
     assert command_events == [
         TrajectoryCommandEvent(
-            trajectory_id="traj-1",
+            episode_id="episode-1",
             seq=0,
             command_id=str(command.id),
             command_type="spawn",
@@ -165,7 +121,7 @@ def test_commands_and_audit_rows_materialize_as_typed_events() -> None:
     ]
     assert audit_events == [
         TrajectoryCommandEvent(
-            trajectory_id="traj-1",
+            episode_id="episode-1",
             seq=0,
             audit_id="audit-1",
             command_id="cmd-1",
@@ -188,14 +144,14 @@ def test_observations_actions_and_rewards_are_typed_rows() -> None:
                 "entity_count": 5,
             }
         ],
-        trajectory_id="traj-1",
+        episode_id="episode-1",
     )
     actions = actions_from_observations(observations)
-    reward = reward_row(trajectory_id="traj-1", reward=1.0)
+    reward = reward_row(episode_id="episode-1", reward=1.0)
 
     assert observations == [
         TrajectoryObservation(
-            trajectory_id="traj-1",
+            episode_id="episode-1",
             seq=0,
             world_id="world-1",
             tick=1,
@@ -204,5 +160,65 @@ def test_observations_actions_and_rewards_are_typed_rows() -> None:
             entity_count=5,
         )
     ]
-    assert actions == [TrajectoryAction(trajectory_id="traj-1", seq=0, tick=1, action_type="step")]
-    assert reward == TrajectoryReward(trajectory_id="traj-1", seq=0, reward=1.0)
+    assert actions == [TrajectoryAction(episode_id="episode-1", seq=0, tick=1, action_type="step")]
+    assert reward == TrajectoryReward(episode_id="episode-1", seq=0, reward=1.0)
+
+
+def test_selection_filters_by_stored_fields_only() -> None:
+    frame = daft.from_pylist(
+        [
+            {"trajectoryreward__episode_id": "episode-1", "trajectoryreward__reward": 1.0},
+            {"trajectoryreward__episode_id": "episode-2", "trajectoryreward__reward": -1.0},
+        ]
+    )
+
+    selected = filter_trajectory_rows(
+        frame,
+        TrajectoryReward,
+        TrajectorySelection(episode_ids=("episode-2",)),
+    )
+    assert [row["trajectoryreward__reward"] for row in selected.collect().to_pylist()] == [-1.0]
+
+    class _NoEpisode(Component):
+        value: int = 0
+
+    with pytest.raises(
+        ValueError,
+        match=r"_NoEpisode does not store requested trajectory filter field\(s\): episode_id",
+    ):
+        filter_trajectory_rows(
+            daft.from_pylist([{"_noepisode__value": 1}]),
+            _NoEpisode,
+            TrajectorySelection(episode_ids=("episode-1",)),
+        )
+
+
+def test_derived_trajectory_view_reconstructs_ordered_evidence() -> None:
+    rows = turns_to_components(
+        "episode-1",
+        [
+            Turn(role="user", content="go"),
+            Turn(role="assistant", content="working"),
+            Turn(role="assistant", content="done"),
+        ],
+    ) + turns_to_components("episode-2", [Turn(role="user", content="other")])
+    shuffled = [rows[3], rows[2], rows[0], rows[1]]
+    prefix = TrajectoryTurn.get_prefix()
+    frame = daft.from_pylist(
+        [{f"{prefix}{name}": value for name, value in row.model_dump().items()} for row in shuffled]
+    )
+
+    view = trajectory(frame, TrajectoryTurn, episode_id="episode-1")
+    ordered = view.collect().to_pylist()
+
+    assert [row[f"{prefix}seq"] for row in ordered] == [0, 1, 2]
+    assert [row[f"{prefix}content"] for row in ordered] == ["go", "working", "done"]
+    assert {row[f"{prefix}episode_id"] for row in ordered} == {"episode-1"}
+
+
+def test_derived_trajectory_view_rejects_unordered_components() -> None:
+    class _Unordered(Component):
+        episode_id: str = ""
+
+    with pytest.raises(ValueError, match="missing field\\(s\\): seq"):
+        trajectory(daft.from_pylist([{"_unordered__episode_id": "e"}]), _Unordered, episode_id="e")

--- a/tests/research/test_components.py
+++ b/tests/research/test_components.py
@@ -48,7 +48,7 @@ class TestExperimentComponent:
         assert issubclass(Experiment, Component)
 
     def test_default_construction(self):
-        # Components follow the Trajectory convention: all fields have
+        # Components follow the evidence-schema convention: all fields have
         # defaults so partial rows from storage deserialize cleanly.
         exp = Experiment()
         assert exp.name == ""

--- a/tests/runtime/test_runtime_dispatch_contracts.py
+++ b/tests/runtime/test_runtime_dispatch_contracts.py
@@ -546,7 +546,7 @@ async def test_pull_forward_runtime_methods_reach_exact_nondurable_specs(
         grader_id="runtime-dispatch",
         implementation_version="1",
     )
-    selection = TrajectorySelection(task_ids=("task-1",))
+    selection = TrajectorySelection(episode_ids=("episode-1",))
     research_config = AutoResearchConfig(
         experiment_name="runtime-dispatch",
         experiment_id="runtime-dispatch-1",


### PR DESCRIPTION
A8.1 of the A8 stack (#704): the canonical episode contract, executed as ruled 2026-07-26. `episode_id` is the one persistent identity for a bounded Mission or hosted Physical-AI execution; a trajectory is a derived DataFrame view and has no persistent identity.

## Contract change (one per PR)

- All persistent evidence Components under `archetype.missions.trajectories` (`TrajectoryTurn`, `TrajectoryCommandEvent`, `TrajectoryObservation`, `TrajectoryAction`, `TrajectoryReward`, `TranscriptArtifactRef`) are re-keyed by `episode_id` (+ `seq`). Persistent `trajectory_id` is removed everywhere.
- **Trajectory header disposition: deleted as a persistent Component.** The `Trajectory` header row was the reification of trajectory-as-identity (it carried both `trajectory_id` and `episode_id` — the half-state). Keeping it re-keyed would have preserved a persistent trajectory fact whose only purpose was identity. Instead, the header's role is served by the derived view: `trajectory(df, component, episode_id=...)` lazily reconstructs one episode's seq-ordered evidence from a persisted table. `trajectory_from_episode_result` and `Trajectory.from_turns` (its only producers; no production callers) are deleted with it. Outcome/coordinate authority stays with the owning families' own facts (Mission facts, evaluation receipts), not a duplicate evidence header.
- `TrajectorySelection` filters one evidence table by `episode_ids` only; filters against a Component that does not store `episode_id` fail with a precise error.
- Transcript facts: `coding_agent_transcript_rows` carries `episode_id`; `TranscriptIngestionResult.trajectory_id` → `episode_id`; an ingested Claude session's `episode_id` is its canonical `claude-session://` source URI (`ClaudeTranscriptSource.episode_id`).
- Type-distinct identifiers preserved, not unified: evaluation's dataset-local `EpisodeRef.episode_id` (int) and the world runtime's lifecycle `EpisodeResult.episode_id` (runtime UUID string) are untouched.
- Clean pre-1.0 epoch: no 0.4 backfill, no dual reads, no compatibility aliases. `TrajectorySpec` never existed in this codebase; nothing was created under that name.
- The adopted A8 rulings are folded into `docs/planning/activity-boundary-refactor.md` ("Rulings closed (2026-07-26)"), per its standing rules.

## Exit oracle (executable)

1. **Fresh-world Mission and hosted-episode evidence joins on `episode_id`** — `tests/integration/test_trajectory_analysis.py::test_fresh_world_mission_and_hosted_evidence_join_on_episode_id` spawns Mission evidence in a fresh world keyed by `hosted_episode_id(...)` and joins it against hosted-episode evidence on `episode_id`.
2. **No persistent `trajectory_id`** — `rg trajectory_id src/` returns no matches (exit 1). No view-local `trajectory_id` variables were retained either.
3. **Derived trajectory view reconstructs ordered evidence** — `tests/missions/trajectories/test_domain.py::test_derived_trajectory_view_reconstructs_ordered_evidence` (pure, out-of-order input rows) and `tests/app/test_trajectory_service.py::test_derived_trajectory_view_orders_persisted_evidence` (through a real world and persisted storage).

## Validation

- `make test` on the rebased head (`d185e53b` base): 2819 passed, 1 failed — the failure is `tests/physical_ai/test_hosted_episode_activities.py::test_lease_expiry_does_not_replay_an_ambiguous_provider_start`, the known parallelism flake (untouched by this PR); it passes in isolation (`1 passed`) and its whole file plus `tests/idempotency/test_idempotency_evals.py` pass together (`25 passed`).
- Focused suites on the rebased head: `uv run pytest tests/missions/trajectories tests/app/test_trajectory_service.py tests/app/test_transcript_ingestion.py tests/integration/test_trajectory_analysis.py tests/integration/test_domain_example_receipts.py tests/evaluation` — 87 passed.
- Pre-rebase: `uv run pytest tests/missions tests/app tests/evaluation tests/wiring` — 852 passed; `make ci` static gates all green (lint/format, lock-check, contract registry + traceability, boundary/idempotency/gate audits, typecheck).
- Not touched: A8.2/A8.3 scope (no rehomes, no `archetype.app` deletion, no outbox changes — not in this slice).

Refs #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
