### PR TITLE
docs: v0.5 tag truth sweep + rehome the #627 mission drain oracle

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -69,10 +69,17 @@ from archetype.missions import (
     CommandValidator,
     CriticPolicy,
 )
-from archetype.missions.sandboxes import AppleContainerSandboxBackend
+from archetype.missions.sandboxes import ModalSandboxBackend, ModalSandboxConfig
+from archetype.missions.sandboxes.modal import MODAL_ACTIVITY_PROTOCOL_EPOCH
 
 
-backend = AppleContainerSandboxBackend()
+backend = ModalSandboxBackend(
+    ModalSandboxConfig(
+        workspace_name="my-workspace",
+        environment_name="main",
+        operation_protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    )
+)
 MISSION_CONFIG = AgentMissionConfig(
     sandbox_backend=backend,
     sandbox_environment=backend.environment,
@@ -133,7 +140,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-Initialize the selected backend's Codex subscription volume once before the
+Initialize the Modal backend's Codex subscription volume once before the
 first live run with `await backend.login_codex()`. This device login is not an
 OpenAI API key and cannot implicitly reuse the credential of the Codex process
 running on the host. The complete backend-selectable setup, including Modal
@@ -266,11 +273,11 @@ sequenceDiagram
     Service-->>Author: terminal projection
 ```
 
-The current PostTick boundary establishes one safety property: no sandbox sees
+The committed-tick boundary establishes one safety property: no sandbox sees
 speculative work. If tick persistence fails, its dispatch cannot leak an
-external side effect. The accepted [Activity](activities.md) target replaces
-process-local delivery after that boundary with exact-receipt projection,
-durable admission, and later-receipt settlement.
+external side effect. The [Activity](activities.md) contract carries delivery
+after that boundary with exact-receipt projection, durable admission, and
+later-receipt settlement.
 
 ### Task state
 
@@ -520,11 +527,18 @@ of process-restart mission continuation.
 
 ### Supported sandbox backends
 
+Modal is the supported end-to-end Mission backend in v0.5: mission submission
+deterministically rejects any other configured backend before admission,
+because only the Modal author and critic paths have the fail-closed Activity
+adapters. Apple Container and Docker remain sandbox capabilities — their
+session, login, and checkpoint/restore lanes below stay tested — but they
+cannot run an end-to-end mission in this release.
+
 | Backend | Role | Checkpoint / restore | Authentication |
 |---|---|---|---|
-| Apple Container | Preferred macOS operational adapter by current operator policy; VM-grade isolation through the host `container` CLI. | Stops, exports the session root filesystem to an atomic content-addressed host-local archive, restarts in `finally`, verifies integrity, and rebuilds a restore image. | Dedicated Apple Container volume and broker VM. |
-| Docker | Linux and CI reference adapter; never selected implicitly on macOS. | `docker commit`, followed by immutable image-ID inspection and same-provider restore. | Optional dedicated Docker volume and broker container. |
-| Modal | Remote paid adapter. | Modal `snapshot_filesystem`, retained with recorded environment lineage and bounded TTL, and restore by exact `im-...` image ID. Expiration may also surface from Modal while resolving the image. | Dedicated Modal Volume and broker sandbox. |
+| Modal | The supported end-to-end Mission backend; remote paid adapter. | Modal `snapshot_filesystem`, retained with recorded environment lineage and bounded TTL, and restore by exact `im-...` image ID. Expiration may also surface from Modal while resolving the image. | Dedicated Modal Volume and broker sandbox. |
+| Apple Container | macOS sandbox capability; VM-grade isolation through the host `container` CLI. Rejected for end-to-end Mission admission. | Stops, exports the session root filesystem to an atomic content-addressed host-local archive, restarts in `finally`, verifies integrity, and rebuilds a restore image. | Dedicated Apple Container volume and broker VM. |
+| Docker | Linux and CI sandbox capability; never selected implicitly on macOS. Rejected for end-to-end Mission admission. | `docker commit`, followed by immutable image-ID inspection and same-provider restore. | Optional dedicated Docker volume and broker container. |
 
 Apple Container and Docker share one digest-pinned Linux base recipe. The
 Codex tarball is fetched from the version inventory, verified against its
@@ -675,9 +689,9 @@ this contract. Cleanup stops creating or consuming its tables and routes while
 leaving existing persisted tables inert; deleting historical operator data is
 a separate, explicit migration decision.
 
-This list describes the shipped V1 Mission/ECS model. The accepted Activity
-target adds generic claim, attempt, and fence mechanics outside that model; it
-does not restore the retired mission-specific subsystem or create an `Attempt`
+This list describes the shipped V1 Mission/ECS model. The Activity contract
+adds generic claim, attempt, and fence mechanics outside that model; it does
+not restore the retired mission-specific subsystem or create an `Attempt`
 Component.
 
 ### Current hardening gaps
@@ -821,9 +835,9 @@ The implementation follows this layout:
 | `archetype/missions/critics/harness.py` | Public-base prewarming, exact-head verification, critic invocation, and structured fail-closed normalization. |
 | `archetype/missions/sandboxes/contracts.py` | Sandbox Backend, Session, process, status, and snapshot value contracts. |
 | `archetype/missions/sandboxes/service.py` | Backend registry and live-session lifetime. |
-| `archetype/missions/sandboxes/apple_container.py` | Operational macOS backend and atomic root-filesystem archive restore. |
-| `archetype/missions/sandboxes/docker.py` | Linux/CI reference backend and immutable image restore. |
-| `archetype/missions/sandboxes/modal.py` | Remote backend, device login, snapshots, and direct live monitor. |
+| `archetype/missions/sandboxes/apple_container.py` | macOS sandbox-capability backend (rejected for end-to-end admission) and atomic root-filesystem archive restore. |
+| `archetype/missions/sandboxes/docker.py` | Linux/CI sandbox-capability backend (rejected for end-to-end admission) and immutable image restore. |
+| `archetype/missions/sandboxes/modal.py` | Supported end-to-end remote backend, device login, snapshots, and direct live monitor. |
 | `archetype/missions/service.py` | Graph materialization, tick/I/O composition, family workflow, and projections. |
 | `archetype/runtime/missions.py` | Mission-author runtime handle and lifecycle. |
 | `examples/11_coding_agent_mission.py` | Real typed dogfood script. |
@@ -831,6 +845,7 @@ The implementation follows this layout:
 | `tests/missions/test_mission_author_world_integration.py` | Exact committed author admission, staging, restart, and settlement oracle. |
 | `tests/missions/test_mission_critic_world_integration.py` | Exact committed critic admission, staging, restart, and settlement oracle. |
 | `tests/missions/test_modal_activity_executors.py` | Modal author and critic provider restart/reconciliation oracle. |
+| `tests/integration/test_mission_runtime_drain.py` | Issue #627 whole-operation shutdown/close drain oracle for admitted mission operations. |
 
 No author imports a Component, processor, `GraphView`, application service, or
 provider SDK to run the built-in workflow.

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -125,7 +125,7 @@ own transitions.
 
 A Resource is tick-time capability access whose process-local lifetime is not
 durable workflow truth. An Activity coordinates work admitted from one
-committed tick and observed by a later committed tick. The accepted
+committed tick and observed by a later committed tick. The
 `archetype.activities` family owns only generic delivery mechanics and consumes
 the lower physical catalog owned by `archetype.storage`. Provider-specific
 recovery meaning stays in the owning family or adapter; application families
@@ -174,6 +174,7 @@ src/archetype/
   storage/           physical rows, catalogs, commits, scans and app tables
   world/             lifecycle, mutation, simulation, query and exact operation models
   commands/          registry, policy, dispatch, durable scheduling and audit projection
+  activities/        generic Activity identity, claims, attempts, fences and settlement
   redaction/         canonical pre-durability scanning, receipts and quarantine
   evaluation/        grading, snapshot pinning, leases and durable receipts
   artifacts/         file values, scans, immutable objects, indexes, views and handlers
@@ -184,9 +185,9 @@ src/archetype/
   wiring.py          sole concrete cross-family composition root
 ```
 
-The Activity migration adds `activities/` as a top-level family over the
-storage-owned Activity catalog. Hosted whole-episode choreography is owned by
-`archetype.physical_ai`; no application mirror is created.
+`activities/` is a top-level family over the storage-owned Activity catalog.
+Hosted whole-episode choreography is owned by `archetype.physical_ai`; no
+application mirror exists.
 
 The mission-adjacent cleanup direction is recorded in
 [Agent Missions V1, section 9](agent-missions.md#9-family-direction-after-v1).
@@ -201,8 +202,8 @@ is no application research facade or service protocol. Typed trajectory
 schemas and pure transforms live under `archetype.missions.trajectories`; the
 mission trajectory service composes world-query functions with the evaluation
 family's pure grader runner. Physical evaluation values, provider protocols,
-pure instruction optimization, terminal views, and the current direct
-world/storage workflow handlers all live under `archetype.physical_ai`.
+pure instruction optimization, terminal views, and the hosted whole-episode
+workflow handlers all live under `archetype.physical_ai`.
 Hosted Activity handling retains those reusable contracts and keeps
 intent-to-Activity-to-observation choreography in `archetype.physical_ai`
 without a single-implementation facade protocol. Claude transcript parsing
@@ -210,24 +211,17 @@ now lives under `archetype.missions.trajectories`;
 `archetype.missions.transcript_service` owns its
 redact-before-durability workflow and consumes the artifacts family directly.
 
-Physical environment and policy providers transfer synchronously into
-`RuntimeResources`, and an identity-ordered exclusive lease covers every
-provider-backed workflow effect. Before releasing that lease, the handler must
-retire its live world writer through world lifecycle authority. The returned
-world/run coordinates remain durable read evidence; they do not authorize a
-later attach/step path to the internal provider processors.
-Composition coalesces retirement by the exact sticky world-cleanup lease and
-registers that complete transaction with `RuntimeResources`. A failed
-retirement remains process-owned for the `workflow-handles` retry phase. Each
-associated provider close first joins those exact retirements, so only
-successful world cleanup can release the cleanup owner and permit provider
-shutdown. Before a private cleanup-only world can issue its first catalog
-registration, world lifecycle synchronously binds the exact catalog and
-`WorldRecord` to the pre-reserved workflow owner. Registry insertion then
-promotes that same owner, without an intervening await, to the canonical sticky
-cleanup lease. Ambiguous registration cleanup, canonical world cleanup, and
-their retries therefore remain one process-owned transaction; no handler may
-bypass it with direct lifecycle destruction.
+Physical execution providers are not installed into retryable ticks. The
+hosted whole-episode workflow admits committed episode intent as one durable
+Activity, executes or reconciles it against the remote Modal provider by
+stable operation identity, and publishes the complete result before its
+bounded reference is observed by a later tick. One world binds at most one
+hosted Modal provider namespace; composition rejects changing it, and the
+per-world hosted binding registers its required projector and closes through
+its registered process owner. The retired distributed per-step physical
+handler path — synchronous provider transfer into `RuntimeResources`,
+private evaluation worlds, and their sticky cleanup leases — is gone with the
+`evaluate_physical_task`/`sweep_physical_instructions` surface it served.
 The former
 production
 `archetype.experiments` umbrella is gone. The repository-root `experiments/`
@@ -319,10 +313,10 @@ or CLI boundary.
 | Artifacts | File values, discovery, metadata scans, immutable content-addressed objects, common/media indexes, storage-backed views, and exact free handlers | Storage port; operations carry explicit durable world and storage coordinates |
 | Evaluation | Snapshot pinning, grader contracts, grading, leasing, recovery, evidence and durable results | Storage port plus world-query functions; operations carry explicit world and storage coordinates |
 | Commands | Exact registration, authorization policy, governed direct/deferred entry, durable admission, order, leasing, lock-held materialization, retry, settlement, dead letters, transactional outbox and analytical audit projection | Storage/control catalog plus exact world handlers |
-| Activities *(accepted target)* | Generic immutable admission, claims, attempts, leases, fences, provider-operation binding, bounded result references/digests, and later-receipt settlement; no family recovery policy | Storage-owned Activity catalog |
+| Activities | Generic immutable admission, claims, attempts, leases, fences, provider-operation binding, bounded result references/digests, and later-receipt settlement; no family recovery policy | Storage-owned Activity catalog |
 | Research | AutoResearch values, ledger state, bounded persisted-control reads, experiment-keyed admission, and the directly awaited multi-run workflow | World registry/lifecycle and storage ports plus world simulation functions and explicit evaluator callbacks |
-| Physical AI | Reusable physical state, schemas, providers, views, and current direct free workflows; hosted Activity choreography moves to `app.physical_ai` | World registry/lifecycle and storage ports plus world mutation/simulation/query functions; accepted app workflow also consumes Activities |
-| Missions *(accepted Activity target)* | Graph materialization, committed-intent Activity composition, terminal projection, transcript ingestion, and trajectory query/evaluation composition. Family processors retain transition authority; Activity or trajectory evidence cannot advance tasks. | Consumes Activities, a structural mission world, family-owned sandbox resource, artifact-family handlers plus redaction/storage ports for transcripts, and world-query plus pure evaluation-grading functions for trajectory reads. |
+| Physical AI | Reusable physical state, schemas, providers, views, pure instruction optimization, and the hosted whole-episode Activity workflow | World registry/lifecycle and storage ports plus world mutation/simulation/query functions; the hosted workflow also consumes Activities |
+| Missions | Graph materialization, committed-intent Activity composition, terminal projection, transcript ingestion, and trajectory query/evaluation composition. Family processors retain transition authority; Activity or trajectory evidence cannot advance tasks. | Consumes Activities, a structural mission world, family-owned sandbox resource, artifact-family handlers plus redaction/storage ports for transcripts, and world-query plus pure evaluation-grading functions for trajectory reads. |
 | Runtime/API adapters | Construct exact family operations and select trusted or actor-aware dispatcher entry | Commands dispatcher plus family models |
 | `RuntimeResources` | Process admission, supervised work, handle ownership, and phased retryable teardown | Dispatcher, audit projection, storage, and registered owners |
 | `archetype.wiring` | Concrete construction, registration, and callback wiring | Every concrete implementation it constructs |
@@ -371,10 +365,9 @@ Durability is family-specific rather than one service-level flag:
 | Deferred command admission | Command ledger | `PENDING` record, order, payload version and principal/origin are durable |
 | Tick | Store plus commit coordinator | All tick rows are durable and the visibility manifest is published |
 | Deferred command outcome | Commit coordinator plus command ledger | Terminal applied outcomes settle atomically with the manifest that makes them visible |
-| Agent Mission dispatch *(current baseline)* | Mission world tick plus process-local post-tick outbox | A `dispatched` task row is durably visible before any sandbox request leaves the world; process restart delivery is not yet proved |
-| Agent Mission Activity *(accepted target)* | Required projector, Activity coordinator, family adapter, and later mission tick | The exact committed dispatch admits `(world_id, kind, activity_id)`; a bounded result is durable before staging; settlement requires Mission completeness evidence bound to that result reference/digest in the exact later receipt |
+| Agent Mission dispatch and review | Required projector, Activity coordinator, family adapter, and later mission tick | The exact committed dispatch admits `(world_id, kind, activity_id)` before any sandbox request leaves the world; a bounded result is durable before staging; settlement requires Mission completeness evidence bound to that result reference/digest in the exact later receipt |
 | Agent Mission acceptance | Mission processors plus world tick | Revision-bound validation and exact-head publication first produce an immutable candidate; a separate critic sandbox stages a complete receipt bound to that candidate's base, head, diff, validator bundle, and policy; only a later task-decision tick accepts, repairs, or exhausts the task |
-| Hosted Physical-AI Activity *(accepted target)* | Physical app workflow, Activity coordinator, durable Arrow/artifact publication, and later physical tick | The complete hosted result is durable by stable operation identity before its bounded reference is observed; a seeded simulator reuses that result rather than assuming GPU replay determinism |
+| Hosted Physical-AI Activity | Physical-AI hosted workflow, Activity coordinator, durable Arrow/artifact publication, and later physical tick | The complete hosted result is durable by stable operation identity before its bounded reference is observed; a seeded simulator reuses that result rather than assuming GPU replay determinism |
 | Typed family rows | Owning family workflow plus `StorageService` and Iceberg | Storage resolves and stamps the durable world/run envelope, the registered schema accepts the rows, and one Iceberg append makes the selected rows visible |
 | Artifact ingestion | Artifacts-family handler plus `StorageService` | The published durable tick is selected before file effects; the immutable object and any media-specific rows are durable before the common `artifact_files` occurrence becomes visible |
 | Coding-agent transcript | Redaction, artifacts-family handler, and storage authority | Raw narrative never becomes durable; the sanitized artifact is indexed and its digest verified before normalized rows keyed to its `artifact_id` are appended |
@@ -601,8 +594,8 @@ resources within the mission family.
 
 `quality/architecture.toml` contains the scalar policy and family
 DAG. Per-family fragments under `quality/architecture.d/` register the
-top-level dispositions for `artifacts`, `commands`, `episodes`, `evaluation`,
-`graph`, `missions`, `physical_ai`, `projections`, `redaction`,
+top-level dispositions for `activities`, `artifacts`, `commands`, `episodes`,
+`evaluation`, `graph`, `missions`, `physical_ai`, `projections`, `redaction`,
 `research`, `storage`, and `world`.
 `scripts/check_architecture.py` enforces their package direction, protocol
 imports, concrete construction, concrete inheritance, and persistent
@@ -681,20 +674,21 @@ dependency. `errors` is the exact common-family module; `runtime`, `api`,
 | `storage` | none |
 | `world` | `storage` |
 | `commands` | `storage`, `world` |
+| `activities` | `storage` |
 | `artifacts` | `storage` |
 | `redaction` | none |
 | `evaluation` | `storage`, `world` |
 | `research` | `storage`, `world` |
-| `physical_ai` | `storage`, `world` |
+| `physical_ai` | `activities`, `storage`, `world` |
 | `episodes` | `artifacts`, `evaluation` |
 | `graph` | none |
-| `missions` | `artifacts`, `episodes`, `graph` |
+| `missions` | `activities`, `artifacts`, `episodes`, `evaluation`, `graph`, `projections`, `redaction`, `storage`, `world` |
 | `projections` | `graph` |
 
-The A2 Activity slice adds one reviewed top-level edge:
-`activities -> storage`. The current graph above remains unchanged until that
-package, its policy fragment, and its executable architecture oracle land
-together.
+The Activity slice is landed: `activities -> storage` is a reviewed top-level
+edge registered in `quality/architecture.d/activities.toml`, and the
+physical-AI and mission consumers declare their `activities` edges in their
+own fragments.
 
 Every family may also import `archetype.core`, stable shared boundary-error
 bases from `archetype.errors`, itself, and third-party libraries. Another
@@ -704,9 +698,10 @@ model/handler pairs and is the sole concrete cross-family composition root.
 `runtime` and `api` consume commands plus the family models and projections they
 expose; CLI remains an HTTP client except for server startup.
 
-The physical-AI handlers exercise exactly the `storage` and `world` edges.
-Physical task and sweep reports remain family-owned terminal projections; the
-workflow does not import or delegate report authority to `evaluation`.
+The physical-AI hosted workflow exercises exactly the `activities`, `storage`,
+and `world` edges. Hosted episode reports remain family-owned terminal
+projections; the workflow does not import or delegate report authority to
+`evaluation`.
 
 The current package ownership is:
 
@@ -717,6 +712,7 @@ src/archetype/
   storage/       Daft execution, catalogs, commits, scans, signatures, session
   world/         registry, lifecycle, simulation, mutation, query, handlers
   commands/      operation registry, dispatch, policy, scheduler, access audit
+  activities/
   graph/
   evaluation/
   research/
@@ -770,7 +766,7 @@ identity and a pinned visibility reference, never live frames. Required
 projection may be retried without rerunning the tick. Public `PostTick`
 observers cannot suppress or acknowledge it. Mission-specific dispatch and
 review intent are consumers of this seam, not special hook semantics. The
-accepted Activity coordinator durably admits that intent after projection;
+Activity coordinator durably admits that intent after projection;
 workers claim outside the world lock and settle only against the later receipt
 that commits their factual observation.
 
@@ -844,9 +840,9 @@ boundary rather than relying on a pre-refactor baseline.
 | lock and shutdown admission | runtime lifecycle and admitted-work race contracts | Landed in world/runtime resources |
 | UUIDv7 run identity and fork/resume continuity | command-flow, fork-storage, and world-resume contracts | Landed in world |
 | episode identity and trajectory derivation | trajectory-domain, trajectory-service, and episode-join contracts | Landed: evidence keyed by `episode_id`, trajectory is a derived view |
-| stable task base, immutable candidate, exact-head critic | coding-agent, critic, mission-service, and capability-eval contracts | Current preservation baseline; author and critic Activity cutovers must preserve it |
-| sandbox cleanup and retryable phased teardown | sandbox-service, runtime-contract, and mission-service race contracts | Process lifetime landed; Activity worker ownership remains |
-| committed required projection and provider reconciliation | generic seam and mission-consumer failpoint contracts | Generic world seam landed; Activity catalog and Mission consumers are A2–A5 |
+| stable task base, immutable candidate, exact-head critic | coding-agent, critic, mission-service, and Modal executor restart contracts | Preserved through the landed author and critic Activity cutovers |
+| sandbox cleanup and retryable phased teardown | sandbox-service, runtime-contract, and mission runtime-drain race contracts | Landed: process lifetime plus Activity binding ownership under the mission owner |
+| committed required projection and provider reconciliation | generic seam and mission-consumer failpoint contracts | Landed: generic world seam, Activity catalog, and the Modal author/critic and hosted physical consumers |
 
 No row permits an implementation to claim completion from an old baseline test
 alone.

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -276,7 +276,7 @@ Source: [`examples/11_coding_agent_mission.py`](https://github.com/VangelisTech/
 - typed `AgentTask` and `CommandValidator` authoring;
 - a temporal `DependsOn` relationship instead of a JSON plan cursor;
 - an expected-nonzero validator for the red regression;
-- committed dispatch through the post-tick outbox;
+- committed dispatch admitted as a durable author Activity after its tick;
 - revision-bound validation and exact-head publication producing an immutable
   candidate rather than acceptance;
 - independent review of that exact candidate in a distinct critic sandbox;
@@ -332,17 +332,5 @@ uv run python examples/13_biome_rts.py
 
 Source: [`examples/13_biome_rts.py`](https://github.com/VangelisTech/archetype/blob/main/examples/13_biome_rts.py)
 
----
-
-## 14. Deterministic Physical-AI Evidence
-
-Use in-process scripted providers to evaluate a reach task, persist telemetry
-and frame references, compare paired instruction trials, and optimize an
-instruction. This is a deterministic mechanism check, not evidence from a real
-simulator, model, GPU, or robot.
-
-```bash
-uv run python examples/14_physical_ai.py
-```
-
-Source: [`examples/14_physical_ai.py`](https://github.com/VangelisTech/archetype/blob/main/examples/14_physical_ai.py)
+The hosted physical-AI episode path has no numbered example script; its
+runnable snippet and contract live in [Physical AI](physical-ai.md).

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -196,15 +196,13 @@ same experiment only after the outer call returns. Runtime shutdown therefore
 joins an admitted AutoResearch call before closing shared dependencies, without
 a research-owned task, owner reservation, or finalizer.
 
-`runtime.evaluate_physical_task(...)` and
-`runtime.sweep_physical_instructions(...)` dispatch typed requests to the
-registered physical-AI handler. The runtime does not install processors,
-reset provider state, spawn trial entities, run episodes, or collect terminal
-rows itself. Returned reports carry the durable world/run identity from which
-their values were derived. Each call pre-reserves process-owned lazy canonical
-cleanup before private-world creation; validation, compensation, and retry all
-remain on that exact owner rather than invoking lifecycle destruction through a
-parallel fallback. The sync runtime exposes the same operations.
+Physical evaluation enters through `world.run_hosted_episode(...)`, which
+dispatches the exact `RunHostedEpisode` operation to the registered
+physical-AI handler. The handle must retain explicit storage coordinates. The
+handler owns hosted Activity admission, remote Modal execution or
+reconciliation by stable operation identity, and durable result publication;
+the runtime does not run episodes or collect terminal rows itself. The sync
+world handle exposes the same operation. See [Physical AI](physical-ai.md).
 
 ### R12 — Typed artifacts and transcript evidence
 
@@ -294,8 +292,11 @@ interchange boundary.
 
 `runtime.missions(name, config=..., storage=...)` returns an async
 `RuntimeMissions` handle. It configures one mission-capable world with the
-built-in Components, graph view, transition processors, post-tick outbox, and
-injected Sandbox Backend plus coding-agent and critic drivers. The family-owned
+built-in Components, graph view, transition processors, durable
+author-and-critic Activity binding, and injected Sandbox Backend plus
+coding-agent and critic drivers. v0.5 admits only the Modal sandbox backend
+for end-to-end missions; submission rejects any other configured backend
+deterministically before admission. The family-owned
 Sandbox Service retains the author Session and owns fresh candidate-scoped
 critic Sessions. Authors submit typed tasks and critic policies; they never
 wire that bundle themselves. A custom critic driver declares `driver_id`, and
@@ -371,7 +372,7 @@ await world.update(eid, Position(x=10))
 await world.add_components(eid, Health(hp=100))
 await world.remove_components(eid, Velocity)
 
-artifact = await world.ingest_artifact(...)
+refs = await world.ingest_artifacts(ArtifactSource(...))
 
 await world.add_processor(MyProcessor())
 await world.remove_processor(MyProcessor)

--- a/examples/11_coding_agent_mission.py
+++ b/examples/11_coding_agent_mission.py
@@ -10,20 +10,17 @@ Inspect the mission without external work:
 
     uv run --extra coding-agent python examples/11_coding_agent_mission.py --dry-run
 
-Apple Container is the macOS operational backend. Initialize its subscription
-credential once, then run the mission (``container system start`` must be up):
-
-    uv run --extra coding-agent python examples/11_coding_agent_mission.py \
-        --backend apple-container --login
-    uv run --extra coding-agent python examples/11_coding_agent_mission.py \
-        --backend apple-container
-
-Modal uses the same Codex subscription through a named remote Volume. Its
-device-login flow is separate from an OpenAI API key and from the local Codex
-session running this script. Initialize it once, then run and optionally stream
-the sandbox's durable live output in the same terminal:
+Modal is the supported end-to-end Mission backend in v0.5; mission admission
+deterministically rejects every other configured backend. Modal uses a Codex
+subscription through a named remote Volume; its device-login flow is separate
+from an OpenAI API key and from the local Codex session running this script.
+Durable author/critic Activity identity additionally needs your Modal
+workspace and environment names. Initialize once, then run and optionally
+stream the sandbox's durable live output in the same terminal:
 
     modal token set --token-id "$MODAL_TOKEN_ID" --token-secret "$MODAL_TOKEN_SECRET"
+    export CODING_AGENT_MODAL_WORKSPACE=my-workspace
+    export CODING_AGENT_MODAL_ENVIRONMENT=main
     uv run --extra coding-agent python examples/11_coding_agent_mission.py \
         --backend modal --login
     uv run --extra coding-agent python examples/11_coding_agent_mission.py \
@@ -34,12 +31,12 @@ To attach from another terminal, copy the printed ``sb-...`` identity:
     uv run --extra coding-agent python examples/11_coding_agent_mission.py \
         --backend modal --monitor sb-...
 
-Docker is the Linux/CI compatibility backend, not the macOS recommendation:
-
-    uv run --extra coding-agent python examples/11_coding_agent_mission.py \
-        --backend docker --login
-    uv run --extra coding-agent python examples/11_coding_agent_mission.py \
-        --backend docker
+Apple Container (macOS) and Docker (Linux/CI) remain sandbox capabilities
+only: their Codex login and checkpoint/restore lanes work, and ``--dry-run``
+inspects their typed configuration, but submitting an end-to-end mission with
+either backend fails closed before admission. Initialize their subscription
+credentials with ``--backend apple-container --login`` (``container system
+start`` must be up) or ``--backend docker --login``.
 
 The subscription credential lives only in a dedicated broker volume. It is
 copied into a mission immediately around Codex, refreshed back to the broker,
@@ -73,6 +70,7 @@ from archetype.missions.sandboxes import (
     SandboxEvent,
     SandboxEventType,
 )
+from archetype.missions.sandboxes.modal import MODAL_ACTIVITY_PROTOCOL_EPOCH
 
 ISSUE = "https://github.com/VangelisTech/archetype/issues/543"
 REPOSITORY = "VangelisTech/archetype"
@@ -204,7 +202,10 @@ def _arguments() -> argparse.Namespace:
 
 
 def _host_default_backend() -> str:
-    return "apple-container" if sys.platform == "darwin" else "docker"
+    # Modal is the only backend admitted for end-to-end missions in v0.5;
+    # apple-container and docker stay selectable for their sandbox-capability
+    # lanes (login, dry-run inspection, checkpoint/restore parity).
+    return "modal"
 
 
 def _backend(name: str) -> tuple[SandboxBackend, str]:
@@ -224,6 +225,9 @@ def _backend(name: str) -> tuple[SandboxBackend, str]:
             image_id=image_id,
             auth_volume_name=auth_volume,
             github_secret_name=os.environ.get("CODING_AGENT_GITHUB_SECRET", "archetype-github"),
+            workspace_name=os.environ.get("CODING_AGENT_MODAL_WORKSPACE") or None,
+            environment_name=os.environ.get("CODING_AGENT_MODAL_ENVIRONMENT") or None,
+            operation_protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
         )
     )
     return backend, backend.environment
@@ -303,6 +307,13 @@ async def main() -> None:
         print(f"  {task.name}{dependency}")
     if arguments.dry_run:
         return
+    if isinstance(backend, ModalSandboxBackend) and (
+        backend.config.workspace_name is None or backend.config.environment_name is None
+    ):
+        raise RuntimeError(
+            "live Modal missions require CODING_AGENT_MODAL_WORKSPACE and "
+            "CODING_AGENT_MODAL_ENVIRONMENT to name the durable Activity namespace"
+        )
 
     monitor_task: asyncio.Task[dict[str, object]] | None = None
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,11 +19,10 @@ uv run python examples/<filename>.py
 | 8 | [`08_htn_resolution.py`](08_htn_resolution.py) | HTN plan resolution as a fan-out AND/OR forest | None |
 | 9 | [`09_cloud_storage.py`](09_cloud_storage.py) | Cloud storage configurations through `StorageConfig` and the runtime API | Optional cloud credentials |
 | 10 | [`10_autoresearch.py`](10_autoresearch.py) | Multi-run autoresearch through the runtime workflow | None |
-| 11 | [`11_coding_agent_mission.py`](11_coding_agent_mission.py) | Typed coding-agent task graph with validators, Apple Container/Docker/Modal backends, checkpoints, and direct Modal monitoring | Codex subscription + GitHub credentials; dry-run needs none |
+| 11 | [`11_coding_agent_mission.py`](11_coding_agent_mission.py) | Typed coding-agent task graph with validators, the supported Modal end-to-end backend, checkpoints, and direct Modal monitoring; Apple Container/Docker are sandbox capabilities only, rejected at mission admission | Codex subscription + GitHub + Modal credentials; dry-run needs none |
 | 11 | [`11_graph_relationships.py`](11_graph_relationships.py) | Edge entities: build a hierarchy, traverse it, read the graph at an earlier tick, cascade after a despawn | None |
 | 12 | [`12_prefabs.py`](12_prefabs.py) | PreFabs: author a template with a subtree, instantiate copies with overrides and IsA lineage, upgrade by re-instantiation | None |
 | 13 | [`13_biome_rts.py`](13_biome_rts.py) | Biome-inspired prefab asset library composed into an RTS command hierarchy, minimap, fog of war, and possessed-unit view | None |
-| 14 | [`14_physical_ai.py`](14_physical_ai.py) | Deterministic task evaluation, paired instruction sweep, persisted telemetry/frame refs, and instruction optimization | None |
 
 ## Supplementary
 

--- a/tests/integration/test_mission_runtime_drain.py
+++ b/tests/integration/test_mission_runtime_drain.py
@@ -380,7 +380,10 @@ def _task() -> AgentTask:
         (
             CommandValidator(
                 "focused",
-                ("sh", "-lc", 'test "$(cat implementation.txt)" = fixed'),
+                # Plain non-login shell: -l would source the runner's profile
+                # (bash-specific in the CI container) and make the validator's
+                # return code environment-dependent.
+                ("sh", "-c", 'test "$(cat implementation.txt)" = fixed'),
             ),
         ),
         max_dispatches=1,

--- a/tests/integration/test_mission_runtime_drain.py
+++ b/tests/integration/test_mission_runtime_drain.py
@@ -1,0 +1,821 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime-lifetime drain contracts for admitted Agent Missions operations.
+
+These tests bind the whole-operation admission contract from issue #627: a
+mission operation admitted before runtime shutdown drains as one supported
+workflow. The race schedule is the issue's dogfood counterfactual — shutdown
+begins while an admitted ``run()`` is blocked in external execution, between
+its committed dispatch and its later observation staging, when no individual
+world call is in flight. An implementation that guards only individual world
+calls drains at that barrier and fails these tests.
+
+v0.5 admits only the Modal sandbox backend end to end, and external execution
+crosses the durable author/critic Activity binding. These tests therefore
+submit through the real Modal-only wiring composition and then replace the two
+provider executors on the composed binding with local Git fakes, so the
+admitted run still exercises the real dispatcher admission, required
+projector, Activity workers, observation stagers, transition processors, and
+world machinery without Modal credentials. The executor seam is exactly the
+external-execution boundary the #627 schedule blocks on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from archetype import ArchetypeRuntime
+from archetype.core.config import StorageConfig
+from archetype.errors import RuntimeShutdownError
+from archetype.missions import (
+    AgentExecution,
+    AgentMissionConfig,
+    AgentTask,
+    CommandValidator,
+    Commit,
+    Sandbox,
+    TaskState,
+    ValidationResult,
+)
+from archetype.missions.activities import AuthorExecutionObservation
+from archetype.missions.coding_agents.contracts import (
+    AgentExecutionResult,
+    CommitObservation,
+    ValidationObservation,
+)
+from archetype.missions.contracts import MissionResult, SubmittedMission
+from archetype.missions.critics import (
+    CriticExecutionResult,
+    CriticReceiptValue,
+    CriticSubjectPolicy,
+    CriticSubjectTransport,
+    bind_critic_subject,
+)
+from archetype.missions.critics.contracts import canonical_digest, validator_bundle_digest
+from archetype.missions.sandboxes import CheckpointRef, SandboxIdentity, SandboxStatus
+from archetype.missions.sandboxes.modal import (
+    MODAL_ACTIVITY_PROTOCOL_EPOCH,
+    ModalSandboxBackend,
+    ModalSandboxConfig,
+)
+from archetype.missions.transitions import (
+    AgentExecutionStatus,
+    CriticConclusion,
+    CriticExecutionStatus,
+)
+from archetype.projections import latest
+from archetype.world.errors import WorldHasUnsettledWorkError
+
+
+def _git(*arguments: str, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _remote(tmp_path: Path) -> Path:
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git("init", "-b", "main", cwd=seed)
+    _git("config", "user.name", "Fixture", cwd=seed)
+    _git("config", "user.email", "fixture@example.com", cwd=seed)
+    (seed / "README.md").write_text("seed\n", encoding="utf-8")
+    _git("add", "README.md", cwd=seed)
+    _git("commit", "-m", "seed", cwd=seed)
+    remote = tmp_path / "remote.git"
+    _git("clone", "--bare", str(seed), str(remote))
+    return remote
+
+
+def _modal_backend() -> ModalSandboxBackend:
+    """Pass v0.5's Modal-only admission without any Modal credential."""
+
+    return ModalSandboxBackend(
+        ModalSandboxConfig(
+            workspace_name="drain-test-workspace",
+            environment_name="drain-test-environment",
+            operation_protocol_epoch=MODAL_ACTIVITY_PROTOCOL_EPOCH,
+        )
+    )
+
+
+class _DrainAuthorExecutor:
+    """Complete real local Git author work, then block inside external execution.
+
+    While blocked, no world call is in flight: the admitted ``run()`` sits
+    between its committed dispatch and its later observation staging.
+    """
+
+    provider = "local-git-author"
+
+    def __init__(
+        self,
+        remote: Path,
+        workspace_root: Path,
+        *,
+        content: str = "fixed",
+    ) -> None:
+        self.remote = remote
+        self.workspace_root = workspace_root
+        self.content = content
+        self.blocked = asyncio.Event()
+        self.release = asyncio.Event()
+        self.probe: Any = None
+        self.probe_outcomes: list[str] = []
+        self.on_execute: Any = None
+        self.execute_calls = 0
+
+    async def execute(
+        self,
+        *,
+        operation_id: str,
+        request: Any,
+        attempt: int,
+        fence: int,
+        retry_guard: Any,
+    ) -> AuthorExecutionObservation:
+        del attempt, fence, retry_guard
+        self.execute_calls += 1
+        digest = hashlib.sha256(operation_id.encode()).hexdigest()
+        workspace = self.workspace_root / digest[:12]
+        _git("clone", str(self.remote), str(workspace))
+        _git("switch", "-c", request.branch, cwd=workspace)
+        _git("config", "user.name", "Drain Author", cwd=workspace)
+        _git("config", "user.email", "author@archetype.local", cwd=workspace)
+        starting_revision = _git("rev-parse", "HEAD", cwd=workspace)
+        (workspace / "implementation.txt").write_text(f"{self.content}\n")
+        _git("add", "implementation.txt", cwd=workspace)
+        message = f"{request.task_name}: drain oracle"
+        _git("commit", "-m", message, cwd=workspace)
+        final_revision = _git("rev-parse", "HEAD", cwd=workspace)
+        validation: list[ValidationObservation] = []
+        for validator in request.validators:
+            actual = subprocess.run(
+                validator.spec.command,
+                cwd=workspace,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            validation.append(
+                ValidationObservation(
+                    validator_id=validator.validator_id,
+                    name=validator.spec.name,
+                    command=validator.spec.command,
+                    expected_returncode=validator.spec.expected_returncode,
+                    actual_returncode=actual.returncode,
+                    revision=final_revision,
+                    stdout=actual.stdout,
+                    stderr=actual.stderr,
+                )
+            )
+        _git("push", "-u", "origin", f"HEAD:refs/heads/{request.branch}", cwd=workspace)
+        diff = subprocess.run(
+            (
+                "git",
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--binary",
+                starting_revision,
+                final_revision,
+            ),
+            cwd=workspace,
+            check=True,
+            capture_output=True,
+        ).stdout
+        observation = AuthorExecutionObservation(
+            result=AgentExecutionResult(
+                mission_id=request.mission_id,
+                task_id=request.task_id,
+                dispatch_id=request.dispatch_id,
+                dispatch_sequence=request.dispatch_sequence,
+                status=AgentExecutionStatus.EXITED,
+                sandbox=SandboxIdentity(
+                    "local",
+                    f"author-{digest[:12]}",
+                    "local-drain-git",
+                ),
+                worktree=str(workspace),
+                agent_session_id=f"session-{digest[:12]}",
+                agent_returncode=0,
+                starting_revision=starting_revision,
+                final_revision=final_revision,
+                diff_digest=hashlib.sha256(diff).hexdigest(),
+                validator_bundle_digest=validator_bundle_digest(
+                    tuple(
+                        (
+                            validator.validator_id,
+                            validator.spec.name,
+                            validator.spec.command,
+                            validator.spec.expected_returncode,
+                            validator.spec.timeout_seconds,
+                        )
+                        for validator in request.validators
+                    )
+                ),
+                agent_stdout="drain author stdout",
+                agent_stderr="",
+                trace_uri=f"local-git://{digest}",
+                validation=tuple(validation),
+                commits=(
+                    CommitObservation(
+                        sha=final_revision,
+                        message=message,
+                        branch=request.branch,
+                        pushed=True,
+                        final_revision=True,
+                    ),
+                ),
+            ),
+            sandbox_status=SandboxStatus.CLOSED,
+        )
+        if self.probe is not None:
+            probe = self.probe
+            self.probe = None
+            try:
+                await probe()
+            except BaseException as error:  # noqa: BLE001 - recorded for assertion
+                self.probe_outcomes.append(f"{type(error).__name__}: {error}")
+            else:
+                self.probe_outcomes.append("returned")
+        if self.on_execute is not None:
+            self.on_execute()
+        self.blocked.set()
+        await self.release.wait()
+        return observation
+
+    async def reconcile(self, *, operation_id: str, request: Any) -> Any:
+        raise AssertionError("the drain author fake never reconciles")
+
+
+class _DrainCriticExecutor:
+    """Recompute the exact candidate diff from the local remote and approve it."""
+
+    provider = "local-git-critic"
+
+    def __init__(self, remote: Path, root: Path) -> None:
+        self.remote = remote
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.execute_calls = 0
+
+    async def execute(
+        self,
+        *,
+        operation_id: str,
+        request: Any,
+        attempt: int,
+        fence: int,
+        retry_guard: Any,
+    ) -> CriticExecutionResult:
+        del attempt, fence, retry_guard
+        self.execute_calls += 1
+        diff = subprocess.run(
+            (
+                "git",
+                "--git-dir",
+                str(self.remote),
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--binary",
+                request.base_revision,
+                request.head_revision,
+            ),
+            check=True,
+            capture_output=True,
+        ).stdout
+        subject_directory = Path(tempfile.mkdtemp(prefix="archetype-drain-critic.", dir=self.root))
+        subject_path = subject_directory / "subject.diff"
+        try:
+            subject_path.write_bytes(diff)
+            subject = bind_critic_subject(
+                CriticSubjectPolicy(
+                    digest=request.diff_digest,
+                    max_bytes=request.subject.max_bytes,
+                ),
+                metadata=f"review:{request.review_id}".encode(),
+                content=subject_path.read_bytes(),
+                transport=CriticSubjectTransport.SANDBOX_FILE,
+                ref=str(subject_path),
+            )
+            completed_at_ms = 200
+            receipt = CriticReceiptValue(
+                review_id=request.review_id,
+                conclusion=CriticConclusion.APPROVED,
+                candidate_digest=request.candidate_digest,
+                policy_digest=request.policy.digest,
+                evidence_digest=canonical_digest({"conclusion": "approved"}),
+                reviewed_base_revision=request.base_revision,
+                reviewed_head_revision=request.head_revision,
+                reviewed_diff_digest=request.diff_digest,
+                validator_bundle_digest=request.validator_bundle_digest,
+                subject_metadata_digest=subject.metadata_digest,
+                subject_digest=subject.subject_digest,
+                subject_content_size_bytes=subject.content_size_bytes,
+                subject_metadata_size_bytes=subject.metadata_size_bytes,
+                subject_size_bytes=subject.total_size_bytes,
+                subject_media_type=subject.media_type,
+                subject_transport=subject.transport.value,
+                subject_ref=subject.ref,
+                reviewed_scope="exact task diff",
+                finding_count=0,
+                blocking_count=0,
+                output_schema_version=request.policy.output_schema_version,
+                completed_at_ms=completed_at_ms,
+            )
+            operation_digest = hashlib.sha256(operation_id.encode()).hexdigest()
+            return CriticExecutionResult(
+                request=request.as_review_request(),
+                status=CriticExecutionStatus.EXITED,
+                sandbox=SandboxIdentity(
+                    "local",
+                    f"critic-{operation_digest[:12]}",
+                    "local-drain-git",
+                ),
+                sandbox_status=SandboxStatus.CLOSED,
+                sandbox_acquired=True,
+                started_at_ms=150,
+                ended_at_ms=completed_at_ms,
+                raw_output='{"conclusion":"approved","schema_version":1}',
+                trace_uri=f"local-git-critic://{operation_digest}",
+                findings=(),
+                receipt=receipt,
+            )
+        finally:
+            if subject_path.exists():
+                subject_path.unlink()
+            subject_directory.rmdir()
+
+    async def reconcile(self, *, operation_id: str, request: Any) -> Any:
+        raise AssertionError("the drain critic fake never reconciles")
+
+
+def _config(backend: ModalSandboxBackend) -> AgentMissionConfig:
+    return AgentMissionConfig(
+        sandbox_backend=backend,
+        sandbox_environment=backend.environment,
+        checkpoint_after_dispatch=False,
+    )
+
+
+def _task() -> AgentTask:
+    return AgentTask(
+        "implementation",
+        "Create implementation.txt containing fixed.",
+        (
+            CommandValidator(
+                "focused",
+                ("sh", "-lc", 'test "$(cat implementation.txt)" = fixed'),
+            ),
+        ),
+        max_dispatches=1,
+    )
+
+
+def _swap_executors(
+    missions: Any,
+    author: _DrainAuthorExecutor,
+    critic: _DrainCriticExecutor,
+) -> Any:
+    """Replace the composed Modal executors at the external-execution seam."""
+
+    service = missions._reservation.require_bound()  # noqa: SLF001 - exact owner oracle
+    binding = service._activity  # noqa: SLF001 - concrete composition oracle
+    binding.author.worker._executor = author  # noqa: SLF001 - executor seam
+    binding.critic.worker._executor = critic  # noqa: SLF001 - executor seam
+    return service
+
+
+async def _spin(iterations: int = 200) -> None:
+    for _ in range(iterations):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_runtime_shutdown_drains_admitted_run_blocked_in_external_execution(
+    tmp_path: Path,
+) -> None:
+    """Issue #627 schedule: graceful shutdown drains the whole admitted run."""
+
+    remote = _remote(tmp_path)
+    author = _DrainAuthorExecutor(remote, tmp_path / "author")
+    critic = _DrainCriticExecutor(remote, tmp_path / "critic")
+    storage = StorageConfig(
+        uri=str(tmp_path / "mission_runtime_drain"),
+        namespace="mission_runtime_drain_contract",
+    )
+    world_id_reentries: list[object] = []
+    scheduled_reentries: list[asyncio.Task[object]] = []
+
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "runtime-drain",
+        config=_config(_modal_backend()),
+        storage=storage,
+    )
+    submitted = await missions.submit(
+        repository=str(remote),
+        branch="agent/runtime-drain",
+        tasks=(_task(),),
+    )
+    _swap_executors(missions, author, critic)
+    world_id = str(missions.world_id)
+
+    # Ordinary admitted work is not teardown: from inside the admitted run,
+    # runtime shutdown and public mission close both reject deterministically.
+    async def teardown_authority_probe() -> None:
+        with pytest.raises(RuntimeError, match="cannot close from an admitted operation"):
+            await runtime.shutdown()
+        with pytest.raises(RuntimeError, match="cannot close from an admitted operation"):
+            await missions.close()
+
+    author.probe = teardown_authority_probe
+
+    def reentry_from_admitted_run() -> None:
+        # Synchronous re-entry from the admitted task and scheduled async
+        # re-entry from a fresh task; neither may deadlock shutdown.
+        try:
+            world_id_reentries.append(str(missions.world_id))
+        except RuntimeError as error:
+            world_id_reentries.append(error)
+        scheduled_reentries.append(asyncio.ensure_future(missions.query()))
+
+    author.on_execute = reentry_from_admitted_run
+
+    run_task = asyncio.create_task(missions.run(submitted))
+    await asyncio.wait_for(author.blocked.wait(), timeout=30)
+    assert author.probe_outcomes == ["returned"]
+
+    shutting_down = asyncio.create_task(runtime.shutdown())
+    await _spin()
+
+    # The admitted run is blocked between world calls; a per-call guard would
+    # observe zero in-flight calls and let shutdown finish here.
+    assert not shutting_down.done()
+
+    # New supported mission operations fail before side effects.
+    executes_before = author.execute_calls
+    with pytest.raises(RuntimeError, match="closed"):
+        await missions.submit(
+            repository=str(remote),
+            branch="agent/late-submit",
+            tasks=(_task(),),
+        )
+    with pytest.raises(RuntimeError, match="closed"):
+        await missions.run(submitted)
+    with pytest.raises(RuntimeError, match="closed"):
+        await missions.restore_sandbox(
+            submitted,
+            CheckpointRef("local", "cp", "local://cp", 1),
+        )
+    with pytest.raises(RuntimeError, match="closed"):
+        await missions.query()
+    with pytest.raises(RuntimeError, match="closed"):
+        runtime.world("rejected-during-shutdown")
+    assert author.execute_calls == executes_before
+
+    author.release.set()
+    result = await asyncio.wait_for(run_task, timeout=120)
+    assert isinstance(result, MissionResult)
+    assert result.status == "succeeded"
+    assert author.execute_calls == 1
+    assert critic.execute_calls == 1
+
+    await asyncio.wait_for(shutting_down, timeout=60)
+
+    # Observer re-entry resolved without wedging shutdown.
+    resolved = await asyncio.wait_for(
+        asyncio.gather(*scheduled_reentries, return_exceptions=True),
+        timeout=30,
+    )
+    assert len(resolved) == len(scheduled_reentries)
+    assert any(not isinstance(item, BaseException) for item in world_id_reentries)
+    assert all(isinstance(item, str | RuntimeError) for item in world_id_reentries)
+
+    # Execution, validation, publication evidence, task decision, and final
+    # sandbox state are durably queryable by a cold reader after the race.
+    async with ArchetypeRuntime() as reader:
+        attached = reader.attach(world_id, storage=storage)
+        executions = latest(await attached.query(AgentExecution)).to_pylist()
+        validations = latest(await attached.query(ValidationResult)).to_pylist()
+        commits = latest(await attached.query(Commit)).to_pylist()
+        states = latest(await attached.query(TaskState)).to_pylist()
+        sandboxes = latest(await attached.query(Sandbox)).to_pylist()
+    validation = ValidationResult.get_prefix()
+    state = TaskState.get_prefix()
+    sandbox = Sandbox.get_prefix()
+    assert len(executions) == 1
+    assert [int(row[f"{validation}actual_returncode"]) for row in validations] == [0]
+    assert len(commits) >= 1
+    assert {row[f"{state}status"] for row in states} == {"accepted"}
+    assert sandboxes
+    assert all(row[f"{sandbox}status"] == SandboxStatus.CLOSED.value for row in sandboxes)
+
+
+@pytest.mark.asyncio
+async def test_runtime_shutdown_preserves_factual_failure_of_admitted_run(
+    tmp_path: Path,
+) -> None:
+    """A run that fails validation returns that factual failure, not a
+    runtime-closed error, when it raced graceful shutdown."""
+
+    remote = _remote(tmp_path)
+    author = _DrainAuthorExecutor(remote, tmp_path / "author", content="broken")
+    critic = _DrainCriticExecutor(remote, tmp_path / "critic")
+    storage = StorageConfig(
+        uri=str(tmp_path / "mission_factual_failure"),
+        namespace="mission_factual_failure_contract",
+    )
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "factual-failure",
+        config=_config(_modal_backend()),
+        storage=storage,
+    )
+    submitted = await missions.submit(
+        repository=str(remote),
+        branch="agent/factual-failure",
+        tasks=(_task(),),
+    )
+    _swap_executors(missions, author, critic)
+    world_id = str(missions.world_id)
+
+    run_task = asyncio.create_task(missions.run(submitted))
+    await asyncio.wait_for(author.blocked.wait(), timeout=30)
+    shutting_down = asyncio.create_task(runtime.shutdown())
+    await _spin()
+    assert not shutting_down.done()
+
+    author.release.set()
+    result = await asyncio.wait_for(run_task, timeout=120)
+    assert isinstance(result, MissionResult)
+    assert result.status == "failed"
+    assert critic.execute_calls == 0
+    await asyncio.wait_for(shutting_down, timeout=60)
+
+    async with ArchetypeRuntime() as reader:
+        attached = reader.attach(world_id, storage=storage)
+        validations = latest(await attached.query(ValidationResult)).to_pylist()
+        states = latest(await attached.query(TaskState)).to_pylist()
+        sandboxes = latest(await attached.query(Sandbox)).to_pylist()
+    validation = ValidationResult.get_prefix()
+    state = TaskState.get_prefix()
+    sandbox = Sandbox.get_prefix()
+    assert any(int(row[f"{validation}actual_returncode"]) != 0 for row in validations)
+    assert any(row[f"{state}status"] == "failed" for row in states)
+    assert sandboxes
+    assert all(row[f"{sandbox}status"] == SandboxStatus.CLOSED.value for row in sandboxes)
+
+
+@pytest.mark.asyncio
+async def test_public_close_and_runtime_shutdown_race_admitted_run(
+    tmp_path: Path,
+) -> None:
+    """Public mission close racing runtime shutdown stays single-flight while
+    both drain the same admitted run."""
+
+    remote = _remote(tmp_path)
+    author = _DrainAuthorExecutor(remote, tmp_path / "author")
+    critic = _DrainCriticExecutor(remote, tmp_path / "critic")
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "close-shutdown-race",
+        config=_config(_modal_backend()),
+        storage=StorageConfig(
+            uri=str(tmp_path / "mission_close_shutdown_race"),
+            namespace="mission_close_shutdown_race_contract",
+        ),
+    )
+    submitted = await missions.submit(
+        repository=str(remote),
+        branch="agent/close-shutdown-race",
+        tasks=(_task(),),
+    )
+    _swap_executors(missions, author, critic)
+    run_task = asyncio.create_task(missions.run(submitted))
+    await asyncio.wait_for(author.blocked.wait(), timeout=30)
+
+    shutting_down = asyncio.create_task(runtime.shutdown())
+    closing = asyncio.create_task(missions.close())
+    await _spin()
+    assert not shutting_down.done()
+    assert not closing.done()
+
+    author.release.set()
+    result = await asyncio.wait_for(run_task, timeout=120)
+    assert result.status == "succeeded"
+    await asyncio.wait_for(asyncio.gather(shutting_down, closing), timeout=60)
+    assert missions._reservation.released  # noqa: SLF001 - exact owner oracle
+
+
+@pytest.mark.asyncio
+async def test_cancelling_admitted_run_does_not_wedge_runtime_shutdown(
+    tmp_path: Path,
+) -> None:
+    """Caller cancellation of the blocked run releases admission and lets the
+    pending graceful shutdown finish.
+
+    Under the v0.5 Activity contract the cancelled run abandons a
+    provider-bound author Activity, so the finished shutdown fails closed with
+    the retained mission owner instead of silently discarding that durable
+    work; settlement belongs to a later process resume's reconciliation."""
+
+    remote = _remote(tmp_path)
+    author = _DrainAuthorExecutor(remote, tmp_path / "author")
+    critic = _DrainCriticExecutor(remote, tmp_path / "critic")
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "cancelled-run",
+        config=_config(_modal_backend()),
+        storage=StorageConfig(
+            uri=str(tmp_path / "mission_cancelled_run"),
+            namespace="mission_cancelled_run_contract",
+        ),
+    )
+    submitted = await missions.submit(
+        repository=str(remote),
+        branch="agent/cancelled-run",
+        tasks=(_task(),),
+    )
+    _swap_executors(missions, author, critic)
+    run_task = asyncio.create_task(missions.run(submitted))
+    await asyncio.wait_for(author.blocked.wait(), timeout=30)
+    shutting_down = asyncio.create_task(runtime.shutdown())
+    await _spin()
+    assert not shutting_down.done()
+
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(run_task, timeout=30)
+    # Cancellation released admission, so the pending shutdown finishes
+    # instead of waiting forever on the cancelled run. It reports the exact
+    # retained owner because the abandoned author Activity is still durably
+    # unsettled and only reconciliation may settle it.
+    with pytest.raises(RuntimeShutdownError) as shutdown_failure:
+        await asyncio.wait_for(shutting_down, timeout=60)
+    assert shutdown_failure.value.phase == "workflow-handles"
+    assert [failure.owner for failure in shutdown_failure.value.failures] == [
+        missions._owner_id  # noqa: SLF001 - exact owner oracle
+    ]
+    assert isinstance(
+        shutdown_failure.value.failures[0].cause,
+        WorldHasUnsettledWorkError,
+    )
+    assert not missions._reservation.released  # noqa: SLF001 - retained for retry
+    # A later serialized shutdown retries the same phase and keeps failing
+    # closed while the Activity remains unsettled; it never discards the owner.
+    with pytest.raises(RuntimeShutdownError):
+        await runtime.shutdown()
+    assert not missions._reservation.released  # noqa: SLF001 - retained for retry
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["submit", "restore_sandbox", "query"])
+async def test_runtime_shutdown_drains_each_admitted_mission_operation(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    """Each admitted public operation keeps graceful shutdown pending and then
+    finishes with its own factual outcome through the real coordinator."""
+
+    remote = _remote(tmp_path)
+    backend = _modal_backend()
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        f"drain-{operation}",
+        config=_config(backend),
+        storage=StorageConfig(
+            uri=str(tmp_path / f"mission_drain_{operation}"),
+            namespace=f"mission_drain_{operation}_contract",
+        ),
+    )
+    submitted = await missions.submit(
+        repository=str(remote),
+        branch=f"agent/drain-{operation}",
+        tasks=(_task(),),
+    )
+    service = missions._reservation.require_bound()  # noqa: SLF001 - exact owner oracle
+    started = asyncio.Event()
+    release = asyncio.Event()
+    original = getattr(service, operation)
+
+    async def barriered(*args: object, **kwargs: object) -> object:
+        started.set()
+        await release.wait()
+        return await original(*args, **kwargs)
+
+    setattr(service, operation, barriered)
+
+    if operation == "submit":
+        admitted = asyncio.create_task(
+            missions.submit(
+                repository=str(remote),
+                branch="agent/drain-late-submit",
+                tasks=(
+                    AgentTask(
+                        "second",
+                        "Create a second explicit task graph.",
+                        (CommandValidator("noop", ("true",)),),
+                    ),
+                ),
+            )
+        )
+    elif operation == "restore_sandbox":
+        admitted = asyncio.create_task(
+            missions.restore_sandbox(
+                submitted,
+                CheckpointRef(
+                    "local",
+                    "cp",
+                    "local://cp",
+                    1,
+                    environment=backend.environment,
+                    source_sandbox_id="sandbox-drain",
+                    owner_id=str(submitted.mission_id),
+                ),
+            )
+        )
+    else:
+        admitted = asyncio.create_task(missions.query())
+
+    await asyncio.wait_for(started.wait(), timeout=30)
+    shutting_down = asyncio.create_task(runtime.shutdown())
+    await _spin()
+    assert not shutting_down.done(), f"shutdown overtook admitted {operation}"
+
+    release.set()
+    if operation == "restore_sandbox":
+        # The checkpoint names another provider; the admitted operation
+        # completes with its own factual provider-contract error, never a
+        # runtime-closed error.
+        with pytest.raises(ValueError, match="checkpoint provider does not match"):
+            await asyncio.wait_for(admitted, timeout=60)
+    else:
+        outcome = await asyncio.wait_for(admitted, timeout=60)
+        if operation == "submit":
+            assert isinstance(outcome, SubmittedMission)
+        else:
+            assert outcome is not None
+    await asyncio.wait_for(shutting_down, timeout=60)
+
+
+@pytest.mark.asyncio
+async def test_closed_mission_handle_rejects_new_operations_by_contract(
+    tmp_path: Path,
+) -> None:
+    """After public close releases the owner, every public operation rejects
+    with the handle's own closed contract, not an internal registry error."""
+
+    runtime = ArchetypeRuntime()
+    missions = runtime.missions(
+        "released-handle",
+        config=_config(_modal_backend()),
+        storage=StorageConfig(
+            uri=str(tmp_path / "mission_released_handle"),
+            namespace="mission_released_handle_contract",
+        ),
+    )
+    await missions.close()
+    assert missions._reservation.released  # noqa: SLF001 - exact owner oracle
+
+    submitted = SubmittedMission(
+        mission_id=1,
+        task_ids=(),
+        repository="owner/repository",
+        branch="agent/released-handle",
+    )
+    with pytest.raises(RuntimeError, match="Agent Missions handle is closed"):
+        await missions.submit(
+            repository="owner/repository",
+            branch="agent/released-handle",
+            tasks=(_task(),),
+        )
+    with pytest.raises(RuntimeError, match="Agent Missions handle is closed"):
+        await missions.run(submitted)
+    with pytest.raises(RuntimeError, match="Agent Missions handle is closed"):
+        await missions.restore_sandbox(
+            submitted,
+            CheckpointRef("local", "cp", "local://cp", 1),
+        )
+    with pytest.raises(RuntimeError, match="Agent Missions handle is closed"):
+        await missions.query()
+    # No mission service was ever constructed, so closing produced no provider
+    # side effects and left nothing bound to the released owner.
+    with pytest.raises(RuntimeError, match="not bound"):
+        missions._reservation.require_bound()  # noqa: SLF001 - exact owner oracle
+    await runtime.shutdown()


### PR DESCRIPTION
Docs-outran-code sweep for the v0.5.0 tag, per the cut plan (#704). Docs + examples + one new test; zero `src/` changes.

## 1. `docs/guide/runtime.md` — deleted physical-evaluation surface
- Replaced the stale `runtime.evaluate_physical_task(...)` / `runtime.sweep_physical_instructions(...)` paragraph (both deleted from the codebase) with the real entry point: `world.run_hosted_episode(...)` dispatching `RunHostedEpisode`, cross-linked to `physical-ai.md`.
- Fixed the canonical-surface sample `world.ingest_artifact(...)` → `world.ingest_artifacts(ArtifactSource(...))` (the method is plural and returns refs).
- R16 now states the Modal-only end-to-end mission admission and the durable author-and-critic Activity binding instead of the retired process-local post-tick outbox.
- Every `runtime.*` / `world.*` / `missions.*` name the doc now uses was cross-checked against `src/archetype/runtime/`; all exist with matching signatures.

## 2. `docs/guide/application-architecture.md` — Activities landed, per-step physical path retired
- Dropped every remaining "*(accepted target)*" / "accepted" status on the landed Activities family and its Mission and hosted physical consumers (§4 prose, §5 ownership table, §7 durability table, §13 oracle table).
- Added `activities/` to both package trees and the fragment list; corrected the §13 dependency-graph table to the machine policy in `quality/architecture.d/` (adds the `activities` row and the declared `physical_ai` and `missions` `activities` edges — the old `missions` row also under-reported its reviewed edges).
- Rewrote the "A2 slice … remains unchanged until … land together" note: the slice is landed and registered.
- Replaced the retired distributed per-step physical handler description (synchronous provider transfer into `RuntimeResources`, private evaluation worlds, sticky cleanup leases) with the current hosted whole-episode Activity contract, and fixed the stale `app.physical_ai` path.
- Merged the obsolete "Agent Mission dispatch *(current baseline)* / process-local post-tick outbox" durability row into the current Activity-backed row (restart delivery is proved by the world-integration and Modal executor restart oracles).

## 3. Mission guide + examples — Modal is the supported release profile
- `agent-missions.md`: §2 authoring example now uses `ModalSandboxBackend` (the previous `AppleContainerSandboxBackend` example is rejected deterministically at admission by `src/archetype/wiring.py`); the "Supported sandbox backends" section states Modal-only end-to-end admission with Apple Container/Docker as sandbox capabilities whose session/login/checkpoint lanes stay tested; file map updated; stale "accepted Activity target" tenses fixed. Heading names unchanged.
- `examples/11_coding_agent_mission.py`: docstring leads with Modal as the only admitted end-to-end backend; CLI default backend is now `modal`; the Modal config supplies the required durable Activity namespace (`workspace_name`/`environment_name`/`operation_protocol_epoch` — previously missing, so a live `--backend modal` run died on a bare wiring assert) with a clear pre-flight error; `--dry-run` receipt unchanged (pinned receipt test still green).
- `examples/README.md` + `docs/guide/examples.md`: reworded the example-11 row; removed the rows/section for `examples/14_physical_ai.py`, deleted with the per-step surface in #717; fixed the "post-tick outbox" bullet.
- `docs/guide/service-protocols.md` already stated the Modal-only contract correctly; left untouched.

## 4. Rehomed #627 oracle — `tests/integration/test_mission_runtime_drain.py`
Recovered from `d13f06b4^` (#716 deleted it, ~636 lines) and ported to the post-A8 composition; all six scenarios survive as executable oracles (8 tests with the parametrized case):

- The Modal-only admission gate is satisfied by a credential-free `ModalSandboxBackend` (namespace trio only), and the two composed provider executors are swapped for local-Git fakes at the author/critic Activity executor seam — exactly the external-execution boundary the #627 schedule blocks on. The real dispatcher admission, required projector, Activity workers, value stores, observation stagers, transition processors, and world/tick machinery all run; the flagship test drives a full mission to `succeeded` (real clone/commit/push, real validator subprocesses, canonical validator-bundle digest, real critic diff recomputation and subject binding) while shutdown is pending.
- Ported semantics kept verbatim: shutdown cannot overtake the admitted run blocked between world calls; teardown-from-inside rejects; late operations reject before provider effects; factual failure is preserved over runtime-closed errors; public close and shutdown race single-flight; per-operation drain for `submit`/`restore_sandbox`/`query`; closed-handle contract rejections; cold-reader durable evidence.
- Two adaptations forced by the new architecture (not silent drops):
  - `restore_sandbox` drain case now completes with the factual `checkpoint provider does not match sandbox spec` rejection (deterministic, pre-network) instead of the old local backend's `NotImplementedError`.
  - The cancellation oracle: cancelling the run mid-external-execution abandons a provider-bound author Activity, so the finished shutdown now fails closed with `RuntimeShutdownError(phase="workflow-handles")` naming the exact retained mission owner (cause `WorldHasUnsettledWorkError`), and a retried shutdown keeps failing closed. The pre-Activity clean-finish assertion is impossible by design: settlement belongs to a later process resume's reconciliation, and silently discarding admitted provider-bound work is exactly what the Activity contract forbids.

## 5. `quality/contracts.toml`
No pinned heading was renamed, so no pin was re-pointed; the file is untouched. `make contract-audit` (registry + traceability) passes.

## Validation
- `make lint` — all audits green (lazy, architecture, observability, lockfile, version-inventory, python-api, api-boundary, idempotency, gate-coverage, operational, ruff)
- `make contract-audit` — registry + traceability current
- `uv run pytest tests/integration/test_mission_runtime_drain.py` — 8 passed
- `make test` — 2742 passed, 6 skipped

Refs #704, #627, #716, #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)