### PR TITLE
fix: bind Archetype 0.6 artifacts to registry provenance

### DIFF
--- a/.github/workflows/publish-archetype-missions.yml
+++ b/.github/workflows/publish-archetype-missions.yml
@@ -1,0 +1,141 @@
+name: Publish archetype-missions
+
+on:
+  workflow_dispatch:
+    inputs:
+      parent_run_id:
+        description: "Authorizing release workflow run"
+        required: true
+        type: string
+      parent_run_attempt:
+        description: "Authorizing release workflow attempt"
+        required: true
+        type: string
+      tag:
+        description: "Exact immutable release tag"
+        required: true
+        type: string
+      expected_commit:
+        description: "Exact release commit"
+        required: true
+        type: string
+      registry:
+        description: "Destination package registry"
+        required: true
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions: {}
+
+concurrency:
+  group: publisher-${{ github.workflow }}-${{ inputs.registry }}-${{ inputs.parent_run_id }}
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Authorize parent release dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Wait for the immutable dispatch allowlist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          set -euo pipefail
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
+          [[ "$REGISTRY" == "testpypi" || "$REGISTRY" == "pypi" ]]
+          artifact="publisher-dispatch-$REGISTRY-$PARENT_RUN_ATTEMPT"
+          for _ in $(seq 1 150); do
+            if count="$(gh api \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID/artifacts?name=$artifact&per_page=100" \
+              --jq '[.artifacts[] | select(.expired == false)] | length')" &&
+              [[ "$count" == "1" ]]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "publisher dispatch allowlist did not become available" >&2
+          exit 1
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify the exact parent and child run identities
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+        run: >-
+          python scripts/verify_publisher_dispatch.py
+          --expected-workflow publish-archetype-missions.yml
+          --distribution archetype-missions
+          --child-run-id "$CHILD_RUN_ID"
+          --parent-run-id "$PARENT_RUN_ID"
+          --parent-run-attempt "$PARENT_RUN_ATTEMPT"
+          --tag "$PUBLISHER_TAG"
+          --expected-commit "$EXPECTED_COMMIT"
+          --registry "$PUBLISHER_REGISTRY"
+          --allowlist
+          ".context/publisher-dispatch/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+
+  publish-testpypi:
+    name: Publish archetype-missions to TestPyPI
+    needs: authorize
+    if: inputs.registry == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: release-testpypi
+    permissions:
+      actions: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist-archetype-missions
+          path: dist/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: true
+
+  publish-pypi:
+    name: Publish archetype-missions to PyPI
+    needs: authorize
+    if: inputs.registry == 'pypi'
+    runs-on: ubuntu-latest
+    environment: release-pypi
+    permissions:
+      actions: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist-archetype-missions
+          path: dist/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+          attestations: true

--- a/.github/workflows/publish-archetype-physical-ai.yml
+++ b/.github/workflows/publish-archetype-physical-ai.yml
@@ -1,0 +1,141 @@
+name: Publish archetype-physical-ai
+
+on:
+  workflow_dispatch:
+    inputs:
+      parent_run_id:
+        description: "Authorizing release workflow run"
+        required: true
+        type: string
+      parent_run_attempt:
+        description: "Authorizing release workflow attempt"
+        required: true
+        type: string
+      tag:
+        description: "Exact immutable release tag"
+        required: true
+        type: string
+      expected_commit:
+        description: "Exact release commit"
+        required: true
+        type: string
+      registry:
+        description: "Destination package registry"
+        required: true
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions: {}
+
+concurrency:
+  group: publisher-${{ github.workflow }}-${{ inputs.registry }}-${{ inputs.parent_run_id }}
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Authorize parent release dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Wait for the immutable dispatch allowlist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          set -euo pipefail
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
+          [[ "$REGISTRY" == "testpypi" || "$REGISTRY" == "pypi" ]]
+          artifact="publisher-dispatch-$REGISTRY-$PARENT_RUN_ATTEMPT"
+          for _ in $(seq 1 150); do
+            if count="$(gh api \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID/artifacts?name=$artifact&per_page=100" \
+              --jq '[.artifacts[] | select(.expired == false)] | length')" &&
+              [[ "$count" == "1" ]]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "publisher dispatch allowlist did not become available" >&2
+          exit 1
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify the exact parent and child run identities
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+        run: >-
+          python scripts/verify_publisher_dispatch.py
+          --expected-workflow publish-archetype-physical-ai.yml
+          --distribution archetype-physical-ai
+          --child-run-id "$CHILD_RUN_ID"
+          --parent-run-id "$PARENT_RUN_ID"
+          --parent-run-attempt "$PARENT_RUN_ATTEMPT"
+          --tag "$PUBLISHER_TAG"
+          --expected-commit "$EXPECTED_COMMIT"
+          --registry "$PUBLISHER_REGISTRY"
+          --allowlist
+          ".context/publisher-dispatch/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+
+  publish-testpypi:
+    name: Publish archetype-physical-ai to TestPyPI
+    needs: authorize
+    if: inputs.registry == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: release-testpypi
+    permissions:
+      actions: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist-archetype-physical-ai
+          path: dist/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: true
+
+  publish-pypi:
+    name: Publish archetype-physical-ai to PyPI
+    needs: authorize
+    if: inputs.registry == 'pypi'
+    runs-on: ubuntu-latest
+    environment: release-pypi
+    permissions:
+      actions: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist-archetype-physical-ai
+          path: dist/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+          attestations: true

--- a/.github/workflows/publish-archetype-research.yml
+++ b/.github/workflows/publish-archetype-research.yml
@@ -1,0 +1,141 @@
+name: Publish archetype-research
+
+on:
+  workflow_dispatch:
+    inputs:
+      parent_run_id:
+        description: "Authorizing release workflow run"
+        required: true
+        type: string
+      parent_run_attempt:
+        description: "Authorizing release workflow attempt"
+        required: true
+        type: string
+      tag:
+        description: "Exact immutable release tag"
+        required: true
+        type: string
+      expected_commit:
+        description: "Exact release commit"
+        required: true
+        type: string
+      registry:
+        description: "Destination package registry"
+        required: true
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions: {}
+
+concurrency:
+  group: publisher-${{ github.workflow }}-${{ inputs.registry }}-${{ inputs.parent_run_id }}
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Authorize parent release dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Wait for the immutable dispatch allowlist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          set -euo pipefail
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
+          [[ "$REGISTRY" == "testpypi" || "$REGISTRY" == "pypi" ]]
+          artifact="publisher-dispatch-$REGISTRY-$PARENT_RUN_ATTEMPT"
+          for _ in $(seq 1 150); do
+            if count="$(gh api \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID/artifacts?name=$artifact&per_page=100" \
+              --jq '[.artifacts[] | select(.expired == false)] | length')" &&
+              [[ "$count" == "1" ]]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "publisher dispatch allowlist did not become available" >&2
+          exit 1
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify the exact parent and child run identities
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+        run: >-
+          python scripts/verify_publisher_dispatch.py
+          --expected-workflow publish-archetype-research.yml
+          --distribution archetype-research
+          --child-run-id "$CHILD_RUN_ID"
+          --parent-run-id "$PARENT_RUN_ID"
+          --parent-run-attempt "$PARENT_RUN_ATTEMPT"
+          --tag "$PUBLISHER_TAG"
+          --expected-commit "$EXPECTED_COMMIT"
+          --registry "$PUBLISHER_REGISTRY"
+          --allowlist
+          ".context/publisher-dispatch/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+
+  publish-testpypi:
+    name: Publish archetype-research to TestPyPI
+    needs: authorize
+    if: inputs.registry == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: release-testpypi
+    permissions:
+      actions: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist-archetype-research
+          path: dist/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: true
+
+  publish-pypi:
+    name: Publish archetype-research to PyPI
+    needs: authorize
+    if: inputs.registry == 'pypi'
+    runs-on: ubuntu-latest
+    environment: release-pypi
+    permissions:
+      actions: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist-archetype-research
+          path: dist/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+          attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,26 @@ jobs:
           path: dist/
           if-no-files-found: error
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-archetype-ecs
+          path: dist/archetype_ecs-*
+          if-no-files-found: error
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-archetype-missions
+          path: dist/archetype_missions-*
+          if-no-files-found: error
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-archetype-physical-ai
+          path: dist/archetype_physical_ai-*
+          if-no-files-found: error
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-archetype-research
+          path: dist/archetype_research-*
+          if-no-files-found: error
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: release-evidence
@@ -348,7 +368,6 @@ jobs:
           --integrity-template
           'https://test.pypi.org/integrity/{distribution}/{version}/{filename}/provenance'
           --publisher-repository VangelisTech/archetype
-          --publisher-workflow release.yml
           --publisher-environment release-testpypi
           --attestation-repository https://github.com/VangelisTech/archetype
           --registry-artifact-host test-files.pythonhosted.org
@@ -365,7 +384,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist
+          name: dist-archetype-ecs
           path: dist/
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
@@ -373,9 +392,51 @@ jobs:
           skip-existing: true
           attestations: true
 
+  publish-testpypi-libraries:
+    name: Publish world libraries to TestPyPI
+    needs: testpypi-preflight
+    if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Dispatch exact TestPyPI publisher runs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python scripts/dispatch_release_publishers.py dispatch
+          --parent-run-id "$GITHUB_RUN_ID"
+          --parent-run-attempt "$GITHUB_RUN_ATTEMPT"
+          --tag "$GITHUB_REF_NAME"
+          --expected-commit "$GITHUB_SHA"
+          --registry testpypi
+          --out publisher-dispatch-testpypi.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: publisher-dispatch-testpypi-${{ github.run_attempt }}
+          path: publisher-dispatch-testpypi.json
+          if-no-files-found: error
+      - name: Await only the allowlisted TestPyPI publisher runs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python scripts/dispatch_release_publishers.py await
+          --parent-run-id "$GITHUB_RUN_ID"
+          --parent-run-attempt "$GITHUB_RUN_ATTEMPT"
+          --tag "$GITHUB_REF_NAME"
+          --expected-commit "$GITHUB_SHA"
+          --registry testpypi
+          --allowlist publisher-dispatch-testpypi.json
+          --out publisher-dispatch-testpypi.json
+
   testpypi-smoke:
     name: TestPyPI installed distribution matrix
-    needs: publish-testpypi
+    needs: [publish-testpypi, publish-testpypi-libraries]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -405,7 +466,6 @@ jobs:
           --integrity-template
           'https://test.pypi.org/integrity/{distribution}/{version}/{filename}/provenance'
           --publisher-repository VangelisTech/archetype
-          --publisher-workflow release.yml
           --publisher-environment release-testpypi
           --attestation-repository https://github.com/VangelisTech/archetype
           --registry-artifact-host test-files.pythonhosted.org
@@ -462,7 +522,6 @@ jobs:
           --integrity-template
           'https://pypi.org/integrity/{distribution}/{version}/{filename}/provenance'
           --publisher-repository VangelisTech/archetype
-          --publisher-workflow release.yml
           --publisher-environment release-pypi
           --attestation-repository https://github.com/VangelisTech/archetype
           --registry-artifact-host files.pythonhosted.org
@@ -478,16 +537,58 @@ jobs:
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist
+          name: dist-archetype-ecs
           path: dist/
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true
           attestations: true
 
+  publish-libraries:
+    name: Publish world libraries to PyPI
+    needs: pypi-preflight
+    if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Dispatch exact PyPI publisher runs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python scripts/dispatch_release_publishers.py dispatch
+          --parent-run-id "$GITHUB_RUN_ID"
+          --parent-run-attempt "$GITHUB_RUN_ATTEMPT"
+          --tag "$GITHUB_REF_NAME"
+          --expected-commit "$GITHUB_SHA"
+          --registry pypi
+          --out publisher-dispatch-pypi.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: publisher-dispatch-pypi-${{ github.run_attempt }}
+          path: publisher-dispatch-pypi.json
+          if-no-files-found: error
+      - name: Await only the allowlisted PyPI publisher runs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python scripts/dispatch_release_publishers.py await
+          --parent-run-id "$GITHUB_RUN_ID"
+          --parent-run-attempt "$GITHUB_RUN_ATTEMPT"
+          --tag "$GITHUB_REF_NAME"
+          --expected-commit "$GITHUB_SHA"
+          --registry pypi
+          --allowlist publisher-dispatch-pypi.json
+          --out publisher-dispatch-pypi.json
+
   registry-smoke:
     name: PyPI installed distribution matrix
-    needs: publish
+    needs: [publish, publish-libraries]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -515,7 +616,6 @@ jobs:
           --integrity-template
           'https://pypi.org/integrity/{distribution}/{version}/{filename}/provenance'
           --publisher-repository VangelisTech/archetype
-          --publisher-workflow release.yml
           --publisher-environment release-pypi
           --attestation-repository https://github.com/VangelisTech/archetype
           --registry-artifact-host files.pythonhosted.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing immutable release tag (for example, v0.5.0)"
+        description: "Existing immutable release tag (for example, v0.6.0)"
         required: true
         type: string
 
@@ -53,12 +53,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
-          version: "latest"
+          version: "0.9.28"
       - run: uv sync --all-packages --all-extras --group dev --group docs
       - name: Verify tag and package version agree
         run: |
@@ -133,12 +134,14 @@ jobs:
       CODING_AGENT_GITHUB_SECRET: ${{ matrix.target == 'operational-release-modal' && vars.CODING_AGENT_GITHUB_SECRET || '' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
-          version: "latest"
+          version: "0.9.28"
       - run: uv sync --all-packages --all-extras --group dev
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -200,9 +203,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
-          version: "latest"
+          version: "0.9.28"
       - name: Provision Python 3.12 with uv
         run: |
           uv sync --python "3.12" --all-packages --all-extras --group dev
@@ -250,12 +255,14 @@ jobs:
       UV_PYTHON: "3.13"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
-          version: "latest"
+          version: "0.9.28"
       - run: uv sync --python "3.13" --all-packages --all-extras --group dev
       - name: Verify Python 3.13 interpreter
         run: >-
@@ -272,6 +279,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
@@ -302,8 +311,164 @@ jobs:
           path: release-evidence-summary.json
           if-no-files-found: error
 
-  publish:
+  testpypi-preflight:
+    name: TestPyPI exact-byte preflight
     needs: [release-evidence-gate, python-compatibility]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Reauthorize the immutable release ref
+        run: >-
+          python scripts/verify_release_ref.py
+          --tag "$GITHUB_REF_NAME"
+          --expected-commit "$GITHUB_SHA"
+          --repository "$GITHUB_REPOSITORY"
+          --actor "$GITHUB_ACTOR"
+          --triggering-actor "$GITHUB_TRIGGERING_ACTOR"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+        with:
+          version: "0.9.28"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-evidence
+          path: evidence/
+      - name: Reject conflicting TestPyPI files
+        run: >-
+          uvx --from pypi-attestations==0.0.30 --with packaging==26.1 python
+          scripts/verify_release_index.py
+          preflight
+          --manifest evidence/release-artifact.json
+          --expected-commit "$GITHUB_SHA"
+          --api-template
+          'https://test.pypi.org/pypi/{distribution}/{version}/json'
+          --integrity-template
+          'https://test.pypi.org/integrity/{distribution}/{version}/{filename}/provenance'
+          --publisher-repository VangelisTech/archetype
+          --publisher-workflow release.yml
+          --publisher-environment release-testpypi
+          --attestation-repository https://github.com/VangelisTech/archetype
+          --attestation-staging
+
+  publish-testpypi:
+    name: Publish attested artifacts to TestPyPI
+    needs: testpypi-preflight
+    if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
+    runs-on: ubuntu-latest
+    environment: release-testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: true
+
+  testpypi-smoke:
+    name: TestPyPI installed distribution matrix
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+        with:
+          version: "0.9.28"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-evidence
+          path: evidence/
+      - name: Verify TestPyPI serves all eight attested files
+        run: >-
+          uvx --from pypi-attestations==0.0.30 --with packaging==26.1 python
+          scripts/verify_release_index.py
+          complete
+          --manifest evidence/release-artifact.json
+          --expected-commit "$GITHUB_SHA"
+          --api-template
+          'https://test.pypi.org/pypi/{distribution}/{version}/json'
+          --integrity-template
+          'https://test.pypi.org/integrity/{distribution}/{version}/{filename}/provenance'
+          --publisher-repository VangelisTech/archetype
+          --publisher-workflow release.yml
+          --publisher-environment release-testpypi
+          --attestation-repository https://github.com/VangelisTech/archetype
+          --attestation-staging
+          --out testpypi-index-evidence.json
+          --attempts 12
+          --interval-seconds 5
+      - name: Install base, selective, and full stacks from TestPyPI
+        run: >-
+          uv run --no-project --with packaging==26.1 python scripts/registry_smoke.py
+          --manifest evidence/release-artifact.json
+          --index-url https://test.pypi.org/simple
+          --extra-index-url https://pypi.org/simple
+          --out testpypi-install-evidence.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: testpypi-index-evidence
+          path: |
+            testpypi-index-evidence.json
+            testpypi-install-evidence.json
+          if-no-files-found: error
+
+  pypi-preflight:
+    name: PyPI exact-byte preflight
+    needs: testpypi-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Reauthorize the immutable release ref
+        run: >-
+          python scripts/verify_release_ref.py
+          --tag "$GITHUB_REF_NAME"
+          --expected-commit "$GITHUB_SHA"
+          --repository "$GITHUB_REPOSITORY"
+          --actor "$GITHUB_ACTOR"
+          --triggering-actor "$GITHUB_TRIGGERING_ACTOR"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+        with:
+          version: "0.9.28"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-evidence
+          path: evidence/
+      - name: Reject conflicting PyPI files
+        run: >-
+          uvx --from pypi-attestations==0.0.30 --with packaging==26.1 python
+          scripts/verify_release_index.py
+          preflight
+          --manifest evidence/release-artifact.json
+          --expected-commit "$GITHUB_SHA"
+          --integrity-template
+          'https://pypi.org/integrity/{distribution}/{version}/{filename}/provenance'
+          --publisher-repository VangelisTech/archetype
+          --publisher-workflow release.yml
+          --publisher-environment release-pypi
+          --attestation-repository https://github.com/VangelisTech/archetype
+
+  publish:
+    needs: pypi-preflight
+    if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     environment: release-pypi
     permissions:
@@ -314,15 +479,70 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+          attestations: true
+
+  registry-smoke:
+    name: PyPI installed distribution matrix
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+        with:
+          version: "0.9.28"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-evidence
+          path: evidence/
+      - name: Verify PyPI serves all eight attested files
+        run: >-
+          uvx --from pypi-attestations==0.0.30 --with packaging==26.1 python
+          scripts/verify_release_index.py
+          complete
+          --manifest evidence/release-artifact.json
+          --expected-commit "$GITHUB_SHA"
+          --integrity-template
+          'https://pypi.org/integrity/{distribution}/{version}/{filename}/provenance'
+          --publisher-repository VangelisTech/archetype
+          --publisher-workflow release.yml
+          --publisher-environment release-pypi
+          --attestation-repository https://github.com/VangelisTech/archetype
+          --out pypi-index-evidence.json
+          --attempts 12
+          --interval-seconds 5
+      - name: Install base, selective, and full stacks from PyPI
+        run: >-
+          uv run --no-project --with packaging==26.1 python scripts/registry_smoke.py
+          --manifest evidence/release-artifact.json
+          --out pypi-install-evidence.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pypi-index-evidence
+          path: |
+            pypi-index-evidence.json
+            pypi-install-evidence.json
+          if-no-files-found: error
 
   github-release:
-    needs: publish
+    needs: registry-smoke
+    if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,7 +351,7 @@ jobs:
           --publisher-workflow release.yml
           --publisher-environment release-testpypi
           --attestation-repository https://github.com/VangelisTech/archetype
-          --attestation-staging
+          --registry-artifact-host test-files.pythonhosted.org
 
   publish-testpypi:
     name: Publish attested artifacts to TestPyPI
@@ -408,7 +408,7 @@ jobs:
           --publisher-workflow release.yml
           --publisher-environment release-testpypi
           --attestation-repository https://github.com/VangelisTech/archetype
-          --attestation-staging
+          --registry-artifact-host test-files.pythonhosted.org
           --out testpypi-index-evidence.json
           --attempts 12
           --interval-seconds 5
@@ -465,6 +465,7 @@ jobs:
           --publisher-workflow release.yml
           --publisher-environment release-pypi
           --attestation-repository https://github.com/VangelisTech/archetype
+          --registry-artifact-host files.pythonhosted.org
 
   publish:
     needs: pypi-preflight
@@ -517,6 +518,7 @@ jobs:
           --publisher-workflow release.yml
           --publisher-environment release-pypi
           --attestation-repository https://github.com/VangelisTech/archetype
+          --registry-artifact-host files.pythonhosted.org
           --out pypi-index-evidence.json
           --attempts 12
           --interval-seconds 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,9 +186,10 @@ Apple lanes download that same matrix; Python 3.13 compatibility runs alongside 
 The evidence gate requires every release receipt to name all four wheel digests.
 
 Publication then proceeds as one fail-closed chain: an unprivileged job rejects any
-conflicting TestPyPI files, a dedicated OIDC job uploads the original `dist/` artifact,
-and isolated environments install the base, each selective library, and the full stack
-from TestPyPI. The same preflight, upload, exact-byte index verification, and five-shape
+conflicting TestPyPI files, then the coordinator and package-specific OIDC workflows
+upload exact distribution slices from the original `dist/` artifact. Isolated
+environments install the base, each selective library, and the full stack from
+TestPyPI. The same preflight, upload, exact-byte index verification, and five-shape
 install matrix run against PyPI. The GitHub Release is created only after PyPI serves
 all eight attested files and the registry-installed matrix passes. Exact matching
 partial uploads are resumable; an existing filename with different bytes fails before
@@ -202,9 +203,20 @@ three new project names on both PyPI and TestPyPI. This preconfigures their OIDC
 identities; it does not reserve or claim the names. Each new name remains claimable
 until the first successful OIDC publication creates the project on that registry.
 All four projects on each registry must trust repository `VangelisTech/archetype`,
-workflow `release.yml`, and the exact environment for that registry: `release-pypi`
-or `release-testpypi`. Protect both GitHub environments to allow only `v*` tags,
-require the release operator's review, and disable administrator bypass.
+the exact workflow below, and the environment for that registry: `release-pypi` or
+`release-testpypi`.
+
+| Project | Trusted Publisher workflow |
+|---|---|
+| `archetype-ecs` | `release.yml` |
+| `archetype-missions` | `publish-archetype-missions.yml` |
+| `archetype-physical-ai` | `publish-archetype-physical-ai.yml` |
+| `archetype-research` | `publish-archetype-research.yml` |
+
+The coordinator publishes ECS directly and dispatches each other distribution's
+direct workflow with an exact-run allowlist. Protect both GitHub environments to
+allow only `v*` tags, require the release operator's review, and disable administrator
+bypass.
 
 The hosted OIDC chain is the sole publishing authority. The read-only
 `make verify-test-index` and `make verify-published` targets are available for operator

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,17 +122,20 @@ the same two targets as the required GitHub Actions jobs.
 | `make version` | reads `packages/archetype-ecs/pyproject.toml` | Print current release-line version |
 | `make lock-check` | `uv lock --check` | Verify lockfile is in sync |
 | `make build` | `uv build --all-packages --no-sources` | Build all four sdists and wheels into `dist/` |
-| `make release-artifact` | build + package smoke + immutable manifest | Record the exact four-wheel/four-sdist matrix |
+| `make release-artifact` | build + wheel/sdist smoke + immutable manifest | Record the exact four-wheel/four-sdist matrix |
 | `make verify-release-artifact` | verify `dist/` against `release-artifact.json` | Reject changed, missing, or extra release artifacts |
 | `make verify-release` | full source profile + installed release-artifact evidence | Run the release verification profile |
 | `make release-check` | sync development dependencies + `verify-release` | Prepare and verify a manual release candidate |
-| `make publish-test` | verify manifest + upload its eight named files | Publish the existing recorded bytes to TestPyPI |
-| `make publish` | verify manifest + upload its eight named files | Publish the existing recorded bytes to PyPI |
+| `make verify-test-index` | exact-byte query + five isolated TestPyPI installs | Verify a TestPyPI rehearsal |
+| `make verify-published` | exact-byte query + five isolated PyPI installs | Verify the published release |
 
-The publish targets deliberately have no build dependency. They refuse a dirty-build
-manifest, a different checkout commit, an incomplete distribution matrix, or any byte
-whose size or digest differs from `release-artifact.json`. Run `make release-check`
-first; never rebuild between attestation and publication.
+Publication is intentionally available only through the hosted release workflow. Its
+environment-scoped OIDC identities produce the provenance required by the same
+workflow's registry preflight and post-publish verification. Local token uploads are
+not a supported release path: even matching bytes would lack the required publisher
+identity and make a partial release impossible to resume. Run `make release-check`,
+then tag and dispatch the hosted workflow; never rebuild between attestation and
+publication.
 
 ### Docs
 
@@ -175,15 +178,35 @@ Release workflow with the same tag as its input. The workflow authorizes the rel
 operator, requires the tag commit to be on `main`, and verifies that the tag agrees
 with the package version.
 
-The release profile builds the four wheels and four sdists once, package-smokes them,
-records every digest, and runs installed-artifact evidence. The external-provider and
+The release profile builds four wheels and four sdists once, package-smokes the wheels,
+rebuilds every sdist and probes their combined stack, records every digest, and runs
+installed-artifact evidence.
+The external-provider and
 Apple lanes download that same matrix; Python 3.13 compatibility runs alongside them.
-The evidence gate requires every release receipt to name all four wheel digests before
-the trusted-publishing job uploads the original `dist/` artifact to PyPI. Only then is
-the GitHub Release created with those same eight files and generated release notes.
+The evidence gate requires every release receipt to name all four wheel digests.
 
-TestPyPI is an explicit manual rehearsal through `make publish-test`; it is not a stage
-in the hosted production workflow.
+Publication then proceeds as one fail-closed chain: an unprivileged job rejects any
+conflicting TestPyPI files, a dedicated OIDC job uploads the original `dist/` artifact,
+and isolated environments install the base, each selective library, and the full stack
+from TestPyPI. The same preflight, upload, exact-byte index verification, and five-shape
+install matrix run against PyPI. The GitHub Release is created only after PyPI serves
+all eight attested files and the registry-installed matrix passes. Exact matching
+partial uploads are resumable; an existing filename with different bytes fails before
+either publishing job receives an OIDC token. A matching pre-existing file is accepted
+only when the registry Integrity API binds its publish attestation to this repository,
+workflow, environment, filename, and digest, and the pinned `pypi-attestations`
+verifier validates the Sigstore proof for the served file.
+
+Before the first four-project release, reserve the three new project names on both
+PyPI and TestPyPI with pending Trusted Publishers. All four projects on each registry
+must trust repository `VangelisTech/archetype`, workflow `release.yml`, and the exact
+environment for that registry: `release-pypi` or `release-testpypi`. Protect both
+GitHub environments to allow only `v*` tags, require the release operator's review,
+and disable administrator bypass.
+
+The hosted OIDC chain is the sole publishing authority. The read-only
+`make verify-test-index` and `make verify-published` targets are available for operator
+diagnosis without creating an alternate upload path.
 
 ### `claude.yml` (Claude Code) — on issue/PR comments
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,12 +197,14 @@ only when the registry Integrity API binds its publish attestation to this repos
 workflow, environment, filename, and digest, and the pinned `pypi-attestations`
 verifier validates the Sigstore proof for the served file.
 
-Before the first four-project release, reserve the three new project names on both
-PyPI and TestPyPI with pending Trusted Publishers. All four projects on each registry
-must trust repository `VangelisTech/archetype`, workflow `release.yml`, and the exact
-environment for that registry: `release-pypi` or `release-testpypi`. Protect both
-GitHub environments to allow only `v*` tags, require the release operator's review,
-and disable administrator bypass.
+Before the first four-project release, register pending Trusted Publishers for the
+three new project names on both PyPI and TestPyPI. This preconfigures their OIDC
+identities; it does not reserve or claim the names. Each new name remains claimable
+until the first successful OIDC publication creates the project on that registry.
+All four projects on each registry must trust repository `VangelisTech/archetype`,
+workflow `release.yml`, and the exact environment for that registry: `release-pypi`
+or `release-testpypi`. Protect both GitHub environments to allow only `v*` tags,
+require the release operator's review, and disable administrator bypass.
 
 The hosted OIDC chain is the sole publishing authority. The read-only
 `make verify-test-index` and `make verify-published` targets are available for operator

--- a/Makefile
+++ b/Makefile
@@ -548,7 +548,7 @@ verify-test-index:
 		--publisher-repository VangelisTech/archetype --publisher-workflow release.yml \
 		--publisher-environment release-testpypi \
 		--attestation-repository https://github.com/VangelisTech/archetype \
-		--attestation-staging \
+		--registry-artifact-host test-files.pythonhosted.org \
 		--attempts 12 --interval-seconds 5
 	@uv run --no-project --with packaging==26.1 python scripts/registry_smoke.py \
 		--manifest "$(RELEASE_ARTIFACT_MANIFEST)" --index-url https://test.pypi.org/simple \
@@ -564,6 +564,7 @@ verify-published:
 		--publisher-repository VangelisTech/archetype --publisher-workflow release.yml \
 		--publisher-environment release-pypi \
 		--attestation-repository https://github.com/VangelisTech/archetype \
+		--registry-artifact-host files.pythonhosted.org \
 		--attempts 12 --interval-seconds 5
 	@uv run --no-project --with packaging==26.1 python scripts/registry_smoke.py \
 		--manifest "$(RELEASE_ARTIFACT_MANIFEST)"

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ help:
 	@echo "  make verify-full    Main-branch profile"
 	@echo "  make verify-release Source profile plus exact installed-artifact release evidence"
 	@echo "  make release-check  Full pre-release validation"
-	@echo "  make publish-test   Verify and publish the recorded artifacts to TestPyPI"
-	@echo "  make publish        Verify and publish the recorded artifacts to PyPI"
+	@echo "  make verify-test-index Verify exact TestPyPI bytes and install matrix"
+	@echo "  make verify-published Verify exact PyPI bytes and install matrix"
 	@echo "  make version        Show current version"
 	@echo ""
 	@echo "Docs:"
@@ -527,21 +527,38 @@ release-check: sync-dev verify-release
 	@echo "Next steps:"
 	@echo "  1. git tag v$(VERSION)"
 	@echo "  2. git push origin v$(VERSION)"
-	@echo "  3. Dispatch the Release workflow for v$(VERSION) (preferred)"
-	@echo "     or run make publish to upload these exact recorded artifacts"
+	@echo "  3. Dispatch the Release workflow for v$(VERSION)"
 
-.PHONY: publish-test
-publish-test:
-	@echo "Verifying and publishing the recorded artifacts to TestPyPI..."
-	@PYTHONPATH=$(PYTHONPATH):. uv run python scripts/release_artifact.py publish \
-		--dist "$(OPERATIONAL_DIST_DIR)" --manifest "$(RELEASE_ARTIFACT_MANIFEST)" \
-		--publish-url https://test.pypi.org/legacy/
+.PHONY: verify-test-index
+verify-test-index:
+	@uvx --from pypi-attestations==0.0.30 --with packaging==26.1 \
+		python scripts/verify_release_index.py \
+		complete --manifest "$(RELEASE_ARTIFACT_MANIFEST)" \
+		--expected-commit "$$(git rev-parse HEAD)" \
+		--api-template 'https://test.pypi.org/pypi/{distribution}/{version}/json' \
+		--integrity-template 'https://test.pypi.org/integrity/{distribution}/{version}/{filename}/provenance' \
+		--publisher-repository VangelisTech/archetype --publisher-workflow release.yml \
+		--publisher-environment release-testpypi \
+		--attestation-repository https://github.com/VangelisTech/archetype \
+		--attestation-staging \
+		--attempts 12 --interval-seconds 5
+	@uv run --no-project --with packaging==26.1 python scripts/registry_smoke.py \
+		--manifest "$(RELEASE_ARTIFACT_MANIFEST)" --index-url https://test.pypi.org/simple \
+		--extra-index-url https://pypi.org/simple
 
-.PHONY: publish
-publish:
-	@echo "Verifying and publishing the recorded artifacts to PyPI..."
-	@PYTHONPATH=$(PYTHONPATH):. uv run python scripts/release_artifact.py publish \
-		--dist "$(OPERATIONAL_DIST_DIR)" --manifest "$(RELEASE_ARTIFACT_MANIFEST)"
+.PHONY: verify-published
+verify-published:
+	@uvx --from pypi-attestations==0.0.30 --with packaging==26.1 \
+		python scripts/verify_release_index.py \
+		complete --manifest "$(RELEASE_ARTIFACT_MANIFEST)" \
+		--expected-commit "$$(git rev-parse HEAD)" \
+		--integrity-template 'https://pypi.org/integrity/{distribution}/{version}/{filename}/provenance' \
+		--publisher-repository VangelisTech/archetype --publisher-workflow release.yml \
+		--publisher-environment release-pypi \
+		--attestation-repository https://github.com/VangelisTech/archetype \
+		--attempts 12 --interval-seconds 5
+	@uv run --no-project --with packaging==26.1 python scripts/registry_smoke.py \
+		--manifest "$(RELEASE_ARTIFACT_MANIFEST)"
 
 # ------------------------------------------------------------------------------
 # Docs (Material for MkDocs)

--- a/Makefile
+++ b/Makefile
@@ -545,7 +545,7 @@ verify-test-index:
 		--expected-commit "$$(git rev-parse HEAD)" \
 		--api-template 'https://test.pypi.org/pypi/{distribution}/{version}/json' \
 		--integrity-template 'https://test.pypi.org/integrity/{distribution}/{version}/{filename}/provenance' \
-		--publisher-repository VangelisTech/archetype --publisher-workflow release.yml \
+		--publisher-repository VangelisTech/archetype \
 		--publisher-environment release-testpypi \
 		--attestation-repository https://github.com/VangelisTech/archetype \
 		--registry-artifact-host test-files.pythonhosted.org \
@@ -561,7 +561,7 @@ verify-published:
 		complete --manifest "$(RELEASE_ARTIFACT_MANIFEST)" \
 		--expected-commit "$$(git rev-parse HEAD)" \
 		--integrity-template 'https://pypi.org/integrity/{distribution}/{version}/{filename}/provenance' \
-		--publisher-repository VangelisTech/archetype --publisher-workflow release.yml \
+		--publisher-repository VangelisTech/archetype \
 		--publisher-environment release-pypi \
 		--attestation-repository https://github.com/VangelisTech/archetype \
 		--registry-artifact-host files.pythonhosted.org \

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,10 @@ operational-wheel:
 		fi; \
 		exit "$$runner_status"
 
+.PHONY: operational-wheel-existing
+operational-wheel-existing:
+	@$(MAKE) --no-print-directory operational-wheel OPERATIONAL_BUILD_COMMAND=true
+
 .PHONY: operational-mission
 operational-mission:
 	@PYTHONPATH=$(PYTHONPATH):. uv run python scripts/run_operational_scenarios.py \
@@ -509,15 +513,19 @@ operational-release-physical-modal-r2: verify-release-artifact
 verify-pr: static test package-smoke
 	@echo "PR verification profile passed"
 
+.PHONY: verify-full-source
+verify-full-source: static test-cov eval-conformance eval-capability examples-smoke operational-runtime operational-commands docs test-process eval-reliability
+	@echo "Full source verification profile passed"
+
 .PHONY: verify-full
-verify-full: static test-cov eval-conformance eval-capability package-smoke examples-smoke operational-runtime operational-commands operational-wheel docs test-process eval-reliability
+verify-full: verify-full-source package-smoke operational-wheel-existing
 	@echo "Full verification profile passed"
 
 .PHONY: verify-release
-verify-release: verify-full operational-release
+verify-release: verify-full-source operational-release
 	@echo "Release verification profile passed"
 
-.NOTPARALLEL: verify-release
+.NOTPARALLEL: verify-full verify-release
 
 .PHONY: release-check
 release-check: sync-dev verify-release

--- a/docs/guide/release-0.6.md
+++ b/docs/guide/release-0.6.md
@@ -86,7 +86,8 @@ Before the first release, register pending Trusted Publishers for the three new
 project names on both PyPI and TestPyPI. Registration preconfigures OIDC; it does
 not reserve or claim a name, and each new name remains claimable until the first
 successful OIDC publication creates the project on that registry. See
-[Repository harness](repository-harness.md) for the exact OIDC identities.
+[Repository harness](repository-harness.md) for the exact, package-specific
+OIDC identities and the direct-workflow bootstrap required for new projects.
 
 For current architecture and installation contracts, continue with
 [World libraries](world-libraries.md), [Runtime](runtime.md), and

--- a/docs/guide/release-0.6.md
+++ b/docs/guide/release-0.6.md
@@ -82,8 +82,10 @@ The 0.6 release is one coordinated set: four wheels and four source
 distributions at version `0.6.0`. Release evidence installs the base framework,
 each individual library with the framework, and the complete stack from those
 exact artifacts. A partial four-project publication is not a completed release.
-The first release requires pending Trusted Publishers for the three new project
-names on both PyPI and TestPyPI; see
+Before the first release, register pending Trusted Publishers for the three new
+project names on both PyPI and TestPyPI. Registration preconfigures OIDC; it does
+not reserve or claim a name, and each new name remains claimable until the first
+successful OIDC publication creates the project on that registry. See
 [Repository harness](repository-harness.md) for the exact OIDC identities.
 
 For current architecture and installation contracts, continue with

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -212,6 +212,14 @@ manual uploads cannot satisfy that recovery path. The gate then uses pinned
 `pypi-attestations` tooling to verify the Sigstore signature and transparency
 evidence against the served artifact.
 
+Registry selection and Sigstore trust selection are deliberately independent.
+The verifier downloads the exact URL reported by each registry, requires
+`test-files.pythonhosted.org` for TestPyPI and `files.pythonhosted.org` for
+PyPI, checks those bytes against the release manifest, and then supplies the
+already-fetched provenance to the pinned verifier. The pinned publisher action
+signs uploads to both registries with production Sigstore trust, so TestPyPI
+verification MUST NOT select the Sigstore staging roots.
+
 Release execution is operator-only. The `Release tags — everettVT only`
 repository ruleset permits only `everettVT` to create `v*` tags; the separate
 immutable-tag ruleset continues to deny tag updates and deletion for everyone.

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -199,7 +199,10 @@ publisher matrix. Configure or verify these identities for each of
 | TestPyPI | `VangelisTech/archetype` | `release.yml` | `release-testpypi` |
 | PyPI | `VangelisTech/archetype` | `release.yml` | `release-pypi` |
 
-Use pending Trusted Publishers to reserve project names that do not yet exist.
+Register pending Trusted Publishers to preconfigure the OIDC identities for
+project names that do not yet exist. This registration does not reserve or
+claim a name: each new name remains claimable until the first successful OIDC
+publication creates the project on that registry.
 Configure both GitHub environments to permit only `v*` tags, require approval
 from `everettVT`, and disable administrator bypass. The publisher action emits
 PEP 740 attestations. Index

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -200,11 +200,14 @@ publisher matrix. Configure or verify these identities for each of
 | PyPI | `VangelisTech/archetype` | `release.yml` | `release-pypi` |
 
 Use pending Trusted Publishers to reserve project names that do not yet exist.
-Both GitHub environments permit only `v*` tags and require approval from
-`everettVT`. The publisher action emits PEP 740 attestations by default. Index
+Configure both GitHub environments to permit only `v*` tags, require approval
+from `everettVT`, and disable administrator bypass. The publisher action emits
+PEP 740 attestations. Index
 preflight permits an exact partial retry only when every existing file has the
 expected publisher identity and digest-bound publish attestation; token or
-manual uploads cannot satisfy that recovery path.
+manual uploads cannot satisfy that recovery path. The gate then uses pinned
+`pypi-attestations` tooling to verify the Sigstore signature and transparency
+evidence against the served artifact.
 
 Release execution is operator-only. The `Release tags — everettVT only`
 repository ruleset permits only `everettVT` to create `v*` tags; the separate

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -190,19 +190,28 @@ result may be `not_run`. The publish job uploads the recorded eight files
 without rebuilding them.
 
 Before the first coordinated release, both registries need the complete OIDC
-publisher matrix. Configure or verify these identities for each of
-`archetype-ecs`, `archetype-missions`, `archetype-physical-ai`, and
-`archetype-research`:
+publisher matrix below. Every row uses repository `VangelisTech/archetype`.
 
-| Registry | Repository | Workflow | GitHub environment |
+| Project | Workflow | TestPyPI environment | PyPI environment |
 |---|---|---|---|
-| TestPyPI | `VangelisTech/archetype` | `release.yml` | `release-testpypi` |
-| PyPI | `VangelisTech/archetype` | `release.yml` | `release-pypi` |
+| `archetype-ecs` | `release.yml` | `release-testpypi` | `release-pypi` |
+| `archetype-missions` | `publish-archetype-missions.yml` | `release-testpypi` | `release-pypi` |
+| `archetype-physical-ai` | `publish-archetype-physical-ai.yml` | `release-testpypi` | `release-pypi` |
+| `archetype-research` | `publish-archetype-research.yml` | `release-testpypi` | `release-pypi` |
 
 Register pending Trusted Publishers to preconfigure the OIDC identities for
 project names that do not yet exist. This registration does not reserve or
 claim a name: each new name remains claimable until the first successful OIDC
 publication creates the project on that registry.
+Pending GitHub publishers are unique by repository, workflow, and environment,
+so multiple not-yet-created projects cannot all use `release.yml` with the same
+environment. PyPI also does not support reusable workflows as Trusted
+Publisher identities. The release therefore keeps the established ECS identity
+in `release.yml` and dispatches one direct, package-specific workflow for each
+new project. The parent records the exact returned child run IDs in an immutable
+allowlist; every child verifies that allowlist and the still-running authorized
+parent before it can reach a protected environment. Each child publisher job is
+checkout-free and receives only the two files for its distribution.
 Configure both GitHub environments to permit only `v*` tags, require approval
 from `everettVT`, and disable administrator bypass. The publisher action emits
 PEP 740 attestations. Index
@@ -278,9 +287,12 @@ gh workflow run release.yml \
   -f tag=v0.6.0
 ```
 
-Approve `release-apple-macos`, then `release-testpypi`, and finally
-`release-pypi` after the TestPyPI installed-distribution matrix succeeds. The
-ephemeral runner deregisters after the Apple job;
+Approve `release-apple-macos`, then every pending `release-testpypi` deployment,
+and finally every pending `release-pypi` deployment after the TestPyPI
+installed-distribution matrix succeeds. The ECS publisher remains in the parent
+run; each new distribution is a separately approved direct workflow run. The
+parent waits for the exact child run IDs and fails unless all of them succeed.
+The ephemeral runner deregisters after the Apple job;
 discard its working directory before preparing a rerun or future release.
 
 Release-lane authentication is explicit and provider-scoped:

--- a/scripts/dispatch_release_publishers.py
+++ b/scripts/dispatch_release_publishers.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dispatch and await the exact per-distribution release publisher runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import time
+from collections.abc import Callable, Mapping, Sequence
+from http.client import HTTPException
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+if __package__:
+    from .release_artifact import DISTRIBUTIONS, PUBLISHER_WORKFLOWS
+else:  # pragma: no cover - exercised by the command-line entry point
+    from release_artifact import DISTRIBUTIONS, PUBLISHER_WORKFLOWS
+
+API_VERSION = "2026-03-10"
+API_ROOT = "https://api.github.com"
+REPOSITORY = "VangelisTech/archetype"
+SCHEMA = "archetype.publisher-dispatch/v1"
+RELEASE_WORKFLOW = "release.yml"
+
+DEFAULT_TIMEOUT_SECONDS = 30 * 60.0
+DEFAULT_INTERVAL_SECONDS = 10.0
+DEFAULT_HTTP_TIMEOUT_SECONDS = 30.0
+MAX_TIMEOUT_SECONDS = 60 * 60.0
+MAX_INTERVAL_SECONDS = 60.0
+MAX_HTTP_TIMEOUT_SECONDS = 60.0
+_MAX_RESPONSE_BYTES = 1024 * 1024
+_TAG = re.compile(r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\Z")
+_COMMIT = re.compile(r"[0-9a-f]{40}\Z")
+_WORKFLOW = re.compile(r"[a-z0-9][a-z0-9-]*\.yml\Z")
+_REGISTRIES = frozenset(("testpypi", "pypi"))
+_IN_PROGRESS_STATUSES = frozenset(("queued", "in_progress", "requested", "waiting", "pending"))
+
+OpenRequest = Callable[..., Any]
+Sleep = Callable[[float], None]
+Monotonic = Callable[[], float]
+
+
+class PublisherDispatchError(RuntimeError):
+    """The publisher run set could not be dispatched or verified safely."""
+
+
+class GitHubAPIError(PublisherDispatchError):
+    """GitHub returned an invalid response or could not be reached."""
+
+
+class _RejectRedirects(HTTPRedirectHandler):
+    """Do not forward the bearer token through an HTTP redirect."""
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> Request | None:
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+_OPEN = build_opener(_RejectRedirects()).open
+
+
+def _positive_integer(value: object, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _duration(value: object, label: str, maximum: float) -> float:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+        or value <= 0
+        or value > maximum
+    ):
+        raise ValueError(f"{label} must be greater than zero and at most {maximum:g} seconds")
+    return float(value)
+
+
+def _token(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 4096
+        or any(ord(character) < 0x21 or ord(character) > 0x7E for character in value)
+    ):
+        raise ValueError("GitHub token must be non-empty printable ASCII without whitespace")
+    return value
+
+
+def _context(
+    *,
+    parent_run_id: object,
+    parent_run_attempt: object,
+    tag: object,
+    expected_commit: object,
+    registry: object,
+) -> tuple[int, int, str, str, str]:
+    run_id = _positive_integer(parent_run_id, "parent run ID")
+    run_attempt = _positive_integer(parent_run_attempt, "parent run attempt")
+    if not isinstance(tag, str) or _TAG.fullmatch(tag) is None:
+        raise ValueError("release tag must be canonical vMAJOR.MINOR.PATCH")
+    if not isinstance(expected_commit, str) or _COMMIT.fullmatch(expected_commit) is None:
+        raise ValueError("expected commit must be one lowercase 40-hex SHA")
+    if not isinstance(registry, str) or registry not in _REGISTRIES:
+        raise ValueError("registry must be testpypi or pypi")
+    return run_id, run_attempt, tag, expected_commit, registry
+
+
+def _publishers() -> tuple[tuple[str, str], ...]:
+    if tuple(PUBLISHER_WORKFLOWS) != DISTRIBUTIONS:
+        raise PublisherDispatchError("publisher workflow mapping must match distribution order")
+    publishers = tuple(
+        (distribution, PUBLISHER_WORKFLOWS[distribution])
+        for distribution in DISTRIBUTIONS
+        if PUBLISHER_WORKFLOWS[distribution] != RELEASE_WORKFLOW
+    )
+    workflows = [workflow for _, workflow in publishers]
+    if not publishers or len(set(workflows)) != len(workflows):
+        raise PublisherDispatchError("publisher workflows must be non-empty and unique")
+    if any(
+        not isinstance(workflow, str) or _WORKFLOW.fullmatch(workflow) is None
+        for workflow in workflows
+    ):
+        raise PublisherDispatchError("publisher workflow names must be safe .yml filenames")
+    return publishers
+
+
+def _response_detail(body: bytes) -> str:
+    try:
+        value = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        value = None
+    if isinstance(value, dict) and isinstance(value.get("message"), str):
+        return value["message"][:500]
+    return body.decode("utf-8", errors="replace").strip()[:500] or "empty response"
+
+
+def _read_response(response: Any) -> bytes:
+    body = response.read(_MAX_RESPONSE_BYTES + 1)
+    if not isinstance(body, bytes):
+        raise GitHubAPIError("GitHub API response body must be bytes")
+    if len(body) > _MAX_RESPONSE_BYTES:
+        raise GitHubAPIError("GitHub API response exceeded the one-megabyte limit")
+    return body
+
+
+def _request_json(
+    method: str,
+    endpoint: str,
+    *,
+    token: str,
+    payload: Mapping[str, Any] | None = None,
+    open_request: OpenRequest = _OPEN,
+    timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Call one fixed-repository GitHub endpoint and require a JSON object."""
+
+    token = _token(token)
+    timeout_seconds = _duration(
+        timeout_seconds,
+        "HTTP timeout",
+        MAX_HTTP_TIMEOUT_SECONDS,
+    )
+    if method not in {"GET", "POST"} or not endpoint.startswith(f"/repos/{REPOSITORY}/actions/"):
+        raise ValueError("GitHub API endpoint is outside the release Actions boundary")
+    url = f"{API_ROOT}{endpoint}"
+    data = None
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "User-Agent": "archetype-release-publisher-dispatch",
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+    if payload is not None:
+        data = json.dumps(dict(payload), sort_keys=True, separators=(",", ":")).encode()
+        headers["Content-Type"] = "application/json"
+    request = Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with open_request(request, timeout=timeout_seconds) as response:
+            final_url = response.geturl()
+            if final_url != url:
+                raise GitHubAPIError(f"GitHub API redirected {endpoint} outside its exact URL")
+            status = getattr(response, "status", None)
+            if status is None:
+                status = response.getcode()
+            body = _read_response(response)
+    except HTTPError as error:
+        try:
+            detail = _response_detail(error.read(_MAX_RESPONSE_BYTES + 1))
+        except (HTTPException, OSError):
+            detail = str(error.reason)
+        raise GitHubAPIError(
+            f"GitHub API {method} {endpoint} failed with HTTP {error.code}: {detail}"
+        ) from error
+    except GitHubAPIError:
+        raise
+    except (HTTPException, OSError, TimeoutError, URLError) as error:
+        reason = getattr(error, "reason", error)
+        raise GitHubAPIError(f"GitHub API {method} {endpoint} failed: {reason}") from error
+
+    if status != 200:
+        raise GitHubAPIError(
+            f"GitHub API {method} {endpoint} returned HTTP {status}: {_response_detail(body)}"
+        )
+    try:
+        value = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise GitHubAPIError(f"GitHub API {method} {endpoint} returned invalid JSON") from error
+    if not isinstance(value, dict):
+        raise GitHubAPIError(f"GitHub API {method} {endpoint} must return a JSON object")
+    return value
+
+
+def _run_api_url(run_id: int) -> str:
+    return f"{API_ROOT}/repos/{REPOSITORY}/actions/runs/{run_id}"
+
+
+def _run_html_url(run_id: int) -> str:
+    return f"https://github.com/{REPOSITORY}/actions/runs/{run_id}"
+
+
+def _dispatch_response(
+    value: Mapping[str, Any],
+    *,
+    distribution: str,
+    workflow: str,
+) -> dict[str, Any]:
+    run_id = value.get("workflow_run_id")
+    if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id < 1:
+        raise PublisherDispatchError(
+            f"GitHub did not return an exact run ID for {distribution} via {workflow}"
+        )
+    expected_api_url = _run_api_url(run_id)
+    expected_html_url = _run_html_url(run_id)
+    if value.get("run_url") != expected_api_url or value.get("html_url") != expected_html_url:
+        raise PublisherDispatchError(
+            f"GitHub returned unexpected run URLs for {distribution} via {workflow}"
+        )
+    return {
+        "distribution": distribution,
+        "workflow": workflow,
+        "run_id": run_id,
+        "url": expected_html_url,
+    }
+
+
+def dispatch_publishers(
+    *,
+    parent_run_id: int,
+    parent_run_attempt: int,
+    tag: str,
+    expected_commit: str,
+    registry: str,
+    token: str,
+    open_request: OpenRequest = _OPEN,
+    http_timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Dispatch each child publisher and return its exact-run allowlist."""
+
+    parent_run_id, parent_run_attempt, tag, expected_commit, registry = _context(
+        parent_run_id=parent_run_id,
+        parent_run_attempt=parent_run_attempt,
+        tag=tag,
+        expected_commit=expected_commit,
+        registry=registry,
+    )
+    token = _token(token)
+    http_timeout_seconds = _duration(
+        http_timeout_seconds,
+        "HTTP timeout",
+        MAX_HTTP_TIMEOUT_SECONDS,
+    )
+    inputs = {
+        "parent_run_id": str(parent_run_id),
+        "parent_run_attempt": str(parent_run_attempt),
+        "tag": tag,
+        "expected_commit": expected_commit,
+        "registry": registry,
+    }
+    runs: list[dict[str, Any]] = []
+    observed_run_ids: set[int] = set()
+    for distribution, workflow in _publishers():
+        endpoint = f"/repos/{REPOSITORY}/actions/workflows/{quote(workflow, safe='')}/dispatches"
+        response = _request_json(
+            "POST",
+            endpoint,
+            token=token,
+            payload={"ref": tag, "inputs": inputs},
+            open_request=open_request,
+            timeout_seconds=http_timeout_seconds,
+        )
+        run = _dispatch_response(
+            response,
+            distribution=distribution,
+            workflow=workflow,
+        )
+        if run["run_id"] in observed_run_ids:
+            raise PublisherDispatchError("GitHub returned a duplicate publisher run ID")
+        observed_run_ids.add(run["run_id"])
+        runs.append(run)
+
+    return {
+        "schema": SCHEMA,
+        "repository": REPOSITORY,
+        "parent_run_id": parent_run_id,
+        "parent_run_attempt": parent_run_attempt,
+        "tag": tag,
+        "commit": expected_commit,
+        "registry": registry,
+        "runs": runs,
+    }
+
+
+def validate_allowlist(
+    value: object,
+    *,
+    parent_run_id: int,
+    parent_run_attempt: int,
+    tag: str,
+    expected_commit: str,
+    registry: str,
+) -> dict[str, Any]:
+    """Validate an immutable dispatch receipt against the parent run context."""
+
+    parent_run_id, parent_run_attempt, tag, expected_commit, registry = _context(
+        parent_run_id=parent_run_id,
+        parent_run_attempt=parent_run_attempt,
+        tag=tag,
+        expected_commit=expected_commit,
+        registry=registry,
+    )
+    if not isinstance(value, dict):
+        raise PublisherDispatchError("publisher dispatch allowlist must be a JSON object")
+    expected_keys = {
+        "schema",
+        "repository",
+        "parent_run_id",
+        "parent_run_attempt",
+        "tag",
+        "commit",
+        "registry",
+        "runs",
+    }
+    if set(value) != expected_keys:
+        raise PublisherDispatchError("publisher dispatch allowlist has unexpected fields")
+    expected_context = {
+        "schema": SCHEMA,
+        "repository": REPOSITORY,
+        "parent_run_id": parent_run_id,
+        "parent_run_attempt": parent_run_attempt,
+        "tag": tag,
+        "commit": expected_commit,
+        "registry": registry,
+    }
+    for field, expected in expected_context.items():
+        if value.get(field) != expected:
+            raise PublisherDispatchError(
+                f"publisher dispatch allowlist has unexpected {field.replace('_', ' ')}"
+            )
+
+    raw_runs = value.get("runs")
+    publishers = _publishers()
+    if not isinstance(raw_runs, list) or len(raw_runs) != len(publishers):
+        raise PublisherDispatchError("publisher dispatch allowlist has the wrong run count")
+    runs: list[dict[str, Any]] = []
+    observed_run_ids: set[int] = set()
+    run_keys = {"distribution", "workflow", "run_id", "url"}
+    for raw, (distribution, workflow) in zip(raw_runs, publishers, strict=True):
+        if not isinstance(raw, dict) or set(raw) != run_keys:
+            raise PublisherDispatchError("publisher dispatch run has unexpected fields")
+        if raw.get("distribution") != distribution or raw.get("workflow") != workflow:
+            raise PublisherDispatchError("publisher dispatch runs are not in distribution order")
+        run_id = raw.get("run_id")
+        if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id < 1:
+            raise PublisherDispatchError(f"publisher dispatch run for {distribution} has no ID")
+        if run_id in observed_run_ids:
+            raise PublisherDispatchError("publisher dispatch allowlist contains a duplicate run ID")
+        if raw.get("url") != _run_html_url(run_id):
+            raise PublisherDispatchError(
+                f"publisher dispatch run for {distribution} has a wrong URL"
+            )
+        observed_run_ids.add(run_id)
+        runs.append(
+            {
+                "distribution": distribution,
+                "workflow": workflow,
+                "run_id": run_id,
+                "url": _run_html_url(run_id),
+            }
+        )
+
+    return {**expected_context, "runs": runs}
+
+
+def _validate_workflow_run(
+    value: Mapping[str, Any],
+    *,
+    distribution: str,
+    workflow: str,
+    run_id: int,
+    tag: str,
+    expected_commit: str,
+) -> bool:
+    workflow_path = f".github/workflows/{workflow}"
+    allowed_paths = {
+        workflow_path,
+        f"{workflow_path}@{tag}",
+        f"{workflow_path}@refs/tags/{tag}",
+    }
+    expected = {
+        "id": run_id,
+        "event": "workflow_dispatch",
+        "head_sha": expected_commit,
+        "head_branch": tag,
+        "url": _run_api_url(run_id),
+        "html_url": _run_html_url(run_id),
+    }
+    for field, expected_value in expected.items():
+        if value.get(field) != expected_value:
+            raise PublisherDispatchError(
+                f"publisher run {run_id} for {distribution} has unexpected {field}"
+            )
+    if value.get("path") not in allowed_paths:
+        raise PublisherDispatchError(
+            f"publisher run {run_id} for {distribution} has unexpected path"
+        )
+    repository = value.get("repository")
+    if not isinstance(repository, dict) or repository.get("full_name") != REPOSITORY:
+        raise PublisherDispatchError(
+            f"publisher run {run_id} for {distribution} has unexpected repository"
+        )
+
+    status = value.get("status")
+    conclusion = value.get("conclusion")
+    if status == "completed":
+        if conclusion != "success":
+            raise PublisherDispatchError(
+                f"publisher run {run_id} for {distribution} completed with {conclusion!r}"
+            )
+        return True
+    if status not in _IN_PROGRESS_STATUSES or conclusion is not None:
+        raise PublisherDispatchError(
+            f"publisher run {run_id} for {distribution} has invalid state "
+            f"status={status!r}, conclusion={conclusion!r}"
+        )
+    return False
+
+
+def await_publishers(
+    allowlist: object,
+    *,
+    parent_run_id: int,
+    parent_run_attempt: int,
+    tag: str,
+    expected_commit: str,
+    registry: str,
+    token: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+    http_timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+    open_request: OpenRequest = _OPEN,
+    sleep: Sleep = time.sleep,
+    monotonic: Monotonic = time.monotonic,
+) -> dict[str, Any]:
+    """Poll only allowlisted child run IDs and require every run to succeed."""
+
+    receipt = validate_allowlist(
+        allowlist,
+        parent_run_id=parent_run_id,
+        parent_run_attempt=parent_run_attempt,
+        tag=tag,
+        expected_commit=expected_commit,
+        registry=registry,
+    )
+    token = _token(token)
+    timeout_seconds = _duration(timeout_seconds, "poll timeout", MAX_TIMEOUT_SECONDS)
+    interval_seconds = _duration(interval_seconds, "poll interval", MAX_INTERVAL_SECONDS)
+    http_timeout_seconds = _duration(
+        http_timeout_seconds,
+        "HTTP timeout",
+        MAX_HTTP_TIMEOUT_SECONDS,
+    )
+    pending = {int(run["run_id"]): run for run in receipt["runs"]}
+    deadline = monotonic() + timeout_seconds
+
+    while pending:
+        for run_id, run in tuple(pending.items()):
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                names = ", ".join(str(value["distribution"]) for value in pending.values())
+                raise PublisherDispatchError(
+                    f"publisher runs did not complete within {timeout_seconds:g} seconds: {names}"
+                )
+            value = _request_json(
+                "GET",
+                f"/repos/{REPOSITORY}/actions/runs/{run_id}",
+                token=token,
+                open_request=open_request,
+                timeout_seconds=min(http_timeout_seconds, remaining),
+            )
+            if _validate_workflow_run(
+                value,
+                distribution=str(run["distribution"]),
+                workflow=str(run["workflow"]),
+                run_id=run_id,
+                tag=tag,
+                expected_commit=expected_commit,
+            ):
+                del pending[run_id]
+
+        if pending:
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                names = ", ".join(str(value["distribution"]) for value in pending.values())
+                raise PublisherDispatchError(
+                    f"publisher runs did not complete within {timeout_seconds:g} seconds: {names}"
+                )
+            sleep(min(interval_seconds, remaining))
+
+    return receipt
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise PublisherDispatchError(
+            f"could not read publisher allowlist {path}: {error}"
+        ) from error
+    except json.JSONDecodeError as error:
+        raise PublisherDispatchError(f"publisher allowlist {path} is not valid JSON") from error
+    if not isinstance(value, dict):
+        raise PublisherDispatchError("publisher dispatch allowlist must be a JSON object")
+    return value
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(dict(value), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _positive_decimal(value: str) -> int:
+    if re.fullmatch(r"[1-9][0-9]*", value) is None:
+        raise argparse.ArgumentTypeError("must be a positive decimal integer")
+    return int(value)
+
+
+def _add_context_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--parent-run-id", type=_positive_decimal, required=True)
+    parser.add_argument("--parent-run-attempt", type=_positive_decimal, required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--registry", choices=sorted(_REGISTRIES), required=True)
+    parser.add_argument("--token-env", default="GITHUB_TOKEN")
+    parser.add_argument(
+        "--http-timeout-seconds",
+        type=float,
+        default=DEFAULT_HTTP_TIMEOUT_SECONDS,
+    )
+    parser.add_argument("--out", type=Path, required=True)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    dispatch_parser = subparsers.add_parser("dispatch", help="dispatch and record exact run IDs")
+    _add_context_arguments(dispatch_parser)
+    await_parser = subparsers.add_parser("await", help="await only the recorded run IDs")
+    _add_context_arguments(await_parser)
+    await_parser.add_argument("--allowlist", type=Path, required=True)
+    await_parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    await_parser.add_argument("--interval-seconds", type=float, default=DEFAULT_INTERVAL_SECONDS)
+    args = parser.parse_args(argv)
+
+    token = os.environ.get(args.token_env)
+    if token is None:
+        parser.error(f"GitHub token environment variable {args.token_env!r} is not set")
+    if args.command == "dispatch":
+        receipt = dispatch_publishers(
+            parent_run_id=args.parent_run_id,
+            parent_run_attempt=args.parent_run_attempt,
+            tag=args.tag,
+            expected_commit=args.expected_commit,
+            registry=args.registry,
+            token=token,
+            http_timeout_seconds=args.http_timeout_seconds,
+        )
+    else:
+        receipt = await_publishers(
+            _load_json(args.allowlist),
+            parent_run_id=args.parent_run_id,
+            parent_run_attempt=args.parent_run_attempt,
+            tag=args.tag,
+            expected_commit=args.expected_commit,
+            registry=args.registry,
+            token=token,
+            http_timeout_seconds=args.http_timeout_seconds,
+            timeout_seconds=args.timeout_seconds,
+            interval_seconds=args.interval_seconds,
+        )
+    _write_json(args.out, receipt)
+    print(
+        f"Publisher {args.command} passed for {len(receipt['runs'])} child runs "
+        f"on {receipt['registry']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_smoke.py
+++ b/scripts/package_smoke.py
@@ -216,6 +216,7 @@ def _rebuild_sdists(
 def _run_matrix(
     *,
     matrix: str,
+    version: str,
     dist_dir: Path,
     wheels: dict[str, Path],
     uv: str,
@@ -286,15 +287,16 @@ from archetype.wiring import RuntimeBootstrapConfig, build_runtime_resources
 
 expected = {expected_libraries!r}
 imports = {_LIBRARY_IMPORTS!r}
-assert archetype.__version__ == "0.6.0"
-assert version("archetype-ecs") == "0.6.0"
+release_version = {version!r}
+assert archetype.__version__ == release_version
+assert version("archetype-ecs") == release_version
 package_root = Path(archetype.__file__).resolve()
 assert "site-packages" in package_root.parts, package_root
 assert not any("/packages/" in value and "/src" in value for value in sys.path), sys.path
 for name, module in imports.items():
     assert (importlib.util.find_spec(module) is not None) is (name in expected), (name, expected)
     if name in expected:
-        assert version("archetype-" + name) == "0.6.0"
+        assert version("archetype-" + name) == release_version
 assert importlib.util.find_spec("archetype.episodes") is None
 resources = build_runtime_resources(RuntimeBootstrapConfig.from_env())
 try:
@@ -337,6 +339,7 @@ def smoke(dist_dir: Path) -> list[dict[str, Any]]:
     }
     if len(set(versions.values())) != 1:
         raise RuntimeError(f"distribution wheel versions do not converge: {versions}")
+    version = next(iter(versions.values()))
     uv = shutil.which("uv")
     if uv is None:
         raise RuntimeError("package smoke requires uv")
@@ -345,6 +348,7 @@ def smoke(dist_dir: Path) -> list[dict[str, Any]]:
         results = [
             _run_matrix(
                 matrix=matrix,
+                version=version,
                 dist_dir=dist_dir,
                 wheels=wheels,
                 uv=uv,
@@ -363,6 +367,7 @@ def smoke(dist_dir: Path) -> list[dict[str, Any]]:
         sdist_probe_root.mkdir()
         rebuilt_result = _run_matrix(
             matrix="all",
+            version=version,
             dist_dir=next(iter(rebuilt_wheels.values())).parent,
             wheels=rebuilt_wheels,
             uv=uv,

--- a/scripts/registry_smoke.py
+++ b/scripts/registry_smoke.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install and probe one complete Archetype release from a package index."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from packaging.version import InvalidVersion, Version
+
+if __package__:
+    from .package_smoke import _DISTRIBUTIONS, _LIBRARY_IMPORTS, _OPERATION_COUNTS
+    from .release_artifact import SCHEMA, artifact_records, manifest_sha256
+else:  # pragma: no cover - exercised by the command-line entry point
+    from package_smoke import _DISTRIBUTIONS, _LIBRARY_IMPORTS, _OPERATION_COUNTS
+    from release_artifact import SCHEMA, artifact_records, manifest_sha256
+
+Run = Callable[..., subprocess.CompletedProcess[str]]
+_COMMIT = re.compile(r"[0-9a-f]{40}\Z")
+
+
+def _release_version(value: str) -> str:
+    """Return one canonical public version or reject ambiguous requirements."""
+
+    try:
+        parsed = Version(value)
+    except InvalidVersion as error:
+        raise argparse.ArgumentTypeError(f"invalid release version {value!r}") from error
+    if (
+        str(parsed) != value
+        or len(parsed.release) != 3
+        or parsed.is_prerelease
+        or parsed.is_postrelease
+        or parsed.is_devrelease
+        or parsed.local is not None
+    ):
+        raise argparse.ArgumentTypeError(
+            "release version must be canonical and cannot be a development or local version"
+        )
+    return value
+
+
+def _manifest_identity(path: Path) -> dict[str, str]:
+    """Return the exact version, commit, and digest of one clean manifest."""
+
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError("release artifact manifest must be an object")
+    if value.get("schema") != SCHEMA or value.get("clean_checkout") is not True:
+        raise ValueError("registry smoke requires a current clean-checkout release manifest")
+    artifact_records(value)
+    version = value.get("version")
+    if not isinstance(version, str):  # pragma: no cover - artifact_records owns this check
+        raise ValueError("release artifact manifest has no version")
+    try:
+        release_version = _release_version(version)
+    except argparse.ArgumentTypeError as error:
+        raise ValueError(str(error)) from error
+    commit = value.get("commit")
+    if not isinstance(commit, str) or _COMMIT.fullmatch(commit) is None:
+        raise ValueError("registry smoke requires a full manifest commit")
+    return {
+        "version": release_version,
+        "commit": commit,
+        "sha256": manifest_sha256(value),
+    }
+
+
+def _manifest_version(path: Path) -> str:
+    """Return the exact public version bound to one clean release manifest."""
+
+    return _manifest_identity(path)["version"]
+
+
+def _index_url(value: str) -> str:
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise argparse.ArgumentTypeError("package index must be an HTTPS base URL")
+    return value.rstrip("/")
+
+
+def _requirements(matrix: str, version: str) -> tuple[str, ...]:
+    exact = {distribution: f"{distribution}=={version}" for distribution in _DISTRIBUTIONS}
+    selected = {
+        "base": (exact["archetype-ecs"],),
+        "missions": (exact["archetype-ecs"], exact["archetype-missions"]),
+        "physical-ai": (exact["archetype-ecs"], exact["archetype-physical-ai"]),
+        "research": (exact["archetype-ecs"], exact["archetype-research"]),
+        "all": tuple(exact[distribution] for distribution in _DISTRIBUTIONS),
+    }
+    try:
+        return selected[matrix]
+    except KeyError as error:  # pragma: no cover - internal caller invariant
+        raise ValueError(f"unknown registry smoke matrix {matrix!r}") from error
+
+
+def _install_commands(
+    *,
+    uv: str,
+    python: Path,
+    requirements: Sequence[str],
+    index_url: str,
+    extra_index_url: str | None,
+) -> tuple[list[str], ...]:
+    command = [
+        uv,
+        "--no-config",
+        "pip",
+        "install",
+        "--python",
+        str(python),
+        "--no-cache",
+        "--only-binary=:all:",
+        "--index-url",
+        index_url,
+    ]
+    if extra_index_url is None:
+        command.extend(requirements)
+        return (command,)
+
+    # Test indexes generally do not mirror third-party dependencies. Install
+    # the exact Archetype artifacts from the target index without dependencies,
+    # then ask the dependency index to satisfy the already-installed packages.
+    # This avoids an extra-index strategy that could silently source an
+    # Archetype wheel from the wrong registry.
+    target = [*command, "--no-deps", *requirements]
+    dependencies = [
+        uv,
+        "--no-config",
+        "pip",
+        "install",
+        "--python",
+        str(python),
+        "--no-cache",
+        "--only-binary=:all:",
+        "--index-url",
+        extra_index_url,
+        *requirements,
+    ]
+    return target, dependencies
+
+
+def _clean_environment() -> dict[str, str]:
+    """Discard ambient Python and resolver configuration for registry evidence."""
+
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if name not in {"PYTHONHOME", "PYTHONPATH"}
+        and not name.startswith("PIP_")
+        and not name.startswith("UV_")
+    }
+
+
+def _run_checked(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    label: str,
+    run: Run,
+) -> None:
+    process = run(
+        list(command),
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if process.returncode:
+        raise RuntimeError(
+            f"registry {label} failed with exit code {process.returncode}\n"
+            f"stdout:\n{process.stdout}\nstderr:\n{process.stderr}"
+        )
+
+
+def _probe_source(matrix: str, version: str) -> str:
+    expected_libraries = {
+        "base": [],
+        "missions": ["missions"],
+        "physical-ai": ["physical-ai"],
+        "research": ["research"],
+        "all": ["missions", "physical-ai", "research"],
+    }[matrix]
+    return f"""
+import asyncio
+import importlib
+import importlib.util
+import json
+import sys
+from importlib.metadata import version
+from pathlib import Path
+
+import archetype
+from archetype.api.app import create_app
+from archetype.runtime.runtime import ArchetypeRuntime, SyncArchetypeRuntime
+from archetype.runtime.world import RuntimeWorld, SyncRuntimeWorld
+from archetype.wiring import RuntimeBootstrapConfig, build_runtime_resources
+
+expected = {expected_libraries!r}
+imports = {_LIBRARY_IMPORTS!r}
+release_version = {version!r}
+assert archetype.__version__ == release_version
+assert version("archetype-ecs") == release_version
+package_root = Path(archetype.__file__).resolve()
+assert "site-packages" in package_root.parts, package_root
+assert not any("/packages/" in value and "/src" in value for value in sys.path), sys.path
+
+for name, module in imports.items():
+    assert (importlib.util.find_spec(module) is not None) is (name in expected), (name, expected)
+    if name in expected:
+        assert version("archetype-" + name) == release_version
+assert importlib.util.find_spec("archetype.episodes") is None
+assert importlib.util.find_spec("archetype.artifacts.contracts") is None
+
+removed_root_names = (
+    "AutoResearchConfig",
+    "AutoResearchResult",
+    "CandidateContext",
+    "EvaluationResult",
+    "HostedEpisodeObservation",
+    "HostedEpisodeRequest",
+    "ModalHostedEpisodeConfig",
+    "ResearchCandidateContext",
+)
+assert not any(hasattr(archetype, name) for name in removed_root_names)
+assert "__getattr__" not in ArchetypeRuntime.__dict__
+assert "__getattr__" not in RuntimeWorld.__dict__
+assert "__getattr__" not in SyncRuntimeWorld.__dict__
+assert "library" not in SyncRuntimeWorld.__dict__
+assert "library" not in SyncArchetypeRuntime.__dict__
+if "missions" in expected:
+    assert not hasattr(importlib.import_module("archetype.missions"), "RuntimeMissions")
+if "research" in expected:
+    research = importlib.import_module("archetype.research")
+    assert not hasattr(research, "CandidateContext")
+    assert not hasattr(importlib.import_module("archetype.research.models"), "CandidateContext")
+
+resources = build_runtime_resources(RuntimeBootstrapConfig.from_env())
+try:
+    names = [manifest.name for manifest in resources.world_library_manifests]
+    assert names == expected, names
+    operation_count = len(resources.dispatcher._registry.specs)
+    assert operation_count == {_OPERATION_COUNTS[matrix]}, operation_count
+finally:
+    asyncio.run(resources.aclose())
+
+app = create_app()
+mission_paths = sorted(
+    path
+    for path in app.openapi()["paths"]
+    if "/missions" in path or "/tasks/" in path
+)
+assert len(mission_paths) == (3 if "missions" in expected else 0), mission_paths
+print(json.dumps({{
+    "matrix": {matrix!r},
+    "libraries": expected,
+    "operations": operation_count,
+    "module": str(package_root),
+    "version": release_version,
+}}))
+"""
+
+
+def _run_matrix(
+    *,
+    matrix: str,
+    version: str,
+    index_url: str,
+    extra_index_url: str | None,
+    uv: str,
+    root: Path,
+    run: Run = subprocess.run,
+) -> dict[str, Any]:
+    environment = root / f"venv-{matrix}"
+    clean_env = _clean_environment()
+    _run_checked(
+        [uv, "--no-config", "venv", "--python", sys.executable, str(environment)],
+        cwd=root,
+        env=clean_env,
+        label=f"{matrix} environment creation",
+        run=run,
+    )
+    python = environment / "bin" / "python"
+    for command in _install_commands(
+        uv=uv,
+        python=python,
+        requirements=_requirements(matrix, version),
+        index_url=index_url,
+        extra_index_url=extra_index_url,
+    ):
+        _run_checked(
+            command,
+            cwd=root,
+            env=clean_env,
+            label=f"{matrix} installation",
+            run=run,
+        )
+    _run_checked(
+        [uv, "--no-config", "pip", "check", "--python", str(python)],
+        cwd=root,
+        env=clean_env,
+        label=f"{matrix} dependency check",
+        run=run,
+    )
+    freeze = run(
+        [uv, "--no-config", "pip", "freeze", "--python", str(python)],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=clean_env,
+    )
+    if freeze.returncode:
+        raise RuntimeError(
+            f"registry {matrix} dependency inventory failed\n"
+            f"stdout:\n{freeze.stdout}\nstderr:\n{freeze.stderr}"
+        )
+    process = run(
+        [str(python), "-c", _probe_source(matrix, version)],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=clean_env,
+    )
+    if process.returncode:
+        raise RuntimeError(
+            f"registry {matrix} package probe failed\n"
+            f"stdout:\n{process.stdout}\nstderr:\n{process.stderr}"
+        )
+    result = json.loads(process.stdout.strip().splitlines()[-1])
+    result["requirements"] = list(_requirements(matrix, version))
+    result["installed_distributions"] = sorted(
+        line for line in freeze.stdout.splitlines() if line.strip()
+    )
+    return result
+
+
+def smoke_registry(
+    *,
+    version: str,
+    index_url: str,
+    extra_index_url: str | None = None,
+) -> list[dict[str, Any]]:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("registry smoke requires uv")
+    with tempfile.TemporaryDirectory(prefix="archetype-registry-smoke-") as temporary:
+        root = Path(temporary)
+        return [
+            _run_matrix(
+                matrix=matrix,
+                version=version,
+                index_url=index_url,
+                extra_index_url=extra_index_url,
+                uv=uv,
+                root=root,
+            )
+            for matrix in _OPERATION_COUNTS
+        ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--index-url", default="https://pypi.org/simple", type=_index_url)
+    parser.add_argument("--extra-index-url", type=_index_url)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+    identity = _manifest_identity(args.manifest)
+    version = identity["version"]
+    results = smoke_registry(
+        version=version,
+        index_url=args.index_url,
+        extra_index_url=args.extra_index_url,
+    )
+    receipt = {
+        "schema": "archetype.registry-install-evidence/v2",
+        "version": version,
+        "manifest_commit": identity["commit"],
+        "manifest_sha256": identity["sha256"],
+        "index_url": args.index_url,
+        "dependency_index_url": args.extra_index_url,
+        "matrices": results,
+    }
+    if args.out is not None:
+        args.out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        "Registry distribution matrix passed: "
+        + ", ".join(f"{row['matrix']}={row['operations']}" for row in results)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_artifact.py
+++ b/scripts/release_artifact.py
@@ -25,6 +25,12 @@ DISTRIBUTIONS = (
     "archetype-research",
 )
 FRAMEWORK_DISTRIBUTION = "archetype-ecs"
+PUBLISHER_WORKFLOWS = {
+    "archetype-ecs": "release.yml",
+    "archetype-missions": "publish-archetype-missions.yml",
+    "archetype-physical-ai": "publish-archetype-physical-ai.yml",
+    "archetype-research": "publish-archetype-research.yml",
+}
 _PACKAGE_PREFIXES = {
     "archetype-ecs": "archetype_ecs",
     "archetype-missions": "archetype_missions",
@@ -33,6 +39,9 @@ _PACKAGE_PREFIXES = {
 }
 _KINDS = ("wheel", "sdist")
 _SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+
+if tuple(PUBLISHER_WORKFLOWS) != DISTRIBUTIONS:  # pragma: no cover
+    raise RuntimeError("release publisher workflow matrix must match distributions exactly")
 
 
 def _sha256(path: Path) -> str:

--- a/scripts/release_artifact.py
+++ b/scripts/release_artifact.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Record, verify, and publish the immutable distribution matrix used by releases."""
+"""Record and verify the immutable distribution matrix used by releases."""
 
 from __future__ import annotations
 
@@ -11,7 +11,6 @@ import hashlib
 import json
 import re
 import subprocess
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -34,7 +33,6 @@ _PACKAGE_PREFIXES = {
 }
 _KINDS = ("wheel", "sdist")
 _SHA256 = re.compile(r"[0-9a-f]{64}\Z")
-Run = Callable[..., subprocess.CompletedProcess[str]]
 
 
 def _sha256(path: Path) -> str:
@@ -43,6 +41,13 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    """Return the canonical digest of one release artifact manifest."""
+
+    encoded = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _git(root: Path, *arguments: str) -> str:
@@ -225,31 +230,6 @@ def verify(
     return manifest
 
 
-def publish_verified(
-    manifest: dict[str, Any],
-    dist: Path,
-    *,
-    expected_commit: str,
-    publish_url: str | None = None,
-    run: Run = subprocess.run,
-) -> dict[str, Any]:
-    """Verify and upload only the eight immutable files named by the manifest."""
-
-    verified = verify(manifest, dist, expected_commit=expected_commit)
-    records = artifact_records(verified)
-    paths = [
-        (dist / str(records[(distribution, kind)]["name"])).resolve()
-        for distribution in DISTRIBUTIONS
-        for kind in _KINDS
-    ]
-    command = ["uv", "publish"]
-    if publish_url is not None:
-        command.extend(("--publish-url", publish_url))
-    command.extend(str(path) for path in paths)
-    run(command, check=True)
-    return verified
-
-
 def _load(path: Path) -> dict[str, Any]:
     value = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(value, dict):
@@ -259,11 +239,10 @@ def _load(path: Path) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", choices=("record", "verify", "publish"))
+    parser.add_argument("command", choices=("record", "verify"))
     parser.add_argument("--root", type=Path, default=Path.cwd())
     parser.add_argument("--dist", type=Path, default=Path("dist"))
     parser.add_argument("--manifest", type=Path, default=Path("release-artifact.json"))
-    parser.add_argument("--publish-url")
     args = parser.parse_args(argv)
     root = args.root.resolve()
     dist = args.dist.resolve()
@@ -274,18 +253,11 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(value, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
-    elif args.command == "verify":
+    else:
         value = verify(
             _load(manifest_path),
             dist,
             expected_commit=_git(root, "rev-parse", "HEAD"),
-        )
-    else:
-        value = publish_verified(
-            _load(manifest_path),
-            dist,
-            expected_commit=_git(root, "rev-parse", "HEAD"),
-            publish_url=args.publish_url,
         )
     framework_wheel = artifact_records(value)[(FRAMEWORK_DISTRIBUTION, "wheel")]
     print(f"Release framework wheel sha256:{framework_wheel['sha256']}")

--- a/scripts/verify_publisher_dispatch.py
+++ b/scripts/verify_publisher_dispatch.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorize one package publisher dispatched by the release workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections.abc import Mapping
+from http.client import HTTPException
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+if __package__:
+    from .release_artifact import PUBLISHER_WORKFLOWS
+else:  # pragma: no cover - exercised by the command-line entry point
+    from release_artifact import PUBLISHER_WORKFLOWS
+
+_API_VERSION = "2026-03-10"
+_AUTOMATION_ACTOR = "github-actions[bot]"
+_COMMIT = re.compile(r"[0-9a-f]{40}\Z")
+_OPERATOR = "everettVT"
+_REPOSITORY = "VangelisTech/archetype"
+_TAG = re.compile(r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\Z")
+_REGISTRY_ENVIRONMENTS = {
+    "testpypi": "release-testpypi",
+    "pypi": "release-pypi",
+}
+_PUBLISHER_WORKFLOWS = frozenset(PUBLISHER_WORKFLOWS.values()) - {"release.yml"}
+
+
+class _RejectRedirects(HTTPRedirectHandler):
+    def redirect_request(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        return None
+
+
+_OPENER = build_opener(_RejectRedirects())
+
+
+def _required_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"parent release run has no {label}")
+    return value
+
+
+def _login(value: object, label: str) -> str:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"parent release run has no {label}")
+    return _required_string(value.get("login"), f"{label} login")
+
+
+def verify_publisher_dispatch(
+    *,
+    repository: str,
+    event_name: str,
+    ref: str,
+    ref_name: str,
+    ref_type: str,
+    commit: str,
+    workflow_ref: str,
+    actor: str,
+    triggering_actor: str,
+    expected_workflow: str,
+    distribution: str,
+    child_run_id: int,
+    parent_run_id: int,
+    parent_run_attempt: int,
+    parent_run: Mapping[str, Any],
+    allowlist: Mapping[str, Any],
+    tag: str,
+    expected_commit: str,
+    registry: str,
+) -> dict[str, Any]:
+    """Bind a child publisher to one live, operator-authorized release run."""
+
+    if repository != _REPOSITORY:
+        raise PermissionError(f"publisher repository must be {_REPOSITORY}")
+    if event_name != "workflow_dispatch":
+        raise PermissionError("publisher must use workflow_dispatch")
+    if actor != _AUTOMATION_ACTOR or triggering_actor != _AUTOMATION_ACTOR:
+        raise PermissionError("publisher must be dispatched by the release workflow token")
+    if _TAG.fullmatch(tag) is None:
+        raise ValueError("publisher tag must be canonical vMAJOR.MINOR.PATCH")
+    if _COMMIT.fullmatch(expected_commit) is None:
+        raise ValueError("publisher expected commit must be a full Git commit")
+    if expected_workflow not in _PUBLISHER_WORKFLOWS:
+        raise ValueError("publisher workflow is not registered to a release distribution")
+    if PUBLISHER_WORKFLOWS.get(distribution) != expected_workflow:
+        raise ValueError("publisher distribution and workflow differ")
+    if registry not in _REGISTRY_ENVIRONMENTS:
+        raise ValueError("publisher registry must be testpypi or pypi")
+    if child_run_id < 1 or parent_run_id < 1 or parent_run_attempt < 1:
+        raise ValueError("publisher parent run coordinates must be positive")
+
+    tag_ref = f"refs/tags/{tag}"
+    exact_workflow_ref = f"{_REPOSITORY}/.github/workflows/{expected_workflow}@{tag_ref}"
+    if ref_type != "tag" or ref != tag_ref or ref_name != tag:
+        raise PermissionError("publisher workflow is not running at the exact release tag")
+    if commit != expected_commit:
+        raise PermissionError("publisher workflow commit differs from the authorized release")
+    if workflow_ref != exact_workflow_ref:
+        raise PermissionError("publisher workflow identity differs from the trusted file and tag")
+
+    if parent_run.get("id") != parent_run_id:
+        raise PermissionError("parent release run identity differs")
+    if parent_run.get("run_attempt") != parent_run_attempt:
+        raise PermissionError("parent release run attempt differs")
+    if parent_run.get("event") != "workflow_dispatch":
+        raise PermissionError("parent release run was not operator-dispatched")
+    parent_paths = {
+        ".github/workflows/release.yml",
+        f".github/workflows/release.yml@{tag}",
+        f".github/workflows/release.yml@refs/tags/{tag}",
+    }
+    if parent_run.get("path") not in parent_paths:
+        raise PermissionError("parent run is not the release workflow")
+    if parent_run.get("head_sha") != expected_commit or parent_run.get("head_branch") != tag:
+        raise PermissionError("parent release run is not bound to the exact tag commit")
+    if parent_run.get("status") != "in_progress" or parent_run.get("conclusion") is not None:
+        raise PermissionError("parent release run is not actively coordinating publication")
+    parent_repository = parent_run.get("repository")
+    if (
+        not isinstance(parent_repository, Mapping)
+        or parent_repository.get("full_name") != repository
+    ):
+        raise PermissionError("parent release run belongs to another repository")
+    if _login(parent_run.get("actor"), "actor") != _OPERATOR:
+        raise PermissionError(f"parent release actor must be {_OPERATOR}")
+    if _login(parent_run.get("triggering_actor"), "triggering actor") != _OPERATOR:
+        raise PermissionError(f"parent release triggering actor must be {_OPERATOR}")
+
+    expected_runs = {
+        distribution: workflow
+        for distribution, workflow in PUBLISHER_WORKFLOWS.items()
+        if workflow != "release.yml"
+    }
+    expected_allowlist_keys = {
+        "schema",
+        "repository",
+        "parent_run_id",
+        "parent_run_attempt",
+        "tag",
+        "commit",
+        "registry",
+        "runs",
+    }
+    if set(allowlist) != expected_allowlist_keys:
+        raise PermissionError("publisher dispatch allowlist has unexpected fields")
+    if allowlist.get("schema") != "archetype.publisher-dispatch/v1":
+        raise PermissionError("publisher dispatch allowlist has an unsupported schema")
+    for field, expected in (
+        ("repository", repository),
+        ("parent_run_id", parent_run_id),
+        ("parent_run_attempt", parent_run_attempt),
+        ("tag", tag),
+        ("commit", expected_commit),
+        ("registry", registry),
+    ):
+        if allowlist.get(field) != expected:
+            raise PermissionError(f"publisher dispatch allowlist {field} differs")
+    raw_runs = allowlist.get("runs")
+    if not isinstance(raw_runs, list) or len(raw_runs) != len(expected_runs):
+        raise PermissionError("publisher dispatch allowlist has an incomplete run matrix")
+    observed_runs: dict[str, Mapping[str, Any]] = {}
+    for value in raw_runs:
+        if not isinstance(value, Mapping):
+            raise TypeError("publisher dispatch allowlist run must be an object")
+        if set(value) != {"distribution", "workflow", "run_id", "url"}:
+            raise PermissionError("publisher dispatch allowlist run has unexpected fields")
+        run_distribution = value.get("distribution")
+        run_workflow = value.get("workflow")
+        run_id = value.get("run_id")
+        url = value.get("url")
+        if (
+            not isinstance(run_distribution, str)
+            or run_distribution in observed_runs
+            or expected_runs.get(run_distribution) != run_workflow
+            or not isinstance(run_id, int)
+            or isinstance(run_id, bool)
+            or run_id < 1
+            or url != f"https://github.com/{repository}/actions/runs/{run_id}"
+        ):
+            raise PermissionError("publisher dispatch allowlist contains an invalid run")
+        observed_runs[run_distribution] = value
+    if observed_runs.keys() != expected_runs.keys():
+        raise PermissionError("publisher dispatch allowlist has the wrong distributions")
+    selected = observed_runs[distribution]
+    if selected.get("workflow") != expected_workflow or selected.get("run_id") != child_run_id:
+        raise PermissionError("publisher run is not authorized by the parent dispatch")
+
+    return {
+        "repository": repository,
+        "workflow": expected_workflow,
+        "tag": tag,
+        "commit": expected_commit,
+        "registry": registry,
+        "environment": _REGISTRY_ENVIRONMENTS[registry],
+        "child_run_id": child_run_id,
+        "parent_run_id": parent_run_id,
+        "parent_run_attempt": parent_run_attempt,
+    }
+
+
+def _fetch_parent_run(repository: str, run_id: int, token: str) -> dict[str, Any]:
+    if not token:
+        raise ValueError("publisher authorization requires GITHUB_TOKEN")
+    url = f"https://api.github.com/repos/{repository}/actions/runs/{run_id}"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "archetype-release-publisher",
+            "X-GitHub-Api-Version": _API_VERSION,
+        },
+    )
+    try:
+        with _OPENER.open(request, timeout=30) as response:
+            payload = json.load(response)
+    except HTTPError as error:
+        raise RuntimeError(f"GitHub parent run lookup failed with HTTP {error.code}") from error
+    except (HTTPException, OSError, URLError, json.JSONDecodeError) as error:
+        reason = getattr(error, "reason", error)
+        raise RuntimeError(f"GitHub parent run lookup failed: {reason}") from error
+    if not isinstance(payload, dict):
+        raise TypeError("GitHub parent run response must be an object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected-workflow", required=True)
+    parser.add_argument("--distribution", required=True)
+    parser.add_argument("--child-run-id", type=int, required=True)
+    parser.add_argument("--parent-run-id", type=int, required=True)
+    parser.add_argument("--parent-run-attempt", type=int, required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--registry", choices=tuple(_REGISTRY_ENVIRONMENTS), required=True)
+    parser.add_argument("--allowlist", type=Path, required=True)
+    args = parser.parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN", "")
+    parent_run = _fetch_parent_run(_REPOSITORY, args.parent_run_id, token)
+    allowlist = json.loads(args.allowlist.read_text(encoding="utf-8"))
+    if not isinstance(allowlist, dict):
+        raise TypeError("publisher dispatch allowlist must be an object")
+    result = verify_publisher_dispatch(
+        repository=os.environ.get("GITHUB_REPOSITORY", ""),
+        event_name=os.environ.get("GITHUB_EVENT_NAME", ""),
+        ref=os.environ.get("GITHUB_REF", ""),
+        ref_name=os.environ.get("GITHUB_REF_NAME", ""),
+        ref_type=os.environ.get("GITHUB_REF_TYPE", ""),
+        commit=os.environ.get("GITHUB_SHA", ""),
+        workflow_ref=os.environ.get("GITHUB_WORKFLOW_REF", ""),
+        actor=os.environ.get("GITHUB_ACTOR", ""),
+        triggering_actor=os.environ.get("GITHUB_TRIGGERING_ACTOR", ""),
+        expected_workflow=args.expected_workflow,
+        distribution=args.distribution,
+        child_run_id=args.child_run_id,
+        parent_run_id=args.parent_run_id,
+        parent_run_attempt=args.parent_run_attempt,
+        parent_run=parent_run,
+        allowlist=allowlist,
+        tag=args.tag,
+        expected_commit=args.expected_commit,
+        registry=args.registry,
+    )
+    print(
+        "Authorized publisher dispatch: "
+        f"{result['workflow']} -> {result['registry']} for {result['tag']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_index.py
+++ b/scripts/verify_release_index.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify that an index contains only the attested release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import importlib.metadata
+import json
+import re
+import subprocess
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import urlopen
+
+if __package__:
+    from .release_artifact import DISTRIBUTIONS, SCHEMA, artifact_records, manifest_sha256
+else:  # pragma: no cover - exercised by the command-line entry point
+    from release_artifact import DISTRIBUTIONS, SCHEMA, artifact_records, manifest_sha256
+
+DEFAULT_API_TEMPLATE = "https://pypi.org/pypi/{distribution}/{version}/json"
+DEFAULT_INTEGRITY_TEMPLATE = (
+    "https://pypi.org/integrity/{distribution}/{version}/{filename}/provenance"
+)
+Fetch = Callable[[str], dict[str, Any] | None]
+Sleep = Callable[[float], None]
+VerifyAttestation = Callable[[str, str, bool], None]
+_COMMIT = re.compile(r"[0-9a-f]{40}\Z")
+_ATTESTATION_TOOL_VERSION = "0.0.30"
+
+
+class IncompleteIndexError(ValueError):
+    """The index has not yet made all required release evidence visible."""
+
+
+def _load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError("release artifact manifest must be an object")
+    return value
+
+
+def _fetch(url: str) -> dict[str, Any] | None:
+    try:
+        with urlopen(url, timeout=30) as response:  # noqa: S310 - validated HTTPS URL
+            payload = json.load(response)
+    except HTTPError as error:
+        if error.code == 404:
+            return None
+        raise RuntimeError(f"release index request failed for {url}: HTTP {error.code}") from error
+    except URLError as error:
+        raise RuntimeError(f"release index request failed for {url}: {error.reason}") from error
+    if not isinstance(payload, dict):
+        raise TypeError(f"release index response for {url} must be an object")
+    return payload
+
+
+def _expected_by_filename(
+    manifest: dict[str, Any],
+    *,
+    expected_commit: str,
+) -> dict[str, dict[str, Any]]:
+    if manifest.get("schema") != SCHEMA:
+        raise ValueError("release index verification requires the current artifact schema")
+    if manifest.get("clean_checkout") is not True:
+        raise ValueError("release index verification requires a clean-checkout manifest")
+    version = manifest.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("release artifact manifest has no version")
+    if _COMMIT.fullmatch(expected_commit) is None:
+        raise ValueError("release index verification requires one full expected commit")
+    commit = manifest.get("commit")
+    if commit != expected_commit:
+        raise ValueError(
+            f"release artifact manifest commit mismatch: {commit!r} != {expected_commit!r}"
+        )
+    return {str(record["name"]): record for record in artifact_records(manifest).values()}
+
+
+def _template_url(template: str, **coordinates: str) -> str:
+    try:
+        value = template.format(
+            distribution=quote(coordinates.get("distribution", ""), safe=""),
+            version=quote(coordinates.get("version", ""), safe=""),
+            filename=quote(coordinates.get("filename", ""), safe=""),
+        )
+    except (KeyError, ValueError) as error:
+        raise ValueError(f"invalid release index URL template {template!r}") from error
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
+        raise ValueError("release index verification requires an HTTPS URL template")
+    return value
+
+
+def _repository_url(value: str) -> str:
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != "github.com"
+        or parsed.username
+        or parsed.password
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or len([part for part in parsed.path.split("/") if part]) != 2
+    ):
+        raise ValueError("attestation repository must be an exact HTTPS GitHub repository URL")
+    return value.rstrip("/")
+
+
+def verify_payloads(
+    manifest: dict[str, Any],
+    payloads: Mapping[str, dict[str, Any] | None],
+    *,
+    require_complete: bool,
+    expected_commit: str,
+) -> dict[str, Any]:
+    """Compare index JSON payloads with the exact release manifest."""
+
+    expected = _expected_by_filename(manifest, expected_commit=expected_commit)
+    version = str(manifest["version"])
+    observed: set[str] = set()
+    observed_records: list[dict[str, Any]] = []
+    project_counts: dict[str, int] = {}
+    for distribution in DISTRIBUTIONS:
+        payload = payloads.get(distribution)
+        if payload is None:
+            project_counts[distribution] = 0
+            continue
+        info = payload.get("info")
+        if not isinstance(info, dict) or info.get("version") != version:
+            raise ValueError(f"index metadata for {distribution} does not identify {version}")
+        urls = payload.get("urls")
+        if not isinstance(urls, list):
+            raise TypeError(f"index metadata for {distribution} has no artifact list")
+        count = 0
+        for value in urls:
+            if not isinstance(value, dict):
+                raise TypeError(f"index artifact for {distribution} must be an object")
+            filename = value.get("filename")
+            if not isinstance(filename, str) or filename in observed:
+                raise ValueError(
+                    f"index contains an invalid or duplicate artifact filename {filename!r}"
+                )
+            record = expected.get(filename)
+            if record is None or record.get("distribution") != distribution:
+                raise ValueError(f"index contains unattested artifact {filename!r}")
+            digests = value.get("digests")
+            sha256 = digests.get("sha256") if isinstance(digests, dict) else None
+            size = value.get("size")
+            if sha256 != record.get("sha256") or size != record.get("size_bytes"):
+                raise ValueError(f"index artifact {filename!r} does not match attested bytes")
+            expected_kind = "bdist_wheel" if record.get("kind") == "wheel" else "sdist"
+            if value.get("packagetype") != expected_kind:
+                raise ValueError(f"index artifact {filename!r} has the wrong package type")
+            if value.get("yanked") is not False:
+                raise ValueError(f"index artifact {filename!r} must be explicitly unyanked")
+            observed.add(filename)
+            observed_records.append(
+                {
+                    "distribution": distribution,
+                    "kind": record["kind"],
+                    "name": filename,
+                    "sha256": record["sha256"],
+                    "size_bytes": record["size_bytes"],
+                }
+            )
+            count += 1
+        project_counts[distribution] = count
+
+    expected_names = set(expected)
+    if require_complete and observed != expected_names:
+        missing = sorted(expected_names - observed)
+        raise IncompleteIndexError(
+            "release index is missing attested artifacts: " + ", ".join(missing)
+        )
+    return {
+        "schema": "archetype.release-index-evidence/v2",
+        "version": version,
+        "manifest_commit": manifest["commit"],
+        "manifest_sha256": manifest_sha256(manifest),
+        "complete": observed == expected_names,
+        "artifact_count": len(observed),
+        "artifacts": sorted(observed_records, key=lambda value: str(value["name"])),
+        "projects": project_counts,
+    }
+
+
+def _statement(value: object, *, filename: str) -> dict[str, Any]:
+    if not isinstance(value, str):
+        raise TypeError(f"release provenance for {filename!r} has no statement")
+    try:
+        decoded = base64.b64decode(value, validate=True)
+        statement = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError) as error:
+        raise ValueError(f"release provenance for {filename!r} has an invalid statement") from error
+    if not isinstance(statement, dict):
+        raise TypeError(f"release provenance statement for {filename!r} must be an object")
+    return statement
+
+
+def verify_provenance(
+    artifacts: list[dict[str, Any]],
+    provenances: Mapping[str, dict[str, Any] | None],
+    *,
+    publisher: Mapping[str, str],
+) -> dict[str, Any]:
+    """Verify PyPI-reported publish provenance for every observed file."""
+
+    expected_publisher = dict(publisher)
+    required_publisher_keys = {"kind", "repository", "workflow", "environment"}
+    if set(expected_publisher) != required_publisher_keys or any(
+        not isinstance(value, str) or not value for value in expected_publisher.values()
+    ):
+        raise ValueError("release provenance requires one exact publisher identity")
+
+    verified: list[str] = []
+    for artifact in artifacts:
+        filename = str(artifact["name"])
+        provenance = provenances.get(filename)
+        if provenance is None:
+            raise IncompleteIndexError(f"release index is missing provenance for {filename!r}")
+        if provenance.get("version") != 1:
+            raise ValueError(f"release provenance for {filename!r} has an unsupported version")
+        bundles = provenance.get("attestation_bundles")
+        if not isinstance(bundles, list) or not bundles:
+            raise ValueError(f"release provenance for {filename!r} has no attestation bundles")
+
+        found_publish = False
+        for bundle in bundles:
+            if not isinstance(bundle, dict) or bundle.get("publisher") != expected_publisher:
+                raise ValueError(f"release provenance for {filename!r} has an unexpected publisher")
+            attestations = bundle.get("attestations")
+            if not isinstance(attestations, list) or not attestations:
+                raise ValueError(f"release provenance for {filename!r} has no attestations")
+            for attestation in attestations:
+                if not isinstance(attestation, dict):
+                    raise TypeError(f"release attestation for {filename!r} must be an object")
+                envelope = attestation.get("envelope")
+                if not isinstance(envelope, dict):
+                    raise TypeError(f"release attestation for {filename!r} has no envelope")
+                statement = _statement(envelope.get("statement"), filename=filename)
+                if statement.get("predicateType") != (
+                    "https://docs.pypi.org/attestations/publish/v1"
+                ):
+                    continue
+                expected_subject = [
+                    {
+                        "name": filename,
+                        "digest": {"sha256": artifact["sha256"]},
+                    }
+                ]
+                if (
+                    statement.get("_type") != "https://in-toto.io/Statement/v1"
+                    or statement.get("subject") != expected_subject
+                    or statement.get("predicate") not in (None, {})
+                ):
+                    raise ValueError(
+                        f"release publish attestation for {filename!r} is not digest-bound"
+                    )
+                found_publish = True
+        if not found_publish:
+            raise ValueError(f"release provenance for {filename!r} has no publish attestation")
+        verified.append(filename)
+
+    return {
+        "publisher": expected_publisher,
+        "artifact_count": len(verified),
+        "artifacts": sorted(verified),
+    }
+
+
+def verify_attestation(
+    filename: str,
+    repository: str,
+    staging: bool,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> None:
+    """Cryptographically verify one registry artifact with the pinned PyPI tool."""
+
+    repository = _repository_url(repository)
+    try:
+        observed_version = importlib.metadata.version("pypi-attestations")
+    except importlib.metadata.PackageNotFoundError as error:
+        raise RuntimeError(
+            f"release verification requires pypi-attestations=={_ATTESTATION_TOOL_VERSION}"
+        ) from error
+    if observed_version != _ATTESTATION_TOOL_VERSION:
+        raise RuntimeError(
+            "release verification requires "
+            f"pypi-attestations=={_ATTESTATION_TOOL_VERSION}, found {observed_version}"
+        )
+    command = [
+        "pypi-attestations",
+        "verify",
+        "pypi",
+        "--repository",
+        repository,
+    ]
+    if staging:
+        command.append("--staging")
+    command.append(f"pypi:{filename}")
+    process = run(command, check=False, capture_output=True, text=True)
+    if process.returncode:
+        raise RuntimeError(
+            f"cryptographic provenance verification failed for {filename!r}\n"
+            f"stdout:\n{process.stdout}\nstderr:\n{process.stderr}"
+        )
+
+
+def verify_index(
+    manifest: dict[str, Any],
+    *,
+    api_template: str,
+    require_complete: bool,
+    expected_commit: str,
+    integrity_template: str | None = None,
+    publisher: Mapping[str, str] | None = None,
+    attestation_repository: str | None = None,
+    attestation_staging: bool = False,
+    fetch: Fetch = _fetch,
+    verify_cryptographic_attestation: VerifyAttestation = verify_attestation,
+    attempts: int = 1,
+    interval_seconds: float = 0,
+    sleep: Sleep = time.sleep,
+) -> dict[str, Any]:
+    if attempts < 1:
+        raise ValueError("release index verification attempts must be positive")
+    version = manifest.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("release artifact manifest has no version")
+    if (integrity_template is None) is not (publisher is None):
+        raise ValueError("integrity template and publisher identity must be configured together")
+    if (integrity_template is None) is not (attestation_repository is None):
+        raise ValueError(
+            "integrity verification and cryptographic attestation repository "
+            "must be configured together"
+        )
+    if attestation_staging and attestation_repository is None:
+        raise ValueError("staging attestation verification requires a repository")
+    if attestation_repository is not None:
+        attestation_repository = _repository_url(attestation_repository)
+        assert publisher is not None
+        if publisher.get("kind") != "GitHub" or publisher.get("repository") != urlparse(
+            attestation_repository
+        ).path.strip("/"):
+            raise ValueError("attestation repository does not match the publisher identity")
+    for attempt in range(attempts):
+        payloads = {
+            distribution: fetch(
+                _template_url(
+                    api_template,
+                    distribution=distribution,
+                    version=version,
+                )
+            )
+            for distribution in DISTRIBUTIONS
+        }
+        try:
+            result = verify_payloads(
+                manifest,
+                payloads,
+                require_complete=require_complete,
+                expected_commit=expected_commit,
+            )
+            result["index_api_template"] = api_template
+            if integrity_template is not None and publisher is not None:
+                provenances = {
+                    str(artifact["name"]): fetch(
+                        _template_url(
+                            integrity_template,
+                            distribution=str(artifact["distribution"]),
+                            version=version,
+                            filename=str(artifact["name"]),
+                        )
+                    )
+                    for artifact in result["artifacts"]
+                }
+                result["integrity_api_template"] = integrity_template
+                result["provenance"] = verify_provenance(
+                    result["artifacts"],
+                    provenances,
+                    publisher=publisher,
+                )
+                assert attestation_repository is not None
+                for artifact in result["artifacts"]:
+                    verify_cryptographic_attestation(
+                        str(artifact["name"]),
+                        attestation_repository,
+                        attestation_staging,
+                    )
+                result["cryptographic_provenance"] = {
+                    "tool": "pypi-attestations",
+                    "tool_version": _ATTESTATION_TOOL_VERSION,
+                    "repository": attestation_repository,
+                    "staging": attestation_staging,
+                    "artifact_count": len(result["artifacts"]),
+                    "artifacts": sorted(str(artifact["name"]) for artifact in result["artifacts"]),
+                }
+            return result
+        except IncompleteIndexError:
+            if not require_complete:
+                raise
+            if attempt + 1 == attempts:
+                raise
+            sleep(interval_seconds)
+    raise AssertionError("release index retry loop did not return")  # pragma: no cover
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("preflight", "complete"))
+    parser.add_argument("--manifest", type=Path, default=Path("release-artifact.json"))
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--api-template", default=DEFAULT_API_TEMPLATE)
+    parser.add_argument("--integrity-template")
+    parser.add_argument("--publisher-kind", default="GitHub")
+    parser.add_argument("--publisher-repository")
+    parser.add_argument("--publisher-workflow")
+    parser.add_argument("--publisher-environment")
+    parser.add_argument("--attestation-repository")
+    parser.add_argument("--attestation-staging", action="store_true")
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--attempts", type=int, default=1)
+    parser.add_argument("--interval-seconds", type=float, default=5)
+    args = parser.parse_args(argv)
+    publisher_values = (
+        args.publisher_repository,
+        args.publisher_workflow,
+        args.publisher_environment,
+    )
+    if args.integrity_template is None and any(publisher_values):
+        parser.error("publisher identity requires --integrity-template")
+    if args.integrity_template is not None and not all(publisher_values):
+        parser.error("integrity verification requires the complete publisher identity")
+    if args.integrity_template is not None and args.attestation_repository is None:
+        parser.error("integrity verification requires --attestation-repository")
+    if args.attestation_repository is not None and args.integrity_template is None:
+        parser.error("attestation verification requires --integrity-template")
+    publisher = (
+        {
+            "kind": args.publisher_kind,
+            "repository": args.publisher_repository,
+            "workflow": args.publisher_workflow,
+            "environment": args.publisher_environment,
+        }
+        if args.integrity_template is not None
+        else None
+    )
+    result = verify_index(
+        _load(args.manifest),
+        api_template=args.api_template,
+        require_complete=args.command == "complete",
+        expected_commit=args.expected_commit,
+        integrity_template=args.integrity_template,
+        publisher=publisher,
+        attestation_repository=args.attestation_repository,
+        attestation_staging=args.attestation_staging,
+        attempts=args.attempts,
+        interval_seconds=args.interval_seconds,
+    )
+    if args.out is not None:
+        args.out.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    state = "complete" if result["complete"] else "safe partial/empty"
+    print(
+        f"Release index {state}: {result['artifact_count']} attested artifacts "
+        f"for {result['version']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_index.py
+++ b/scripts/verify_release_index.py
@@ -24,9 +24,21 @@ from urllib.parse import quote, unquote, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
 if __package__:
-    from .release_artifact import DISTRIBUTIONS, SCHEMA, artifact_records, manifest_sha256
+    from .release_artifact import (
+        DISTRIBUTIONS,
+        PUBLISHER_WORKFLOWS,
+        SCHEMA,
+        artifact_records,
+        manifest_sha256,
+    )
 else:  # pragma: no cover - exercised by the command-line entry point
-    from release_artifact import DISTRIBUTIONS, SCHEMA, artifact_records, manifest_sha256
+    from release_artifact import (
+        DISTRIBUTIONS,
+        PUBLISHER_WORKFLOWS,
+        SCHEMA,
+        artifact_records,
+        manifest_sha256,
+    )
 
 DEFAULT_API_TEMPLATE = "https://pypi.org/pypi/{distribution}/{version}/json"
 DEFAULT_INTEGRITY_TEMPLATE = (
@@ -341,16 +353,28 @@ def verify_provenance(
 ) -> dict[str, Any]:
     """Verify PyPI-reported publish provenance for every observed file."""
 
-    expected_publisher = dict(publisher)
-    required_publisher_keys = {"kind", "repository", "workflow", "environment"}
-    if set(expected_publisher) != required_publisher_keys or any(
-        not isinstance(value, str) or not value for value in expected_publisher.values()
+    publisher_base = dict(publisher)
+    required_publisher_keys = {"kind", "repository", "environment"}
+    if set(publisher_base) != required_publisher_keys or any(
+        not isinstance(value, str) or not value for value in publisher_base.values()
     ):
-        raise ValueError("release provenance requires one exact publisher identity")
+        raise ValueError("release provenance requires one exact publisher identity base")
+
+    expected_publishers = {
+        distribution: {
+            **publisher_base,
+            "workflow": PUBLISHER_WORKFLOWS[distribution],
+        }
+        for distribution in DISTRIBUTIONS
+    }
 
     verified: list[str] = []
     for artifact in artifacts:
         filename = str(artifact["name"])
+        distribution = artifact.get("distribution")
+        if not isinstance(distribution, str) or distribution not in expected_publishers:
+            raise ValueError(f"release artifact {filename!r} has an unknown distribution")
+        expected_publisher = expected_publishers[distribution]
         provenance = provenances.get(filename)
         if provenance is None:
             raise IncompleteIndexError(f"release index is missing provenance for {filename!r}")
@@ -398,7 +422,7 @@ def verify_provenance(
         verified.append(filename)
 
     return {
-        "publisher": expected_publisher,
+        "publishers": expected_publishers,
         "artifact_count": len(verified),
         "artifacts": sorted(verified),
     }
@@ -620,7 +644,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--integrity-template")
     parser.add_argument("--publisher-kind", default="GitHub")
     parser.add_argument("--publisher-repository")
-    parser.add_argument("--publisher-workflow")
     parser.add_argument("--publisher-environment")
     parser.add_argument("--attestation-repository")
     parser.add_argument("--registry-artifact-host")
@@ -630,7 +653,6 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     publisher_values = (
         args.publisher_repository,
-        args.publisher_workflow,
         args.publisher_environment,
     )
     if args.integrity_template is None and any(publisher_values):
@@ -650,7 +672,6 @@ def main(argv: list[str] | None = None) -> int:
         {
             "kind": args.publisher_kind,
             "repository": args.publisher_repository,
-            "workflow": args.publisher_workflow,
             "environment": args.publisher_environment,
         }
         if args.integrity_template is not None

--- a/scripts/verify_release_index.py
+++ b/scripts/verify_release_index.py
@@ -40,6 +40,10 @@ class IncompleteIndexError(ValueError):
     """The index has not yet made all required release evidence visible."""
 
 
+class CryptographicVerificationError(RuntimeError):
+    """The registry artifact could not yet be cryptographically verified."""
+
+
 def _load(path: Path) -> dict[str, Any]:
     value = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(value, dict):
@@ -316,7 +320,7 @@ def verify_attestation(
     command.append(f"pypi:{filename}")
     process = run(command, check=False, capture_output=True, text=True)
     if process.returncode:
-        raise RuntimeError(
+        raise CryptographicVerificationError(
             f"cryptographic provenance verification failed for {filename!r}\n"
             f"stdout:\n{process.stdout}\nstderr:\n{process.stderr}"
         )
@@ -412,6 +416,13 @@ def verify_index(
                     "artifacts": sorted(str(artifact["name"]) for artifact in result["artifacts"]),
                 }
             return result
+        except CryptographicVerificationError as error:
+            if attempt + 1 == attempts:
+                raise CryptographicVerificationError(
+                    "cryptographic provenance verification exhausted "
+                    f"{attempts} attempt(s)\n{error}"
+                ) from error
+            sleep(interval_seconds)
         except IncompleteIndexError:
             if not require_complete:
                 raise

--- a/scripts/verify_release_index.py
+++ b/scripts/verify_release_index.py
@@ -8,17 +8,20 @@ from __future__ import annotations
 
 import argparse
 import base64
+import hashlib
 import importlib.metadata
 import json
 import re
 import subprocess
 import time
 from collections.abc import Callable, Mapping
+from http.client import HTTPException, HTTPMessage
 from pathlib import Path
-from typing import Any
+from tempfile import TemporaryDirectory
+from typing import IO, Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote, urlparse
-from urllib.request import urlopen
+from urllib.parse import quote, unquote, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
 if __package__:
     from .release_artifact import DISTRIBUTIONS, SCHEMA, artifact_records, manifest_sha256
@@ -30,10 +33,14 @@ DEFAULT_INTEGRITY_TEMPLATE = (
     "https://pypi.org/integrity/{distribution}/{version}/{filename}/provenance"
 )
 Fetch = Callable[[str], dict[str, Any] | None]
+FetchBytes = Callable[[str, int], bytes]
 Sleep = Callable[[float], None]
-VerifyAttestation = Callable[[str, str, bool], None]
+VerifyAttestation = Callable[[Mapping[str, Any], Mapping[str, Any], str], None]
 _COMMIT = re.compile(r"[0-9a-f]{40}\Z")
 _ATTESTATION_TOOL_VERSION = "0.0.30"
+_ATTESTATION_TIMEOUT_SECONDS = 180
+_ARTIFACT_HOSTS = {"files.pythonhosted.org", "test-files.pythonhosted.org"}
+_DOWNLOAD_CHUNK_SIZE = 64 * 1024
 
 
 class IncompleteIndexError(ValueError):
@@ -42,6 +49,29 @@ class IncompleteIndexError(ValueError):
 
 class CryptographicVerificationError(RuntimeError):
     """The registry artifact could not yet be cryptographically verified."""
+
+
+class RegistryTransportError(RuntimeError):
+    """The package registry could not yet return a complete response."""
+
+
+class _RejectRedirects(HTTPRedirectHandler):
+    """Keep registry artifact downloads on the already validated host."""
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> Request | None:
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+_ARTIFACT_OPENER = build_opener(_RejectRedirects())
 
 
 def _load(path: Path) -> dict[str, Any]:
@@ -58,12 +88,92 @@ def _fetch(url: str) -> dict[str, Any] | None:
     except HTTPError as error:
         if error.code == 404:
             return None
-        raise RuntimeError(f"release index request failed for {url}: HTTP {error.code}") from error
-    except URLError as error:
-        raise RuntimeError(f"release index request failed for {url}: {error.reason}") from error
+        raise RegistryTransportError(
+            f"release index request failed for {url}: HTTP {error.code}"
+        ) from error
+    except (HTTPException, OSError, URLError) as error:
+        reason = getattr(error, "reason", error)
+        raise RegistryTransportError(f"release index request failed for {url}: {reason}") from error
     if not isinstance(payload, dict):
         raise TypeError(f"release index response for {url} must be an object")
     return payload
+
+
+def _fetch_bytes(url: str, expected_size: int) -> bytes:
+    if isinstance(expected_size, bool) or expected_size < 0:
+        raise ValueError("release artifact size must be a non-negative integer")
+    try:
+        with _ARTIFACT_OPENER.open(
+            url,
+            timeout=30,
+        ) as response:  # noqa: S310 - validated PyPI host; redirects disabled
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    observed_length = int(content_length)
+                except ValueError as error:
+                    raise RegistryTransportError(
+                        f"release artifact response for {url} has invalid Content-Length"
+                    ) from error
+                if observed_length != expected_size:
+                    raise RegistryTransportError(
+                        f"release artifact response for {url} has unexpected Content-Length"
+                    )
+
+            content = bytearray()
+            remaining = expected_size + 1
+            while remaining:
+                chunk = response.read(min(_DOWNLOAD_CHUNK_SIZE, remaining))
+                if not chunk:
+                    break
+                content.extend(chunk)
+                remaining -= len(chunk)
+            if len(content) != expected_size:
+                raise RegistryTransportError(
+                    f"release artifact response for {url} has unexpected size"
+                )
+            return bytes(content)
+    except HTTPError as error:
+        raise RegistryTransportError(
+            f"release artifact request failed for {url}: HTTP {error.code}"
+        ) from error
+    except (HTTPException, OSError, URLError) as error:
+        reason = getattr(error, "reason", error)
+        raise RegistryTransportError(
+            f"release artifact request failed for {url}: {reason}"
+        ) from error
+
+
+def _artifact_url(
+    value: object,
+    *,
+    filename: str,
+    expected_host: str | None = None,
+) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"index artifact {filename!r} has no download URL")
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc not in _ARTIFACT_HOSTS
+        or (expected_host is not None and parsed.netloc != expected_host)
+        or parsed.username
+        or parsed.password
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or unquote(parsed.path.rsplit("/", 1)[-1]) != filename
+    ):
+        raise ValueError(f"index artifact {filename!r} has an unexpected download URL")
+    return value
+
+
+def _registry_artifact_host(value: str) -> str:
+    if value not in _ARTIFACT_HOSTS:
+        raise ValueError(
+            "registry artifact host must be files.pythonhosted.org or test-files.pythonhosted.org"
+        )
+    return value
 
 
 def _expected_by_filename(
@@ -131,6 +241,7 @@ def verify_payloads(
     *,
     require_complete: bool,
     expected_commit: str,
+    expected_artifact_host: str | None = None,
 ) -> dict[str, Any]:
     """Compare index JSON payloads with the exact release manifest."""
 
@@ -172,6 +283,11 @@ def verify_payloads(
                 raise ValueError(f"index artifact {filename!r} has the wrong package type")
             if value.get("yanked") is not False:
                 raise ValueError(f"index artifact {filename!r} must be explicitly unyanked")
+            artifact_url = _artifact_url(
+                value.get("url"),
+                filename=filename,
+                expected_host=expected_artifact_host,
+            )
             observed.add(filename)
             observed_records.append(
                 {
@@ -180,6 +296,7 @@ def verify_payloads(
                     "name": filename,
                     "sha256": record["sha256"],
                     "size_bytes": record["size_bytes"],
+                    "url": artifact_url,
                 }
             )
             count += 1
@@ -288,15 +405,28 @@ def verify_provenance(
 
 
 def verify_attestation(
-    filename: str,
+    artifact: Mapping[str, Any],
+    provenance: Mapping[str, Any],
     repository: str,
-    staging: bool,
     *,
     run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    fetch_bytes: FetchBytes = _fetch_bytes,
 ) -> None:
     """Cryptographically verify one registry artifact with the pinned PyPI tool."""
 
     repository = _repository_url(repository)
+    filename = artifact.get("name")
+    if not isinstance(filename, str):
+        raise TypeError("cryptographic verification requires an artifact filename")
+    artifact_url = _artifact_url(artifact.get("url"), filename=filename)
+    expected_sha256 = artifact.get("sha256")
+    expected_size = artifact.get("size_bytes")
+    if (
+        not isinstance(expected_sha256, str)
+        or not isinstance(expected_size, int)
+        or isinstance(expected_size, bool)
+    ):
+        raise TypeError(f"cryptographic verification metadata is incomplete for {filename!r}")
     try:
         observed_version = importlib.metadata.version("pypi-attestations")
     except importlib.metadata.PackageNotFoundError as error:
@@ -308,22 +438,56 @@ def verify_attestation(
             "release verification requires "
             f"pypi-attestations=={_ATTESTATION_TOOL_VERSION}, found {observed_version}"
         )
-    command = [
-        "pypi-attestations",
-        "verify",
-        "pypi",
-        "--repository",
-        repository,
-    ]
-    if staging:
-        command.append("--staging")
-    command.append(f"pypi:{filename}")
-    process = run(command, check=False, capture_output=True, text=True)
-    if process.returncode:
+    try:
+        distribution_bytes = fetch_bytes(artifact_url, expected_size)
+    except (HTTPException, OSError, RuntimeError, TypeError, ValueError) as error:
         raise CryptographicVerificationError(
-            f"cryptographic provenance verification failed for {filename!r}\n"
-            f"stdout:\n{process.stdout}\nstderr:\n{process.stderr}"
+            f"cryptographic verification could not fetch {filename!r}: {error}"
+        ) from error
+    if (
+        len(distribution_bytes) != expected_size
+        or hashlib.sha256(distribution_bytes).hexdigest() != expected_sha256
+    ):
+        raise CryptographicVerificationError(
+            f"cryptographic verification downloaded unexpected bytes for {filename!r}"
         )
+
+    with TemporaryDirectory(prefix="archetype-pypi-attestation-") as directory:
+        artifact_path = Path(directory, filename)
+        provenance_path = Path(directory, f"{filename}.provenance.json")
+        artifact_path.write_bytes(distribution_bytes)
+        provenance_path.write_text(
+            json.dumps(dict(provenance), separators=(",", ":")),
+            encoding="utf-8",
+        )
+        command = [
+            "pypi-attestations",
+            "verify",
+            "pypi",
+            "--repository",
+            repository,
+            "--provenance-file",
+            str(provenance_path),
+        ]
+        command.append(str(artifact_path))
+        try:
+            process = run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_ATTESTATION_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise CryptographicVerificationError(
+                "cryptographic provenance verification timed out for "
+                f"{filename!r} after {_ATTESTATION_TIMEOUT_SECONDS} seconds"
+            ) from error
+        if process.returncode:
+            raise CryptographicVerificationError(
+                f"cryptographic provenance verification failed for {filename!r}\n"
+                f"stdout:\n{process.stdout}\nstderr:\n{process.stderr}"
+            )
 
 
 def verify_index(
@@ -335,7 +499,7 @@ def verify_index(
     integrity_template: str | None = None,
     publisher: Mapping[str, str] | None = None,
     attestation_repository: str | None = None,
-    attestation_staging: bool = False,
+    registry_artifact_host: str | None = None,
     fetch: Fetch = _fetch,
     verify_cryptographic_attestation: VerifyAttestation = verify_attestation,
     attempts: int = 1,
@@ -354,32 +518,37 @@ def verify_index(
             "integrity verification and cryptographic attestation repository "
             "must be configured together"
         )
-    if attestation_staging and attestation_repository is None:
-        raise ValueError("staging attestation verification requires a repository")
+    if (attestation_repository is None) is not (registry_artifact_host is None):
+        raise ValueError(
+            "cryptographic attestation verification requires one registry artifact host"
+        )
     if attestation_repository is not None:
         attestation_repository = _repository_url(attestation_repository)
+        assert registry_artifact_host is not None
+        registry_artifact_host = _registry_artifact_host(registry_artifact_host)
         assert publisher is not None
         if publisher.get("kind") != "GitHub" or publisher.get("repository") != urlparse(
             attestation_repository
         ).path.strip("/"):
             raise ValueError("attestation repository does not match the publisher identity")
     for attempt in range(attempts):
-        payloads = {
-            distribution: fetch(
-                _template_url(
-                    api_template,
-                    distribution=distribution,
-                    version=version,
-                )
-            )
-            for distribution in DISTRIBUTIONS
-        }
         try:
+            payloads = {
+                distribution: fetch(
+                    _template_url(
+                        api_template,
+                        distribution=distribution,
+                        version=version,
+                    )
+                )
+                for distribution in DISTRIBUTIONS
+            }
             result = verify_payloads(
                 manifest,
                 payloads,
                 require_complete=require_complete,
                 expected_commit=expected_commit,
+                expected_artifact_host=registry_artifact_host,
             )
             result["index_api_template"] = api_template
             if integrity_template is not None and publisher is not None:
@@ -402,16 +571,20 @@ def verify_index(
                 )
                 assert attestation_repository is not None
                 for artifact in result["artifacts"]:
+                    filename = str(artifact["name"])
+                    provenance = provenances[filename]
+                    assert provenance is not None
                     verify_cryptographic_attestation(
-                        str(artifact["name"]),
+                        artifact,
+                        provenance,
                         attestation_repository,
-                        attestation_staging,
                     )
                 result["cryptographic_provenance"] = {
                     "tool": "pypi-attestations",
                     "tool_version": _ATTESTATION_TOOL_VERSION,
                     "repository": attestation_repository,
-                    "staging": attestation_staging,
+                    "registry_artifact_host": registry_artifact_host,
+                    "sigstore_environment": "production",
                     "artifact_count": len(result["artifacts"]),
                     "artifacts": sorted(str(artifact["name"]) for artifact in result["artifacts"]),
                 }
@@ -421,6 +594,12 @@ def verify_index(
                 raise CryptographicVerificationError(
                     "cryptographic provenance verification exhausted "
                     f"{attempts} attempt(s)\n{error}"
+                ) from error
+            sleep(interval_seconds)
+        except RegistryTransportError as error:
+            if attempt + 1 == attempts:
+                raise RegistryTransportError(
+                    f"release registry transport exhausted {attempts} attempt(s)\n{error}"
                 ) from error
             sleep(interval_seconds)
         except IncompleteIndexError:
@@ -444,7 +623,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--publisher-workflow")
     parser.add_argument("--publisher-environment")
     parser.add_argument("--attestation-repository")
-    parser.add_argument("--attestation-staging", action="store_true")
+    parser.add_argument("--registry-artifact-host")
     parser.add_argument("--out", type=Path)
     parser.add_argument("--attempts", type=int, default=1)
     parser.add_argument("--interval-seconds", type=float, default=5)
@@ -462,6 +641,11 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("integrity verification requires --attestation-repository")
     if args.attestation_repository is not None and args.integrity_template is None:
         parser.error("attestation verification requires --integrity-template")
+    if (args.attestation_repository is None) is not (args.registry_artifact_host is None):
+        parser.error(
+            "attestation verification requires --attestation-repository and "
+            "--registry-artifact-host"
+        )
     publisher = (
         {
             "kind": args.publisher_kind,
@@ -480,7 +664,7 @@ def main(argv: list[str] | None = None) -> int:
         integrity_template=args.integrity_template,
         publisher=publisher,
         attestation_repository=args.attestation_repository,
-        attestation_staging=args.attestation_staging,
+        registry_artifact_host=args.registry_artifact_host,
         attempts=args.attempts,
         interval_seconds=args.interval_seconds,
     )

--- a/scripts/verify_release_ref.py
+++ b/scripts/verify_release_ref.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Revalidate the exact immutable release ref immediately before publication."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+_COMMIT = re.compile(r"[0-9a-f]{40}\Z")
+_TAG = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+\Z")
+_REPOSITORY = "VangelisTech/archetype"
+_OPERATOR = "everettVT"
+Run = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _git(root: Path, arguments: Sequence[str], *, run: Run) -> str:
+    process = run(
+        ["git", *arguments],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode:
+        raise RuntimeError(
+            f"release ref git command failed: {' '.join(arguments)}\n"
+            f"stdout:\n{process.stdout}\nstderr:\n{process.stderr}"
+        )
+    return process.stdout.strip()
+
+
+def verify_release_ref(
+    *,
+    root: Path,
+    tag: str,
+    expected_commit: str,
+    repository: str,
+    actor: str,
+    triggering_actor: str,
+    run: Run = subprocess.run,
+) -> dict[str, str]:
+    """Require the authorized operator and one unchanged remote tag commit."""
+
+    if repository != _REPOSITORY:
+        raise ValueError(f"release repository must be {_REPOSITORY}")
+    if actor != _OPERATOR or triggering_actor != _OPERATOR:
+        raise PermissionError(f"release publication requires {_OPERATOR}")
+    if _TAG.fullmatch(tag) is None:
+        raise ValueError("release tag must be canonical vMAJOR.MINOR.PATCH")
+    if _COMMIT.fullmatch(expected_commit) is None:
+        raise ValueError("release expected commit must be a full Git commit")
+
+    local_commit = _git(root, ("rev-parse", "HEAD"), run=run)
+    if local_commit != expected_commit:
+        raise ValueError(
+            f"release checkout moved: expected {expected_commit}, observed {local_commit}"
+        )
+
+    reference = f"refs/tags/{tag}"
+    remote = _git(root, ("ls-remote", "origin", reference, f"{reference}^{{}}"), run=run)
+    references: dict[str, str] = {}
+    for line in remote.splitlines():
+        fields = line.split("\t")
+        if len(fields) != 2 or _COMMIT.fullmatch(fields[0]) is None:
+            raise ValueError("release remote returned malformed tag evidence")
+        if fields[1] in references:
+            raise ValueError("release remote returned duplicate tag evidence")
+        references[fields[1]] = fields[0]
+    remote_commit = references.get(f"{reference}^{{}}", references.get(reference))
+    if set(references) - {reference, f"{reference}^{{}}"} or remote_commit is None:
+        raise ValueError(f"release tag {tag!r} is missing or ambiguous on origin")
+    if remote_commit != expected_commit:
+        raise ValueError(f"release tag moved: expected {expected_commit}, observed {remote_commit}")
+    return {
+        "repository": repository,
+        "tag": tag,
+        "commit": expected_commit,
+        "actor": actor,
+        "triggering_actor": triggering_actor,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--actor", required=True)
+    parser.add_argument("--triggering-actor", required=True)
+    args = parser.parse_args(argv)
+    result = verify_release_ref(
+        root=Path.cwd(),
+        tag=args.tag,
+        expected_commit=args.expected_commit,
+        repository=args.repository,
+        actor=args.actor,
+        triggering_actor=args.triggering_actor,
+    )
+    print(f"Authorized immutable release ref: {result['tag']} at {result['commit']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_dispatch_release_publishers.py
+++ b/tests/scripts/test_dispatch_release_publishers.py
@@ -1,0 +1,460 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for exact-run release publisher dispatch and completion."""
+
+from __future__ import annotations
+
+import io
+import json
+from email.message import Message
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import unquote
+
+import pytest
+
+from scripts import dispatch_release_publishers as target
+
+PARENT_RUN_ID = 123456
+PARENT_RUN_ATTEMPT = 2
+TAG = "v0.6.0"
+COMMIT = "a" * 40
+TOKEN = "github-test-token"
+REGISTRY = "testpypi"
+
+
+class _Response:
+    def __init__(
+        self,
+        url: str,
+        payload: object,
+        *,
+        status: int = 200,
+        final_url: str | None = None,
+    ) -> None:
+        self.status = status
+        self._url = final_url or url
+        self._body = json.dumps(payload).encode()
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def geturl(self) -> str:
+        return self._url
+
+    def read(self, amount: int = -1) -> bytes:
+        return self._body[:amount] if amount >= 0 else self._body
+
+
+def _context() -> dict[str, Any]:
+    return {
+        "parent_run_id": PARENT_RUN_ID,
+        "parent_run_attempt": PARENT_RUN_ATTEMPT,
+        "tag": TAG,
+        "expected_commit": COMMIT,
+        "registry": REGISTRY,
+    }
+
+
+def _run_id(index: int) -> int:
+    return 9000 + index
+
+
+def _allowlist() -> dict[str, Any]:
+    return {
+        "schema": target.SCHEMA,
+        "repository": target.REPOSITORY,
+        "parent_run_id": PARENT_RUN_ID,
+        "parent_run_attempt": PARENT_RUN_ATTEMPT,
+        "tag": TAG,
+        "commit": COMMIT,
+        "registry": REGISTRY,
+        "runs": [
+            {
+                "distribution": distribution,
+                "workflow": workflow,
+                "run_id": _run_id(index),
+                "url": target._run_html_url(_run_id(index)),
+            }
+            for index, (distribution, workflow) in enumerate(target._publishers(), start=1)
+        ],
+    }
+
+
+def _headers(request: Any) -> dict[str, str]:
+    return {key.lower(): value for key, value in request.header_items()}
+
+
+def _run_payload(
+    run: dict[str, Any],
+    *,
+    status: str = "completed",
+    conclusion: str | None = "success",
+) -> dict[str, Any]:
+    run_id = run["run_id"]
+    return {
+        "id": run_id,
+        "path": f".github/workflows/{run['workflow']}",
+        "event": "workflow_dispatch",
+        "head_sha": COMMIT,
+        "head_branch": TAG,
+        "repository": {"full_name": target.REPOSITORY},
+        "status": status,
+        "conclusion": conclusion,
+        "url": target._run_api_url(run_id),
+        "html_url": target._run_html_url(run_id),
+    }
+
+
+def test_dispatch_posts_every_child_and_returns_exact_allowlist() -> None:
+    publishers = target._publishers()
+    calls: list[tuple[str, dict[str, Any], float]] = []
+
+    def open_request(request: Any, *, timeout: float) -> _Response:
+        workflow = unquote(request.full_url.split("/workflows/", 1)[1].split("/", 1)[0])
+        index = [value for _, value in publishers].index(workflow) + 1
+        payload = json.loads(request.data)
+        calls.append((workflow, payload, timeout))
+        headers = _headers(request)
+        assert request.get_method() == "POST"
+        assert headers["accept"] == "application/vnd.github+json"
+        assert headers["authorization"] == f"Bearer {TOKEN}"
+        assert headers["x-github-api-version"] == target.API_VERSION
+        run_id = _run_id(index)
+        return _Response(
+            request.full_url,
+            {
+                "workflow_run_id": run_id,
+                "run_url": target._run_api_url(run_id),
+                "html_url": target._run_html_url(run_id),
+            },
+        )
+
+    receipt = target.dispatch_publishers(
+        **_context(),
+        token=TOKEN,
+        open_request=open_request,
+        http_timeout_seconds=17,
+    )
+
+    assert receipt == _allowlist()
+    assert [workflow for workflow, _payload, _timeout in calls] == [
+        workflow for _distribution, workflow in publishers
+    ]
+    assert all(timeout == 17 for _workflow, _payload, timeout in calls)
+    assert [payload for _workflow, payload, _timeout in calls] == [
+        {
+            "ref": TAG,
+            "inputs": {
+                "parent_run_id": str(PARENT_RUN_ID),
+                "parent_run_attempt": str(PARENT_RUN_ATTEMPT),
+                "tag": TAG,
+                "expected_commit": COMMIT,
+                "registry": REGISTRY,
+            },
+        }
+        for _ in publishers
+    ]
+    assert all(workflow != target.RELEASE_WORKFLOW for _distribution, workflow in publishers)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("workflow_run_id", 0),
+        ("run_url", "https://api.github.com/repos/other/repo/actions/runs/9001"),
+        ("html_url", "https://github.com/other/repo/actions/runs/9001"),
+    ],
+)
+def test_dispatch_rejects_inexact_run_details(field: str, value: object) -> None:
+    def open_request(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        payload: dict[str, object] = {
+            "workflow_run_id": 9001,
+            "run_url": target._run_api_url(9001),
+            "html_url": target._run_html_url(9001),
+        }
+        payload[field] = value
+        return _Response(request.full_url, payload)
+
+    with pytest.raises(target.PublisherDispatchError, match="exact run ID|run URLs"):
+        target.dispatch_publishers(
+            **_context(),
+            token=TOKEN,
+            open_request=open_request,
+        )
+
+
+def test_await_polls_only_allowlisted_ids_until_every_run_succeeds() -> None:
+    allowlist = _allowlist()
+    polls: dict[int, int] = {}
+    sleeps: list[float] = []
+    now = [0.0]
+
+    def open_request(request: Any, *, timeout: float) -> _Response:
+        assert request.get_method() == "GET"
+        assert timeout <= 11
+        run_id = int(request.full_url.rsplit("/", 1)[1])
+        assert run_id in {run["run_id"] for run in allowlist["runs"]}
+        polls[run_id] = polls.get(run_id, 0) + 1
+        run = next(run for run in allowlist["runs"] if run["run_id"] == run_id)
+        if polls[run_id] == 1:
+            payload = _run_payload(run, status="queued", conclusion=None)
+        else:
+            payload = _run_payload(run)
+        return _Response(request.full_url, payload)
+
+    def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        now[0] += seconds
+
+    receipt = target.await_publishers(
+        allowlist,
+        **_context(),
+        token=TOKEN,
+        timeout_seconds=30,
+        interval_seconds=3,
+        http_timeout_seconds=11,
+        open_request=open_request,
+        sleep=sleep,
+        monotonic=lambda: now[0],
+    )
+
+    assert receipt == allowlist
+    assert polls == {run["run_id"]: 2 for run in allowlist["runs"]}
+    assert sleeps == [3]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".github/workflows/{workflow}",
+        ".github/workflows/{workflow}@{tag}",
+        ".github/workflows/{workflow}@refs/tags/{tag}",
+    ],
+)
+def test_await_accepts_only_exact_supported_workflow_path_forms(path: str) -> None:
+    allowlist = _allowlist()
+    runs = {run["run_id"]: run for run in allowlist["runs"]}
+
+    def open_request(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        run_id = int(request.full_url.rsplit("/", 1)[1])
+        run = runs[run_id]
+        payload = _run_payload(run)
+        payload["path"] = path.format(workflow=run["workflow"], tag=TAG)
+        return _Response(request.full_url, payload)
+
+    assert (
+        target.await_publishers(
+            allowlist,
+            **_context(),
+            token=TOKEN,
+            open_request=open_request,
+        )
+        == allowlist
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("id", 999999),
+        ("path", ".github/workflows/release.yml"),
+        ("event", "push"),
+        ("head_sha", "b" * 40),
+        ("head_branch", "v0.6.1"),
+        ("url", "https://api.github.com/repos/other/repo/actions/runs/9001"),
+        ("html_url", "https://github.com/other/repo/actions/runs/9001"),
+        ("repository", {"full_name": "other/repo"}),
+    ],
+)
+def test_await_rejects_wrong_run_identity(field: str, value: object) -> None:
+    allowlist = _allowlist()
+    first = allowlist["runs"][0]
+
+    def open_request(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        payload = _run_payload(first)
+        payload[field] = value
+        return _Response(request.full_url, payload)
+
+    with pytest.raises(target.PublisherDispatchError, match="unexpected"):
+        target.await_publishers(
+            allowlist,
+            **_context(),
+            token=TOKEN,
+            open_request=open_request,
+        )
+
+
+def test_await_fails_on_a_completed_non_successful_run() -> None:
+    allowlist = _allowlist()
+    first = allowlist["runs"][0]
+
+    def open_request(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        return _Response(request.full_url, _run_payload(first, conclusion="failure"))
+
+    with pytest.raises(target.PublisherDispatchError, match="completed with 'failure'"):
+        target.await_publishers(
+            allowlist,
+            **_context(),
+            token=TOKEN,
+            open_request=open_request,
+        )
+
+
+def test_await_timeout_and_interval_are_bounded() -> None:
+    allowlist = _allowlist()
+    runs = {run["run_id"]: run for run in allowlist["runs"]}
+    calls: list[int] = []
+    sleeps: list[float] = []
+    now = [0.0]
+
+    def open_request(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        run_id = int(request.full_url.rsplit("/", 1)[1])
+        calls.append(run_id)
+        return _Response(
+            request.full_url,
+            _run_payload(runs[run_id], status="in_progress", conclusion=None),
+        )
+
+    def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        now[0] += seconds
+
+    with pytest.raises(target.PublisherDispatchError, match="within 5 seconds"):
+        target.await_publishers(
+            allowlist,
+            **_context(),
+            token=TOKEN,
+            timeout_seconds=5,
+            interval_seconds=2,
+            open_request=open_request,
+            sleep=sleep,
+            monotonic=lambda: now[0],
+        )
+
+    assert calls == [run["run_id"] for run in allowlist["runs"]] * 3
+    assert sleeps == [2, 2, 1]
+    with pytest.raises(ValueError, match="at most 3600"):
+        target.await_publishers(
+            allowlist,
+            **_context(),
+            token=TOKEN,
+            timeout_seconds=target.MAX_TIMEOUT_SECONDS + 1,
+        )
+    with pytest.raises(ValueError, match="at most 60"):
+        target.await_publishers(
+            allowlist,
+            **_context(),
+            token=TOKEN,
+            interval_seconds=target.MAX_INTERVAL_SECONDS + 1,
+        )
+
+
+def test_allowlist_rejects_wrong_context_order_and_forged_urls() -> None:
+    wrong_context = _allowlist()
+    wrong_context["parent_run_attempt"] = PARENT_RUN_ATTEMPT + 1
+    with pytest.raises(target.PublisherDispatchError, match="parent run attempt"):
+        target.validate_allowlist(wrong_context, **_context())
+
+    wrong_order = _allowlist()
+    wrong_order["runs"][0], wrong_order["runs"][1] = (
+        wrong_order["runs"][1],
+        wrong_order["runs"][0],
+    )
+    with pytest.raises(target.PublisherDispatchError, match="distribution order"):
+        target.validate_allowlist(wrong_order, **_context())
+
+    forged = _allowlist()
+    forged["runs"][0]["url"] = "https://github.com/other/repo/actions/runs/9001"
+    with pytest.raises(target.PublisherDispatchError, match="wrong URL"):
+        target.validate_allowlist(forged, **_context())
+
+
+def test_github_api_errors_are_diagnostic_and_redirects_fail_closed() -> None:
+    def forbidden(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        raise HTTPError(
+            request.full_url,
+            403,
+            "Forbidden",
+            hdrs=Message(),
+            fp=io.BytesIO(b'{"message":"permission denied"}'),
+        )
+
+    with pytest.raises(target.GitHubAPIError, match="HTTP 403: permission denied"):
+        target.dispatch_publishers(
+            **_context(),
+            token=TOKEN,
+            open_request=forbidden,
+        )
+
+    def unavailable(request: Any, *, timeout: float) -> _Response:
+        del request, timeout
+        raise URLError("offline")
+
+    with pytest.raises(target.GitHubAPIError, match="offline"):
+        target.dispatch_publishers(
+            **_context(),
+            token=TOKEN,
+            open_request=unavailable,
+        )
+
+    def redirected(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        return _Response(
+            request.full_url,
+            {},
+            final_url="https://example.invalid/redirected",
+        )
+
+    with pytest.raises(target.GitHubAPIError, match="redirected"):
+        target.dispatch_publishers(
+            **_context(),
+            token=TOKEN,
+            open_request=redirected,
+        )
+
+
+@pytest.mark.parametrize("token", ["", " leading", "two words", "line\nbreak", "snowman-☃"])
+def test_invalid_tokens_are_rejected_before_network(token: str) -> None:
+    called = False
+
+    def open_request(_request: Any, *, timeout: float) -> _Response:
+        nonlocal called
+        del timeout
+        called = True
+        raise AssertionError("network must not be called")
+
+    with pytest.raises(ValueError, match="GitHub token"):
+        target.dispatch_publishers(
+            **_context(),
+            token=token,
+            open_request=open_request,
+        )
+    assert called is False
+
+
+def test_receipt_serialization_is_deterministic(tmp_path: Any) -> None:
+    receipt = _allowlist()
+    path = tmp_path / "publisher-dispatch.json"
+
+    target._write_json(path, receipt)
+
+    assert (
+        path.read_text(encoding="utf-8")
+        == json.dumps(
+            receipt,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )

--- a/tests/scripts/test_package_smoke.py
+++ b/tests/scripts/test_package_smoke.py
@@ -193,6 +193,7 @@ def test_smoke_runs_full_stack_probe_against_rebuilt_sdist_wheels(
     ]
     assert len(probes) == 6
     assert probes[-1]["matrix"] == "all"
+    assert all(probe["version"] == "0.6.0" for probe in probes)
     assert probes[-1]["wheels"] == rebuilt
     assert probes[-1]["dist_dir"] == rebuilt_root
     assert probes[-1]["root"].name == "sdist-probe"

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -281,6 +281,7 @@ def test_manual_registry_verification_matches_the_hosted_release_oracles() -> No
         assert '--manifest "$(RELEASE_ARTIFACT_MANIFEST)"' in body
         assert "--integrity-template" in body
         assert "--publisher-repository VangelisTech/archetype" in body
+        assert "--registry-artifact-host" in body
     test_index = re.search(
         r"^verify-test-index:[^\n]*\n(?P<body>(?:\t.*\n)+)",
         makefile,
@@ -289,6 +290,15 @@ def test_manual_registry_verification_matches_the_hosted_release_oracles() -> No
     assert test_index is not None
     assert "https://test.pypi.org/simple" in test_index.group("body")
     assert "https://pypi.org/simple" in test_index.group("body")
+    assert "--registry-artifact-host test-files.pythonhosted.org" in test_index.group("body")
+    assert "--attestation-staging" not in test_index.group("body")
+    published = re.search(
+        r"^verify-published:[^\n]*\n(?P<body>(?:\t.*\n)+)",
+        makefile,
+        re.MULTILINE,
+    )
+    assert published is not None
+    assert "--registry-artifact-host files.pythonhosted.org" in published.group("body")
 
 
 def test_every_release_scenario_is_installed_wheel_applicable() -> None:
@@ -427,7 +437,8 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "scripts/verify_release_ref.py" in test_preflight
     assert "--publisher-environment release-testpypi" in test_preflight
     assert "pypi-attestations==0.0.30" in test_preflight
-    assert "--attestation-staging" in test_preflight
+    assert "--registry-artifact-host test-files.pythonhosted.org" in test_preflight
+    assert "--attestation-staging" not in test_preflight
     assert '--expected-commit "$GITHUB_SHA"' in test_preflight
     assert "needs: testpypi-preflight" in publish_test
     assert "environment: release-testpypi" in publish_test
@@ -439,13 +450,15 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "testpypi-install-evidence.json" in test_smoke
     assert "--publisher-environment release-testpypi" in test_smoke
     assert "pypi-attestations==0.0.30" in test_smoke
-    assert "--attestation-staging" in test_smoke
+    assert "--registry-artifact-host test-files.pythonhosted.org" in test_smoke
+    assert "--attestation-staging" not in test_smoke
     assert '--expected-commit "$GITHUB_SHA"' in test_smoke
     assert "needs: testpypi-smoke" in pypi_preflight
     assert "scripts/verify_release_index.py" in pypi_preflight
     assert "scripts/verify_release_ref.py" in pypi_preflight
     assert "--publisher-environment release-pypi" in pypi_preflight
     assert "pypi-attestations==0.0.30" in pypi_preflight
+    assert "--registry-artifact-host files.pythonhosted.org" in pypi_preflight
     assert '--expected-commit "$GITHUB_SHA"' in pypi_preflight
     assert "needs: pypi-preflight" in publish
     assert "needs: publish" in registry_smoke
@@ -455,6 +468,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "pypi-install-evidence.json" in registry_smoke
     assert "--publisher-environment release-pypi" in registry_smoke
     assert "pypi-attestations==0.0.30" in registry_smoke
+    assert "--registry-artifact-host files.pythonhosted.org" in registry_smoke
     assert '--expected-commit "$GITHUB_SHA"' in registry_smoke
     assert "needs: registry-smoke" in github_release
 

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import tomllib
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -107,7 +108,10 @@ def test_release_publish_requires_credentialed_r2_evidence() -> None:
     assert "target: operational-release-r2" in external
     assert "tests/infrastructure/test_r2_idempotency.py" in external
     assert "operational-release-r2-results.json" in gate
-    assert "needs: [release-evidence-gate, python-compatibility]" in publish
+    assert "needs: [release-evidence-gate, python-compatibility]" in _job(
+        workflow, "testpypi-preflight"
+    )
+    assert "needs: pypi-preflight" in publish
 
     selected = _select_scenarios(
         load_scenarios(),
@@ -197,7 +201,7 @@ def test_required_release_execution_cannot_accept_not_run(
     assert passed is False
     assert envelope["outcome"] == "failed"
     assert envelope["status_counts"] == {"passed": 0, "failed": 1, "not_run": 0}
-    (result,) = envelope["results"]
+    (result,) = cast(list[dict[str, str]], envelope["results"])
     assert result["status"] == "failed"
     assert "release cadence requires execution" in result["reason"]
 
@@ -237,30 +241,39 @@ def test_release_profile_builds_and_tests_one_exact_artifact_matrix() -> None:
     assert '--wheel-dir "$(OPERATIONAL_DIST_DIR)"' in release_runner.group("body")
 
 
-def test_manual_publish_targets_upload_only_the_recorded_artifact_matrix() -> None:
+def test_hosted_oidc_is_the_only_publish_authority() -> None:
     makefile = MAKEFILE.read_text(encoding="utf-8")
-    for target in ("publish-test", "publish"):
+    release_artifact = (ROOT / "scripts" / "release_artifact.py").read_text(encoding="utf-8")
+    assert re.search(r"^publish(?:-test)?:", makefile, re.MULTILINE) is None
+    assert "uv publish" not in makefile
+    assert 'choices=("record", "verify")' in release_artifact
+    assert "uv publish" not in release_artifact
+    assert "--publish-url" not in release_artifact
+
+
+def test_manual_registry_verification_matches_the_hosted_release_oracles() -> None:
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    for target in ("verify-test-index", "verify-published"):
         match = re.search(
-            rf"^{target}:(?P<dependencies>[^\n]*)\n(?P<body>(?:\t.*\n)+)",
+            rf"^{target}:[^\n]*\n(?P<body>(?:\t.*\n)+)",
             makefile,
             re.MULTILINE,
         )
         assert match is not None
-        assert match.group("dependencies").strip() == ""
         body = match.group("body")
-        assert "scripts/release_artifact.py publish" in body
-        assert '--dist "$(OPERATIONAL_DIST_DIR)"' in body
+        assert "scripts/verify_release_index.py" in body
+        assert "scripts/registry_smoke.py" in body
         assert '--manifest "$(RELEASE_ARTIFACT_MANIFEST)"' in body
-        assert "make build" not in body
-        assert "uv publish" not in body
-
-    test_target = re.search(
-        r"^publish-test:[^\n]*\n(?P<body>(?:\t.*\n)+)",
+        assert "--integrity-template" in body
+        assert "--publisher-repository VangelisTech/archetype" in body
+    test_index = re.search(
+        r"^verify-test-index:[^\n]*\n(?P<body>(?:\t.*\n)+)",
         makefile,
         re.MULTILINE,
     )
-    assert test_target is not None
-    assert "--publish-url https://test.pypi.org/legacy/" in test_target.group("body")
+    assert test_index is not None
+    assert "https://test.pypi.org/simple" in test_index.group("body")
+    assert "https://pypi.org/simple" in test_index.group("body")
 
 
 def test_every_release_scenario_is_installed_wheel_applicable() -> None:
@@ -343,7 +356,13 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     apple = _job(workflow, "apple-evidence")
     compatibility = _job(workflow, "python-compatibility")
     gate = _job(workflow, "release-evidence-gate")
+    test_preflight = _job(workflow, "testpypi-preflight")
+    publish_test = _job(workflow, "publish-testpypi")
+    test_smoke = _job(workflow, "testpypi-smoke")
+    pypi_preflight = _job(workflow, "pypi-preflight")
     publish = _job(workflow, "publish")
+    registry_smoke = _job(workflow, "registry-smoke")
+    github_release = _job(workflow, "github-release")
 
     assert "make verify-release" in profile
     assert "uv sync --all-packages --all-extras --group dev --group docs" in profile
@@ -388,12 +407,70 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert 'UV_PYTHON: "3.13"' in compatibility
     assert 'uv sync --python "3.13" --all-packages --all-extras --group dev' in compatibility
     assert "sys.version_info[:2] == (3, 13)" in compatibility
-    assert "needs: [release-evidence-gate, python-compatibility]" in publish
-    assert "name: dist" in publish
-    assert "pypa/gh-action-pypi-publish@" in publish
-    assert "actions/checkout@" not in publish
-    assert "uv build" not in publish
-    assert "make build" not in publish
+    assert "needs: [release-evidence-gate, python-compatibility]" in test_preflight
+    assert "scripts/verify_release_index.py" in test_preflight
+    assert "scripts/verify_release_ref.py" in test_preflight
+    assert "--publisher-environment release-testpypi" in test_preflight
+    assert "pypi-attestations==0.0.30" in test_preflight
+    assert "--attestation-staging" in test_preflight
+    assert '--expected-commit "$GITHUB_SHA"' in test_preflight
+    assert "needs: testpypi-preflight" in publish_test
+    assert "environment: release-testpypi" in publish_test
+    assert "repository-url: https://test.pypi.org/legacy/" in publish_test
+    assert "needs: publish-testpypi" in test_smoke
+    assert "scripts/verify_release_index.py" in test_smoke
+    assert "scripts/registry_smoke.py" in test_smoke
+    assert "--manifest evidence/release-artifact.json" in test_smoke
+    assert "testpypi-install-evidence.json" in test_smoke
+    assert "--publisher-environment release-testpypi" in test_smoke
+    assert "pypi-attestations==0.0.30" in test_smoke
+    assert "--attestation-staging" in test_smoke
+    assert '--expected-commit "$GITHUB_SHA"' in test_smoke
+    assert "needs: testpypi-smoke" in pypi_preflight
+    assert "scripts/verify_release_index.py" in pypi_preflight
+    assert "scripts/verify_release_ref.py" in pypi_preflight
+    assert "--publisher-environment release-pypi" in pypi_preflight
+    assert "pypi-attestations==0.0.30" in pypi_preflight
+    assert '--expected-commit "$GITHUB_SHA"' in pypi_preflight
+    assert "needs: pypi-preflight" in publish
+    assert "needs: publish" in registry_smoke
+    assert "scripts/verify_release_index.py" in registry_smoke
+    assert "scripts/registry_smoke.py" in registry_smoke
+    assert "--manifest evidence/release-artifact.json" in registry_smoke
+    assert "pypi-install-evidence.json" in registry_smoke
+    assert "--publisher-environment release-pypi" in registry_smoke
+    assert "pypi-attestations==0.0.30" in registry_smoke
+    assert '--expected-commit "$GITHUB_SHA"' in registry_smoke
+    assert "needs: registry-smoke" in github_release
+
+    for publishing_job in (publish_test, publish):
+        assert "name: dist" in publishing_job
+        assert "pypa/gh-action-pypi-publish@" in publishing_job
+        assert "skip-existing: true" in publishing_job
+        assert "attestations: true" in publishing_job
+        assert "id-token: write" in publishing_job
+        assert "actions/checkout@" not in publishing_job
+        assert "run:" not in publishing_job
+        assert "uv build" not in publishing_job
+        assert "make build" not in publishing_job
+        assert "github.triggering_actor == 'everettVT'" in publishing_job
+
+    assert "github.triggering_actor == 'everettVT'" in github_release
+    assert 'version: "latest"' not in workflow
+    assert workflow.count('version: "0.9.28"') == 8
+    assert workflow.count("persist-credentials: false") == 10
+
+
+def test_release_workflow_pins_every_external_action_to_a_full_commit() -> None:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    references = re.findall(r"^\s*- uses:\s+([^\s#]+)", workflow, re.MULTILINE)
+
+    assert references
+    assert {
+        reference
+        for reference in references
+        if re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", reference) is None
+    } == set()
 
 
 def test_release_workflow_is_operator_dispatched_from_an_immutable_tag() -> None:
@@ -414,6 +491,8 @@ def test_release_workflow_is_operator_dispatched_from_an_immutable_tag() -> None
     assert "needs: authorize-release" in profile
     assert "needs: authorize-release" in compatibility
     assert 'git merge-base --is-ancestor "${GITHUB_REF_NAME}^{commit}" origin/main' in profile
+    assert "scripts/verify_release_ref.py" in _job(workflow, "testpypi-preflight")
+    assert "scripts/verify_release_ref.py" in _job(workflow, "pypi-preflight")
     assert "tag_name: ${{ github.ref_name }}" in github_release
 
 

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -58,26 +58,33 @@ def test_pull_request_workflow_has_only_two_jobs() -> None:
 def test_local_pr_profile_matches_the_two_ci_jobs() -> None:
     makefile = MAKEFILE.read_text(encoding="utf-8")
     verify_pr = re.search(r"^verify-pr:(?P<dependencies>[^\n]*)$", makefile, re.MULTILINE)
+    verify_full_source = re.search(
+        r"^verify-full-source:(?P<dependencies>[^\n]*)$", makefile, re.MULTILINE
+    )
     verify_full = re.search(r"^verify-full:(?P<dependencies>[^\n]*)$", makefile, re.MULTILINE)
 
     assert verify_pr is not None
     assert verify_pr.group("dependencies").split() == ["static", "test", "package-smoke"]
+    assert verify_full_source is not None
     assert verify_full is not None
-    full = verify_full.group("dependencies").split()
+    source = verify_full_source.group("dependencies").split()
     for target in (
         "test-cov",
         "eval-conformance",
         "eval-reliability",
         "eval-capability",
-        "package-smoke",
         "examples-smoke",
         "operational-runtime",
         "operational-commands",
-        "operational-wheel",
         "docs",
         "test-process",
     ):
-        assert target in full
+        assert target in source
+    assert verify_full.group("dependencies").split() == [
+        "verify-full-source",
+        "package-smoke",
+        "operational-wheel-existing",
+    ]
 
 
 def test_review_gate_and_merge_queue_are_not_executable_workflows() -> None:
@@ -161,17 +168,19 @@ def test_operational_receipts_cover_commands_and_runtime_from_source_and_wheel()
         r"^operational-runtime:\n(?P<body>(?:\t.*\n)+)", makefile, re.MULTILINE
     )
     wheel = re.search(r"^operational-wheel:\n(?P<body>(?:\t.*\n)+)", makefile, re.MULTILINE)
-    verify_full = re.search(r"^verify-full:(?P<dependencies>[^\n]*)$", makefile, re.MULTILINE)
+    verify_full_source = re.search(
+        r"^verify-full-source:(?P<dependencies>[^\n]*)$", makefile, re.MULTILINE
+    )
     assert source_commands is not None
     assert source_runtime is not None
     assert wheel is not None
-    assert verify_full is not None
+    assert verify_full_source is not None
     assert source_commands.group("body").count("--scenario dogfood.commands.local") == 1
     assert wheel.group("body").count("--scenario dogfood.commands.local") == 1
     assert source_runtime.group("body").count("--scenario dogfood.runtime.loopback") == 1
     assert wheel.group("body").count("--scenario dogfood.runtime.loopback") == 1
     assert '--wheel-dir "$(OPERATIONAL_DIST_DIR)"' in wheel.group("body")
-    dependencies = verify_full.group("dependencies").split()
+    dependencies = verify_full_source.group("dependencies").split()
     assert "operational-commands" in dependencies
     assert "operational-runtime" in dependencies
 
@@ -219,7 +228,7 @@ def test_release_profile_builds_and_tests_one_exact_artifact_matrix() -> None:
     )
     assert verify_release is not None
     assert verify_release.group("dependencies").split() == [
-        "verify-full",
+        "verify-full-source",
         "operational-release",
     ]
     assert release_artifact is not None
@@ -232,6 +241,12 @@ def test_release_profile_builds_and_tests_one_exact_artifact_matrix() -> None:
     assert artifact_body.count("scripts/release_artifact.py record") == 1
     assert operational_release.group("dependencies").split() == ["release-artifact"]
     assert "--min-tier 0 --max-tier 4" in operational_release.group("body")
+    assert makefile.count("$(MAKE) --no-print-directory build") == 2
+    assert (
+        "operational-wheel-existing:\n"
+        "\t@$(MAKE) --no-print-directory operational-wheel OPERATIONAL_BUILD_COMMAND=true"
+    ) in makefile
+    assert ".NOTPARALLEL: verify-full verify-release" in makefile
     release_runner = re.search(
         r"^define RUN_RELEASE_SCENARIOS\n(?P<body>.*?)^endef$",
         makefile,

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -15,6 +15,7 @@ from typing import cast
 
 import pytest
 
+from scripts.release_artifact import DISTRIBUTIONS, PUBLISHER_WORKFLOWS
 from scripts.run_operational_scenarios import _select_scenarios, run_scenarios
 from scripts.validate_operational_scenarios import load_scenarios
 
@@ -281,6 +282,7 @@ def test_manual_registry_verification_matches_the_hosted_release_oracles() -> No
         assert '--manifest "$(RELEASE_ARTIFACT_MANIFEST)"' in body
         assert "--integrity-template" in body
         assert "--publisher-repository VangelisTech/archetype" in body
+        assert "--publisher-workflow" not in body
         assert "--registry-artifact-host" in body
     test_index = re.search(
         r"^verify-test-index:[^\n]*\n(?P<body>(?:\t.*\n)+)",
@@ -299,6 +301,63 @@ def test_manual_registry_verification_matches_the_hosted_release_oracles() -> No
     )
     assert published is not None
     assert "--registry-artifact-host files.pythonhosted.org" in published.group("body")
+
+
+def test_new_distribution_publishers_are_direct_isolated_workflows() -> None:
+    assert tuple(PUBLISHER_WORKFLOWS) == DISTRIBUTIONS
+    assert PUBLISHER_WORKFLOWS["archetype-ecs"] == "release.yml"
+    release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    profile = _job(release, "release-profile")
+
+    for distribution, workflow_name in PUBLISHER_WORKFLOWS.items():
+        prefix = distribution.replace("-", "_")
+        assert f"name: dist-{distribution}\n" in profile
+        assert f"path: dist/{prefix}-*" in profile
+        if distribution == "archetype-ecs":
+            continue
+
+        path = ROOT / ".github" / "workflows" / workflow_name
+        workflow = path.read_text(encoding="utf-8")
+        authorize = _job(workflow, "authorize")
+        testpypi = _job(workflow, "publish-testpypi")
+        pypi = _job(workflow, "publish-pypi")
+
+        assert "workflow_dispatch:" in workflow
+        assert "workflow_call:" not in workflow
+        assert "push:" not in workflow
+        assert "group: archetype-release" not in workflow
+        references = re.findall(r"^\s*- uses:\s+([^\s#]+)", workflow, re.MULTILINE)
+        assert references
+        assert all(
+            re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", reference) is not None for reference in references
+        )
+        assert "actions: read" in authorize
+        assert "contents: read" in authorize
+        assert "id-token: write" not in authorize
+        assert "scripts/verify_publisher_dispatch.py" in authorize
+        assert f"--expected-workflow {workflow_name}" in authorize
+        assert f"--distribution {distribution}" in authorize
+        assert "publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}" in (
+            authorize
+        )
+
+        for registry, job in (("testpypi", testpypi), ("pypi", pypi)):
+            environment = f"release-{registry}"
+            assert f"if: inputs.registry == '{registry}'" in job
+            assert f"environment: {environment}" in job
+            assert "actions: read" in job
+            assert "id-token: write" in job
+            assert f"name: dist-{distribution}" in job
+            assert "run-id: ${{ inputs.parent_run_id }}" in job
+            assert "github-token: ${{ github.token }}" in job
+            assert "pypa/gh-action-pypi-publish@" in job
+            assert "skip-existing: true" in job
+            assert "attestations: true" in job
+            assert "actions/checkout@" not in job
+            assert "run:" not in job
+            assert job.count("- uses:") == 2
+        assert "repository-url: https://test.pypi.org/legacy/" in testpypi
+        assert "repository-url:" not in pypi
 
 
 def test_every_release_scenario_is_installed_wheel_applicable() -> None:
@@ -383,9 +442,11 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     gate = _job(workflow, "release-evidence-gate")
     test_preflight = _job(workflow, "testpypi-preflight")
     publish_test = _job(workflow, "publish-testpypi")
+    publish_test_libraries = _job(workflow, "publish-testpypi-libraries")
     test_smoke = _job(workflow, "testpypi-smoke")
     pypi_preflight = _job(workflow, "pypi-preflight")
     publish = _job(workflow, "publish")
+    publish_libraries = _job(workflow, "publish-libraries")
     registry_smoke = _job(workflow, "registry-smoke")
     github_release = _job(workflow, "github-release")
 
@@ -443,7 +504,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "needs: testpypi-preflight" in publish_test
     assert "environment: release-testpypi" in publish_test
     assert "repository-url: https://test.pypi.org/legacy/" in publish_test
-    assert "needs: publish-testpypi" in test_smoke
+    assert "needs: [publish-testpypi, publish-testpypi-libraries]" in test_smoke
     assert "scripts/verify_release_index.py" in test_smoke
     assert "scripts/registry_smoke.py" in test_smoke
     assert "--manifest evidence/release-artifact.json" in test_smoke
@@ -461,7 +522,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "--registry-artifact-host files.pythonhosted.org" in pypi_preflight
     assert '--expected-commit "$GITHUB_SHA"' in pypi_preflight
     assert "needs: pypi-preflight" in publish
-    assert "needs: publish" in registry_smoke
+    assert "needs: [publish, publish-libraries]" in registry_smoke
     assert "scripts/verify_release_index.py" in registry_smoke
     assert "scripts/registry_smoke.py" in registry_smoke
     assert "--manifest evidence/release-artifact.json" in registry_smoke
@@ -473,7 +534,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "needs: registry-smoke" in github_release
 
     for publishing_job in (publish_test, publish):
-        assert "name: dist" in publishing_job
+        assert "name: dist-archetype-ecs" in publishing_job
         assert "pypa/gh-action-pypi-publish@" in publishing_job
         assert "skip-existing: true" in publishing_job
         assert "attestations: true" in publishing_job
@@ -484,10 +545,33 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         assert "make build" not in publishing_job
         assert "github.triggering_actor == 'everettVT'" in publishing_job
 
+    for registry, coordinator in (
+        ("testpypi", publish_test_libraries),
+        ("pypi", publish_libraries),
+    ):
+        assert f"--registry {registry}" in coordinator
+        assert "actions: write" in coordinator
+        assert "contents: read" in coordinator
+        assert "id-token: write" not in coordinator
+        assert "scripts/dispatch_release_publishers.py dispatch" in coordinator
+        assert "scripts/dispatch_release_publishers.py await" in coordinator
+        assert '--parent-run-id "$GITHUB_RUN_ID"' in coordinator
+        assert '--parent-run-attempt "$GITHUB_RUN_ATTEMPT"' in coordinator
+        assert '--tag "$GITHUB_REF_NAME"' in coordinator
+        assert '--expected-commit "$GITHUB_SHA"' in coordinator
+        assert f"publisher-dispatch-{registry}.json" in coordinator
+        assert f"name: publisher-dispatch-{registry}-${{{{ github.run_attempt }}}}" in coordinator
+        assert (
+            coordinator.index("dispatch_release_publishers.py dispatch")
+            < coordinator.index(f"name: publisher-dispatch-{registry}-")
+            < coordinator.index("dispatch_release_publishers.py await")
+        )
+        assert "github.triggering_actor == 'everettVT'" in coordinator
+
     assert "github.triggering_actor == 'everettVT'" in github_release
     assert 'version: "latest"' not in workflow
     assert workflow.count('version: "0.9.28"') == 8
-    assert workflow.count("persist-credentials: false") == 10
+    assert workflow.count("persist-credentials: false") == 12
 
 
 def test_release_workflow_pins_every_external_action_to_a_full_commit() -> None:

--- a/tests/scripts/test_registry_smoke.py
+++ b/tests/scripts/test_registry_smoke.py
@@ -1,0 +1,233 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for post-publication package-index verification."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.registry_smoke import (
+    _clean_environment,
+    _install_commands,
+    _manifest_identity,
+    _manifest_version,
+    _probe_source,
+    _release_version,
+    _requirements,
+    _run_checked,
+    _run_matrix,
+)
+from scripts.release_artifact import DISTRIBUTIONS, SCHEMA, manifest_sha256
+
+
+def _manifest() -> dict[str, object]:
+    prefixes = {
+        "archetype-ecs": "archetype_ecs",
+        "archetype-missions": "archetype_missions",
+        "archetype-physical-ai": "archetype_physical_ai",
+        "archetype-research": "archetype_research",
+    }
+    return {
+        "schema": SCHEMA,
+        "version": "0.6.0",
+        "commit": "a" * 40,
+        "clean_checkout": True,
+        "artifacts": [
+            {
+                "distribution": distribution,
+                "kind": kind,
+                "name": (
+                    f"{prefixes[distribution]}-0.6.0-py3-none-any.whl"
+                    if kind == "wheel"
+                    else f"{prefixes[distribution]}-0.6.0.tar.gz"
+                ),
+                "sha256": "a" * 64,
+                "size_bytes": 1,
+            }
+            for distribution in DISTRIBUTIONS
+            for kind in ("wheel", "sdist")
+        ],
+    }
+
+
+def test_registry_matrix_pins_every_selected_distribution() -> None:
+    assert _requirements("base", "0.6.0") == ("archetype-ecs==0.6.0",)
+    assert _requirements("missions", "0.6.0") == (
+        "archetype-ecs==0.6.0",
+        "archetype-missions==0.6.0",
+    )
+    assert _requirements("physical-ai", "0.6.0") == (
+        "archetype-ecs==0.6.0",
+        "archetype-physical-ai==0.6.0",
+    )
+    assert _requirements("research", "0.6.0") == (
+        "archetype-ecs==0.6.0",
+        "archetype-research==0.6.0",
+    )
+    assert _requirements("all", "0.6.0") == (
+        "archetype-ecs==0.6.0",
+        "archetype-missions==0.6.0",
+        "archetype-physical-ai==0.6.0",
+        "archetype-research==0.6.0",
+    )
+
+
+@pytest.mark.parametrize("value", ["v0.6.0", "0.6", "0.6.0+local", "0.6.0.dev1"])
+def test_registry_smoke_rejects_noncanonical_release_versions(value: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        _release_version(value)
+
+
+def test_production_index_install_uses_no_cache_or_fallback() -> None:
+    (command,) = _install_commands(
+        uv="uv",
+        python=Path("/venv/bin/python"),
+        requirements=("archetype-ecs==0.6.0",),
+        index_url="https://pypi.org/simple",
+        extra_index_url=None,
+    )
+
+    assert command == [
+        "uv",
+        "--no-config",
+        "pip",
+        "install",
+        "--python",
+        "/venv/bin/python",
+        "--no-cache",
+        "--only-binary=:all:",
+        "--index-url",
+        "https://pypi.org/simple",
+        "archetype-ecs==0.6.0",
+    ]
+    assert "--extra-index-url" not in command
+    assert "--no-config" in command
+    assert "--only-binary=:all:" in command
+
+
+def test_test_index_mode_sources_internal_artifacts_before_dependencies() -> None:
+    requirements = _requirements("all", "0.6.0")
+    target, dependencies = _install_commands(
+        uv="uv",
+        python=Path("/venv/bin/python"),
+        requirements=requirements,
+        index_url="https://test.pypi.org/simple",
+        extra_index_url="https://pypi.org/simple",
+    )
+
+    assert target[-len(requirements) :] == list(requirements)
+    assert target[target.index("--index-url") + 1] == "https://test.pypi.org/simple"
+    assert "--no-deps" in target
+    assert dependencies[-len(requirements) :] == list(requirements)
+    assert dependencies[dependencies.index("--index-url") + 1] == "https://pypi.org/simple"
+    assert "--no-deps" not in dependencies
+    assert "--extra-index-url" not in target + dependencies
+    assert "--no-config" in target and "--no-config" in dependencies
+    assert "--only-binary=:all:" in target and "--only-binary=:all:" in dependencies
+
+
+def test_registry_probe_rejects_split_compatibility_facades() -> None:
+    probe = _probe_source("all", "0.6.0")
+
+    assert "assert not any(hasattr(archetype, name)" in probe
+    assert '"__getattr__" not in ArchetypeRuntime.__dict__' in probe
+    assert 'not hasattr(importlib.import_module("archetype.missions"), "RuntimeMissions")' in probe
+    assert 'not hasattr(research, "CandidateContext")' in probe
+    assert 'find_spec("archetype.artifacts.contracts") is None' in probe
+    assert '"library" not in SyncRuntimeWorld.__dict__' in probe
+    assert '"library" not in SyncArchetypeRuntime.__dict__' in probe
+
+
+def test_registry_smoke_derives_version_from_clean_manifest(tmp_path: Path) -> None:
+    path = tmp_path / "release-artifact.json"
+    path.write_text(json.dumps(_manifest()), encoding="utf-8")
+
+    assert _manifest_version(path) == "0.6.0"
+    assert _manifest_identity(path) == {
+        "version": "0.6.0",
+        "commit": "a" * 40,
+        "sha256": manifest_sha256(_manifest()),
+    }
+
+    value = _manifest()
+    value["clean_checkout"] = False
+    path.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="clean-checkout"):
+        _manifest_version(path)
+
+
+def test_registry_commands_discard_ambient_resolver_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PIP_INDEX_URL", "https://wrong.invalid/simple")
+    monkeypatch.setenv("UV_EXTRA_INDEX_URL", "https://wrong.invalid/simple")
+    monkeypatch.setenv("PYTHONPATH", "/workspace/packages")
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    clean = _clean_environment()
+
+    assert clean["PATH"] == "/usr/bin"
+    assert "PIP_INDEX_URL" not in clean
+    assert "UV_EXTRA_INDEX_URL" not in clean
+    assert "PYTHONPATH" not in clean
+
+
+def test_registry_command_failure_preserves_resolver_diagnostics(tmp_path: Path) -> None:
+    def fail(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess([], 2, stdout="resolver output", stderr="missing wheel")
+
+    with pytest.raises(RuntimeError, match=r"(?s)resolver output.*missing wheel"):
+        _run_checked(
+            ["uv", "pip", "install"],
+            cwd=tmp_path,
+            env={},
+            label="test installation",
+            run=fail,
+        )
+
+
+def test_registry_matrix_receipt_records_requirements_and_resolved_inventory(
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[2:4] == ["pip", "freeze"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="zeta==2\narchetype-ecs==0.6.0\n",
+                stderr="",
+            )
+        if command[0].endswith("/bin/python"):
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    '{"matrix":"base","libraries":[],"operations":37,'
+                    '"module":"site-packages/archetype","version":"0.6.0"}\n'
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    result = _run_matrix(
+        matrix="base",
+        version="0.6.0",
+        index_url="https://pypi.org/simple",
+        extra_index_url=None,
+        uv="uv",
+        root=tmp_path,
+        run=run,
+    )
+
+    assert result["requirements"] == ["archetype-ecs==0.6.0"]
+    assert result["installed_distributions"] == ["archetype-ecs==0.6.0", "zeta==2"]
+    assert any(command[2:4] == ["pip", "freeze"] for command in calls)

--- a/tests/scripts/test_release_evidence.py
+++ b/tests/scripts/test_release_evidence.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 
 import hashlib
 import json
-import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from scripts.release_artifact import DISTRIBUTIONS, _distribution_files, publish_verified, record
+from scripts.release_artifact import DISTRIBUTIONS, _distribution_files, record
 from scripts.release_artifact import SCHEMA as ARTIFACT_SCHEMA
 from scripts.release_artifact import verify as verify_artifact
 from scripts.verify_release_evidence import RESULT_SCHEMA, SUMMARY_SCHEMA, verify
@@ -273,63 +272,6 @@ def test_release_artifact_verification_requires_exact_checkout_commit(
 
     with pytest.raises(ValueError, match="release artifact commit mismatch"):
         verify_artifact(manifest, dist, expected_commit="a" * 40)
-
-
-@pytest.mark.parametrize(
-    "publish_url",
-    [None, "https://test.pypi.org/legacy/"],
-)
-def test_manual_publish_uploads_only_the_verified_recorded_artifacts(
-    tmp_path: Path,
-    publish_url: str | None,
-) -> None:
-    dist, manifest_path, _wheels = _artifact(tmp_path)
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    calls: list[tuple[list[str], dict[str, object]]] = []
-
-    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls.append((command, kwargs))
-        return subprocess.CompletedProcess(command, 0)
-
-    assert (
-        publish_verified(
-            manifest,
-            dist,
-            expected_commit="a" * 40,
-            publish_url=publish_url,
-            run=run,
-        )
-        is manifest
-    )
-
-    prefix = ["uv", "publish"]
-    if publish_url is not None:
-        prefix.extend(("--publish-url", publish_url))
-    expected_paths = [
-        str((dist / artifact["name"]).resolve()) for artifact in manifest["artifacts"]
-    ]
-    assert calls == [(prefix + expected_paths, {"check": True})]
-
-
-def test_manual_publish_refuses_changed_bytes_before_upload(tmp_path: Path) -> None:
-    dist, manifest_path, _wheels = _artifact(tmp_path)
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    (dist / "archetype_research-0.6.0.tar.gz").write_bytes(b"changed")
-    called = False
-
-    def run(_command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        nonlocal called
-        called = True
-        return subprocess.CompletedProcess([], 0)
-
-    with pytest.raises(ValueError, match="archetype-research sdist .* mismatch"):
-        publish_verified(
-            manifest,
-            dist,
-            expected_commit="a" * 40,
-            run=run,
-        )
-    assert called is False
 
 
 def test_release_evidence_requires_every_scenario_on_framework_wheel(tmp_path: Path) -> None:

--- a/tests/scripts/test_release_index.py
+++ b/tests/scripts/test_release_index.py
@@ -1,0 +1,438 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for idempotent, exact-byte package-index publication."""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from typing import Any, cast
+
+import pytest
+
+from scripts.release_artifact import DISTRIBUTIONS, SCHEMA
+from scripts.verify_release_index import (
+    IncompleteIndexError,
+    verify_attestation,
+    verify_index,
+    verify_payloads,
+    verify_provenance,
+)
+
+COMMIT = "a" * 40
+
+_PREFIXES = {
+    "archetype-ecs": "archetype_ecs",
+    "archetype-missions": "archetype_missions",
+    "archetype-physical-ai": "archetype_physical_ai",
+    "archetype-research": "archetype_research",
+}
+
+
+def _manifest() -> dict[str, Any]:
+    records = []
+    for index, distribution in enumerate(DISTRIBUTIONS):
+        prefix = _PREFIXES[distribution]
+        records.extend(
+            (
+                {
+                    "distribution": distribution,
+                    "kind": "wheel",
+                    "name": f"{prefix}-0.6.0-py3-none-any.whl",
+                    "sha256": f"{index + 1:064x}",
+                    "size_bytes": 100 + index,
+                },
+                {
+                    "distribution": distribution,
+                    "kind": "sdist",
+                    "name": f"{prefix}-0.6.0.tar.gz",
+                    "sha256": f"{index + 11:064x}",
+                    "size_bytes": 200 + index,
+                },
+            )
+        )
+    return {
+        "schema": SCHEMA,
+        "version": "0.6.0",
+        "commit": "a" * 40,
+        "clean_checkout": True,
+        "artifacts": records,
+    }
+
+
+def _payloads(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    payloads = {
+        distribution: {"info": {"version": manifest["version"]}, "urls": []}
+        for distribution in DISTRIBUTIONS
+    }
+    for record in manifest["artifacts"]:
+        urls = cast(list[dict[str, Any]], payloads[record["distribution"]]["urls"])
+        urls.append(
+            {
+                "filename": record["name"],
+                "digests": {"sha256": record["sha256"]},
+                "size": record["size_bytes"],
+                "packagetype": "bdist_wheel" if record["kind"] == "wheel" else "sdist",
+                "yanked": False,
+            }
+        )
+    return payloads
+
+
+def _publisher(environment: str = "release-pypi") -> dict[str, str]:
+    return {
+        "kind": "GitHub",
+        "repository": "VangelisTech/archetype",
+        "workflow": "release.yml",
+        "environment": environment,
+    }
+
+
+def _provenance(record: dict[str, Any], publisher: dict[str, str]) -> dict[str, Any]:
+    statement = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [
+            {
+                "name": record["name"],
+                "digest": {"sha256": record["sha256"]},
+            }
+        ],
+        "predicateType": "https://docs.pypi.org/attestations/publish/v1",
+        "predicate": None,
+    }
+    encoded = base64.b64encode(json.dumps(statement, separators=(",", ":")).encode()).decode()
+    return {
+        "version": 1,
+        "attestation_bundles": [
+            {
+                "publisher": dict(publisher),
+                "attestations": [{"envelope": {"statement": encoded}}],
+            }
+        ],
+    }
+
+
+def test_preflight_accepts_empty_or_exact_partial_publication() -> None:
+    manifest = _manifest()
+    complete = _payloads(manifest)
+    payloads: dict[str, dict[str, Any] | None] = {
+        distribution: None for distribution in DISTRIBUTIONS
+    }
+    payloads["archetype-ecs"] = {
+        "info": complete["archetype-ecs"]["info"],
+        "urls": complete["archetype-ecs"]["urls"][:1],
+    }
+
+    result = verify_payloads(
+        manifest,
+        payloads,
+        require_complete=False,
+        expected_commit=COMMIT,
+    )
+
+    assert result["complete"] is False
+    assert result["artifact_count"] == 1
+    assert result["projects"]["archetype-ecs"] == 1
+
+
+def test_complete_index_requires_all_eight_attested_artifacts() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+
+    result = verify_payloads(
+        manifest,
+        payloads,
+        require_complete=True,
+        expected_commit=COMMIT,
+    )
+
+    assert result["complete"] is True
+    assert result["artifact_count"] == 8
+    assert result["manifest_commit"] == "a" * 40
+    assert len(result["manifest_sha256"]) == 64
+    assert [row["name"] for row in result["artifacts"]] == sorted(
+        record["name"] for record in manifest["artifacts"]
+    )
+    payloads["archetype-research"]["urls"].pop()
+    with pytest.raises(ValueError, match="missing attested artifacts"):
+        verify_payloads(
+            manifest,
+            payloads,
+            require_complete=True,
+            expected_commit=COMMIT,
+        )
+
+
+@pytest.mark.parametrize("field", ["sha256", "size", "packagetype", "yanked"])
+def test_index_rejects_non_attested_artifact_metadata(field: str) -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    record = payloads["archetype-missions"]["urls"][0]
+    if field == "sha256":
+        record["digests"]["sha256"] = "f" * 64
+    elif field == "size":
+        record["size"] = -1
+    elif field == "packagetype":
+        record["packagetype"] = "sdist"
+    else:
+        record["yanked"] = True
+
+    with pytest.raises(ValueError, match="does not match|wrong package type|unyanked"):
+        verify_payloads(
+            manifest,
+            payloads,
+            require_complete=False,
+            expected_commit=COMMIT,
+        )
+
+
+def test_index_rejects_unattested_filename() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    payloads["archetype-research"]["urls"][0]["filename"] = "surprise.whl"
+
+    with pytest.raises(ValueError, match="unattested artifact"):
+        verify_payloads(
+            manifest,
+            payloads,
+            require_complete=False,
+            expected_commit=COMMIT,
+        )
+
+
+def test_remote_verifier_requests_each_exact_project_version() -> None:
+    manifest = _manifest()
+    requested: list[str] = []
+
+    def fetch(url: str) -> None:
+        requested.append(url)
+        return None
+
+    result = verify_index(
+        manifest,
+        api_template="https://index.invalid/{distribution}/{version}",
+        require_complete=False,
+        expected_commit=COMMIT,
+        fetch=fetch,
+    )
+
+    assert requested == [
+        f"https://index.invalid/{distribution}/0.6.0" for distribution in DISTRIBUTIONS
+    ]
+    assert result["artifact_count"] == 0
+
+
+def test_complete_index_retries_only_missing_attested_files() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    incomplete = {**payloads, "archetype-research": None}
+    rounds = iter((incomplete, payloads))
+    current: dict[str, dict[str, Any] | None] = {}
+    sleeps: list[float] = []
+
+    def fetch(url: str) -> dict[str, Any] | None:
+        distribution = url.split("/")[-2]
+        if distribution == DISTRIBUTIONS[0]:
+            current.clear()
+            current.update(next(rounds))
+        return current[distribution]
+
+    result = verify_index(
+        manifest,
+        api_template="https://index.invalid/{distribution}/{version}",
+        require_complete=True,
+        expected_commit=COMMIT,
+        fetch=fetch,
+        attempts=2,
+        interval_seconds=7,
+        sleep=sleeps.append,
+    )
+
+    assert result["complete"] is True
+    assert sleeps == [7]
+
+
+def test_provenance_binds_every_file_to_exact_publisher_and_digest() -> None:
+    manifest = _manifest()
+    result = verify_payloads(
+        manifest,
+        _payloads(manifest),
+        require_complete=True,
+        expected_commit=COMMIT,
+    )
+    publisher = _publisher()
+    provenances = {
+        record["name"]: _provenance(record, publisher) for record in manifest["artifacts"]
+    }
+
+    evidence = verify_provenance(result["artifacts"], provenances, publisher=publisher)
+
+    assert evidence == {
+        "publisher": publisher,
+        "artifact_count": 8,
+        "artifacts": sorted(provenances),
+    }
+
+
+def test_provenance_rejects_wrong_publisher_or_subject_digest() -> None:
+    manifest = _manifest()
+    result = verify_payloads(
+        manifest,
+        _payloads(manifest),
+        require_complete=True,
+        expected_commit=COMMIT,
+    )
+    publisher = _publisher()
+    record = manifest["artifacts"][0]
+    observed = next(value for value in result["artifacts"] if value["name"] == record["name"])
+    provenance = _provenance(record, publisher)
+
+    provenance["attestation_bundles"][0]["publisher"]["workflow"] = "other.yml"
+    with pytest.raises(ValueError, match="unexpected publisher"):
+        verify_provenance([observed], {record["name"]: provenance}, publisher=publisher)
+
+    provenance = _provenance(record, publisher)
+    envelope = provenance["attestation_bundles"][0]["attestations"][0]["envelope"]
+    statement = json.loads(base64.b64decode(envelope["statement"]))
+    statement["subject"][0]["digest"]["sha256"] = "f" * 64
+    envelope["statement"] = base64.b64encode(json.dumps(statement).encode()).decode()
+    with pytest.raises(ValueError, match="not digest-bound"):
+        verify_provenance([observed], {record["name"]: provenance}, publisher=publisher)
+
+
+def test_complete_index_retries_provenance_propagation() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    publisher = _publisher()
+    records = {record["name"]: record for record in manifest["artifacts"]}
+    missing_once = {next(iter(records))}
+    sleeps: list[float] = []
+
+    def fetch(url: str) -> dict[str, Any] | None:
+        if "/pypi/" in url:
+            return payloads[url.split("/")[-3]]
+        filename = url.split("/")[-2]
+        if filename in missing_once:
+            missing_once.remove(filename)
+            return None
+        return _provenance(records[filename], publisher)
+
+    result = verify_index(
+        manifest,
+        api_template="https://index.invalid/pypi/{distribution}/{version}/json",
+        integrity_template=(
+            "https://index.invalid/integrity/{distribution}/{version}/{filename}/provenance"
+        ),
+        publisher=publisher,
+        attestation_repository="https://github.com/VangelisTech/archetype",
+        require_complete=True,
+        expected_commit=COMMIT,
+        fetch=fetch,
+        verify_cryptographic_attestation=lambda *_args: None,
+        attempts=2,
+        interval_seconds=3,
+        sleep=sleeps.append,
+    )
+
+    assert result["provenance"]["artifact_count"] == 8
+    assert result["index_api_template"].startswith("https://index.invalid/")
+    assert sleeps == [3]
+
+
+def test_remote_verifier_rejects_non_https_templates() -> None:
+    with pytest.raises(ValueError, match="HTTPS URL template"):
+        verify_index(
+            _manifest(),
+            api_template="http://index.invalid/{distribution}/{version}",
+            require_complete=False,
+            expected_commit=COMMIT,
+            fetch=lambda _url: None,
+        )
+
+
+def test_preflight_requires_provenance_and_crypto_for_exact_partial_upload() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    publisher = _publisher()
+    first = cast(dict[str, Any], manifest["artifacts"][0])
+    partial = {distribution: None for distribution in DISTRIBUTIONS}
+    partial[first["distribution"]] = {
+        "info": payloads[first["distribution"]]["info"],
+        "urls": payloads[first["distribution"]]["urls"][:1],
+    }
+    crypto: list[tuple[str, str, bool]] = []
+
+    def fetch(url: str) -> dict[str, Any] | None:
+        if "/integrity/" in url:
+            return _provenance(first, publisher)
+        distribution = url.split("/")[-2]
+        return partial[distribution]
+
+    result = verify_index(
+        manifest,
+        api_template="https://index.invalid/{distribution}/{version}",
+        integrity_template=(
+            "https://index.invalid/integrity/{distribution}/{version}/{filename}/provenance"
+        ),
+        publisher=publisher,
+        attestation_repository="https://github.com/VangelisTech/archetype",
+        require_complete=False,
+        expected_commit=COMMIT,
+        fetch=fetch,
+        verify_cryptographic_attestation=lambda *values: crypto.append(values),
+    )
+
+    assert result["artifact_count"] == 1
+    assert crypto == [
+        (
+            first["name"],
+            "https://github.com/VangelisTech/archetype",
+            False,
+        )
+    ]
+
+    def token_upload(url: str) -> dict[str, Any] | None:
+        if "/integrity/" in url:
+            return None
+        return fetch(url)
+
+    with pytest.raises(IncompleteIndexError, match="missing provenance"):
+        verify_index(
+            manifest,
+            api_template="https://index.invalid/{distribution}/{version}",
+            integrity_template=(
+                "https://index.invalid/integrity/{distribution}/{version}/{filename}/provenance"
+            ),
+            publisher=publisher,
+            attestation_repository="https://github.com/VangelisTech/archetype",
+            require_complete=False,
+            expected_commit=COMMIT,
+            fetch=token_upload,
+            verify_cryptographic_attestation=lambda *_args: None,
+        )
+
+
+def test_cryptographic_verifier_is_pinned_and_preserves_failure_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.verify_release_index.importlib.metadata.version",
+        lambda _name: "0.0.30",
+    )
+    calls: list[list[str]] = []
+
+    def fail(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, "verification output", "bad signature")
+
+    with pytest.raises(RuntimeError, match=r"(?s)verification output.*bad signature"):
+        verify_attestation(
+            "archetype_ecs-0.6.0-py3-none-any.whl",
+            "https://github.com/VangelisTech/archetype",
+            True,
+            run=fail,
+        )
+
+    assert calls[0][-2:] == ["--staging", "pypi:archetype_ecs-0.6.0-py3-none-any.whl"]

--- a/tests/scripts/test_release_index.py
+++ b/tests/scripts/test_release_index.py
@@ -6,16 +6,23 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import subprocess
+import threading
+from collections.abc import Mapping
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
+from scripts import verify_release_index as release_index
 from scripts.release_artifact import DISTRIBUTIONS, SCHEMA
 from scripts.verify_release_index import (
     CryptographicVerificationError,
     IncompleteIndexError,
+    RegistryTransportError,
     verify_attestation,
     verify_index,
     verify_payloads,
@@ -63,7 +70,11 @@ def _manifest() -> dict[str, Any]:
     }
 
 
-def _payloads(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+def _payloads(
+    manifest: dict[str, Any],
+    *,
+    artifact_host: str = "files.pythonhosted.org",
+) -> dict[str, dict[str, Any]]:
     payloads = {
         distribution: {"info": {"version": manifest["version"]}, "urls": []}
         for distribution in DISTRIBUTIONS
@@ -77,6 +88,7 @@ def _payloads(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
                 "size": record["size_bytes"],
                 "packagetype": "bdist_wheel" if record["kind"] == "wheel" else "sdist",
                 "yanked": False,
+                "url": f"https://{artifact_host}/packages/{record['name']}",
             }
         )
     return payloads
@@ -195,6 +207,46 @@ def test_index_rejects_unattested_filename() -> None:
     payloads["archetype-research"]["urls"][0]["filename"] = "surprise.whl"
 
     with pytest.raises(ValueError, match="unattested artifact"):
+        verify_payloads(
+            manifest,
+            payloads,
+            require_complete=False,
+            expected_commit=COMMIT,
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.invalid/packages/archetype_ecs-0.6.0-py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/a-different-file.whl",
+        "http://files.pythonhosted.org/packages/archetype_ecs-0.6.0-py3-none-any.whl",
+        "https://user@files.pythonhosted.org/packages/archetype_ecs-0.6.0-py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/archetype_ecs-0.6.0-py3-none-any.whl?download=1",
+        "https://files.pythonhosted.org/packages/archetype_ecs-0.6.0-py3-none-any.whl#fragment",
+        "https://files.pythonhosted.org/packages/%2Farchetype_ecs-0.6.0-py3-none-any.whl",
+    ],
+)
+def test_index_rejects_untrusted_or_mismatched_artifact_url(url: str) -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    payloads["archetype-ecs"]["urls"][0]["url"] = url
+
+    with pytest.raises(ValueError, match="unexpected download URL"):
+        verify_payloads(
+            manifest,
+            payloads,
+            require_complete=False,
+            expected_commit=COMMIT,
+        )
+
+
+def test_index_requires_an_artifact_download_url() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    del payloads["archetype-ecs"]["urls"][0]["url"]
+
+    with pytest.raises(TypeError, match="has no download URL"):
         verify_payloads(
             manifest,
             payloads,
@@ -328,6 +380,7 @@ def test_complete_index_retries_provenance_propagation() -> None:
         ),
         publisher=publisher,
         attestation_repository="https://github.com/VangelisTech/archetype",
+        registry_artifact_host="files.pythonhosted.org",
         require_complete=True,
         expected_commit=COMMIT,
         fetch=fetch,
@@ -342,24 +395,28 @@ def test_complete_index_retries_provenance_propagation() -> None:
     assert sleeps == [3]
 
 
-def test_complete_index_retries_transient_staging_crypto_propagation() -> None:
+@pytest.mark.parametrize("failure_phase", ["index", "integrity"])
+def test_complete_index_retries_transient_registry_transport(failure_phase: str) -> None:
     manifest = _manifest()
     payloads = _payloads(manifest)
-    publisher = _publisher("release-testpypi")
+    publisher = _publisher()
     records = {record["name"]: record for record in manifest["artifacts"]}
-    calls: list[tuple[str, str, bool]] = []
+    failed = False
     sleeps: list[float] = []
 
     def fetch(url: str) -> dict[str, Any]:
-        if "/pypi/" in url:
+        nonlocal failed
+        is_index = "/pypi/" in url
+        if not failed and (
+            (failure_phase == "index" and is_index)
+            or (failure_phase == "integrity" and not is_index)
+        ):
+            failed = True
+            raise RegistryTransportError(f"transient {failure_phase} transport failure")
+        if is_index:
             return payloads[url.split("/")[-3]]
         filename = url.split("/")[-2]
         return _provenance(records[filename], publisher)
-
-    def verify_crypto(filename: str, repository: str, staging: bool) -> None:
-        calls.append((filename, repository, staging))
-        if len(calls) == 1:
-            raise CryptographicVerificationError("staging provenance is still propagating")
 
     result = verify_index(
         manifest,
@@ -369,7 +426,55 @@ def test_complete_index_retries_transient_staging_crypto_propagation() -> None:
         ),
         publisher=publisher,
         attestation_repository="https://github.com/VangelisTech/archetype",
-        attestation_staging=True,
+        registry_artifact_host="files.pythonhosted.org",
+        require_complete=True,
+        expected_commit=COMMIT,
+        fetch=fetch,
+        verify_cryptographic_attestation=lambda *_args: None,
+        attempts=2,
+        interval_seconds=2,
+        sleep=sleeps.append,
+    )
+
+    assert result["complete"] is True
+    assert failed is True
+    assert sleeps == [2]
+
+
+def test_complete_index_retries_transient_testpypi_crypto_propagation() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest, artifact_host="test-files.pythonhosted.org")
+    publisher = _publisher("release-testpypi")
+    records = {record["name"]: record for record in manifest["artifacts"]}
+    calls: list[tuple[str, str, str]] = []
+    sleeps: list[float] = []
+
+    def fetch(url: str) -> dict[str, Any]:
+        if "/pypi/" in url:
+            return payloads[url.split("/")[-3]]
+        filename = url.split("/")[-2]
+        return _provenance(records[filename], publisher)
+
+    def verify_crypto(
+        artifact: Mapping[str, Any],
+        provenance: Mapping[str, Any],
+        repository: str,
+    ) -> None:
+        filename = cast(str, artifact["name"])
+        assert provenance == _provenance(records[filename], publisher)
+        calls.append((filename, cast(str, artifact["url"]), repository))
+        if len(calls) == 1:
+            raise CryptographicVerificationError("TestPyPI provenance is still propagating")
+
+    result = verify_index(
+        manifest,
+        api_template="https://index.invalid/pypi/{distribution}/{version}/json",
+        integrity_template=(
+            "https://index.invalid/integrity/{distribution}/{version}/{filename}/provenance"
+        ),
+        publisher=publisher,
+        attestation_repository="https://github.com/VangelisTech/archetype",
+        registry_artifact_host="test-files.pythonhosted.org",
         require_complete=True,
         expected_commit=COMMIT,
         fetch=fetch,
@@ -379,12 +484,13 @@ def test_complete_index_retries_transient_staging_crypto_propagation() -> None:
         sleep=sleeps.append,
     )
 
-    assert result["cryptographic_provenance"]["staging"] is True
+    assert result["cryptographic_provenance"]["sigstore_environment"] == "production"
     assert result["cryptographic_provenance"]["artifact_count"] == 8
     assert len(calls) == 9
     assert all(
-        repository == "https://github.com/VangelisTech/archetype" and staging is True
-        for _filename, repository, staging in calls
+        artifact_url.startswith("https://test-files.pythonhosted.org/")
+        and repository == "https://github.com/VangelisTech/archetype"
+        for _filename, artifact_url, repository in calls
     )
     assert sleeps == [4]
 
@@ -394,7 +500,7 @@ def test_complete_index_exhausts_persistent_crypto_failure_with_diagnostics() ->
     payloads = _payloads(manifest)
     publisher = _publisher()
     records = {record["name"]: record for record in manifest["artifacts"]}
-    calls: list[tuple[str, str, bool]] = []
+    calls: list[tuple[str, str]] = []
     sleeps: list[float] = []
 
     def fetch(url: str) -> dict[str, Any]:
@@ -403,8 +509,13 @@ def test_complete_index_exhausts_persistent_crypto_failure_with_diagnostics() ->
         filename = url.split("/")[-2]
         return _provenance(records[filename], publisher)
 
-    def verify_crypto(filename: str, repository: str, staging: bool) -> None:
-        calls.append((filename, repository, staging))
+    def verify_crypto(
+        artifact: Mapping[str, Any],
+        _provenance: Mapping[str, Any],
+        repository: str,
+    ) -> None:
+        filename = cast(str, artifact["name"])
+        calls.append((filename, repository))
         raise CryptographicVerificationError(
             f"cryptographic provenance verification failed for {filename!r}\n"
             "stdout:\nregistry response\nstderr:\nbad signature"
@@ -425,6 +536,7 @@ def test_complete_index_exhausts_persistent_crypto_failure_with_diagnostics() ->
             ),
             publisher=publisher,
             attestation_repository="https://github.com/VangelisTech/archetype",
+            registry_artifact_host="files.pythonhosted.org",
             require_complete=True,
             expected_commit=COMMIT,
             fetch=fetch,
@@ -435,8 +547,7 @@ def test_complete_index_exhausts_persistent_crypto_failure_with_diagnostics() ->
         )
 
     assert len(calls) == 3
-    assert len({filename for filename, _repository, _staging in calls}) == 1
-    assert all(staging is False for _filename, _repository, staging in calls)
+    assert len({filename for filename, _repository in calls}) == 1
     assert sleeps == [2, 2]
 
 
@@ -461,7 +572,7 @@ def test_preflight_requires_provenance_and_crypto_for_exact_partial_upload() -> 
         "info": payloads[first["distribution"]]["info"],
         "urls": payloads[first["distribution"]]["urls"][:1],
     }
-    crypto: list[tuple[str, str, bool]] = []
+    crypto: list[tuple[str, str, str]] = []
 
     def fetch(url: str) -> dict[str, Any] | None:
         if "/integrity/" in url:
@@ -477,18 +588,25 @@ def test_preflight_requires_provenance_and_crypto_for_exact_partial_upload() -> 
         ),
         publisher=publisher,
         attestation_repository="https://github.com/VangelisTech/archetype",
+        registry_artifact_host="files.pythonhosted.org",
         require_complete=False,
         expected_commit=COMMIT,
         fetch=fetch,
-        verify_cryptographic_attestation=lambda *values: crypto.append(values),
+        verify_cryptographic_attestation=lambda artifact, provenance, repository: crypto.append(
+            (
+                cast(str, artifact["name"]),
+                cast(str, provenance["attestation_bundles"][0]["publisher"]["environment"]),
+                repository,
+            )
+        ),
     )
 
     assert result["artifact_count"] == 1
     assert crypto == [
         (
             first["name"],
+            "release-pypi",
             "https://github.com/VangelisTech/archetype",
-            False,
         )
     ]
 
@@ -506,6 +624,7 @@ def test_preflight_requires_provenance_and_crypto_for_exact_partial_upload() -> 
             ),
             publisher=publisher,
             attestation_repository="https://github.com/VangelisTech/archetype",
+            registry_artifact_host="files.pythonhosted.org",
             require_complete=False,
             expected_commit=COMMIT,
             fetch=token_upload,
@@ -513,25 +632,233 @@ def test_preflight_requires_provenance_and_crypto_for_exact_partial_upload() -> 
         )
 
 
-def test_cryptographic_verifier_is_pinned_and_preserves_failure_output(
+def test_testpypi_verifier_uses_local_files_and_production_sigstore(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         "scripts.verify_release_index.importlib.metadata.version",
         lambda _name: "0.0.30",
     )
+    filename = "archetype_ecs-0.6.0-py3-none-any.whl"
+    distribution_bytes = b"exact TestPyPI artifact bytes"
+    provenance = {"version": 1, "attestation_bundles": []}
+    artifact = {
+        "name": filename,
+        "sha256": hashlib.sha256(distribution_bytes).hexdigest(),
+        "size_bytes": len(distribution_bytes),
+        "url": f"https://test-files.pythonhosted.org/packages/{filename}",
+    }
     calls: list[list[str]] = []
+    observed_files: list[tuple[bytes, dict[str, Any]]] = []
 
     def fail(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         calls.append(command)
+        provenance_path = Path(command[command.index("--provenance-file") + 1])
+        observed_files.append(
+            (
+                Path(command[-1]).read_bytes(),
+                json.loads(provenance_path.read_text(encoding="utf-8")),
+            )
+        )
         return subprocess.CompletedProcess(command, 1, "verification output", "bad signature")
 
     with pytest.raises(RuntimeError, match=r"(?s)verification output.*bad signature"):
         verify_attestation(
-            "archetype_ecs-0.6.0-py3-none-any.whl",
+            artifact,
+            provenance,
             "https://github.com/VangelisTech/archetype",
-            True,
             run=fail,
+            fetch_bytes=lambda url, expected_size: (
+                distribution_bytes
+                if url == artifact["url"] and expected_size == len(distribution_bytes)
+                else pytest.fail(f"unexpected artifact download: url={url}, size={expected_size}")
+            ),
         )
 
-    assert calls[0][-2:] == ["--staging", "pypi:archetype_ecs-0.6.0-py3-none-any.whl"]
+    assert calls[0][-1].endswith(filename)
+    assert "--staging" not in calls[0]
+    assert not any(value.startswith("pypi:") for value in calls[0])
+    assert observed_files == [(distribution_bytes, provenance)]
+
+
+@pytest.mark.parametrize(
+    "downloaded",
+    [
+        b"different registry bytes",
+        b"EXPECTED REGISTRY BYTES",
+    ],
+)
+def test_cryptographic_verifier_rejects_downloaded_byte_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    downloaded: bytes,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.verify_release_index.importlib.metadata.version",
+        lambda _name: "0.0.30",
+    )
+    filename = "archetype_ecs-0.6.0.tar.gz"
+    expected = b"expected registry bytes"
+    artifact = {
+        "name": filename,
+        "sha256": hashlib.sha256(expected).hexdigest(),
+        "size_bytes": len(expected),
+        "url": f"https://files.pythonhosted.org/packages/{filename}",
+    }
+
+    with pytest.raises(CryptographicVerificationError, match="unexpected bytes"):
+        verify_attestation(
+            artifact,
+            {"version": 1},
+            "https://github.com/VangelisTech/archetype",
+            run=lambda *_args, **_kwargs: pytest.fail("verifier must not run"),
+            fetch_bytes=lambda _url, _expected_size: downloaded,
+        )
+
+
+def test_index_rejects_cross_registry_artifact_url() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+
+    with pytest.raises(ValueError, match="unexpected download URL"):
+        verify_payloads(
+            manifest,
+            payloads,
+            require_complete=True,
+            expected_commit=COMMIT,
+            expected_artifact_host="test-files.pythonhosted.org",
+        )
+
+
+def test_cryptographic_verifier_wraps_transient_download_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.verify_release_index.importlib.metadata.version",
+        lambda _name: "0.0.30",
+    )
+    filename = "archetype_ecs-0.6.0.tar.gz"
+    artifact = {
+        "name": filename,
+        "sha256": hashlib.sha256(b"artifact").hexdigest(),
+        "size_bytes": len(b"artifact"),
+        "url": f"https://files.pythonhosted.org/packages/{filename}",
+    }
+
+    def fail_download(_url: str, _expected_size: int) -> bytes:
+        raise TimeoutError("registry read timed out")
+
+    with pytest.raises(
+        CryptographicVerificationError,
+        match=r"could not fetch.*registry read timed out",
+    ):
+        verify_attestation(
+            artifact,
+            {"version": 1},
+            "https://github.com/VangelisTech/archetype",
+            run=lambda *_args, **_kwargs: pytest.fail("verifier must not run"),
+            fetch_bytes=fail_download,
+        )
+
+
+def test_cryptographic_verifier_bounds_subprocess_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.verify_release_index.importlib.metadata.version",
+        lambda _name: "0.0.30",
+    )
+    filename = "archetype_ecs-0.6.0.tar.gz"
+    distribution_bytes = b"artifact"
+    artifact = {
+        "name": filename,
+        "sha256": hashlib.sha256(distribution_bytes).hexdigest(),
+        "size_bytes": len(distribution_bytes),
+        "url": f"https://files.pythonhosted.org/packages/{filename}",
+    }
+
+    def timeout(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        timeout_seconds = cast(float, kwargs["timeout"])
+        raise subprocess.TimeoutExpired(command, timeout_seconds)
+
+    with pytest.raises(CryptographicVerificationError, match="timed out.*180 seconds"):
+        verify_attestation(
+            artifact,
+            {"version": 1},
+            "https://github.com/VangelisTech/archetype",
+            run=timeout,
+            fetch_bytes=lambda _url, _expected_size: distribution_bytes,
+        )
+
+
+def test_artifact_downloader_rejects_redirects() -> None:
+    target_requests: list[str] = []
+
+    class RedirectHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler protocol
+            if self.path == "/redirect":
+                self.send_response(302)
+                self.send_header("Location", "/target")
+                self.end_headers()
+                return
+            target_requests.append(self.path)
+            self.send_response(200)
+            self.send_header("Content-Length", "8")
+            self.end_headers()
+            self.wfile.write(b"artifact")
+
+        def log_message(self, format: str, *args: Any) -> None:
+            del format, args
+            return None
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = cast(tuple[str, int], server.server_address)
+        with pytest.raises(RuntimeError, match="HTTP 302"):
+            release_index._fetch_bytes(f"http://{host}:{port}/redirect", 8)
+        assert target_requests == []
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
+def test_artifact_downloader_caps_response_at_expected_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class OversizedResponse:
+        headers: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.read_sizes: list[int] = []
+
+        def __enter__(self) -> OversizedResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self, size: int) -> bytes:
+            self.read_sizes.append(size)
+            return b"x" * size
+
+    class OversizedOpener:
+        def __init__(self, response: OversizedResponse) -> None:
+            self.response = response
+
+        def open(self, _url: str, *, timeout: int) -> OversizedResponse:
+            assert timeout == 30
+            return self.response
+
+    response = OversizedResponse()
+    monkeypatch.setattr(release_index, "_ARTIFACT_OPENER", OversizedOpener(response))
+
+    with pytest.raises(RuntimeError, match="unexpected size"):
+        release_index._fetch_bytes(
+            "https://files.pythonhosted.org/packages/artifact.whl",
+            8,
+        )
+
+    assert response.read_sizes == [9]

--- a/tests/scripts/test_release_index.py
+++ b/tests/scripts/test_release_index.py
@@ -14,6 +14,7 @@ import pytest
 
 from scripts.release_artifact import DISTRIBUTIONS, SCHEMA
 from scripts.verify_release_index import (
+    CryptographicVerificationError,
     IncompleteIndexError,
     verify_attestation,
     verify_index,
@@ -339,6 +340,104 @@ def test_complete_index_retries_provenance_propagation() -> None:
     assert result["provenance"]["artifact_count"] == 8
     assert result["index_api_template"].startswith("https://index.invalid/")
     assert sleeps == [3]
+
+
+def test_complete_index_retries_transient_staging_crypto_propagation() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    publisher = _publisher("release-testpypi")
+    records = {record["name"]: record for record in manifest["artifacts"]}
+    calls: list[tuple[str, str, bool]] = []
+    sleeps: list[float] = []
+
+    def fetch(url: str) -> dict[str, Any]:
+        if "/pypi/" in url:
+            return payloads[url.split("/")[-3]]
+        filename = url.split("/")[-2]
+        return _provenance(records[filename], publisher)
+
+    def verify_crypto(filename: str, repository: str, staging: bool) -> None:
+        calls.append((filename, repository, staging))
+        if len(calls) == 1:
+            raise CryptographicVerificationError("staging provenance is still propagating")
+
+    result = verify_index(
+        manifest,
+        api_template="https://index.invalid/pypi/{distribution}/{version}/json",
+        integrity_template=(
+            "https://index.invalid/integrity/{distribution}/{version}/{filename}/provenance"
+        ),
+        publisher=publisher,
+        attestation_repository="https://github.com/VangelisTech/archetype",
+        attestation_staging=True,
+        require_complete=True,
+        expected_commit=COMMIT,
+        fetch=fetch,
+        verify_cryptographic_attestation=verify_crypto,
+        attempts=2,
+        interval_seconds=4,
+        sleep=sleeps.append,
+    )
+
+    assert result["cryptographic_provenance"]["staging"] is True
+    assert result["cryptographic_provenance"]["artifact_count"] == 8
+    assert len(calls) == 9
+    assert all(
+        repository == "https://github.com/VangelisTech/archetype" and staging is True
+        for _filename, repository, staging in calls
+    )
+    assert sleeps == [4]
+
+
+def test_complete_index_exhausts_persistent_crypto_failure_with_diagnostics() -> None:
+    manifest = _manifest()
+    payloads = _payloads(manifest)
+    publisher = _publisher()
+    records = {record["name"]: record for record in manifest["artifacts"]}
+    calls: list[tuple[str, str, bool]] = []
+    sleeps: list[float] = []
+
+    def fetch(url: str) -> dict[str, Any]:
+        if "/pypi/" in url:
+            return payloads[url.split("/")[-3]]
+        filename = url.split("/")[-2]
+        return _provenance(records[filename], publisher)
+
+    def verify_crypto(filename: str, repository: str, staging: bool) -> None:
+        calls.append((filename, repository, staging))
+        raise CryptographicVerificationError(
+            f"cryptographic provenance verification failed for {filename!r}\n"
+            "stdout:\nregistry response\nstderr:\nbad signature"
+        )
+
+    with pytest.raises(
+        CryptographicVerificationError,
+        match=(
+            r"(?s)exhausted 3 attempt\(s\).*cryptographic provenance verification failed"
+            r".*registry response.*bad signature"
+        ),
+    ):
+        verify_index(
+            manifest,
+            api_template="https://index.invalid/pypi/{distribution}/{version}/json",
+            integrity_template=(
+                "https://index.invalid/integrity/{distribution}/{version}/{filename}/provenance"
+            ),
+            publisher=publisher,
+            attestation_repository="https://github.com/VangelisTech/archetype",
+            require_complete=True,
+            expected_commit=COMMIT,
+            fetch=fetch,
+            verify_cryptographic_attestation=verify_crypto,
+            attempts=3,
+            interval_seconds=2,
+            sleep=sleeps.append,
+        )
+
+    assert len(calls) == 3
+    assert len({filename for filename, _repository, _staging in calls}) == 1
+    assert all(staging is False for _filename, _repository, staging in calls)
+    assert sleeps == [2, 2]
 
 
 def test_remote_verifier_rejects_non_https_templates() -> None:

--- a/tests/scripts/test_release_index.py
+++ b/tests/scripts/test_release_index.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 import pytest
 
 from scripts import verify_release_index as release_index
-from scripts.release_artifact import DISTRIBUTIONS, SCHEMA
+from scripts.release_artifact import DISTRIBUTIONS, PUBLISHER_WORKFLOWS, SCHEMA
 from scripts.verify_release_index import (
     CryptographicVerificationError,
     IncompleteIndexError,
@@ -98,12 +98,15 @@ def _publisher(environment: str = "release-pypi") -> dict[str, str]:
     return {
         "kind": "GitHub",
         "repository": "VangelisTech/archetype",
-        "workflow": "release.yml",
         "environment": environment,
     }
 
 
 def _provenance(record: dict[str, Any], publisher: dict[str, str]) -> dict[str, Any]:
+    exact_publisher = {
+        **publisher,
+        "workflow": PUBLISHER_WORKFLOWS[record["distribution"]],
+    }
     statement = {
         "_type": "https://in-toto.io/Statement/v1",
         "subject": [
@@ -120,7 +123,7 @@ def _provenance(record: dict[str, Any], publisher: dict[str, str]) -> dict[str, 
         "version": 1,
         "attestation_bundles": [
             {
-                "publisher": dict(publisher),
+                "publisher": exact_publisher,
                 "attestations": [{"envelope": {"statement": encoded}}],
             }
         ],
@@ -323,7 +326,13 @@ def test_provenance_binds_every_file_to_exact_publisher_and_digest() -> None:
     evidence = verify_provenance(result["artifacts"], provenances, publisher=publisher)
 
     assert evidence == {
-        "publisher": publisher,
+        "publishers": {
+            distribution: {
+                **publisher,
+                "workflow": PUBLISHER_WORKFLOWS[distribution],
+            }
+            for distribution in DISTRIBUTIONS
+        },
         "artifact_count": 8,
         "artifacts": sorted(provenances),
     }

--- a/tests/scripts/test_verify_publisher_dispatch.py
+++ b/tests/scripts/test_verify_publisher_dispatch.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for release-authorized distribution publisher dispatches."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from scripts.release_artifact import PUBLISHER_WORKFLOWS
+from scripts.verify_publisher_dispatch import verify_publisher_dispatch
+
+_AUTOMATION_ACTOR = "github-actions[bot]"
+_COMMIT = "a" * 40
+_DISTRIBUTION = "archetype-missions"
+_PARENT_RUN_ATTEMPT = 2
+_PARENT_RUN_ID = 101
+_REPOSITORY = "VangelisTech/archetype"
+_TAG = "v0.6.0"
+_WORKFLOW = "publish-archetype-missions.yml"
+
+
+def _run_ids() -> dict[str, int]:
+    return {
+        distribution: 201 + index
+        for index, (distribution, workflow) in enumerate(PUBLISHER_WORKFLOWS.items())
+        if workflow != "release.yml"
+    }
+
+
+def _parent_run() -> dict[str, Any]:
+    return {
+        "id": _PARENT_RUN_ID,
+        "run_attempt": _PARENT_RUN_ATTEMPT,
+        "event": "workflow_dispatch",
+        "path": ".github/workflows/release.yml",
+        "head_sha": _COMMIT,
+        "head_branch": _TAG,
+        "status": "in_progress",
+        "conclusion": None,
+        "repository": {"full_name": _REPOSITORY},
+        "actor": {"login": "everettVT"},
+        "triggering_actor": {"login": "everettVT"},
+    }
+
+
+def _allowlist() -> dict[str, Any]:
+    run_ids = _run_ids()
+    return {
+        "schema": "archetype.publisher-dispatch/v1",
+        "repository": _REPOSITORY,
+        "parent_run_id": _PARENT_RUN_ID,
+        "parent_run_attempt": _PARENT_RUN_ATTEMPT,
+        "tag": _TAG,
+        "commit": _COMMIT,
+        "registry": "testpypi",
+        "runs": [
+            {
+                "distribution": distribution,
+                "workflow": workflow,
+                "run_id": run_ids[distribution],
+                "url": (f"https://github.com/{_REPOSITORY}/actions/runs/{run_ids[distribution]}"),
+            }
+            for distribution, workflow in PUBLISHER_WORKFLOWS.items()
+            if workflow != "release.yml"
+        ],
+    }
+
+
+def _arguments() -> dict[str, Any]:
+    return {
+        "repository": _REPOSITORY,
+        "event_name": "workflow_dispatch",
+        "ref": f"refs/tags/{_TAG}",
+        "ref_name": _TAG,
+        "ref_type": "tag",
+        "commit": _COMMIT,
+        "workflow_ref": (f"{_REPOSITORY}/.github/workflows/{_WORKFLOW}@refs/tags/{_TAG}"),
+        "actor": _AUTOMATION_ACTOR,
+        "triggering_actor": _AUTOMATION_ACTOR,
+        "expected_workflow": _WORKFLOW,
+        "distribution": _DISTRIBUTION,
+        "child_run_id": _run_ids()[_DISTRIBUTION],
+        "parent_run_id": _PARENT_RUN_ID,
+        "parent_run_attempt": _PARENT_RUN_ATTEMPT,
+        "parent_run": _parent_run(),
+        "allowlist": _allowlist(),
+        "tag": _TAG,
+        "expected_commit": _COMMIT,
+        "registry": "testpypi",
+    }
+
+
+def test_verify_publisher_dispatch_accepts_allowlisted_bot_child_and_live_parent() -> None:
+    result = verify_publisher_dispatch(**_arguments())
+
+    assert result == {
+        "repository": _REPOSITORY,
+        "workflow": _WORKFLOW,
+        "tag": _TAG,
+        "commit": _COMMIT,
+        "registry": "testpypi",
+        "environment": "release-testpypi",
+        "child_run_id": _run_ids()[_DISTRIBUTION],
+        "parent_run_id": _PARENT_RUN_ID,
+        "parent_run_attempt": _PARENT_RUN_ATTEMPT,
+    }
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        f".github/workflows/release.yml@{_TAG}",
+        f".github/workflows/release.yml@refs/tags/{_TAG}",
+    ],
+)
+def test_verify_publisher_dispatch_accepts_ref_qualified_parent_path(path: str) -> None:
+    arguments = _arguments()
+    arguments["parent_run"]["path"] = path
+
+    verify_publisher_dispatch(**arguments)
+
+
+@pytest.mark.parametrize("field", ["actor", "triggering_actor"])
+def test_verify_publisher_dispatch_rejects_manual_child_actor(field: str) -> None:
+    arguments = _arguments()
+    arguments[field] = "everettVT"
+
+    with pytest.raises(PermissionError, match="release workflow token"):
+        verify_publisher_dispatch(**arguments)
+
+
+def test_verify_publisher_dispatch_rejects_child_run_not_in_allowlist() -> None:
+    arguments = _arguments()
+    selected = next(
+        run for run in arguments["allowlist"]["runs"] if run["distribution"] == _DISTRIBUTION
+    )
+    selected["run_id"] += 1000
+    selected["url"] = f"https://github.com/{_REPOSITORY}/actions/runs/{selected['run_id']}"
+
+    with pytest.raises(PermissionError, match="not authorized"):
+        verify_publisher_dispatch(**arguments)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("expected_workflow", "unknown.yml", "not registered"),
+        (
+            "expected_workflow",
+            "publish-archetype-physical-ai.yml",
+            "distribution and workflow differ",
+        ),
+        ("distribution", "archetype-physical-ai", "distribution and workflow differ"),
+    ],
+)
+def test_verify_publisher_dispatch_rejects_wrong_workflow_or_distribution(
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    arguments = _arguments()
+    arguments[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        verify_publisher_dispatch(**arguments)
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("id", "identity differs"),
+        ("path", "not the release workflow"),
+        ("status", "not actively coordinating"),
+        ("actor", "actor must be everettVT"),
+        ("triggering_actor", "triggering actor must be everettVT"),
+        ("tag", "exact tag commit"),
+        ("sha", "exact tag commit"),
+        ("attempt", "attempt differs"),
+        ("repository", "another repository"),
+    ],
+)
+def test_verify_publisher_dispatch_rejects_wrong_parent_run(
+    case: str,
+    message: str,
+) -> None:
+    arguments = _arguments()
+    parent = arguments["parent_run"]
+    if case == "id":
+        parent["id"] += 1
+    elif case == "path":
+        parent["path"] = ".github/workflows/other.yml"
+    elif case == "status":
+        parent["status"] = "completed"
+        parent["conclusion"] = "success"
+    elif case == "actor":
+        parent["actor"] = {"login": "someone-else"}
+    elif case == "triggering_actor":
+        parent["triggering_actor"] = {"login": "someone-else"}
+    elif case == "tag":
+        parent["head_branch"] = "v0.6.1"
+    elif case == "sha":
+        parent["head_sha"] = "b" * 40
+    elif case == "attempt":
+        parent["run_attempt"] += 1
+    elif case == "repository":
+        parent["repository"] = {"full_name": "someone-else/archetype"}
+
+    with pytest.raises(PermissionError, match=message):
+        verify_publisher_dispatch(**arguments)
+
+
+@pytest.mark.parametrize(
+    ("case", "error", "message"),
+    [
+        ("schema", PermissionError, "unsupported schema"),
+        ("extra_top_level", PermissionError, "unexpected fields"),
+        ("not_a_list", PermissionError, "incomplete run matrix"),
+        ("missing", PermissionError, "incomplete run matrix"),
+        ("duplicate", PermissionError, "invalid run"),
+        ("wrong_workflow", PermissionError, "invalid run"),
+        ("boolean_run_id", PermissionError, "invalid run"),
+        ("wrong_url", PermissionError, "invalid run"),
+        ("non_object", TypeError, "must be an object"),
+        ("extra_run_field", PermissionError, "unexpected fields"),
+    ],
+)
+def test_verify_publisher_dispatch_rejects_malformed_allowlist_matrix(
+    case: str,
+    error: type[Exception],
+    message: str,
+) -> None:
+    arguments = _arguments()
+    allowlist = deepcopy(arguments["allowlist"])
+    arguments["allowlist"] = allowlist
+    runs = allowlist["runs"]
+    if case == "schema":
+        allowlist["schema"] = "archetype.publisher-dispatch/v2"
+    elif case == "extra_top_level":
+        allowlist["extra"] = True
+    elif case == "not_a_list":
+        allowlist["runs"] = {}
+    elif case == "missing":
+        runs.pop()
+    elif case == "duplicate":
+        runs[1] = deepcopy(runs[0])
+    elif case == "wrong_workflow":
+        runs[0]["workflow"] = "other.yml"
+    elif case == "boolean_run_id":
+        runs[0]["run_id"] = True
+    elif case == "wrong_url":
+        runs[0]["url"] += "?download=1"
+    elif case == "non_object":
+        runs[0] = "not-an-object"
+    elif case == "extra_run_field":
+        runs[0]["extra"] = True
+
+    with pytest.raises(error, match=message):
+        verify_publisher_dispatch(**arguments)

--- a/tests/scripts/test_verify_release_ref.py
+++ b/tests/scripts/test_verify_release_ref.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for immediate pre-publication ref authorization."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_release_ref import verify_release_ref
+
+COMMIT = "a" * 40
+
+
+def _run(
+    command: list[str],
+    **_kwargs: object,
+) -> subprocess.CompletedProcess[str]:
+    if command[1:3] == ["rev-parse", "HEAD"]:
+        return subprocess.CompletedProcess(command, 0, stdout=COMMIT + "\n", stderr="")
+    return subprocess.CompletedProcess(
+        command,
+        0,
+        stdout=f"{'b' * 40}\trefs/tags/v0.6.0\n{COMMIT}\trefs/tags/v0.6.0^{{}}\n",
+        stderr="",
+    )
+
+
+def test_release_ref_accepts_exact_annotated_tag_and_operator(tmp_path: Path) -> None:
+    result = verify_release_ref(
+        root=tmp_path,
+        tag="v0.6.0",
+        expected_commit=COMMIT,
+        repository="VangelisTech/archetype",
+        actor="everettVT",
+        triggering_actor="everettVT",
+        run=_run,
+    )
+
+    assert result["commit"] == COMMIT
+    assert result["tag"] == "v0.6.0"
+
+
+def test_release_ref_rejects_rerun_by_another_actor(tmp_path: Path) -> None:
+    with pytest.raises(PermissionError, match="requires everettVT"):
+        verify_release_ref(
+            root=tmp_path,
+            tag="v0.6.0",
+            expected_commit=COMMIT,
+            repository="VangelisTech/archetype",
+            actor="everettVT",
+            triggering_actor="another-user",
+            run=_run,
+        )
+
+
+def test_release_ref_rejects_moved_remote_tag(tmp_path: Path) -> None:
+    def moved(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if command[1:3] == ["rev-parse", "HEAD"]:
+            return _run(command, **kwargs)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=f"{'b' * 40}\trefs/tags/v0.6.0\n",
+            stderr="",
+        )
+
+    with pytest.raises(ValueError, match="release tag moved"):
+        verify_release_ref(
+            root=tmp_path,
+            tag="v0.6.0",
+            expected_commit=COMMIT,
+            repository="VangelisTech/archetype",
+            actor="everettVT",
+            triggering_actor="everettVT",
+            run=moved,
+        )
+
+
+def test_release_ref_rejects_duplicate_remote_evidence(tmp_path: Path) -> None:
+    def duplicate(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if command[1:3] == ["rev-parse", "HEAD"]:
+            return _run(command, **kwargs)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(f"{COMMIT}\trefs/tags/v0.6.0\n{COMMIT}\trefs/tags/v0.6.0\n"),
+            stderr="",
+        )
+
+    with pytest.raises(ValueError, match="duplicate tag evidence"):
+        verify_release_ref(
+            root=tmp_path,
+            tag="v0.6.0",
+            expected_commit=COMMIT,
+            repository="VangelisTech/archetype",
+            actor="everettVT",
+            triggering_actor="everettVT",
+            run=duplicate,
+        )

--- a/tests/scripts/test_world_library_docs.py
+++ b/tests/scripts/test_world_library_docs.py
@@ -91,6 +91,18 @@ def test_pending_trusted_publishers_do_not_claim_new_project_names() -> None:
         assert "remains claimable until the first successful oidc publication" in content
 
 
+def test_contributing_names_each_trusted_publisher_workflow() -> None:
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+    for workflow in (
+        "release.yml",
+        "publish-archetype-missions.yml",
+        "publish-archetype-physical-ai.yml",
+        "publish-archetype-research.yml",
+    ):
+        assert f"`{workflow}`" in contributing
+
+
 def test_missions_reference_renders_the_primary_workflow_methods() -> None:
     runtime = (ROOT / "packages/archetype-missions/src/archetype/missions/runtime.py").read_text(
         encoding="utf-8"

--- a/tests/scripts/test_world_library_docs.py
+++ b/tests/scripts/test_world_library_docs.py
@@ -76,6 +76,21 @@ def test_clean_break_release_note_is_reader_visible() -> None:
     assert "guide/release-0.6.md" in navigation
 
 
+def test_pending_trusted_publishers_do_not_claim_new_project_names() -> None:
+    release_docs = (
+        ROOT / "CONTRIBUTING.md",
+        ROOT / "docs/guide/release-0.6.md",
+        ROOT / "docs/guide/repository-harness.md",
+    )
+
+    for path in release_docs:
+        content = " ".join(path.read_text(encoding="utf-8").lower().split())
+        assert "register pending trusted publishers" in content
+        assert "preconfigur" in content
+        assert "does not reserve or claim" in content
+        assert "remains claimable until the first successful oidc publication" in content
+
+
 def test_missions_reference_renders_the_primary_workflow_methods() -> None:
     runtime = (ROOT / "packages/archetype-missions/src/archetype/missions/runtime.py").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Stack

**3 / 4 — release artifacts and registry provenance**

Depends on #789, which depends on #787. Review only the commits and diff from
`architecture-review-api-surface` to this branch.

- #787 — distribution foundation
- #789 — supported API and normative documentation
- **#790 — release artifacts and registry provenance (this PR)**
- #791 — hosted publisher hardening

## Summary

- derive package-smoke expectations from the coordinated release version
- build the four wheels and four source distributions exactly once per release
  verification run and reuse that immutable artifact set
- bind the artifact manifest to the exact commit, filenames, sizes, and
  SHA-256 digests
- verify TestPyPI/PyPI project versions, distribution metadata, integrity
  attestations, repository/workflow/environment identity, and artifact digests
- retry only registry attestation propagation; never re-upload an artifact
- document that pending Trusted Publishers configure OIDC but do not reserve
  the three new project names

## Review focus

- provenance authority and failure-closed behavior
- the one-build/eight-artifact invariant
- registry propagation retry boundaries
- coordinated-version assumptions across the four distributions

## Validation

- `make ci`
- 3,116 passed, 21 skipped
- all static/security/architecture/contract audits green
- installed operation matrix: 37 / 44 / 38 / 38 / 46 / 46
