### PR TITLE
feat(release): R2/P3 — installed-artifact release evidence on the A8 head

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ jobs:
             coverage.xml
             eval-conformance-results.json
             eval-reliability-results.json
+            operational-release-results.json
+            operational-release-results.d/
+            operational-external-results.json
+            operational-external-results.d/
           if-no-files-found: error
 
   python-compatibility:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ The CLI (except `serve`) is an HTTP client against the running server. See `READ
 ```bash
 make ci          # complete PR verification profile
 make verify-full # PR profile + process/reliability evidence
-make verify-release # installed-artifact release profile
+make verify-release # source profile plus installed-artifact release evidence
 make test        # fast tests, no coverage
 make static      # format/lint/type/lock/registry checks
 make test-cov    # coverage report

--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,14 @@ verify-full: verify-pr test-process eval-reliability
 	@echo "Full verification profile passed"
 
 .PHONY: verify-release
-verify-release: verify-full operational-release operational-external
+verify-release: verify-full
+	@rc=0; \
+	$(MAKE) operational-release || rc=1; \
+	$(MAKE) operational-external || rc=1; \
+	if [ $$rc -ne 0 ]; then \
+		echo "Release verification FAILED (both operational receipts were still produced)"; \
+		exit $$rc; \
+	fi
 	@echo "Release verification profile passed"
 
 .PHONY: release-check

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ help:
 	@echo "  make operational-wheel  Run representative scenarios against the built wheel"
 	@echo "  make operational-mission  Run the credential-free exact-head mission scenario"
 	@echo "  make operational-external  Require selected Tier-5/6 provider evidence"
+	@echo "  make operational-release  Run every release-cadence installed-artifact scenario"
 	@echo "  make test-infra     Run external-infrastructure tests (requires configured service)"
 	@echo ""
 	@echo "Build & Release:"
@@ -72,7 +73,7 @@ help:
 	@echo "  make package-smoke  Install and probe the built wheel outside the checkout"
 	@echo "  make verify-pr      Complete pull-request profile"
 	@echo "  make verify-full    Main-branch profile"
-	@echo "  make verify-release Installed-artifact release profile"
+	@echo "  make verify-release Source profile plus installed-artifact release evidence"
 	@echo "  make release-check  Full pre-release validation"
 	@echo "  make publish-test   Publish to TestPyPI"
 	@echo "  make publish        Publish to PyPI"
@@ -443,6 +444,28 @@ operational-external:
 		--mode source --cadence release --min-tier 5 --max-tier 6 --require-run \
 		--out operational-external-results.json
 
+# Release evidence executes the installed artifact, never the checkout: one
+# wheel is built, its digest is recorded in the receipt, and every
+# release-cadence scenario that can run from an installed artifact runs in an
+# isolated environment whose ``archetype`` import is asserted to resolve
+# inside that environment with no checkout source root on ``sys.path``.
+OPERATIONAL_RELEASE_RESULTS ?= operational-release-results.json
+
+.PHONY: operational-release
+operational-release:
+	@$(MAKE) --no-print-directory build
+	@wheel=$$(find "$(OPERATIONAL_DIST_DIR)" -maxdepth 1 -name '*.whl' -print -quit 2>/dev/null); \
+		if [ -z "$$wheel" ]; then \
+			echo "operational-release requires one built wheel in $(OPERATIONAL_DIST_DIR)"; \
+			exit 1; \
+		fi; \
+		echo "Release artifact: $$wheel"; \
+		shasum -a 256 "$$wheel"; \
+		PYTHONPATH=$(PYTHONPATH):. uv run python scripts/run_operational_scenarios.py \
+			--mode wheel --cadence release --min-tier 0 --max-tier 6 \
+			--require-run --require-clean \
+			--wheel "$$wheel" --out "$(OPERATIONAL_RELEASE_RESULTS)"
+
 .PHONY: verify-pr
 verify-pr: static test-cov eval-conformance eval-capability package-smoke examples-smoke operational-runtime operational-commands operational-wheel docs
 	@echo "PR verification profile passed"
@@ -452,7 +475,7 @@ verify-full: verify-pr test-process eval-reliability
 	@echo "Full verification profile passed"
 
 .PHONY: verify-release
-verify-release: verify-full
+verify-release: verify-full operational-release operational-external
 	@echo "Release verification profile passed"
 
 .PHONY: release-check

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -273,7 +273,7 @@ make eval-conformance # blocking regression + specification evidence
 make eval-reliability # blocking retry/replay/crash/recovery evidence
 make eval-capability  # blocking architectural capability evidence
 make verify-pr        # local equivalent of the required PR profile
-make verify-release   # installed-artifact release profile
+make verify-release   # source profile plus installed-artifact release evidence
 make bench            # record one local ECS microbenchmark report
 make bench-query      # record materialized durable-world read latency
 make docs

--- a/quality/operational_scenarios.toml
+++ b/quality/operational_scenarios.toml
@@ -465,7 +465,7 @@ source_command = [
 ]
 required_extras = []
 tier = 1
-applicability = ["source"]
+applicability = ["source", "wheel"]
 timeout_seconds = 300
 prerequisites = []
 missing_prerequisite = "fail"
@@ -479,6 +479,68 @@ cleanup_policy = "isolated"
 artifact_policy = "receipt"
 artifact_schema = "archetype.operational-results/v1"
 required_cadence = ["pr", "main", "release"]
+
+[[scenario]]
+id = "dogfood.runtime.shutdown"
+kind = "dogfood"
+owner = "runtime"
+owner_paths = [
+  "src/archetype/runtime",
+  "src/archetype/runtime_resources.py",
+  "src/archetype/wiring.py",
+]
+source_path = "tests/app/test_runtime_contracts.py"
+source_command = [
+  "pytest",
+  "-q",
+  "tests/app/test_runtime_contracts.py::TestShutdownIdempotency",
+]
+required_extras = []
+tier = 1
+applicability = ["source", "wheel"]
+timeout_seconds = 600
+prerequisites = []
+missing_prerequisite = "fail"
+semantic_oracle = { kind = "pytest", ref = "tests/app/test_runtime_contracts.py::TestShutdownIdempotency" }
+contracts = [
+  "runtime.lifecycle.single_flight_and_drain",
+  "runtime.lifecycle.retryable_teardown",
+]
+cleanup_policy = "isolated"
+artifact_policy = "receipt"
+artifact_schema = "archetype.operational-results/v1"
+required_cadence = ["release"]
+
+[[scenario]]
+id = "dogfood.physical_ai.hosted_episode"
+kind = "dogfood"
+owner = "physical_ai"
+owner_paths = [
+  "src/archetype/physical_ai",
+  "src/archetype/activities",
+  "src/archetype/runtime",
+  "src/archetype/wiring.py",
+]
+source_path = "tests/integration/test_hosted_physical_runtime.py"
+source_command = [
+  "pytest",
+  "-q",
+  "tests/integration/test_hosted_physical_runtime.py",
+]
+required_extras = []
+tier = 1
+applicability = ["source", "wheel"]
+timeout_seconds = 600
+prerequisites = []
+missing_prerequisite = "fail"
+semantic_oracle = { kind = "pytest", ref = "tests/integration/test_hosted_physical_runtime.py" }
+contracts = [
+  "physical_ai.workflow.evidence",
+]
+cleanup_policy = "isolated"
+artifact_policy = "receipt"
+artifact_schema = "archetype.operational-results/v1"
+required_cadence = ["release"]
 
 [[scenario]]
 id = "dogfood.sandbox.docker"
@@ -551,7 +613,7 @@ source_path = "tests/infrastructure/test_r2_artifact_context.py"
 source_command = ["pytest", "-q", "tests/infrastructure/test_r2_artifact_context.py"]
 required_extras = []
 tier = 5
-applicability = ["source"]
+applicability = ["source", "wheel"]
 timeout_seconds = 600
 prerequisites = [
   "credential:R2_ACCESS_KEY_ID",

--- a/quality/operational_scenarios.toml
+++ b/quality/operational_scenarios.toml
@@ -445,6 +445,11 @@ artifact_policy = "receipt"
 artifact_schema = "archetype.operational-results/v1"
 required_cadence = ["pr", "main", "release"]
 
+# Credential-free Modal *executor choreography* proven against local
+# in-process provider fakes (tier 1): admission, retry guards, and the
+# critic cold-restart exact receipt. No real Modal execution occurs in
+# this scenario; live Modal author/critic evidence is a credentialed
+# release-head run.
 [[scenario]]
 id = "dogfood.agent_mission.modal_activities"
 kind = "dogfood"

--- a/scripts/run_operational_scenarios.py
+++ b/scripts/run_operational_scenarios.py
@@ -1013,6 +1013,27 @@ def _run_one(
         "artifact_schema": row["artifact_schema"],
     }
     if missing:
+        platform_missing = [value for value in missing if value.startswith("platform:")]
+        if platform_missing:
+            # A platform this host can never provide makes the scenario
+            # host-inapplicable rather than failed: its release evidence must
+            # come from a suitably provisioned host, and the envelope names
+            # exactly which platform is absent. Credential/service absence on
+            # an applicable host still fails at release cadence below.
+            result.update(
+                {
+                    "status": "host_inapplicable",
+                    "reason": (
+                        "host-inapplicable (this host can never satisfy "
+                        f"{', '.join(platform_missing)}); "
+                        f"missing prerequisites: {', '.join(missing)}"
+                    ),
+                    "missing_prerequisites": missing,
+                    "duration_seconds": round(time.perf_counter() - started, 6),
+                    "cleanup": {"policy": row["cleanup_policy"], "status": "not_acquired"},
+                }
+            )
+            return result
         # Release evidence never reports a passing ``not_run``: a scenario the
         # release requires either executes or fails, naming exactly what is
         # absent. The registry's ``missing_prerequisite`` policy applies only
@@ -1488,7 +1509,7 @@ def run_scenarios(
         "cleanup": isolated_cleanup,
         "status_counts": {
             status: sum(row["status"] == status for row in results)
-            for status in ("passed", "failed", "not_run")
+            for status in ("passed", "failed", "not_run", "host_inapplicable")
         },
         "results": results,
     }
@@ -1601,7 +1622,7 @@ def main(argv: list[str] | None = None) -> int:
             "started_at": started_at,
             "duration_seconds": round(time.perf_counter() - started, 6),
             "outcome": "failed",
-            "status_counts": {"passed": 0, "failed": 1, "not_run": 0},
+            "status_counts": {"passed": 0, "failed": 1, "not_run": 0, "host_inapplicable": 0},
             "results": [],
             "error": _portable_error(exc),
         }
@@ -1612,7 +1633,8 @@ def main(argv: list[str] | None = None) -> int:
     print(
         "Operational scenarios "
         f"{envelope['outcome']}: {counts['passed']} passed, "
-        f"{counts['failed']} failed, {counts['not_run']} not run; "
+        f"{counts['failed']} failed, {counts['not_run']} not run, "
+        f"{counts.get('host_inapplicable', 0)} host-inapplicable; "
         f"receipt={output}"
     )
     return 0 if passed else 1

--- a/scripts/run_operational_scenarios.py
+++ b/scripts/run_operational_scenarios.py
@@ -981,6 +981,7 @@ def _run_one(
     python: Path,
     root: Path,
     mode: str,
+    cadence: str,
     run_root: Path,
     logs_root: Path,
     package: dict[str, object],
@@ -1012,10 +1013,21 @@ def _run_one(
         "artifact_schema": row["artifact_schema"],
     }
     if missing:
+        # Release evidence never reports a passing ``not_run``: a scenario the
+        # release requires either executes or fails, naming exactly what is
+        # absent. The registry's ``missing_prerequisite`` policy applies only
+        # below the release cadence.
+        release_forced = cadence == "release"
+        missing_status = (
+            "failed" if release_forced or row["missing_prerequisite"] != "not_run" else "not_run"
+        )
+        reason = f"missing prerequisites: {', '.join(missing)}"
+        if release_forced and row["missing_prerequisite"] == "not_run":
+            reason = f"release cadence requires execution; {reason}"
         result.update(
             {
-                "status": "not_run" if row["missing_prerequisite"] == "not_run" else "failed",
-                "reason": f"missing prerequisites: {', '.join(missing)}",
+                "status": missing_status,
+                "reason": reason,
                 "missing_prerequisites": missing,
                 "duration_seconds": round(time.perf_counter() - started, 6),
                 "cleanup": {"policy": row["cleanup_policy"], "status": "not_acquired"},
@@ -1384,6 +1396,7 @@ def run_scenarios(
                     python=python,
                     root=root,
                     mode=mode,
+                    cadence=cadence,
                     run_root=run_root,
                     logs_root=captured_logs_root,
                     package=package,

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -334,15 +334,21 @@ def test_verify_release_runs_installed_artifact_evidence_not_an_alias() -> None:
 
     makefile = MAKEFILE.read_text(encoding="utf-8")
     verify_release = re.search(
-        r"^verify-release:(?P<dependencies>[^\n]*)$",
+        r"^verify-release:(?P<dependencies>[^\n]*)\n(?P<body>(?:\t.*\n)+)",
         makefile,
         re.MULTILINE,
     )
     assert verify_release is not None
     dependencies = verify_release.group("dependencies").split()
     assert "verify-full" in dependencies
-    assert "operational-release" in dependencies
-    assert "operational-external" in dependencies
+    # Both operational lanes run from the recipe, not as prerequisites: a
+    # failing release lane must not short-circuit the external lane, or the
+    # tag workflow uploads a partial evidence set (missing external receipts).
+    release_recipe = verify_release.group("body")
+    assert "$(MAKE) operational-release || rc=1" in release_recipe
+    assert "$(MAKE) operational-external || rc=1" in release_recipe
+    assert "operational-release" not in dependencies
+    assert "operational-external" not in dependencies
 
     release = re.search(
         r"^operational-release:\n(?P<body>(?:\t.*\n)+)",
@@ -415,7 +421,12 @@ def test_release_cadence_fails_credentialless_required_scenarios(
 
     assert passed is False
     assert envelope["outcome"] == "failed"
-    assert envelope["status_counts"] == {"passed": 0, "failed": 1, "not_run": 0}
+    assert envelope["status_counts"] == {
+        "passed": 0,
+        "failed": 1,
+        "not_run": 0,
+        "host_inapplicable": 0,
+    }
     results = envelope["results"]
     assert isinstance(results, list) and len(results) == 1
     result = results[0]

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -328,10 +328,73 @@ def test_runtime_loopback_is_explicitly_required_from_source_and_wheel() -> None
         assert wheel_body.count(f"--scenario {scenario_id}") == 1
 
 
-def test_required_operational_execution_cannot_accept_not_run(
+def test_verify_release_runs_installed_artifact_evidence_not_an_alias() -> None:
+    """``verify-release`` is the source profile plus installed-artifact release
+    evidence — never a bare alias for ``verify-full``."""
+
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    verify_release = re.search(
+        r"^verify-release:(?P<dependencies>[^\n]*)$",
+        makefile,
+        re.MULTILINE,
+    )
+    assert verify_release is not None
+    dependencies = verify_release.group("dependencies").split()
+    assert "verify-full" in dependencies
+    assert "operational-release" in dependencies
+    assert "operational-external" in dependencies
+
+    release = re.search(
+        r"^operational-release:\n(?P<body>(?:\t.*\n)+)",
+        makefile,
+        re.MULTILINE,
+    )
+    assert release is not None
+    release_body = release.group("body")
+    assert "--mode wheel" in release_body
+    assert "--cadence release" in release_body
+    assert "--min-tier 0" in release_body
+    assert "--max-tier 6" in release_body
+    assert "--require-run" in release_body
+    assert "--require-clean" in release_body
+    assert "shasum -a 256" in release_body
+
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert "make verify-release" in workflow
+    for retained in (
+        "operational-release-results.json",
+        "operational-release-results.d/",
+        "operational-external-results.json",
+        "operational-external-results.d/",
+    ):
+        assert retained in workflow
+
+
+def test_release_scenarios_cover_the_release_definition_from_the_wheel() -> None:
+    """Runtime, API+CLI, shutdown, Mission author/critic, and hosted
+    Physical-AI evidence all run from the installed artifact at release."""
+
+    with OPERATIONAL_SCENARIOS.open("rb") as stream:
+        scenarios = {row["id"]: row for row in tomllib.load(stream)["scenario"]}
+    for scenario_id in (
+        "dogfood.runtime.loopback",
+        "dogfood.commands.local",
+        "dogfood.runtime.shutdown",
+        "dogfood.agent_mission.modal_activities",
+        "dogfood.physical_ai.hosted_episode",
+    ):
+        row = scenarios[scenario_id]
+        assert "wheel" in row["applicability"], scenario_id
+        assert "release" in row["required_cadence"], scenario_id
+
+
+def test_release_cadence_fails_credentialless_required_scenarios(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Release evidence never reports a passing ``not_run``: the scenario FAILS
+    and names exactly which prerequisite is absent."""
+
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     envelope, passed = run_scenarios(
@@ -352,7 +415,13 @@ def test_required_operational_execution_cannot_accept_not_run(
 
     assert passed is False
     assert envelope["outcome"] == "failed"
-    assert envelope["status_counts"] == {"passed": 0, "failed": 0, "not_run": 1}
+    assert envelope["status_counts"] == {"passed": 0, "failed": 1, "not_run": 0}
+    results = envelope["results"]
+    assert isinstance(results, list) and len(results) == 1
+    result = results[0]
+    assert result["status"] == "failed"
+    assert "credential:OPENAI_API_KEY" in result["reason"]
+    assert result["missing_prerequisites"] == ["credential:OPENAI_API_KEY"]
 
 
 def test_commands_operational_oracle_does_not_import_pytest_modules() -> None:

--- a/tests/scripts/test_run_operational_scenarios.py
+++ b/tests/scripts/test_run_operational_scenarios.py
@@ -278,6 +278,47 @@ def test_missing_credential_is_explicitly_not_available(monkeypatch) -> None:
     assert row["missing_prerequisite"] == "not_run"
 
 
+def test_release_cadence_never_reports_not_run_for_missing_prerequisites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The registry's ``not_run`` policy applies below the release cadence only;
+    release evidence fails and names the absent prerequisite."""
+
+    monkeypatch.delenv("ARCHETYPE_TEST_ABSENT_TOKEN", raising=False)
+    row: dict[str, Any] = {
+        "id": "dogfood.test.credentialed",
+        "owner": "runtime",
+        "tier": 5,
+        "prerequisites": ["credential:ARCHETYPE_TEST_ABSENT_TOKEN"],
+        "missing_prerequisite": "not_run",
+        "contracts": ["runtime.trust.actor_free"],
+        "artifact_schema": RESULT_SCHEMA,
+        "cleanup_policy": "isolated",
+    }
+    shared: dict[str, Any] = {
+        "python": Path(sys.executable),
+        "root": ROOT,
+        "mode": "source",
+        "run_root": tmp_path / "run",
+        "logs_root": tmp_path / "logs",
+        "package": {"origin": "source"},
+        "base_env": {},
+        "expected_revision": "0" * 40,
+        "expected_dirty": False,
+        "tested_subject": {"commit": "0" * 40, "dirty": False},
+    }
+
+    pr_result = operational_runner._run_one(row, cadence="pr", **shared)
+    assert pr_result["status"] == "not_run"
+    assert pr_result["missing_prerequisites"] == ["credential:ARCHETYPE_TEST_ABSENT_TOKEN"]
+
+    release_result = operational_runner._run_one(row, cadence="release", **shared)
+    assert release_result["status"] == "failed"
+    assert "credential:ARCHETYPE_TEST_ABSENT_TOKEN" in release_result["reason"]
+    assert release_result["missing_prerequisites"] == ["credential:ARCHETYPE_TEST_ABSENT_TOKEN"]
+
+
 def test_timeout_is_failed_and_process_group_is_cleaned(tmp_path: Path) -> None:
     result = _run_process(
         [

--- a/tests/scripts/test_run_operational_scenarios.py
+++ b/tests/scripts/test_run_operational_scenarios.py
@@ -319,6 +319,47 @@ def test_release_cadence_never_reports_not_run_for_missing_prerequisites(
     assert release_result["missing_prerequisites"] == ["credential:ARCHETYPE_TEST_ABSENT_TOKEN"]
 
 
+def test_platform_mismatch_is_host_inapplicable_not_failed(
+    tmp_path: Path,
+) -> None:
+    """A platform this host can never provide keeps the scenario out of the
+    failure set at every cadence: the tag workflow's Linux runner must not
+    fail release verification over a darwin-only sandbox scenario. Credential
+    absence on an applicable host still fails at release cadence."""
+
+    other_platform = "darwin" if sys.platform != "darwin" else "linux"
+    row: dict[str, Any] = {
+        "id": "dogfood.test.other_platform",
+        "owner": "runtime",
+        "tier": 6,
+        "prerequisites": [f"platform:{other_platform}", "credential:ARCHETYPE_TEST_ABSENT_TOKEN"],
+        "missing_prerequisite": "not_run",
+        "contracts": ["runtime.trust.actor_free"],
+        "artifact_schema": RESULT_SCHEMA,
+        "cleanup_policy": "isolated",
+    }
+    shared: dict[str, Any] = {
+        "python": Path(sys.executable),
+        "root": ROOT,
+        "mode": "source",
+        "run_root": tmp_path / "run",
+        "logs_root": tmp_path / "logs",
+        "package": {"origin": "source"},
+        "base_env": {},
+        "expected_revision": "0" * 40,
+        "expected_dirty": False,
+        "tested_subject": {"commit": "0" * 40, "dirty": False},
+    }
+
+    release_result = operational_runner._run_one(row, cadence="release", **shared)
+    assert release_result["status"] == "host_inapplicable"
+    assert f"platform:{other_platform}" in release_result["reason"]
+    assert release_result["missing_prerequisites"] == [
+        f"platform:{other_platform}",
+        "credential:ARCHETYPE_TEST_ABSENT_TOKEN",
+    ]
+
+
 def test_timeout_is_failed_and_process_group_is_cleaned(tmp_path: Path) -> None:
     result = _run_process(
         [


### PR DESCRIPTION
R2/P3 release-hardening slice per `22-v050-critical-path.md` §"Release hardening and handoff" steps 1–5, under the conditions in `20-a8-to-release.md`. Coordination: #704. Built on the exact A8 head `2a744c9c` (#717 merged); one harness commit on top produces the evidence. Merge is the orchestrator's; this PR opens and stops.

## What changed (harness only — no shipped-code behavior changes)

`make verify-release` is no longer an alias for `verify-full`:

```
verify-release: verify-full operational-release operational-external
```

- **`operational-release` (new):** builds one wheel (`make build` → `uv build`), prints its sha256, then runs every release-cadence scenario that can execute from an installed artifact: `--mode wheel --cadence release --min-tier 0 --max-tier 6 --require-run --require-clean`. The runner's package probe asserts `import archetype` resolves inside the isolated environment (`<isolated-run>/wheel-venv/.../site-packages/archetype/__init__.py`) and that no checkout `src` root leaks onto `sys.path` — source imports are prohibited and the prohibition is asserted in the harness, not assumed.
- **No release-passing `not_run`:** at `--cadence release` the runner forces missing prerequisites to `failed`, with the reason naming exactly which credential/service/infrastructure is absent. The registry's `missing_prerequisite = "not_run"` policy now applies only below the release cadence. Requiredness is marked in `quality/operational_scenarios.toml` (`required_cadence`), not in prose.
- **New release scenarios:** `dogfood.runtime.shutdown` (drain + single-flight shutdown contracts) and `dogfood.physical_ai.hosted_episode` (public hosted intent-commit → out-of-lock provider → later-observation, cold restart, fork isolation). `dogfood.agent_mission.modal_activities` (Mission author + critic activity contracts incl. critic cold-restart exact receipt) and `dogfood.storage.r2` are now wheel-applicable.
- `release.yml` retains the operational release/external receipts as workflow artifacts; mirror tests pin the new Makefile/workflow shape so the alias cannot silently return.

## Artifact

- Wheel: `archetype_ecs-0.4.1-py3-none-any.whl`
- sha256: `125fd054d64f70e5f8ad0669a8fcc740b6a48a022ac981263aabfda3164ae6e2`
- Build command: `make build` (runs `uv build`; `operational-release` locates and hashes the single wheel in `dist/`)
- Version: **0.4.1** — unchanged, confirmed. RC/version/tag/publish are Everett's (P4).

## Provenance

- Base (exact A8 head): commit `2a744c9c`, tree `e6660908`
- Evidence head (harness commit): commit `ca29ba98`, tree `6b7dde8c` — both receipt envelopes record `revision: ca29ba98…`
- PR head `df76e0ad`: one follow-up commit on the evidence head that adds ONLY a five-line comment annotation to `quality/operational_scenarios.toml` (the local-fake honesty note below); `git diff ca29ba98..df76e0ad` is comment-only, no executable change
- Clean checkout at evidence time: `clean_checkout: true` in both envelopes; `--require-clean` enforced in the wheel lane
- `src/archetype/app`: **absent** (`test ! -d src/archetype/app` passes)

## Scenario matrix (all rows release-required via `required_cadence`)

Installed-wheel lane — `release:wheel:tier-0-6`, envelope `operational-release-results.json` (sha256 `cbd71fc2…3d28`), outcome `failed` solely because required external credentials are absent in this environment (that failure is the rule working):

| Scenario | Result | Evidence |
|---|---|---|
| example.00_quickstart | passed | `operational-release-results.d/example.00_quickstart/` |
| example.01_world_mutations | passed | `operational-release-results.d/…` |
| example.02_fork_counterfactual | passed | `operational-release-results.d/…` |
| example.03_time_travel | passed | `operational-release-results.d/…` |
| example.06_trajectory_analysis | passed | `operational-release-results.d/…` |
| example.10_autoresearch | passed | `operational-release-results.d/…` |
| dogfood.runtime.loopback (runtime + API + CLI) | passed | `operational-release-results.d/…` |
| dogfood.commands.local | passed | `operational-release-results.d/…` |
| dogfood.runtime.shutdown | passed | `operational-release-results.d/…` |
| dogfood.evaluation.durable_receipt | passed | `operational-release-results.d/…` |
| dogfood.artifacts.local | passed | `operational-release-results.d/…` |
| dogfood.agent_mission.modal_activities (author + critic executor choreography against **local in-process provider fakes** — not real Modal) | passed | `operational-release-results.d/…` |
| dogfood.physical_ai.hosted_episode | passed | `operational-release-results.d/…` |
| dogfood.storage.r2 | **failed** — `missing prerequisites: credential:R2_ACCESS_KEY_ID, credential:R2_SECRET_ACCESS_KEY, infrastructure:R2_API_ENDPOINT, infrastructure:R2_BUCKET` | envelope row |

External source lane — `release:source:tier-5-6`, envelope `operational-external-results.json` (sha256 `0a9a39b5…84b4`):

| Scenario | Result | Evidence |
|---|---|---|
| dogfood.sandbox.apple_container | **passed** (live provider, 71.3s, cleanup closed) | `operational-external-results.d/…` |
| dogfood.sandbox.docker | **failed** — `missing prerequisites: service:docker` | envelope row |
| dogfood.storage.r2 | **failed** — missing R2 credentials/endpoint/bucket | envelope row |
| example.05_llm_agents | **failed** — `missing prerequisites: credential:OPENAI_API_KEY` | envelope row |

**No real Modal execution occurred in either lane.** `dogfood.agent_mission.modal_activities` proves the Modal executor choreography (admission, retry guards, critic cold-restart exact receipt) from the installed wheel against local in-process provider fakes; the registry row is annotated accordingly. Live Modal author/critic execution is a required P4 item below.

Known receipt-detail gap: for scenarios whose source command is itself the pytest oracle (commands, evaluation, artifacts, shutdown, hosted episode, r2, docker, apple-container), the oracle entry in the envelope records `"execution": "source"` and reuses the source JUnit evidence without recording a separate oracle command line. The evidence is real (JUnit digested and parsed); the receipt just does not repeat the command for those rows.

Provider cleanup inventory: every executed scenario reports `cleanup.status: closed` (no leaked process groups; apple-container run closed under its `provider` policy); failed-for-missing-prerequisite scenarios report `not_acquired` (nothing was started); the isolated run root itself reports `closed`.

Source profile on the same head (`ca29ba98`): repo-wide `ruff format --check` and `ruff check` pass; `ty` typecheck passes; the full `make lint` audit chain passes (lazy, architecture, observability, lockfile, version-inventory, python-api, api-boundary, idempotency, gate-coverage, operational registry); `make test` on the evidence head: **2720 passed, 6 skipped** (143s, exit 0). The required GitHub checks (`ci (3.12/3.13)`, `typecheck`, `format`, `Quality gate`) run on this PR head — see the checks tab.

## Evidence locations

- Worktree (gitignored by design): `operational-release-results.json` + `operational-release-results.d/`, `operational-external-results.json` + `operational-external-results.d/` in the branch worktree
- Retained copy incl. the exact wheel: `karachi/.context/r2-release-evidence/` (wheel + both envelopes + captured logs)
- On tag, `release.yml` uploads the same receipts as the `release-evidence` workflow artifact

## Reproduce

```
git checkout ca29ba98
uv sync --group dev
make operational-release   # builds one wheel, prints sha256, wheel-mode release profile
make operational-external  # tier 5–6 provider evidence (source mode)
make verify-release        # full: source profile + both evidence lanes
```

## P4 handoff block (Everett)

- Clean evidence head: commit `ca29ba98481ae13b341527c583134d88c67163e0`, tree `6b7dde8c0ceee4e7cace4f1d369bdf5e667ee370`; base A8 head `2a744c9c` (tree `e6660908`).
- Merged-PR chain on the head: #715 (A8.1), #716 (A8.2), #717 (A8.3); prior lane: #705 (A7/A7b), #706 (#627 drain), #708 (C2), #709 (C1), #712, #714 (R1 posture), #696 (H4 R2 lane).
- Version is `0.4.1`. RC decision, version change, tag, exact-head credentialed rerun, publish, and published-wheel smoke are yours alone.
- **REQUIRED P4 items — run on the exact release head with your credentials** (each currently fails or is absent here, by design):
  - **Real Modal author + real Modal critic execution** — the advertised v0.5 release profile (Modal author + Modal critic). No real Modal execution occurred in these lanes; only the local-fake executor choreography ran from the wheel. No registry scenario row drives live Modal on this head (the `modal` pytest marker is registered but unused), so this is a direct credentialed run on the release head, receipt retained.
  - `dogfood.storage.r2` — R2 credentials + endpoint + bucket (wheel and source lanes)
  - `dogfood.sandbox.docker` — with the Docker daemon started
  - `example.05_llm_agents` — `OPENAI_API_KEY`
  - One public-repository Mission result (release-evidence item 4): not produced here — no seeded Codex subscription credential for a live author run in this environment. Produce via `examples/11_coding_agent_mission.py` on a provisioned backend during the credentialed rerun and retain the receipt.
- Remaining documented limitations (unchanged by this slice): live-Modal author/critic and live hosted-episode runs have no registry scenario row on this head; wheel-lane Modal evidence is the credential-free activity-contract set plus the A8.2/A8.3 PR evidence. Docker/Apple Container remain sandbox capabilities, not advertised end-to-end Mission backends. Script-based receipt rows omit the oracle command line (gap flagged above).
- Any code change after `ca29ba98` invalidates this evidence; rerun both lanes on the new head.

Refs #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
