### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,3 +346,32 @@ change, and report the exact validation that ran. See
 | `src/archetype/core/aio/async_world.py` | World runtime |
 | `tests/app/test_runtime_contracts.py` | Executable runtime contracts |
 | `tests/sync/test_sync_stack_contracts.py` | Executable sync engine contracts |
+
+## Cursor Cloud specific instructions
+
+The dev environment is Python 3.12 + `uv` (installed on `PATH` at `/usr/local/bin`).
+Dependencies are refreshed automatically on startup via `uv sync --group dev`
+(same as `make sync-dev`). Run everything through `uv run` / `make` so the
+`.venv` and `PYTHONPATH=src` are used. Standard commands live in `README.md`,
+`CONTRIBUTING.md`, and the `Makefile`.
+
+Non-obvious caveats discovered during setup:
+
+- `make static` runs `lockfile-audit` (a `pip-audit` CVE scan) as its last
+  step. It currently fails because the quarantined pinned dependency versions
+  have CVEs disclosed after the lock's `exclude-newer` cutoff. This is a
+  supply-chain report, not a code defect. The code-quality gates —
+  `format-check`, `ruff` lint, `typecheck`, `lock-check`, `contract-audit`,
+  `benchmark-audit` — all pass. Run those directly (or `make lint` minus the
+  audit) when you only need the code-quality signal.
+- `make typecheck` shells out to `uvx ty@0.0.48`, which downloads the `ty`
+  binary on first use; it needs `uvx` on `PATH` and network access.
+- Storage is fail-closed under `ARCHETYPE_DATA_ROOT`: examples default to
+  writing `./archetype_data` relative to the current directory, so a
+  containment root that does not contain the cwd raises a "storage path
+  escapes ARCHETYPE_DATA_ROOT" error. Either leave `ARCHETYPE_DATA_ROOT`
+  unset, or run from a working directory inside the root.
+- The CLI (every command except `serve`) is a thin HTTP client against a
+  running `archetype serve`. Use `--role {admin,operator,player,viewer}` for
+  dev-mode bearer auth. `make operational-runtime` starts an isolated
+  loopback server and exercises the full serve+CLI lifecycle end to end.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for `archetype` (dataframe-first ECS runtime) in Cursor Cloud, and records durable startup guidance for future agents.

- Dev environment: Python 3.12 + `uv` (installed on `PATH`), dependencies via `uv sync --group dev` (`make sync-dev`). This is registered as the VM update script.
- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing the non-obvious caveats found during setup.

The only code change is documentation (`AGENTS.md`); no application code was modified.

## Verification

| Stage | Command | Result |
|---|---|---|
| Library entry point | `examples/00_quickstart.py` (+ 01/02/03/04/07) | All run; quickstart prints `3` |
| Lint / static | `format-check`, `ruff check`, `make typecheck`, `lock-check`, `contract-audit`, `benchmark-audit` | All pass |
| Tests | `make test` | **2816 passed, 10 skipped** |
| App (serve + CLI) | `archetype serve` + CLI world/spawn/run/query/history | Full lifecycle works |
| End-to-end scenario | `make operational-runtime` | 1 passed |

`make static` additionally runs `lockfile-audit` (a `pip-audit` CVE scan), which currently fails on the quarantined pinned dependency versions (CVEs disclosed after the lockfile cutoff). This is a supply-chain report, not a code defect, and is documented in AGENTS.md.

## Hello-world evidence (running API server + CLI)

Created a world, spawned a `Mission` entity, ran ticks, and read back append-only history and the RBAC audit log through the running `archetype serve` process:

```
$ curl /healthz            -> {"status":"ok"}
$ archetype world create hello-archetype --role admin
$ archetype entity spawn $WID --components '[{"type":"Mission",...}]' --role player  -> Spawned entity: 1
$ archetype run $WID --steps 3 --role operator  -> Run complete: 3 ticks
$ archetype query $WID Mission --role viewer     -> entity rows at ticks 0..3
$ archetype history $WID --role viewer           -> spawn/step/run/query all "succeeded"
```

[Hello-world evidence log](https://cursor.com/agents/bc-ad744a40-0e58-4e23-90d9-7fb6b3886b47/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_evidence.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad744a40-0e58-4e23-90d9-7fb6b3886b47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad744a40-0e58-4e23-90d9-7fb6b3886b47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

