### PR TITLE
fix(ci): reject blocked reviewer verdicts

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -17,6 +17,15 @@ reviewer identity, backend/model identity, assigned-category coverage, and the
 changed-file manifest. `scripts/review_aggregation.py` stamps that trusted
 provenance into digest-bound receipts.
 
+Each lens result also declares `review_status` as `complete` or `blocked`.
+Schema validity is not review evidence by itself: only `complete` can be
+normalized into a reviewer receipt. A reviewer MUST use `blocked` when a tool,
+sandbox, permission, or other admission failure prevents any required
+repository inspection. The validator rejects that result as a verdict, gives
+the same seat its one bounded retry, and then records an infrastructure-failure
+receipt if inspection remains blocked. That receipt is neutral; if every seat
+for a lens is neutral, aggregation fails closed.
+
 Aggregation uses one exact key:
 
 ```text

--- a/.github/review/prompts/lens-retry.md
+++ b/.github/review/prompts/lens-retry.md
@@ -26,6 +26,11 @@ contain no model-authored reviewer identity, assigned-category claim, or file
 manifest echo. `review_context.files` may contain changed paths only; cite
 other repository evidence in prose.
 
+Set `review_status` to `complete` only if the required repository inspection
+actually completed. If inspection is still unavailable, do not fabricate a
+verdict: set `review_status` to `blocked`, explain the blocker in `summary` and
+`review_context`, and return no findings.
+
 Use only read, grep, glob, and list capabilities. Do not execute code, edit
 files, fetch URLs, post comments, or push commits.
 

--- a/.github/review/prompts/lens-review.md
+++ b/.github/review/prompts/lens-review.md
@@ -27,9 +27,15 @@ contain changed paths only. Cite unchanged protected-base files inside
 assessment or finding evidence prose. Every finding must anchor to an actual
 changed line.
 
-An empty `findings` array is valid only after a complete lens review. Do not
-return schema examples, placeholders, generic style advice, missing-test
-requests, or findings outside this lens.
+Set `review_status` to `complete` only after every required changed file,
+rulebook, diff, and protected-base source was inspectable and the lens review
+finished. If a tool, sandbox, permission, or other admission failure prevents
+that inspection, set `review_status` to `blocked`, explain the exact blocker in
+`summary` and `review_context`, and return no findings. A blocked result is
+infrastructure evidence, never a clean verdict. An empty `findings` array is
+valid only with a complete lens review. Do not return schema examples,
+placeholders, generic style advice, missing-test requests, or findings outside
+this lens.
 
 Use only read, grep, glob, and list capabilities. Do not execute candidate or
 repository code, edit files, fetch URLs, post comments, or push commits.

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -462,8 +462,9 @@ jobs:
       # route to adjudication — a degraded bench earns more scrutiny. A lens
       # whose entire bench records infra failure still fails the gate closed
       # at aggregation. Steps before the detector (checkout, scope) failing
-      # still fail this job: an infra receipt is only honest when the seat
-      # actually saw the diff.
+      # still fail this job. A reviewer that explicitly reports blocked
+      # repository inspection gets one retry, then a neutral runner receipt;
+      # it can never become a clean verdict.
       - name: Record infra failure when no validated receipt exists
         if: ${{ !cancelled() && steps.contract.outcome == 'success' }}
         env:
@@ -473,7 +474,14 @@ jobs:
             exit 0
           fi
           failure_class=schema
-          detail="reviewer produced no schema-valid structured output after the bounded retry"
+          detail="reviewer produced no verdict-valid structured output after the bounded retry"
+          reported_blocked="$(python3 scripts/footgun_review_gate.py reported-blocked \
+            --result "${REVIEW_DIR}/first-structured-output.json" \
+            --result "${REVIEW_DIR}/retry-structured-output.json")"
+          if [[ "$reported_blocked" == "true" ]]; then
+            failure_class=runner
+            detail="reviewer reported blocked required repository inspection after the bounded retry"
+          fi
           for raw in "${RUNNER_TEMP}/opencode-raw.txt" "${RUNNER_TEMP}/opencode-retry-raw.txt" \
                      "${RUNNER_TEMP}/codex-raw.txt" "${RUNNER_TEMP}/codex-retry-raw.txt" \
                      "${REVIEW_DIR}/first-structured-output.json" "${REVIEW_DIR}/retry-structured-output.json"; do

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -481,16 +481,17 @@ jobs:
           if [[ "$reported_blocked" == "true" ]]; then
             failure_class=runner
             detail="reviewer reported blocked required repository inspection after the bounded retry"
+          else
+            for raw in "${RUNNER_TEMP}/opencode-raw.txt" "${RUNNER_TEMP}/opencode-retry-raw.txt" \
+                       "${RUNNER_TEMP}/codex-raw.txt" "${RUNNER_TEMP}/codex-retry-raw.txt" \
+                       "${REVIEW_DIR}/first-structured-output.json" "${REVIEW_DIR}/retry-structured-output.json"; do
+              if [ -f "$raw" ] && grep -qiE "usage limit|spend limit|rate.?limit|\b429\b|quota" "$raw"; then
+                failure_class=quota
+                detail="provider reported a quota or rate limit after the bounded retry"
+                break
+              fi
+            done
           fi
-          for raw in "${RUNNER_TEMP}/opencode-raw.txt" "${RUNNER_TEMP}/opencode-retry-raw.txt" \
-                     "${RUNNER_TEMP}/codex-raw.txt" "${RUNNER_TEMP}/codex-retry-raw.txt" \
-                     "${REVIEW_DIR}/first-structured-output.json" "${REVIEW_DIR}/retry-structured-output.json"; do
-            if [ -f "$raw" ] && grep -qiE "usage limit|spend limit|rate.?limit|\b429\b|quota" "$raw"; then
-              failure_class=quota
-              detail="provider quota/rate limit: $(grep -ioE '[^\n]{0,160}(usage limit|spend limit|rate.?limit|quota)[^\n]{0,160}' "$raw" | head -1)"
-              break
-            fi
-          done
           python3 scripts/footgun_review_gate.py infra-receipt \
             --lens "${LENS}" \
             --reviewer "${REVIEWER_ID}" \

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -90,6 +90,22 @@ replaces it. “The cache never loses an acknowledged append” needs a
 deterministic append-versus-flush race test before it becomes a durability
 scenario spanning flush triggers and storage backends.
 
+## Deterministic model-review evidence
+
+Schema-conforming reviewer prose is not sufficient evidence of repository
+inspection. Every independent lens result MUST declare `review_status` as
+`complete` or `blocked`, and only `complete` may become a verdict-bearing
+reviewer receipt. A reviewer MUST report `blocked` when any required changed
+file, diff, rulebook, or protected-base source could not be inspected because
+of a tool, sandbox, permission, or other admission failure. It MUST NOT turn
+that failure into an empty clean verdict.
+
+The exact-scope normalizer rejects `blocked` as a verdict and gives the seat
+its single bounded retry. If inspection remains blocked, the workflow records
+a neutral infrastructure-failure receipt rather than findings or a clean
+result. A surviving seat still owns its lens verdict; a lens whose entire
+bench is neutral fails aggregation closed.
+
 ## Scenario admission
 
 Add or retain a task in `evals/` when all of the following are true:

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -355,7 +355,9 @@ def retry_feedback(error: GateError) -> str:
         "Return one corrected, complete structured result for the same exact head. "
         "Use only the model-authored fields in the supplied schema. Cover every "
         "changed path in review_context, anchor findings to changed lines, and "
-        "preserve substantive analysis that remains valid.\n"
+        "preserve substantive analysis that remains valid. Set review_status to "
+        "complete only if repository inspection actually completes; otherwise "
+        "keep it blocked rather than fabricating a verdict.\n"
     )
 
 
@@ -832,6 +834,18 @@ def _append_github_outputs(path: Path, values: Mapping[str, str | int]) -> None:
             output.write(f"{key}={value}\n")
 
 
+def reviewer_reported_blocked(result_paths: Sequence[Path]) -> bool:
+    """Return whether any structured attempt explicitly reports blocked inspection."""
+    for path in result_paths:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(value, Mapping) and value.get("review_status") == "blocked":
+            return True
+    return False
+
+
 def _scope_command(args: argparse.Namespace) -> None:
     scope, diff = build_scope(args.base, args.head)
     _write_json(args.scope, scope)
@@ -1131,6 +1145,10 @@ def _infra_receipt_command(args: argparse.Namespace) -> None:
     )
 
 
+def _reported_blocked_command(args: argparse.Namespace) -> None:
+    print("true" if reviewer_reported_blocked(args.results) else "false")
+
+
 def _extract_command(args: argparse.Namespace) -> None:
     raw = args.raw.read_text(encoding="utf-8")
     extracted = extract_structured_json(raw)
@@ -1427,6 +1445,19 @@ def _parser() -> argparse.ArgumentParser:
     infra.add_argument("--detail", required=True)
     infra.add_argument("--output", type=Path, required=True)
     infra.set_defaults(handler=_infra_receipt_command)
+
+    reported_blocked = subparsers.add_parser(
+        "reported-blocked",
+        help="classify whether structured reviewer output reported blocked inspection",
+    )
+    reported_blocked.add_argument(
+        "--result",
+        dest="results",
+        type=Path,
+        action="append",
+        required=True,
+    )
+    reported_blocked.set_defaults(handler=_reported_blocked_command)
     return parser
 
 

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -835,14 +835,16 @@ def _append_github_outputs(path: Path, values: Mapping[str, str | int]) -> None:
 
 
 def reviewer_reported_blocked(result_paths: Sequence[Path]) -> bool:
-    """Return whether any structured attempt explicitly reports blocked inspection."""
-    for path in result_paths:
+    """Return whether the latest classifiable attempt reports blocked inspection."""
+    for path in reversed(result_paths):
         try:
             value = _load_json(path)
         except GateError:
             continue
-        if isinstance(value, Mapping) and value.get("review_status") == "blocked":
-            return True
+        if isinstance(value, Mapping):
+            status = value.get("review_status")
+            if status in {"complete", "blocked"}:
+                return status == "blocked"
     return False
 
 

--- a/scripts/footgun_review_gate.py
+++ b/scripts/footgun_review_gate.py
@@ -838,8 +838,8 @@ def reviewer_reported_blocked(result_paths: Sequence[Path]) -> bool:
     """Return whether any structured attempt explicitly reports blocked inspection."""
     for path in result_paths:
         try:
-            value = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            value = _load_json(path)
+        except GateError:
             continue
         if isinstance(value, Mapping) and value.get("review_status") == "blocked":
             return True

--- a/scripts/review_contracts.py
+++ b/scripts/review_contracts.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from string import Template
 from typing import Any, Literal, TypedDict
 
-MODEL_RESULT_SCHEMA_VERSION = 2
+MODEL_RESULT_SCHEMA_VERSION = 3
 REVIEW_BUNDLE_KIND = "archetype-review-bundle"
 REVIEW_BUNDLE_VERSION = 2
 ADJUDICATION_RECEIPT_KIND = "archetype-review-adjudication-receipt"
@@ -44,6 +44,7 @@ DESIGN_BRIEF_PROMPT_CHAR_LIMIT = 900_000
 DESIGN_BRIEF_RETRY_PROMPT_CHAR_LIMIT = 1_000_000
 
 SEVERITIES = ("blocking", "advisory")
+REVIEW_STATUSES = ("complete", "blocked")
 FOOTGUN_LENS_KIND = "footgun"
 DESIGN_LENS_KIND = "design"
 
@@ -74,6 +75,7 @@ class FootgunFinding(TypedDict):
 class FootgunLensResult(TypedDict):
     schema_version: int
     head_sha: str
+    review_status: Literal["complete", "blocked"]
     summary: str
     review_context: list[ReviewContext]
     findings: list[FootgunFinding]
@@ -101,6 +103,7 @@ class DesignFinding(TypedDict):
 class DesignLensResult(TypedDict):
     schema_version: int
     head_sha: str
+    review_status: Literal["complete", "blocked"]
     summary: str
     review_context: list[ReviewContext]
     findings: list[DesignFinding]
@@ -553,11 +556,12 @@ def footgun_result_schema(categories: Sequence[str]) -> dict[str, Any]:
     return _strict_object(
         {
             "head_sha": {"type": "string", "pattern": _SHA_RE},
+            "review_status": {"type": "string", "enum": list(REVIEW_STATUSES)},
             "summary": _text_schema(80),
             "review_context": _review_context_schema(),
             "findings": {"type": "array", "items": finding},
         },
-        ("head_sha", "summary", "review_context", "findings"),
+        ("head_sha", "review_status", "summary", "review_context", "findings"),
     )
 
 
@@ -603,11 +607,12 @@ def design_result_schema(categories: Sequence[str]) -> dict[str, Any]:
     return _strict_object(
         {
             "head_sha": {"type": "string", "pattern": _SHA_RE},
+            "review_status": {"type": "string", "enum": list(REVIEW_STATUSES)},
             "summary": _text_schema(80),
             "review_context": _review_context_schema(),
             "findings": {"type": "array", "items": finding},
         },
-        ("head_sha", "summary", "review_context", "findings"),
+        ("head_sha", "review_status", "summary", "review_context", "findings"),
     )
 
 
@@ -852,11 +857,19 @@ def normalize_lens_result(
 ) -> FootgunLensResult | DesignLensResult:
     _exact_keys(
         raw_result,
-        ("head_sha", "summary", "review_context", "findings"),
+        ("head_sha", "review_status", "summary", "review_context", "findings"),
         "lens result",
     )
     if raw_result.get("head_sha") != head_sha:
         raise ReviewError("review head_sha does not match the pull request head")
+    review_status = raw_result.get("review_status")
+    if review_status not in REVIEW_STATUSES:
+        raise ReviewError(f"review_status must be one of {', '.join(REVIEW_STATUSES)}")
+    if review_status != "complete":
+        raise ReviewError(
+            "review_status is 'blocked'; repository inspection must complete "
+            "before a reviewer verdict can be accepted"
+        )
     summary = _text(raw_result.get("summary"), "summary", 80)
     context = _normalize_review_context(raw_result.get("review_context"), scoped_files)
     findings = _expect_list(raw_result.get("findings"), "findings")
@@ -921,6 +934,7 @@ def normalize_lens_result(
         return {
             "schema_version": MODEL_RESULT_SCHEMA_VERSION,
             "head_sha": head_sha,
+            "review_status": "complete",
             "summary": summary,
             "review_context": context,
             "findings": normalized_footguns,
@@ -1018,6 +1032,7 @@ def normalize_lens_result(
     return {
         "schema_version": MODEL_RESULT_SCHEMA_VERSION,
         "head_sha": head_sha,
+        "review_status": "complete",
         "summary": summary,
         "review_context": context,
         "findings": normalized_design,

--- a/tests/scripts/review_test_support.py
+++ b/tests/scripts/review_test_support.py
@@ -96,6 +96,7 @@ def scope() -> dict[str, Any]:
 def raw_result(*, findings: list[dict[str, Any]] | None = None) -> dict[str, Any]:
     return {
         "head_sha": HEAD_SHA,
+        "review_status": "complete",
         "summary": (
             "The complete review inspected both changed files through the assigned lens "
             "and compared their behavior with the relevant protected-base contracts."

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -401,6 +401,8 @@ def test_cli_attempt_routes_blocked_inspection_to_retry_without_a_verdict(tmp_pa
 def test_blocked_failure_classification_reads_structured_status_without_model_prose(
     tmp_path,
 ):
+    first_path = tmp_path / "first.json"
+    retry_path = tmp_path / "retry.json"
     blocked_path = tmp_path / "blocked.json"
     malformed_path = tmp_path / "malformed.json"
     blocked = raw_result()
@@ -413,6 +415,23 @@ def test_blocked_failure_classification_reads_structured_status_without_model_pr
     blocked["review_status"] = "complete"
     blocked_path.write_text(json.dumps(blocked), encoding="utf-8")
     assert not reviewer_reported_blocked([malformed_path, blocked_path])
+
+    first = raw_result()
+    first["review_status"] = "blocked"
+    first_path.write_text(json.dumps(first), encoding="utf-8")
+    retry = raw_result()
+    retry["review_status"] = "complete"
+    retry_path.write_text(json.dumps(retry), encoding="utf-8")
+    assert not reviewer_reported_blocked([first_path, retry_path])
+
+    retry_path.write_text("{not-json", encoding="utf-8")
+    assert reviewer_reported_blocked([first_path, retry_path])
+
+    retry["review_status"] = "blocked"
+    retry_path.write_text(json.dumps(retry), encoding="utf-8")
+    first["review_status"] = "complete"
+    first_path.write_text(json.dumps(first), encoding="utf-8")
+    assert reviewer_reported_blocked([first_path, retry_path])
 
 
 def test_cli_materializes_one_bounded_design_brief_correction(tmp_path):

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -42,6 +42,7 @@ from footgun_review_gate import (  # noqa: E402
     render_evidence,
     render_human_design_brief,
     review_payload,
+    reviewer_reported_blocked,
     validate_result,
     verify_posted_evidence,
 )
@@ -50,7 +51,7 @@ from review_aggregation import (  # noqa: E402
     finalize_review_bundle,
     make_infra_failure_receipt,
 )
-from review_contracts import artifact_digest  # noqa: E402
+from review_contracts import MODEL_RESULT_SCHEMA_VERSION, artifact_digest  # noqa: E402
 from review_test_support import (  # noqa: E402
     ANCHORS,
     BASE_SHA,
@@ -141,10 +142,11 @@ def test_github_scope_fails_closed_when_head_changes_during_fetch():
 def test_lens_validation_uses_exact_model_contract_without_provenance_echoes():
     normalized = validate_result(raw_result(), scope(), DIFF, lens="authority")
 
-    assert normalized["schema_version"] == 2
+    assert normalized["schema_version"] == MODEL_RESULT_SCHEMA_VERSION
     assert set(normalized) == {
         "schema_version",
         "head_sha",
+        "review_status",
         "summary",
         "review_context",
         "findings",
@@ -337,6 +339,80 @@ def test_cli_normalize_stamps_reviewer_and_prompt_provenance(tmp_path):
     assert re.fullmatch(r"[0-9a-f]{64}", receipt["prompt_digest"])
     assert re.fullmatch(r"[0-9a-f]{64}", receipt["artifact_digest"])
     assert "reviewer_id" not in receipt["result"]
+
+
+def test_cli_attempt_routes_blocked_inspection_to_retry_without_a_verdict(tmp_path):
+    scope_path = tmp_path / "scope.json"
+    diff_path = tmp_path / "review.diff"
+    result_path = tmp_path / "result.json"
+    prompt_path = tmp_path / "prompt.md"
+    output_path = tmp_path / "receipt.json"
+    feedback_path = tmp_path / "feedback.txt"
+    github_output_path = tmp_path / "github-output.txt"
+    blocked = raw_result()
+    blocked["review_status"] = "blocked"
+    blocked["summary"] = (
+        "The read-only sandbox blocked every repository read, so this attempt could "
+        "not inspect the changed files and cannot provide a reviewer verdict."
+    )
+    blocked["review_context"][0]["assessment"] = (
+        "The manifest paths identify the attempted scope, but sandbox admission "
+        "failed before their source contents could be inspected."
+    )
+    scope_path.write_text(json.dumps(scope()), encoding="utf-8")
+    diff_path.write_text(DIFF, encoding="utf-8")
+    result_path.write_text(json.dumps(blocked), encoding="utf-8")
+    prompt_path.write_text("trusted prompt\n", encoding="utf-8")
+
+    assert (
+        gate.main(
+            [
+                "attempt",
+                "--scope",
+                str(scope_path),
+                "--diff",
+                str(diff_path),
+                "--result",
+                str(result_path),
+                "--prompt",
+                str(prompt_path),
+                "--output",
+                str(output_path),
+                "--feedback",
+                str(feedback_path),
+                "--github-output",
+                str(github_output_path),
+                "--lens",
+                "authority",
+                "--reviewer",
+                "codex",
+            ]
+        )
+        == 0
+    )
+
+    assert not output_path.exists()
+    assert github_output_path.read_text(encoding="utf-8") == "valid=false\n"
+    feedback = feedback_path.read_text(encoding="utf-8")
+    assert "repository inspection must complete" in feedback
+    assert "keep it blocked rather than fabricating a verdict" in feedback
+
+
+def test_blocked_failure_classification_reads_structured_status_without_model_prose(
+    tmp_path,
+):
+    blocked_path = tmp_path / "blocked.json"
+    malformed_path = tmp_path / "malformed.json"
+    blocked = raw_result()
+    blocked["review_status"] = "blocked"
+    blocked["summary"] = "candidate-controlled text that must never become workflow output"
+    blocked_path.write_text(json.dumps(blocked), encoding="utf-8")
+    malformed_path.write_text("{not-json", encoding="utf-8")
+
+    assert reviewer_reported_blocked([tmp_path / "missing.json", malformed_path, blocked_path])
+    blocked["review_status"] = "complete"
+    blocked_path.write_text(json.dumps(blocked), encoding="utf-8")
+    assert not reviewer_reported_blocked([malformed_path, blocked_path])
 
 
 def test_cli_materializes_one_bounded_design_brief_correction(tmp_path):
@@ -726,5 +802,14 @@ def test_lens_seat_failure_records_an_infra_receipt_instead_of_failing():
     assert "infra-receipt" in workflow
     # Quota classification must recognize the exact 2026-07-26 error shape.
     assert "usage limit|spend limit|rate.?limit" in workflow
+    # A schema-valid admission failure is runner infrastructure, never a
+    # schema failure or an accepted clean verdict. Classification reads the
+    # structured files and emits only a constant bounded detail.
+    assert "footgun_review_gate.py reported-blocked" in workflow
+    assert "failure_class=runner" in workflow
+    assert (
+        'detail="reviewer reported blocked required repository inspection '
+        'after the bounded retry"' in workflow
+    )
     # The bounded retry no longer hard-fails the job; the receipt decides.
     assert "Require retry completion" not in workflow

--- a/tests/scripts/test_footgun_review_gate.py
+++ b/tests/scripts/test_footgun_review_gate.py
@@ -811,5 +811,13 @@ def test_lens_seat_failure_records_an_infra_receipt_instead_of_failing():
         'detail="reviewer reported blocked required repository inspection '
         'after the bounded retry"' in workflow
     )
+    classification = workflow.split('if [[ "$reported_blocked" == "true" ]]', 1)[1]
+    classification = classification.split(
+        "python3 scripts/footgun_review_gate.py infra-receipt",
+        1,
+    )[0]
+    assert classification.index("else") < classification.index("failure_class=quota")
+    assert 'detail="provider reported a quota or rate limit after the bounded retry"' in workflow
+    assert "provider quota/rate limit: $(" not in workflow
     # The bounded retry no longer hard-fails the job; the receipt decides.
     assert "Require retry completion" not in workflow

--- a/tests/scripts/test_review_aggregation.py
+++ b/tests/scripts/test_review_aggregation.py
@@ -42,6 +42,7 @@ from review_aggregation import (  # noqa: E402
 )
 from review_contracts import (  # noqa: E402
     ReviewError,
+    artifact_digest,
     normalize_adjudication_result,
     render_adjudication_prompt,
 )
@@ -111,6 +112,24 @@ def test_fan_out_fails_closed_when_one_reviewer_receipt_is_missing():
     with pytest.raises(ReviewError, match="configured fan-out"):
         assemble_preliminary_bundle(
             receipts,
+            head_sha=HEAD_SHA,
+            scoped_files=FILES,
+            anchors=ANCHORS,
+        )
+
+
+def test_blocked_inspection_cannot_be_recast_as_a_validated_receipt():
+    receipt = reviewer_receipts()[0]
+    receipt["result"]["review_status"] = "blocked"
+    receipt["result"]["summary"] = (
+        "Repository inspection was blocked before any changed file could be read, "
+        "so this result cannot provide a reviewer verdict for the assigned lens."
+    )
+    receipt["artifact_digest"] = artifact_digest(receipt["result"])
+
+    with pytest.raises(ReviewError, match="repository inspection must complete"):
+        validate_reviewer_receipt(
+            receipt,
             head_sha=HEAD_SHA,
             scoped_files=FILES,
             anchors=ANCHORS,

--- a/tests/scripts/test_review_contracts.py
+++ b/tests/scripts/test_review_contracts.py
@@ -107,7 +107,14 @@ def test_footgun_return_schema_contains_failure_evidence_not_provenance_echoes()
     properties = schema["properties"]
     finding = properties["findings"]["items"]
 
-    assert set(properties) == {"head_sha", "summary", "review_context", "findings"}
+    assert set(properties) == {
+        "head_sha",
+        "review_status",
+        "summary",
+        "review_context",
+        "findings",
+    }
+    assert properties["review_status"]["enum"] == ["complete", "blocked"]
     assert "reviewed_files" not in properties
     assert "reviewed_categories" not in properties
     assert "reviewer_id" not in properties
@@ -131,6 +138,28 @@ def test_lens_normalizer_rejects_model_authored_provenance():
     result["reviewer_id"] = "claude"
 
     with pytest.raises(ReviewError, match="fields do not match"):
+        normalize_lens_result(
+            result,
+            lens="authority",
+            head_sha=HEAD_SHA,
+            scoped_files=FILES,
+            anchors=ANCHORS,
+        )
+
+
+def test_lens_normalizer_rejects_blocked_repository_inspection():
+    result = raw_result()
+    result["review_status"] = "blocked"
+    result["summary"] = (
+        "The sandbox denied every repository read, so no changed file or protected-base "
+        "contract could be inspected and this result is not a review verdict."
+    )
+    result["review_context"][0]["assessment"] = (
+        "The changed paths are listed only to bind the failed attempt; repository "
+        "inspection was blocked before any source content could be evaluated."
+    )
+
+    with pytest.raises(ReviewError, match="repository inspection must complete"):
         normalize_lens_result(
             result,
             lens="authority",
@@ -210,7 +239,10 @@ def test_prompts_render_from_named_files_with_adjacent_exact_schemas():
     assert "independent reviewer `claude`" in lens_prompt
     assert ".claude/skills/footgun-detector/SKILL.md" in lens_prompt
     assert '"failing_input_or_sequence"' in lens_prompt
+    assert "infrastructure evidence, never a clean verdict" in lens_prompt
     assert "single bounded correction attempt" in retry_prompt
+    assert "If inspection is still unavailable" in retry_prompt
+    assert "set `review_status` to `blocked`" in retry_prompt
     assert "Act as a falsifier, not a voter" in adjudication_prompt
     assert '"recommended_severity"' in adjudication_prompt
     assert "ready-for-human-review" in brief_prompt


### PR DESCRIPTION
## Why

The fresh deterministic review of release PR #724 exposed a fail-open evidence
path. All six Codex lens receipts were stamped `validated` with empty findings
even though their own summaries said the read-only runner failed before any
rulebook, diff, or repository file could be inspected:

> `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`

Run `30302459332` was cancelled before it could arm auto-merge. This PR makes
that explicit admission failure non-verdict evidence.

## What changed

- require every lens result to declare `review_status: complete | blocked`;
- accept only `complete` when normalizing or revalidating a verdict-bearing
  reviewer receipt;
- route `blocked` through the existing one bounded retry, then record a neutral
  `runner` infrastructure receipt if inspection remains unavailable;
- classify the structured status without emitting model-authored prose;
- retain the existing aggregate rule that an all-neutral lens fails closed;
- version the shared model-result contract and document the behavior in the
  review rulebook and normative repository-harness guide.

## Validation

- `74 passed` across the focused review contract, aggregation, and workflow
  suites;
- Ruff format and lint;
- `ty`;
- lock, contract, benchmark, architecture, observability, API-boundary,
  idempotency, gate-coverage, operational, and version-inventory audits;
- workflow YAML parse, typos, and `git diff --check`;
- independent patch review: no findings.
