### PR TITLE
fix(ci): stop failing adjudication seats on line-suffixed evidence paths

### DIFF
--- a/.github/review/prompts/adjudication.md
+++ b/.github/review/prompts/adjudication.md
@@ -21,6 +21,14 @@ refutation. Preserve disagreement:
 Do not edit files, run code, fetch URLs, post comments, or inspect another
 cluster. Use only read, grep, glob, and list capabilities.
 
+Every `evidence[].path` must be a repository file — a scoped changed file or a
+protected-base file — written as the bare path with no line-number suffix
+(`src/pkg/module.py`, never `src/pkg/module.py:12-40`). Put line numbers in the
+explanation. The review working files you were told to read
+(`.footgun-review.diff`, `.footgun-review-scope.json`, anything under
+`.footgun-review-output/`) are prompt inputs, not evidence; citing them fails
+validation.
+
 Return exactly one JSON object matching this schema:
 
 $output_schema

--- a/scripts/review_contracts.py
+++ b/scripts/review_contracts.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from string import Template
@@ -1059,6 +1060,31 @@ def normalize_lens_result(
     }
 
 
+# The gate's own scratch files. The adjudication prompt directs the model to
+# read them, so models cite them as evidence; they prove nothing about the
+# repository and must be rejected by name rather than by filesystem accident
+# (they exist in the working directory while the gate runs).
+_REVIEW_WORKING_FILES = frozenset(
+    {
+        ".footgun-review.diff",
+        ".footgun-review-scope.json",
+    }
+)
+_REVIEW_WORKING_DIR_PREFIX = ".footgun-review-output/"
+_EVIDENCE_LINE_SUFFIX = re.compile(r":\d+(?:-\d+)?$")
+
+
+def _adjudication_evidence_path(path: str) -> str:
+    """Normalize a model-cited evidence path to a bare repository path.
+
+    Models habitually cite ``path:line`` or ``path:start-end``. The location
+    detail is welcome in the explanation, but the existence check needs the
+    bare path — otherwise every line-suffixed citation of a real file fails
+    validation and the adjudication seat dies for a formatting habit.
+    """
+    return _EVIDENCE_LINE_SUFFIX.sub("", path)
+
+
 def normalize_adjudication_result(
     raw_result: Mapping[str, Any],
     *,
@@ -1097,13 +1123,21 @@ def normalize_adjudication_result(
         label = f"adjudication evidence[{index}]"
         item = _expect_mapping(raw_evidence, label)
         _exact_keys(item, ("path", "explanation"), label)
-        path = _text(item.get("path"), f"{label}.path")
+        path = _adjudication_evidence_path(
+            _text(item.get("path"), f"{label}.path"),
+        )
         # An adjudication can downgrade a blocking claim to advisory — and
         # advisory findings no longer publish as threads — so a hallucinated
         # evidence path would make a blocking claim silently disappear from
         # review. Evidence must name a file the adjudicator could actually
         # have seen: a scoped changed file or a real protected-base file
         # (the gate runs with the protected base as the working directory).
+        # The gate's own working files are prompt inputs, not evidence.
+        if path in _REVIEW_WORKING_FILES or path.startswith(_REVIEW_WORKING_DIR_PREFIX):
+            raise ReviewError(
+                f"{label}.path {path!r} is a review working file; cite the "
+                "repository file that carries the evidence instead"
+            )
         if path not in scoped_files and not Path(path).is_file():
             raise ReviewError(
                 f"{label}.path {path!r} is neither a scoped file nor a "

--- a/tests/scripts/test_review_contracts.py
+++ b/tests/scripts/test_review_contracts.py
@@ -682,3 +682,86 @@ def test_adjudication_evidence_paths_must_be_real():
         scoped_files=["new.py", "old.py"],
     )
     assert normalized["evidence"][0]["path"] == "pyproject.toml"
+
+
+def test_adjudication_evidence_line_suffix_is_normalized():
+    """``path:line`` citations of real files validate as the bare path.
+
+    Adjudicator models habitually append ``:line`` or ``:start-end`` to the
+    files they cite; the location belongs in the explanation, but it must not
+    fail the seat when the underlying file is real.
+    """
+    raw = {
+        "head_sha": HEAD_SHA,
+        "cluster_id": "cluster-1",
+        "disposition": "confirmed",
+        "recommended_severity": "blocking",
+        "evidence": [
+            {
+                "path": "old.py:12-40",
+                "explanation": "The failing sequence is reproducible at lines 12-40.",
+            },
+            {
+                "path": "pyproject.toml:7",
+                "explanation": "The declared dependency contradicts the claim baseline.",
+            },
+        ],
+        "rationale": (
+            "Both citations point at real repository files; the line suffixes "
+            "are a formatting habit, not fabricated evidence."
+        ),
+        "recommended_action": "Keep the claim blocking in the receipt.",
+    }
+
+    normalized = normalize_adjudication_result(
+        raw,
+        head_sha=HEAD_SHA,
+        cluster_id="cluster-1",
+        scoped_files=["new.py", "old.py"],
+    )
+    assert [item["path"] for item in normalized["evidence"]] == [
+        "old.py",
+        "pyproject.toml",
+    ]
+
+
+def test_adjudication_evidence_rejects_review_working_files():
+    """The gate's own scratch files are prompt inputs, never evidence.
+
+    They exist in the working directory while the gate runs, so the
+    filesystem check alone would accept them even though they prove nothing
+    about the repository.
+    """
+    raw = {
+        "head_sha": HEAD_SHA,
+        "cluster_id": "cluster-1",
+        "disposition": "confirmed",
+        "recommended_severity": "advisory",
+        "evidence": [
+            {
+                "path": ".footgun-review.diff:7607-7631",
+                "explanation": "The hunk shows the claimed behavior in the diff itself.",
+            }
+        ],
+        "rationale": (
+            "Citing the review diff instead of the repository file must fail "
+            "validation deterministically rather than by filesystem accident."
+        ),
+        "recommended_action": "Downgrade the claim to advisory in the receipt.",
+    }
+
+    for path in (
+        ".footgun-review.diff:7607-7631",
+        ".footgun-review.diff",
+        ".footgun-review-scope.json",
+        ".footgun-review-output/validated/preliminary-review-bundle.json:2390-2424",
+        ".footgun-review-output/validated/preliminary-review-bundle.json",
+    ):
+        raw["evidence"][0]["path"] = path
+        with pytest.raises(ReviewError, match="review working file"):
+            normalize_adjudication_result(
+                raw,
+                head_sha=HEAD_SHA,
+                cluster_id="cluster-1",
+                scoped_files=["new.py", "old.py"],
+            )


### PR DESCRIPTION
## What

Adjudication seats die on a formatting habit: models cite evidence as `path:line-range`, and `normalize_adjudication_result` rejects any path that is not verbatim a scoped file or an existing base file. Tonight this killed adjudications on #724 (twice), #727 (2 of 4 clusters), and #722 (2 clusters) — each failure collapses the whole gate with "no verdict exists, refusing to proceed".

A second, related hole: the adjudication prompt **instructs** the model to read `.footgun-review.diff` / `.footgun-review-output/...`, so models cite those as evidence. With a bare path those scratch files would actually pass the `is_file()` check (they exist in the working directory during the run) even though they prove nothing about the repository.

## Changes

1. `_adjudication_evidence_path` strips a trailing `:N` / `:N-M` suffix before the existence check; the bare path is stored, and line detail stays in the explanation.
2. Review working files are rejected **by name** as evidence — deterministic, instead of depending on what happens to exist in the runner's cwd.
3. The adjudication prompt states both rules explicitly.

Verdict semantics (confirmed/refuted/unresolved, severity rules, hallucinated-path rejection) are unchanged — `tests/scripts` suite passes (440), with new regressions for both rules.

## Why now

Queue-reliability under the frozen-harness policy (H1–H4 class, "may land as needed"): the release queue is currently losing ~half its adjudication seats to this, and every loss costs a full gate cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)