### PR TITLE
fix: reauthorize hosted Archetype 0.6 publication

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Keep actionlint's runner model aligned with the repository-owned release
+# runner group. Built-in self-hosted, macOS, and ARM64 labels need no entry.
+self-hosted-runner:
+  labels:
+    - archetype-apple-container-macos-26

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -172,11 +172,12 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: f11df81ebc1ba9b7450c59398474827a
+          DOCS_DEPLOY_BRANCH: ${{ github.head_ref || 'main' }}
         run: |
           set -o pipefail
           npx --yes wrangler pages deploy site/ \
             --project-name=archetype-docs \
-            --branch=${{ github.head_ref || 'main' }} \
+            --branch="$DOCS_DEPLOY_BRANCH" \
             --commit-dirty=true 2>&1 | tee /tmp/deploy.log
           url=$(grep -oP 'https://[a-z0-9-]+\.archetype-docs\.pages\.dev' /tmp/deploy.log | head -1)
           if [ -z "$url" ]; then

--- a/.github/workflows/publish-archetype-missions.yml
+++ b/.github/workflows/publish-archetype-missions.yml
@@ -19,6 +19,10 @@ on:
         description: "Exact release commit"
         required: true
         type: string
+      expected_tag_object:
+        description: "Exact immutable release tag object"
+        required: true
+        type: string
       registry:
         description: "Destination package registry"
         required: true
@@ -79,6 +83,7 @@ jobs:
         env:
           CHILD_RUN_ID: ${{ github.run_id }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
           GITHUB_TOKEN: ${{ github.token }}
           PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
           PARENT_RUN_ID: ${{ inputs.parent_run_id }}
@@ -93,6 +98,7 @@ jobs:
           --parent-run-attempt "$PARENT_RUN_ATTEMPT"
           --tag "$PUBLISHER_TAG"
           --expected-commit "$EXPECTED_COMMIT"
+          --expected-tag-object "$EXPECTED_TAG_OBJECT"
           --registry "$PUBLISHER_REGISTRY"
           --allowlist
           ".context/publisher-dispatch/publisher-dispatch-$PUBLISHER_REGISTRY.json"
@@ -113,6 +119,153 @@ jobs:
           path: dist/
           run-id: ${{ inputs.parent_run_id }}
           github-token: ${{ github.token }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch-live/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Reauthorize the live parent release
+        shell: bash
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_DISTRIBUTION: archetype-missions
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+          PUBLISHER_WORKFLOW: publish-archetype-missions.yml
+        run: |
+          set -euo pipefail
+          fail() { echo "parent release check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] || fail "wrong event"
+          [[ "$GITHUB_ACTOR" == "github-actions[bot]" ]] || fail "wrong actor"
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "github-actions[bot]" ]] || fail "wrong triggering actor"
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent run ID"
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent attempt"
+          [[ "$CHILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid child run ID"
+          [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid release commit"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid tag object"
+          [[ "$PUBLISHER_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "invalid release tag"
+          [[ "$PUBLISHER_REGISTRY" == "testpypi" || "$PUBLISHER_REGISTRY" == "pypi" ]] || fail "invalid registry"
+          [[ "$GITHUB_SHA" == "$EXPECTED_COMMIT" ]] || fail "child commit differs"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/$PUBLISHER_WORKFLOW@refs/tags/$PUBLISHER_TAG"
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]] || fail "child workflow differs"
+
+          allowlist=".context/publisher-dispatch-live/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+          child_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$CHILD_RUN_ID"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --arg tag_object "$EXPECTED_TAG_OBJECT" \
+            --arg registry "$PUBLISHER_REGISTRY" \
+            --arg distribution "$PUBLISHER_DISTRIBUTION" \
+            --arg workflow "$PUBLISHER_WORKFLOW" \
+            --arg url "$child_url" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            --argjson child_run_id "$CHILD_RUN_ID" \
+            '
+              type == "object" and
+              (keys | sort) ==
+                (["schema", "repository", "parent_run_id", "parent_run_attempt",
+                  "tag", "commit", "tag_object", "registry", "runs"] | sort) and
+              .schema == "archetype.publisher-dispatch/v2" and
+              .repository == $repository and
+              .parent_run_id == $parent_run_id and
+              .parent_run_attempt == $parent_run_attempt and
+              .tag == $tag and
+              .commit == $commit and
+              .tag_object == $tag_object and
+              .registry == $registry and
+              (.runs | type) == "array" and
+              ([.runs[] | select(
+                type == "object" and
+                (keys | sort) == (["distribution", "workflow", "run_id", "url"] | sort) and
+                .distribution == $distribution and
+                .workflow == $workflow and
+                .run_id == $child_run_id and
+                .url == $url
+              )] | length) == 1
+            ' "$allowlist" >/dev/null || fail "child run is not allowlisted"
+
+          parent_json="$(gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID")" || fail "parent lookup failed"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            '
+              type == "object" and
+              .id == $parent_run_id and
+              .run_attempt == $parent_run_attempt and
+              .event == "workflow_dispatch" and
+              (.path == ".github/workflows/release.yml" or
+                .path == (".github/workflows/release.yml@" + $tag) or
+                .path == (".github/workflows/release.yml@refs/tags/" + $tag)) and
+              .head_sha == $commit and
+              .head_branch == $tag and
+              .status == "in_progress" and
+              .conclusion == null and
+              .repository.full_name == $repository and
+              .actor.login == "everettVT" and
+              .triggering_actor.login == "everettVT"
+            ' <<< "$parent_json" >/dev/null || fail "parent is no longer authorized and live"
+      - name: Reauthorize the remote release tag
+        shell: bash
+        env:
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          fail() { echo "release tag check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "authorized tag object is not 40-hex"
+
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          [[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]] || fail "remote tag object differs"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -135,6 +288,153 @@ jobs:
           path: dist/
           run-id: ${{ inputs.parent_run_id }}
           github-token: ${{ github.token }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch-live/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Reauthorize the live parent release
+        shell: bash
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_DISTRIBUTION: archetype-missions
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+          PUBLISHER_WORKFLOW: publish-archetype-missions.yml
+        run: |
+          set -euo pipefail
+          fail() { echo "parent release check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] || fail "wrong event"
+          [[ "$GITHUB_ACTOR" == "github-actions[bot]" ]] || fail "wrong actor"
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "github-actions[bot]" ]] || fail "wrong triggering actor"
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent run ID"
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent attempt"
+          [[ "$CHILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid child run ID"
+          [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid release commit"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid tag object"
+          [[ "$PUBLISHER_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "invalid release tag"
+          [[ "$PUBLISHER_REGISTRY" == "testpypi" || "$PUBLISHER_REGISTRY" == "pypi" ]] || fail "invalid registry"
+          [[ "$GITHUB_SHA" == "$EXPECTED_COMMIT" ]] || fail "child commit differs"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/$PUBLISHER_WORKFLOW@refs/tags/$PUBLISHER_TAG"
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]] || fail "child workflow differs"
+
+          allowlist=".context/publisher-dispatch-live/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+          child_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$CHILD_RUN_ID"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --arg tag_object "$EXPECTED_TAG_OBJECT" \
+            --arg registry "$PUBLISHER_REGISTRY" \
+            --arg distribution "$PUBLISHER_DISTRIBUTION" \
+            --arg workflow "$PUBLISHER_WORKFLOW" \
+            --arg url "$child_url" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            --argjson child_run_id "$CHILD_RUN_ID" \
+            '
+              type == "object" and
+              (keys | sort) ==
+                (["schema", "repository", "parent_run_id", "parent_run_attempt",
+                  "tag", "commit", "tag_object", "registry", "runs"] | sort) and
+              .schema == "archetype.publisher-dispatch/v2" and
+              .repository == $repository and
+              .parent_run_id == $parent_run_id and
+              .parent_run_attempt == $parent_run_attempt and
+              .tag == $tag and
+              .commit == $commit and
+              .tag_object == $tag_object and
+              .registry == $registry and
+              (.runs | type) == "array" and
+              ([.runs[] | select(
+                type == "object" and
+                (keys | sort) == (["distribution", "workflow", "run_id", "url"] | sort) and
+                .distribution == $distribution and
+                .workflow == $workflow and
+                .run_id == $child_run_id and
+                .url == $url
+              )] | length) == 1
+            ' "$allowlist" >/dev/null || fail "child run is not allowlisted"
+
+          parent_json="$(gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID")" || fail "parent lookup failed"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            '
+              type == "object" and
+              .id == $parent_run_id and
+              .run_attempt == $parent_run_attempt and
+              .event == "workflow_dispatch" and
+              (.path == ".github/workflows/release.yml" or
+                .path == (".github/workflows/release.yml@" + $tag) or
+                .path == (".github/workflows/release.yml@refs/tags/" + $tag)) and
+              .head_sha == $commit and
+              .head_branch == $tag and
+              .status == "in_progress" and
+              .conclusion == null and
+              .repository.full_name == $repository and
+              .actor.login == "everettVT" and
+              .triggering_actor.login == "everettVT"
+            ' <<< "$parent_json" >/dev/null || fail "parent is no longer authorized and live"
+      - name: Reauthorize the remote release tag
+        shell: bash
+        env:
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          fail() { echo "release tag check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "authorized tag object is not 40-hex"
+
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          [[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]] || fail "remote tag object differs"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true

--- a/.github/workflows/publish-archetype-physical-ai.yml
+++ b/.github/workflows/publish-archetype-physical-ai.yml
@@ -19,6 +19,10 @@ on:
         description: "Exact release commit"
         required: true
         type: string
+      expected_tag_object:
+        description: "Exact immutable release tag object"
+        required: true
+        type: string
       registry:
         description: "Destination package registry"
         required: true
@@ -79,6 +83,7 @@ jobs:
         env:
           CHILD_RUN_ID: ${{ github.run_id }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
           GITHUB_TOKEN: ${{ github.token }}
           PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
           PARENT_RUN_ID: ${{ inputs.parent_run_id }}
@@ -93,6 +98,7 @@ jobs:
           --parent-run-attempt "$PARENT_RUN_ATTEMPT"
           --tag "$PUBLISHER_TAG"
           --expected-commit "$EXPECTED_COMMIT"
+          --expected-tag-object "$EXPECTED_TAG_OBJECT"
           --registry "$PUBLISHER_REGISTRY"
           --allowlist
           ".context/publisher-dispatch/publisher-dispatch-$PUBLISHER_REGISTRY.json"
@@ -113,6 +119,153 @@ jobs:
           path: dist/
           run-id: ${{ inputs.parent_run_id }}
           github-token: ${{ github.token }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch-live/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Reauthorize the live parent release
+        shell: bash
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_DISTRIBUTION: archetype-physical-ai
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+          PUBLISHER_WORKFLOW: publish-archetype-physical-ai.yml
+        run: |
+          set -euo pipefail
+          fail() { echo "parent release check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] || fail "wrong event"
+          [[ "$GITHUB_ACTOR" == "github-actions[bot]" ]] || fail "wrong actor"
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "github-actions[bot]" ]] || fail "wrong triggering actor"
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent run ID"
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent attempt"
+          [[ "$CHILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid child run ID"
+          [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid release commit"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid tag object"
+          [[ "$PUBLISHER_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "invalid release tag"
+          [[ "$PUBLISHER_REGISTRY" == "testpypi" || "$PUBLISHER_REGISTRY" == "pypi" ]] || fail "invalid registry"
+          [[ "$GITHUB_SHA" == "$EXPECTED_COMMIT" ]] || fail "child commit differs"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/$PUBLISHER_WORKFLOW@refs/tags/$PUBLISHER_TAG"
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]] || fail "child workflow differs"
+
+          allowlist=".context/publisher-dispatch-live/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+          child_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$CHILD_RUN_ID"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --arg tag_object "$EXPECTED_TAG_OBJECT" \
+            --arg registry "$PUBLISHER_REGISTRY" \
+            --arg distribution "$PUBLISHER_DISTRIBUTION" \
+            --arg workflow "$PUBLISHER_WORKFLOW" \
+            --arg url "$child_url" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            --argjson child_run_id "$CHILD_RUN_ID" \
+            '
+              type == "object" and
+              (keys | sort) ==
+                (["schema", "repository", "parent_run_id", "parent_run_attempt",
+                  "tag", "commit", "tag_object", "registry", "runs"] | sort) and
+              .schema == "archetype.publisher-dispatch/v2" and
+              .repository == $repository and
+              .parent_run_id == $parent_run_id and
+              .parent_run_attempt == $parent_run_attempt and
+              .tag == $tag and
+              .commit == $commit and
+              .tag_object == $tag_object and
+              .registry == $registry and
+              (.runs | type) == "array" and
+              ([.runs[] | select(
+                type == "object" and
+                (keys | sort) == (["distribution", "workflow", "run_id", "url"] | sort) and
+                .distribution == $distribution and
+                .workflow == $workflow and
+                .run_id == $child_run_id and
+                .url == $url
+              )] | length) == 1
+            ' "$allowlist" >/dev/null || fail "child run is not allowlisted"
+
+          parent_json="$(gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID")" || fail "parent lookup failed"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            '
+              type == "object" and
+              .id == $parent_run_id and
+              .run_attempt == $parent_run_attempt and
+              .event == "workflow_dispatch" and
+              (.path == ".github/workflows/release.yml" or
+                .path == (".github/workflows/release.yml@" + $tag) or
+                .path == (".github/workflows/release.yml@refs/tags/" + $tag)) and
+              .head_sha == $commit and
+              .head_branch == $tag and
+              .status == "in_progress" and
+              .conclusion == null and
+              .repository.full_name == $repository and
+              .actor.login == "everettVT" and
+              .triggering_actor.login == "everettVT"
+            ' <<< "$parent_json" >/dev/null || fail "parent is no longer authorized and live"
+      - name: Reauthorize the remote release tag
+        shell: bash
+        env:
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          fail() { echo "release tag check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "authorized tag object is not 40-hex"
+
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          [[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]] || fail "remote tag object differs"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -135,6 +288,153 @@ jobs:
           path: dist/
           run-id: ${{ inputs.parent_run_id }}
           github-token: ${{ github.token }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch-live/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Reauthorize the live parent release
+        shell: bash
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_DISTRIBUTION: archetype-physical-ai
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+          PUBLISHER_WORKFLOW: publish-archetype-physical-ai.yml
+        run: |
+          set -euo pipefail
+          fail() { echo "parent release check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] || fail "wrong event"
+          [[ "$GITHUB_ACTOR" == "github-actions[bot]" ]] || fail "wrong actor"
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "github-actions[bot]" ]] || fail "wrong triggering actor"
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent run ID"
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent attempt"
+          [[ "$CHILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid child run ID"
+          [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid release commit"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid tag object"
+          [[ "$PUBLISHER_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "invalid release tag"
+          [[ "$PUBLISHER_REGISTRY" == "testpypi" || "$PUBLISHER_REGISTRY" == "pypi" ]] || fail "invalid registry"
+          [[ "$GITHUB_SHA" == "$EXPECTED_COMMIT" ]] || fail "child commit differs"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/$PUBLISHER_WORKFLOW@refs/tags/$PUBLISHER_TAG"
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]] || fail "child workflow differs"
+
+          allowlist=".context/publisher-dispatch-live/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+          child_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$CHILD_RUN_ID"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --arg tag_object "$EXPECTED_TAG_OBJECT" \
+            --arg registry "$PUBLISHER_REGISTRY" \
+            --arg distribution "$PUBLISHER_DISTRIBUTION" \
+            --arg workflow "$PUBLISHER_WORKFLOW" \
+            --arg url "$child_url" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            --argjson child_run_id "$CHILD_RUN_ID" \
+            '
+              type == "object" and
+              (keys | sort) ==
+                (["schema", "repository", "parent_run_id", "parent_run_attempt",
+                  "tag", "commit", "tag_object", "registry", "runs"] | sort) and
+              .schema == "archetype.publisher-dispatch/v2" and
+              .repository == $repository and
+              .parent_run_id == $parent_run_id and
+              .parent_run_attempt == $parent_run_attempt and
+              .tag == $tag and
+              .commit == $commit and
+              .tag_object == $tag_object and
+              .registry == $registry and
+              (.runs | type) == "array" and
+              ([.runs[] | select(
+                type == "object" and
+                (keys | sort) == (["distribution", "workflow", "run_id", "url"] | sort) and
+                .distribution == $distribution and
+                .workflow == $workflow and
+                .run_id == $child_run_id and
+                .url == $url
+              )] | length) == 1
+            ' "$allowlist" >/dev/null || fail "child run is not allowlisted"
+
+          parent_json="$(gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID")" || fail "parent lookup failed"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            '
+              type == "object" and
+              .id == $parent_run_id and
+              .run_attempt == $parent_run_attempt and
+              .event == "workflow_dispatch" and
+              (.path == ".github/workflows/release.yml" or
+                .path == (".github/workflows/release.yml@" + $tag) or
+                .path == (".github/workflows/release.yml@refs/tags/" + $tag)) and
+              .head_sha == $commit and
+              .head_branch == $tag and
+              .status == "in_progress" and
+              .conclusion == null and
+              .repository.full_name == $repository and
+              .actor.login == "everettVT" and
+              .triggering_actor.login == "everettVT"
+            ' <<< "$parent_json" >/dev/null || fail "parent is no longer authorized and live"
+      - name: Reauthorize the remote release tag
+        shell: bash
+        env:
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          fail() { echo "release tag check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "authorized tag object is not 40-hex"
+
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          [[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]] || fail "remote tag object differs"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true

--- a/.github/workflows/publish-archetype-research.yml
+++ b/.github/workflows/publish-archetype-research.yml
@@ -19,6 +19,10 @@ on:
         description: "Exact release commit"
         required: true
         type: string
+      expected_tag_object:
+        description: "Exact immutable release tag object"
+        required: true
+        type: string
       registry:
         description: "Destination package registry"
         required: true
@@ -79,6 +83,7 @@ jobs:
         env:
           CHILD_RUN_ID: ${{ github.run_id }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
           GITHUB_TOKEN: ${{ github.token }}
           PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
           PARENT_RUN_ID: ${{ inputs.parent_run_id }}
@@ -93,6 +98,7 @@ jobs:
           --parent-run-attempt "$PARENT_RUN_ATTEMPT"
           --tag "$PUBLISHER_TAG"
           --expected-commit "$EXPECTED_COMMIT"
+          --expected-tag-object "$EXPECTED_TAG_OBJECT"
           --registry "$PUBLISHER_REGISTRY"
           --allowlist
           ".context/publisher-dispatch/publisher-dispatch-$PUBLISHER_REGISTRY.json"
@@ -113,6 +119,153 @@ jobs:
           path: dist/
           run-id: ${{ inputs.parent_run_id }}
           github-token: ${{ github.token }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch-live/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Reauthorize the live parent release
+        shell: bash
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_DISTRIBUTION: archetype-research
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+          PUBLISHER_WORKFLOW: publish-archetype-research.yml
+        run: |
+          set -euo pipefail
+          fail() { echo "parent release check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] || fail "wrong event"
+          [[ "$GITHUB_ACTOR" == "github-actions[bot]" ]] || fail "wrong actor"
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "github-actions[bot]" ]] || fail "wrong triggering actor"
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent run ID"
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent attempt"
+          [[ "$CHILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid child run ID"
+          [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid release commit"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid tag object"
+          [[ "$PUBLISHER_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "invalid release tag"
+          [[ "$PUBLISHER_REGISTRY" == "testpypi" || "$PUBLISHER_REGISTRY" == "pypi" ]] || fail "invalid registry"
+          [[ "$GITHUB_SHA" == "$EXPECTED_COMMIT" ]] || fail "child commit differs"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/$PUBLISHER_WORKFLOW@refs/tags/$PUBLISHER_TAG"
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]] || fail "child workflow differs"
+
+          allowlist=".context/publisher-dispatch-live/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+          child_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$CHILD_RUN_ID"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --arg tag_object "$EXPECTED_TAG_OBJECT" \
+            --arg registry "$PUBLISHER_REGISTRY" \
+            --arg distribution "$PUBLISHER_DISTRIBUTION" \
+            --arg workflow "$PUBLISHER_WORKFLOW" \
+            --arg url "$child_url" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            --argjson child_run_id "$CHILD_RUN_ID" \
+            '
+              type == "object" and
+              (keys | sort) ==
+                (["schema", "repository", "parent_run_id", "parent_run_attempt",
+                  "tag", "commit", "tag_object", "registry", "runs"] | sort) and
+              .schema == "archetype.publisher-dispatch/v2" and
+              .repository == $repository and
+              .parent_run_id == $parent_run_id and
+              .parent_run_attempt == $parent_run_attempt and
+              .tag == $tag and
+              .commit == $commit and
+              .tag_object == $tag_object and
+              .registry == $registry and
+              (.runs | type) == "array" and
+              ([.runs[] | select(
+                type == "object" and
+                (keys | sort) == (["distribution", "workflow", "run_id", "url"] | sort) and
+                .distribution == $distribution and
+                .workflow == $workflow and
+                .run_id == $child_run_id and
+                .url == $url
+              )] | length) == 1
+            ' "$allowlist" >/dev/null || fail "child run is not allowlisted"
+
+          parent_json="$(gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID")" || fail "parent lookup failed"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            '
+              type == "object" and
+              .id == $parent_run_id and
+              .run_attempt == $parent_run_attempt and
+              .event == "workflow_dispatch" and
+              (.path == ".github/workflows/release.yml" or
+                .path == (".github/workflows/release.yml@" + $tag) or
+                .path == (".github/workflows/release.yml@refs/tags/" + $tag)) and
+              .head_sha == $commit and
+              .head_branch == $tag and
+              .status == "in_progress" and
+              .conclusion == null and
+              .repository.full_name == $repository and
+              .actor.login == "everettVT" and
+              .triggering_actor.login == "everettVT"
+            ' <<< "$parent_json" >/dev/null || fail "parent is no longer authorized and live"
+      - name: Reauthorize the remote release tag
+        shell: bash
+        env:
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          fail() { echo "release tag check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "authorized tag object is not 40-hex"
+
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          [[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]] || fail "remote tag object differs"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -135,6 +288,153 @@ jobs:
           path: dist/
           run-id: ${{ inputs.parent_run_id }}
           github-token: ${{ github.token }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}
+          path: .context/publisher-dispatch-live/
+          run-id: ${{ inputs.parent_run_id }}
+          github-token: ${{ github.token }}
+      - name: Reauthorize the live parent release
+        shell: bash
+        env:
+          CHILD_RUN_ID: ${{ github.run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.parent_run_attempt }}
+          PARENT_RUN_ID: ${{ inputs.parent_run_id }}
+          PUBLISHER_DISTRIBUTION: archetype-research
+          PUBLISHER_REGISTRY: ${{ inputs.registry }}
+          PUBLISHER_TAG: ${{ inputs.tag }}
+          PUBLISHER_WORKFLOW: publish-archetype-research.yml
+        run: |
+          set -euo pipefail
+          fail() { echo "parent release check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] || fail "wrong event"
+          [[ "$GITHUB_ACTOR" == "github-actions[bot]" ]] || fail "wrong actor"
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "github-actions[bot]" ]] || fail "wrong triggering actor"
+          [[ "$PARENT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent run ID"
+          [[ "$PARENT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || fail "invalid parent attempt"
+          [[ "$CHILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "invalid child run ID"
+          [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid release commit"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "invalid tag object"
+          [[ "$PUBLISHER_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "invalid release tag"
+          [[ "$PUBLISHER_REGISTRY" == "testpypi" || "$PUBLISHER_REGISTRY" == "pypi" ]] || fail "invalid registry"
+          [[ "$GITHUB_SHA" == "$EXPECTED_COMMIT" ]] || fail "child commit differs"
+          expected_workflow_ref="$GITHUB_REPOSITORY/.github/workflows/$PUBLISHER_WORKFLOW@refs/tags/$PUBLISHER_TAG"
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]] || fail "child workflow differs"
+
+          allowlist=".context/publisher-dispatch-live/publisher-dispatch-$PUBLISHER_REGISTRY.json"
+          child_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$CHILD_RUN_ID"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --arg tag_object "$EXPECTED_TAG_OBJECT" \
+            --arg registry "$PUBLISHER_REGISTRY" \
+            --arg distribution "$PUBLISHER_DISTRIBUTION" \
+            --arg workflow "$PUBLISHER_WORKFLOW" \
+            --arg url "$child_url" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            --argjson child_run_id "$CHILD_RUN_ID" \
+            '
+              type == "object" and
+              (keys | sort) ==
+                (["schema", "repository", "parent_run_id", "parent_run_attempt",
+                  "tag", "commit", "tag_object", "registry", "runs"] | sort) and
+              .schema == "archetype.publisher-dispatch/v2" and
+              .repository == $repository and
+              .parent_run_id == $parent_run_id and
+              .parent_run_attempt == $parent_run_attempt and
+              .tag == $tag and
+              .commit == $commit and
+              .tag_object == $tag_object and
+              .registry == $registry and
+              (.runs | type) == "array" and
+              ([.runs[] | select(
+                type == "object" and
+                (keys | sort) == (["distribution", "workflow", "run_id", "url"] | sort) and
+                .distribution == $distribution and
+                .workflow == $workflow and
+                .run_id == $child_run_id and
+                .url == $url
+              )] | length) == 1
+            ' "$allowlist" >/dev/null || fail "child run is not allowlisted"
+
+          parent_json="$(gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$PARENT_RUN_ID")" || fail "parent lookup failed"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$PUBLISHER_TAG" \
+            --arg commit "$EXPECTED_COMMIT" \
+            --argjson parent_run_id "$PARENT_RUN_ID" \
+            --argjson parent_run_attempt "$PARENT_RUN_ATTEMPT" \
+            '
+              type == "object" and
+              .id == $parent_run_id and
+              .run_attempt == $parent_run_attempt and
+              .event == "workflow_dispatch" and
+              (.path == ".github/workflows/release.yml" or
+                .path == (".github/workflows/release.yml@" + $tag) or
+                .path == (".github/workflows/release.yml@refs/tags/" + $tag)) and
+              .head_sha == $commit and
+              .head_branch == $tag and
+              .status == "in_progress" and
+              .conclusion == null and
+              .repository.full_name == $repository and
+              .actor.login == "everettVT" and
+              .triggering_actor.login == "everettVT"
+            ' <<< "$parent_json" >/dev/null || fail "parent is no longer authorized and live"
+      - name: Reauthorize the remote release tag
+        shell: bash
+        env:
+          EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          fail() { echo "release tag check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "authorized tag object is not 40-hex"
+
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          [[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]] || fail "remote tag object differs"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,49 @@ jobs:
         with:
           name: dist-archetype-ecs
           path: dist/
+      - name: Reauthorize the remote release tag
+        shell: bash
+        env:
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          fail() { echo "release tag check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -539,6 +582,49 @@ jobs:
         with:
           name: dist-archetype-ecs
           path: dist/
+      - name: Reauthorize the remote release tag
+        shell: bash
+        env:
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          fail() { echo "release tag check failed: $*" >&2; exit 1; }
+
+          [[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,15 @@ jobs:
     name: Authorize release operator
     runs-on: ubuntu-latest
     permissions: {}
+    outputs:
+      tag_object_sha: ${{ steps.release_ref.outputs.tag_object_sha }}
     steps:
       - name: Require everettVT and an exact release tag
+        id: release_ref
+        shell: bash
         env:
           RELEASE_ACTOR: ${{ github.actor }}
+          RELEASE_COMMIT: ${{ github.sha }}
           RELEASE_EVENT: ${{ github.event_name }}
           RELEASE_INPUT_TAG: ${{ inputs.tag }}
           RELEASE_REF_NAME: ${{ github.ref_name }}
@@ -32,16 +37,47 @@ jobs:
           RELEASE_REPOSITORY: ${{ github.repository }}
           RELEASE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
-          test "$RELEASE_REPOSITORY" = "VangelisTech/archetype"
-          test "$RELEASE_EVENT" = "workflow_dispatch"
-          test "$RELEASE_ACTOR" = "everettVT"
-          test "$RELEASE_TRIGGERING_ACTOR" = "everettVT"
-          test "$RELEASE_REF_TYPE" = "tag"
-          test "$RELEASE_INPUT_TAG" = "$RELEASE_REF_NAME"
-          case "$RELEASE_REF_NAME" in
-            v*) ;;
-            *) echo "release ref must be a v* tag" >&2; exit 1 ;;
-          esac
+          set -euo pipefail
+          fail() { echo "release authorization failed: $*" >&2; exit 1; }
+
+          [[ "$RELEASE_REPOSITORY" == "VangelisTech/archetype" ]] || fail "wrong repository"
+          [[ "$RELEASE_EVENT" == "workflow_dispatch" ]] || fail "wrong event"
+          [[ "$RELEASE_ACTOR" == "everettVT" ]] || fail "wrong actor"
+          [[ "$RELEASE_TRIGGERING_ACTOR" == "everettVT" ]] || fail "wrong triggering actor"
+          [[ "$RELEASE_REF_TYPE" == "tag" ]] || fail "workflow ref is not a tag"
+          [[ "$RELEASE_INPUT_TAG" == "$RELEASE_REF_NAME" ]] || fail "input and ref differ"
+          [[ "$RELEASE_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
+          [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "release commit is not 40-hex"
+
+          tag_ref="refs/tags/$RELEASE_REF_NAME"
+          remote="https://github.com/VangelisTech/archetype.git"
+          output="$(git ls-remote --exit-code "$remote" "$tag_ref" "$tag_ref^{}")"
+          direct_sha=
+          peeled_sha=
+          while IFS= read -r line; do
+            sha=
+            ref=
+            extra=
+            IFS=$'\t' read -r sha ref extra <<< "$line"
+            [[ -z "$extra" ]] || fail "malformed ls-remote output"
+            [[ "$line" == "$sha"$'\t'"$ref" ]] || fail "malformed ls-remote output"
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "remote SHA is not 40-hex"
+            case "$ref" in
+              "$tag_ref")
+                [[ -z "$direct_sha" ]] || fail "duplicate direct tag ref"
+                direct_sha="$sha"
+                ;;
+              "$tag_ref^{}")
+                [[ -z "$peeled_sha" ]] || fail "duplicate peeled tag ref"
+                peeled_sha="$sha"
+                ;;
+              *) fail "unexpected remote ref $ref" ;;
+            esac
+          done <<< "$output"
+          [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          resolved_sha="${peeled_sha:-$direct_sha}"
+          [[ "$resolved_sha" == "$RELEASE_COMMIT" ]] || fail "remote tag commit differs"
+          printf 'tag_object_sha=%s\n' "$direct_sha" >> "$GITHUB_OUTPUT"
 
   release-profile:
     name: Release verification
@@ -333,7 +369,7 @@ jobs:
 
   testpypi-preflight:
     name: TestPyPI exact-byte preflight
-    needs: [release-evidence-gate, python-compatibility]
+    needs: [authorize-release, release-evidence-gate, python-compatibility]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -346,6 +382,7 @@ jobs:
           python scripts/verify_release_ref.py
           --tag "$GITHUB_REF_NAME"
           --expected-commit "$GITHUB_SHA"
+          --expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"
           --repository "$GITHUB_REPOSITORY"
           --actor "$GITHUB_ACTOR"
           --triggering-actor "$GITHUB_TRIGGERING_ACTOR"
@@ -374,7 +411,7 @@ jobs:
 
   publish-testpypi:
     name: Publish attested artifacts to TestPyPI
-    needs: testpypi-preflight
+    needs: [authorize-release, testpypi-preflight]
     if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     environment: release-testpypi
@@ -389,6 +426,7 @@ jobs:
       - name: Reauthorize the remote release tag
         shell: bash
         env:
+          EXPECTED_TAG_OBJECT: ${{ needs.authorize-release.outputs.tag_object_sha }}
           RELEASE_INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
@@ -399,6 +437,7 @@ jobs:
           [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
           [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
           [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "authorized tag object is not 40-hex"
 
           tag_ref="refs/tags/$GITHUB_REF_NAME"
           [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
@@ -427,6 +466,7 @@ jobs:
             esac
           done <<< "$output"
           [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          [[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]] || fail "remote tag object differs"
           resolved_sha="${peeled_sha:-$direct_sha}"
           [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -532,7 +572,7 @@ jobs:
 
   pypi-preflight:
     name: PyPI exact-byte preflight
-    needs: testpypi-smoke
+    needs: [authorize-release, testpypi-smoke]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -545,6 +585,7 @@ jobs:
           python scripts/verify_release_ref.py
           --tag "$GITHUB_REF_NAME"
           --expected-commit "$GITHUB_SHA"
+          --expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"
           --repository "$GITHUB_REPOSITORY"
           --actor "$GITHUB_ACTOR"
           --triggering-actor "$GITHUB_TRIGGERING_ACTOR"
@@ -570,7 +611,7 @@ jobs:
           --registry-artifact-host files.pythonhosted.org
 
   publish:
-    needs: pypi-preflight
+    needs: [authorize-release, pypi-preflight]
     if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     environment: release-pypi
@@ -585,6 +626,7 @@ jobs:
       - name: Reauthorize the remote release tag
         shell: bash
         env:
+          EXPECTED_TAG_OBJECT: ${{ needs.authorize-release.outputs.tag_object_sha }}
           RELEASE_INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
@@ -595,6 +637,7 @@ jobs:
           [[ "$GITHUB_REF_NAME" == "$RELEASE_INPUT_TAG" ]] || fail "input and ref differ"
           [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "tag must be canonical vMAJOR.MINOR.PATCH"
           [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "GITHUB_SHA is not 40-hex"
+          [[ "$EXPECTED_TAG_OBJECT" =~ ^[0-9a-f]{40}$ ]] || fail "authorized tag object is not 40-hex"
 
           tag_ref="refs/tags/$GITHUB_REF_NAME"
           [[ "$GITHUB_REF" == "$tag_ref" ]] || fail "workflow ref is not the exact tag ref"
@@ -623,6 +666,7 @@ jobs:
             esac
           done <<< "$output"
           [[ -n "$direct_sha" ]] || fail "direct tag ref is absent"
+          [[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]] || fail "remote tag object differs"
           resolved_sha="${peeled_sha:-$direct_sha}"
           [[ "$resolved_sha" == "$GITHUB_SHA" ]] || fail "remote tag commit differs"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -722,7 +766,7 @@ jobs:
           if-no-files-found: error
 
   github-release:
-    needs: registry-smoke
+    needs: [authorize-release, registry-smoke]
     if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     permissions:
@@ -740,6 +784,7 @@ jobs:
           python scripts/verify_release_ref.py
           --tag "$GITHUB_REF_NAME"
           --expected-commit "$GITHUB_SHA"
+          --expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"
           --repository "$GITHUB_REPOSITORY"
           --actor "$GITHUB_ACTOR"
           --triggering-actor "$GITHUB_TRIGGERING_ACTOR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -649,6 +649,14 @@ jobs:
         with:
           name: dist
           path: dist/
+      - name: Reauthorize the immutable release ref before GitHub Release creation
+        run: >-
+          python scripts/verify_release_ref.py
+          --tag "$GITHUB_REF_NAME"
+          --expected-commit "$GITHUB_SHA"
+          --repository "$GITHUB_REPOSITORY"
+          --actor "$GITHUB_ACTOR"
+          --triggering-actor "$GITHUB_TRIGGERING_ACTOR"
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,7 +477,7 @@ jobs:
 
   publish-testpypi-libraries:
     name: Publish world libraries to TestPyPI
-    needs: testpypi-preflight
+    needs: [authorize-release, testpypi-preflight]
     if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -497,6 +497,7 @@ jobs:
           --parent-run-attempt "$GITHUB_RUN_ATTEMPT"
           --tag "$GITHUB_REF_NAME"
           --expected-commit "$GITHUB_SHA"
+          --expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"
           --registry testpypi
           --out publisher-dispatch-testpypi.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -513,6 +514,7 @@ jobs:
           --parent-run-attempt "$GITHUB_RUN_ATTEMPT"
           --tag "$GITHUB_REF_NAME"
           --expected-commit "$GITHUB_SHA"
+          --expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"
           --registry testpypi
           --allowlist publisher-dispatch-testpypi.json
           --out publisher-dispatch-testpypi.json
@@ -676,7 +678,7 @@ jobs:
 
   publish-libraries:
     name: Publish world libraries to PyPI
-    needs: pypi-preflight
+    needs: [authorize-release, pypi-preflight]
     if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -696,6 +698,7 @@ jobs:
           --parent-run-attempt "$GITHUB_RUN_ATTEMPT"
           --tag "$GITHUB_REF_NAME"
           --expected-commit "$GITHUB_SHA"
+          --expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"
           --registry pypi
           --out publisher-dispatch-pypi.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -712,6 +715,7 @@ jobs:
           --parent-run-attempt "$GITHUB_RUN_ATTEMPT"
           --tag "$GITHUB_REF_NAME"
           --expected-commit "$GITHUB_SHA"
+          --expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"
           --registry pypi
           --allowlist publisher-dispatch-pypi.json
           --out publisher-dispatch-pypi.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,13 @@ only when the registry Integrity API binds its publish attestation to this repos
 workflow, environment, filename, and digest, and the pinned `pypi-attestations`
 verifier validates the Sigstore proof for the served file.
 
+Immediately before each OIDC publisher action, its checkout-free job performs one
+inline `git ls-remote` check against the literal canonical repository without
+checking out or executing repository files or scripts.
+The exact canonical `vMAJOR.MINOR.PATCH` tag, including an annotated tag's peeled
+commit, must still resolve to the workflow's original `GITHUB_SHA`. This narrows the
+final mutable-ref window without exposing the publish token to checked-out code.
+
 Before the first four-project release, register pending Trusted Publishers for the
 three new project names on both PyPI and TestPyPI. This preconfigures their OIDC
 identities; it does not reserve or claim the names. Each new name remains claimable

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo "  make format         Format code (ruff)"
 	@echo "  make lint           Lint code (ruff)"
 	@echo "  make static         All version-independent blocking validation"
+	@echo "  make actionlint-audit  Validate active GitHub Actions workflows"
 	@echo "  make contract-audit Validate normative sources and executable oracles"
 	@echo "  make benchmark-audit Validate benchmark ownership and policies"
 	@echo "  make operational-audit Validate operational scenario ownership and policies"
@@ -145,8 +146,12 @@ operational-audit:
 	@PYTHONPATH=$(PYTHONPATH):. uv run python scripts/validate_operational_scenarios.py
 
 .PHONY: static
-static: format-check lint typecheck lock-check contract-audit benchmark-audit
+static: format-check lint typecheck lock-check contract-audit benchmark-audit actionlint-audit
 	@echo "Static validation passed"
+
+.PHONY: actionlint-audit
+actionlint-audit:
+	@uv run python scripts/run_actionlint.py
 
 .PHONY: lockfile-audit
 lockfile-audit:

--- a/Makefile
+++ b/Makefile
@@ -538,9 +538,10 @@ release-check: sync-dev verify-release
 	@echo "✅ Release check passed for v$(VERSION)"
 	@echo ""
 	@echo "Next steps:"
-	@echo "  1. git tag v$(VERSION)"
-	@echo "  2. git push origin v$(VERSION)"
-	@echo "  3. Dispatch the Release workflow for v$(VERSION)"
+	@echo "  1. git fetch origin main"
+	@echo "  2. git tag -a v$(VERSION) origin/main -m \"Release v$(VERSION)\""
+	@echo "  3. git push origin refs/tags/v$(VERSION):refs/tags/v$(VERSION)"
+	@echo "  4. Dispatch the Release workflow for v$(VERSION)"
 
 .PHONY: verify-test-index
 verify-test-index:

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -229,6 +229,13 @@ already-fetched provenance to the pinned verifier. The pinned publisher action
 signs uploads to both registries with production Sigstore trust, so TestPyPI
 verification MUST NOT select the Sigstore staging roots.
 
+Each OIDC publisher remains checkout-free. Immediately before publication it
+runs one inline `git ls-remote` check against the literal canonical repository
+without checking out or executing repository files or scripts. The exact
+canonical `vMAJOR.MINOR.PATCH` tag must still
+resolve to the workflow's original `GITHUB_SHA`; annotated tags are compared by
+their peeled commit. No repository script executes with the publish identity.
+
 Release execution is operator-only. The `Release tags — everettVT only`
 repository ruleset permits only `everettVT` to create `v*` tags; the separate
 immutable-tag ruleset continues to deny tag updates and deletion for everyone.

--- a/scripts/dispatch_release_publishers.py
+++ b/scripts/dispatch_release_publishers.py
@@ -317,7 +317,7 @@ def dispatch_publishers(
             "POST",
             endpoint,
             token=token,
-            payload={"ref": tag, "inputs": inputs},
+            payload={"ref": tag, "inputs": inputs, "return_run_details": True},
             open_request=open_request,
             timeout_seconds=http_timeout_seconds,
         )

--- a/scripts/dispatch_release_publishers.py
+++ b/scripts/dispatch_release_publishers.py
@@ -28,7 +28,7 @@ else:  # pragma: no cover - exercised by the command-line entry point
 API_VERSION = "2026-03-10"
 API_ROOT = "https://api.github.com"
 REPOSITORY = "VangelisTech/archetype"
-SCHEMA = "archetype.publisher-dispatch/v1"
+SCHEMA = "archetype.publisher-dispatch/v2"
 RELEASE_WORKFLOW = "release.yml"
 
 DEFAULT_TIMEOUT_SECONDS = 30 * 60.0
@@ -111,17 +111,20 @@ def _context(
     parent_run_attempt: object,
     tag: object,
     expected_commit: object,
+    expected_tag_object: object,
     registry: object,
-) -> tuple[int, int, str, str, str]:
+) -> tuple[int, int, str, str, str, str]:
     run_id = _positive_integer(parent_run_id, "parent run ID")
     run_attempt = _positive_integer(parent_run_attempt, "parent run attempt")
     if not isinstance(tag, str) or _TAG.fullmatch(tag) is None:
         raise ValueError("release tag must be canonical vMAJOR.MINOR.PATCH")
     if not isinstance(expected_commit, str) or _COMMIT.fullmatch(expected_commit) is None:
         raise ValueError("expected commit must be one lowercase 40-hex SHA")
+    if not isinstance(expected_tag_object, str) or _COMMIT.fullmatch(expected_tag_object) is None:
+        raise ValueError("expected tag object must be one lowercase 40-hex SHA")
     if not isinstance(registry, str) or registry not in _REGISTRIES:
         raise ValueError("registry must be testpypi or pypi")
-    return run_id, run_attempt, tag, expected_commit, registry
+    return run_id, run_attempt, tag, expected_commit, expected_tag_object, registry
 
 
 def _publishers() -> tuple[tuple[str, str], ...]:
@@ -269,6 +272,7 @@ def dispatch_publishers(
     parent_run_attempt: int,
     tag: str,
     expected_commit: str,
+    expected_tag_object: str,
     registry: str,
     token: str,
     open_request: OpenRequest = _OPEN,
@@ -276,11 +280,19 @@ def dispatch_publishers(
 ) -> dict[str, Any]:
     """Dispatch each child publisher and return its exact-run allowlist."""
 
-    parent_run_id, parent_run_attempt, tag, expected_commit, registry = _context(
+    (
+        parent_run_id,
+        parent_run_attempt,
+        tag,
+        expected_commit,
+        expected_tag_object,
+        registry,
+    ) = _context(
         parent_run_id=parent_run_id,
         parent_run_attempt=parent_run_attempt,
         tag=tag,
         expected_commit=expected_commit,
+        expected_tag_object=expected_tag_object,
         registry=registry,
     )
     token = _token(token)
@@ -294,6 +306,7 @@ def dispatch_publishers(
         "parent_run_attempt": str(parent_run_attempt),
         "tag": tag,
         "expected_commit": expected_commit,
+        "expected_tag_object": expected_tag_object,
         "registry": registry,
     }
     runs: list[dict[str, Any]] = []
@@ -325,6 +338,7 @@ def dispatch_publishers(
         "parent_run_attempt": parent_run_attempt,
         "tag": tag,
         "commit": expected_commit,
+        "tag_object": expected_tag_object,
         "registry": registry,
         "runs": runs,
     }
@@ -337,15 +351,24 @@ def validate_allowlist(
     parent_run_attempt: int,
     tag: str,
     expected_commit: str,
+    expected_tag_object: str,
     registry: str,
 ) -> dict[str, Any]:
     """Validate an immutable dispatch receipt against the parent run context."""
 
-    parent_run_id, parent_run_attempt, tag, expected_commit, registry = _context(
+    (
+        parent_run_id,
+        parent_run_attempt,
+        tag,
+        expected_commit,
+        expected_tag_object,
+        registry,
+    ) = _context(
         parent_run_id=parent_run_id,
         parent_run_attempt=parent_run_attempt,
         tag=tag,
         expected_commit=expected_commit,
+        expected_tag_object=expected_tag_object,
         registry=registry,
     )
     if not isinstance(value, dict):
@@ -357,6 +380,7 @@ def validate_allowlist(
         "parent_run_attempt",
         "tag",
         "commit",
+        "tag_object",
         "registry",
         "runs",
     }
@@ -369,6 +393,7 @@ def validate_allowlist(
         "parent_run_attempt": parent_run_attempt,
         "tag": tag,
         "commit": expected_commit,
+        "tag_object": expected_tag_object,
         "registry": registry,
     }
     for field, expected in expected_context.items():
@@ -472,6 +497,7 @@ def await_publishers(
     parent_run_attempt: int,
     tag: str,
     expected_commit: str,
+    expected_tag_object: str,
     registry: str,
     token: str,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
@@ -489,6 +515,7 @@ def await_publishers(
         parent_run_attempt=parent_run_attempt,
         tag=tag,
         expected_commit=expected_commit,
+        expected_tag_object=expected_tag_object,
         registry=registry,
     )
     token = _token(token)
@@ -568,6 +595,7 @@ def _add_context_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--parent-run-attempt", type=_positive_decimal, required=True)
     parser.add_argument("--tag", required=True)
     parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--expected-tag-object", required=True)
     parser.add_argument("--registry", choices=sorted(_REGISTRIES), required=True)
     parser.add_argument("--token-env", default="GITHUB_TOKEN")
     parser.add_argument(
@@ -599,6 +627,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             parent_run_attempt=args.parent_run_attempt,
             tag=args.tag,
             expected_commit=args.expected_commit,
+            expected_tag_object=args.expected_tag_object,
             registry=args.registry,
             token=token,
             http_timeout_seconds=args.http_timeout_seconds,
@@ -610,6 +639,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             parent_run_attempt=args.parent_run_attempt,
             tag=args.tag,
             expected_commit=args.expected_commit,
+            expected_tag_object=args.expected_tag_object,
             registry=args.registry,
             token=token,
             http_timeout_seconds=args.http_timeout_seconds,

--- a/scripts/run_actionlint.py
+++ b/scripts/run_actionlint.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install a checksum-pinned actionlint binary and lint active workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import platform
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+_VERSION = "1.7.12"
+_RELEASE = f"https://github.com/rhysd/actionlint/releases/download/v{_VERSION}"
+
+
+@dataclass(frozen=True)
+class _Asset:
+    archive: str
+    sha256: str
+
+
+_ASSETS = {
+    ("Darwin", "x86_64"): _Asset(
+        "actionlint_1.7.12_darwin_amd64.tar.gz",
+        "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644",
+    ),
+    ("Darwin", "arm64"): _Asset(
+        "actionlint_1.7.12_darwin_arm64.tar.gz",
+        "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f",
+    ),
+    ("Linux", "x86_64"): _Asset(
+        "actionlint_1.7.12_linux_amd64.tar.gz",
+        "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+    ),
+    ("Linux", "arm64"): _Asset(
+        "actionlint_1.7.12_linux_arm64.tar.gz",
+        "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6",
+    ),
+}
+_MACHINE_ALIASES = {
+    "AMD64": "x86_64",
+    "aarch64": "arm64",
+}
+
+
+def _digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _asset(*, system: str, machine: str) -> _Asset:
+    normalized_machine = _MACHINE_ALIASES.get(machine, machine)
+    try:
+        return _ASSETS[(system, normalized_machine)]
+    except KeyError as error:
+        raise RuntimeError(
+            f"actionlint {_VERSION} has no pinned asset for {system}/{normalized_machine}"
+        ) from error
+
+
+def _load_archive(*, cache: Path, asset: _Asset) -> bytes:
+    archive = cache / asset.archive
+    if archive.is_file():
+        value = archive.read_bytes()
+        if _digest(value) == asset.sha256:
+            return value
+
+    request = urllib.request.Request(
+        f"{_RELEASE}/{asset.archive}",
+        headers={"User-Agent": "archetype-actionlint-bootstrap"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        value = response.read()
+    observed = _digest(value)
+    if observed != asset.sha256:
+        raise RuntimeError(
+            f"actionlint archive checksum mismatch: expected {asset.sha256}, observed {observed}"
+        )
+
+    cache.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=cache, delete=False) as stream:
+        temporary = Path(stream.name)
+        stream.write(value)
+    os.replace(temporary, archive)
+    return value
+
+
+def install_actionlint(
+    *,
+    root: Path,
+    system: str | None = None,
+    machine: str | None = None,
+) -> Path:
+    """Materialize the verified binary for the current supported platform."""
+
+    selected = _asset(
+        system=system or platform.system(),
+        machine=machine or platform.machine(),
+    )
+    cache = root / ".venv" / "tools" / "actionlint" / _VERSION
+    archive = _load_archive(cache=cache, asset=selected)
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as bundle:
+        try:
+            member = bundle.getmember("actionlint")
+        except KeyError as error:
+            raise RuntimeError("verified actionlint archive has no actionlint binary") from error
+        if not member.isfile():
+            raise RuntimeError("verified actionlint archive member is not a regular file")
+        source = bundle.extractfile(member)
+        if source is None:
+            raise RuntimeError("could not read verified actionlint archive member")
+        binary_bytes = source.read()
+    if not binary_bytes:
+        raise RuntimeError("verified actionlint archive contains an empty binary")
+
+    destination = cache / selected.archive.removesuffix(".tar.gz") / "actionlint"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as stream:
+        temporary = Path(stream.name)
+        stream.write(binary_bytes)
+    temporary.chmod(0o755)
+    os.replace(temporary, destination)
+    return destination
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    binary = install_actionlint(root=root)
+    print(f"Running checksum-pinned actionlint {_VERSION}")
+    process = subprocess.run(
+        [
+            str(binary),
+            "-no-color",
+            # Optional host tools would make the gate machine-dependent. Ruff
+            # owns Python linting; shell checks can gain their own pinned lane.
+            "-pyflakes=",
+            "-shellcheck=",
+        ],
+        cwd=root,
+        check=False,
+    )
+    return process.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_publisher_dispatch.py
+++ b/scripts/verify_publisher_dispatch.py
@@ -76,6 +76,7 @@ def verify_publisher_dispatch(
     allowlist: Mapping[str, Any],
     tag: str,
     expected_commit: str,
+    expected_tag_object: str,
     registry: str,
 ) -> dict[str, Any]:
     """Bind a child publisher to one live, operator-authorized release run."""
@@ -90,6 +91,8 @@ def verify_publisher_dispatch(
         raise ValueError("publisher tag must be canonical vMAJOR.MINOR.PATCH")
     if _COMMIT.fullmatch(expected_commit) is None:
         raise ValueError("publisher expected commit must be a full Git commit")
+    if not isinstance(expected_tag_object, str) or _COMMIT.fullmatch(expected_tag_object) is None:
+        raise ValueError("publisher expected tag object must be a full Git object ID")
     if expected_workflow not in _PUBLISHER_WORKFLOWS:
         raise ValueError("publisher workflow is not registered to a release distribution")
     if PUBLISHER_WORKFLOWS.get(distribution) != expected_workflow:
@@ -148,12 +151,13 @@ def verify_publisher_dispatch(
         "parent_run_attempt",
         "tag",
         "commit",
+        "tag_object",
         "registry",
         "runs",
     }
     if set(allowlist) != expected_allowlist_keys:
         raise PermissionError("publisher dispatch allowlist has unexpected fields")
-    if allowlist.get("schema") != "archetype.publisher-dispatch/v1":
+    if allowlist.get("schema") != "archetype.publisher-dispatch/v2":
         raise PermissionError("publisher dispatch allowlist has an unsupported schema")
     for field, expected in (
         ("repository", repository),
@@ -161,6 +165,7 @@ def verify_publisher_dispatch(
         ("parent_run_attempt", parent_run_attempt),
         ("tag", tag),
         ("commit", expected_commit),
+        ("tag_object", expected_tag_object),
         ("registry", registry),
     ):
         if allowlist.get(field) != expected:
@@ -200,6 +205,7 @@ def verify_publisher_dispatch(
         "workflow": expected_workflow,
         "tag": tag,
         "commit": expected_commit,
+        "tag_object": expected_tag_object,
         "registry": registry,
         "environment": _REGISTRY_ENVIRONMENTS[registry],
         "child_run_id": child_run_id,
@@ -243,6 +249,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--parent-run-attempt", type=int, required=True)
     parser.add_argument("--tag", required=True)
     parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--expected-tag-object", required=True)
     parser.add_argument("--registry", choices=tuple(_REGISTRY_ENVIRONMENTS), required=True)
     parser.add_argument("--allowlist", type=Path, required=True)
     args = parser.parse_args(argv)
@@ -270,6 +277,7 @@ def main(argv: list[str] | None = None) -> int:
         allowlist=allowlist,
         tag=args.tag,
         expected_commit=args.expected_commit,
+        expected_tag_object=args.expected_tag_object,
         registry=args.registry,
     )
     print(

--- a/scripts/verify_release_ref.py
+++ b/scripts/verify_release_ref.py
@@ -40,12 +40,13 @@ def verify_release_ref(
     root: Path,
     tag: str,
     expected_commit: str,
+    expected_tag_object: str,
     repository: str,
     actor: str,
     triggering_actor: str,
     run: Run = subprocess.run,
 ) -> dict[str, str]:
-    """Require the authorized operator and one unchanged remote tag commit."""
+    """Require the authorized operator and one unchanged remote tag identity."""
 
     if repository != _REPOSITORY:
         raise ValueError(f"release repository must be {_REPOSITORY}")
@@ -55,6 +56,8 @@ def verify_release_ref(
         raise ValueError("release tag must be canonical vMAJOR.MINOR.PATCH")
     if _COMMIT.fullmatch(expected_commit) is None:
         raise ValueError("release expected commit must be a full Git commit")
+    if _COMMIT.fullmatch(expected_tag_object) is None:
+        raise ValueError("release expected tag object must be a full Git object")
 
     local_commit = _git(root, ("rev-parse", "HEAD"), run=run)
     if local_commit != expected_commit:
@@ -72,14 +75,25 @@ def verify_release_ref(
         if fields[1] in references:
             raise ValueError("release remote returned duplicate tag evidence")
         references[fields[1]] = fields[0]
-    remote_commit = references.get(f"{reference}^{{}}", references.get(reference))
-    if set(references) - {reference, f"{reference}^{{}}"} or remote_commit is None:
+    remote_tag_object = references.get(reference)
+    remote_commit = references.get(f"{reference}^{{}}", remote_tag_object)
+    if (
+        set(references) - {reference, f"{reference}^{{}}"}
+        or remote_tag_object is None
+        or remote_commit is None
+    ):
         raise ValueError(f"release tag {tag!r} is missing or ambiguous on origin")
+    if remote_tag_object != expected_tag_object:
+        raise ValueError(
+            "release tag object moved: "
+            f"expected {expected_tag_object}, observed {remote_tag_object}"
+        )
     if remote_commit != expected_commit:
         raise ValueError(f"release tag moved: expected {expected_commit}, observed {remote_commit}")
     return {
         "repository": repository,
         "tag": tag,
+        "tag_object": expected_tag_object,
         "commit": expected_commit,
         "actor": actor,
         "triggering_actor": triggering_actor,
@@ -90,6 +104,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--tag", required=True)
     parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--expected-tag-object", required=True)
     parser.add_argument("--repository", required=True)
     parser.add_argument("--actor", required=True)
     parser.add_argument("--triggering-actor", required=True)
@@ -98,11 +113,15 @@ def main(argv: list[str] | None = None) -> int:
         root=Path.cwd(),
         tag=args.tag,
         expected_commit=args.expected_commit,
+        expected_tag_object=args.expected_tag_object,
         repository=args.repository,
         actor=args.actor,
         triggering_actor=args.triggering_actor,
     )
-    print(f"Authorized immutable release ref: {result['tag']} at {result['commit']}")
+    print(
+        "Authorized immutable release ref: "
+        f"{result['tag']} object {result['tag_object']} at {result['commit']}"
+    )
     return 0
 
 

--- a/tests/scripts/test_actionlint.py
+++ b/tests/scripts/test_actionlint.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for the checksum-pinned actionlint bootstrap and static gate."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import tarfile
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+import scripts.run_actionlint as actionlint
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _archive(binary: bytes = b"verified-actionlint") -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as bundle:
+        member = tarfile.TarInfo("actionlint")
+        member.mode = 0o755
+        member.size = len(binary)
+        bundle.addfile(member, io.BytesIO(binary))
+    return output.getvalue()
+
+
+def test_static_profile_uses_the_pinned_actionlint_gate() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    bootstrap = (ROOT / "scripts" / "run_actionlint.py").read_text(encoding="utf-8")
+    config = (ROOT / ".github" / "actionlint.yaml").read_text(encoding="utf-8")
+    docs_workflow = (ROOT / ".github" / "workflows" / "docs.yml").read_text(encoding="utf-8")
+
+    static = re.search(r"^static:(?P<dependencies>[^\n]+)$", makefile, re.MULTILINE)
+    assert static is not None
+    assert "actionlint-audit" in static.group("dependencies").split()
+    assert "uv run python scripts/run_actionlint.py" in makefile
+    assert '_VERSION = "1.7.12"' in bootstrap
+    for digest in (
+        "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644",
+        "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f",
+        "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+        "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6",
+    ):
+        assert digest in bootstrap
+    assert "archetype-apple-container-macos-26" in config
+    assert "DOCS_DEPLOY_BRANCH: ${{ github.head_ref || 'main' }}" in docs_workflow
+    assert '--branch="$DOCS_DEPLOY_BRANCH"' in docs_workflow
+
+
+def test_actionlint_install_accepts_only_the_pinned_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _archive()
+    asset = actionlint._Asset(  # noqa: SLF001 - executable bootstrap contract
+        archive="actionlint_test.tar.gz",
+        sha256=hashlib.sha256(archive).hexdigest(),
+    )
+    monkeypatch.setattr(actionlint, "_ASSETS", {("Test", "x86_64"): asset})
+
+    def download(request: urllib.request.Request, timeout: int) -> io.BytesIO:
+        assert request.full_url.endswith("/actionlint_test.tar.gz")
+        assert timeout == 30
+        return io.BytesIO(archive)
+
+    monkeypatch.setattr(actionlint.urllib.request, "urlopen", download)
+    binary = actionlint.install_actionlint(
+        root=tmp_path,
+        system="Test",
+        machine="x86_64",
+    )
+
+    assert binary.read_bytes() == b"verified-actionlint"
+    assert binary.stat().st_mode & 0o111
+
+    def reject_network(*_args: object, **_kwargs: object) -> io.BytesIO:
+        raise AssertionError("the verified archive should be reused")
+
+    monkeypatch.setattr(actionlint.urllib.request, "urlopen", reject_network)
+    assert (
+        actionlint.install_actionlint(
+            root=tmp_path,
+            system="Test",
+            machine="x86_64",
+        ).read_bytes()
+        == b"verified-actionlint"
+    )
+
+
+def test_actionlint_install_rejects_a_checksum_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asset = actionlint._Asset(  # noqa: SLF001 - executable bootstrap contract
+        archive="actionlint_test.tar.gz",
+        sha256="0" * 64,
+    )
+    monkeypatch.setattr(actionlint, "_ASSETS", {("Test", "x86_64"): asset})
+    monkeypatch.setattr(
+        actionlint.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: io.BytesIO(_archive()),
+    )
+
+    with pytest.raises(RuntimeError, match="archive checksum mismatch"):
+        actionlint.install_actionlint(
+            root=tmp_path,
+            system="Test",
+            machine="x86_64",
+        )
+
+
+def test_actionlint_install_rejects_an_unpinned_platform(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="has no pinned asset"):
+        actionlint.install_actionlint(root=tmp_path, system="Plan9", machine="mips")

--- a/tests/scripts/test_dispatch_release_publishers.py
+++ b/tests/scripts/test_dispatch_release_publishers.py
@@ -20,6 +20,7 @@ PARENT_RUN_ID = 123456
 PARENT_RUN_ATTEMPT = 2
 TAG = "v0.6.0"
 COMMIT = "a" * 40
+TAG_OBJECT = "b" * 40
 TOKEN = "github-test-token"
 REGISTRY = "testpypi"
 
@@ -56,6 +57,7 @@ def _context() -> dict[str, Any]:
         "parent_run_attempt": PARENT_RUN_ATTEMPT,
         "tag": TAG,
         "expected_commit": COMMIT,
+        "expected_tag_object": TAG_OBJECT,
         "registry": REGISTRY,
     }
 
@@ -72,6 +74,7 @@ def _allowlist() -> dict[str, Any]:
         "parent_run_attempt": PARENT_RUN_ATTEMPT,
         "tag": TAG,
         "commit": COMMIT,
+        "tag_object": TAG_OBJECT,
         "registry": REGISTRY,
         "runs": [
             {
@@ -154,6 +157,7 @@ def test_dispatch_posts_every_child_and_returns_exact_allowlist() -> None:
                 "parent_run_attempt": str(PARENT_RUN_ATTEMPT),
                 "tag": TAG,
                 "expected_commit": COMMIT,
+                "expected_tag_object": TAG_OBJECT,
                 "registry": REGISTRY,
             },
         }
@@ -365,6 +369,11 @@ def test_allowlist_rejects_wrong_context_order_and_forged_urls() -> None:
     with pytest.raises(target.PublisherDispatchError, match="parent run attempt"):
         target.validate_allowlist(wrong_context, **_context())
 
+    wrong_tag_object = _allowlist()
+    wrong_tag_object["tag_object"] = "c" * 40
+    with pytest.raises(target.PublisherDispatchError, match="tag object"):
+        target.validate_allowlist(wrong_tag_object, **_context())
+
     wrong_order = _allowlist()
     wrong_order["runs"][0], wrong_order["runs"][1] = (
         wrong_order["runs"][1],
@@ -377,6 +386,23 @@ def test_allowlist_rejects_wrong_context_order_and_forged_urls() -> None:
     forged["runs"][0]["url"] = "https://github.com/other/repo/actions/runs/9001"
     with pytest.raises(target.PublisherDispatchError, match="wrong URL"):
         target.validate_allowlist(forged, **_context())
+
+
+@pytest.mark.parametrize("tag_object", ["", "A" * 40, "a" * 39, 7, None])
+def test_context_rejects_malformed_tag_object(tag_object: object) -> None:
+    context = _context()
+    context["expected_tag_object"] = tag_object
+
+    with pytest.raises(ValueError, match="expected tag object"):
+        target.validate_allowlist(_allowlist(), **context)
+
+
+def test_allowlist_rejects_the_previous_schema() -> None:
+    allowlist = _allowlist()
+    allowlist["schema"] = "archetype.publisher-dispatch/v1"
+
+    with pytest.raises(target.PublisherDispatchError, match="unexpected schema"):
+        target.validate_allowlist(allowlist, **_context())
 
 
 def test_github_api_errors_are_diagnostic_and_redirects_fail_closed() -> None:

--- a/tests/scripts/test_dispatch_release_publishers.py
+++ b/tests/scripts/test_dispatch_release_publishers.py
@@ -152,6 +152,7 @@ def test_dispatch_posts_every_child_and_returns_exact_allowlist() -> None:
     assert [payload for _workflow, payload, _timeout in calls] == [
         {
             "ref": TAG,
+            "return_run_details": True,
             "inputs": {
                 "parent_run_id": str(PARENT_RUN_ID),
                 "parent_run_attempt": str(PARENT_RUN_ATTEMPT),

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -325,6 +325,8 @@ def test_new_distribution_publishers_are_direct_isolated_workflows() -> None:
         assert "workflow_dispatch:" in workflow
         assert "workflow_call:" not in workflow
         assert "push:" not in workflow
+        assert "expected_tag_object:" in workflow
+        assert 'description: "Exact immutable release tag object"' in workflow
         assert "group: archetype-release" not in workflow
         references = re.findall(r"^\s*- uses:\s+([^\s#]+)", workflow, re.MULTILINE)
         assert references
@@ -337,6 +339,8 @@ def test_new_distribution_publishers_are_direct_isolated_workflows() -> None:
         assert "scripts/verify_publisher_dispatch.py" in authorize
         assert f"--expected-workflow {workflow_name}" in authorize
         assert f"--distribution {distribution}" in authorize
+        assert "EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}" in authorize
+        assert '--expected-tag-object "$EXPECTED_TAG_OBJECT"' in authorize
         assert "publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}" in (
             authorize
         )
@@ -354,8 +358,42 @@ def test_new_distribution_publishers_are_direct_isolated_workflows() -> None:
             assert "skip-existing: true" in job
             assert "attestations: true" in job
             assert "actions/checkout@" not in job
-            assert "run:" not in job
-            assert job.count("- uses:") == 2
+            assert job.count("run:") == 2
+            assert job.count("- uses:") == 3
+            assert job.count("actions/download-artifact@") == 2
+            assert "name: Reauthorize the live parent release" in job
+            assert "publisher-dispatch-${{ inputs.registry }}-${{ inputs.parent_run_attempt }}" in (
+                job
+            )
+            assert "path: .context/publisher-dispatch-live/" in job
+            assert "GH_TOKEN: ${{ github.token }}" in job
+            assert f"PUBLISHER_DISTRIBUTION: {distribution}" in job
+            assert f"PUBLISHER_WORKFLOW: {workflow_name}" in job
+            assert 'parent_json="$(gh api' in job
+            assert '.status == "in_progress"' in job
+            assert ".conclusion == null" in job
+            assert '.actor.login == "everettVT"' in job
+            assert '.triggering_actor.login == "everettVT"' in job
+            assert '.schema == "archetype.publisher-dispatch/v2"' in job
+            assert ".run_id == $child_run_id" in job
+            assert "name: Reauthorize the remote release tag" in job
+            assert "EXPECTED_TAG_OBJECT: ${{ inputs.expected_tag_object }}" in job
+            assert "RELEASE_INPUT_TAG: ${{ inputs.tag }}" in job
+            assert "git ls-remote --exit-code" in job
+            assert '[[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]]' in job
+            assert 'resolved_sha="${peeled_sha:-$direct_sha}"' in job
+            assert '[[ "$resolved_sha" == "$GITHUB_SHA" ]]' in job
+            assert "scripts/" not in job
+            assert (
+                job.index("actions/download-artifact@")
+                < job.index(
+                    "name: publisher-dispatch-${{ inputs.registry }}-"
+                    "${{ inputs.parent_run_attempt }}"
+                )
+                < job.index("name: Reauthorize the live parent release")
+                < job.index("name: Reauthorize the remote release tag")
+                < job.index("pypa/gh-action-pypi-publish@")
+            )
         assert "repository-url: https://test.pypi.org/legacy/" in testpypi
         assert "repository-url:" not in pypi
 
@@ -569,6 +607,13 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         assert '--parent-run-attempt "$GITHUB_RUN_ATTEMPT"' in coordinator
         assert '--tag "$GITHUB_REF_NAME"' in coordinator
         assert '--expected-commit "$GITHUB_SHA"' in coordinator
+        assert (
+            coordinator.count(
+                '--expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"'
+            )
+            == 2
+        )
+        assert "needs: [authorize-release," in coordinator
         assert f"publisher-dispatch-{registry}.json" in coordinator
         assert f"name: publisher-dispatch-{registry}-${{{{ github.run_attempt }}}}" in coordinator
         assert (
@@ -666,7 +711,7 @@ def test_release_workflow_is_operator_dispatched_from_an_immutable_tag() -> None
         assert "scripts/verify_release_ref.py" in job
         assert '--expected-commit "$GITHUB_SHA"' in job
         assert (
-            '--expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}" in job
+            '--expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"' in job
         )
     assert "tag_name: ${{ github.ref_name }}" in github_release
 

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -569,6 +569,11 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         assert "github.triggering_actor == 'everettVT'" in coordinator
 
     assert "github.triggering_actor == 'everettVT'" in github_release
+    assert "scripts/verify_release_ref.py" in github_release
+    assert '--expected-commit "$GITHUB_SHA"' in github_release
+    assert github_release.index("scripts/verify_release_ref.py") < github_release.index(
+        "softprops/action-gh-release@"
+    )
     assert 'version: "latest"' not in workflow
     assert workflow.count('version: "0.9.28"') == 8
     assert workflow.count("persist-credentials: false") == 12
@@ -604,8 +609,10 @@ def test_release_workflow_is_operator_dispatched_from_an_immutable_tag() -> None
     assert "needs: authorize-release" in profile
     assert "needs: authorize-release" in compatibility
     assert 'git merge-base --is-ancestor "${GITHUB_REF_NAME}^{commit}" origin/main' in profile
-    assert "scripts/verify_release_ref.py" in _job(workflow, "testpypi-preflight")
-    assert "scripts/verify_release_ref.py" in _job(workflow, "pypi-preflight")
+    for job_id in ("testpypi-preflight", "pypi-preflight", "github-release"):
+        job = _job(workflow, job_id)
+        assert "scripts/verify_release_ref.py" in job
+        assert '--expected-commit "$GITHUB_SHA"' in job
     assert "tag_name: ${{ github.ref_name }}" in github_release
 
 

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -116,10 +116,10 @@ def test_release_publish_requires_credentialed_r2_evidence() -> None:
     assert "target: operational-release-r2" in external
     assert "tests/infrastructure/test_r2_idempotency.py" in external
     assert "operational-release-r2-results.json" in gate
-    assert "needs: [release-evidence-gate, python-compatibility]" in _job(
+    assert "needs: [authorize-release, release-evidence-gate, python-compatibility]" in _job(
         workflow, "testpypi-preflight"
     )
-    assert "needs: pypi-preflight" in publish
+    assert "needs: [authorize-release, pypi-preflight]" in publish
 
     selected = _select_scenarios(
         load_scenarios(),
@@ -493,7 +493,9 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert 'UV_PYTHON: "3.13"' in compatibility
     assert 'uv sync --python "3.13" --all-packages --all-extras --group dev' in compatibility
     assert "sys.version_info[:2] == (3, 13)" in compatibility
-    assert "needs: [release-evidence-gate, python-compatibility]" in test_preflight
+    assert "needs: [authorize-release, release-evidence-gate, python-compatibility]" in (
+        test_preflight
+    )
     assert "scripts/verify_release_index.py" in test_preflight
     assert "scripts/verify_release_ref.py" in test_preflight
     assert "--publisher-environment release-testpypi" in test_preflight
@@ -501,7 +503,11 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "--registry-artifact-host test-files.pythonhosted.org" in test_preflight
     assert "--attestation-staging" not in test_preflight
     assert '--expected-commit "$GITHUB_SHA"' in test_preflight
-    assert "needs: testpypi-preflight" in publish_test
+    assert (
+        '--expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"'
+        in test_preflight
+    )
+    assert "needs: [authorize-release, testpypi-preflight]" in publish_test
     assert "environment: release-testpypi" in publish_test
     assert "repository-url: https://test.pypi.org/legacy/" in publish_test
     assert "needs: [publish-testpypi, publish-testpypi-libraries]" in test_smoke
@@ -514,14 +520,18 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "--registry-artifact-host test-files.pythonhosted.org" in test_smoke
     assert "--attestation-staging" not in test_smoke
     assert '--expected-commit "$GITHUB_SHA"' in test_smoke
-    assert "needs: testpypi-smoke" in pypi_preflight
+    assert "needs: [authorize-release, testpypi-smoke]" in pypi_preflight
     assert "scripts/verify_release_index.py" in pypi_preflight
     assert "scripts/verify_release_ref.py" in pypi_preflight
     assert "--publisher-environment release-pypi" in pypi_preflight
     assert "pypi-attestations==0.0.30" in pypi_preflight
     assert "--registry-artifact-host files.pythonhosted.org" in pypi_preflight
     assert '--expected-commit "$GITHUB_SHA"' in pypi_preflight
-    assert "needs: pypi-preflight" in publish
+    assert (
+        '--expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"'
+        in pypi_preflight
+    )
+    assert "needs: [authorize-release, pypi-preflight]" in publish
     assert "needs: [publish, publish-libraries]" in registry_smoke
     assert "scripts/verify_release_index.py" in registry_smoke
     assert "scripts/registry_smoke.py" in registry_smoke
@@ -531,7 +541,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "pypi-attestations==0.0.30" in registry_smoke
     assert "--registry-artifact-host files.pythonhosted.org" in registry_smoke
     assert '--expected-commit "$GITHUB_SHA"' in registry_smoke
-    assert "needs: registry-smoke" in github_release
+    assert "needs: [authorize-release, registry-smoke]" in github_release
 
     for publishing_job in (publish_test, publish):
         assert "name: dist-archetype-ecs" in publishing_job
@@ -582,6 +592,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "shell: bash" in check
     assert "set -euo pipefail" in check
     assert "RELEASE_INPUT_TAG: ${{ inputs.tag }}" in check
+    assert "EXPECTED_TAG_OBJECT: ${{ needs.authorize-release.outputs.tag_object_sha }}" in check
     assert '[[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]]' in check
     assert '[[ "$GITHUB_REF" == "$tag_ref" ]]' in check
     assert "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$" in check
@@ -589,6 +600,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert 'remote="https://github.com/VangelisTech/archetype.git"' in check
     assert '"$tag_ref" "$tag_ref^{}"' in check
     assert '[[ "$sha" =~ ^[0-9a-f]{40}$ ]]' in check
+    assert '[[ "$direct_sha" == "$EXPECTED_TAG_OBJECT" ]]' in check
     assert 'resolved_sha="${peeled_sha:-$direct_sha}"' in check
     assert '[[ "$resolved_sha" == "$GITHUB_SHA" ]]' in check
     assert "scripts/" not in check
@@ -604,6 +616,10 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "github.triggering_actor == 'everettVT'" in github_release
     assert "scripts/verify_release_ref.py" in github_release
     assert '--expected-commit "$GITHUB_SHA"' in github_release
+    assert (
+        '--expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}"'
+        in github_release
+    )
     assert github_release.index("scripts/verify_release_ref.py") < github_release.index(
         "softprops/action-gh-release@"
     )
@@ -635,10 +651,13 @@ def test_release_workflow_is_operator_dispatched_from_an_immutable_tag() -> None
     assert "push:\n    tags:" not in workflow
     assert "RELEASE_ACTOR: ${{ github.actor }}" in authorize
     assert "RELEASE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}" in authorize
-    assert 'test "$RELEASE_ACTOR" = "everettVT"' in authorize
-    assert 'test "$RELEASE_TRIGGERING_ACTOR" = "everettVT"' in authorize
-    assert 'test "$RELEASE_REF_TYPE" = "tag"' in authorize
-    assert 'test "$RELEASE_INPUT_TAG" = "$RELEASE_REF_NAME"' in authorize
+    assert '[[ "$RELEASE_ACTOR" == "everettVT" ]]' in authorize
+    assert '[[ "$RELEASE_TRIGGERING_ACTOR" == "everettVT" ]]' in authorize
+    assert '[[ "$RELEASE_REF_TYPE" == "tag" ]]' in authorize
+    assert '[[ "$RELEASE_INPUT_TAG" == "$RELEASE_REF_NAME" ]]' in authorize
+    assert "tag_object_sha: ${{ steps.release_ref.outputs.tag_object_sha }}" in authorize
+    assert "git ls-remote --exit-code" in authorize
+    assert "printf 'tag_object_sha=%s\\n'" in authorize
     assert "needs: authorize-release" in profile
     assert "needs: authorize-release" in compatibility
     assert 'git merge-base --is-ancestor "${GITHUB_REF_NAME}^{commit}" origin/main' in profile
@@ -646,6 +665,9 @@ def test_release_workflow_is_operator_dispatched_from_an_immutable_tag() -> None
         job = _job(workflow, job_id)
         assert "scripts/verify_release_ref.py" in job
         assert '--expected-commit "$GITHUB_SHA"' in job
+        assert (
+            '--expected-tag-object "${{ needs.authorize-release.outputs.tag_object_sha }}" in job
+        )
     assert "tag_name: ${{ github.ref_name }}" in github_release
 
 

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -88,6 +88,22 @@ def test_local_pr_profile_matches_the_two_ci_jobs() -> None:
     ]
 
 
+def test_release_check_emits_the_immutable_annotated_tag_recipe() -> None:
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    target = re.search(
+        r"^release-check:[^\n]*\n(?P<body>(?:\t.*\n)+)",
+        makefile,
+        re.MULTILINE,
+    )
+
+    assert target is not None
+    body = target.group("body")
+    assert "git fetch origin main" in body
+    assert 'git tag -a v$(VERSION) origin/main -m \\"Release v$(VERSION)\\"' in body
+    assert "git push origin refs/tags/v$(VERSION):refs/tags/v$(VERSION)" in body
+    assert 'git tag v$(VERSION)"' not in body
+
+
 def test_review_gate_and_merge_queue_are_not_executable_workflows() -> None:
     active = ROOT / ".github" / "workflows"
     for name in (

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -540,7 +540,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         assert "attestations: true" in publishing_job
         assert "id-token: write" in publishing_job
         assert "actions/checkout@" not in publishing_job
-        assert "run:" not in publishing_job
+        assert publishing_job.count("run:") == 1
         assert "uv build" not in publishing_job
         assert "make build" not in publishing_job
         assert "github.triggering_actor == 'everettVT'" in publishing_job
@@ -567,6 +567,39 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
             < coordinator.index("dispatch_release_publishers.py await")
         )
         assert "github.triggering_actor == 'everettVT'" in coordinator
+
+    publisher_check = re.compile(
+        r"      - name: Reauthorize the remote release tag\n"
+        r"(?P<step>.*?)(?=      - uses: pypa/gh-action-pypi-publish@)",
+        re.DOTALL,
+    )
+    publish_test_check = publisher_check.search(publish_test)
+    publish_check = publisher_check.search(publish)
+    assert publish_test_check is not None
+    assert publish_check is not None
+    assert publish_test_check.group("step") == publish_check.group("step")
+    check = publish_test_check.group("step")
+    assert "shell: bash" in check
+    assert "set -euo pipefail" in check
+    assert "RELEASE_INPUT_TAG: ${{ inputs.tag }}" in check
+    assert '[[ "$GITHUB_REPOSITORY" == "VangelisTech/archetype" ]]' in check
+    assert '[[ "$GITHUB_REF" == "$tag_ref" ]]' in check
+    assert "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$" in check
+    assert "git ls-remote --exit-code" in check
+    assert 'remote="https://github.com/VangelisTech/archetype.git"' in check
+    assert '"$tag_ref" "$tag_ref^{}"' in check
+    assert '[[ "$sha" =~ ^[0-9a-f]{40}$ ]]' in check
+    assert 'resolved_sha="${peeled_sha:-$direct_sha}"' in check
+    assert '[[ "$resolved_sha" == "$GITHUB_SHA" ]]' in check
+    assert "scripts/" not in check
+    assert "uses:" not in check
+    for publishing_job in (publish_test, publish):
+        assert (
+            publishing_job.index("actions/download-artifact@")
+            < publishing_job.index("name: Reauthorize the remote release tag")
+            < publishing_job.index("pypa/gh-action-pypi-publish@")
+        )
+        assert publishing_job.count("- uses:") == 2
 
     assert "github.triggering_actor == 'everettVT'" in github_release
     assert "scripts/verify_release_ref.py" in github_release

--- a/tests/scripts/test_release_publisher_parent_check.py
+++ b/tests/scripts/test_release_publisher_parent_check.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral contracts for checkout-free child publisher reauthorization."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from scripts.release_artifact import PUBLISHER_WORKFLOWS
+
+ROOT = Path(__file__).resolve().parents[2]
+AUTOMATION_ACTOR = "github-actions[bot]"
+CHILD_RUN_ID = 201
+COMMIT = "a" * 40
+DISTRIBUTION = "archetype-missions"
+PARENT_RUN_ATTEMPT = 2
+PARENT_RUN_ID = 101
+REGISTRY = "testpypi"
+REPOSITORY = "VangelisTech/archetype"
+TAG = "v0.6.0"
+TAG_OBJECT = "b" * 40
+WORKFLOW = "publish-archetype-missions.yml"
+
+
+def _job(workflow: str, job_id: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_id)}:\n(?P<body>.*?)(?=^  [a-z][a-z0-9-]*:\n|\Z)",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"workflow lost the {job_id!r} job"
+    return match.group("body")
+
+
+def _parent_check_bodies() -> tuple[str, ...]:
+    bodies: list[str] = []
+    for workflow_name in PUBLISHER_WORKFLOWS.values():
+        if workflow_name == "release.yml":
+            continue
+        workflow = (ROOT / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+        for job_id in ("publish-testpypi", "publish-pypi"):
+            job = _job(workflow, job_id)
+            step_marker = "      - name: Reauthorize the live parent release\n"
+            assert job.count(step_marker) == 1
+            _, step = job.split(step_marker)
+            run_marker = "        run: |\n"
+            assert step.count(run_marker) >= 1
+            _, shell_and_tag_check = step.split(run_marker, maxsplit=1)
+            raw_body, tag_marker, _ = shell_and_tag_check.partition(
+                "      - name: Reauthorize the remote release tag\n"
+            )
+            assert tag_marker
+
+            lines = raw_body.splitlines()
+            assert lines
+            assert all(not line or line.startswith("          ") for line in lines)
+            bodies.append("\n".join(line[10:] if line else "" for line in lines) + "\n")
+
+    assert len(bodies) == (len(PUBLISHER_WORKFLOWS) - 1) * 2
+    return tuple(bodies)
+
+
+def _parent_check_body() -> str:
+    bodies = _parent_check_bodies()
+    assert len(set(bodies)) == 1
+    return bodies[0]
+
+
+def _run_ids() -> dict[str, int]:
+    return {
+        distribution: CHILD_RUN_ID + index
+        for index, (distribution, workflow) in enumerate(PUBLISHER_WORKFLOWS.items())
+        if workflow != "release.yml"
+    }
+
+
+def _allowlist() -> dict[str, Any]:
+    run_ids = _run_ids()
+    return {
+        "schema": "archetype.publisher-dispatch/v2",
+        "repository": REPOSITORY,
+        "parent_run_id": PARENT_RUN_ID,
+        "parent_run_attempt": PARENT_RUN_ATTEMPT,
+        "tag": TAG,
+        "commit": COMMIT,
+        "tag_object": TAG_OBJECT,
+        "registry": REGISTRY,
+        "runs": [
+            {
+                "distribution": distribution,
+                "workflow": workflow,
+                "run_id": run_ids[distribution],
+                "url": f"https://github.com/{REPOSITORY}/actions/runs/{run_ids[distribution]}",
+            }
+            for distribution, workflow in PUBLISHER_WORKFLOWS.items()
+            if workflow != "release.yml"
+        ],
+    }
+
+
+def _parent_run() -> dict[str, Any]:
+    return {
+        "id": PARENT_RUN_ID,
+        "run_attempt": PARENT_RUN_ATTEMPT,
+        "event": "workflow_dispatch",
+        "path": ".github/workflows/release.yml",
+        "head_sha": COMMIT,
+        "head_branch": TAG,
+        "status": "in_progress",
+        "conclusion": None,
+        "repository": {"full_name": REPOSITORY},
+        "actor": {"login": "everettVT"},
+        "triggering_actor": {"login": "everettVT"},
+    }
+
+
+def _run_parent_check(
+    tmp_path: Path,
+    *,
+    parent_run: dict[str, Any] | None = None,
+    allowlist: dict[str, Any] | None = None,
+    gh_status: int = 0,
+    expect_gh: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    gh_arguments = tmp_path / "gh-arguments.txt"
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf \'%s\\n\' "$@" > "$FAKE_GH_ARGUMENTS"\n'
+        "printf '%s' \"$FAKE_GH_OUTPUT\"\n"
+        'exit "$FAKE_GH_STATUS"\n',
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    evidence = tmp_path / ".context" / "publisher-dispatch-live"
+    evidence.mkdir(parents=True)
+    (evidence / f"publisher-dispatch-{REGISTRY}.json").write_text(
+        json.dumps(allowlist or _allowlist()),
+        encoding="utf-8",
+    )
+    run_ids = _run_ids()
+    environment = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GH_ARGUMENTS": str(gh_arguments),
+        "FAKE_GH_OUTPUT": json.dumps(parent_run or _parent_run()),
+        "FAKE_GH_STATUS": str(gh_status),
+        "CHILD_RUN_ID": str(run_ids[DISTRIBUTION]),
+        "EXPECTED_COMMIT": COMMIT,
+        "EXPECTED_TAG_OBJECT": TAG_OBJECT,
+        "GH_TOKEN": "test-token",
+        "GITHUB_ACTOR": AUTOMATION_ACTOR,
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_REPOSITORY": REPOSITORY,
+        "GITHUB_SHA": COMMIT,
+        "GITHUB_TRIGGERING_ACTOR": AUTOMATION_ACTOR,
+        "GITHUB_WORKFLOW_REF": (f"{REPOSITORY}/.github/workflows/{WORKFLOW}@refs/tags/{TAG}"),
+        "PARENT_RUN_ATTEMPT": str(PARENT_RUN_ATTEMPT),
+        "PARENT_RUN_ID": str(PARENT_RUN_ID),
+        "PUBLISHER_DISTRIBUTION": DISTRIBUTION,
+        "PUBLISHER_REGISTRY": REGISTRY,
+        "PUBLISHER_TAG": TAG,
+        "PUBLISHER_WORKFLOW": WORKFLOW,
+    }
+    result = subprocess.run(  # noqa: S603 - exact trusted workflow shell under test
+        ["bash", "-c", _parent_check_body()],
+        cwd=tmp_path,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if expect_gh:
+        assert gh_arguments.read_text(encoding="utf-8").splitlines() == [
+            "api",
+            "-H",
+            "X-GitHub-Api-Version: 2026-03-10",
+            f"/repos/{REPOSITORY}/actions/runs/{PARENT_RUN_ID}",
+        ]
+    else:
+        assert not gh_arguments.exists()
+    return result
+
+
+def test_child_publishers_execute_identical_parent_check_shells() -> None:
+    bodies = _parent_check_bodies()
+
+    assert len(set(bodies)) == 1
+    assert all("${{" not in body for body in bodies)
+
+
+def test_parent_check_accepts_the_live_exact_parent_and_allowlisted_child(
+    tmp_path: Path,
+) -> None:
+    result = _run_parent_check(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_parent_check_rejects_a_canceled_parent(tmp_path: Path) -> None:
+    parent = _parent_run()
+    parent["status"] = "completed"
+    parent["conclusion"] = "cancelled"
+
+    result = _run_parent_check(tmp_path, parent_run=parent)
+
+    assert result.returncode != 0
+    assert "parent is no longer authorized and live" in result.stderr
+
+
+def test_parent_check_rejects_a_different_parent_attempt(tmp_path: Path) -> None:
+    parent = _parent_run()
+    parent["run_attempt"] += 1
+
+    result = _run_parent_check(tmp_path, parent_run=parent)
+
+    assert result.returncode != 0
+    assert "parent is no longer authorized and live" in result.stderr
+
+
+def test_parent_check_rejects_a_different_operator(tmp_path: Path) -> None:
+    parent = _parent_run()
+    parent["triggering_actor"] = {"login": "someone-else"}
+
+    result = _run_parent_check(tmp_path, parent_run=parent)
+
+    assert result.returncode != 0
+    assert "parent is no longer authorized and live" in result.stderr
+
+
+def test_parent_check_rejects_a_child_missing_from_the_allowlist(tmp_path: Path) -> None:
+    allowlist = deepcopy(_allowlist())
+    selected = next(run for run in allowlist["runs"] if run["distribution"] == DISTRIBUTION)
+    selected["run_id"] += 1000
+    selected["url"] = f"https://github.com/{REPOSITORY}/actions/runs/{selected['run_id']}"
+
+    result = _run_parent_check(tmp_path, allowlist=allowlist, expect_gh=False)
+
+    assert result.returncode != 0
+    assert "child run is not allowlisted" in result.stderr
+
+
+def test_parent_check_rejects_a_different_tag_object_receipt(tmp_path: Path) -> None:
+    allowlist = _allowlist()
+    allowlist["tag_object"] = "c" * 40
+
+    result = _run_parent_check(tmp_path, allowlist=allowlist, expect_gh=False)
+
+    assert result.returncode != 0
+    assert "child run is not allowlisted" in result.stderr
+
+
+def test_parent_check_fails_closed_when_github_lookup_fails(tmp_path: Path) -> None:
+    result = _run_parent_check(tmp_path, gh_status=2)
+
+    assert result.returncode != 0
+    assert "parent lookup failed" in result.stderr

--- a/tests/scripts/test_release_publisher_tag_check.py
+++ b/tests/scripts/test_release_publisher_tag_check.py
@@ -16,7 +16,9 @@ ROOT = Path(__file__).resolve().parents[2]
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 PUBLISHER_JOBS = ("publish-testpypi", "publish")
 EXPECTED_COMMIT = "a" * 40
-OTHER_COMMIT = "b" * 40
+EXPECTED_TAG_OBJECT = "b" * 40
+REPLACEMENT_TAG_OBJECT = "c" * 40
+OTHER_COMMIT = "d" * 40
 TAG = "v0.6.0"
 TAG_REF = f"refs/tags/{TAG}"
 REMOTE = "https://github.com/VangelisTech/archetype.git"
@@ -69,6 +71,7 @@ def _run_tag_check(
     output: str,
     tag: str = TAG,
     expected_commit: str = EXPECTED_COMMIT,
+    expected_tag_object: str = EXPECTED_TAG_OBJECT,
     git_status: int = 0,
     expect_git: bool = True,
 ) -> subprocess.CompletedProcess[str]:
@@ -96,6 +99,7 @@ def _run_tag_check(
         "GITHUB_REF_TYPE": "tag",
         "GITHUB_REPOSITORY": "VangelisTech/archetype",
         "GITHUB_SHA": expected_commit,
+        "EXPECTED_TAG_OBJECT": expected_tag_object,
         "RELEASE_INPUT_TAG": tag,
     }
     result = subprocess.run(  # noqa: S603 - exact trusted workflow shell under test
@@ -131,6 +135,7 @@ def test_publisher_tag_check_accepts_a_lightweight_tag(tmp_path: Path) -> None:
     result = _run_tag_check(
         tmp_path,
         output=f"{EXPECTED_COMMIT}\t{TAG_REF}\n",
+        expected_tag_object=EXPECTED_COMMIT,
     )
 
     assert result.returncode == 0, result.stderr
@@ -139,7 +144,7 @@ def test_publisher_tag_check_accepts_a_lightweight_tag(tmp_path: Path) -> None:
 def test_publisher_tag_check_accepts_an_annotated_tag(tmp_path: Path) -> None:
     result = _run_tag_check(
         tmp_path,
-        output=(f"{OTHER_COMMIT}\t{TAG_REF}\n{EXPECTED_COMMIT}\t{TAG_REF}^{{}}\n"),
+        output=(f"{EXPECTED_TAG_OBJECT}\t{TAG_REF}\n{EXPECTED_COMMIT}\t{TAG_REF}^{{}}\n"),
     )
 
     assert result.returncode == 0, result.stderr
@@ -149,10 +154,21 @@ def test_publisher_tag_check_rejects_a_moved_commit(tmp_path: Path) -> None:
     result = _run_tag_check(
         tmp_path,
         output=f"{OTHER_COMMIT}\t{TAG_REF}\n",
+        expected_tag_object=OTHER_COMMIT,
     )
 
     assert result.returncode != 0
     assert "remote tag commit differs" in result.stderr
+
+
+def test_publisher_tag_check_rejects_replaced_annotated_tag_object(tmp_path: Path) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output=(f"{REPLACEMENT_TAG_OBJECT}\t{TAG_REF}\n{EXPECTED_COMMIT}\t{TAG_REF}^{{}}\n"),
+    )
+
+    assert result.returncode != 0
+    assert "remote tag object differs" in result.stderr
 
 
 def test_publisher_tag_check_rejects_a_duplicate_ref(tmp_path: Path) -> None:

--- a/tests/scripts/test_release_publisher_tag_check.py
+++ b/tests/scripts/test_release_publisher_tag_check.py
@@ -1,0 +1,234 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral contracts for the checkout-free publisher tag reauthorization."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+PUBLISHER_JOBS = ("publish-testpypi", "publish")
+EXPECTED_COMMIT = "a" * 40
+OTHER_COMMIT = "b" * 40
+TAG = "v0.6.0"
+TAG_REF = f"refs/tags/{TAG}"
+REMOTE = "https://github.com/VangelisTech/archetype.git"
+
+
+def _job(workflow: str, job_id: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_id)}:\n(?P<body>.*?)(?=^  [a-z][a-z0-9-]*:\n|\Z)",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"workflow lost the {job_id!r} job"
+    return match.group("body")
+
+
+def _tag_check_bodies() -> tuple[str, str]:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    bodies: list[str] = []
+    for job_id in PUBLISHER_JOBS:
+        job = _job(workflow, job_id)
+        step_marker = "      - name: Reauthorize the remote release tag\n"
+        assert job.count(step_marker) == 1
+        _, step = job.split(step_marker)
+        run_marker = "        run: |\n"
+        assert step.count(run_marker) == 1
+        _, shell_and_publisher = step.split(run_marker)
+        raw_body, publisher_marker, _ = shell_and_publisher.partition(
+            "      - uses: pypa/gh-action-pypi-publish@"
+        )
+        assert publisher_marker
+
+        lines = raw_body.splitlines()
+        assert lines
+        assert all(not line or line.startswith("          ") for line in lines)
+        bodies.append("\n".join(line[10:] if line else "" for line in lines) + "\n")
+
+    assert len(bodies) == 2
+    return bodies[0], bodies[1]
+
+
+def _tag_check_body() -> str:
+    testpypi, pypi = _tag_check_bodies()
+    assert testpypi == pypi
+    return pypi
+
+
+def _run_tag_check(
+    tmp_path: Path,
+    *,
+    output: str,
+    tag: str = TAG,
+    expected_commit: str = EXPECTED_COMMIT,
+    git_status: int = 0,
+    expect_git: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    git_arguments = tmp_path / "git-arguments.txt"
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf \'%s\\n\' "$@" > "$FAKE_GIT_ARGUMENTS"\n'
+        "printf '%s' \"$FAKE_GIT_OUTPUT\"\n"
+        'exit "$FAKE_GIT_STATUS"\n',
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+
+    environment = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_ARGUMENTS": str(git_arguments),
+        "FAKE_GIT_OUTPUT": output,
+        "FAKE_GIT_STATUS": str(git_status),
+        "GITHUB_REF": f"refs/tags/{tag}",
+        "GITHUB_REF_NAME": tag,
+        "GITHUB_REF_TYPE": "tag",
+        "GITHUB_REPOSITORY": "VangelisTech/archetype",
+        "GITHUB_SHA": expected_commit,
+        "RELEASE_INPUT_TAG": tag,
+    }
+    result = subprocess.run(  # noqa: S603 - exact trusted workflow shell under test
+        ["bash", "-c", _tag_check_body()],
+        cwd=tmp_path,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    if expect_git:
+        assert git_arguments.read_text(encoding="utf-8").splitlines() == [
+            "ls-remote",
+            "--exit-code",
+            REMOTE,
+            f"refs/tags/{tag}",
+            f"refs/tags/{tag}^{{}}",
+        ]
+    else:
+        assert not git_arguments.exists()
+    return result
+
+
+def test_publisher_jobs_execute_identical_tag_check_shells() -> None:
+    testpypi, pypi = _tag_check_bodies()
+
+    assert testpypi == pypi
+    assert "${{" not in pypi
+
+
+def test_publisher_tag_check_accepts_a_lightweight_tag(tmp_path: Path) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output=f"{EXPECTED_COMMIT}\t{TAG_REF}\n",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_publisher_tag_check_accepts_an_annotated_tag(tmp_path: Path) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output=(f"{OTHER_COMMIT}\t{TAG_REF}\n{EXPECTED_COMMIT}\t{TAG_REF}^{{}}\n"),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_publisher_tag_check_rejects_a_moved_commit(tmp_path: Path) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output=f"{OTHER_COMMIT}\t{TAG_REF}\n",
+    )
+
+    assert result.returncode != 0
+    assert "remote tag commit differs" in result.stderr
+
+
+def test_publisher_tag_check_rejects_a_duplicate_ref(tmp_path: Path) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output=(f"{EXPECTED_COMMIT}\t{TAG_REF}\n{EXPECTED_COMMIT}\t{TAG_REF}\n"),
+    )
+
+    assert result.returncode != 0
+    assert "duplicate direct tag ref" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        f"{EXPECTED_COMMIT} {TAG_REF}\n",
+        f"{EXPECTED_COMMIT}\t{TAG_REF}\textra\n",
+    ],
+    ids=("missing-tab", "extra-field"),
+)
+def test_publisher_tag_check_rejects_malformed_output(
+    tmp_path: Path,
+    output: str,
+) -> None:
+    result = _run_tag_check(tmp_path, output=output)
+
+    assert result.returncode != 0
+    assert "malformed ls-remote output" in result.stderr
+
+
+def test_publisher_tag_check_rejects_an_unexpected_ref(tmp_path: Path) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output=f"{EXPECTED_COMMIT}\trefs/tags/v0.6.1\n",
+    )
+
+    assert result.returncode != 0
+    assert "unexpected remote ref" in result.stderr
+
+
+def test_publisher_tag_check_requires_the_direct_ref(tmp_path: Path) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output=f"{EXPECTED_COMMIT}\t{TAG_REF}^{{}}\n",
+    )
+
+    assert result.returncode != 0
+    assert "direct tag ref is absent" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["v00.6.0", "v0.6.0; echo injected"],
+    ids=("noncanonical", "shell-injection"),
+)
+def test_publisher_tag_check_rejects_an_invalid_tag(
+    tmp_path: Path,
+    tag: str,
+) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output=f"{EXPECTED_COMMIT}\t{TAG_REF}\n",
+        tag=tag,
+        expect_git=False,
+    )
+
+    assert result.returncode != 0
+    assert "tag must be canonical" in result.stderr
+    assert "injected" not in result.stdout
+
+
+def test_publisher_tag_check_fails_closed_when_git_fails(tmp_path: Path) -> None:
+    result = _run_tag_check(
+        tmp_path,
+        output="",
+        git_status=2,
+    )
+
+    assert result.returncode != 0

--- a/tests/scripts/test_release_publisher_tag_check.py
+++ b/tests/scripts/test_release_publisher_tag_check.py
@@ -12,9 +12,10 @@ from pathlib import Path
 
 import pytest
 
+from scripts.release_artifact import PUBLISHER_WORKFLOWS
+
 ROOT = Path(__file__).resolve().parents[2]
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
-PUBLISHER_JOBS = ("publish-testpypi", "publish")
 EXPECTED_COMMIT = "a" * 40
 EXPECTED_TAG_OBJECT = "b" * 40
 REPLACEMENT_TAG_OBJECT = "c" * 40
@@ -34,10 +35,23 @@ def _job(workflow: str, job_id: str) -> str:
     return match.group("body")
 
 
-def _tag_check_bodies() -> tuple[str, str]:
-    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+def _publisher_jobs() -> tuple[tuple[Path, str], ...]:
+    jobs: list[tuple[Path, str]] = []
+    for workflow in PUBLISHER_WORKFLOWS.values():
+        path = ROOT / ".github" / "workflows" / workflow
+        job_ids = (
+            ("publish-testpypi", "publish")
+            if workflow == "release.yml"
+            else ("publish-testpypi", "publish-pypi")
+        )
+        jobs.extend((path, job_id) for job_id in job_ids)
+    return tuple(jobs)
+
+
+def _tag_check_bodies() -> tuple[str, ...]:
     bodies: list[str] = []
-    for job_id in PUBLISHER_JOBS:
+    for path, job_id in _publisher_jobs():
+        workflow = path.read_text(encoding="utf-8")
         job = _job(workflow, job_id)
         step_marker = "      - name: Reauthorize the remote release tag\n"
         assert job.count(step_marker) == 1
@@ -55,14 +69,14 @@ def _tag_check_bodies() -> tuple[str, str]:
         assert all(not line or line.startswith("          ") for line in lines)
         bodies.append("\n".join(line[10:] if line else "" for line in lines) + "\n")
 
-    assert len(bodies) == 2
-    return bodies[0], bodies[1]
+    assert len(bodies) == len(PUBLISHER_WORKFLOWS) * 2
+    return tuple(bodies)
 
 
 def _tag_check_body() -> str:
-    testpypi, pypi = _tag_check_bodies()
-    assert testpypi == pypi
-    return pypi
+    bodies = _tag_check_bodies()
+    assert len(set(bodies)) == 1
+    return bodies[0]
 
 
 def _run_tag_check(
@@ -125,10 +139,10 @@ def _run_tag_check(
 
 
 def test_publisher_jobs_execute_identical_tag_check_shells() -> None:
-    testpypi, pypi = _tag_check_bodies()
+    bodies = _tag_check_bodies()
 
-    assert testpypi == pypi
-    assert "${{" not in pypi
+    assert len(set(bodies)) == 1
+    assert all("${{" not in body for body in bodies)
 
 
 def test_publisher_tag_check_accepts_a_lightweight_tag(tmp_path: Path) -> None:

--- a/tests/scripts/test_verify_publisher_dispatch.py
+++ b/tests/scripts/test_verify_publisher_dispatch.py
@@ -15,6 +15,7 @@ from scripts.verify_publisher_dispatch import verify_publisher_dispatch
 
 _AUTOMATION_ACTOR = "github-actions[bot]"
 _COMMIT = "a" * 40
+_TAG_OBJECT = "b" * 40
 _DISTRIBUTION = "archetype-missions"
 _PARENT_RUN_ATTEMPT = 2
 _PARENT_RUN_ID = 101
@@ -50,12 +51,13 @@ def _parent_run() -> dict[str, Any]:
 def _allowlist() -> dict[str, Any]:
     run_ids = _run_ids()
     return {
-        "schema": "archetype.publisher-dispatch/v1",
+        "schema": "archetype.publisher-dispatch/v2",
         "repository": _REPOSITORY,
         "parent_run_id": _PARENT_RUN_ID,
         "parent_run_attempt": _PARENT_RUN_ATTEMPT,
         "tag": _TAG,
         "commit": _COMMIT,
+        "tag_object": _TAG_OBJECT,
         "registry": "testpypi",
         "runs": [
             {
@@ -90,6 +92,7 @@ def _arguments() -> dict[str, Any]:
         "allowlist": _allowlist(),
         "tag": _TAG,
         "expected_commit": _COMMIT,
+        "expected_tag_object": _TAG_OBJECT,
         "registry": "testpypi",
     }
 
@@ -102,6 +105,7 @@ def test_verify_publisher_dispatch_accepts_allowlisted_bot_child_and_live_parent
         "workflow": _WORKFLOW,
         "tag": _TAG,
         "commit": _COMMIT,
+        "tag_object": _TAG_OBJECT,
         "registry": "testpypi",
         "environment": "release-testpypi",
         "child_run_id": _run_ids()[_DISTRIBUTION],
@@ -203,7 +207,7 @@ def test_verify_publisher_dispatch_rejects_wrong_parent_run(
     elif case == "tag":
         parent["head_branch"] = "v0.6.1"
     elif case == "sha":
-        parent["head_sha"] = "b" * 40
+        parent["head_sha"] = "c" * 40
     elif case == "attempt":
         parent["run_attempt"] += 1
     elif case == "repository":
@@ -238,7 +242,7 @@ def test_verify_publisher_dispatch_rejects_malformed_allowlist_matrix(
     arguments["allowlist"] = allowlist
     runs = allowlist["runs"]
     if case == "schema":
-        allowlist["schema"] = "archetype.publisher-dispatch/v2"
+        allowlist["schema"] = "archetype.publisher-dispatch/v1"
     elif case == "extra_top_level":
         allowlist["extra"] = True
     elif case == "not_a_list":
@@ -259,4 +263,21 @@ def test_verify_publisher_dispatch_rejects_malformed_allowlist_matrix(
         runs[0]["extra"] = True
 
     with pytest.raises(error, match=message):
+        verify_publisher_dispatch(**arguments)
+
+
+def test_verify_publisher_dispatch_rejects_different_tag_object_in_allowlist() -> None:
+    arguments = _arguments()
+    arguments["allowlist"]["tag_object"] = "c" * 40
+
+    with pytest.raises(PermissionError, match="tag_object differs"):
+        verify_publisher_dispatch(**arguments)
+
+
+@pytest.mark.parametrize("value", ["", "B" * 40, "b" * 39, 3, None])
+def test_verify_publisher_dispatch_rejects_malformed_tag_object(value: object) -> None:
+    arguments = _arguments()
+    arguments["expected_tag_object"] = value
+
+    with pytest.raises(ValueError, match="expected tag object"):
         verify_publisher_dispatch(**arguments)

--- a/tests/scripts/test_verify_release_ref.py
+++ b/tests/scripts/test_verify_release_ref.py
@@ -13,6 +13,7 @@ import pytest
 from scripts.verify_release_ref import verify_release_ref
 
 COMMIT = "a" * 40
+TAG_OBJECT = "b" * 40
 
 
 def _run(
@@ -24,7 +25,7 @@ def _run(
     return subprocess.CompletedProcess(
         command,
         0,
-        stdout=f"{'b' * 40}\trefs/tags/v0.6.0\n{COMMIT}\trefs/tags/v0.6.0^{{}}\n",
+        stdout=f"{TAG_OBJECT}\trefs/tags/v0.6.0\n{COMMIT}\trefs/tags/v0.6.0^{{}}\n",
         stderr="",
     )
 
@@ -34,6 +35,7 @@ def test_release_ref_accepts_exact_annotated_tag_and_operator(tmp_path: Path) ->
         root=tmp_path,
         tag="v0.6.0",
         expected_commit=COMMIT,
+        expected_tag_object=TAG_OBJECT,
         repository="VangelisTech/archetype",
         actor="everettVT",
         triggering_actor="everettVT",
@@ -41,6 +43,7 @@ def test_release_ref_accepts_exact_annotated_tag_and_operator(tmp_path: Path) ->
     )
 
     assert result["commit"] == COMMIT
+    assert result["tag_object"] == TAG_OBJECT
     assert result["tag"] == "v0.6.0"
 
 
@@ -50,6 +53,7 @@ def test_release_ref_rejects_rerun_by_another_actor(tmp_path: Path) -> None:
             root=tmp_path,
             tag="v0.6.0",
             expected_commit=COMMIT,
+            expected_tag_object=TAG_OBJECT,
             repository="VangelisTech/archetype",
             actor="everettVT",
             triggering_actor="another-user",
@@ -73,6 +77,7 @@ def test_release_ref_rejects_moved_remote_tag(tmp_path: Path) -> None:
             root=tmp_path,
             tag="v0.6.0",
             expected_commit=COMMIT,
+            expected_tag_object=TAG_OBJECT,
             repository="VangelisTech/archetype",
             actor="everettVT",
             triggering_actor="everettVT",
@@ -96,8 +101,35 @@ def test_release_ref_rejects_duplicate_remote_evidence(tmp_path: Path) -> None:
             root=tmp_path,
             tag="v0.6.0",
             expected_commit=COMMIT,
+            expected_tag_object=TAG_OBJECT,
             repository="VangelisTech/archetype",
             actor="everettVT",
             triggering_actor="everettVT",
             run=duplicate,
+        )
+
+
+def test_release_ref_rejects_replaced_annotated_tag_object(tmp_path: Path) -> None:
+    replacement = "c" * 40
+
+    def replaced(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if command[1:3] == ["rev-parse", "HEAD"]:
+            return _run(command, **kwargs)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(f"{replacement}\trefs/tags/v0.6.0\n{COMMIT}\trefs/tags/v0.6.0^{{}}\n"),
+            stderr="",
+        )
+
+    with pytest.raises(ValueError, match="release tag object moved"):
+        verify_release_ref(
+            root=tmp_path,
+            tag="v0.6.0",
+            expected_commit=COMMIT,
+            expected_tag_object=TAG_OBJECT,
+            repository="VangelisTech/archetype",
+            actor="everettVT",
+            triggering_actor="everettVT",
+            run=replaced,
         )


### PR DESCRIPTION
## Stack

**4 / 4 — hosted publisher hardening**

Depends on #790 → #789 → #787. Review only the commits and diff from
`architecture-review-release-provenance` to this branch.

- #787 — distribution foundation
- #789 — supported API and normative documentation
- #790 — release artifacts and registry provenance
- **#791 — hosted publisher hardening (this PR)**

## Summary

- add checksum-pinned `actionlint` to continuous static checks
- remove unsafe inline use of pull-request branch names in the docs workflow
- revalidate the canonical immutable tag immediately before GitHub Release
  creation
- repeat tag/ref authorization inside each checkout-free OIDC publisher job,
  immediately before package publication
- execute the exact inline publisher check against controlled fake `git`
  responses, covering lightweight and annotated success plus moved,
  duplicate, malformed, missing, noncanonical, injected, and failed refs

## Review focus

- trust-boundary placement in the hosted release workflow
- whether every external mutation is preceded by fresh immutable-ref evidence
- shell/action expression safety and the executable fake-remote oracle

## Validation

- `make ci`: 3,132 passed, 21 skipped
- `make verify-release`: 84.68% coverage; regression/spec 23/23;
  capability 6/6; idempotency 20/20; source scenarios 16/16; exact-wheel
  scenarios 22/22
- installed operation matrix: 37 / 44 / 38 / 38 / 46 / 46
- release receipt binds commit
  `839fe9c62904728ecec6b4898862cc4d8ace4302` to exactly eight artifacts
- release framework wheel SHA-256:
  `0844a0d7d4b070c46f8bd171659e365855ef01b6e70fadd4c58839fde222d925`

## External release setup

Code is green. Before the first hosted 0.6 publication, repository/registry
administrators still need to protect the exact `release-testpypi` and
`release-pypi` environments, verify the immutable `v*` tag ruleset has no
bypass actor, and register/confirm pending Trusted Publishers for all four
project names on TestPyPI and PyPI.
