### PR TITLE
fix: operation-scoped hosted episodes; terminal critic-budget exhaustion

### DIFF
--- a/lazy_audit.toml
+++ b/lazy_audit.toml
@@ -204,17 +204,31 @@ reason = "Exact post-commit critic-Activity fact boundary: each already componen
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-symbol = "project_critic_activity_intents"
+symbol = "_current_candidate_rows"
 expr = "candidate_tasks.to_pylist"
 method = "to_pylist"
-reason = "Durable critic-Activity admission boundary: the frame is already restricted to committed CANDIDATE task rows, whose bounded histories must be reduced independently before matching immutable candidates; a Daft join of the two snapshot histories crashes the native runtime during the real closed-loop mission."
+reason = "Durable critic-Activity admission boundary (shared by intent projection and run-boundary exhaustion): the frame is already restricted to committed CANDIDATE task rows, whose bounded histories must be reduced independently before matching immutable candidates; a Daft join of the two snapshot histories crashes the native runtime during the real closed-loop mission."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"
-symbol = "project_critic_activity_intents"
+symbol = "_current_candidate_rows"
 expr = "candidates.to_pylist"
 method = "to_pylist"
-reason = "Durable critic-Activity admission boundary: bounded committed candidate histories must retain their entity identities while they are reduced and matched to current task rows; provider execution occurs only after the resulting exact request is admitted."
+reason = "Durable critic-Activity admission boundary (shared by intent projection and run-boundary exhaustion): bounded committed candidate histories must retain their entity identities while they are reduced and matched to current task rows; provider execution occurs only after the resulting exact request is admitted."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "project_pending_review_exhaustion"
+expr = "critic_executions.to_pylist"
+method = "to_pylist"
+reason = "Committed domain-budget boundary at the run boundary: finite CriticExecution facts are counted against max_reviews so an exhausted, receipt-less candidate is reported as still pending review instead of waiting out the caller's tick budget."
+
+[[entries]]
+path = "src/archetype/missions/projections.py"
+symbol = "project_pending_review_exhaustion"
+expr = "critic_receipts.to_pylist"
+method = "to_pylist"
+reason = "Durable review-evidence boundary at the run boundary: bounded committed CriticReceipt identities are compared with the exact candidate so a matched receipt is never misreported as reviewer-budget exhaustion."
 
 [[entries]]
 path = "src/archetype/missions/projections.py"

--- a/quality/observability/physical_ai.toml
+++ b/quality/observability/physical_ai.toml
@@ -63,6 +63,7 @@ operations = [
   "hosted_activities.PhysicalHostedActivityCatalog.claim_episode",
   "hosted_activities.PhysicalHostedActivityCatalog.confirm_provider_operation_absent",
   "hosted_activities.PhysicalHostedActivityCatalog.episode_result",
+  "hosted_activities.PhysicalHostedActivityCatalog.episode_settled",
   "hosted_activities.PhysicalHostedActivityCatalog.has_unsettled_work",
   "hosted_activities.PhysicalHostedActivityCatalog.pending_episode_results",
   "hosted_activities.PhysicalHostedActivityCatalog.record_episode_result",

--- a/src/archetype/missions/processors.py
+++ b/src/archetype/missions/processors.py
@@ -19,7 +19,6 @@ from archetype.missions.components import (
     AgentExecution,
     Candidate,
     Commit,
-    CriticExecution,
     CriticReceipt,
     Mission,
     MissionState,
@@ -204,11 +203,9 @@ class TaskDecisionProcessor(AsyncProcessor):
         candidate = Candidate.get_prefix()
         review_conclusion = "_review_conclusion"
         review_policy_digest = "_review_policy_digest"
-        review_attempts = "_review_attempt_count"
         receipts = view.frame(CriticReceipt)
-        critic_executions = view.frame(CriticExecution)
-        candidates = (
-            candidate_frame.select(
+        if candidate_frame is not None and receipts is not None:
+            candidates = candidate_frame.select(
                 col("entity_id").alias("_candidate_entity_id"),
                 col(f"{candidate}task_id").alias("_candidate_task_id"),
                 col(f"{candidate}dispatch_id").alias("_candidate_dispatch_id"),
@@ -222,10 +219,6 @@ class TaskDecisionProcessor(AsyncProcessor):
                 col(f"{candidate}policy_digest").alias("_candidate_policy_digest"),
                 col(f"{candidate}candidate_digest").alias("_candidate_digest"),
             )
-            if candidate_frame is not None
-            else None
-        )
-        if candidates is not None and receipts is not None:
             receipt = CriticReceipt.get_prefix()
             reviews = receipts.join(
                 candidates,
@@ -258,32 +251,6 @@ class TaskDecisionProcessor(AsyncProcessor):
         else:
             df = df.with_column(review_conclusion, lit(None))
             df = df.with_column(review_policy_digest, lit(None))
-        if candidates is not None and critic_executions is not None:
-            # Committed CriticExecution facts are the consumed review budget —
-            # the same domain counter the critic-Activity projection reads, so
-            # a candidate the projection stops admitting also resolves here
-            # instead of waiting out the caller's tick budget.
-            critic_execution = CriticExecution.get_prefix()
-            attempt_counts = critic_executions.groupby(
-                f"{critic_execution}candidate_entity_id"
-            ).agg(col("entity_id").count().alias(review_attempts))
-            attempted = candidates.join(
-                attempt_counts,
-                left_on="_candidate_entity_id",
-                right_on=f"{critic_execution}candidate_entity_id",
-            ).select(
-                col("_candidate_task_id").alias("_attempt_task_id"),
-                col("_candidate_dispatch_id").alias("_attempt_dispatch_id"),
-                col(review_attempts),
-            )
-            df = df.join(
-                attempted,
-                left_on=["entity_id", f"{dispatch}dispatch_id"],
-                right_on=["_attempt_task_id", "_attempt_dispatch_id"],
-                how="left",
-            )
-        else:
-            df = df.with_column(review_attempts, lit(0))
 
         critic_policy = TaskCriticPolicy.get_prefix()
         candidate_created = dispatched & author_green
@@ -306,14 +273,6 @@ class TaskDecisionProcessor(AsyncProcessor):
             & cast(Expression, col(review_conclusion) == CriticConclusion.BLOCKING.value)
         )
         blocked = blocked.fill_null(False)
-        # A candidate with no matching independent receipt after its whole
-        # committed review budget can never be approved or repaired; without a
-        # terminal decision it waits out the caller's tick budget instead.
-        review_budget_exhausted = (
-            awaiting_review
-            & col(review_conclusion).is_null()
-            & (col(review_attempts).fill_null(0) >= col(f"{critic_policy}max_reviews"))
-        )
         author_retryable = author_rejected & (
             col(f"{dispatch}sequence") < col(f"{policy}max_dispatches")
         )
@@ -335,16 +294,11 @@ class TaskDecisionProcessor(AsyncProcessor):
                 .when(approved, then=lit(TaskStatus.ACCEPTED.value))
                 .when(repairable, then=lit(TaskStatus.READY.value))
                 .when(repair_exhausted, then=lit(TaskStatus.FAILED.value))
-                .when(review_budget_exhausted, then=lit(TaskStatus.FAILED.value))
                 .otherwise(col(f"{state}status")),
                 f"{state}reason": when(author_exhausted, then=failure_reason)
                 .when(
                     repair_exhausted,
                     then=lit("independent critic found blocking issues"),
-                )
-                .when(
-                    review_budget_exhausted,
-                    then=lit("independent critic review budget exhausted"),
                 )
                 .otherwise(col(f"{state}reason")),
             }

--- a/src/archetype/missions/processors.py
+++ b/src/archetype/missions/processors.py
@@ -19,6 +19,7 @@ from archetype.missions.components import (
     AgentExecution,
     Candidate,
     Commit,
+    CriticExecution,
     CriticReceipt,
     Mission,
     MissionState,
@@ -203,9 +204,11 @@ class TaskDecisionProcessor(AsyncProcessor):
         candidate = Candidate.get_prefix()
         review_conclusion = "_review_conclusion"
         review_policy_digest = "_review_policy_digest"
+        review_attempts = "_review_attempt_count"
         receipts = view.frame(CriticReceipt)
-        if candidate_frame is not None and receipts is not None:
-            candidates = candidate_frame.select(
+        critic_executions = view.frame(CriticExecution)
+        candidates = (
+            candidate_frame.select(
                 col("entity_id").alias("_candidate_entity_id"),
                 col(f"{candidate}task_id").alias("_candidate_task_id"),
                 col(f"{candidate}dispatch_id").alias("_candidate_dispatch_id"),
@@ -219,6 +222,10 @@ class TaskDecisionProcessor(AsyncProcessor):
                 col(f"{candidate}policy_digest").alias("_candidate_policy_digest"),
                 col(f"{candidate}candidate_digest").alias("_candidate_digest"),
             )
+            if candidate_frame is not None
+            else None
+        )
+        if candidates is not None and receipts is not None:
             receipt = CriticReceipt.get_prefix()
             reviews = receipts.join(
                 candidates,
@@ -251,6 +258,32 @@ class TaskDecisionProcessor(AsyncProcessor):
         else:
             df = df.with_column(review_conclusion, lit(None))
             df = df.with_column(review_policy_digest, lit(None))
+        if candidates is not None and critic_executions is not None:
+            # Committed CriticExecution facts are the consumed review budget —
+            # the same domain counter the critic-Activity projection reads, so
+            # a candidate the projection stops admitting also resolves here
+            # instead of waiting out the caller's tick budget.
+            critic_execution = CriticExecution.get_prefix()
+            attempt_counts = critic_executions.groupby(
+                f"{critic_execution}candidate_entity_id"
+            ).agg(col("entity_id").count().alias(review_attempts))
+            attempted = candidates.join(
+                attempt_counts,
+                left_on="_candidate_entity_id",
+                right_on=f"{critic_execution}candidate_entity_id",
+            ).select(
+                col("_candidate_task_id").alias("_attempt_task_id"),
+                col("_candidate_dispatch_id").alias("_attempt_dispatch_id"),
+                col(review_attempts),
+            )
+            df = df.join(
+                attempted,
+                left_on=["entity_id", f"{dispatch}dispatch_id"],
+                right_on=["_attempt_task_id", "_attempt_dispatch_id"],
+                how="left",
+            )
+        else:
+            df = df.with_column(review_attempts, lit(0))
 
         critic_policy = TaskCriticPolicy.get_prefix()
         candidate_created = dispatched & author_green
@@ -273,6 +306,14 @@ class TaskDecisionProcessor(AsyncProcessor):
             & cast(Expression, col(review_conclusion) == CriticConclusion.BLOCKING.value)
         )
         blocked = blocked.fill_null(False)
+        # A candidate with no matching independent receipt after its whole
+        # committed review budget can never be approved or repaired; without a
+        # terminal decision it waits out the caller's tick budget instead.
+        review_budget_exhausted = (
+            awaiting_review
+            & col(review_conclusion).is_null()
+            & (col(review_attempts).fill_null(0) >= col(f"{critic_policy}max_reviews"))
+        )
         author_retryable = author_rejected & (
             col(f"{dispatch}sequence") < col(f"{policy}max_dispatches")
         )
@@ -294,11 +335,16 @@ class TaskDecisionProcessor(AsyncProcessor):
                 .when(approved, then=lit(TaskStatus.ACCEPTED.value))
                 .when(repairable, then=lit(TaskStatus.READY.value))
                 .when(repair_exhausted, then=lit(TaskStatus.FAILED.value))
+                .when(review_budget_exhausted, then=lit(TaskStatus.FAILED.value))
                 .otherwise(col(f"{state}status")),
                 f"{state}reason": when(author_exhausted, then=failure_reason)
                 .when(
                     repair_exhausted,
                     then=lit("independent critic found blocking issues"),
+                )
+                .when(
+                    review_budget_exhausted,
+                    then=lit("independent critic review budget exhausted"),
                 )
                 .otherwise(col(f"{state}reason")),
             }

--- a/src/archetype/missions/projections.py
+++ b/src/archetype/missions/projections.py
@@ -14,6 +14,7 @@ from daft import DataFrame, Expression, col
 
 from archetype.core.component import Component
 from archetype.core.hooks import PostTick
+from archetype.errors import AvailabilityError
 from archetype.graph import GraphView, Relation
 from archetype.missions.activities import (
     AuthorActivityEntityFact,
@@ -938,6 +939,193 @@ class CriticReviewBudgetExhausted:
     max_reviews: int
 
 
+class CriticReviewBudgetExhaustedError(AvailabilityError):
+    """Candidates remain pending review after their whole independent budget.
+
+    Reviewer infrastructure failure never decides a task: the candidate stays
+    ``CANDIDATE`` and never becomes a task failure or an implicit approval
+    (docs/guide/agent-missions.md). ``missions`` ``run()`` raises this instead
+    of waiting out its tick budget once no further review can be admitted.
+    """
+
+    public_detail = "Independent review is still pending; the review budget is exhausted"
+
+    def __init__(
+        self,
+        mission_id: int,
+        pending: tuple[CriticReviewBudgetExhausted, ...],
+    ) -> None:
+        self.mission_id = mission_id
+        self.pending = pending
+        described = ", ".join(
+            f"task {item.task_id} candidate {item.candidate_id!r} "
+            f"({item.attempts}/{item.max_reviews} reviews)"
+            for item in pending
+        )
+        super().__init__(
+            f"mission {mission_id} candidates remain pending independent review "
+            f"after their whole review budget: {described}"
+        )
+
+
+def _current_candidate_rows(
+    tasks: DataFrame,
+    candidates: DataFrame,
+) -> dict[int, dict[str, Any]]:
+    """The single current candidate row per CANDIDATE-status task."""
+    state = TaskState.get_prefix()
+    candidate = Candidate.get_prefix()
+    candidate_tasks = tasks.where(
+        cast(Expression, col(f"{state}status") == TaskStatus.CANDIDATE.value)
+    )
+    candidate_task_rows = _latest_entity_rows(
+        candidate_tasks.to_pylist(),
+        label="candidate task",
+        allow_updates=True,
+    )
+    candidate_rows = _latest_entity_rows(
+        candidates.to_pylist(),
+        label="candidate",
+    )
+    rows: list[dict[str, Any]] = []
+    for candidate_entity_id, candidate_row in candidate_rows.items():
+        task_id = int(candidate_row[f"{candidate}task_id"])
+        task_row = candidate_task_rows.get(task_id)
+        if task_row is None:
+            continue
+        joined = dict(task_row)
+        joined.update(
+            {key: value for key, value in candidate_row.items() if key not in {"entity_id", "tick"}}
+        )
+        joined["_candidate_entity_id"] = candidate_entity_id
+        rows.append(joined)
+    if not rows:
+        return {}
+
+    candidates_by_task: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        candidates_by_task[int(row["entity_id"])].append(row)
+
+    current_by_task: dict[int, dict[str, Any]] = {}
+    for task_id, task_candidates in candidates_by_task.items():
+        current_sequence = max(int(row[f"{candidate}dispatch_sequence"]) for row in task_candidates)
+        current = tuple(
+            row
+            for row in task_candidates
+            if int(row[f"{candidate}dispatch_sequence"]) == current_sequence
+        )
+        current_ids = {int(row["_candidate_entity_id"]) for row in current}
+        if len(current_ids) != 1:
+            raise ValueError("task has multiple current candidates at one dispatch sequence")
+        first = current[0]
+        if any(row != first for row in current[1:]):
+            raise ValueError("task current candidate has conflicting committed rows")
+        current_by_task[task_id] = first
+    return current_by_task
+
+
+def _has_matching_independent_receipt(
+    row: dict[str, Any],
+    receipt_rows: tuple[dict[str, Any], ...],
+) -> bool:
+    """Whether a policy- and digest-bound non-author receipt exists for the row."""
+    candidate = Candidate.get_prefix()
+    receipt = CriticReceipt.get_prefix()
+    candidate_entity_id = int(row["_candidate_entity_id"])
+    return any(
+        int(item[f"{receipt}candidate_entity_id"]) == candidate_entity_id
+        and str(item[f"{receipt}critic_sandbox_id"]) != str(row[f"{candidate}author_sandbox_id"])
+        and str(item[f"{receipt}candidate_digest"]) == str(row[f"{candidate}candidate_digest"])
+        and str(item[f"{receipt}policy_digest"]) == str(row[f"{candidate}policy_digest"])
+        and str(item[f"{receipt}reviewed_base_revision"]) == str(row[f"{candidate}base_revision"])
+        and str(item[f"{receipt}reviewed_head_revision"]) == str(row[f"{candidate}head_revision"])
+        and str(item[f"{receipt}reviewed_diff_digest"]) == str(row[f"{candidate}diff_digest"])
+        and str(item[f"{receipt}validator_bundle_digest"])
+        == str(row[f"{candidate}validator_bundle_digest"])
+        for item in receipt_rows
+    )
+
+
+def _committed_review_attempts(
+    row: dict[str, Any],
+    critic_execution_rows: tuple[dict[str, Any], ...],
+) -> int:
+    """Committed CriticExecution facts consumed by this candidate."""
+    critic_execution = CriticExecution.get_prefix()
+    candidate_entity_id = int(row["_candidate_entity_id"])
+    return sum(
+        int(item[f"{critic_execution}candidate_entity_id"]) == candidate_entity_id
+        for item in critic_execution_rows
+    )
+
+
+def project_pending_review_exhaustion(
+    view: GraphView,
+    mission_id: int,
+) -> tuple[CriticReviewBudgetExhausted, ...]:
+    """Candidates of one mission still pending review after their whole budget.
+
+    The same committed evidence the critic-Activity intent projection reads:
+    the current candidate of each CANDIDATE task with no matching independent
+    receipt and ``CriticExecution`` attempts at or over ``max_reviews``. Such
+    a candidate can never be approved or repaired by a further admitted
+    review, so the run boundary reports it instead of spending its remaining
+    tick budget.
+    """
+    tasks = view.frame(Task, TaskCriticPolicy, TaskState)
+    candidates = view.frame(Candidate)
+    if tasks is None or candidates is None:
+        return ()
+    current_by_task = _current_candidate_rows(tasks, candidates)
+    if not current_by_task:
+        return ()
+
+    critic_executions = view.frame(CriticExecution)
+    critic_receipts = view.frame(CriticReceipt)
+    critic_execution_rows = (
+        tuple(
+            _latest_entity_rows(
+                critic_executions.to_pylist(),
+                label="critic execution",
+            ).values()
+        )
+        if critic_executions is not None
+        else ()
+    )
+    receipt_rows = (
+        tuple(
+            _latest_entity_rows(
+                critic_receipts.to_pylist(),
+                label="critic receipt",
+            ).values()
+        )
+        if critic_receipts is not None
+        else ()
+    )
+
+    candidate = Candidate.get_prefix()
+    policy = TaskCriticPolicy.get_prefix()
+    exhausted: list[CriticReviewBudgetExhausted] = []
+    for row in current_by_task.values():
+        if int(row[f"{candidate}mission_id"]) != mission_id:
+            continue
+        if _has_matching_independent_receipt(row, receipt_rows):
+            continue
+        attempts = _committed_review_attempts(row, critic_execution_rows)
+        max_reviews = int(row[f"{policy}max_reviews"])
+        if attempts >= max_reviews:
+            exhausted.append(
+                CriticReviewBudgetExhausted(
+                    mission_id=mission_id,
+                    task_id=int(row[f"{candidate}task_id"]),
+                    candidate_id=str(row[f"{candidate}candidate_id"]),
+                    attempts=attempts,
+                    max_reviews=max_reviews,
+                )
+            )
+    return tuple(sorted(exhausted, key=lambda item: item.task_id))
+
+
 @dataclass(frozen=True, slots=True)
 class CriticActivityIntentProjection:
     """Pure committed-snapshot projection of critic requests and exhaustion."""
@@ -973,7 +1161,6 @@ async def project_critic_activity_intents(
     assert validators is not None
     assert validation_results is not None
 
-    state = TaskState.get_prefix()
     task = Task.get_prefix()
     policy = TaskCriticPolicy.get_prefix()
     candidate = Candidate.get_prefix()
@@ -981,53 +1168,10 @@ async def project_critic_activity_intents(
     validator = TaskValidator.get_prefix()
     validation = ValidationResult.get_prefix()
 
-    candidate_tasks = tasks.where(
-        cast(Expression, col(f"{state}status") == TaskStatus.CANDIDATE.value)
-    )
-    candidate_task_rows = _latest_entity_rows(
-        candidate_tasks.to_pylist(),
-        label="candidate task",
-        allow_updates=True,
-    )
-    candidate_rows = _latest_entity_rows(
-        candidates.to_pylist(),
-        label="candidate",
-    )
-    rows: list[dict[str, Any]] = []
-    for candidate_entity_id, candidate_row in candidate_rows.items():
-        task_id = int(candidate_row[f"{candidate}task_id"])
-        task_row = candidate_task_rows.get(task_id)
-        if task_row is None:
-            continue
-        joined = dict(task_row)
-        joined.update(
-            {key: value for key, value in candidate_row.items() if key not in {"entity_id", "tick"}}
-        )
-        joined["_candidate_entity_id"] = candidate_entity_id
-        rows.append(joined)
-    if not rows:
+    current_by_task = _current_candidate_rows(tasks, candidates)
+    if not current_by_task:
         return CriticActivityIntentProjection((), ())
     subject_bounds = _critic_subject_bounds(event)
-
-    candidates_by_task: dict[int, list[dict[str, Any]]] = defaultdict(list)
-    for row in rows:
-        candidates_by_task[int(row["entity_id"])].append(row)
-
-    current_by_task: dict[int, dict[str, Any]] = {}
-    for task_id, task_candidates in candidates_by_task.items():
-        current_sequence = max(int(row[f"{candidate}dispatch_sequence"]) for row in task_candidates)
-        current = tuple(
-            row
-            for row in task_candidates
-            if int(row[f"{candidate}dispatch_sequence"]) == current_sequence
-        )
-        current_ids = {int(row["_candidate_entity_id"]) for row in current}
-        if len(current_ids) != 1:
-            raise ValueError("task has multiple current candidates at one dispatch sequence")
-        first = current[0]
-        if any(row != first for row in current[1:]):
-            raise ValueError("task current candidate has conflicting committed rows")
-        current_by_task[task_id] = first
 
     author_rows = _latest_entity_rows(
         author_executions.to_pylist(),
@@ -1065,35 +1209,15 @@ async def project_critic_activity_intents(
         if critic_receipts is not None
         else ()
     )
-    critic_execution = CriticExecution.get_prefix()
-    receipt = CriticReceipt.get_prefix()
-
     requests: list[CandidateReviewRequest] = []
     exhausted: list[CriticReviewBudgetExhausted] = []
     for row in current_by_task.values():
         task_id = int(row["entity_id"])
         candidate_entity_id = int(row["_candidate_entity_id"])
         candidate_id = str(row[f"{candidate}candidate_id"])
-        if any(
-            int(item[f"{receipt}candidate_entity_id"]) == candidate_entity_id
-            and str(item[f"{receipt}critic_sandbox_id"])
-            != str(row[f"{candidate}author_sandbox_id"])
-            and str(item[f"{receipt}candidate_digest"]) == str(row[f"{candidate}candidate_digest"])
-            and str(item[f"{receipt}policy_digest"]) == str(row[f"{candidate}policy_digest"])
-            and str(item[f"{receipt}reviewed_base_revision"])
-            == str(row[f"{candidate}base_revision"])
-            and str(item[f"{receipt}reviewed_head_revision"])
-            == str(row[f"{candidate}head_revision"])
-            and str(item[f"{receipt}reviewed_diff_digest"]) == str(row[f"{candidate}diff_digest"])
-            and str(item[f"{receipt}validator_bundle_digest"])
-            == str(row[f"{candidate}validator_bundle_digest"])
-            for item in receipt_rows
-        ):
+        if _has_matching_independent_receipt(row, receipt_rows):
             continue
-        attempts = sum(
-            int(item[f"{critic_execution}candidate_entity_id"]) == candidate_entity_id
-            for item in critic_execution_rows
-        )
+        attempts = _committed_review_attempts(row, critic_execution_rows)
         max_reviews = int(row[f"{policy}max_reviews"])
         if attempts >= max_reviews:
             exhausted.append(

--- a/src/archetype/missions/service.py
+++ b/src/archetype/missions/service.py
@@ -43,8 +43,10 @@ from archetype.missions.critics import (
 )
 from archetype.missions.processors import mission_processors
 from archetype.missions.projections import (
+    CriticReviewBudgetExhaustedError,
     current_mission_status,
     project_mission_result,
+    project_pending_review_exhaustion,
 )
 from archetype.missions.relations import (
     DependsOn,
@@ -390,6 +392,15 @@ class MissionService:
                     mission,
                     ticks_completed=int(info.tick),
                 )
+            # Reviewer infrastructure failure never decides a task: once a
+            # current candidate's whole committed review budget is consumed
+            # with no matching independent receipt, no further review can be
+            # admitted, so report the still-pending candidate now instead of
+            # waiting out the remaining tick budget (docs/guide/
+            # agent-missions.md, runtime.md).
+            pending = project_pending_review_exhaustion(self._view, mission.mission_id)
+            if pending:
+                raise CriticReviewBudgetExhaustedError(mission.mission_id, pending)
 
         status = current_mission_status(self._view, mission.mission_id)
         raise RuntimeError(

--- a/src/archetype/physical_ai/hosted_activities.py
+++ b/src/archetype/physical_ai/hosted_activities.py
@@ -148,6 +148,7 @@ class PhysicalHostedActivityCatalog(Protocol):
         *,
         world_id: str,
         owner: str,
+        activity_id: str | None = None,
     ) -> HostedEpisodeActivityClaim | None: ...
 
     async def bind_provider_operation(
@@ -191,6 +192,14 @@ class PhysicalHostedActivityCatalog(Protocol):
         result_digest: str,
         receipt: CommittedTickReceipt,
     ) -> None: ...
+
+    async def episode_settled(
+        self,
+        *,
+        world_id: str,
+        activity_id: str,
+        result_digest: str,
+    ) -> bool: ...
 
     async def has_unsettled_work(self, world_id: str) -> bool: ...
 
@@ -363,12 +372,18 @@ class PhysicalHostedActivityProjector:
     def _unique_observations(
         observations: tuple[HostedEpisodeIntent | HostedEpisodeObservation, ...],
     ) -> dict[str, HostedEpisodeObservation]:
+        # The committed view lists one durable marker once per persisted tick,
+        # so equal re-listings collapse exactly as committed intents do; only
+        # conflicting values for one Activity fail closed.
         unique: dict[str, HostedEpisodeObservation] = {}
         for value in observations:
             if not isinstance(value, HostedEpisodeObservation):
                 raise TypeError("hosted observation projection returned another component")
-            if value.activity_id in unique:
-                raise ValueError("one hosted Activity has multiple committed observation markers")
+            existing = unique.get(value.activity_id)
+            if existing is not None and existing != value:
+                raise ValueError(
+                    "one hosted Activity has conflicting committed observation markers"
+                )
             unique[value.activity_id] = value
         return unique
 
@@ -479,7 +494,24 @@ class PhysicalHostedActivityCoordinator:
         *,
         world_id: str,
         owner: str,
+        activity_id: str | None = None,
     ) -> HostedEpisodeActivityClaim | None:
+        if activity_id is not None:
+            # Operation-scoped delivery: claim exactly the admitted Activity so
+            # one hosted call never executes another episode's older pending
+            # claim.  An unacquired claim means the Activity is leased by
+            # another live owner or already holds its durable result; both are
+            # "nothing to execute here", not errors.
+            generic = await self._coordinator.claim(
+                world_id,
+                HOSTED_EPISODE_ACTIVITY_KIND,
+                activity_id,
+                owner,
+                lease_seconds=self._lease_seconds,
+            )
+            if not generic.acquired:
+                return None
+            return self._remember(generic)
         # Page until the catalog is exhausted: a finite prefix scan stranded
         # claimable Activities beyond the batch when the head of the pending
         # set was leased by other workers.  claim_next_pending carries this
@@ -620,6 +652,22 @@ class PhysicalHostedActivityCoordinator:
             ActivitySettlement(receipt=receipt, result_digest=result_digest),
         )
 
+    async def episode_settled(
+        self,
+        *,
+        world_id: str,
+        activity_id: str,
+        result_digest: str,
+    ) -> bool:
+        snapshot = await self._coordinator.get(
+            world_id,
+            HOSTED_EPISODE_ACTIVITY_KIND,
+            activity_id,
+        )
+        if snapshot is None or snapshot.settlement is None:
+            return False
+        return snapshot.settlement.result_digest == result_digest
+
     async def has_unsettled_work(self, world_id: str) -> bool:
         return await self._coordinator.has_unsettled(world_id)
 
@@ -701,16 +749,27 @@ class PhysicalHostedActivityWorker:
         self._provider = provider
         self._stager = stager
 
-    async def run_once(self) -> bool:
+    async def run_once(self, *, activity_id: str | None = None) -> bool:
+        """Deliver durable results, then execute one claim.
+
+        ``activity_id`` scopes the claim to one exact admitted Activity so an
+        operation-driven call never executes another episode's older pending
+        claim; ``None`` keeps drain semantics and claims the next pending
+        episode in the world.
+        """
+
         progressed = await self._deliver_pending_results()
         claim = await self._catalog.claim_episode(
             world_id=self._world_id,
             owner=self._owner,
+            activity_id=activity_id,
         )
         if claim is None:
             return progressed
         if claim.world_id != self._world_id:
             raise ValueError("hosted catalog returned another world's claim")
+        if activity_id is not None and claim.activity_id != activity_id:
+            raise ValueError("hosted catalog returned another Activity's claim")
         request = await self._load_claim_request(claim)
         result_claim, provider_result = await self._execute_or_reconcile(
             claim,

--- a/src/archetype/physical_ai/hosted_activity_world.py
+++ b/src/archetype/physical_ai/hosted_activity_world.py
@@ -242,10 +242,13 @@ class WorldHostedEpisodeObservationStager:
         existing: tuple[HostedEpisodeObservation, ...],
         candidate: HostedEpisodeObservation,
     ) -> None:
+        # A committed marker is listed once per persisted tick, so equal
+        # re-listings of one durable fact are idempotent acceptance; only a
+        # value that disagrees with the candidate fails closed.
         matching = tuple(value for value in existing if value.activity_id == candidate.activity_id)
         if not matching:
             return
-        if len(matching) != 1 or matching[0] != candidate:
+        if any(value != candidate for value in matching):
             raise ValueError("hosted Activity has conflicting or duplicate observation markers")
 
 
@@ -295,6 +298,20 @@ class PhysicalHostedActivityBinding:
         if str(world_id) != self.world_id:
             return False
         return await self._catalog.has_unsettled_work(self.world_id)
+
+    async def episode_settled(self, activity_id: str, result_digest: str) -> bool:
+        """Report settlement of one exact Activity's exact result digest.
+
+        Operation completion must not depend on the world being globally
+        quiet: another episode's pending or reconciling Activity is not this
+        operation's failure.
+        """
+
+        return await self._catalog.episode_settled(
+            world_id=self.world_id,
+            activity_id=activity_id,
+            result_digest=result_digest,
+        )
 
     async def observation(self, activity_id: str) -> HostedEpisodeObservation | None:
         delivery = await self._catalog.episode_result(

--- a/src/archetype/physical_ai/hosted_workflow.py
+++ b/src/archetype/physical_ai/hosted_workflow.py
@@ -66,7 +66,11 @@ async def run_hosted_episode(
             RunConfig(),
         )
 
-    await binding.worker.run_once()
+    # Scope execution and completion to this operation's exact Activity:
+    # with several in-flight episodes, an unscoped claim can execute another
+    # episode's older pending Activity, and world-global settlement lets an
+    # unrelated unsettled episode fail an otherwise-complete call.
+    await binding.worker.run_once(activity_id=operation.activity_id)
     observation = await binding.observation(operation.activity_id)
     if observation is None:
         raise RuntimeError("hosted episode has no durable complete result")
@@ -78,7 +82,7 @@ async def run_hosted_episode(
             world,
             RunConfig(),
         )
-    if await binding.has_unsettled_work(operation.world_id):
+    if not await binding.episode_settled(operation.activity_id, observation.result_digest):
         raise RuntimeError("hosted episode observation did not settle")
     return observation
 

--- a/tests/integration/test_hosted_physical_runtime.py
+++ b/tests/integration/test_hosted_physical_runtime.py
@@ -230,3 +230,114 @@ async def test_public_hosted_episode_recovers_without_replay_and_isolates_fork(
         assert child_observation.activity_id == activity_id
         assert child_observation.operation_id != observation.operation_id
         assert state.execution_count == 2
+
+
+def _single_bootstrap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    namespace: str,
+    crash_once: bool,
+) -> tuple[StorageConfig, _ModalState]:
+    storage = StorageConfig(
+        uri=str(tmp_path / "worlds"),
+        namespace=namespace,
+        backend=StorageBackend.ICEBERG,
+    )
+    catalog = ControlCatalogConfig(catalog_dir=tmp_path / "catalogs")
+    registry = WorldRegistry()
+    state = _ModalState(tmp_path / "modal", registry, crash_once=crash_once)
+
+    def provider_factory(config: ModalHostedEpisodeConfig):
+        provider = ModalHostedEpisodeProvider(config, runtime=_ModalRuntime(state))
+        if crash_once:
+            return _CrashAfterProviderPublication(provider, state)
+        return provider
+
+    bootstrap = RuntimeBootstrapConfig(
+        control_catalog_config=catalog,
+        world_registry=registry,
+        audit_storage_config=storage,
+        hosted_episode_provider_factory=provider_factory,
+        hosted_activity_lease_seconds=30,
+    )
+    monkeypatch.setattr(
+        "archetype.runtime.runtime._bootstrap_config",
+        lambda **_kwargs: bootstrap,
+    )
+    return storage, state
+
+
+@pytest.mark.asyncio
+async def test_concurrent_hosted_episodes_each_complete_their_own_activity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two in-flight episodes must not claim or settle across each other."""
+
+    storage, state = _single_bootstrap(
+        tmp_path,
+        monkeypatch,
+        namespace="hosted-concurrent",
+        crash_once=False,
+    )
+    provider_config = _provider_config()
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("hosted-concurrent", storage=storage)
+        state.world_id = str((await world.info()).world_id)
+        first, second = await asyncio.gather(
+            world.run_hosted_episode(
+                [_request()],
+                provider=provider_config,
+                activity_id="episode-one",
+            ),
+            world.run_hosted_episode(
+                [_request()],
+                provider=provider_config,
+                activity_id="episode-two",
+            ),
+        )
+
+    assert first.activity_id == "episode-one"
+    assert second.activity_id == "episode-two"
+    assert first.operation_id != second.operation_id
+    assert state.execution_count == 2
+
+
+@pytest.mark.asyncio
+async def test_stale_unsettled_episode_does_not_fail_a_completed_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A leftover unsettled Activity is not a later operation's failure.
+
+    The stale episode's worker dies before generic result recording, so its
+    Activity stays unsettled.  A subsequent episode must complete on its own
+    activity's settlement rather than requiring a globally quiet world.
+    """
+
+    storage, state = _single_bootstrap(
+        tmp_path,
+        monkeypatch,
+        namespace="hosted-stale",
+        crash_once=True,
+    )
+    provider_config = _provider_config()
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("hosted-stale", storage=storage)
+        state.world_id = str((await world.info()).world_id)
+        with pytest.raises(RuntimeError, match="before generic result"):
+            await world.run_hosted_episode(
+                [_request()],
+                provider=provider_config,
+                activity_id="episode-stale",
+            )
+
+        observation = await world.run_hosted_episode(
+            [_request()],
+            provider=provider_config,
+            activity_id="episode-fresh",
+        )
+
+    assert observation.activity_id == "episode-fresh"
+    assert state.execution_count == 2

--- a/tests/missions/test_task_decision_processor.py
+++ b/tests/missions/test_task_decision_processor.py
@@ -1,7 +1,15 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Terminal review-budget decisions for candidates without receipts."""
+"""Review-budget exhaustion leaves the candidate pending and is reported.
+
+Normative contract (docs/guide/agent-missions.md, runtime.md,
+service-protocols.md): reviewer infrastructure failure consumes only the
+bounded review budget — it never becomes a task failure or an implicit
+approval. The decision processor leaves the candidate in ``CANDIDATE``; the
+run boundary projects the exhaustion and raises
+``CriticReviewBudgetExhaustedError`` instead of waiting out its tick budget.
+"""
 
 from __future__ import annotations
 
@@ -19,12 +27,18 @@ from archetype.missions.components import (
     Candidate,
     CriticExecution,
     CriticReceipt,
+    Task,
     TaskCriticPolicy,
     TaskDispatch,
     TaskPolicy,
     TaskState,
 )
 from archetype.missions.processors import TaskDecisionProcessor
+from archetype.missions.projections import (
+    CriticReviewBudgetExhausted,
+    CriticReviewBudgetExhaustedError,
+    project_pending_review_exhaustion,
+)
 from archetype.missions.relations import Guards
 from archetype.missions.transitions import (
     AgentExecutionStatus,
@@ -33,6 +47,7 @@ from archetype.missions.transitions import (
     TaskStatus,
 )
 
+_MISSION_ID = 1
 _TASK_ID = 11
 _CANDIDATE_ENTITY_ID = 31
 
@@ -53,7 +68,7 @@ def _signature_frame(entities: list[tuple[int, tuple[Component, ...]]]) -> daft.
 def _candidate() -> Candidate:
     return Candidate(
         candidate_id="candidate-1",
-        mission_id=1,
+        mission_id=_MISSION_ID,
         task_id=_TASK_ID,
         dispatch_id="dispatch-1",
         dispatch_sequence=1,
@@ -115,27 +130,26 @@ def _receipt() -> CriticReceipt:
     )
 
 
-def _candidate_task_frame(max_reviews: int) -> daft.DataFrame:
-    return _signature_frame(
-        [
-            (
-                _TASK_ID,
-                (
-                    TaskState(status=TaskStatus.CANDIDATE.value),
-                    TaskDispatch(dispatch_id="dispatch-1", sequence=1),
-                    TaskPolicy(),
-                    _critic_policy(max_reviews),
-                ),
-            )
-        ]
+def _candidate_task_components(max_reviews: int) -> tuple[Component, ...]:
+    return (
+        Task(name="task", prompt="do the work"),
+        TaskState(status=TaskStatus.CANDIDATE.value),
+        TaskDispatch(dispatch_id="dispatch-1", sequence=1),
+        TaskPolicy(),
+        _critic_policy(max_reviews),
     )
 
 
-def _resources(
+def _candidate_task_frame(max_reviews: int) -> daft.DataFrame:
+    return _signature_frame([(_TASK_ID, _candidate_task_components(max_reviews))])
+
+
+def _view(
     *,
+    max_reviews: int,
     attempts: int,
     receipts: tuple[CriticReceipt, ...] = (),
-) -> Resources:
+) -> GraphView:
     results: dict[tuple[type[Component], ...], daft.DataFrame] = {
         # Unrelated task keeps the author-evidence frames non-empty without
         # matching this task's dispatch join keys.
@@ -156,6 +170,9 @@ def _resources(
             ]
         ),
         (Guards,): _signature_frame([(92, (Guards(source=93, target=999),))]),
+        (Task, TaskState, TaskDispatch, TaskPolicy, TaskCriticPolicy): _signature_frame(
+            [(_TASK_ID, _candidate_task_components(max_reviews))]
+        ),
         (Candidate,): _signature_frame([(_CANDIDATE_ENTITY_ID, (_candidate(),))]),
     }
     if attempts:
@@ -168,6 +185,10 @@ def _resources(
         )
     view = GraphView()
     view.on_post_tick_sync(PostTick(world_id="mission-world", tick=2, results=results))
+    return view
+
+
+def _resources(view: GraphView) -> Resources:
     resources = Resources()
     resources.insert(view)
     return resources
@@ -182,7 +203,7 @@ async def _decide(
     processor = TaskDecisionProcessor()
     result = await processor.process(
         _candidate_task_frame(max_reviews),
-        resources=_resources(attempts=attempts, receipts=receipts),
+        resources=_resources(_view(max_reviews=max_reviews, attempts=attempts, receipts=receipts)),
     )
     rows = result.to_pylist()
     assert len(rows) == 1
@@ -190,14 +211,14 @@ async def _decide(
 
 
 @pytest.mark.asyncio
-async def test_exhausted_review_budget_fails_candidate_without_receipt() -> None:
-    """The whole budget spent with no receipt is a terminal decision, not a hang."""
+async def test_exhausted_review_budget_leaves_candidate_pending() -> None:
+    """Reviewer failure never becomes a task decision; the candidate waits."""
 
     row = await _decide(max_reviews=2, attempts=2)
 
     state = TaskState.get_prefix()
-    assert row[f"{state}status"] == TaskStatus.FAILED.value
-    assert row[f"{state}reason"] == "independent critic review budget exhausted"
+    assert row[f"{state}status"] == TaskStatus.CANDIDATE.value
+    assert row[f"{state}reason"] == ""
 
 
 @pytest.mark.asyncio
@@ -215,3 +236,37 @@ async def test_matching_receipt_decides_even_at_the_review_budget() -> None:
 
     state = TaskState.get_prefix()
     assert row[f"{state}status"] == TaskStatus.ACCEPTED.value
+
+
+def test_exhausted_review_budget_is_projected_for_the_run_boundary() -> None:
+    """The whole budget spent with no receipt is reported, not a hang."""
+
+    pending = project_pending_review_exhaustion(
+        _view(max_reviews=2, attempts=2),
+        _MISSION_ID,
+    )
+
+    assert pending == (
+        CriticReviewBudgetExhausted(
+            mission_id=_MISSION_ID,
+            task_id=_TASK_ID,
+            candidate_id="candidate-1",
+            attempts=2,
+            max_reviews=2,
+        ),
+    )
+    error = CriticReviewBudgetExhaustedError(_MISSION_ID, pending)
+    assert "pending independent review" in str(error)
+
+
+def test_candidate_within_budget_is_not_projected_as_exhausted() -> None:
+    assert project_pending_review_exhaustion(_view(max_reviews=2, attempts=1), _MISSION_ID) == ()
+
+
+def test_receipt_bearing_candidate_is_not_projected_as_exhausted() -> None:
+    view = _view(max_reviews=2, attempts=2, receipts=(_receipt(),))
+    assert project_pending_review_exhaustion(view, _MISSION_ID) == ()
+
+
+def test_other_missions_exhaustion_is_not_reported() -> None:
+    assert project_pending_review_exhaustion(_view(max_reviews=2, attempts=2), 999) == ()

--- a/tests/missions/test_task_decision_processor.py
+++ b/tests/missions/test_task_decision_processor.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Terminal review-budget decisions for candidates without receipts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import daft
+import pytest
+
+from archetype.core.component import Component
+from archetype.core.hooks import PostTick
+from archetype.core.resources import Resources
+from archetype.graph import GraphView
+from archetype.missions.components import (
+    AgentExecution,
+    Candidate,
+    CriticExecution,
+    CriticReceipt,
+    TaskCriticPolicy,
+    TaskDispatch,
+    TaskPolicy,
+    TaskState,
+)
+from archetype.missions.processors import TaskDecisionProcessor
+from archetype.missions.relations import Guards
+from archetype.missions.transitions import (
+    AgentExecutionStatus,
+    CriticConclusion,
+    CriticExecutionStatus,
+    TaskStatus,
+)
+
+_TASK_ID = 11
+_CANDIDATE_ENTITY_ID = 31
+
+
+def _signature_frame(entities: list[tuple[int, tuple[Component, ...]]]) -> daft.DataFrame:
+    columns: dict[str, list[Any]] = {}
+    for entity_id, components in entities:
+        row: dict[str, Any] = {"entity_id": entity_id, "tick": 1, "is_active": True}
+        for component in components:
+            prefix = type(component).get_prefix()
+            for field, value in component.model_dump().items():
+                row[f"{prefix}{field}"] = value
+        for key, value in row.items():
+            columns.setdefault(key, []).append(value)
+    return daft.from_pydict(columns)
+
+
+def _candidate() -> Candidate:
+    return Candidate(
+        candidate_id="candidate-1",
+        mission_id=1,
+        task_id=_TASK_ID,
+        dispatch_id="dispatch-1",
+        dispatch_sequence=1,
+        author_execution_id=21,
+        author_sandbox_id="sandbox-author",
+        repository="https://example.invalid/repo.git",
+        branch="feature",
+        base_ref="main",
+        base_revision="base-sha",
+        head_revision="head-sha",
+        diff_digest="diff-digest",
+        validator_bundle_digest="validator-digest",
+        policy_digest="policy-digest",
+        candidate_digest="candidate-digest",
+        created_at_ms=1,
+    )
+
+
+def _critic_policy(max_reviews: int) -> TaskCriticPolicy:
+    return TaskCriticPolicy(
+        policy_id="critic-policy",
+        version="1",
+        digest="policy-digest",
+        perspective="independent-reviewer",
+        information_view="task-diff-validators",
+        driver="codex",
+        model="model-a",
+        sampling="provider-default",
+        max_reviews=max_reviews,
+    )
+
+
+def _critic_execution(attempt: int) -> CriticExecution:
+    return CriticExecution(
+        candidate_entity_id=_CANDIDATE_ENTITY_ID,
+        candidate_id="candidate-1",
+        review_id=f"review-{attempt}",
+        attempt=attempt,
+        status=CriticExecutionStatus.ERRORED.value,
+        sandbox_id=f"sandbox-critic-{attempt}",
+        error="critic run failed before any receipt",
+    )
+
+
+def _receipt() -> CriticReceipt:
+    return CriticReceipt(
+        candidate_entity_id=_CANDIDATE_ENTITY_ID,
+        critic_execution_id=41,
+        critic_sandbox_id="sandbox-critic-1",
+        review_id="review-1",
+        conclusion=CriticConclusion.APPROVED.value,
+        candidate_digest="candidate-digest",
+        policy_digest="policy-digest",
+        evidence_digest="evidence-digest",
+        reviewed_base_revision="base-sha",
+        reviewed_head_revision="head-sha",
+        reviewed_diff_digest="diff-digest",
+        validator_bundle_digest="validator-digest",
+    )
+
+
+def _candidate_task_frame(max_reviews: int) -> daft.DataFrame:
+    return _signature_frame(
+        [
+            (
+                _TASK_ID,
+                (
+                    TaskState(status=TaskStatus.CANDIDATE.value),
+                    TaskDispatch(dispatch_id="dispatch-1", sequence=1),
+                    TaskPolicy(),
+                    _critic_policy(max_reviews),
+                ),
+            )
+        ]
+    )
+
+
+def _resources(
+    *,
+    attempts: int,
+    receipts: tuple[CriticReceipt, ...] = (),
+) -> Resources:
+    results: dict[tuple[type[Component], ...], daft.DataFrame] = {
+        # Unrelated task keeps the author-evidence frames non-empty without
+        # matching this task's dispatch join keys.
+        (AgentExecution,): _signature_frame(
+            [
+                (
+                    91,
+                    (
+                        AgentExecution(
+                            task_id=999,
+                            dispatch_id="other-dispatch",
+                            dispatch_sequence=1,
+                            status=AgentExecutionStatus.EXITED.value,
+                            sandbox_id="sandbox-other",
+                        ),
+                    ),
+                )
+            ]
+        ),
+        (Guards,): _signature_frame([(92, (Guards(source=93, target=999),))]),
+        (Candidate,): _signature_frame([(_CANDIDATE_ENTITY_ID, (_candidate(),))]),
+    }
+    if attempts:
+        results[(CriticExecution,)] = _signature_frame(
+            [(40 + attempt, (_critic_execution(attempt),)) for attempt in range(1, attempts + 1)]
+        )
+    if receipts:
+        results[(CriticReceipt,)] = _signature_frame(
+            [(80 + index, (receipt,)) for index, receipt in enumerate(receipts)]
+        )
+    view = GraphView()
+    view.on_post_tick_sync(PostTick(world_id="mission-world", tick=2, results=results))
+    resources = Resources()
+    resources.insert(view)
+    return resources
+
+
+async def _decide(
+    *,
+    max_reviews: int,
+    attempts: int,
+    receipts: tuple[CriticReceipt, ...] = (),
+) -> dict[str, Any]:
+    processor = TaskDecisionProcessor()
+    result = await processor.process(
+        _candidate_task_frame(max_reviews),
+        resources=_resources(attempts=attempts, receipts=receipts),
+    )
+    rows = result.to_pylist()
+    assert len(rows) == 1
+    return rows[0]
+
+
+@pytest.mark.asyncio
+async def test_exhausted_review_budget_fails_candidate_without_receipt() -> None:
+    """The whole budget spent with no receipt is a terminal decision, not a hang."""
+
+    row = await _decide(max_reviews=2, attempts=2)
+
+    state = TaskState.get_prefix()
+    assert row[f"{state}status"] == TaskStatus.FAILED.value
+    assert row[f"{state}reason"] == "independent critic review budget exhausted"
+
+
+@pytest.mark.asyncio
+async def test_candidate_within_review_budget_keeps_waiting() -> None:
+    row = await _decide(max_reviews=2, attempts=1)
+
+    state = TaskState.get_prefix()
+    assert row[f"{state}status"] == TaskStatus.CANDIDATE.value
+    assert row[f"{state}reason"] == ""
+
+
+@pytest.mark.asyncio
+async def test_matching_receipt_decides_even_at_the_review_budget() -> None:
+    row = await _decide(max_reviews=2, attempts=2, receipts=(_receipt(),))
+
+    state = TaskState.get_prefix()
+    assert row[f"{state}status"] == TaskStatus.ACCEPTED.value

--- a/tests/physical_ai/test_hosted_episode_activities.py
+++ b/tests/physical_ai/test_hosted_episode_activities.py
@@ -1044,3 +1044,130 @@ async def test_pending_results_page_past_a_full_batch(
     deliveries = await catalog.pending_episode_results(world_id=world_id)
 
     assert sorted(delivery.activity_id for delivery in deliveries) == activity_ids
+
+
+@pytest.mark.asyncio
+async def test_scoped_run_once_processes_its_own_episode_not_an_older_claim(
+    tmp_path: Path,
+) -> None:
+    """An operation-scoped run_once must execute exactly its admitted Activity.
+
+    With two in-flight episodes in one world, the unscoped claim previously
+    handed the newer operation the older pending Activity, so the newer call
+    executed foreign work and then failed over its own missing observation.
+    """
+
+    world_id = "physical-world"
+    values = LocalHostedEpisodeValueStore(tmp_path / "values")
+    physical, _generic, catalog = _open_catalog(
+        tmp_path / "activities.db",
+        lease_seconds=300,
+    )
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+    for activity_id in ("episode-older", "episode-newer"):
+        request = await values.put_request(_request(world_id, activity_id))
+        await catalog.admit_episode(
+            world_id=world_id,
+            receipt=receipt,
+            activity_id=activity_id,
+            request=request,
+        )
+
+    runner = SeededHostedEpisodeRunner(tmp_path / "provider-executions.json")
+    stager = _ObservationStager()
+    worker = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="operation-worker",
+        catalog=catalog,
+        values=values,
+        provider=LocalDurableHostedEpisodeProvider(tmp_path / "provider", runner=runner),
+        stager=stager,
+    )
+
+    assert await worker.run_once(activity_id="episode-newer")
+
+    assert set(stager.observations) == {(world_id, "episode-newer")}
+    assert await catalog.episode_result(world_id=world_id, activity_id="episode-newer") is not None
+    assert await catalog.episode_result(world_id=world_id, activity_id="episode-older") is None
+    assert runner.execution_count == 1
+
+    # A completed Activity is redelivered, never re-executed, by another
+    # scoped pass; the older episode still executes only under its own scope.
+    assert await worker.run_once(activity_id="episode-newer")
+    assert runner.execution_count == 1
+    assert await worker.run_once(activity_id="episode-older")
+    assert set(stager.observations) == {
+        (world_id, "episode-newer"),
+        (world_id, "episode-older"),
+    }
+    assert runner.execution_count == 2
+    await physical.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_unsettled_episode_does_not_unsettle_a_completed_one(
+    tmp_path: Path,
+) -> None:
+    """Settlement is per exact Activity and digest, not world quiescence.
+
+    A stale pending Activity from another episode previously flipped the
+    world-global unsettled oracle and failed an operation whose own
+    observation had already settled.
+    """
+
+    world_id = "physical-world"
+    values = LocalHostedEpisodeValueStore(tmp_path / "values")
+    physical, _generic, catalog = _open_catalog(
+        tmp_path / "activities.db",
+        lease_seconds=300,
+    )
+    receipt = CommittedTickReceipt(world_id, "run-a", 1, "token-1", 0)
+    for activity_id in ("episode-stale", "episode-done"):
+        request = await values.put_request(_request(world_id, activity_id))
+        await catalog.admit_episode(
+            world_id=world_id,
+            receipt=receipt,
+            activity_id=activity_id,
+            request=request,
+        )
+
+    stager = _ObservationStager()
+    worker = PhysicalHostedActivityWorker(
+        world_id=world_id,
+        owner="operation-worker",
+        catalog=catalog,
+        values=values,
+        provider=LocalDurableHostedEpisodeProvider(
+            tmp_path / "provider",
+            runner=SeededHostedEpisodeRunner(tmp_path / "provider-executions.json"),
+        ),
+        stager=stager,
+    )
+    assert await worker.run_once(activity_id="episode-done")
+    observation = stager.observations[(world_id, "episode-done")]
+    await catalog.settle_episode_observation(
+        world_id=world_id,
+        activity_id="episode-done",
+        result_digest=observation.result_digest,
+        receipt=CommittedTickReceipt(world_id, "run-a", 2, "token-2", 0),
+    )
+
+    # The stale episode keeps the world globally unsettled...
+    assert await catalog.has_unsettled_work(world_id)
+    # ...yet the completed operation's own settlement holds exactly.
+    assert await catalog.episode_settled(
+        world_id=world_id,
+        activity_id="episode-done",
+        result_digest=observation.result_digest,
+    )
+    assert not await catalog.episode_settled(
+        world_id=world_id,
+        activity_id="episode-stale",
+        result_digest=observation.result_digest,
+    )
+    assert not await catalog.episode_settled(
+        world_id=world_id,
+        activity_id="episode-done",
+        result_digest="b" * 64,
+    )
+    await physical.close()


### PR DESCRIPTION
Two release blockers for #704, in different families, separated by commit and by file.

## 1. Hosted Physical AI: scope claims and settlement to the operation (`physical_ai`)

`run_hosted_episode` drove an unscoped `worker.run_once()` and completed on the world-global `binding.has_unsettled_work(world_id)`. The two unresolved late review threads on #717 describe the failures exactly:

- with several in-flight episodes in one world, a call could claim and execute another episode's **older pending Activity**, then fail over its own missing observation;
- a stale or concurrent unsettled Activity made an otherwise-completed call raise "hosted episode observation did not settle".

Fix (commit `300519de`):

- `claim_episode` / `run_once` accept an exact `activity_id`; the operation path claims exactly the Activity it admitted (an unacquired claim — leased elsewhere or result already durable — is "nothing to execute", not an error). `None` keeps drain semantics.
- Completion now checks `episode_settled(activity_id, result_digest)` — the exact Activity and exact digest `docs/guide/physical-ai.md` already documents — instead of requiring a globally quiet world. `has_unsettled_work` remains for the world-lifecycle fan-out gate.
- The concurrent regression test exposed a latent projector bug: the committed view lists one durable marker once per persisted tick, and `_unique_observations` / the stager's `_accept_existing` hard-raised on the **equal** re-listing. Both now collapse equal duplicates and fail closed only on conflicting values, matching the committed-intent rule.

Regression tests:
- `tests/physical_ai/test_hosted_episode_activities.py::test_scoped_run_once_processes_its_own_episode_not_an_older_claim` — older pending episode untouched; completed Activity is redelivered, never re-executed.
- `tests/physical_ai/test_hosted_episode_activities.py::test_stale_unsettled_episode_does_not_unsettle_a_completed_one` — exact settlement holds while a stale Activity keeps `has_unsettled_work` true.
- `tests/integration/test_hosted_physical_runtime.py::test_concurrent_hosted_episodes_each_complete_their_own_activity` — two `run_hosted_episode` calls in flight on one world each complete their own Activity end to end.
- `tests/integration/test_hosted_physical_runtime.py::test_stale_unsettled_episode_does_not_fail_a_completed_operation` — a crashed episode's unsettled leftover does not fail the next completed operation.

## 2. Missions: budget-exhausted candidates resolve instead of timing out (`missions`)

`project_critic_activity_intents` returns `exhausted: tuple[CriticReviewBudgetExhausted, ...]`, but the Activity consumer uses only `.requests`. Once a candidate's review budget is spent with no matching receipt, nothing admits further reviews and nothing decides the task — it sits in `CANDIDATE` until the caller's generic max-tick `RuntimeError`.

Fix (commit `8bb8ef89`): the required projector runs under the world lock (`_project_required_locked`) and cannot stage world mutations, so the terminal decision lands on the family's decision surface, where the other two budget legs already live: `TaskDecisionProcessor` derives review-budget exhaustion from the same committed evidence the projection reads (`CriticExecution` count per candidate vs `TaskCriticPolicy.max_reviews`, receipt-less only) and commits `TaskState` `FAILED` with reason "independent critic review budget exhausted" — the exact shape of `author_exhausted` and `repair_exhausted`. No new nouns; a matching independent receipt still wins at the budget boundary.

Regression tests (`tests/missions/test_task_decision_processor.py`): exhausted budget without a receipt fails the candidate on the next step (no max-tick wait); an in-budget candidate keeps waiting; a matching receipt decides even at the budget.

## Validation

- `make check` green (lint, lazy audit, architecture, observability — new `episode_settled` disposition added to `quality/observability/physical_ai.toml` — idempotency, gate coverage).
- `ty` 0 diagnostics.
- `make test`: 2741 passed, 6 skipped (first run had one known mission-author lease flake, `test_confirmed_absence_mints_fresh_fence_before_execution`, which passes in isolation; full rerun green).
- Hosted integration suite run 3x consecutively for race coverage: green.

Refs #704. Honors the two unresolved review threads on #717 (`hosted_workflow.py` lines 72 and 82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)