### PR TITLE
docs: require Modal v2 auth volume

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -608,6 +608,15 @@ export CODING_AGENT_GITHUB_SECRET="archetype-github"
 modal secret create -e "$CODING_AGENT_MODAL_ENVIRONMENT" \
   "$CODING_AGENT_GITHUB_SECRET" GITHUB_TOKEN=-
 
+# Create the v2 auth Volume if it does not already exist. The lookup also
+# verifies that an existing Volume has the required version.
+if ! uv run --extra coding-agent python -c \
+  'import modal, sys; modal.Volume.from_name(sys.argv[1], environment_name=sys.argv[2], version=2).hydrate()' \
+  "$CODEX_AUTH_VOLUME" "$CODING_AGENT_MODAL_ENVIRONMENT"; then
+  modal volume create -e "$CODING_AGENT_MODAL_ENVIRONMENT" \
+    "$CODEX_AUTH_VOLUME" --version 2
+fi
+
 # One-time Codex subscription device login into the named broker Volume.
 uv run --extra coding-agent python examples/11_coding_agent_mission.py --login
 

--- a/tests/scripts/test_agent_mission_docs.py
+++ b/tests/scripts/test_agent_mission_docs.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression contracts for the Agent Missions operator guide."""
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_GUIDE = _ROOT / "docs" / "guide" / "agent-missions.md"
+
+
+def test_modal_auth_volume_setup_selects_environment_name_and_v2() -> None:
+    guide = _GUIDE.read_text()
+    setup_command = (
+        'modal volume create -e "$CODING_AGENT_MODAL_ENVIRONMENT" \\\n'
+        '    "$CODEX_AUTH_VOLUME" --version 2'
+    )
+
+    assert setup_command in guide
+    assert guide.index(setup_command) < guide.index(
+        "python examples/11_coding_agent_mission.py --login"
+    )


### PR DESCRIPTION
## What changed

- document idempotent creation and verification of the Codex auth Volume as VolumeFS v2
- bind the selected Modal environment and configured Volume name explicitly
- add a deterministic operator-guide regression contract

## Why

The live v0.5 Agent Mission probe found that `modal volume create` defaults to v1 while the shipped Modal backend opens the auth Volume with `version=2`. A fresh operator setup could therefore create an incompatible credential Volume.

## Evidence

This exact revision was authored and pushed by the real Modal-backed Agent Mission. Its product validators and a separate clean-worktree verification passed:

- `uv run pytest -q tests/scripts/test_agent_mission_docs.py`
- `uv run ruff check tests/scripts/test_agent_mission_docs.py`
- `uv run --extra docs mkdocs build`
- `git diff --check origin/main...HEAD`