### PR TITLE
fix: cover release-required Biome dogfood

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
           if-no-files-found: error
 
   apple-evidence:
-    name: Release evidence (Apple Container)
+    name: Release evidence (Biome + Apple Container)
     needs: release-profile
     env:
       # actions/setup-python's macOS distributions are non-relocatable and
@@ -259,7 +259,7 @@ jobs:
         - ARM64
         - archetype-apple-container-macos-26
     environment: release-apple-macos
-    timeout-minutes: 35
+    timeout-minutes: 75
     permissions:
       contents: read
     steps:
@@ -283,6 +283,8 @@ jobs:
           path: .context/downloaded-release-evidence/
       - name: Restore exact artifact manifest
         run: cp .context/downloaded-release-evidence/release-artifact.json release-artifact.json
+      - name: Run pinned Biome exact installed-artifact scenario
+        run: make operational-release-biome
       - name: Start Apple Container service
         run: |
           test "$(uname -m)" = "arm64"
@@ -290,13 +292,14 @@ jobs:
           command -v container
           container system start
           container system status
-      - name: Run exact installed-artifact scenario
+      - name: Run Apple Container exact installed-artifact scenario
         run: make operational-release-apple
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: release-operational-release-apple-evidence
           path: |
+            operational-release-biome-results.json
             operational-release-apple-results.json
             operational-release-*-results.d/
           if-no-files-found: error
@@ -363,6 +366,7 @@ jobs:
           evidence/operational-release-openai-results.json
           evidence/operational-release-docker-results.json
           evidence/operational-release-r2-results.json
+          evidence/operational-release-biome-results.json
           evidence/operational-release-apple-results.json
           evidence/operational-release-modal-results.json
           evidence/operational-release-physical-modal-r2-results.json

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ help:
 	@echo "  make operational-mission  Run the credential-free exact-head mission scenario"
 	@echo "  make operational-external  Require selected Tier-5/6 provider evidence"
 	@echo "  make operational-release  Run credential-free release evidence against the wheel matrix"
+	@echo "  make operational-release-biome  Run the pinned live Biome wheel evidence"
 	@echo "  make operational-release-modal  Run the paid live Modal/Codex wheel evidence"
 	@echo "  make test-infra     Run external-infrastructure tests (requires configured service)"
 	@echo ""
@@ -505,6 +506,10 @@ operational-release-r2: verify-release-artifact
 .PHONY: operational-release-apple
 operational-release-apple: verify-release-artifact
 	$(call RUN_RELEASE_SCENARIOS,--min-tier 0 --max-tier 6 --scenario dogfood.sandbox.apple_container --out operational-release-apple-results.json)
+
+.PHONY: operational-release-biome
+operational-release-biome: verify-release-artifact
+	$(call RUN_RELEASE_SCENARIOS,--min-tier 0 --max-tier 6 --scenario example.14_biome_agent --out operational-release-biome-results.json,ARCHETYPE_BIOME_LIVE=1)
 
 .PHONY: operational-release-modal
 operational-release-modal: verify-release-artifact

--- a/docs/guide/prefab-libraries.md
+++ b/docs/guide/prefab-libraries.md
@@ -347,7 +347,12 @@ The pinned compatibility set is:
 | Project | Revision | Reason |
 |---|---|---|
 | `SanderMertens/biome` | `d3372c2b3d7491b9260727292c27e554d12c0478` | Upstream game and prefab library used by the dogfood |
-| `SanderMertens/flecs` | `fd137d63deccded67aba4a0dd8a8a4231d24e897` on `script_await` | Public branch containing the async script task/future API used by Biome |
+| `SanderMertens/flecs` | `fd137d63deccded67aba4a0dd8a8a4231d24e897`, originally from `script_await` | Exact commit containing the async script task/future API used by Biome |
+
+Named upstream branches are provenance, not immutable inputs. The current
+`script_await` history has diverged from this compatibility commit, so the
+bootstrap fetches the exact SHA explicitly before detached checkout instead of
+assuming the pin remains reachable from the branch tip.
 
 The bootstrap passes `FETCHCONTENT_SOURCE_DIR_FLECS` to CMake because the
 checked-in Biome CMake configuration currently names Sander's local Flecs

--- a/docs/guide/release-0.6.md
+++ b/docs/guide/release-0.6.md
@@ -108,6 +108,18 @@ successful OIDC publication creates the project on that registry. See
 [Repository harness](repository-harness.md) for the exact, package-specific
 OIDC identities and the direct-workflow bootstrap required for new projects.
 
+Release publication also requires the live, pinned Biome scenario. The
+release-only proof runs on the same approved, one-job ephemeral Apple Silicon
+Mac used for Apple Container evidence. It fail-closes on the Darwin, build-tool,
+and explicit-live prerequisites; builds and launches the checked-in Biome and
+Flecs revisions in an active WindowServer/Metal session; waits for REST
+readiness; proves the native mission plus durable Archetype evidence; and
+closes the process and port. Biome runs before Apple Container under the single
+`release-apple-macos` approval. Its
+`operational-release-biome-results.json` receipt is an explicit input to the
+exact-wheel evidence gate, so TestPyPI approval cannot follow a missing,
+`not_run`, dirty-revision, wrong-wheel, failed, or unclosed Biome result.
+
 For current architecture and installation contracts, continue with
 [World libraries](world-libraries.md), [Runtime](runtime.md), and
 [API stability](api-stability.md).

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -185,11 +185,12 @@ It validates all five wheels, package-smokes the four-package world stack and
 Smol independently, rebuilds all five source distributions through isolated
 PEP 517, and repeats both probes against the rebuilt wheels. Credential-free
 release scenarios run against an isolated install of the exact four-wheel
-world stack; OpenAI, Docker, R2, Apple Container, and Modal scenario lanes use
-that same stack. Publication is gated by an aggregate receipt check: every
-release-required scenario must have passed, every receipt must name the release
-commit and all four world-stack wheel digests, and no result may be `not_run`.
-The publish job uploads the recorded ten files without rebuilding them.
+world stack; OpenAI, Docker, R2, live Biome, Apple Container, and Modal scenario
+lanes use that same stack. Publication is gated by an aggregate receipt check:
+every release-required scenario must have passed, every receipt must name the
+release commit and all four world-stack wheel digests, and no result may be
+`not_run`. The publish job uploads the recorded ten files without rebuilding
+them.
 
 Before the first coordinated release, both registries need the complete OIDC
 publisher matrix below. Every row uses repository `VangelisTech/archetype`.
@@ -247,20 +248,47 @@ The workflow requires both `github.actor` and `github.triggering_actor` to be
 tag push does not start release work: the operator dispatches `release.yml` at
 the existing tag and supplies the same tag as its confirmation input.
 
-The Apple lane has a second, infrastructure-level boundary. Organization runner
-group `archetype-release-macos` allows only this repository and an exact
-tag-qualified `.github/workflows/release.yml`; the job must request that group,
-not merely a guessable label. Environment `release-apple-macos` permits only
-`v*` tags and requires approval from `everettVT` before the job reaches the Mac.
+The shared Biome and Apple Container lane has a second, infrastructure-level
+boundary. Release job `apple-evidence`, displayed as
+`Release evidence (Biome + Apple Container)`, requests organization runner
+group `archetype-release-macos` plus the `self-hosted`, `macOS`, `ARM64`, and
+`archetype-apple-container-macos-26` labels. The group allows only this
+repository and an exact tag-qualified `.github/workflows/release.yml`; the job
+must request that group, not merely a guessable label. Environment
+`release-apple-macos` permits only `v*` tags and requires approval from
+`everettVT` before the job reaches the Mac.
+
 The runner MUST be ephemeral, MUST be registered only after the group is pinned
-to the exact release tag, and MUST run from a disposable directory. A separate
-macOS login is not required: the runner may use the operator's current account,
-but it inherits that account's host permissions while the one authorized job is
-active. Never install this runner as a persistent service. The Apple job uses
-`uv` to provision Python in that account's cache; it does not use
-`actions/setup-python` or create GitHub's `/Users/runner/hostedtoolcache` path.
-These controls are required because GitHub does not treat a self-hosted runner
-for a public repository as an isolated trusted machine.
+to the exact release tag, and MUST run from a disposable directory. It also
+MUST be a logged-in Apple Silicon host with an active WindowServer and
+Metal-capable display session. A separate macOS login is not required: the
+runner may use the operator's current account, but it inherits that account's
+host permissions while the one authorized job is active. Never install this
+runner as a persistent service. The job uses `uv` to provision Python in that
+account's cache; it does not use `actions/setup-python` or create GitHub's
+`/Users/runner/hostedtoolcache` path. These controls are required because
+GitHub does not treat a self-hosted runner for a public repository as an
+isolated trusted machine.
+
+One environment approval admits one bounded 75-minute Mac job. The Biome proof
+runs first, before the job starts Apple Container. Its registry row fail-closes
+unless the host is Darwin, `git`, `cmake`, `cargo`, and `pkg-config` are
+available, and the Make target has explicitly opted into live execution with
+`ARCHETYPE_BIOME_LIVE=1`. The release-only test builds and launches the exact
+checked-in Biome and Flecs revisions in the active GUI/Metal session, waits for
+the local REST service, proves the native mining mission and durable Archetype
+evidence, and guarantees process and port cleanup. The job then starts Apple
+Container, runs its exact-wheel parity proof, and stops the service in an
+always-run cleanup step.
+
+Both results travel in the existing
+`release-operational-release-apple-evidence` artifact. The aggregate
+`release-evidence-gate` names `operational-release-biome-results.json` and
+`operational-release-apple-results.json` as explicit inputs to
+`scripts/verify_release_evidence.py`; artifact presence alone is insufficient.
+Each receipt must be passing installed-wheel evidence bound to the clean
+release commit and exact four-wheel artifact matrix, with closed cleanup and no
+failed or `not_run` result.
 
 For each release, use this order:
 
@@ -297,13 +325,15 @@ gh workflow run release.yml \
   -f tag=v0.6.0
 ```
 
-Approve `release-apple-macos`, then every pending `release-testpypi` deployment,
-and finally every pending `release-pypi` deployment after the TestPyPI
+Approve `release-apple-macos` once; the admitted job runs Biome evidence and
+then Apple Container evidence in that order. After the exact-evidence gate
+succeeds, approve every pending `release-testpypi` deployment. Approve every
+pending `release-pypi` deployment only after the TestPyPI
 installed-distribution matrix succeeds. The ECS publisher remains in the parent
 run; each new distribution is a separately approved direct workflow run. The
 parent waits for the exact child run IDs and fails unless all of them succeed.
-The ephemeral runner deregisters after the Apple job;
-discard its working directory before preparing a rerun or future release.
+The ephemeral runner deregisters after the shared Mac job; discard its working
+directory before preparing a rerun or future release.
 
 Release-lane authentication is explicit and provider-scoped:
 
@@ -313,6 +343,7 @@ Release-lane authentication is explicit and provider-scoped:
 | Docker | The runner's local Docker context and daemon authorize the parity operation; the lane does not perform registry login. |
 | Cloudflare R2 | `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` authenticate the account, while `R2_API_ENDPOINT` and `R2_BUCKET` select the exact substrate. |
 | Physical AI (Modal + R2) | The same scoped Modal and R2 credentials run one T4-backed seeded episode. Modal owns provider execution and immutable result blobs; the Archetype World commits intent and observation evidence to a unique R2 prefix, then a fresh runtime cold-resumes and reconciles the same digest without replay. |
+| Biome | No cloud credential is accepted. The explicitly enabled release target builds and launches the pinned upstream Biome/Flecs sources on the logged-in Mac, and the live test proves the active GUI/Metal process, loopback REST readiness, native mission result, durable Archetype evidence, and cleanup. |
 | Apple Container | A one-job ephemeral, bare-metal Apple Silicon runner in the exact-workflow-restricted `archetype-release-macos` group supplies the local host authority. It may run under the operator's current macOS account and bears `self-hosted`, `macOS`, `ARM64`, and `archetype-apple-container-macos-26`. The job provisions Python 3.12 through `uv`, verifies macOS 26, and starts the local `container` service; it creates no macOS login or `/Users/runner` tool cache, and accepts no Apple cloud token. GitHub-hosted arm64 macOS runners are not substitutes because they do not expose the Virtualization.framework VM support required by Apple Container. |
 | Modal Agent Mission | `MODAL_TOKEN_ID` plus `MODAL_TOKEN_SECRET` authenticate the Modal control plane. Actions repository variable `CODING_AGENT_MODAL_PROFILE` becomes the SDK selector `MODAL_PROFILE`; `CODING_AGENT_MODAL_ENVIRONMENT` becomes both the Archetype selector and SDK selector `MODAL_ENVIRONMENT`, while the workspace and remaining Environment-scoped variables bind all named objects. `CODEX_AUTH_VOLUME` supplies the separately device-authenticated Codex `auth.json`. `CODING_AGENT_GITHUB_SECRET` names the Modal Secret resolved for the isolated publisher, but the paid live lane deliberately pushes to a provider-local bare remote and never attaches that secret or mutates GitHub. Deterministic broker contracts separately prove that only the exact GitHub push process can receive `GITHUB_TOKEN`. Modal Connect Tokens authenticate the two transient viewport URLs. |
 

--- a/examples/14_biome_agent.py
+++ b/examples/14_biome_agent.py
@@ -16,37 +16,32 @@ Prepare, launch, act, verify, and keep the game open:
 from __future__ import annotations
 
 import argparse
-import subprocess
 import sys
-import time
 from pathlib import Path
 
 from biome_agent import (
-    BiomeAgentDecision,
     BiomeClient,
-    BiomeEpisodeState,
-    BiomeMission,
-    BiomeMissionOutcome,
     ExtractionGoal,
     FlecsRemoteError,
-    GoalDirectedDrillPolicy,
-    monitor_mission,
-    plan_mission,
+    run_durable_episode,
+    wait_until_ready,
 )
 from biome_agent.bootstrap import (
     BIOME_REVISION,
+    BIOME_URL,
     DEFAULT_CHECKOUT_ROOT,
     FLECS_REVISION,
     launch,
     prepare,
+    terminate,
 )
 
-from archetype import ArchetypeRuntime, StorageConfig
+from archetype import StorageConfig
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--url", default="http://127.0.0.1:27750")
+    parser.add_argument("--url", default=BIOME_URL)
     parser.add_argument("--resource", default="Copper")
     parser.add_argument("--amount", type=int, default=10)
     parser.add_argument("--timeout", type=float, default=15.0)
@@ -68,31 +63,6 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _wait_until_ready(client: BiomeClient, process, timeout: float = 30.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if client.is_ready():
-            return True
-        if process is not None and process.poll() is not None:
-            return False
-        time.sleep(0.1)
-    return False
-
-
-def _state_from_trace(trace) -> BiomeEpisodeState:
-    sample = trace.final_sample
-    drill = sample.drill if sample else None
-    return BiomeEpisodeState(
-        phase="succeeded" if trace.success else "failed",
-        target_entity=trace.plan.action.target_path,
-        deposit_amount=sample.deposit_amount if sample else trace.plan.target.amount,
-        extracted=trace.extracted,
-        drill_entity=trace.plan.action.drill_path,
-        powered=drill.powered if drill else False,
-        stored_amount=drill.stored_amount if drill else 0,
-    )
-
-
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     process = None
@@ -100,6 +70,8 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.launch:
+            if args.url.rstrip("/") != BIOME_URL:
+                raise ValueError(f"--launch owns the exact local endpoint {BIOME_URL}")
             print("Preparing pinned upstream Biome and Flecs revisions...")
             print(
                 "WARNING: upstream Flecs REST binds 0.0.0.0:27750 without authentication; "
@@ -110,7 +82,7 @@ def main(argv: list[str] | None = None) -> int:
             launched_from_pins = True
 
         with BiomeClient(args.url) as client:
-            if not _wait_until_ready(client, process, timeout=30.0 if process else 0.5):
+            if not wait_until_ready(client, process, timeout=30.0 if process else 0.5):
                 message = (
                     "Biome is not listening at "
                     f"{args.url}. Run with --launch, or start the pinned game separately."
@@ -122,102 +94,40 @@ def main(argv: list[str] | None = None) -> int:
                 return 0
 
             goal = ExtractionGoal(resource=args.resource, amount=args.amount)
-            policy = GoalDirectedDrillPolicy()
             storage = StorageConfig(uri=args.storage_uri, namespace="biome_agent")
-
-            with ArchetypeRuntime.sync() as runtime:
-                world = runtime.world("live-biome-agent", storage=storage)
-                episode = world.spawn(
-                    BiomeMission(
-                        environment_uri=args.url,
-                        resource=goal.resource,
-                        target_amount=goal.amount,
-                        biome_revision=BIOME_REVISION
-                        if launched_from_pins
-                        else "external-unverified",
-                        flecs_revision=FLECS_REVISION
-                        if launched_from_pins
-                        else "external-unverified",
-                    ),
-                    BiomeEpisodeState(),
-                )
-                world.step()
-
-                plan = plan_mission(client, policy, goal)
-                world.update(
-                    episode,
-                    BiomeEpisodeState(
-                        phase="observed",
-                        target_entity=plan.action.target_path,
-                        deposit_amount=plan.target.amount,
-                    ),
-                )
-                world.step()
-
-                client.deploy(plan.action)
-                world.add_components(
-                    episode,
-                    BiomeAgentDecision(
-                        target_entity=plan.action.target_path,
-                        drill_x=plan.action.drill_cell.x,
-                        drill_y=plan.action.drill_cell.y,
-                        power_x=plan.action.power_cell.x,
-                        power_y=plan.action.power_cell.y,
-                    ),
-                )
-                world.update(
-                    episode,
-                    BiomeEpisodeState(
-                        phase="action_applied",
-                        target_entity=plan.action.target_path,
-                        deposit_amount=plan.target.amount,
-                        drill_entity=plan.action.drill_path,
-                    ),
-                )
-                world.step()
-
-                trace = monitor_mission(
-                    client,
-                    plan,
-                    timeout=args.timeout,
-                    poll_interval=args.poll_interval,
-                )
-                final_sample = trace.final_sample
-                elapsed = final_sample.elapsed_seconds if final_sample else 0.0
-                world.update(episode, _state_from_trace(trace))
-                world.add_components(
-                    episode,
-                    BiomeMissionOutcome(
-                        success=trace.success,
-                        extracted=trace.extracted,
-                        reason=trace.reason,
-                        elapsed_seconds=elapsed,
-                    ),
-                )
-                world.step()
-                info = world.info()
-
-                drill = final_sample.drill if final_sample else None
-                print(f"Goal: extract {goal.amount} {goal.resource}")
-                print(
-                    "Decision:",
-                    f"{plan.action.target_path} -> {plan.action.drill_path}",
-                    f"powered by {plan.action.power_path}",
-                )
-                print(
-                    "Native result:",
-                    f"extracted={trace.extracted}",
-                    f"powered={drill.powered if drill else False}",
-                    f"stored={drill.stored_amount if drill else 0}",
-                )
-                print(
-                    "Archetype evidence:",
-                    f"world_id={info.world_id}",
-                    f"run_id={info.run_id}",
-                    f"ticks={info.tick}",
-                )
-                print(trace.reason)
-                return 0 if trace.success else 1
+            result = run_durable_episode(
+                client,
+                goal,
+                storage=storage,
+                biome_revision=BIOME_REVISION if launched_from_pins else "external-unverified",
+                flecs_revision=FLECS_REVISION if launched_from_pins else "external-unverified",
+                timeout=args.timeout,
+                poll_interval=args.poll_interval,
+            )
+            trace = result.trace
+            plan = trace.plan
+            final_sample = trace.final_sample
+            drill = final_sample.drill if final_sample else None
+            print(f"Goal: extract {goal.amount} {goal.resource}")
+            print(
+                "Decision:",
+                f"{plan.action.target_path} -> {plan.action.drill_path}",
+                f"powered by {plan.action.power_path}",
+            )
+            print(
+                "Native result:",
+                f"extracted={trace.extracted}",
+                f"powered={drill.powered if drill else False}",
+                f"stored={drill.stored_amount if drill else 0}",
+            )
+            print(
+                "Archetype evidence:",
+                f"world_id={result.world_id}",
+                f"run_id={result.run_id}",
+                f"committed_tick={result.committed_tick}",
+            )
+            print(trace.reason)
+            return 0 if trace.success else 1
     except (FlecsRemoteError, LookupError, RuntimeError, ValueError) as exc:
         print(f"Biome mission failed: {exc}", file=sys.stderr)
         return 1
@@ -225,13 +135,8 @@ def main(argv: list[str] | None = None) -> int:
         if process is not None:
             if args.keep_open and process.poll() is None:
                 print(f"Biome remains open (pid={process.pid}).")
-            elif process.poll() is None:
-                process.terminate()
-                try:
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=5)
+            else:
+                terminate(process)
 
 
 if __name__ == "__main__":

--- a/examples/biome_agent/__init__.py
+++ b/examples/biome_agent/__init__.py
@@ -21,6 +21,7 @@ from .contracts import (
     PlaceExtractorAction,
     TerrainCell,
 )
+from .episode import DurableBiomeEpisodeResult, run_durable_episode, wait_until_ready
 from .mission import monitor_mission, plan_mission, run_mission
 from .policy import GoalDirectedDrillPolicy
 
@@ -33,6 +34,7 @@ __all__ = [
     "BiomeObservation",
     "DepositObservation",
     "DrillObservation",
+    "DurableBiomeEpisodeResult",
     "ExtractionGoal",
     "FlecsRemoteError",
     "GoalDirectedDrillPolicy",
@@ -43,5 +45,7 @@ __all__ = [
     "TerrainCell",
     "monitor_mission",
     "plan_mission",
+    "run_durable_episode",
     "run_mission",
+    "wait_until_ready",
 ]

--- a/examples/biome_agent/bootstrap.py
+++ b/examples/biome_agent/bootstrap.py
@@ -119,7 +119,6 @@ def _wait_for_port_close(host: str, port: int, timeout: float) -> bool:
 def _ensure_checkout(
     path: Path,
     repository: str,
-    remote_ref: str,
     revision: str,
 ) -> None:
     if path.exists() and not (path / ".git").is_dir():
@@ -133,10 +132,8 @@ def _ensure_checkout(
     if remote not in accepted:
         raise RuntimeError(f"{path} has unexpected origin {remote!r}")
 
-    # The provenance branch is allowed to move or be rewritten. Fetch it for
-    # upstream context, then request the immutable object explicitly so a
-    # checkout never depends on the revision remaining in branch history.
-    _run(["git", "fetch", "origin", remote_ref], cwd=path)
+    # Named upstream branches are provenance labels only. Fetch the immutable
+    # object directly so branch deletion or rewriting cannot block release.
     _run(["git", "fetch", "--no-tags", "--depth=1", "origin", revision], cwd=path)
     _run(["git", "checkout", "--detach", revision], cwd=path)
     actual = _output(["git", "rev-parse", "HEAD"], cwd=path)
@@ -188,8 +185,8 @@ def prepare(
     build = biome / "build-agent"
     scene = biome / "etc" / "scenes" / "archetype_agent.flecs"
 
-    _ensure_checkout(biome, BIOME_REPOSITORY, BIOME_REF, BIOME_REVISION)
-    _ensure_checkout(flecs, FLECS_REPOSITORY, FLECS_REF, FLECS_REVISION)
+    _ensure_checkout(biome, BIOME_REPOSITORY, BIOME_REVISION)
+    _ensure_checkout(flecs, FLECS_REPOSITORY, FLECS_REVISION)
     _stage_native_bridge(biome)
     shutil.copyfile(MISSION_SCENE, scene)
 

--- a/examples/biome_agent/bootstrap.py
+++ b/examples/biome_agent/bootstrap.py
@@ -5,8 +5,12 @@
 
 from __future__ import annotations
 
+import os
 import shutil
+import signal
+import socket
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -17,6 +21,14 @@ BIOME_REF = "main"
 FLECS_REPOSITORY = "https://github.com/SanderMertens/flecs.git"
 FLECS_REVISION = "fd137d63deccded67aba4a0dd8a8a4231d24e897"
 FLECS_REF = "script_await"
+
+BIOME_HOST = "127.0.0.1"
+BIOME_PORT = 27750
+BIOME_URL = f"http://{BIOME_HOST}:{BIOME_PORT}"
+
+_PROCESS_TERM_GRACE_SECONDS = 5.0
+_PROCESS_KILL_GRACE_SECONDS = 5.0
+_PORT_CLOSE_GRACE_SECONDS = 5.0
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CHECKOUT_ROOT = _REPOSITORY_ROOT / ".context" / "upstream"
@@ -44,7 +56,64 @@ def _run(command: list[str], *, cwd: Path | None = None) -> None:
 
 
 def _output(command: list[str], *, cwd: Path | None = None) -> str:
-    return subprocess.check_output(command, cwd=cwd, text=True).strip()
+    # Preserve leading columns from machine-readable output such as
+    # ``git status --porcelain`` while removing its final line ending.
+    return subprocess.check_output(command, cwd=cwd, text=True).rstrip()
+
+
+def _revision_file(checkout: Path, revision: str, path: str) -> str:
+    return subprocess.check_output(
+        ["git", "show", f"{revision}:{path}"],
+        cwd=checkout,
+        text=True,
+    )
+
+
+def is_process_group_alive(process_group: int) -> bool:
+    """Return whether any process remains in an owned process group."""
+
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def is_port_open(host: str = BIOME_HOST, port: int = BIOME_PORT) -> bool:
+    """Return whether a TCP listener is reachable at the Biome endpoint."""
+
+    try:
+        with socket.create_connection((host, port), timeout=0.2):
+            return True
+    except OSError:
+        return False
+
+
+def _signal_process_group(process_group: int, requested_signal: signal.Signals) -> None:
+    try:
+        os.killpg(process_group, requested_signal)
+    except (PermissionError, ProcessLookupError):
+        pass
+
+
+def _wait_for_process_group_exit(process_group: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not is_process_group_alive(process_group):
+            return True
+        time.sleep(0.05)
+    return not is_process_group_alive(process_group)
+
+
+def _wait_for_port_close(host: str, port: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not is_port_open(host, port):
+            return True
+        time.sleep(0.05)
+    return not is_port_open(host, port)
 
 
 def _ensure_checkout(
@@ -64,7 +133,11 @@ def _ensure_checkout(
     if remote not in accepted:
         raise RuntimeError(f"{path} has unexpected origin {remote!r}")
 
+    # The provenance branch is allowed to move or be rewritten. Fetch it for
+    # upstream context, then request the immutable object explicitly so a
+    # checkout never depends on the revision remaining in branch history.
     _run(["git", "fetch", "origin", remote_ref], cwd=path)
+    _run(["git", "fetch", "--no-tags", "--depth=1", "origin", revision], cwd=path)
     _run(["git", "checkout", "--detach", revision], cwd=path)
     actual = _output(["git", "rev-parse", "HEAD"], cwd=path)
     if actual != revision:
@@ -96,11 +169,7 @@ def _stage_native_bridge(biome: Path) -> None:
     """Patch only the managed checkout with the Archetype-owned C bridge."""
 
     main = biome / "src" / "main.c"
-    pristine = subprocess.check_output(
-        ["git", "show", f"{BIOME_REVISION}:src/main.c"],
-        cwd=biome,
-        text=True,
-    )
+    pristine = _revision_file(biome, BIOME_REVISION, "src/main.c")
     main.write_text(_patch_main(pristine))
     shutil.copyfile(NATIVE_MODULE, biome / "src" / "modules" / NATIVE_MODULE.name)
 
@@ -147,11 +216,103 @@ def prepare(
     return BiomeCheckout(root, biome, flecs, build, executable, scene)
 
 
+def _verify_pinned_checkout(checkout: BiomeCheckout) -> None:
+    revisions = (
+        ("Biome", checkout.biome, BIOME_REVISION),
+        ("Flecs", checkout.flecs, FLECS_REVISION),
+    )
+    for label, path, expected in revisions:
+        actual = _output(["git", "rev-parse", "HEAD"], cwd=path)
+        if actual != expected:
+            raise RuntimeError(
+                f"refusing to launch {label} revision {actual!r}; expected exact pin {expected}"
+            )
+
+    biome_status = _output(
+        ["git", "status", "--porcelain", "--untracked-files=all"], cwd=checkout.biome
+    )
+    allowed_biome_paths = {
+        "etc/scenes/archetype_agent.flecs",
+        "src/main.c",
+        "src/modules/archetype_biome.c",
+    }
+    unexpected_biome_paths = sorted(
+        line[3:]
+        for line in biome_status.splitlines()
+        if line[3:] not in allowed_biome_paths and not line[3:].startswith("build-agent/")
+    )
+    if unexpected_biome_paths:
+        raise RuntimeError(
+            "refusing to launch a Biome checkout with unrelated source changes: "
+            f"{unexpected_biome_paths}"
+        )
+    flecs_status = _output(
+        ["git", "status", "--porcelain", "--untracked-files=all"], cwd=checkout.flecs
+    )
+    if flecs_status:
+        raise RuntimeError("refusing to launch a Flecs checkout with local source changes")
+
+    expected_build = (checkout.biome / "build-agent").resolve()
+    expected_executable = (expected_build / "biome").resolve()
+    expected_scene = (checkout.biome / "etc" / "scenes" / MISSION_SCENE.name).resolve()
+    if checkout.build.resolve() != expected_build:
+        raise RuntimeError("refusing to launch a Biome build outside the managed pinned checkout")
+    if checkout.executable.resolve() != expected_executable or not os.access(
+        checkout.executable, os.X_OK
+    ):
+        raise RuntimeError("refusing to launch an unexpected or non-executable Biome binary")
+    if (
+        checkout.scene.resolve() != expected_scene
+        or checkout.scene.read_bytes() != MISSION_SCENE.read_bytes()
+    ):
+        raise RuntimeError("refusing to launch without the exact Archetype Biome mission scene")
+    expected_main = _patch_main(_revision_file(checkout.biome, BIOME_REVISION, "src/main.c"))
+    if (checkout.biome / "src" / "main.c").read_text() != expected_main:
+        raise RuntimeError("refusing to launch with an unexpected Biome main.c bridge")
+    if (
+        checkout.biome / "src" / "modules" / NATIVE_MODULE.name
+    ).read_bytes() != NATIVE_MODULE.read_bytes():
+        raise RuntimeError("refusing to launch with an unexpected native Biome bridge")
+
+
 def launch(checkout: BiomeCheckout) -> subprocess.Popen[bytes]:
     """Launch the pinned game and its Flecs REST server."""
 
+    _verify_pinned_checkout(checkout)
+    if is_port_open():
+        raise RuntimeError(f"refusing to launch Biome while {BIOME_HOST}:{BIOME_PORT} is in use")
     return subprocess.Popen(
         [str(checkout.executable), "--scene", "etc/scenes/archetype_agent.flecs"],
         cwd=checkout.biome,
         start_new_session=True,
     )
+
+
+def terminate(
+    process: subprocess.Popen[bytes],
+    *,
+    host: str = BIOME_HOST,
+    port: int = BIOME_PORT,
+    term_timeout: float = _PROCESS_TERM_GRACE_SECONDS,
+    kill_timeout: float = _PROCESS_KILL_GRACE_SECONDS,
+    port_timeout: float = _PORT_CLOSE_GRACE_SECONDS,
+) -> None:
+    """Terminate the complete owned Biome process group and prove port closure."""
+
+    process_group = process.pid
+    _signal_process_group(process_group, signal.SIGTERM)
+    try:
+        process.wait(timeout=term_timeout)
+    except subprocess.TimeoutExpired:
+        _signal_process_group(process_group, signal.SIGKILL)
+        try:
+            process.wait(timeout=kill_timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"Biome process leader {process.pid} could not be reaped") from exc
+
+    if not _wait_for_process_group_exit(process_group, term_timeout):
+        _signal_process_group(process_group, signal.SIGKILL)
+    if not _wait_for_process_group_exit(process_group, kill_timeout):
+        raise RuntimeError(f"Biome process group {process_group} survived cleanup")
+    if not _wait_for_port_close(host, port, port_timeout):
+        raise RuntimeError(f"Biome REST port {host}:{port} survived cleanup")

--- a/examples/biome_agent/episode.py
+++ b/examples/biome_agent/episode.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Durable Archetype evidence for one live Biome control episode."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from dataclasses import dataclass
+
+from archetype import ArchetypeRuntime, StorageConfig
+
+from .client import BiomeClient
+from .components import (
+    BiomeAgentDecision,
+    BiomeEpisodeState,
+    BiomeMission,
+    BiomeMissionOutcome,
+)
+from .contracts import ExtractionGoal, MissionTrace
+from .mission import monitor_mission, plan_mission
+from .policy import GoalDirectedDrillPolicy
+
+
+@dataclass(frozen=True, slots=True)
+class DurableBiomeEpisodeResult:
+    """Native mission result bound to its durable Archetype coordinates."""
+
+    trace: MissionTrace
+    biome_revision: str
+    flecs_revision: str
+    world_id: str
+    run_id: str
+    committed_tick: int
+    episode_entity_id: int
+
+
+def wait_until_ready(
+    client: BiomeClient,
+    process: subprocess.Popen[bytes] | None,
+    *,
+    timeout: float = 30.0,
+) -> bool:
+    """Wait until Flecs REST is ready or the owned Biome process exits."""
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if client.is_ready():
+            return True
+        if process is not None and process.poll() is not None:
+            return False
+        time.sleep(0.1)
+    return False
+
+
+def _state_from_trace(trace: MissionTrace) -> BiomeEpisodeState:
+    sample = trace.final_sample
+    drill = sample.drill if sample else None
+    return BiomeEpisodeState(
+        phase="succeeded" if trace.success else "failed",
+        target_entity=trace.plan.action.target_path,
+        deposit_amount=sample.deposit_amount if sample else trace.plan.target.amount,
+        extracted=trace.extracted,
+        drill_entity=trace.plan.action.drill_path,
+        powered=drill.powered if drill else False,
+        stored_amount=drill.stored_amount if drill else 0,
+    )
+
+
+def run_durable_episode(
+    client: BiomeClient,
+    goal: ExtractionGoal,
+    *,
+    storage: StorageConfig,
+    biome_revision: str,
+    flecs_revision: str,
+    timeout: float = 15.0,
+    poll_interval: float = 0.25,
+    world_name: str = "live-biome-agent",
+) -> DurableBiomeEpisodeResult:
+    """Act in native Biome and persist the complete episode in Archetype."""
+
+    if not biome_revision or not flecs_revision:
+        raise ValueError("Biome and Flecs revisions must not be empty")
+
+    policy = GoalDirectedDrillPolicy()
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.world(world_name, storage=storage)
+        episode = world.spawn(
+            BiomeMission(
+                environment_uri=client.base_url,
+                resource=goal.resource,
+                target_amount=goal.amount,
+                biome_revision=biome_revision,
+                flecs_revision=flecs_revision,
+            ),
+            BiomeEpisodeState(),
+        )
+        world.step()
+
+        plan = plan_mission(client, policy, goal)
+        world.update(
+            episode,
+            BiomeEpisodeState(
+                phase="observed",
+                target_entity=plan.action.target_path,
+                deposit_amount=plan.target.amount,
+            ),
+        )
+        world.step()
+
+        client.deploy(plan.action)
+        world.add_components(
+            episode,
+            BiomeAgentDecision(
+                target_entity=plan.action.target_path,
+                drill_x=plan.action.drill_cell.x,
+                drill_y=plan.action.drill_cell.y,
+                power_x=plan.action.power_cell.x,
+                power_y=plan.action.power_cell.y,
+            ),
+        )
+        world.update(
+            episode,
+            BiomeEpisodeState(
+                phase="action_applied",
+                target_entity=plan.action.target_path,
+                deposit_amount=plan.target.amount,
+                drill_entity=plan.action.drill_path,
+            ),
+        )
+        world.step()
+
+        trace = monitor_mission(
+            client,
+            plan,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+        final_sample = trace.final_sample
+        elapsed = final_sample.elapsed_seconds if final_sample else 0.0
+        world.update(episode, _state_from_trace(trace))
+        world.add_components(
+            episode,
+            BiomeMissionOutcome(
+                success=trace.success,
+                extracted=trace.extracted,
+                reason=trace.reason,
+                elapsed_seconds=elapsed,
+            ),
+        )
+        world.step()
+        info = world.info()
+        if info.tick < 1:  # pragma: no cover - guarded by the four successful steps above
+            raise RuntimeError("Biome episode did not publish a durable tick")
+
+        return DurableBiomeEpisodeResult(
+            trace=trace,
+            biome_revision=biome_revision,
+            flecs_revision=flecs_revision,
+            world_id=str(info.world_id),
+            run_id=str(info.run_id),
+            committed_tick=info.tick - 1,
+            episode_entity_id=episode,
+        )

--- a/quality/operational_scenarios.toml
+++ b/quality/operational_scenarios.toml
@@ -368,14 +368,21 @@ kind = "example"
 owner = "missions"
 owner_paths = ["examples/biome_agent"]
 source_path = "examples/14_biome_agent.py"
-source_command = ["python", "examples/14_biome_agent.py", "--require-live"]
+source_command = ["pytest", "-q", "tests/infrastructure/test_biome_live.py::test_pinned_biome_episode"]
 required_extras = []
 tier = 6
 applicability = ["source", "wheel"]
-timeout_seconds = 900
-prerequisites = ["infrastructure:ARCHETYPE_BIOME_LIVE"]
+timeout_seconds = 1800
+prerequisites = [
+  "platform:darwin",
+  "binary:git",
+  "binary:cmake",
+  "binary:cargo",
+  "binary:pkg-config",
+  "infrastructure:ARCHETYPE_BIOME_LIVE",
+]
 missing_prerequisite = "not_run"
-semantic_oracle = { kind = "pytest", ref = "tests/examples/test_biome_agent_contract.py::test_monitor_requires_native_power_targeting_and_deposit_delta" }
+semantic_oracle = { kind = "pytest", ref = "tests/infrastructure/test_biome_live.py::test_pinned_biome_episode" }
 contracts = ["missions.environment.pinned"]
 cleanup_policy = "isolated"
 artifact_policy = "receipt"

--- a/tests/examples/test_biome_agent_contract.py
+++ b/tests/examples/test_biome_agent_contract.py
@@ -5,11 +5,19 @@
 
 from __future__ import annotations
 
+import os
+import signal
+import socket
+import subprocess
 import sys
+import time
 from pathlib import Path
+from uuid import UUID
 
 import httpx
 import pytest
+
+from archetype import ArchetypeRuntime, StorageConfig
 
 _EXAMPLES = Path(__file__).resolve().parents[2] / "examples"
 if str(_EXAMPLES) not in sys.path:
@@ -17,6 +25,9 @@ if str(_EXAMPLES) not in sys.path:
 
 from biome_agent import (  # noqa: E402
     BiomeClient,
+    BiomeEpisodeState,
+    BiomeMission,
+    BiomeMissionOutcome,
     BiomeObservation,
     DepositObservation,
     DrillObservation,
@@ -26,12 +37,20 @@ from biome_agent import (  # noqa: E402
     PlaceExtractorAction,
     TerrainCell,
     monitor_mission,
+    run_durable_episode,
 )
+from biome_agent import bootstrap as biome_bootstrap  # noqa: E402
 from biome_agent.bootstrap import (  # noqa: E402
+    BIOME_HOST,
     BIOME_REVISION,
     FLECS_REF,
     FLECS_REVISION,
     MISSION_SCENE,
+    BiomeCheckout,
+    is_port_open,
+    is_process_group_alive,
+    launch,
+    terminate,
 )
 
 
@@ -224,6 +243,92 @@ def test_monitor_requires_native_power_targeting_and_deposit_delta() -> None:
     assert trace.final_sample.drill.stored_amount == 4
 
 
+def test_durable_episode_returns_and_reopens_native_and_tick_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _deposit("mission.copper_site", "Copper", 100, 30, 24)
+
+    class NativeEpisodeClient:
+        base_url = "http://127.0.0.1:27750"
+
+        def __init__(self) -> None:
+            self.deployed = False
+
+        def observe(self) -> BiomeObservation:
+            return BiomeObservation((target,), frozenset({target.cell}))
+
+        def deploy(self, action: PlaceExtractorAction) -> None:
+            assert action.target_path == target.entity_path
+            self.deployed = True
+
+        def get_deposit(self, entity_path: str) -> DepositObservation:
+            assert self.deployed
+            assert entity_path == target.entity_path
+            return _deposit(entity_path, "Copper", 96, 30, 24)
+
+        def get_drill(self, entity_path: str, resource: str) -> DrillObservation:
+            assert self.deployed
+            return DrillObservation(
+                entity_id=7,
+                entity_path=entity_path,
+                powered=True,
+                deposit_path=target.entity_path,
+                stored_resource=resource,
+                stored_amount=4,
+            )
+
+    monkeypatch.setenv("ARCHETYPE_CATALOG_DIR", str(tmp_path / "catalog"))
+    monkeypatch.delenv("ARCHETYPE_CONTROL_CATALOG_URL", raising=False)
+    monkeypatch.delenv("ARCHETYPE_CONTROL_CATALOG_TOKEN", raising=False)
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="biome_episode")
+    result = run_durable_episode(
+        NativeEpisodeClient(),  # type: ignore[arg-type]
+        ExtractionGoal("Copper", 3),
+        storage=storage,
+        biome_revision=BIOME_REVISION,
+        flecs_revision=FLECS_REVISION,
+        timeout=1,
+        poll_interval=0,
+        world_name="biome-contract",
+    )
+
+    assert result.trace.success
+    assert result.trace.extracted == 4
+    assert result.biome_revision == BIOME_REVISION
+    assert result.flecs_revision == FLECS_REVISION
+    assert result.committed_tick == 3
+    UUID(result.world_id)
+    UUID(result.run_id)
+
+    # A fresh runtime performs a cold read from the same physical storage. The
+    # returned coordinates are useful release evidence only if this succeeds.
+    with ArchetypeRuntime.sync() as runtime:
+        world = runtime.attach(result.world_id, storage=storage)
+        info = world.info()
+        rows = world.query(
+            BiomeMission,
+            BiomeEpisodeState,
+            BiomeMissionOutcome,
+            entity_ids=[result.episode_entity_id],
+        ).to_pylist()
+
+    assert str(info.run_id) == result.run_id
+    assert info.tick == result.committed_tick
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["tick"] == result.committed_tick
+    assert row["biomemission__biome_revision"] == BIOME_REVISION
+    assert row["biomemission__flecs_revision"] == FLECS_REVISION
+    assert row["biomeepisodestate__phase"] == "succeeded"
+    assert row["biomeepisodestate__target_entity"] == target.entity_path
+    assert row["biomeepisodestate__deposit_amount"] == 96
+    assert row["biomeepisodestate__powered"] is True
+    assert row["biomeepisodestate__stored_amount"] == 4
+    assert row["biomemissionoutcome__success"] is True
+    assert row["biomemissionoutcome__extracted"] == 4
+
+
 def test_bootstrap_pins_the_compatible_public_flecs_branch_without_vendoring() -> None:
     assert len(BIOME_REVISION) == 40
     assert FLECS_REF == "script_await"
@@ -233,6 +338,212 @@ def test_bootstrap_pins_the_compatible_public_flecs_branch_without_vendoring() -
     assert "environment.CopperOre" in scene
     assert "mission_base : buildings.Base" in scene
     assert "agent_drill : buildings.Drill" not in scene
+
+
+def test_checkout_fetches_the_exact_revision_after_its_provenance_ref_moves(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "checkout"
+    (checkout / ".git").mkdir(parents=True)
+    repository = "https://example.invalid/upstream.git"
+    remote_ref = "moving-feature-branch"
+    revision = "1" * 40
+    commands: list[list[str]] = []
+
+    def record_run(command: list[str], *, cwd: Path | None = None) -> None:
+        assert cwd == checkout
+        commands.append(command)
+
+    def git_output(command: list[str], *, cwd: Path | None = None) -> str:
+        assert cwd == checkout
+        if command[1:4] == ["config", "--get", "remote.origin.url"]:
+            return repository
+        assert command[1:3] == ["rev-parse", "HEAD"]
+        return revision
+
+    monkeypatch.setattr(biome_bootstrap, "_run", record_run)
+    monkeypatch.setattr(biome_bootstrap, "_output", git_output)
+
+    biome_bootstrap._ensure_checkout(
+        checkout,
+        repository,
+        remote_ref,
+        revision,
+    )
+
+    assert commands == [
+        ["git", "fetch", "origin", remote_ref],
+        ["git", "fetch", "--no-tags", "--depth=1", "origin", revision],
+        ["git", "checkout", "--detach", revision],
+    ]
+
+
+def test_git_output_preserves_porcelain_status_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def porcelain_output(*_args, **_kwargs) -> str:
+        return " M src/main.c\n"
+
+    monkeypatch.setattr(biome_bootstrap.subprocess, "check_output", porcelain_output)
+
+    assert biome_bootstrap._output(["git", "status"]) == " M src/main.c"
+
+
+def test_launch_revalidates_exact_upstream_heads_and_starts_an_owned_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    biome = tmp_path / "biome"
+    flecs = tmp_path / "flecs"
+    build = biome / "build-agent"
+    scene = biome / "etc" / "scenes" / MISSION_SCENE.name
+    executable = build / "biome"
+    main = biome / "src" / "main.c"
+    native = biome / "src" / "modules" / biome_bootstrap.NATIVE_MODULE.name
+    flecs.mkdir(parents=True)
+    scene.parent.mkdir(parents=True)
+    build.mkdir(parents=True)
+    native.parent.mkdir(parents=True)
+    scene.write_bytes(MISSION_SCENE.read_bytes())
+    executable.write_text("#!/bin/sh\nexit 0\n")
+    executable.chmod(0o755)
+    pristine_main = '#include "biome.h"\n\nint main(void) {\n    ECS_IMPORT(world, biomeUi);\n}\n'
+    main.write_text(biome_bootstrap._patch_main(pristine_main))
+    native.write_bytes(biome_bootstrap.NATIVE_MODULE.read_bytes())
+    checkout = BiomeCheckout(tmp_path, biome, flecs, build, executable, scene)
+
+    revisions = {biome: BIOME_REVISION, flecs: FLECS_REVISION}
+    statuses = {
+        biome: "\n".join(
+            (
+                "?? build-agent/biome",
+                "?? etc/scenes/archetype_agent.flecs",
+                " M src/main.c",
+                "?? src/modules/archetype_biome.c",
+            )
+        ),
+        flecs: "",
+    }
+
+    def git_output(command, *, cwd=None):
+        if command[1:3] == ["rev-parse", "HEAD"]:
+            assert cwd is not None
+            return revisions[cwd]
+        assert command[1:3] == ["status", "--porcelain"]
+        assert cwd is not None
+        return statuses[cwd]
+
+    monkeypatch.setattr(
+        biome_bootstrap,
+        "_output",
+        git_output,
+    )
+    monkeypatch.setattr(
+        biome_bootstrap,
+        "_revision_file",
+        lambda _checkout, _revision, _path: pristine_main,
+    )
+    monkeypatch.setattr(biome_bootstrap, "is_port_open", lambda *args, **kwargs: False)
+    launched: list[tuple[list[str], dict[str, object]]] = []
+    sentinel = object()
+
+    def popen(command, **kwargs):
+        launched.append((command, kwargs))
+        return sentinel
+
+    monkeypatch.setattr(biome_bootstrap.subprocess, "Popen", popen)
+
+    assert launch(checkout) is sentinel
+    assert launched == [
+        (
+            [str(executable), "--scene", "etc/scenes/archetype_agent.flecs"],
+            {"cwd": biome, "start_new_session": True},
+        )
+    ]
+
+    revisions[biome] = "0" * 40
+    with pytest.raises(RuntimeError, match="expected exact pin"):
+        launch(checkout)
+    assert len(launched) == 1
+
+    revisions[biome] = BIOME_REVISION
+    statuses[biome] = " M src/unrelated.c"
+    with pytest.raises(RuntimeError, match="unrelated source changes"):
+        launch(checkout)
+    assert len(launched) == 1
+
+
+def test_terminate_closes_owned_descendants_and_listener(tmp_path: Path) -> None:
+    with socket.socket() as reservation:
+        reservation.bind((BIOME_HOST, 0))
+        port = reservation.getsockname()[1]
+
+    marker = tmp_path / "ready"
+    child_source = """
+import socket
+import sys
+import time
+from pathlib import Path
+
+listener = socket.socket()
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind((sys.argv[1], int(sys.argv[2])))
+listener.listen()
+Path(sys.argv[3]).write_text("ready")
+time.sleep(60)
+"""
+    leader_source = """
+import subprocess
+import sys
+import time
+
+subprocess.Popen([sys.executable, "-c", sys.argv[1], *sys.argv[2:]])
+time.sleep(60)
+"""
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            leader_source,
+            child_source,
+            BIOME_HOST,
+            str(port),
+            str(marker),
+        ],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not marker.exists():
+            time.sleep(0.05)
+        assert marker.is_file()
+        assert is_port_open(BIOME_HOST, port)
+
+        terminate(
+            process,
+            host=BIOME_HOST,
+            port=port,
+            term_timeout=1,
+            kill_timeout=2,
+            port_timeout=2,
+        )
+
+        assert not is_process_group_alive(process.pid)
+        assert not is_port_open(BIOME_HOST, port)
+    finally:
+        if is_process_group_alive(process.pid):
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=2)
 
 
 def test_goal_and_action_reject_ambiguous_or_injected_values() -> None:

--- a/tests/examples/test_biome_agent_contract.py
+++ b/tests/examples/test_biome_agent_contract.py
@@ -340,19 +340,20 @@ def test_bootstrap_pins_the_compatible_public_flecs_branch_without_vendoring() -
     assert "agent_drill : buildings.Drill" not in scene
 
 
-def test_checkout_fetches_the_exact_revision_after_its_provenance_ref_moves(
+def test_checkout_fetches_the_exact_revision_without_a_mutable_provenance_ref(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     checkout = tmp_path / "checkout"
     (checkout / ".git").mkdir(parents=True)
     repository = "https://example.invalid/upstream.git"
-    remote_ref = "moving-feature-branch"
     revision = "1" * 40
     commands: list[list[str]] = []
 
     def record_run(command: list[str], *, cwd: Path | None = None) -> None:
         assert cwd == checkout
+        if command[:3] == ["git", "fetch", "origin"]:
+            raise AssertionError("mutable provenance refs must never be fetched")
         commands.append(command)
 
     def git_output(command: list[str], *, cwd: Path | None = None) -> str:
@@ -368,12 +369,10 @@ def test_checkout_fetches_the_exact_revision_after_its_provenance_ref_moves(
     biome_bootstrap._ensure_checkout(
         checkout,
         repository,
-        remote_ref,
         revision,
     )
 
     assert commands == [
-        ["git", "fetch", "origin", remote_ref],
         ["git", "fetch", "--no-tags", "--depth=1", "origin", revision],
         ["git", "checkout", "--detach", revision],
     ]

--- a/tests/examples/test_biome_agent_contract.py
+++ b/tests/examples/test_biome_agent_contract.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 import os
+import runpy
 import signal
 import socket
 import subprocess
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 from uuid import UUID
 
 import httpx
@@ -70,6 +73,116 @@ def _deposit(
         terrain="biome.terrain.Terrain",
         cell=TerrainCell(x, y),
     )
+
+
+def test_numbered_example_entrypoint_runs_the_pinned_durable_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    namespace = runpy.run_path(str(_EXAMPLES / "14_biome_agent.py"))
+    calls: dict[str, object] = {}
+
+    class Process:
+        pid = 4321
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    process = Process()
+
+    class Client:
+        def __init__(self, url: str) -> None:
+            calls["url"] = url
+
+        def __enter__(self) -> Client:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    def prepare_entrypoint(checkout_root: Path, *, jobs: int | None = None) -> object:
+        calls["prepare"] = (checkout_root, jobs)
+        return object()
+
+    def launch_entrypoint(checkout: object) -> Process:
+        calls["checkout"] = checkout
+        return process
+
+    def run_entrypoint(client: Client, goal: ExtractionGoal, **kwargs: object) -> object:
+        calls["run"] = (client, goal, kwargs)
+        action = SimpleNamespace(
+            target_path="mission.iron",
+            drill_path="scene.buildings.agent_drill",
+            power_path="scene.buildings.agent_solar",
+        )
+        trace = SimpleNamespace(
+            plan=SimpleNamespace(action=action),
+            final_sample=SimpleNamespace(drill=SimpleNamespace(powered=True, stored_amount=4)),
+            extracted=4,
+            success=True,
+            reason="goal reached",
+        )
+        return SimpleNamespace(
+            trace=trace,
+            world_id="world-1",
+            run_id="run-1",
+            committed_tick=3,
+        )
+
+    namespace.update(
+        {
+            "BiomeClient": Client,
+            "prepare": prepare_entrypoint,
+            "launch": launch_entrypoint,
+            "wait_until_ready": lambda *_args, **_kwargs: True,
+            "run_durable_episode": run_entrypoint,
+            "terminate": lambda owned: calls.setdefault("terminated", owned),
+        }
+    )
+    main = namespace["main"]
+    main.__globals__.update(namespace)
+
+    returncode = main(
+        [
+            "--launch",
+            "--resource",
+            "Iron",
+            "--amount",
+            "4",
+            "--timeout",
+            "2",
+            "--poll-interval",
+            "0.1",
+            "--checkout-root",
+            str(tmp_path / "upstream"),
+            "--jobs",
+            "3",
+            "--storage-uri",
+            str(tmp_path / "store"),
+        ]
+    )
+
+    assert returncode == 0
+    assert calls["prepare"] == (tmp_path / "upstream", 3)
+    assert calls["terminated"] is process
+    _client, goal, kwargs = cast(
+        tuple[Client, ExtractionGoal, dict[str, object]],
+        calls["run"],
+    )
+    assert goal == ExtractionGoal("Iron", 4)
+    assert kwargs["biome_revision"] == BIOME_REVISION
+    assert kwargs["flecs_revision"] == FLECS_REVISION
+    assert kwargs["timeout"] == 2
+    assert kwargs["poll_interval"] == 0.1
+    storage = kwargs["storage"]
+    assert isinstance(storage, StorageConfig)
+    assert storage.uri == str(tmp_path / "store")
+    assert storage.namespace == "biome_agent"
+    output = capsys.readouterr()
+    assert "Native result: extracted=4 powered=True stored=4" in output.out
+    assert "Archetype evidence: world_id=world-1 run_id=run-1 committed_tick=3" in output.out
+    assert output.err == ""
 
 
 def test_client_reads_reflected_deposits_and_occupancy() -> None:

--- a/tests/infrastructure/test_biome_live.py
+++ b/tests/infrastructure/test_biome_live.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Release-only evidence against exact upstream Biome and Flecs revisions."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from archetype import ArchetypeRuntime, StorageConfig
+
+_EXAMPLES = Path(__file__).resolve().parents[2] / "examples"
+if str(_EXAMPLES) not in sys.path:
+    sys.path.insert(0, str(_EXAMPLES))
+
+from biome_agent import (  # noqa: E402
+    BiomeClient,
+    BiomeEpisodeState,
+    BiomeMission,
+    BiomeMissionOutcome,
+    ExtractionGoal,
+    run_durable_episode,
+    wait_until_ready,
+)
+from biome_agent.bootstrap import (  # noqa: E402
+    BIOME_HOST,
+    BIOME_PORT,
+    BIOME_REVISION,
+    FLECS_REVISION,
+    is_port_open,
+    is_process_group_alive,
+    launch,
+    prepare,
+    terminate,
+)
+
+_LIVE = os.environ.get("ARCHETYPE_BIOME_LIVE") == "1"
+
+pytestmark = [
+    pytest.mark.contract("missions.environment.pinned"),
+    pytest.mark.integration,
+    pytest.mark.external,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not _LIVE,
+        reason="set ARCHETYPE_BIOME_LIVE=1 for pinned macOS Biome release evidence",
+    ),
+]
+
+
+def _require_live_macos_host() -> None:
+    assert platform.system() == "Darwin", "live Biome evidence requires macOS"
+    missing = [name for name in ("git", "cmake", "cargo", "pkg-config") if not shutil.which(name)]
+    assert not missing, f"live Biome evidence is missing required tools: {missing}"
+
+    process_uid = os.geteuid()
+    console_uid = os.stat("/dev/console").st_uid
+    assert process_uid != 0 and console_uid == process_uid, (
+        "live Biome evidence must run as the user who owns the active GUI session"
+    )
+    window_server = subprocess.run(
+        ["/usr/bin/pgrep", "-x", "WindowServer"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert window_server.returncode == 0, "live Biome evidence requires WindowServer"
+
+    profile = subprocess.run(
+        ["/usr/sbin/system_profiler", "SPDisplaysDataType", "-json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    displays = json.loads(profile.stdout).get("SPDisplaysDataType", [])
+    metal_values = [
+        value
+        for display in displays
+        if isinstance(display, dict)
+        for key, value in display.items()
+        if key == "spdisplays_mtlgpufamilysupport" or key.startswith("spdisplays_metal")
+    ]
+    assert metal_values and all(
+        "unsupported" not in str(value).casefold() for value in metal_values
+    ), "live Biome evidence requires a Metal-capable GPU"
+    online_displays = [
+        driver
+        for display in displays
+        if isinstance(display, dict)
+        for driver in display.get("spdisplays_ndrvs", [])
+        if isinstance(driver, dict) and driver.get("spdisplays_online") == "spdisplays_yes"
+    ]
+    assert online_displays, "live Biome evidence requires an online display in the GUI session"
+
+
+def test_pinned_biome_episode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prove native control, cold durable evidence, and owned cleanup together."""
+
+    _require_live_macos_host()
+    monkeypatch.setenv("ARCHETYPE_CATALOG_DIR", str(tmp_path / "catalog"))
+    monkeypatch.delenv("ARCHETYPE_CONTROL_CATALOG_URL", raising=False)
+    monkeypatch.delenv("ARCHETYPE_CONTROL_CATALOG_TOKEN", raising=False)
+
+    checkout = prepare(tmp_path / "upstream")
+    storage = StorageConfig(uri=str(tmp_path / "store"), namespace="biome_release")
+    goal = ExtractionGoal(resource="Copper", amount=10)
+    process = None
+    process_group: int | None = None
+    try:
+        assert not is_port_open(), f"release host already has a listener on {BIOME_PORT}"
+        process = launch(checkout)
+        process_group = process.pid
+        with BiomeClient() as client:
+            assert wait_until_ready(client, process, timeout=60), (
+                "pinned Biome exited or did not expose Flecs REST"
+            )
+            result = run_durable_episode(
+                client,
+                goal,
+                storage=storage,
+                biome_revision=BIOME_REVISION,
+                flecs_revision=FLECS_REVISION,
+                timeout=30,
+                poll_interval=0.25,
+                world_name="biome-release-evidence",
+            )
+
+        trace = result.trace
+        sample = trace.final_sample
+        assert trace.success, trace.reason
+        assert sample is not None
+        assert sample.drill is not None
+        drill = sample.drill
+        assert trace.extracted >= goal.amount
+        assert trace.plan.target.amount - sample.deposit_amount == trace.extracted
+        assert sample.deposit_amount < trace.plan.target.amount
+        assert drill.powered is True
+        assert drill.deposit_path == trace.plan.action.target_path
+        assert drill.stored_resource == trace.plan.action.resource
+        assert drill.stored_amount >= goal.amount
+        assert result.biome_revision == BIOME_REVISION
+        assert result.flecs_revision == FLECS_REVISION
+        assert result.committed_tick == 3
+        UUID(result.world_id)
+        UUID(result.run_id)
+
+        # Recompose the runtime after the writer is gone and read the exact
+        # component row from durable storage. This prevents info-only evidence.
+        with ArchetypeRuntime.sync() as runtime:
+            world = runtime.attach(result.world_id, storage=storage)
+            info = world.info()
+            rows = world.query(
+                BiomeMission,
+                BiomeEpisodeState,
+                BiomeMissionOutcome,
+                entity_ids=[result.episode_entity_id],
+            ).to_pylist()
+
+        assert str(info.world_id) == result.world_id
+        assert str(info.run_id) == result.run_id
+        assert info.tick == result.committed_tick
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["tick"] == result.committed_tick
+        assert row["biomemission__biome_revision"] == BIOME_REVISION
+        assert row["biomemission__flecs_revision"] == FLECS_REVISION
+        assert row["biomeepisodestate__phase"] == "succeeded"
+        assert row["biomeepisodestate__target_entity"] == trace.plan.action.target_path
+        assert row["biomeepisodestate__deposit_amount"] == sample.deposit_amount
+        assert row["biomeepisodestate__extracted"] == trace.extracted
+        assert row["biomeepisodestate__drill_entity"] == trace.plan.action.drill_path
+        assert row["biomeepisodestate__powered"] is True
+        assert row["biomeepisodestate__stored_amount"] == drill.stored_amount
+        assert row["biomemissionoutcome__success"] is True
+        assert row["biomemissionoutcome__extracted"] == trace.extracted
+    finally:
+        if process is not None:
+            terminate(process)
+        if process_group is not None:
+            assert not is_process_group_alive(process_group), (
+                f"Biome process group {process_group} survived live evidence"
+            )
+        assert not is_port_open(BIOME_HOST, BIOME_PORT), "Biome REST port survived live evidence"

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -498,6 +498,92 @@ def test_live_physical_ai_release_scenario_binds_modal_compute_to_r2() -> None:
     assert "ARCHETYPE_MODAL_PHYSICAL_R2_LIVE=1" in MAKEFILE.read_text(encoding="utf-8")
 
 
+def test_live_biome_release_scenario_requires_the_pinned_macos_host() -> None:
+    with OPERATIONAL_SCENARIOS.open("rb") as stream:
+        scenarios = tomllib.load(stream)["scenario"]
+    biome = next(row for row in scenarios if row["id"] == "example.14_biome_agent")
+    nodeid = "tests/infrastructure/test_biome_live.py::test_pinned_biome_episode"
+
+    assert biome["source_path"] == "examples/14_biome_agent.py"
+    assert biome["source_command"] == ["pytest", "-q", nodeid]
+    assert biome["semantic_oracle"] == {"kind": "pytest", "ref": nodeid}
+    assert biome["timeout_seconds"] == 1800
+    assert set(biome["prerequisites"]) == {
+        "platform:darwin",
+        "binary:git",
+        "binary:cmake",
+        "binary:cargo",
+        "binary:pkg-config",
+        "infrastructure:ARCHETYPE_BIOME_LIVE",
+    }
+
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    target = re.search(
+        r"^operational-release-biome:[^\n]*\n(?P<body>(?:\t.*\n)+)",
+        makefile,
+        re.MULTILINE,
+    )
+    assert target is not None
+    assert "--scenario example.14_biome_agent" in target.group("body")
+    assert "--out operational-release-biome-results.json" in target.group("body")
+    assert "ARCHETYPE_BIOME_LIVE=1" in target.group("body")
+
+
+def test_every_high_tier_release_scenario_has_an_explicit_workflow_receipt() -> None:
+    with OPERATIONAL_SCENARIOS.open("rb") as stream:
+        scenarios = tomllib.load(stream)["scenario"]
+    high_tier = {
+        row["id"]
+        for row in scenarios
+        if "release" in row["required_cadence"] and int(row["tier"]) > 4
+    }
+    assert high_tier
+
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    release_targets: dict[str, tuple[str, str]] = {}
+    for match in re.finditer(
+        r"^(?P<target>operational-release-[a-z0-9-]+):[^\n]*\n"
+        r"(?P<body>(?:\t.*\n)+)",
+        makefile,
+        re.MULTILINE,
+    ):
+        body = match.group("body")
+        scenario = re.search(r"--scenario\s+([a-z0-9._-]+)", body)
+        receipt = re.search(r"--out\s+(operational-release-[a-z0-9-]+-results\.json)", body)
+        if scenario is not None and receipt is not None:
+            release_targets[match.group("target")] = (scenario.group(1), receipt.group(1))
+
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    external = _job(workflow, "external-evidence")
+    apple = _job(workflow, "apple-evidence")
+    gate = _job(workflow, "release-evidence-gate")
+    workflow_receipts = {
+        target: receipt
+        for target, receipt in re.findall(
+            r"^\s+target:\s+(operational-release-[a-z0-9-]+)\n"
+            r"\s+receipt:\s+(operational-release-[a-z0-9-]+-results\.json)$",
+            external,
+            re.MULTILINE,
+        )
+    }
+    for target in re.findall(r"run:\s+make\s+(operational-release-[a-z0-9-]+)", apple):
+        assert target in release_targets
+        receipt = release_targets[target][1]
+        assert receipt in apple
+        workflow_receipts[target] = receipt
+
+    targets_by_scenario: dict[str, list[tuple[str, str]]] = {}
+    for target, (scenario, receipt) in release_targets.items():
+        targets_by_scenario.setdefault(scenario, []).append((target, receipt))
+
+    for scenario in sorted(high_tier):
+        mappings = targets_by_scenario.get(scenario, [])
+        assert len(mappings) == 1, f"{scenario} must map to one release Make target"
+        target, receipt = mappings[0]
+        assert workflow_receipts.get(target) == receipt
+        assert f"evidence/{receipt}" in gate
+
+
 def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
     profile = _job(workflow, "release-profile")
@@ -537,6 +623,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         assert "--min-tier 0 --max-tier 6" in make_target.group("body")
     assert "tests/infrastructure/test_r2_idempotency.py" in external
     assert "scripts/verify_release_evidence.py" in gate
+    assert "operational-release-biome-results.json" in gate
     assert "operational-release-apple-results.json" in gate
     assert "operational-release-modal-results.json" in gate
     assert "operational-release-physical-modal-r2-results.json" in gate
@@ -544,16 +631,23 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
     assert "cancel-in-progress: false" in workflow
     assert "runs-on: ${{ fromJSON(matrix.runner) }}" in external
     assert "operational-release-apple" not in external
+    assert "operational-release-biome" not in external
     assert "group: archetype-release-macos" in apple
     assert "archetype-apple-container-macos-26" in apple
     assert "environment: release-apple-macos" in apple
+    assert "timeout-minutes: 75" in apple
     assert "- uses: actions/setup-python@" not in apple
     assert 'UV_PYTHON: "3.12"' in apple
     assert 'uv sync --python "3.12" --all-packages --all-extras --group dev' in apple
     assert "sys.version_info[:2] == (3, 12)" in apple
     assert 'test "$(uname -m)" = "arm64"' in apple
+    assert "make operational-release-biome" in apple
     assert "container system status" in apple
     assert "make operational-release-apple" in apple
+    assert apple.index("make operational-release-biome") < apple.index("container system start")
+    assert "name: release-operational-release-apple-evidence" in apple
+    assert "operational-release-biome-results.json" in apple
+    assert "pattern: release-operational-release-*-evidence" in gate
     assert "needs: [release-profile, external-evidence, apple-evidence]" in gate
     assert 'UV_PYTHON: "3.13"' in compatibility
     assert 'uv sync --python "3.13" --all-packages --all-extras --group dev' in compatibility


### PR DESCRIPTION
## Summary

- make the release-required Biome scenario a genuine pinned macOS/Metal live test
- share one durable episode helper between the CLI and the exact release oracle
- run Biome before Apple Container on the exact-tag-restricted ephemeral Mac job
- require and aggregate a distinct exact-wheel Biome evidence receipt
- statically prove every release-required tier-5/6 scenario has one workflow lane and consumed receipt

This is the ninth and final PR in the Archetype 0.6.0 review stack. Its base is
`architecture-review-docs` / #798.

## Correctness findings

The first genuine run found that the upstream `script_await` branch had
diverged from the pinned Flecs commit. The compatible SHA remains directly
fetchable, so the bootstrap now fetches the immutable object explicitly before
detached checkout and no longer depends on named-ref reachability.

The next run found that generic `.strip()` handling corrupted the leading
column of `git status --porcelain`. Output handling now preserves that column,
with focused regressions for both failures.

## Validation

- `make ci` — 3,123 passed, 22 skipped; five wheels, five sdists, complete isolated install matrix
- `ARCHETYPE_BIOME_LIVE=1 uv run pytest -q tests/infrastructure/test_biome_live.py::test_pinned_biome_episode --junitxml=.context/biome-live-junit.xml` — 1 passed in 116.89s
- focused Biome/harness contracts — 17 passed, 1 expected live skip
- checksum-pinned actionlint 1.7.12
- Ruff format/lint, ty, and `git diff --check`

The live oracle proved exact Biome/Flecs revisions, native target binding,
power, deposit reduction, stored output, cold durable Archetype evidence at
committed tick 3, and complete process-group/port cleanup.
