### PR TITLE
docs: organize guidance by package

### DIFF
--- a/.claude/skills/footgun-detector/SKILL.md
+++ b/.claude/skills/footgun-detector/SKILL.md
@@ -44,12 +44,14 @@ Check every changed file in the diff against the categories below. For each file
 **Sibling sweep.** When the diff fixes or establishes an invariant — a guard,
 an unwind, a containment check, an ordering — enumerate the codebase's mirror
 implementations and verify each sibling upholds the same invariant in this
-same review: sync (`core/sync/`) vs async (`core/aio/`) worlds, LanceDB vs
-Iceberg storage paths, `create_world` vs `fork_world` vs `open_world_mutable`
-lifecycle. A sibling that violates the invariant is a finding even though its
-code is unchanged; anchor it to the changed line that establishes the
-invariant it breaks. This exists because serial rounds on one PR repeatedly
-found the fixed hunk's unfixed twin one round later.
+same review: the `AsyncWorld` engine vs the `ArchetypeRuntime.sync()` blocking
+facade, LanceDB vs Iceberg storage paths, and `create_world` vs `fork_world` vs
+`open_world_mutable` lifecycle. `archetype-smol` is an independent educational
+engine, not a production sibling unless the changed contract explicitly names
+it. A sibling that violates the invariant is a finding even though its code is
+unchanged; anchor it to the changed line that establishes the invariant it
+breaks. This exists because serial rounds on one PR repeatedly found the fixed
+hunk's unfixed twin one round later.
 
 In deterministic CI, the working tree is the protected base. Use it for
 surrounding context and `.footgun-review.diff` for the exact candidate changes;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,4 +393,5 @@ change, and report the exact validation that ran. See
 | `packages/archetype-physical-ai/src/archetype/physical_ai/_extension.py` | Physical-AI manifest and installation |
 | `packages/archetype-research/src/archetype/research/_extension.py` | Research manifest and installation |
 | `tests/app/test_runtime_contracts.py` | Executable runtime contracts |
-| `tests/sync/test_sync_stack_contracts.py` | Executable sync engine contracts |
+| `tests/core/test_no_legacy_sync_kernel.py` | Parallel sync-kernel removal and supported blocking-runtime boundary |
+| `packages/archetype-smol/tests/test_smol.py` | Independent educational Smol engine contracts |

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -1,0 +1,54 @@
+# Framework
+
+| | |
+|---|---|
+| Distribution | `archetype-ecs` |
+| Import package | `archetype` |
+| Primary entry point | `ArchetypeRuntime` |
+| Depends on a world library | No |
+
+The framework owns the generic ECS and process host: Components, Processors,
+worlds, append-only ticks, storage, commands, Activities, artifacts,
+evaluation, runtime lifetime, REST hosting, and the CLI.
+
+Missions, Physical AI, and Research are separately installed libraries. Their
+domain values and workflows do not belong to the framework root API.
+
+For a deliberately bounded synchronous teaching loop without production
+runtime or storage semantics, see [Smol](../smol/index.md).
+
+## Learn the engine
+
+- [Quickstart](../guide/quickstart.md)
+- [Components](../guide/components.md)
+- [Processors](../guide/processors.md)
+- [Working with worlds](../guide/working-with-worlds.md)
+- [History and forks](../guide/history-and-forks.md)
+- [Core architecture](../guide/core-architecture.md)
+
+## Build and extend
+
+- [Building simulations](../guide/building-simulations.md)
+- [Resources](../guide/resources.md)
+- [Lifecycle hooks](../guide/hooks.md)
+- [Prefab libraries](../guide/prefab-libraries.md)
+- [Custom commands](../guide/custom-commands.md)
+
+## Run and operate
+
+- [Runtime contract](../guide/runtime.md)
+- [Activities](../guide/activities.md)
+- [Storage](../guide/stores.md)
+- [Artifacts](../guide/artifacts.md)
+- [Access control and audit](../guide/command-gate.md)
+- [Running a server](../guide/api-layer.md)
+
+## Reference
+
+- [Python API](../reference/python-api.md)
+- [Framework evaluation](../reference/python/evaluation.md)
+- [REST API](../reference/rest-api.md)
+- [CLI](../reference/cli.md)
+
+For framework internals, cross-package architecture, and executable contract
+evidence, continue to [Maintainers](../maintainers/index.md).

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -227,7 +227,16 @@ packages/archetype-physical-ai/src/archetype/physical_ai/
 packages/archetype-research/src/archetype/research/
   _extension.py      private Research composition adapter
   ...                AutoResearch values, ledger, views and workflow
+
+packages/archetype-smol/src/archetype/smol/
+  ...                independent synchronous in-memory teaching engine
 ```
+
+`archetype-smol` shares vocabulary with the production ECS but is not a
+framework family, world library, compatibility facade, or composition adapter.
+It imports neither `archetype-ecs` nor any world library. Its independently
+bounded API keeps educational simplification from weakening production
+durability, concurrency, or lifecycle contracts.
 
 `activities/` is a top-level family over the storage-owned Activity catalog.
 Hosted whole-episode choreography is owned by `archetype.physical_ai`; no
@@ -827,6 +836,9 @@ packages/archetype-physical-ai/src/archetype/physical_ai/
 packages/archetype-research/src/archetype/research/
   _extension.py  private manifest and Research composition adapter
   AutoResearch values, ledger, views, workflow, typed runtime adapter
+
+packages/archetype-smol/src/archetype/smol/
+  independent synchronous in-memory teaching engine; no framework dependency
 ```
 
 Historical note (superseded): before PR4, the design used

--- a/docs/guide/core-architecture.md
+++ b/docs/guide/core-architecture.md
@@ -2,9 +2,8 @@
 
 ## Purpose and Scope
 
-This page is the hub for Archetype's **engine**. Start with the
-[Runtime guide](runtime.md) for the supported application handles, then use
-this page to drill into each box.
+This page is the hub for Archetype's **engine**. It is the same mental model as
+the [Framework overview](../framework/index.md), expanded so you can drill into each box.
 
 Product features — HTTP hosting, command gate, agent missions, physical AI,
 prefabs — live in the [Application layer](app-overview.md). They compose on

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -5,9 +5,10 @@
 Use `ArchetypeRuntime` for a Python script. It owns one process resource graph,
 then gives you a lazy handle for each world.
 
-This page gets you from install to a running world. It uses the same core
-primitives as the [Overview](../index.md): components, processors, world,
-query, update, store.
+This page gets you from install to a running world. It uses the framework's
+core primitives: components, processors, worlds, queries, updates, and
+storage. See the [Framework overview](../framework/index.md) for the package
+map.
 
 For a copy-and-run script, see
 [`examples/00_quickstart.py`](https://github.com/VangelisTech/archetype/blob/main/examples/00_quickstart.py).
@@ -15,9 +16,21 @@ For the fuller workflow, see [Building simulations](building-simulations.md).
 
 ## Install
 
-```bash
-pip install archetype-ecs
-```
+<!-- markdownlint-disable MD046 -->
+
+=== "uv"
+
+    ```bash
+    uv add archetype-ecs
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install archetype-ecs
+    ```
+
+<!-- markdownlint-enable MD046 -->
 
 From a checkout, run `make sync-dev` instead.
 

--- a/docs/guide/world-libraries.md
+++ b/docs/guide/world-libraries.md
@@ -29,31 +29,62 @@ The `archetype` import package is intentionally extensible. The framework owns
 subpackages. Family-qualified imports are canonical even though their code is
 released from another distribution.
 
+`archetype-smol` is intentionally outside this framework/library graph. It is
+a separate synchronous in-memory teaching engine, has no dependency on
+`archetype-ecs`, publishes no extension manifest, and is never selected by an
+`archetype-ecs` extra. See [Smol](../smol/index.md).
+
 ## 2. Trusted Python extension boundary
 
 ### Installation
 
 Choose the smallest installation that owns the behavior your application uses:
 
-```bash
-# Generic framework only
-uv add archetype-ecs
+<!-- markdownlint-disable MD046 -->
 
-# One world library; each pulls in a compatible framework
-uv add archetype-missions
-uv add archetype-physical-ai
-uv add archetype-research
+=== "uv"
 
-# Every first-party world library
-uv add "archetype-ecs[all]"
-```
+    ```bash
+    # Generic framework only
+    uv add archetype-ecs
+
+    # One world library; each pulls in a compatible framework
+    uv add archetype-missions
+    uv add archetype-physical-ai
+    uv add archetype-research
+
+    # Every first-party world library
+    uv add "archetype-ecs[all]"
+
+    # A selective combination
+    uv add "archetype-ecs[missions,research]"
+    ```
+
+=== "pip"
+
+    ```bash
+    # Generic framework only
+    pip install archetype-ecs
+
+    # One world library; each pulls in a compatible framework
+    pip install archetype-missions
+    pip install archetype-physical-ai
+    pip install archetype-research
+
+    # Every first-party world library
+    pip install "archetype-ecs[all]"
+
+    # A selective combination
+    pip install "archetype-ecs[missions,research]"
+    ```
+
+<!-- markdownlint-enable MD046 -->
 
 The framework also exposes selective `missions`, `physical-ai`, and `research`
 extras, which may be combined, for example
-`uv add "archetype-ecs[missions,research]"`. Replace `uv add` with
-`pip install` when using pip. Provider-specific dependencies remain library
-extras: Missions exposes `modal`; Physical AI exposes `modal`, `sim`, and
-`all`.
+`archetype-ecs[missions,research]`. Provider-specific dependencies remain
+library extras: Missions exposes `modal`; Physical AI exposes `modal`, `sim`,
+and `all`.
 
 Installing a library is sufficient for ordinary process composition. Its wheel
 publishes an entry point, and `ArchetypeRuntime` and the FastAPI host discover
@@ -161,8 +192,9 @@ the discovery or lifecycle protocol for the library itself.
 
 ## 6. Packaging and release policy
 
-The repository is one uv workspace with one lock and four independently built
-projects. Published dependencies use normal version ranges; uv workspace source
+The repository is one uv workspace with one lock and five independently built
+projects: the framework, three world libraries, and the separate Smol teaching
+engine. Published dependencies use normal version ranges; uv workspace source
 overrides are development-only. Every wheel MUST build with workspace sources
 disabled and pass an isolated install/import smoke test.
 
@@ -186,6 +218,8 @@ Each distribution is built and tested independently. The 0.6 distributions are
 published as one coordinated release set, which MUST also pass a full-stack
 matrix proving deterministic composition, operation dispatch, router
 installation, process teardown, and duplicate/incompatible manifest failure.
+Smol receives its own isolated install and behavior proof; it is not inserted
+into the framework extension matrix.
 See [Archetype 0.6](release-0.6.md) for the exact clean-break upgrade contract.
 
 ## 7. Executable evidence
@@ -194,7 +228,7 @@ Required evidence includes:
 
 - base-only editable and wheel installs;
 - each library with the base, both editable and from wheels;
-- a full-stack install of all first-party libraries;
+- a full-stack install of all three first-party world libraries;
 - exact operation inventories for each installation set;
 - base runtime and API startup with zero extensions;
 - deterministic manifest ordering independent of entry-point order;

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,252 +1,113 @@
-# Overview
+# Archetype
 
-## Purpose and Scope
+Archetype is a DataFrame-first ECS framework with separately installed world
+libraries for coding-agent missions, physical-AI episodes, and AutoResearch.
+Choose the smallest distribution that owns the behavior you need, then compose
+libraries through their typed adapters.
 
-Archetype is a dataframe-first Entity-Component-System (ECS) simulation
-engine. Components hold typed state. Processors transform matching entities as
-Daft DataFrames. A world runs ticks and appends each result to columnar
-storage, so history, forks, and audit come from the same write path as the
-simulation.
+## Choose a package
 
-This page is the map of the **core primitives**. Everything else in the
-project — `ArchetypeRuntime`, the HTTP service, command gate, agent missions,
-prefabs, graphs — sits on top of this model. Learn the core first; the product
-layers are easier once the boxes below are solid.
+| Package | Import | Use it for |
+|---|---|---|
+| [Framework](framework/index.md) | `archetype-ecs` / `archetype` | Worlds, ticks, storage, commands, Activities, artifacts, evaluation, API, and CLI hosting |
+| [Smol](smol/index.md) | `archetype-smol` / `archetype.smol` | A tiny synchronous, in-memory DataFrame ECS for education and experimentation |
+| [Missions](missions/index.md) | `archetype-missions` / `archetype.missions` | Coding-agent missions, sandboxes, sessions, transcripts, and trajectory evidence |
+| [Physical AI](physical-ai/index.md) | `archetype-physical-ai` / `archetype.physical_ai` | Physical state, policies, hosted episodes, and provider recovery |
+| [Research](research/index.md) | `archetype-research` / `archetype.research` | Generic AutoResearch candidates, evaluators, experiments, and ledger state |
 
-[Start the quickstart](guide/quickstart.md) ·
-[Choose world libraries](guide/world-libraries.md) ·
-[Browse examples](guide/examples.md)
-
-For installation and a first run, see [Quickstart](guide/quickstart.md).
-For the normative application contracts, see
-[Architecture Overview](guide/architecture.md).
-
-## Key Capabilities
-
-| Capability | What it means |
-|---|---|
-| **Columnar ECS** | Entities that share a component set live in one archetype table |
-| **Lazy DataFrames** | Processors are Daft transforms over populations, not per-entity loops |
-| **Append-only history** | Each tick writes new rows; past state is a query, not a replay hack |
-| **Read/write split** | `AsyncQueryManager` reads; `AsyncUpdateManager` appends; the world orchestrates |
-| **Pluggable storage** | `AsyncStore` sits under the same query/update facades (LanceDB by default) |
-
-## Where to go
-
-| Goal | Guide |
-|---|---|
-| Run your first world | [Quickstart](guide/quickstart.md) |
-| Build a simulation | [Building simulations](guide/building-simulations.md) |
-| Model state | [Components](guide/components.md) |
-| Write behavior | [Processors](guide/processors.md) |
-| Spawn, query, and fork | [Working with worlds](guide/working-with-worlds.md) |
-| Inspect past state | [History and forks](guide/history-and-forks.md) |
-| Install Missions, Physical AI, or Research | [World libraries](guide/world-libraries.md) |
-| Run a coding-agent software factory | [Agent Missions](guide/agent-missions.md) |
-| Upgrade to the clean 0.6 split | [Archetype 0.6](guide/release-0.6.md) |
-| Run a service over HTTP | [Service hosting](guide/app-overview.md) |
-| Find an exact method or endpoint | [Reference](reference/python-api.md) |
-
-## System Architecture
-
-### High-level component relationships
+The three world libraries depend on `archetype-ecs`, never on one another. An
+application may compose any combination through their public adapters. Smol is
+independent of that graph and does not load world libraries.
 
 ```mermaid
-graph TB
-    App["Application / ArchetypeRuntime"]
-    World["AsyncWorld"]
-    System["AsyncSystem"]
-    QM["AsyncQueryManager"]
-    UM["AsyncUpdateManager"]
-    Store["AsyncStore"]
-
-    subgraph "Storage backends"
-        Lance["LanceDB"]
-        Other["Other stores"]
-    end
-
-    subgraph "Data processing"
-        Daft["Daft DataFrames"]
-        Arrow["PyArrow"]
-    end
-
-    App --> World
-    World --> System
-    World --> QM
-    World --> UM
-    QM --> Store
-    UM --> Store
-    System --> QM
-
-    Store --> Daft
-    Daft --> Arrow
-    Daft --> Lance
-    Daft --> Other
+graph BT
+    App["Your application"] --> Smol["archetype-smol"]
+    App --> ECS["archetype-ecs"]
+    Missions["archetype-missions"] --> ECS["archetype-ecs"]
+    Physical["archetype-physical-ai"] --> ECS
+    Research["archetype-research"] --> ECS
+    App --> Missions
+    App --> Physical
+    App --> Research
 ```
 
-The world is the orchestrator. It does not touch tables directly: reads go
-through `AsyncQueryManager`, writes through `AsyncUpdateManager`, and behavior
-through `AsyncSystem` + processors.
+## Install
 
-## Core ECS Components
+<!-- markdownlint-disable MD046 -->
 
-### Code entity mapping
+=== "uv"
 
-```mermaid
-graph LR
-    subgraph "World management"
-        Runtime["ArchetypeRuntime"]
-        World["AsyncWorld"]
-    end
+    ```bash
+    # Framework only
+    uv add archetype-ecs
 
-    subgraph "ECS processing"
-        System["AsyncSystem"]
-        Processor["AsyncProcessor"]
-    end
+    # Small educational engine instead of the production framework
+    uv add archetype-smol
 
-    subgraph "Data management"
-        QM["AsyncQueryManager"]
-        UM["AsyncUpdateManager"]
-        Store["AsyncStore"]
-    end
+    # One world library; it installs a compatible framework
+    uv add archetype-missions
+    uv add archetype-physical-ai
+    uv add archetype-research
 
-    subgraph "Base types"
-        Component["Component"]
-        Archetype["Archetype / signature"]
-    end
+    # Complete world-library stack
+    uv add "archetype-ecs[all]"
+    ```
 
-    Runtime --> World
-    World --> System
-    World --> QM
-    World --> UM
-    QM --> Store
-    UM --> Store
-    System --> Processor
-    Processor --> Component
-    Component --> Archetype
-    Store --> Archetype
+=== "pip"
+
+    ```bash
+    # Framework only
+    pip install archetype-ecs
+
+    # Small educational engine instead of the production framework
+    pip install archetype-smol
+
+    # One world library; it installs a compatible framework
+    pip install archetype-missions
+    pip install archetype-physical-ai
+    pip install archetype-research
+
+    # Complete world-library stack
+    pip install "archetype-ecs[all]"
+    ```
+
+<!-- markdownlint-enable MD046 -->
+
+For selective extras, trust boundaries, and composition behavior, see
+[World libraries](guide/world-libraries.md).
+
+## Start here
+
+- New to Archetype: follow the [Framework quickstart](guide/quickstart.md).
+- Choosing distributions: read [World libraries](guide/world-libraries.md).
+- Upgrading across the clean break: read [Archetype 0.6](guide/release-0.6.md).
+- Looking for runnable code: browse [Examples](guide/examples.md).
+- Contributing or reviewing contracts: enter the [Maintainers](maintainers/index.md)
+  section.
+
+## One runtime, explicit domain adapters
+
+The framework owns process and world lifetime:
+
+```python
+import asyncio
+
+from archetype import ArchetypeRuntime
+from archetype.research import Research
+
+
+async def main() -> None:
+    async with ArchetypeRuntime() as runtime:
+        world = runtime.world("experiment")
+        research = Research(world)
+
+
+asyncio.run(main())
 ```
 
-| Primitive | Role |
-|---|---|
-| `Component` | Typed fields on an entity (`Position`, `Velocity`, …) |
-| `AsyncProcessor` | Declares required components; transforms their DataFrame |
-| `AsyncSystem` | Runs eligible processors in priority order for an archetype |
-| `AsyncWorld` | Spawns entities, steps/runs ticks, owns the live simulation |
-| `AsyncQueryManager` | Read facade over the store |
-| `AsyncUpdateManager` | Append facade over the store |
-| `AsyncStore` | Physical tables keyed by archetype signature |
-| `Archetype` | The component-set → table schema grouping |
+Installed libraries add typed adapters without adding domain methods to the
+generic runtime or world.
 
-`ArchetypeRuntime` is the usual script entry point: it owns process lifetime
-and returns lazy world handles. The boxes above are still what a tick
-actually moves through.
-
-## Processing Pipeline
-
-### One simulation step
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant World as AsyncWorld
-    participant System as AsyncSystem
-    participant QM as AsyncQueryManager
-    participant UM as AsyncUpdateManager
-    participant Store as AsyncStore
-
-    App->>World: step() / run(steps=N)
-    World->>System: execute per active archetype
-    loop For each eligible processor
-        System->>QM: query required components
-        QM->>Store: load archetype DataFrame(s)
-        Store-->>QM: Dict[signature, DataFrame]
-        System->>System: processor.process(df, ...)
-    end
-    System-->>World: transformed archetype data
-    World->>UM: update(archetype data)
-    UM->>Store: append rows for this tick
-    World->>World: advance tick
-```
-
-Teaching model: query → transform → append → advance. The async world fans
-this out per active archetype table; the read/write split stays the same.
-
-## Entity-Component-System Pattern
-
-```mermaid
-graph LR
-    subgraph "Components"
-        Position["Position<br/>x: float"]
-        Velocity["Velocity<br/>dx: float"]
-    end
-
-    subgraph "Entities"
-        E1["Entity 1<br/>Position + Velocity"]
-        E2["Entity 2<br/>Position + Velocity"]
-    end
-
-    subgraph "Processors"
-        Move["Move<br/>components = (Position, Velocity)"]
-    end
-
-    subgraph "Processing"
-        DF["Daft DataFrame<br/>one archetype table"]
-        Transform["df.with_columns(...)<br/>position__x += velocity__dx"]
-    end
-
-    Position --> E1
-    Velocity --> E1
-    Position --> E2
-    Velocity --> E2
-    E1 --> DF
-    E2 --> DF
-    Move --> Transform
-    DF --> Transform
-```
-
-Entities are IDs. Components are data. Processors are bulk transforms over
-every entity that has the declared component set.
-
-## Archetypes
-
-Entities that share the same component types share an **archetype** — and
-therefore one table schema.
-
-```mermaid
-flowchart LR
-    E["Entity with components"] --> Sig["Signature<br/>(Position, Velocity)"]
-    Sig --> Table["Archetype table<br/>one schema, many rows"]
-    Table --> Tick["Rows keyed by<br/>world / run / tick"]
-```
-
-Different component sets → different signatures → different tables. That is
-why processors can assume their columns exist: the system only runs a
-processor when its components are a subset of the archetype signature.
-
-## Above the core
-
-The rest of Archetype layers product semantics on this engine:
-
-```mermaid
-graph TB
-    Product["Runtime, REST, CLI, missions, prefabs, graphs"]
-    Core["AsyncWorld · AsyncSystem · AsyncProcessor · AsyncQueryManager · AsyncUpdateManager · AsyncStore"]
-    Data["Daft DataFrames · columnar tables"]
-
-    Product --> Core
-    Core --> Data
-```
-
-When docs talk about command gates, forks, or agent missions, they are
-describing what sits on the top box — not a different storage model.
-
-## Next Steps
-
-- [Quickstart](guide/quickstart.md) — install and run your first world
-- [Core architecture](guide/core-architecture.md) — drill into each engine box
-- [Building simulations](guide/building-simulations.md) — components, processors, worlds in practice
-- [Application layer](guide/app-overview.md) — runtime, gateway, and product families
-- [Agent Missions](guide/agent-missions.md) — software-factory workflow on the same core
-- [Examples](guide/examples.md) — copy-and-run scripts
-- [History and forks](guide/history-and-forks.md) — query past ticks and branch a run
+Installing a world library authorizes its trusted Python extension code to run
+during process composition. The framework remains useful with no world library
+installed.

--- a/docs/maintainers/index.md
+++ b/docs/maintainers/index.md
@@ -1,0 +1,31 @@
+# Maintainers
+
+This section contains architecture, normative contracts, executable evidence,
+release machinery, and historical records. Reader-facing package guides live
+under Framework, Smol, Missions, Physical AI, and Research.
+
+## Architecture and specifications
+
+- [Architecture in one page](../guide/architecture.md)
+- [Application architecture](../guide/application-architecture.md)
+- [World-library contract](../guide/world-libraries.md)
+- [Runtime contract](../guide/runtime.md)
+- [Specification index](../guide/specification.md)
+- [Contract traceability](../reference/contract-traceability.md)
+
+## Development and evidence
+
+- [Contributing](../guide/contributing.md)
+- [Repository harness](../guide/repository-harness.md)
+- [Repository checks](../guide/evals.md)
+- [API stability and docstrings](../guide/api-stability.md)
+- [Version inventory](../reference/version-inventory.md)
+
+## Release and history
+
+- [Archetype 0.6](../guide/release-0.6.md)
+- [Storage migration](../guide/storage-migration.md)
+- [Historical records](../history/index.md)
+
+Focused specifications remain canonical in their owning package sections. The
+maintainer indexes link to them rather than redefining their behavior.

--- a/docs/missions/index.md
+++ b/docs/missions/index.md
@@ -1,0 +1,39 @@
+# Missions
+
+| | |
+|---|---|
+| Distribution | `archetype-missions` |
+| Import package | `archetype.missions` |
+| Typed adapters | `Missions`, `MissionWorld` |
+| Dependency | `archetype-ecs` |
+
+Missions owns coding-agent mission state and behavior: task graphs, transition
+processors, author and critic Activities, sandbox resources, sessions,
+transcripts, trajectory evidence, and result projections.
+
+It does not add mission methods to `ArchetypeRuntime` or `RuntimeWorld`, and it
+does not depend on Physical AI or Research.
+
+## Start
+
+- [Agent Missions](../guide/agent-missions.md)
+- [Mission Activity recovery](recovery.md)
+- [Coding-agent mission example](../guide/examples.md#11a-coding-agent-mission)
+- [Mission Factory assets](../guide/mission-factory-assets.md)
+
+## Evidence
+
+- [Trajectories](../guide/trajectories.md)
+- [Transcript ingestion](transcripts.md)
+- [Python API: Missions](../reference/python/missions.md)
+- [Python API: transcripts](../reference/python/transcripts.md)
+- [Missions REST API](../reference/rest-api-missions.md)
+
+## Composition
+
+A software-research application may use Missions to produce bounded coding
+evidence and Research to optimize candidates. The application composes those
+public adapters; neither library imports the other.
+
+For installation and trusted extension behavior, see
+[World libraries](../guide/world-libraries.md).

--- a/docs/physical-ai/index.md
+++ b/docs/physical-ai/index.md
@@ -1,0 +1,30 @@
+# Physical AI
+
+| | |
+|---|---|
+| Distribution | `archetype-physical-ai` |
+| Import package | `archetype.physical_ai` |
+| Typed adapter | `PhysicalAI` |
+| Dependency | `archetype-ecs` |
+
+Physical AI owns physical state, local policy and environment adapters, hosted
+episode choreography, provider configuration, recovery, and completeness
+evidence.
+
+It does not place hosted-episode behavior on the generic framework world and
+does not depend on Missions or Research.
+
+## Start
+
+- [Run a hosted episode](../guide/physical-ai.md#run-a-hosted-episode)
+- [Committed-state sequence](../guide/physical-ai.md#committed-state-sequence)
+- [Canonical episode contract](../guide/physical-ai.md#canonical-episode-contract)
+
+## Reference
+
+- [Physical AI API](../reference/python/physical-ai.md)
+- [Host configuration](../reference/python/physical-ai-host.md)
+- [Optimization API](../reference/python/physical-ai-optimization.md)
+
+For installation and trusted extension behavior, see
+[World libraries](../guide/world-libraries.md).

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,0 +1,33 @@
+# Research
+
+| | |
+|---|---|
+| Distribution | `archetype-research` |
+| Import package | `archetype.research` |
+| Typed adapter | `Research` |
+| Dependency | `archetype-ecs` |
+
+Research is the minimal AutoResearch world library. It owns candidates,
+evaluators, experiment identity, ledger state, views, admission, and the
+directly awaited optimization workflow.
+
+Coding-agent sessions, transcripts, and trajectory schemas remain Missions
+behavior. Research may retain bounded external evidence without importing or
+duplicating another library.
+
+## Start
+
+- [AutoResearch](../guide/autoresearch.md)
+- [AutoResearch example](../guide/examples.md#10-autoresearch)
+- [Research Python API](../reference/python/autoresearch.md)
+
+## Framework evaluation
+
+Generic graders, outcomes, contracts, and durable evaluation receipts belong
+to `archetype-ecs`, not Research. Research consumes those framework contracts
+when an optimization workflow needs them. See the
+[Framework evaluation Python API](../reference/python/evaluation.md) for that
+separate surface.
+
+For installation and trusted extension behavior, see
+[World libraries](../guide/world-libraries.md).

--- a/docs/smol/index.md
+++ b/docs/smol/index.md
@@ -115,7 +115,7 @@ serialization policy.
 
 ## Choose the production framework when
 
-Use [`archetype-ecs`](../guide/runtime.md) when work needs durable worlds,
+Use [`archetype-ecs`](../framework/index.md) when work needs durable worlds,
 append-only storage, crash recovery, concurrent execution, commands,
 Activities, artifacts, evaluation, API hosting, or separately installed world
 libraries. There is no migration or alias promise between the two engines;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,9 +30,14 @@ theme:
     - navigation.instant
     - navigation.instant.prefetch
     - navigation.instant.progress
+    - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
+    - navigation.indexes
+    - navigation.path
     - navigation.footer
     - toc.follow
+    - content.tabs.link
     - content.code.copy
     - search.suggest
     - search.highlight
@@ -46,86 +51,105 @@ extra:
 copyright: Copyright &copy; 2026 Vangelis Tech
 
 nav:
-  - GETTING STARTED:
-      - Overview: index.md
-      - Quickstart: guide/quickstart.md
-      - Core Architecture: guide/core-architecture.md
+  - Start:
+      - index.md
       - Install World Libraries: guide/world-libraries.md
-      - Archetype 0.6: guide/release-0.6.md
+      - Framework Quickstart: guide/quickstart.md
       - Choose an Example: guide/examples.md
-  - USER GUIDE:
-      - Building Simulations: guide/building-simulations.md
-      - Components: guide/components.md
-      - Processors: guide/processors.md
-      - Worlds: guide/working-with-worlds.md
-      - History and Forks: guide/history-and-forks.md
-      - Prefab Libraries: guide/prefab-libraries.md
-      - Authoring Prefab Libraries: guide/authoring-prefab-libraries.md
-      - Mission Factory Assets: guide/mission-factory-assets.md
-      - Resources: guide/resources.md
-      - Lifecycle Hooks: guide/hooks.md
-      - Storage: guide/stores.md
-      - Configuration: guide/run-config.md
-  - APPLICATION LAYER:
-      - Overview: guide/app-overview.md
-      - Activities: guide/activities.md
-      - Access Control and Audit: guide/command-gate.md
-      - Custom Commands: guide/custom-commands.md
-      - Token Quotas: guide/token-quotas.md
-      - Running a Server: guide/api-layer.md
-      - Agent Missions: guide/agent-missions.md
-      - Trajectories: guide/trajectories.md
-      - Physical AI: guide/physical-ai.md
-      - AutoResearch: guide/autoresearch.md
-      - Tragedy of the Commons: experiments/tragedy-of-the-commons.md
-  - REFERENCE:
-      - PYTHON API:
-          - Overview: reference/python-api.md
+      - Python API Map: reference/python-api.md
+      - Upgrade to Archetype 0.6: guide/release-0.6.md
+  - Framework:
+      - framework/index.md
+      - Learn:
+          - Core Architecture: guide/core-architecture.md
+          - Building Simulations: guide/building-simulations.md
+          - Components: guide/components.md
+          - Processors: guide/processors.md
+          - Worlds: guide/working-with-worlds.md
+          - History and Forks: guide/history-and-forks.md
+      - Build and Extend:
+          - Prefab Libraries: guide/prefab-libraries.md
+          - Authoring Prefab Libraries: guide/authoring-prefab-libraries.md
+          - Resources: guide/resources.md
+          - Lifecycle Hooks: guide/hooks.md
+          - Configuration: guide/run-config.md
+      - Runtime and Operations:
+          - Application Overview: guide/app-overview.md
+          - Runtime Contract: guide/runtime.md
+          - Activities: guide/activities.md
+          - Access Control and Audit: guide/command-gate.md
+          - Audit Log: guide/audit-log.md
+          - Custom Commands: guide/custom-commands.md
+          - Token Quotas: guide/token-quotas.md
+          - Storage: guide/stores.md
+          - Storage Migration: guide/storage-migration.md
+          - Artifacts: guide/artifacts.md
+          - Dataset and Evaluation Ontology: guide/dataset-eval-ontology.md
+          - Running a Server: guide/api-layer.md
+      - Examples:
+          - Tragedy of the Commons: experiments/tragedy-of-the-commons.md
+      - Reference:
           - Runtime: reference/python/runtime.md
           - World Handle: reference/python/world-handle.md
           - Runtime Models: reference/python/runtime-models.md
           - File Artifacts: reference/python/artifacts.md
-          - Agent Missions: reference/python/missions.md
-          - Coding-Agent Transcripts: reference/python/transcripts.md
           - Building Blocks: reference/python/building-blocks.md
           - Hooks and Identity: reference/python/hooks.md
           - Configuration: reference/python/configuration.md
-          - AutoResearch: reference/python/autoresearch.md
           - Framework Evaluation: reference/python/evaluation.md
-          - Physical AI: reference/python/physical-ai.md
-          - Physical AI Optimization: reference/python/physical-ai-optimization.md
-          - Physical AI Host Configuration: reference/python/physical-ai-host.md
           - Core Engine: reference/python/core.md
           - Storage Backends: reference/python/storage.md
-      - Framework REST API: reference/rest-api.md
-      - Missions REST API: reference/rest-api-missions.md
-      - CLI: reference/cli.md
-  - DEVELOPMENT:
-      - Contributing: guide/contributing.md
-      - API Stability and Docstrings: guide/api-stability.md
-      - Contract Traceability: reference/contract-traceability.md
-      - Version Inventory: reference/version-inventory.md
-      - Architecture Overview: guide/architecture.md
-      - Application Architecture: guide/application-architecture.md
-      - Runtime Contract: guide/runtime.md
-      - Observability: guide/observability.md
-      - Specifications: guide/specification.md
-      - Service Protocols: guide/service-protocols.md
-      - Execution Hierarchy: guide/execution-hierarchy.md
-      - World Lifecycle: guide/world-lifecycle.md
-      - Durable Discovery: guide/durable-discovery.md
-      - Atomic Visibility: guide/atomic-visibility.md
-      - Storage Migration: guide/storage-migration.md
-      - Artifacts: guide/artifacts.md
-      - Dataset and Evaluation Ontology: guide/dataset-eval-ontology.md
-      - Audit Log: guide/audit-log.md
-      - Repository Harness: guide/repository-harness.md
-      - Repository Checks: guide/evals.md
-      - Performance Benchmarking: guide/benchmarking.md
-      - Benchmark Runs:
-          - Modal OpenCode Single-H200 (2026-07-18): guide/benchmark-runs/modal-opencode-single-h200-2026-07-18.md
-      - Mutation Testing: guide/mutation-testing.md
-      - CORE INTERNALS:
+          - REST API: reference/rest-api.md
+          - CLI: reference/cli.md
+      - Specifications:
+          - Execution Hierarchy: guide/execution-hierarchy.md
+          - World Lifecycle: guide/world-lifecycle.md
+          - Durable Discovery: guide/durable-discovery.md
+          - Atomic Visibility: guide/atomic-visibility.md
+  - Smol:
+      - smol/index.md
+  - Missions:
+      - missions/index.md
+      - Agent Missions: guide/agent-missions.md
+      - Mission Activity Recovery: missions/recovery.md
+      - Trajectories: guide/trajectories.md
+      - Transcript Ingestion: missions/transcripts.md
+      - Mission Factory Assets: guide/mission-factory-assets.md
+      - Python API:
+          - Missions: reference/python/missions.md
+          - Transcripts: reference/python/transcripts.md
+      - REST API: reference/rest-api-missions.md
+  - Physical AI:
+      - physical-ai/index.md
+      - Physical AI: guide/physical-ai.md
+      - Python API:
+          - Core Surface: reference/python/physical-ai.md
+          - Optimization: reference/python/physical-ai-optimization.md
+          - Host Configuration: reference/python/physical-ai-host.md
+  - Research:
+      - research/index.md
+      - AutoResearch: guide/autoresearch.md
+      - Python API: reference/python/autoresearch.md
+  - Maintainers:
+      - maintainers/index.md
+      - Architecture and Contracts:
+          - Architecture Overview: guide/architecture.md
+          - Application Architecture: guide/application-architecture.md
+          - Specifications: guide/specification.md
+          - Service Protocols: guide/service-protocols.md
+          - Observability: guide/observability.md
+          - Contract Traceability: reference/contract-traceability.md
+      - Development:
+          - Contributing: guide/contributing.md
+          - API Stability and Docstrings: guide/api-stability.md
+          - Repository Harness: guide/repository-harness.md
+          - Repository Checks: guide/evals.md
+          - Performance Benchmarking: guide/benchmarking.md
+          - Benchmark Runs:
+              - Modal OpenCode Single-H200 (2026-07-18): guide/benchmark-runs/modal-opencode-single-h200-2026-07-18.md
+          - Mutation Testing: guide/mutation-testing.md
+          - Version Inventory: reference/version-inventory.md
+      - Core Internals:
           - Archetypes: guide/archetype.md
           - Systems: guide/system-execution.md
           - World Internals: guide/worlds.md
@@ -134,17 +158,17 @@ nav:
           - Data Flow: guide/data-flow.md
           - Durable Commands: guide/durable-commands.md
           - Services: guide/services.md
-  - HISTORY:
-      - About Historical Records: history/index.md
-      - AGENT DEBRIEFS:
-          - Coding-Agent Missions (2026-07-18): history/agent-debriefs/2026-07-18-coding-agent-missions.md
-      - READINESS INVENTORIES:
-          - Coding-Agent Mission Readiness (2026-07-18): history/readiness/2026-07-18-coding-agent-missions.md
-      - ARCHITECTURE REPORTS:
-          - Security Program Review (2026-03-28): reports/2026-03-28-security-program-review.md
-          - Service-Layer Redesign (2026-04-25): reports/2026-04-25-service-layer-redesign.md
-          - Robot Evals Extraction (2026-07-16): reports/2026-07-16-robot-evals-extraction.md
-          - Contract-Centered Quality System (2026-07-17): reports/2026-07-17-contract-centered-quality-system.md
+      - History:
+          - About Historical Records: history/index.md
+          - Agent Debriefs:
+              - Coding-Agent Missions (2026-07-18): history/agent-debriefs/2026-07-18-coding-agent-missions.md
+          - Readiness Inventories:
+              - Coding-Agent Mission Readiness (2026-07-18): history/readiness/2026-07-18-coding-agent-missions.md
+          - Architecture Reports:
+              - Security Program Review (2026-03-28): reports/2026-03-28-security-program-review.md
+              - Service-Layer Redesign (2026-04-25): reports/2026-04-25-service-layer-redesign.md
+              - Robot Evals Extraction (2026-07-16): reports/2026-07-16-robot-evals-extraction.md
+              - Contract-Centered Quality System (2026-07-17): reports/2026-07-17-contract-centered-quality-system.md
 
 markdown_extensions:
   - admonition
@@ -158,6 +182,8 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid

--- a/tests/scripts/test_world_library_docs.py
+++ b/tests/scripts/test_world_library_docs.py
@@ -142,14 +142,14 @@ def test_missions_reference_renders_the_primary_workflow_methods() -> None:
 def test_split_rest_references_are_navigable() -> None:
     navigation = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
 
-    assert "- Framework REST API: reference/rest-api.md" in navigation
-    assert "- Missions REST API: reference/rest-api-missions.md" in navigation
+    assert "- REST API: reference/rest-api.md" in navigation
+    assert "- REST API: reference/rest-api-missions.md" in navigation
 
 
 def test_split_research_and_evaluation_references_are_navigable() -> None:
     navigation = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
 
-    assert "- AutoResearch: reference/python/autoresearch.md" in navigation
+    assert "- Python API: reference/python/autoresearch.md" in navigation
     assert "- Framework Evaluation: reference/python/evaluation.md" in navigation
     assert "AutoResearch and Evaluation" not in navigation
 

--- a/tests/spec_contracts/test_documentation_contracts.py
+++ b/tests/spec_contracts/test_documentation_contracts.py
@@ -9,6 +9,8 @@ import ast
 import re
 from pathlib import Path
 
+import yaml
+
 _GUIDE_ROOT = Path("docs/guide")
 _COMMAND_TOTAL_PATTERNS = (
     re.compile(r"\b(\d+)\s+command\s+types?\b", re.IGNORECASE),
@@ -28,6 +30,54 @@ _BEGINNER_EXAMPLES = (
     Path("examples/00_quickstart.py"),
     Path("examples/simulation_script.py"),
 )
+_PRODUCTION_ENGINE_DOCS = (
+    Path("AGENTS.md"),
+    Path("LEARNINGS.md"),
+    Path(".claude/skills/footgun-detector/SKILL.md"),
+    _GUIDE_ROOT / "api-stability.md",
+    _GUIDE_ROOT / "architecture.md",
+    _GUIDE_ROOT / "atomic-visibility.md",
+    _GUIDE_ROOT / "contributing.md",
+    _GUIDE_ROOT / "core-architecture.md",
+    _GUIDE_ROOT / "data-flow.md",
+    Path("docs/design/split-step-ffi.md"),
+    _GUIDE_ROOT / "hooks.md",
+    _GUIDE_ROOT / "mutation-testing.md",
+    _GUIDE_ROOT / "specification.md",
+    _GUIDE_ROOT / "system-execution.md",
+)
+_RETIRED_SYNC_SURFACE = re.compile(
+    r"\b(?:SyncWorld|SyncSystem|SyncProcessor|SyncStore|SyncHookHandler|"
+    r"QueryManager|UpdateManager)\b|core/sync/|tests/sync/"
+)
+
+
+class _MkDocsLoader(yaml.SafeLoader):
+    """Safe YAML loader that treats MkDocs callable references as inert text."""
+
+
+_MkDocsLoader.add_multi_constructor(
+    "tag:yaml.org,2002:python/name:",
+    lambda _loader, suffix, _node: suffix,
+)
+
+
+def _nav_paths(items: list[object]) -> list[str]:
+    """Return every Markdown path beneath one MkDocs navigation branch."""
+
+    paths: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            paths.append(item)
+            continue
+        if not isinstance(item, dict):
+            continue
+        for child in item.values():
+            if isinstance(child, str):
+                paths.append(child)
+            elif isinstance(child, list):
+                paths.extend(_nav_paths(child))
+    return paths
 
 
 def test_guides_do_not_freeze_numeric_command_type_claims() -> None:
@@ -42,6 +92,27 @@ def test_guides_do_not_freeze_numeric_command_type_claims() -> None:
                 stale.append(f"{guide}:{line} freezes a global command-type total")
 
     assert not stale, "global command-type totals are no longer a contract:\n" + "\n".join(stale)
+
+
+def test_production_docs_teach_one_async_engine_and_its_blocking_facade() -> None:
+    """Retired core-sync names cannot drift back into current reader guidance."""
+
+    stale: dict[str, list[str]] = {}
+    for path in _PRODUCTION_ENGINE_DOCS:
+        matches = sorted(set(_RETIRED_SYNC_SURFACE.findall(path.read_text())))
+        if matches:
+            stale[str(path)] = matches
+
+    assert stale == {}
+
+    system = (_GUIDE_ROOT / "system-execution.md").read_text()
+    specification = (_GUIDE_ROOT / "specification.md").read_text()
+    smol = Path("docs/smol/index.md").read_text()
+
+    assert "same `AsyncWorld`/`AsyncSystem` engine" in system
+    assert "with ArchetypeRuntime.sync()" in system
+    assert "`AsyncQueryManager.query_archetype()`" in specification
+    assert "separate engine, not a compatibility facade" in smol
 
 
 def test_trusted_runtime_example_keeps_rbac_at_the_adapter_boundary() -> None:
@@ -197,3 +268,109 @@ def test_mkdocs_resolves_all_distribution_source_roots() -> None:
         assert library_source_root in extension
 
     assert "- Install World Libraries: guide/world-libraries.md" in config
+
+
+def test_package_navigation_has_one_explicit_owner_per_page() -> None:
+    """The reader-facing information architecture mirrors distribution ownership."""
+
+    config = yaml.load(Path("mkdocs.yml").read_text(), Loader=_MkDocsLoader)
+    branches = {name: children for item in config["nav"] for name, children in item.items()}
+
+    assert tuple(branches) == (
+        "Start",
+        "Framework",
+        "Smol",
+        "Missions",
+        "Physical AI",
+        "Research",
+        "Maintainers",
+    )
+    assert branches["Framework"][0] == "framework/index.md"
+    assert branches["Smol"][0] == "smol/index.md"
+    assert branches["Missions"][0] == "missions/index.md"
+    assert branches["Physical AI"][0] == "physical-ai/index.md"
+    assert branches["Research"][0] == "research/index.md"
+    assert branches["Maintainers"][0] == "maintainers/index.md"
+
+    paths_by_branch = {name: _nav_paths(children) for name, children in branches.items()}
+    all_paths = [path for paths in paths_by_branch.values() for path in paths]
+    assert len(all_paths) == len(set(all_paths)), "a documentation page has multiple nav owners"
+
+    expected_package_paths = {
+        "Missions": {
+            "guide/agent-missions.md",
+            "guide/trajectories.md",
+            "guide/mission-factory-assets.md",
+            "missions/recovery.md",
+            "missions/transcripts.md",
+            "reference/python/missions.md",
+            "reference/python/transcripts.md",
+            "reference/rest-api-missions.md",
+        },
+        "Physical AI": {
+            "guide/physical-ai.md",
+            "reference/python/physical-ai.md",
+            "reference/python/physical-ai-optimization.md",
+            "reference/python/physical-ai-host.md",
+        },
+        "Research": {
+            "guide/autoresearch.md",
+            "reference/python/autoresearch.md",
+        },
+    }
+    assert "reference/python/evaluation.md" in paths_by_branch["Framework"]
+    assert paths_by_branch["Smol"] == ["smol/index.md"]
+    for owner, expected in expected_package_paths.items():
+        assert expected <= set(paths_by_branch[owner])
+        assert expected.isdisjoint(paths_by_branch["Framework"])
+
+
+def test_package_navigation_enables_native_and_content_tabs() -> None:
+    """Package switching and short equivalent variants use supported Material features."""
+
+    config = Path("mkdocs.yml").read_text()
+
+    for feature in (
+        "navigation.tabs",
+        "navigation.tabs.sticky",
+        "navigation.sections",
+        "navigation.indexes",
+        "content.tabs.link",
+    ):
+        assert f"- {feature}" in config
+    assert "- pymdownx.tabbed:" in config
+    assert "alternate_style: true" in config
+
+    for path in (
+        Path("docs/index.md"),
+        Path("docs/smol/index.md"),
+        _GUIDE_ROOT / "quickstart.md",
+        _GUIDE_ROOT / "world-libraries.md",
+    ):
+        page = path.read_text()
+        assert page.count('=== "uv"') == 1
+        assert page.count('=== "pip"') == 1
+        uv_block, pip_block = page.split('=== "pip"', maxsplit=1)
+        uv_commands = [
+            line.strip().removeprefix("uv add ")
+            for line in uv_block.splitlines()
+            if line.strip().startswith("uv add ")
+        ]
+        pip_commands = [
+            line.strip().removeprefix("pip install ")
+            for line in pip_block.splitlines()
+            if line.strip().startswith("pip install ")
+        ]
+        assert uv_commands
+        assert uv_commands == pip_commands
+
+
+def test_package_landings_link_framework_evaluation_to_its_owner() -> None:
+    """Research names the framework contract without absorbing its API reference."""
+
+    evaluation_link = "../reference/python/evaluation.md"
+    framework = Path("docs/framework/index.md").read_text()
+    research = Path("docs/research/index.md").read_text()
+
+    assert f"[Framework evaluation]({evaluation_link})" in framework
+    assert f"[Framework evaluation Python API]({evaluation_link})" in research


### PR DESCRIPTION
## Summary

- reorganize the documentation into package-oriented top-level tabs
- add landing pages for Framework, Smol, Missions, Physical AI, and Research
- use content tabs for installation choices and async/blocking runtime examples
- label generated Python references with their owning distribution

## Stack

This is the eighth and final PR in the 0.6 preparation stack and is based on `architecture-review-smol`. Review this PR against that branch.

## Why

The navigation now mirrors the installable architecture, so each package can explain its own contract without blending framework and world-library responsibilities on the same page.

## Validation

- `make docs`
- `make ci`

