### PR TITLE
fix(release): retain credentialed R2 evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
           uv run python scripts/run_operational_scenarios.py
           --mode source
           --cadence release
+          --min-tier 5
+          --max-tier 5
           --scenario dogfood.storage.r2
           --require-run
           --expected-revision "$GITHUB_SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,61 @@ jobs:
       - run: uv sync --group dev
       - run: make test
 
+  r2-release:
+    name: Cloudflare R2 release verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_API_ENDPOINT: ${{ vars.R2_API_ENDPOINT }}
+      R2_BUCKET: ${{ vars.R2_BUCKET }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+        with:
+          version: "latest"
+      - run: uv sync --group dev
+      - name: Require release R2 configuration
+        run: |
+          test -n "$R2_ACCESS_KEY_ID"
+          test -n "$R2_SECRET_ACCESS_KEY"
+          test -n "$R2_API_ENDPOINT"
+          test -n "$R2_BUCKET"
+          case "$R2_BUCKET" in
+            */*) echo "R2_BUCKET must be a bucket name, not a path" >&2; exit 1 ;;
+          esac
+      - name: Verify physical retry visibility
+        run: >-
+          PYTHONPATH="${PYTHONPATH:-}:."
+          uv run pytest -q tests/infrastructure/test_r2_idempotency.py
+      - name: Verify the public-runtime R2 scenario
+        run: >-
+          PYTHONPATH="${PYTHONPATH:-}:."
+          uv run python scripts/run_operational_scenarios.py
+          --mode source
+          --cadence release
+          --scenario dogfood.storage.r2
+          --require-run
+          --expected-revision "$GITHUB_SHA"
+          --require-clean
+          --out r2-release-results.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: r2-release-evidence
+          path: |
+            r2-release-results.json
+            r2-release-results.d/
+          if-no-files-found: error
+
   publish:
-    needs: [release-profile, python-compatibility]
+    needs: [release-profile, python-compatibility, r2-release]
     runs-on: ubuntu-latest
     environment: release-pypi
     permissions:

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -125,32 +125,20 @@ Before writing processors or Daft UDFs, `LEARNINGS.md` is also mandatory; it
 records execution-model footguns that are too implementation-specific for the
 normative contracts.
 
-## Deterministic review fan-out
+## Advisory AI review
 
-The PR review gate runs six named lenses with two independent reviewers per
-lens. Five lenses cover the footgun rulebook; `design-coherence` separately
-covers clean code, local pattern consistency, and concrete-over-abstract
-design. Design-coherence findings are advisory-only.
+Codex and Cursor Bugbot can provide review suggestions on pull requests.
+Their findings are advisory inputs to maintainer judgment: neither reviewer is
+a required status context, and provider failure cannot block a merge. Convert
+confirmed behavioral findings into deterministic tests, lints, audits, or
+operational scenarios so the same issue class does not require repeated model
+review.
 
-The review surface is intentionally split by ownership:
-
-- `.github/review/prompts/` contains the exact model prompts as plain Markdown.
-- `scripts/review_contracts.py` contains lens assignments, reviewer policy,
-  typed model return values, adjacent JSON Schemas, and normalizers.
-- `scripts/review_aggregation.py` clusters only exact
-  `(lens, category, path, side, line)` matches and preserves every original
-  finding in its reviewer receipt.
-- `scripts/footgun_review_gate.py` binds evidence to the exact PR scope,
-  orchestrates selective adjudication, and renders GitHub evidence.
-
-Two distinct reviewers reporting the same exact anchor corroborate a claim.
-Silence from the other reviewer is not disagreement. A singleton blocking
-claim or severity conflict receives a targeted falsification pass.
-Adjudication may confirm, refute, or leave the claim unresolved; it never
-deletes the original evidence. Refuted and unresolved claims become explicit
-human-decision threads. The final human design-review brief organizes the
-change into a suggested reading order and presents design notes, affected
-invariants, validation evidence, and decisions without claiming approval.
+The retired deterministic multi-lens gate and merge-queue orchestration are
+preserved only as historical incident evidence under
+`quality/quarantine/review-gate/`. Do not move those files back into active
+workflow or test paths. Any future review automation requires a new,
+cost-bounded design and explicit approval.
 
 ## Contribution Policy
 

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from scripts.run_operational_scenarios import _select_scenarios
+from scripts.validate_operational_scenarios import load_scenarios
+
 ROOT = Path(__file__).resolve().parents[2]
 QUALITY_WORKFLOW = ROOT / ".github" / "workflows" / "python-tests.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
@@ -98,3 +101,14 @@ def test_release_publish_requires_credentialed_r2_evidence() -> None:
     assert "--require-run" in r2_release
     assert "r2-release-results.json" in r2_release
     assert "needs: [release-profile, python-compatibility, r2-release]" in publish
+
+    selected = _select_scenarios(
+        load_scenarios(),
+        mode="source",
+        cadence="release",
+        scenario_ids={"dogfood.storage.r2"},
+        kind=None,
+        min_tier=5,
+        max_tier=5,
+    )
+    assert [row["id"] for row in selected] == ["dogfood.storage.r2"]

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 QUALITY_WORKFLOW = ROOT / ".github" / "workflows" / "python-tests.yml"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 MAKEFILE = ROOT / "Makefile"
 QUARANTINE = ROOT / "quality" / "quarantine" / "review-gate"
 
@@ -75,3 +76,23 @@ def test_review_gate_and_merge_queue_are_not_executable_workflows() -> None:
     ):
         assert not (active / name).exists()
         assert (QUARANTINE / "workflows" / name).is_file()
+
+
+def test_release_publish_requires_credentialed_r2_evidence() -> None:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    r2_release = _job(workflow, "r2-release")
+    publish = _job(workflow, "publish")
+
+    for variable in (
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "R2_API_ENDPOINT",
+        "R2_BUCKET",
+    ):
+        assert variable in r2_release
+    assert "tests/infrastructure/test_r2_idempotency.py" in r2_release
+    assert "--scenario dogfood.storage.r2" in r2_release
+    assert "--cadence release" in r2_release
+    assert "--require-run" in r2_release
+    assert "r2-release-results.json" in r2_release
+    assert "needs: [release-profile, python-compatibility, r2-release]" in publish

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -91,6 +91,8 @@ def test_release_publish_requires_credentialed_r2_evidence() -> None:
     ):
         assert variable in r2_release
     assert "tests/infrastructure/test_r2_idempotency.py" in r2_release
+    assert "--min-tier 5" in r2_release
+    assert "--max-tier 5" in r2_release
     assert "--scenario dogfood.storage.r2" in r2_release
     assert "--cadence release" in r2_release
     assert "--require-run" in r2_release


### PR DESCRIPTION
Follow-up to #743 addressing the two late Codex review findings:

- keeps Cloudflare R2 off the ordinary PR path but makes credentialed R2 idempotency and public-runtime evidence a release publish prerequisite
- replaces stale contributor documentation for the retired deterministic gate with the advisory Codex/Cursor policy
- adds a deterministic workflow contract proving publish depends on R2 release evidence

Validation:
- `uv run pytest -q tests/scripts/test_quality_workflow.py` — 4 passed
- `make static`
- `git diff --check`