### PR TITLE
release: version 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-ecs"
-version = "0.4.1"
+version = "0.5.0"
 description = "Dataframe-first, append-only ECS runtime for simulations and AI agents. Built on Daft with LanceDB time-travel storage."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/archetype/__init__.py
+++ b/src/archetype/__init__.py
@@ -39,7 +39,7 @@ from typing import Any
 # `setdefault` honors an explicit `DO_NOT_TRACK=0` if a user wants telemetry on.
 os.environ.setdefault("DO_NOT_TRACK", "1")
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 __all__ = [
     # Core types

--- a/src/archetype/physical_ai/hosted_modal.py
+++ b/src/archetype/physical_ai/hosted_modal.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import importlib.metadata
 import json
 import os
 import re
@@ -742,9 +743,14 @@ def build_seeded_modal_hosted_episode_app(
         create_if_missing=True,
     )
     if image is None:
+        # Pin the installed distribution to the running version so the seeded
+        # image never reports a different version than the overlaid sources
+        # (scripts/package_smoke.py version-consistency contract). Callers on
+        # unpublished versions pass an explicit image instead.
+        installed = importlib.metadata.version("archetype-ecs")
         image = (
             modal.Image.debian_slim(python_version="3.12")
-            .uv_pip_install("archetype-ecs==0.4.1")
+            .uv_pip_install(f"archetype-ecs=={installed}")
             .add_local_python_source("archetype", copy=True)
         )
     app = modal.App(config.app_name)

--- a/uv.lock
+++ b/uv.lock
@@ -192,7 +192,7 @@ wheels = [
 
 [[package]]
 name = "archetype-ecs"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
Version bump 0.4.1 → 0.5.0 (pyproject + __version__ + lockfile), per the closeout plan's Everett-owned release sequence. Lands through the normal gate and queue — both proven end-to-end tonight by #688/#694. After this merges: `make verify-release` + external evidence against the exact landed commit, tag `v0.5.0`, release workflow, published-wheel verification — all yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)