### PR TITLE
test(activities): drive crash-window lease expiry with a manual clock

### DIFF
--- a/tests/app/test_application_review_contracts.py
+++ b/tests/app/test_application_review_contracts.py
@@ -141,7 +141,9 @@ async def test_stop_admission_then_wait_drained_joins_admitted_autoresearch(
             prepare_candidate=prepare_candidate,
         )
         operation = asyncio.create_task(dispatcher.apply(model))
-        await asyncio.wait_for(entered.wait(), timeout=1)
+        # Generous under CI load (issue #720): reaching prepare_candidate
+        # includes Iceberg writes and admission on a shared loaded runner.
+        await asyncio.wait_for(entered.wait(), timeout=30)
 
         drain: asyncio.Task[None] | None = None
         try:

--- a/tests/integration/test_hosted_physical_runtime.py
+++ b/tests/integration/test_hosted_physical_runtime.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -29,6 +30,7 @@ from archetype.physical_ai.hosted_episode import (
     build_hosted_episode_results,
 )
 from archetype.physical_ai.hosted_modal import ModalHostedEpisodeProvider
+from archetype.storage.activity_catalog import SqliteActivityCatalog
 from archetype.storage.config import ControlCatalogConfig
 from archetype.wiring import RuntimeBootstrapConfig
 from archetype.world.registry import WorldRegistry
@@ -177,19 +179,29 @@ async def test_public_hosted_episode_recovers_without_replay_and_isolates_fork(
             world_registry=first_registry,
             audit_storage_config=storage,
             hosted_episode_provider_factory=provider_factory,
-            hosted_activity_lease_seconds=0.5,
+            hosted_activity_lease_seconds=300,
         ),
         RuntimeBootstrapConfig(
             control_catalog_config=catalog,
             world_registry=second_registry,
             audit_storage_config=storage,
             hosted_episode_provider_factory=provider_factory,
-            hosted_activity_lease_seconds=0.5,
+            hosted_activity_lease_seconds=300,
         ),
     ]
     monkeypatch.setattr(
         "archetype.runtime.runtime._bootstrap_config",
         lambda **_kwargs: configs.pop(0),
+    )
+    # Lease expiry between the two runtime generations is driven by this
+    # manual clock instead of racing a sub-second wall-clock lease against
+    # runner load (issue #720): within a phase the clock is frozen, so the
+    # crashed generation's claim cannot expire while its episode is still
+    # running.
+    clock = [time.time()]
+    monkeypatch.setattr(
+        "archetype.wiring.SqliteActivityCatalog",
+        lambda path: SqliteActivityCatalog(path, now_seconds=lambda: clock[0]),
     )
 
     activity_id = "restart-proof"
@@ -206,7 +218,7 @@ async def test_public_hosted_episode_recovers_without_replay_and_isolates_fork(
             )
 
     assert state.execution_count == 1
-    await asyncio.sleep(0.55)
+    clock[0] += 301.0
 
     state.registry = second_registry
     async with ArchetypeRuntime() as runtime:

--- a/tests/physical_ai/test_hosted_episode_activities.py
+++ b/tests/physical_ai/test_hosted_episode_activities.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-import asyncio
+import time
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -263,12 +264,17 @@ def _open_catalog(
     path: Path,
     *,
     lease_seconds: float = 0.01,
+    now_seconds: Callable[[], float] | None = None,
 ) -> tuple[
     SqliteActivityCatalog,
     ActivityCoordinator,
     PhysicalHostedActivityCoordinator,
 ]:
-    physical = SqliteActivityCatalog(path)
+    physical = (
+        SqliteActivityCatalog(path)
+        if now_seconds is None
+        else SqliteActivityCatalog(path, now_seconds=now_seconds)
+    )
     generic = ActivityCoordinator(physical)
     return (
         physical,
@@ -353,7 +359,15 @@ async def test_cold_restart_recovers_first_provider_result_without_second_episod
             intent=intent,
         )
     )
-    physical, generic, catalog = _open_catalog(catalog_path)
+    # Lease expiry between process generations is driven by this manual
+    # clock, not by racing wall-clock leases against runner load (issue
+    # #720). Within a phase the clock is frozen, so no lease can expire
+    # mid-run.
+    clock = [time.time()]
+    physical, generic, catalog = _open_catalog(
+        catalog_path,
+        now_seconds=lambda: clock[0],
+    )
     projector = PhysicalHostedActivityProjector(
         reader=reader,
         catalog=catalog,
@@ -388,7 +402,7 @@ async def test_cold_restart_recovers_first_provider_result_without_second_episod
         await first_worker.run_once()
     assert first_runner.execution_count == 1
     await physical.close()
-    await asyncio.sleep(0.02)
+    clock[0] += 301.0
 
     # Reconstruct every Archetype-side object. The provider index is the first
     # durable result, so generic catalog recording cannot trigger another run.
@@ -396,6 +410,7 @@ async def test_cold_restart_recovers_first_provider_result_without_second_episod
     recovered_physical, recovered_generic, recovered_catalog = _open_catalog(
         catalog_path,
         lease_seconds=30,
+        now_seconds=lambda: clock[0],
     )
     recovered_runner = SeededHostedEpisodeRunner(counter_path)
     crash_before_stage = _ObservationStager(crash_once=True)
@@ -418,7 +433,10 @@ async def test_cold_restart_recovers_first_provider_result_without_second_episod
     await recovered_physical.close()
 
     # A third process redelivers the bounded result and stages the same marker.
-    final_physical, _final_generic, final_catalog = _open_catalog(catalog_path)
+    final_physical, _final_generic, final_catalog = _open_catalog(
+        catalog_path,
+        now_seconds=lambda: clock[0],
+    )
     final_stager = _ObservationStager()
     final_runner = SeededHostedEpisodeRunner(counter_path)
     final_worker = PhysicalHostedActivityWorker(
@@ -444,7 +462,10 @@ async def test_cold_restart_recovers_first_provider_result_without_second_episod
     # The worker dies after staging but before a tick commits. A new process has
     # no staged mutation, so it redelivers the same immutable marker and still
     # does not touch the provider.
-    restage_physical, restage_generic, restage_catalog = _open_catalog(catalog_path)
+    restage_physical, restage_generic, restage_catalog = _open_catalog(
+        catalog_path,
+        now_seconds=lambda: clock[0],
+    )
     restage_stager = _ObservationStager()
     restage_worker = PhysicalHostedActivityWorker(
         world_id=world_id,
@@ -567,7 +588,14 @@ async def test_lease_expiry_does_not_replay_an_ambiguous_provider_start(
             intent=intent,
         )
     )
-    physical, _generic, catalog = _open_catalog(catalog_path)
+    # Lease expiry is driven by this manual clock, not by racing a 10ms
+    # wall-clock lease against runner load (issue #720). Within a phase the
+    # clock is frozen, so no lease can expire mid-run.
+    clock = [time.time()]
+    physical, _generic, catalog = _open_catalog(
+        catalog_path,
+        now_seconds=lambda: clock[0],
+    )
     await PhysicalHostedActivityProjector(
         reader=reader,
         catalog=catalog,
@@ -589,9 +617,12 @@ async def test_lease_expiry_does_not_replay_an_ambiguous_provider_start(
         await first.run_once()
     assert seeded.execution_count == 1
     await physical.close()
-    await asyncio.sleep(0.02)
+    clock[0] += 301.0
 
-    recovered_physical, _generic, recovered_catalog = _open_catalog(catalog_path)
+    recovered_physical, _generic, recovered_catalog = _open_catalog(
+        catalog_path,
+        now_seconds=lambda: clock[0],
+    )
     healthy_runner = SeededHostedEpisodeRunner(counter_path)
     recovered = PhysicalHostedActivityWorker(
         world_id=world_id,


### PR DESCRIPTION
## What

Closes the #720 flake family. The crash-window suites raced sub-second wall-clock leases against loaded CI runners — a 10ms unit-test lease, a 0.5s runtime lease with a 0.55s sleep, and a 1s drain-entry timeout — so claims could expire while an episode was still mid-run. Failure signatures: `ActivityClaimError: activity claim lease expired` and drain `TimeoutError`. This hit five runs tonight alone (#727, #719, #703, #722 ×2) during the release push.

## How

`SqliteActivityCatalog` already accepts an injectable `now_seconds` clock (the missions crash-window tests already use it). This PR extends the same pattern to the remaining wall-clock offenders:

- **tests/physical_ai/test_hosted_episode_activities.py** — `_open_catalog` passes `now_seconds` through; the two expiry tests freeze one manual clock across process generations and advance it past the lease (`clock[0] += 301`) instead of sleeping. A frozen clock means **no lease can expire mid-phase**, and the deliberate expiry is exact rather than racy.
- **tests/integration/test_hosted_physical_runtime.py** — the restart/fork recovery test monkeypatches `archetype.wiring.SqliteActivityCatalog` to inject the manual clock, raises `hosted_activity_lease_seconds` to 300, and advances the clock between runtime generations instead of `sleep(0.55)`.
- **tests/app/test_application_review_contracts.py** — the drain-entry wait derates 1s → 30s (reaching `prepare_candidate` includes Iceberg writes under CI load); the drain wait itself was already 30s.

Test-only change; no runtime surface touched. Suites pass 3× consecutively and run ~1.5s faster (the sleeps are gone).

Fixes #720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)