### PR TITLE
ci: benchmark GitHub and Modal runners nightly

### DIFF
--- a/.github/workflows/nightly-runner-benchmark-trigger.yml
+++ b/.github/workflows/nightly-runner-benchmark-trigger.yml
@@ -1,0 +1,50 @@
+name: Nightly runner benchmark trigger
+
+on:
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: nightly-runner-benchmark-trigger
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch after main moves
+    runs-on: ubuntu-latest
+    env:
+      RUNNER_ENABLED: ${{ vars.ARCHETYPE_MODAL_RUNNER_ENABLED }}
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const enabled = process.env.RUNNER_ENABLED === "true";
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              ...context.repo,
+              workflow_id: "nightly-runner-benchmark.yml",
+              branch: "main",
+              status: "success",
+              per_page: 1,
+            });
+            const previous = data.workflow_runs[0];
+            const moved = !previous || previous.head_sha !== context.sha;
+            const shouldRun = enabled && moved;
+            if (shouldRun) {
+              await github.rest.actions.createWorkflowDispatch({
+                ...context.repo,
+                workflow_id: "nightly-runner-benchmark.yml",
+                ref: "main",
+              });
+            }
+            await core.summary
+              .addHeading("Nightly runner benchmark trigger")
+              .addRaw(`Runner enabled: ${enabled}\n`)
+              .addRaw(`Current main head: ${context.sha}\n`)
+              .addRaw(`Last successful benchmark: ${previous?.head_sha ?? "none"}\n`)
+              .addRaw(`Benchmark dispatched: ${shouldRun}\n`)
+              .write();

--- a/.github/workflows/nightly-runner-benchmark-watchdog.yml
+++ b/.github/workflows/nightly-runner-benchmark-watchdog.yml
@@ -1,0 +1,46 @@
+name: Nightly runner benchmark watchdog
+
+on:
+  schedule:
+    - cron: "17 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  cancel-stale:
+    name: Cancel stranded benchmark runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const cutoff = Date.now() - 45 * 60 * 1000;
+            const statuses = ["queued", "in_progress"];
+            const pages = await Promise.all(
+              statuses.map((status) => github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  ...context.repo,
+                  workflow_id: "nightly-runner-benchmark.yml",
+                  status,
+                  per_page: 100,
+                },
+              )),
+            );
+            const runs = pages.flat();
+            const stale = runs.filter(
+              (run) => Date.parse(run.created_at) < cutoff,
+            );
+            for (const run of stale) {
+              await github.rest.actions.cancelWorkflowRun({
+                ...context.repo,
+                run_id: run.id,
+              });
+            }
+            await core.summary
+              .addHeading("Nightly runner benchmark watchdog")
+              .addRaw(`Cancelled stale runs: ${stale.length}\n`)
+              .write();

--- a/.github/workflows/nightly-runner-benchmark.yml
+++ b/.github/workflows/nightly-runner-benchmark.yml
@@ -2,6 +2,8 @@ name: Nightly runner benchmark
 
 on:
   workflow_dispatch:
+  push:
+    branches: [everettVT/modal-ci-benchmark]
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-runner-benchmark.yml
+++ b/.github/workflows/nightly-runner-benchmark.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   DO_NOT_TRACK: "1"
-  RUNNER_MODAL_REVISION: "ead484bd5dcb05f8093cff918ffa26fa8b5644c7"
+  RUNNER_MODAL_REVISION: "faf075bb466e7a32f950e06a0aa5ed0e71fee4f6"
 
 jobs:
   hosted_static:

--- a/.github/workflows/nightly-runner-benchmark.yml
+++ b/.github/workflows/nightly-runner-benchmark.yml
@@ -58,7 +58,7 @@ jobs:
       - self-hosted
       - modal
       - archetype-nightly
-      - job-${{ github.run_id }}-${{ github.job }}
+      - job-${{ github.run_id }}-modal-static
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -79,7 +79,7 @@ jobs:
       - self-hosted
       - modal
       - archetype-nightly
-      - job-${{ github.run_id }}-${{ github.job }}
+      - job-${{ github.run_id }}-modal-tests
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/nightly-runner-benchmark.yml
+++ b/.github/workflows/nightly-runner-benchmark.yml
@@ -1,0 +1,137 @@
+name: Nightly runner benchmark
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: nightly-runner-benchmark
+  cancel-in-progress: true
+
+env:
+  DO_NOT_TRACK: "1"
+  RUNNER_MODAL_REVISION: "ead484bd5dcb05f8093cff918ffa26fa8b5644c7"
+
+jobs:
+  hosted_static:
+    name: Hosted Static
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.11.28"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --group dev
+      - run: make static
+
+  hosted_tests:
+    name: Hosted Tests (3.12)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.11.28"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --group dev
+      - run: make test
+
+  modal_static:
+    name: Modal Static
+    runs-on:
+      - self-hosted
+      - modal
+      - archetype-nightly
+      - job-${{ github.run_id }}-${{ github.job }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.11.28"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --group dev
+      - run: make static
+
+  modal_tests:
+    name: Modal Tests (3.12)
+    runs-on:
+      - self-hosted
+      - modal
+      - archetype-nightly
+      - job-${{ github.run_id }}-${{ github.job }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.11.28"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --group dev
+      - run: make test
+
+  report:
+    name: Publish paired runner report
+    needs: [hosted_static, hosted_tests, modal_static, modal_tests]
+    if: >-
+      needs.hosted_static.result == 'success' &&
+      needs.hosted_tests.result == 'success' &&
+      needs.modal_static.result == 'success' &&
+      needs.modal_tests.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Read this workflow run's job metadata
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const fs = require("fs");
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              { ...context.repo, run_id: context.runId, per_page: 100 },
+            );
+            fs.writeFileSync("runner-jobs.json", JSON.stringify({ jobs }));
+      - name: Build the revision-bound report
+        run: >-
+          python scripts/report_runner_benchmark.py
+          --jobs-json runner-jobs.json
+          --out runner-benchmark.json
+          --summary "$GITHUB_STEP_SUMMARY"
+          --repository "$GITHUB_REPOSITORY"
+          --revision "$GITHUB_SHA"
+          --run-id "$GITHUB_RUN_ID"
+          --modal-cpu 4
+          --modal-memory-mib 16384
+          --runner-modal-revision "$RUNNER_MODAL_REVISION"
+      - name: Retain the paired report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: runner-benchmark-${{ github.sha }}
+          path: runner-benchmark.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/nightly-runner-benchmark.yml
+++ b/.github/workflows/nightly-runner-benchmark.yml
@@ -2,8 +2,6 @@ name: Nightly runner benchmark
 
 on:
   workflow_dispatch:
-  push:
-    branches: [everettVT/modal-ci-benchmark]
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-runner-benchmark.yml
+++ b/.github/workflows/nightly-runner-benchmark.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   DO_NOT_TRACK: "1"
-  RUNNER_MODAL_REVISION: "faf075bb466e7a32f950e06a0aa5ed0e71fee4f6"
+  RUNNER_MODAL_REVISION: "639befc05b88000c3b6770d41e9df42081270cec"
 
 jobs:
   hosted_static:

--- a/docs/guide/benchmarking.md
+++ b/docs/guide/benchmarking.md
@@ -84,9 +84,10 @@ does not make the Subscriber API a production dependency.
 
 ## Trend tracking is an operational decision
 
-The repository does not currently archive benchmark history or label timing
-changes as regressions. A useful automated trend gate first needs all of the
-following:
+The repository does not retain long-term product benchmark history or label
+timing changes as regressions. The CI-runner comparison below keeps paired
+reports for 30 days as evaluation evidence, not as a stable performance
+baseline. A useful automated trend gate first needs all of the following:
 
 - a stable dedicated runner;
 - durable artifact retention;
@@ -99,6 +100,32 @@ the context needed to revisit comparison once those prerequisites exist.
 
 Remaining workload coverage and the runner/retention decision stay tracked in
 [issue #141](https://github.com/VangelisTech/archetype/issues/141).
+
+## Nightly CI runner comparison
+
+The advisory `repository.ci_runner.turnaround` benchmark compares the existing
+GitHub-hosted PR commands with an ephemeral Modal runner on one exact `main`
+revision. A small hosted trigger checks nightly and dispatches the benchmark
+only when `main` differs from the latest successful paired run. Manual
+dispatch of the trigger performs the same movement check. The trigger remains
+inert until the repository variable `ARCHETYPE_MODAL_RUNNER_ENABLED` is exactly
+`true`, so merging the harness before deploying the runner cannot strand jobs.
+
+Successful paired runs retain
+`archetype.ci-runner-benchmark/v1` JSON for 30 days. The report records the
+revision, runner identities and labels, requested Modal resources, queue time,
+execution time, total time, and each substrate's two-job critical path. The
+reporter rejects missing, failed, duplicate, or non-monotonic job observations
+before writing timing evidence. A separate hosted watchdog cancels a benchmark
+that remains queued or in progress for more than 45 minutes. The comparison is
+not a PR check or a performance regression gate.
+
+The Modal control plane is deployed from
+[`VangelisTech/runner-modal@ead484b`](https://github.com/VangelisTech/runner-modal/commit/ead484bd5dcb05f8093cff918ffa26fa8b5644c7).
+Its job entrypoint removes the repository-administration token before starting
+Docker, another child process, or the Actions runner; benchmark steps receive
+only the ordinary job-scoped Actions token. The exact fork revision and
+requested Modal resources are bound into every retained report.
 
 ## Add a workload
 

--- a/docs/guide/benchmarking.md
+++ b/docs/guide/benchmarking.md
@@ -121,7 +121,7 @@ that remains queued or in progress for more than 45 minutes. The comparison is
 not a PR check or a performance regression gate.
 
 The Modal control plane is deployed from
-[`VangelisTech/runner-modal@ead484b`](https://github.com/VangelisTech/runner-modal/commit/ead484bd5dcb05f8093cff918ffa26fa8b5644c7).
+[`VangelisTech/runner-modal@faf075b`](https://github.com/VangelisTech/runner-modal/commit/faf075bb466e7a32f950e06a0aa5ed0e71fee4f6).
 Its job entrypoint removes the repository-administration token before starting
 Docker, another child process, or the Actions runner; benchmark steps receive
 only the ordinary job-scoped Actions token. The exact fork revision and

--- a/docs/guide/benchmarking.md
+++ b/docs/guide/benchmarking.md
@@ -121,7 +121,7 @@ that remains queued or in progress for more than 45 minutes. The comparison is
 not a PR check or a performance regression gate.
 
 The Modal control plane is deployed from
-[`VangelisTech/runner-modal@faf075b`](https://github.com/VangelisTech/runner-modal/commit/faf075bb466e7a32f950e06a0aa5ed0e71fee4f6).
+[`VangelisTech/runner-modal@639befc`](https://github.com/VangelisTech/runner-modal/commit/639befc05b88000c3b6770d41e9df42081270cec).
 Its job entrypoint removes the repository-administration token before starting
 Docker, another child process, or the Actions runner; benchmark steps receive
 only the ordinary job-scoped Actions token. The exact fork revision and

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -331,9 +331,11 @@ outcome authority and retry/failure behavior.
 
 The required PR workflow owns static checks and fast product tests on Python
 3.12. Repository scenarios, coverage, packaging, examples, documentation, and
-compatibility evidence belong to full or release validation. Benchmarks stay
-user-triggered because shared CI hardware does not provide a trustworthy
-performance baseline.
+compatibility evidence belong to full or release validation. Product-runtime
+benchmarks stay user-triggered because shared CI hardware does not provide a
+trustworthy performance baseline. The advisory CI-runner benchmark is the
+narrow exception: the shared runner substrate is itself the subject, so it
+runs paired jobs only after `main` moves and never becomes a regression gate.
 
 Use these entry points:
 

--- a/quality/benchmarks.toml
+++ b/quality/benchmarks.toml
@@ -48,3 +48,20 @@ metrics = [
   { name = "python_conversion_s", direction = "lower" },
   { name = "udf_operator_accumulated_duration_median_s", direction = "lower" },
 ]
+
+[[benchmark]]
+id = "repository.ci_runner.turnaround"
+suite = "ci_runner_turnaround"
+owner = "repository-harness"
+entrypoint = "scripts/report_runner_benchmark.py"
+correctness_oracles = ["tests/static/test_runner_benchmark_report.py"]
+report_schema = "archetype.ci-runner-benchmark/v1"
+comparison_policy = "advisory"
+stable_runner = false
+profiles = ["nightly"]
+metrics = [
+  { name = "hosted_critical_path_s", direction = "lower" },
+  { name = "modal_critical_path_s", direction = "lower" },
+  { name = "modal_minus_hosted_s", direction = "lower" },
+  { name = "hosted_over_modal_ratio", direction = "higher" },
+]

--- a/scripts/report_runner_benchmark.py
+++ b/scripts/report_runner_benchmark.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build one paired GitHub-hosted versus Modal runner benchmark report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "archetype.ci-runner-benchmark/v1"
+JOBS = {
+    "Hosted Static": ("hosted_static", "github-hosted"),
+    "Hosted Tests (3.12)": ("hosted_tests", "github-hosted"),
+    "Modal Static": ("modal_static", "modal"),
+    "Modal Tests (3.12)": ("modal_tests", "modal"),
+}
+
+
+def parse_time(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"job {field} must be a non-empty timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"job {field} is not an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"job {field} must include a timezone")
+    return parsed
+
+
+def measurement(row: Mapping[str, Any], *, runner: str) -> dict[str, Any]:
+    if row.get("conclusion") != "success":
+        raise ValueError(f"job {row.get('name')!r} did not succeed")
+    created = parse_time(row.get("created_at"), field="created_at")
+    started = parse_time(row.get("started_at"), field="started_at")
+    completed = parse_time(row.get("completed_at"), field="completed_at")
+    if not created <= started <= completed:
+        raise ValueError(f"job {row.get('name')!r} has non-monotonic timestamps")
+    labels = row.get("labels")
+    if not isinstance(labels, list) or not all(isinstance(item, str) for item in labels):
+        raise ValueError(f"job {row.get('name')!r} labels must be strings")
+    runner_name = row.get("runner_name")
+    if not isinstance(runner_name, str) or not runner_name:
+        raise ValueError(f"job {row.get('name')!r} has no runner identity")
+    return {
+        "runner": runner,
+        "runner_name": runner_name,
+        "labels": labels,
+        "queue_s": round((started - created).total_seconds(), 3),
+        "execution_s": round((completed - started).total_seconds(), 3),
+        "total_s": round((completed - created).total_seconds(), 3),
+    }
+
+
+def build_report(
+    payload: Mapping[str, Any],
+    *,
+    repository: str,
+    revision: str,
+    run_id: int,
+    modal_cpu: float,
+    modal_memory_mib: int,
+    runner_modal_revision: str,
+) -> dict[str, Any]:
+    rows = payload.get("jobs")
+    if not isinstance(rows, list):
+        raise ValueError("jobs payload must contain a jobs list")
+    selected: dict[str, dict[str, Any]] = {}
+    for display_name, (key, runner) in JOBS.items():
+        matches = [row for row in rows if isinstance(row, dict) and row.get("name") == display_name]
+        if len(matches) != 1:
+            raise ValueError(f"expected exactly one {display_name!r} job")
+        selected[key] = measurement(matches[0], runner=runner)
+
+    hosted_critical = max(
+        selected["hosted_static"]["total_s"],
+        selected["hosted_tests"]["total_s"],
+    )
+    modal_critical = max(
+        selected["modal_static"]["total_s"],
+        selected["modal_tests"]["total_s"],
+    )
+    return {
+        "schema": SCHEMA,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "repository": repository,
+        "revision": revision,
+        "workflow_run_id": run_id,
+        "configuration": {
+            "hosted_label": "ubuntu-latest",
+            "modal_cpu_physical_cores": modal_cpu,
+            "modal_memory_mib": modal_memory_mib,
+            "runner_modal_revision": runner_modal_revision,
+            "commands": {
+                "static": "make static",
+                "tests": "make test",
+            },
+        },
+        "jobs": selected,
+        "comparison": {
+            "hosted_critical_path_s": hosted_critical,
+            "modal_critical_path_s": modal_critical,
+            "modal_minus_hosted_s": round(modal_critical - hosted_critical, 3),
+            "hosted_over_modal_ratio": round(hosted_critical / modal_critical, 4),
+        },
+    }
+
+
+def summary(report: Mapping[str, Any]) -> str:
+    jobs = report["jobs"]
+    comparison = report["comparison"]
+    return "\n".join(
+        (
+            "## Nightly runner benchmark",
+            "",
+            f"Revision: `{report['revision']}`",
+            "",
+            "| Lane | Queue | Execution | Total |",
+            "|---|---:|---:|---:|",
+            *(
+                f"| {name} | {jobs[key]['queue_s']:.1f}s | "
+                f"{jobs[key]['execution_s']:.1f}s | {jobs[key]['total_s']:.1f}s |"
+                for name, key in (
+                    ("Hosted static", "hosted_static"),
+                    ("Hosted tests", "hosted_tests"),
+                    ("Modal static", "modal_static"),
+                    ("Modal tests", "modal_tests"),
+                )
+            ),
+            "",
+            f"Hosted critical path: {comparison['hosted_critical_path_s']:.1f}s  ",
+            f"Modal critical path: {comparison['modal_critical_path_s']:.1f}s  ",
+            f"Hosted/Modal ratio: {comparison['hosted_over_modal_ratio']:.3f}x",
+            "",
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jobs-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--run-id", type=int, required=True)
+    parser.add_argument("--modal-cpu", type=float, required=True)
+    parser.add_argument("--modal-memory-mib", type=int, required=True)
+    parser.add_argument("--runner-modal-revision", required=True)
+    args = parser.parse_args(argv)
+    with args.jobs_json.open(encoding="utf-8") as stream:
+        payload = json.load(stream)
+    report = build_report(
+        payload,
+        repository=args.repository,
+        revision=args.revision,
+        run_id=args.run_id,
+        modal_cpu=args.modal_cpu,
+        modal_memory_mib=args.modal_memory_mib,
+        runner_modal_revision=args.runner_modal_revision,
+    )
+    args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    if args.summary is not None:
+        args.summary.write_text(summary(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/static/test_runner_benchmark_report.py
+++ b/tests/static/test_runner_benchmark_report.py
@@ -140,7 +140,8 @@ def test_cli_writes_one_bounded_json_report(tmp_path: Path) -> None:
 def test_workflow_runs_only_for_a_new_main_revision_or_manual_dispatch() -> None:
     workflow = Path(".github/workflows/nightly-runner-benchmark.yml").read_text()
     assert "workflow_dispatch:" in workflow
-    assert "job-${{ github.run_id }}-${{ github.job }}" in workflow
+    assert "job-${{ github.run_id }}-modal-static" in workflow
+    assert "job-${{ github.run_id }}-modal-tests" in workflow
     assert "runner-benchmark-${{ github.sha }}" in workflow
     trigger = Path(".github/workflows/nightly-runner-benchmark-trigger.yml").read_text()
     assert "schedule:" in trigger

--- a/tests/static/test_runner_benchmark_report.py
+++ b/tests/static/test_runner_benchmark_report.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from scripts.report_runner_benchmark import SCHEMA, build_report, main
+
+
+def job(
+    name: str,
+    *,
+    runner_name: str,
+    started: str = "2026-08-11T09:00:05Z",
+    completed: str = "2026-08-11T09:01:05Z",
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "conclusion": "success",
+        "created_at": "2026-08-11T09:00:00Z",
+        "started_at": started,
+        "completed_at": completed,
+        "runner_name": runner_name,
+        "labels": ["ubuntu-latest"],
+    }
+
+
+def payload() -> dict[str, object]:
+    return {
+        "jobs": [
+            job("Hosted Static", runner_name="GitHub Actions 1"),
+            job(
+                "Hosted Tests (3.12)",
+                runner_name="GitHub Actions 2",
+                completed="2026-08-11T09:05:05Z",
+            ),
+            job("Modal Static", runner_name="job-modal-static"),
+            job(
+                "Modal Tests (3.12)",
+                runner_name="job-modal-tests",
+                started="2026-08-11T09:00:10Z",
+                completed="2026-08-11T09:04:10Z",
+            ),
+        ]
+    }
+
+
+def test_report_binds_revision_resources_and_paired_critical_paths() -> None:
+    report = build_report(
+        payload(),
+        repository="VangelisTech/archetype",
+        revision="a" * 40,
+        run_id=42,
+        modal_cpu=4.0,
+        modal_memory_mib=16_384,
+        runner_modal_revision="ead484b",
+    )
+    assert report["schema"] == SCHEMA
+    assert report["revision"] == "a" * 40
+    assert report["configuration"]["modal_cpu_physical_cores"] == 4.0
+    assert report["configuration"]["runner_modal_revision"] == "ead484b"
+    assert report["comparison"] == {
+        "hosted_critical_path_s": 305.0,
+        "modal_critical_path_s": 250.0,
+        "modal_minus_hosted_s": -55.0,
+        "hosted_over_modal_ratio": 1.22,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda rows: rows.pop(), "exactly one"),
+        (lambda rows: rows[0].update(conclusion="failure"), "did not succeed"),
+        (
+            lambda rows: rows[0].update(started_at="2026-08-11T08:59:59Z"),
+            "non-monotonic",
+        ),
+    ],
+)
+def test_report_rejects_incomplete_or_incorrect_measurements(
+    mutation: Callable[[list[dict[str, object]]], object],
+    message: str,
+) -> None:
+    candidate = payload()
+    rows = cast(list[dict[str, object]], candidate["jobs"])
+    mutation(rows)
+    with pytest.raises(ValueError, match=message):
+        build_report(
+            candidate,
+            repository="VangelisTech/archetype",
+            revision="a" * 40,
+            run_id=42,
+            modal_cpu=4.0,
+            modal_memory_mib=16_384,
+            runner_modal_revision="ead484b",
+        )
+
+
+def test_cli_writes_one_bounded_json_report(tmp_path: Path) -> None:
+    jobs_path = tmp_path / "jobs.json"
+    out_path = tmp_path / "report.json"
+    summary_path = tmp_path / "summary.md"
+    jobs_path.write_text(json.dumps(payload()))
+    assert (
+        main(
+            [
+                "--jobs-json",
+                str(jobs_path),
+                "--out",
+                str(out_path),
+                "--summary",
+                str(summary_path),
+                "--repository",
+                "VangelisTech/archetype",
+                "--revision",
+                "b" * 40,
+                "--run-id",
+                "43",
+                "--modal-cpu",
+                "4",
+                "--modal-memory-mib",
+                "16384",
+                "--runner-modal-revision",
+                "ead484b",
+            ]
+        )
+        == 0
+    )
+    assert json.loads(out_path.read_text())["schema"] == SCHEMA
+    assert "Hosted/Modal ratio" in summary_path.read_text()
+
+
+def test_workflow_runs_only_for_a_new_main_revision_or_manual_dispatch() -> None:
+    workflow = Path(".github/workflows/nightly-runner-benchmark.yml").read_text()
+    assert "workflow_dispatch:" in workflow
+    assert "job-${{ github.run_id }}-${{ github.job }}" in workflow
+    assert "runner-benchmark-${{ github.sha }}" in workflow
+    trigger = Path(".github/workflows/nightly-runner-benchmark-trigger.yml").read_text()
+    assert "schedule:" in trigger
+    assert "ARCHETYPE_MODAL_RUNNER_ENABLED" in trigger
+    assert 'workflow_id: "nightly-runner-benchmark.yml"' in trigger
+    assert "previous.head_sha !== context.sha" in trigger
+    assert "const shouldRun = enabled && moved" in trigger
+    assert "createWorkflowDispatch" in trigger
+    watchdog = Path(".github/workflows/nightly-runner-benchmark-watchdog.yml").read_text()
+    assert 'const statuses = ["queued", "in_progress"]' in watchdog


### PR DESCRIPTION
## Summary

- compare the required Static and Tests (3.12) commands on GitHub-hosted and ephemeral Modal runners at the same main revision
- dispatch only when main has moved since the last successful paired result and the runner is explicitly enabled
- retain a fail-closed, revision/resource-bound JSON report for 30 days and cancel stranded runs
- register and document the advisory repository benchmark

The control plane is pinned to VangelisTech/runner-modal@639befc05b88000c3b6770d41e9df42081270cec. The fork removes the runner-administration token before workflow processes start, uses schedulable literal job labels, and provides an executable Ubuntu runner image. Its hardening/configuration PR is https://github.com/VangelisTech/runner-modal/pull/1.

## Validation

- `uv run ruff check scripts/report_runner_benchmark.py tests/static/test_runner_benchmark_report.py`
- `uvx ty@0.0.48 check --python .venv scripts/report_runner_benchmark.py tests/static/test_runner_benchmark_report.py`
- `uv run pytest -q tests/static/test_runner_benchmark_report.py` (6 passed)
- `make benchmark-audit`
- `PYTHONPATH=src:. uv run python scripts/generate_contract_traceability.py --check`
- YAML parse and `git diff --check`

`make static` reaches the existing lockfile security audit and fails on vulnerabilities already present on main (aiohttp, h2, pymdown-extensions, and pypdf); no rerun was attempted per repository policy.

## Dogfood baseline

Run https://github.com/VangelisTech/archetype/actions/runs/31619038210 exercised both substrates with one-use JIT runners and no reusable GitHub credential in Modal:

- Hosted Static: 3s queue + 34s execution = 37s total
- Modal Static: 69s cold-build queue + 33s execution = 102s total
- Hosted Tests: 4s queue + 343s execution = 347s total, success
- Modal Tests: 69s cold-build queue + 219s execution = 288s total, with 2 runtime-semantics failures after 2,791 passing tests

The first result is diagnostic, not a valid green benchmark report. It found the two operational runner defects fixed in the pinned fork and one remaining Modal process-timeout incompatibility in `tests/scripts/test_operational_capture.py`. The feature remains disabled until that incompatibility is resolved or explicitly classified.

## Activation

`ARCHETYPE_MODAL_RUNNER_ENABLED` is set to `false`. Enable only after deploying the pinned fork with a repo-scoped runner credential and registering its signed `workflow_job` webhook.
