### PR TITLE
fix: sanitize API permission denials

### DIFF
--- a/src/archetype/api/errors.py
+++ b/src/archetype/api/errors.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 def raise_api_error(exc: Exception, *, conflict: bool = False) -> NoReturn:
     """Map service-layer exceptions to stable REST errors."""
     if isinstance(exc, PermissionError):
-        raise HTTPException(status_code=403, detail=str(exc)) from None
+        raise HTTPException(status_code=403, detail="Permission denied") from None
     # WorldNotFoundError extends LookupError, not KeyError; without the
     # explicit branch it fell through to the 500 fallback (issue #180).
     if isinstance(exc, WorldNotFoundError | KeyError):

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -171,6 +171,22 @@ def test_payload_rejection_contract_maps_to_safe_unprocessable_content() -> None
     assert secret not in raised.value.detail
 
 
+def test_permission_denial_does_not_expose_actor_or_roles() -> None:
+    actor_id = "private-actor-id"
+    roles = "admin, operator"
+    error = PermissionError(
+        f"actor {actor_id} with roles [{roles}] cannot execute permission destroy_world"
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        raise_api_error(error)
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail == "Permission denied"
+    assert actor_id not in raised.value.detail
+    assert roles not in raised.value.detail
+
+
 def test_catalog_schema_mismatch_remains_an_internal_error() -> None:
     with pytest.raises(HTTPException) as raised:
         raise_api_error(CatalogSchemaMismatchError("private schema detail"))


### PR DESCRIPTION
## Summary

- return a fixed `Permission denied` detail for API 403 responses
- keep the original internal exception from crossing the HTTP boundary
- add a regression proving actor IDs and role assignments are absent from the response

## Security impact

The current audit in #792 confirmed that `commands.policy` embeds the actor ID and full role set in `PermissionError`, while the API forwarded `str(exc)` verbatim and the CLI printed it. This closes that disclosure at the API boundary without changing internal authorization behavior.

## Validation

- `uv run pytest -q tests/api/test_errors.py` — 13 passed
- `make static` — passed, including `pip-audit` with no known vulnerabilities