### PR TITLE
ci: restrict release runner to operator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,58 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing immutable release tag (for example, v0.5.0)"
+        required: true
+        type: string
 
 permissions: {}
 
-# The Modal lane uses one static CODEX_AUTH_VOLUME. Keep tag workflows
+# The Modal lane uses one static CODEX_AUTH_VOLUME. Keep release workflows
 # single-flight because that credential broker has no concurrent-owner contract.
 concurrency:
   group: archetype-release
   cancel-in-progress: false
 
 jobs:
+  authorize-release:
+    name: Authorize release operator
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require everettVT and an exact release tag
+        env:
+          RELEASE_ACTOR: ${{ github.actor }}
+          RELEASE_EVENT: ${{ github.event_name }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          test "$RELEASE_REPOSITORY" = "VangelisTech/archetype"
+          test "$RELEASE_EVENT" = "workflow_dispatch"
+          test "$RELEASE_ACTOR" = "everettVT"
+          test "$RELEASE_TRIGGERING_ACTOR" = "everettVT"
+          test "$RELEASE_REF_TYPE" = "tag"
+          test "$RELEASE_INPUT_TAG" = "$RELEASE_REF_NAME"
+          case "$RELEASE_REF_NAME" in
+            v*) ;;
+            *) echo "release ref must be a v* tag" >&2; exit 1 ;;
+          esac
+
   release-profile:
     name: Release verification
+    needs: authorize-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
@@ -29,7 +61,10 @@ jobs:
           version: "latest"
       - run: uv sync --group dev --extra docs --extra coding-agent
       - name: Verify tag and package version agree
-        run: test "${GITHUB_REF_NAME#v}" = "$(make --no-print-directory version)"
+        run: |
+          test "${GITHUB_REF_NAME#v}" = "$(make --no-print-directory version)"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "${GITHUB_REF_NAME}^{commit}" origin/main
       - run: make verify-release
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -68,13 +103,6 @@ jobs:
             runner: '["ubuntu-latest"]'
             target: operational-release-r2
             receipt: operational-release-r2-results.json
-          - name: Apple Container
-            # Apple Container uses Virtualization.framework. This custom label
-            # is reserved for a bare-metal Apple Silicon host on macOS 26;
-            # GitHub-hosted arm64 macOS runners cannot provide nested VMs.
-            runner: '["self-hosted","macOS","ARM64","archetype-apple-container-macos-26"]'
-            target: operational-release-apple
-            receipt: operational-release-apple-results.json
           - name: Modal Agent Mission
             runner: '["ubuntu-latest"]'
             target: operational-release-modal
@@ -118,14 +146,6 @@ jobs:
           path: .context/downloaded-release-evidence/
       - name: Restore exact artifact manifest
         run: cp .context/downloaded-release-evidence/release-artifact.json release-artifact.json
-      - name: Start Apple Container service
-        if: matrix.target == 'operational-release-apple'
-        run: |
-          test "$(uname -m)" = "arm64"
-          test "$(sw_vers -productVersion | cut -d. -f1)" -ge 26
-          command -v container
-          container system start
-          container system status
       - name: Verify Docker service
         if: matrix.target == 'operational-release-docker'
         run: docker info
@@ -155,8 +175,63 @@ jobs:
             operational-release-*-results.d/
           if-no-files-found: error
 
+  apple-evidence:
+    name: Release evidence (Apple Container)
+    needs: release-profile
+    runs-on:
+      group: archetype-release-macos
+      labels:
+        - self-hosted
+        - macOS
+        - ARM64
+        - archetype-apple-container-macos-26
+    environment: release-apple-macos
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+        with:
+          version: "latest"
+      - run: uv sync --group dev --extra coding-agent
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist/
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-evidence
+          path: .context/downloaded-release-evidence/
+      - name: Restore exact artifact manifest
+        run: cp .context/downloaded-release-evidence/release-artifact.json release-artifact.json
+      - name: Start Apple Container service
+        run: |
+          test "$(uname -m)" = "arm64"
+          test "$(sw_vers -productVersion | cut -d. -f1)" -ge 26
+          command -v container
+          container system start
+          container system status
+      - name: Run exact installed-artifact scenario
+        run: make operational-release-apple
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: release-operational-release-apple-evidence
+          path: |
+            operational-release-apple-results.json
+            operational-release-*-results.d/
+          if-no-files-found: error
+      - name: Stop Apple Container service
+        if: always()
+        run: container system stop
+
   python-compatibility:
     name: Python 3.13 compatibility
+    needs: authorize-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -182,7 +257,7 @@ jobs:
 
   release-evidence-gate:
     name: Exact release evidence
-    needs: [release-profile, external-evidence]
+    needs: [release-profile, external-evidence, apple-evidence]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -244,6 +319,7 @@ jobs:
           path: dist/
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
+          tag_name: ${{ github.ref_name }}
           files: dist/*
           generate_release_notes: true
           draft: false

--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -575,12 +575,15 @@ publication, and any live viewport grant.
 | Docker | The local Docker context/daemon authenticates the host operation; `docker info` must succeed. Archetype neither runs `docker login` nor owns registry credentials for the default locally built image. | Unsupported. The parity adapter has no `login_codex()`, auth-volume configuration, or `codex_oauth` execution capability. | Unsupported. The parity adapter exposes no GitHub or generic process-secret capability. | Not implemented. |
 | Modal | The Modal SDK uses the selected authenticated profile or `MODAL_TOKEN_ID` plus `MODAL_TOKEN_SECRET`. The workspace, Environment, App, Volume, Dict, Secret, and Sandbox identities are explicit configuration. Ordinary create/restore and login verify the configured workspace and Environment against the ambient SDK context before mutation. Named provider work verifies the ambient workspace, then scopes every provider object lookup and mutation explicitly to the configured Environment. A typical workstation setup uses `modal token set`; in Actions, repository variable `CODING_AGENT_MODAL_PROFILE` is exported as the SDK selector `MODAL_PROFILE`, and `CODING_AGENT_MODAL_ENVIRONMENT` is exported as both the Archetype selector and SDK selector `MODAL_ENVIRONMENT`. | `ModalSandboxBackend.login_codex()` runs `codex login --device-auth` in a temporary login sandbox and persists only `auth.json` in `ModalSandboxConfig.auth_volume_name` (default `archetype-codex-auth`). The admitted app-server path copies that file into its mission sandbox only through app-server `thread/start`; an awaited barrier deletes and verifies absence of the exact file before `turn/start`, TUI attachment, or model-driven tool execution. Mission execution never writes its copy back to the Volume, and generic mission `exec` rejects `codex_oauth`. | `ModalSandboxConfig.github_secret_name` (default `archetype-github`) resolves a Modal Secret containing `GITHUB_TOKEN`. The controller streams the exact validated Git object bundle through a hard byte cap into the separate non-agent broker, verifies its size, digest, and Git object identity there, and attaches the Secret only to its final push process. Generic mission `exec` rejects `github`. | `issue_spectate_grant()` and `issue_takeover_grant()` mint distinct, port-scoped Modal Sandbox Connect Tokens after Modal control-plane authentication. The bearer URLs are transient trusted-maintainer capabilities. |
 
-Release parity for Apple Container runs only on the labeled self-hosted
-bare-metal Apple Silicon macOS 26 runner. A GitHub-hosted arm64 macOS runner is
-not an authentication or execution substitute: Apple Container requires local
-Virtualization.framework VM support. That lane inherits only the self-host
-operator's `container` service authority and does not receive Modal, Codex,
-GitHub, or Apple cloud credentials.
+Release parity for Apple Container runs only on the one-job ephemeral,
+dedicated-account, bare-metal Apple Silicon macOS 26 runner. The organization
+runner group is restricted to the exact tag-qualified release workflow, the
+release actor and rerun actor must both be `everettVT`, and the protected Apple
+environment requires that operator's approval. A GitHub-hosted arm64 macOS
+runner is not an authentication or execution substitute: Apple Container
+requires local Virtualization.framework VM support. That lane inherits only
+the dedicated runner account's `container` service authority and does not
+receive Modal, Codex, GitHub, or Apple cloud credentials.
 
 For a live v0.5 Mission, set up Modal, Codex, and GitHub independently:
 

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -175,13 +175,72 @@ execution and receipt retention land with the owning release-gate slices. A
 declared cadence MUST NOT be reported as satisfied until its workflow invokes
 the scenario and retains the resulting receipt.
 
-The tag workflow builds one wheel after the source profile, records its digest,
-and runs every credential-free release scenario against that exact installed
-artifact. OpenAI, Docker, R2, Apple Container, and the Modal Agent Mission
-execute in mandatory platform/provider lanes that download the same immutable
-distribution. Publication is gated by an aggregate receipt check: every
-release-required scenario must have passed, every receipt must name the release
-commit and wheel digest, and no result may be `not_run`.
+The operator-dispatched tag workflow builds one wheel after the source profile,
+records its digest, and runs every credential-free release scenario against
+that exact installed artifact. OpenAI, Docker, R2, Apple Container, and the
+Modal Agent Mission execute in mandatory platform/provider lanes that download
+the same immutable distribution. Publication is gated by an aggregate receipt
+check: every release-required scenario must have passed, every receipt must name
+the release commit and wheel digest, and no result may be `not_run`.
+
+Release execution is operator-only. The `Release tags — everettVT only`
+repository ruleset permits only `everettVT` to create `v*` tags; the separate
+immutable-tag ruleset continues to deny tag updates and deletion for everyone.
+The workflow requires both `github.actor` and `github.triggering_actor` to be
+`everettVT`, so another user's run cannot become authorized through a rerun. A
+tag push does not start release work: the operator dispatches `release.yml` at
+the existing tag and supplies the same tag as its confirmation input.
+
+The Apple lane has a second, infrastructure-level boundary. Organization runner
+group `archetype-release-macos` allows only this repository and an exact
+tag-qualified `.github/workflows/release.yml`; the job must request that group,
+not merely a guessable label. Environment `release-apple-macos` permits only
+`v*` tags and requires approval from `everettVT` before the job reaches the Mac.
+The runner MUST be ephemeral, MUST be registered only after the group is pinned
+to the exact release tag, and MUST run from a disposable directory under a
+dedicated macOS account that has no access to the operator's normal home,
+keychain, SSH agent, or cloud credentials. Never install this runner as a
+persistent service. These controls are required because GitHub does not treat a
+self-hosted runner for a public repository as an isolated trusted machine.
+
+For each release, use this order:
+
+```bash
+# 1. Create the reviewed tag. The ruleset rejects every other GitHub actor.
+git fetch origin main
+git tag -a v0.5.0 origin/main -m "Release v0.5.0"
+git push origin refs/tags/v0.5.0
+
+# 2. Before registering any runner, pin its group to the immutable tag.
+uv run python scripts/configure_release_runner_group.py v0.5.0
+
+# 3. In a fresh runner directory under the dedicated macOS account, use the
+#    current organization-runner package and a one-hour registration token.
+export ARCHETYPE_RUNNER_TOKEN="$(
+  gh api --method POST orgs/VangelisTech/actions/runners/registration-token \
+    --jq .token
+)"
+./config.sh \
+  --url https://github.com/VangelisTech \
+  --token "$ARCHETYPE_RUNNER_TOKEN" \
+  --runnergroup archetype-release-macos \
+  --name archetype-release-macos \
+  --labels archetype-apple-container-macos-26 \
+  --ephemeral \
+  --unattended
+unset ARCHETYPE_RUNNER_TOKEN
+./run.sh
+
+# 4. From a second terminal, dispatch only at the same immutable tag.
+gh workflow run release.yml \
+  --repo VangelisTech/archetype \
+  --ref v0.5.0 \
+  -f tag=v0.5.0
+```
+
+Approve `release-apple-macos`, then approve `release-pypi` only after its
+evidence gate succeeds. The ephemeral runner deregisters after the Apple job;
+discard its working directory before preparing a rerun or future release.
 
 Release-lane authentication is explicit and provider-scoped:
 
@@ -190,13 +249,14 @@ Release-lane authentication is explicit and provider-scoped:
 | OpenAI | The job receives only `OPENAI_API_KEY` from the Actions secret of the same name. |
 | Docker | The runner's local Docker context and daemon authorize the parity operation; the lane does not perform registry login. |
 | Cloudflare R2 | `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` authenticate the account, while `R2_API_ENDPOINT` and `R2_BUCKET` select the exact substrate. |
-| Apple Container | A self-hosted bare-metal Apple Silicon runner bearing `self-hosted`, `macOS`, `ARM64`, and `archetype-apple-container-macos-26` supplies the local host authority. The job verifies macOS 26 and starts the local `container` service; no Apple cloud token is accepted. GitHub-hosted arm64 macOS runners are not substitutes because the provider needs Virtualization.framework VM support. |
+| Apple Container | A one-job ephemeral, dedicated-account, bare-metal Apple Silicon runner in the exact-workflow-restricted `archetype-release-macos` group supplies the local host authority. It also bears `self-hosted`, `macOS`, `ARM64`, and `archetype-apple-container-macos-26`. The job verifies macOS 26 and starts the local `container` service; no Apple cloud token is accepted. GitHub-hosted arm64 macOS runners are not substitutes because the provider needs Virtualization.framework VM support. |
 | Modal Agent Mission | `MODAL_TOKEN_ID` plus `MODAL_TOKEN_SECRET` authenticate the Modal control plane. Actions repository variable `CODING_AGENT_MODAL_PROFILE` becomes the SDK selector `MODAL_PROFILE`; `CODING_AGENT_MODAL_ENVIRONMENT` becomes both the Archetype selector and SDK selector `MODAL_ENVIRONMENT`, while the workspace and remaining Environment-scoped variables bind all named objects. `CODEX_AUTH_VOLUME` supplies the separately device-authenticated Codex `auth.json`. `CODING_AGENT_GITHUB_SECRET` names the Modal Secret resolved for the isolated publisher, but the paid live lane deliberately pushes to a provider-local bare remote and never attaches that secret or mutates GitHub. Deterministic broker contracts separately prove that only the exact GitHub push process can receive `GITHUB_TOKEN`. Modal Connect Tokens authenticate the two transient viewport URLs. |
 
-The tag workflow is serialized under one release concurrency group because its
-configured Codex auth Volume is a static mutable credential broker. Concurrent
-release runs must use distinct auth Volumes before that serialization can be
-relaxed. Agent Mission provider details and operator setup are normative in
+The operator-dispatched release workflow is serialized under one release
+concurrency group because its configured Codex auth Volume is a static mutable
+credential broker. Concurrent release runs must use distinct auth Volumes
+before that serialization can be relaxed. Agent Mission provider details and
+operator setup are normative in
 [Agent Missions](agent-missions.md#authentication-paths-by-provider).
 
 `not_run` is never a pass. It is acceptable only when the manifest makes the

--- a/scripts/configure_release_runner_group.py
+++ b/scripts/configure_release_runner_group.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pin the release Mac runner group to one immutable release workflow ref."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from collections.abc import Sequence
+from typing import Any
+from urllib.parse import quote
+
+OWNER = "VangelisTech"
+REPOSITORY = "archetype"
+RELEASE_OPERATOR = "everettVT"
+RUNNER_GROUP = "archetype-release-macos"
+WORKFLOW_PATH = ".github/workflows/release.yml"
+TAG_PATTERN = re.compile(r"v[0-9A-Za-z][0-9A-Za-z._+-]*\Z")
+
+
+def _gh_api(
+    endpoint: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    command = ["gh", "api", "--method", method, endpoint]
+    serialized = None
+    if payload is not None:
+        command.extend(("--input", "-"))
+        serialized = json.dumps(payload)
+    completed = subprocess.run(
+        command,
+        input=serialized,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"gh api failed for {endpoint}: {detail}")
+    if not completed.stdout.strip():
+        return None
+    return json.loads(completed.stdout)
+
+
+def _selected_workflow(tag: str) -> str:
+    if TAG_PATTERN.fullmatch(tag) is None:
+        raise ValueError("release tag must start with v and contain no slash")
+    return f"{OWNER}/{REPOSITORY}/{WORKFLOW_PATH}@refs/tags/{tag}"
+
+
+def _group_payload(repo_id: int, tag: str) -> dict[str, Any]:
+    return {
+        "name": RUNNER_GROUP,
+        "visibility": "selected",
+        "allows_public_repositories": True,
+        "restricted_to_workflows": True,
+        "selected_repository_ids": [repo_id],
+        "selected_workflows": [_selected_workflow(tag)],
+    }
+
+
+def _require_release_ref(tag: str) -> tuple[int, str]:
+    user = _gh_api("user")
+    if user["login"] != RELEASE_OPERATOR:
+        raise RuntimeError(f"gh must be authenticated as {RELEASE_OPERATOR}")
+
+    repo = _gh_api(f"repos/{OWNER}/{REPOSITORY}")
+    repo_id = int(repo["id"])
+    encoded_tag = quote(tag, safe="")
+    _gh_api(f"repos/{OWNER}/{REPOSITORY}/contents/{WORKFLOW_PATH}?ref={encoded_tag}")
+    comparison = _gh_api(
+        f"repos/{OWNER}/{REPOSITORY}/compare/{encoded_tag}...{repo['default_branch']}"
+    )
+    if comparison["status"] not in {"ahead", "identical"}:
+        raise RuntimeError(
+            f"{tag} must point to a commit on {repo['default_branch']}; "
+            f"comparison was {comparison['status']}"
+        )
+    return repo_id, str(repo["default_branch"])
+
+
+def configure(tag: str) -> dict[str, Any]:
+    _selected_workflow(tag)
+    repo_id, _ = _require_release_ref(tag)
+    groups = _gh_api(f"orgs/{OWNER}/actions/runner-groups")["runner_groups"]
+    group = next((row for row in groups if row["name"] == RUNNER_GROUP), None)
+
+    payload = _group_payload(repo_id, tag)
+    if group is None:
+        group = _gh_api(
+            f"orgs/{OWNER}/actions/runner-groups",
+            method="POST",
+            payload=payload,
+        )
+    else:
+        group_id = int(group["id"])
+        runners = _gh_api(f"orgs/{OWNER}/actions/runner-groups/{group_id}/runners")
+        if int(runners["total_count"]) != 0:
+            raise RuntimeError(
+                "refusing to change runner-group authority while a runner is registered"
+            )
+        update = dict(payload)
+        update.pop("selected_repository_ids")
+        group = _gh_api(
+            f"orgs/{OWNER}/actions/runner-groups/{group_id}",
+            method="PATCH",
+            payload=update,
+        )
+        _gh_api(
+            f"orgs/{OWNER}/actions/runner-groups/{group_id}/repositories/{repo_id}",
+            method="PUT",
+        )
+
+    expected = [_selected_workflow(tag)]
+    if not group["restricted_to_workflows"] or group["selected_workflows"] != expected:
+        raise RuntimeError("GitHub did not retain the exact workflow restriction")
+    if group["visibility"] != "selected" or not group["allows_public_repositories"]:
+        raise RuntimeError("GitHub did not retain the selected public repository policy")
+    return group
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="existing release tag, for example v0.5.0")
+    args = parser.parse_args(argv)
+    group = configure(args.tag)
+    print(
+        f"runner group {group['name']} ({group['id']}) is pinned to "
+        f"{group['selected_workflows'][0]}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_configure_release_runner_group.py
+++ b/tests/scripts/test_configure_release_runner_group.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the operator-only release runner-group configurator."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts import configure_release_runner_group as target
+
+
+def test_runner_group_payload_is_exact_ref_and_deny_by_default() -> None:
+    payload = target._group_payload(957180054, "v0.5.0")
+
+    assert payload == {
+        "name": "archetype-release-macos",
+        "visibility": "selected",
+        "allows_public_repositories": True,
+        "restricted_to_workflows": True,
+        "selected_repository_ids": [957180054],
+        "selected_workflows": [
+            "VangelisTech/archetype/.github/workflows/release.yml@refs/tags/v0.5.0"
+        ],
+    }
+
+
+@pytest.mark.parametrize("tag", ["0.5.0", "v0.5.0/other", "v 0.5.0", "v"])
+def test_runner_group_payload_rejects_ambiguous_refs(tag: str) -> None:
+    with pytest.raises(ValueError, match="release tag"):
+        target._group_payload(957180054, tag)
+
+
+def test_configure_refuses_to_retarget_a_group_with_a_registered_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(target, "_require_release_ref", lambda tag: (957180054, "main"))
+    calls: list[tuple[str, str]] = []
+
+    def fake_api(
+        endpoint: str,
+        *,
+        method: str = "GET",
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        del payload
+        calls.append((method, endpoint))
+        if endpoint == "orgs/VangelisTech/actions/runner-groups":
+            return {"runner_groups": [{"id": 3, "name": target.RUNNER_GROUP}]}
+        if endpoint.endswith("/3/runners"):
+            return {"total_count": 1}
+        raise AssertionError(f"unexpected API call: {method} {endpoint}")
+
+    monkeypatch.setattr(target, "_gh_api", fake_api)
+
+    with pytest.raises(RuntimeError, match="while a runner is registered"):
+        target.configure("v0.5.0")
+
+    assert all(method != "PATCH" for method, _ in calls)
+
+
+def test_configure_restricts_existing_group_before_runner_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(target, "_require_release_ref", lambda tag: (957180054, "main"))
+    calls: list[tuple[str, str, dict[str, Any] | None]] = []
+    expected_workflow = target._selected_workflow("v0.5.0")
+
+    def fake_api(
+        endpoint: str,
+        *,
+        method: str = "GET",
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        calls.append((method, endpoint, payload))
+        if endpoint == "orgs/VangelisTech/actions/runner-groups":
+            return {"runner_groups": [{"id": 3, "name": target.RUNNER_GROUP}]}
+        if endpoint.endswith("/3/runners"):
+            return {"total_count": 0}
+        if method == "PATCH":
+            assert payload is not None
+            return {
+                "id": 3,
+                **payload,
+                "selected_workflows": [expected_workflow],
+            }
+        if method == "PUT" and endpoint.endswith("/repositories/957180054"):
+            return None
+        raise AssertionError(f"unexpected API call: {method} {endpoint}")
+
+    monkeypatch.setattr(target, "_gh_api", fake_api)
+
+    group = target.configure("v0.5.0")
+
+    assert group["selected_workflows"] == [expected_workflow]
+    patch = next(payload for method, _, payload in calls if method == "PATCH")
+    assert patch is not None
+    assert "selected_repository_ids" not in patch
+    assert patch["restricted_to_workflows"] is True

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -273,6 +273,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
     profile = _job(workflow, "release-profile")
     external = _job(workflow, "external-evidence")
+    apple = _job(workflow, "apple-evidence")
     compatibility = _job(workflow, "python-compatibility")
     gate = _job(workflow, "release-evidence-gate")
     publish = _job(workflow, "publish")
@@ -284,7 +285,6 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         "operational-release-openai",
         "operational-release-docker",
         "operational-release-r2",
-        "operational-release-apple",
         "operational-release-modal",
     ):
         assert f"target: {target}" in external
@@ -302,16 +302,39 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "group: archetype-release" in workflow
     assert "cancel-in-progress: false" in workflow
     assert "runs-on: ${{ fromJSON(matrix.runner) }}" in external
-    assert (
-        'runner: \'["self-hosted","macOS","ARM64","archetype-apple-container-macos-26"]\''
-        in external
-    )
-    assert 'test "$(uname -m)" = "arm64"' in external
-    assert "container system status" in external
+    assert "operational-release-apple" not in external
+    assert "group: archetype-release-macos" in apple
+    assert "archetype-apple-container-macos-26" in apple
+    assert "environment: release-apple-macos" in apple
+    assert 'test "$(uname -m)" = "arm64"' in apple
+    assert "container system status" in apple
+    assert "make operational-release-apple" in apple
+    assert "needs: [release-profile, external-evidence, apple-evidence]" in gate
     assert 'UV_PYTHON: "3.13"' in compatibility
     assert 'uv sync --python "3.13" --group dev' in compatibility
     assert "sys.version_info[:2] == (3, 13)" in compatibility
     assert "needs: [release-evidence-gate, python-compatibility]" in publish
+
+
+def test_release_workflow_is_operator_dispatched_from_an_immutable_tag() -> None:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    authorize = _job(workflow, "authorize-release")
+    profile = _job(workflow, "release-profile")
+    compatibility = _job(workflow, "python-compatibility")
+    github_release = _job(workflow, "github-release")
+
+    assert "workflow_dispatch:" in workflow
+    assert "push:\n    tags:" not in workflow
+    assert "RELEASE_ACTOR: ${{ github.actor }}" in authorize
+    assert "RELEASE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}" in authorize
+    assert 'test "$RELEASE_ACTOR" = "everettVT"' in authorize
+    assert 'test "$RELEASE_TRIGGERING_ACTOR" = "everettVT"' in authorize
+    assert 'test "$RELEASE_REF_TYPE" = "tag"' in authorize
+    assert 'test "$RELEASE_INPUT_TAG" = "$RELEASE_REF_NAME"' in authorize
+    assert "needs: authorize-release" in profile
+    assert "needs: authorize-release" in compatibility
+    assert 'git merge-base --is-ancestor "${GITHUB_REF_NAME}^{commit}" origin/main' in profile
+    assert "tag_name: ${{ github.ref_name }}" in github_release
 
 
 def test_commands_operational_oracle_does_not_import_pytest_modules() -> None:


### PR DESCRIPTION
## What changed

- makes the release an explicit `everettVT` dispatch at an existing immutable tag
- checks both the original and rerun actor before any release work
- isolates Apple Container evidence in the exact-workflow-restricted `archetype-release-macos` runner group
- requires the protected `release-apple-macos` environment
- adds a checked operator utility that pins the runner group to one exact tag and refuses to retarget while a runner is registered
- documents one-job ephemeral Mac runner setup and adds executable workflow/configurator contracts

## Why

The repository is public. A custom self-hosted label is routing, not an authorization boundary. The release Mac must never accept contributor-controlled workflows.

## Impact

Tag creation and release execution are operator-only. Releases become an explicit immutable-tag dispatch. The Mac runner is registered only after the group is pinned to that tag and automatically deregisters after one job.

## Validation

- `make ci`
- 2,815 passed, 7 skipped
- focused release policy contracts: 21 passed