### PR TITLE
fix: guard Biome release process cleanup

### DIFF
--- a/docs/guide/prefab-libraries.md
+++ b/docs/guide/prefab-libraries.md
@@ -373,10 +373,11 @@ that does not change the server's bind address or add server-side
 authorization.
 
 At the pinned Biome revision the upstream repository does not declare a
-license. Archetype therefore does not vendor, modify, package, or redistribute
-Biome source or assets. The bootstrap creates a local checkout for the user.
-Obtain permission or a declared upstream license before distributing a
-derived Biome build.
+license. Archetype therefore does not vendor, package, or redistribute Biome
+source, assets, or the derived executable. The bootstrap patches only its
+disposable local checkout to register the Archetype-owned bridge and produce
+a private executable for the evidence run. Obtain permission or a declared
+upstream license before distributing that derived build or any copied asset.
 
 For a package-owned example that compiles framework prefab graphs into Agent
 Missions authoring values, continue with the

--- a/docs/guide/release-0.6.md
+++ b/docs/guide/release-0.6.md
@@ -114,7 +114,10 @@ Mac used for Apple Container evidence. It fail-closes on the Darwin, build-tool,
 and explicit-live prerequisites; builds and launches the checked-in Biome and
 Flecs revisions in an active WindowServer/Metal session; waits for REST
 readiness; proves the native mission plus durable Archetype evidence; and
-closes the process and port. Biome runs before Apple Container under the single
+closes the process and port. Before the native executable can start, a
+runner-owned guardian acknowledges its isolated process group; parent EOF,
+timeout, or cancellation then triggers independent TERM/KILL and loopback-port
+closure proof. Biome runs before Apple Container under the single
 `release-apple-macos` approval. Its
 `operational-release-biome-results.json` receipt is an explicit input to the
 exact-wheel evidence gate, so TestPyPI approval cannot follow a missing,

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -282,8 +282,11 @@ must acknowledge ownership before a launch wrapper starts Biome and remains
 the group's kernel-identifiable session leader. An exact private marker exposes
 native-target exit without abandoning that ownership anchor; parent EOF,
 timeout, or cancellation makes the guardian reap the group and prove the
-loopback listener closed. The job then starts Apple Container, runs its
-exact-wheel parity proof, and stops the service in an always-run cleanup step.
+loopback listener closed. A normal release records group and port liveness at
+publication, so a premature release cannot become truthful merely because the
+target exits before final cleanup. The job then starts Apple Container, runs
+its exact-wheel parity proof, and stops the service in an always-run cleanup
+step.
 
 Both results travel in the existing
 `release-operational-release-apple-evidence` artifact. The aggregate

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -277,9 +277,12 @@ available, and the Make target has explicitly opted into live execution with
 `ARCHETYPE_BIOME_LIVE=1`. The release-only test builds and launches the exact
 checked-in Biome and Flecs revisions in the active GUI/Metal session, waits for
 the local REST service, proves the native mining mission and durable Archetype
-evidence, and guarantees process and port cleanup. The job then starts Apple
-Container, runs its exact-wheel parity proof, and stops the service in an
-always-run cleanup step.
+evidence, and guarantees process and port cleanup. A separate-session guardian
+must acknowledge ownership before a launch wrapper starts Biome and remains
+the group's kernel-identifiable session leader; parent EOF, timeout, or
+cancellation makes that guardian reap the group and prove the loopback listener
+closed. The job then starts Apple Container, runs its exact-wheel parity proof,
+and stops the service in an always-run cleanup step.
 
 Both results travel in the existing
 `release-operational-release-apple-evidence` artifact. The aggregate

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -279,10 +279,11 @@ checked-in Biome and Flecs revisions in the active GUI/Metal session, waits for
 the local REST service, proves the native mining mission and durable Archetype
 evidence, and guarantees process and port cleanup. A separate-session guardian
 must acknowledge ownership before a launch wrapper starts Biome and remains
-the group's kernel-identifiable session leader; parent EOF, timeout, or
-cancellation makes that guardian reap the group and prove the loopback listener
-closed. The job then starts Apple Container, runs its exact-wheel parity proof,
-and stops the service in an always-run cleanup step.
+the group's kernel-identifiable session leader. An exact private marker exposes
+native-target exit without abandoning that ownership anchor; parent EOF,
+timeout, or cancellation makes the guardian reap the group and prove the
+loopback listener closed. The job then starts Apple Container, runs its
+exact-wheel parity proof, and stops the service in an always-run cleanup step.
 
 Both results travel in the existing
 `release-operational-release-apple-evidence` artifact. The aggregate

--- a/examples/biome_agent/bootstrap.py
+++ b/examples/biome_agent/bootstrap.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -34,6 +35,7 @@ _PROCESS_KILL_GRACE_SECONDS = 5.0
 _PORT_CLOSE_GRACE_SECONDS = 5.0
 _PROCESS_LEASE_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_FILE"
 _PROCESS_LEASE_WRAPPER_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_WRAPPER"
+_PROCESS_TARGET_STATUS_DIR_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_TARGET_STATUS_DIR"
 _PROCESS_LEASE_SCHEMA = "archetype.operational-process-lease/v1"
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
@@ -55,6 +57,59 @@ class BiomeCheckout:
     build: Path
     executable: Path
     scene: Path
+
+
+@dataclass(frozen=True)
+class BiomeProcess:
+    """Owned group leader with prompt native-target exit observation."""
+
+    _leader: subprocess.Popen[bytes]
+    _target_status: Path | None = None
+
+    @property
+    def pid(self) -> int:
+        return self._leader.pid
+
+    def poll(self) -> int | None:
+        leader_returncode = self._leader.poll()
+        if leader_returncode is not None or self._target_status is None:
+            return leader_returncode
+        if not self._target_status.is_file():
+            return None
+        try:
+            payload = json.loads(self._target_status.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise RuntimeError("Biome target exit marker is invalid") from exc
+        lease_id = f"biome:{self.pid}"
+        returncode = payload.get("returncode") if isinstance(payload, dict) else None
+        target_pid = payload.get("target_pid") if isinstance(payload, dict) else None
+        expected = {
+            "schema": _PROCESS_LEASE_SCHEMA,
+            "lease_id": lease_id,
+            "pid": self.pid,
+            "process_group": self.pid,
+            "status": "target_exited",
+        }
+        if (
+            not isinstance(payload, dict)
+            or set(payload) != {*expected, "target_pid", "returncode"}
+            or any(payload.get(key) != value for key, value in expected.items())
+            or not isinstance(target_pid, int)
+            or isinstance(target_pid, bool)
+            or target_pid <= 1
+            or not isinstance(returncode, int)
+            or isinstance(returncode, bool)
+        ):
+            raise RuntimeError("Biome target exit marker is invalid")
+        return returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self._leader.wait(timeout=timeout)
+
+
+def _target_status_path(directory: Path, lease_id: str) -> Path:
+    digest = hashlib.sha256(lease_id.encode()).hexdigest()
+    return directory / f"{digest}.target.json"
 
 
 def _run(command: list[str], *, cwd: Path | None = None) -> None:
@@ -306,17 +361,22 @@ def _verify_pinned_checkout(checkout: BiomeCheckout) -> None:
         raise RuntimeError("refusing to launch with an unexpected native Biome bridge")
 
 
-def launch(checkout: BiomeCheckout) -> subprocess.Popen[bytes]:
+def launch(checkout: BiomeCheckout) -> BiomeProcess:
     """Launch the pinned game and its Flecs REST server."""
 
     _verify_pinned_checkout(checkout)
     if is_port_open():
         raise RuntimeError(f"refusing to launch Biome while {BIOME_HOST}:{BIOME_PORT} is in use")
     command = [str(checkout.executable), "--scene", "etc/scenes/archetype_agent.flecs"]
+    target_status_dir: Path | None = None
     if os.environ.get(_PROCESS_LEASE_ENV) is not None:
         wrapper = os.environ.get(_PROCESS_LEASE_WRAPPER_ENV)
         if not wrapper:
             raise RuntimeError("operational Biome launch requires the process lease wrapper")
+        target_status_dir_value = os.environ.get(_PROCESS_TARGET_STATUS_DIR_ENV)
+        if not target_status_dir_value:
+            raise RuntimeError("operational Biome launch requires target status evidence")
+        target_status_dir = Path(target_status_dir_value)
         command = [
             sys.executable,
             wrapper,
@@ -330,15 +390,21 @@ def launch(checkout: BiomeCheckout) -> subprocess.Popen[bytes]:
             "--",
             *command,
         ]
-    return subprocess.Popen(
+    leader = subprocess.Popen(
         command,
         cwd=checkout.biome,
         start_new_session=True,
     )
+    target_status = (
+        _target_status_path(target_status_dir, f"biome:{leader.pid}")
+        if target_status_dir is not None
+        else None
+    )
+    return BiomeProcess(leader, target_status)
 
 
 def _terminate_owned_process(
-    process: subprocess.Popen[bytes],
+    process: BiomeProcess | subprocess.Popen[bytes],
     *,
     host: str = BIOME_HOST,
     port: int = BIOME_PORT,
@@ -368,7 +434,7 @@ def _terminate_owned_process(
 
 
 def terminate(
-    process: subprocess.Popen[bytes],
+    process: BiomeProcess | subprocess.Popen[bytes],
     *,
     host: str = BIOME_HOST,
     port: int = BIOME_PORT,

--- a/examples/biome_agent/bootstrap.py
+++ b/examples/biome_agent/bootstrap.py
@@ -177,16 +177,30 @@ def _wait_for_port_close(host: str, port: int, timeout: float) -> bool:
     return not is_port_open(host, port)
 
 
-def _release_process_lease(process_id: int) -> bool:
+def _release_process_lease(
+    process_id: int,
+    *,
+    host: str,
+    port: int,
+) -> bool:
     """Record release only after local group and port closure were proven."""
 
     lease_path = os.environ.get(_PROCESS_LEASE_ENV)
     if lease_path is None:
         return False
+    group_was_alive = is_process_group_alive(process_id)
+    port_was_open = is_port_open(host, port)
+    if group_was_alive or port_was_open:
+        raise RuntimeError(
+            "refusing to release a live operational process lease "
+            f"(group_alive={group_was_alive}, port_open={port_was_open})"
+        )
     payload: dict[str, object] = {
         "schema": _PROCESS_LEASE_SCHEMA,
         "operation": "release",
         "lease_id": f"biome:{process_id}",
+        "group_was_alive": group_was_alive,
+        "port_was_open": port_was_open,
     }
 
     encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
@@ -453,7 +467,7 @@ def terminate(
         port_timeout=port_timeout,
     )
     try:
-        _release_process_lease(process.pid)
+        _release_process_lease(process.pid, host=host, port=port)
     except Exception as exc:
         raise RuntimeError(
             f"Biome closed, but its operational process lease could not be released: {exc}"

--- a/examples/biome_agent/bootstrap.py
+++ b/examples/biome_agent/bootstrap.py
@@ -5,11 +5,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import signal
 import socket
+import stat
 import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +32,9 @@ BIOME_URL = f"http://{BIOME_HOST}:{BIOME_PORT}"
 _PROCESS_TERM_GRACE_SECONDS = 5.0
 _PROCESS_KILL_GRACE_SECONDS = 5.0
 _PORT_CLOSE_GRACE_SECONDS = 5.0
+_PROCESS_LEASE_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_FILE"
+_PROCESS_LEASE_WRAPPER_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_WRAPPER"
+_PROCESS_LEASE_SCHEMA = "archetype.operational-process-lease/v1"
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CHECKOUT_ROOT = _REPOSITORY_ROOT / ".context" / "upstream"
@@ -114,6 +120,34 @@ def _wait_for_port_close(host: str, port: int, timeout: float) -> bool:
             return True
         time.sleep(0.05)
     return not is_port_open(host, port)
+
+
+def _release_process_lease(process_id: int) -> bool:
+    """Record release only after local group and port closure were proven."""
+
+    lease_path = os.environ.get(_PROCESS_LEASE_ENV)
+    if lease_path is None:
+        return False
+    payload: dict[str, object] = {
+        "schema": _PROCESS_LEASE_SCHEMA,
+        "operation": "release",
+        "lease_id": f"biome:{process_id}",
+    }
+
+    encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(lease_path, flags, 0o600)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise RuntimeError("operational process lease journal is not a regular file")
+        if os.write(descriptor, encoded) != len(encoded):
+            raise RuntimeError("operational process lease journal accepted a partial record")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    return True
 
 
 def _ensure_checkout(
@@ -278,14 +312,32 @@ def launch(checkout: BiomeCheckout) -> subprocess.Popen[bytes]:
     _verify_pinned_checkout(checkout)
     if is_port_open():
         raise RuntimeError(f"refusing to launch Biome while {BIOME_HOST}:{BIOME_PORT} is in use")
+    command = [str(checkout.executable), "--scene", "etc/scenes/archetype_agent.flecs"]
+    if os.environ.get(_PROCESS_LEASE_ENV) is not None:
+        wrapper = os.environ.get(_PROCESS_LEASE_WRAPPER_ENV)
+        if not wrapper:
+            raise RuntimeError("operational Biome launch requires the process lease wrapper")
+        command = [
+            sys.executable,
+            wrapper,
+            "exec",
+            "--lease-prefix",
+            "biome",
+            "--host",
+            BIOME_HOST,
+            "--port",
+            str(BIOME_PORT),
+            "--",
+            *command,
+        ]
     return subprocess.Popen(
-        [str(checkout.executable), "--scene", "etc/scenes/archetype_agent.flecs"],
+        command,
         cwd=checkout.biome,
         start_new_session=True,
     )
 
 
-def terminate(
+def _terminate_owned_process(
     process: subprocess.Popen[bytes],
     *,
     host: str = BIOME_HOST,
@@ -313,3 +365,30 @@ def terminate(
         raise RuntimeError(f"Biome process group {process_group} survived cleanup")
     if not _wait_for_port_close(host, port, port_timeout):
         raise RuntimeError(f"Biome REST port {host}:{port} survived cleanup")
+
+
+def terminate(
+    process: subprocess.Popen[bytes],
+    *,
+    host: str = BIOME_HOST,
+    port: int = BIOME_PORT,
+    term_timeout: float = _PROCESS_TERM_GRACE_SECONDS,
+    kill_timeout: float = _PROCESS_KILL_GRACE_SECONDS,
+    port_timeout: float = _PORT_CLOSE_GRACE_SECONDS,
+) -> None:
+    """Close owned Biome state, then release its operational guardian lease."""
+
+    _terminate_owned_process(
+        process,
+        host=host,
+        port=port,
+        term_timeout=term_timeout,
+        kill_timeout=kill_timeout,
+        port_timeout=port_timeout,
+    )
+    try:
+        _release_process_lease(process.pid)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Biome closed, but its operational process lease could not be released: {exc}"
+        ) from exc

--- a/examples/biome_agent/episode.py
+++ b/examples/biome_agent/episode.py
@@ -5,9 +5,9 @@
 
 from __future__ import annotations
 
-import subprocess
 import time
 from dataclasses import dataclass
+from typing import Protocol
 
 from archetype import ArchetypeRuntime, StorageConfig
 
@@ -36,9 +36,13 @@ class DurableBiomeEpisodeResult:
     episode_entity_id: int
 
 
+class _PollableProcess(Protocol):
+    def poll(self) -> int | None: ...
+
+
 def wait_until_ready(
     client: BiomeClient,
-    process: subprocess.Popen[bytes] | None,
+    process: _PollableProcess | None,
     *,
     timeout: float = 30.0,
 ) -> bool:
@@ -46,10 +50,10 @@ def wait_until_ready(
 
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if client.is_ready():
-            return True
         if process is not None and process.poll() is not None:
             return False
+        if client.is_ready():
+            return True
         time.sleep(0.1)
     return False
 

--- a/scripts/process_lease_guardian.py
+++ b/scripts/process_lease_guardian.py
@@ -7,7 +7,8 @@
 ``serve`` runs outside the scenario session and treats EOF on its parent-owned
 stdin pipe as the cleanup signal. ``exec`` is a fail-closed launch wrapper: it
 registers its own new-session PID/PGID, waits for the live guardian to
-acknowledge ownership, and only then replaces itself with the target command.
+acknowledge ownership, retains session leadership, and reports target exit
+without abandoning any descendants that still belong to the group.
 """
 
 from __future__ import annotations
@@ -34,6 +35,7 @@ ACK_DIR_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_ACK_DIR"
 READY_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_READY_FILE"
 CLOSED_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_CLOSED_FILE"
 WRAPPER_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_WRAPPER"
+TARGET_STATUS_DIR_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_TARGET_STATUS_DIR"
 LEASE_SCHEMA = "archetype.operational-process-lease/v1"
 RESULT_SCHEMA = "archetype.operational-process-lease-cleanup/v1"
 _TERM_GRACE_SECONDS = 5.0
@@ -150,6 +152,13 @@ def _lease_history(
 def _marker_path(directory: Path, lease_id: str) -> Path:
     digest = hashlib.sha256(lease_id.encode()).hexdigest()
     return directory / f"{digest}.ack"
+
+
+def target_status_path(directory: Path, lease_id: str) -> Path:
+    """Return the stable private target-status path for one acknowledged lease."""
+
+    digest = hashlib.sha256(lease_id.encode()).hexdigest()
+    return directory / f"{digest}.target.json"
 
 
 def _write_marker(path: Path, payload: dict[str, object]) -> None:
@@ -426,6 +435,7 @@ def execute(*, lease_prefix: str, host: str, port: int, command: list[str]) -> N
     ack_dir = _required_env_path(ACK_DIR_ENV)
     ready_file = _required_env_path(READY_ENV)
     closed_file = _required_env_path(CLOSED_ENV)
+    target_status_dir = _required_env_path(TARGET_STATUS_DIR_ENV)
     process_id = os.getpid()
     if os.getpgrp() != process_id:
         raise RuntimeError("guarded exec must be launched as a new session leader")
@@ -462,7 +472,24 @@ def execute(*, lease_prefix: str, host: str, port: int, command: list[str]) -> N
     if closed_file.exists():
         raise RuntimeError("process lease guardian closed before target exec")
     target = subprocess.Popen(command, env=os.environ.copy())
-    target.wait()
+    target_returncode = target.wait()
+    try:
+        _write_marker(
+            target_status_path(target_status_dir, lease_id),
+            {
+                "schema": LEASE_SCHEMA,
+                "lease_id": lease_id,
+                "pid": process_id,
+                "process_group": process_id,
+                "status": "target_exited",
+                "target_pid": target.pid,
+                "returncode": target_returncode,
+            },
+        )
+    except OSError:
+        # Failure to report must not abandon the kernel ownership anchor. The
+        # caller will time out and the independent guardian will still reap it.
+        pass
     # The wrapper intentionally remains the kernel-visible session leader even
     # after an unexpected target exit. Its owner will observe failed readiness
     # or I/O, close the group through ``terminate()``, and only then release the

--- a/scripts/process_lease_guardian.py
+++ b/scripts/process_lease_guardian.py
@@ -55,6 +55,14 @@ class ProcessLease:
     birth_identity: str
 
 
+@dataclass(frozen=True)
+class ReleaseObservation:
+    """Liveness captured at the instant a release was published."""
+
+    group_was_alive: bool
+    port_was_open: bool
+
+
 def _strict_json_object(encoded: str, *, line_number: int) -> dict[str, Any]:
     def reject_constant(value: str) -> None:
         raise ValueError(f"non-standard JSON constant {value}")
@@ -109,16 +117,16 @@ def _parse_lease(payload: dict[str, Any], *, line_number: int) -> ProcessLease:
 
 def _lease_history(
     path: Path,
-) -> tuple[dict[str, ProcessLease], set[str], list[str]]:
+) -> tuple[dict[str, ProcessLease], dict[str, ReleaseObservation], list[str]]:
     leases: dict[str, ProcessLease] = {}
-    released: set[str] = set()
+    releases: dict[str, ReleaseObservation] = {}
     errors: list[str] = []
     if not path.exists():
-        return leases, released, errors
+        return leases, releases, errors
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError as exc:
-        return leases, released, [f"could not read lease journal: {type(exc).__name__}: {exc}"]
+        return leases, releases, [f"could not read lease journal: {type(exc).__name__}: {exc}"]
 
     for line_number, encoded in enumerate(lines, start=1):
         if not encoded.strip():
@@ -139,14 +147,20 @@ def _lease_history(
                     raise TypeError(f"lease line {line_number} has an invalid lease_id")
                 if lease_id not in leases:
                     raise ValueError(f"lease line {line_number} releases an unknown lease")
-                if lease_id in released:
+                if lease_id in releases:
                     raise ValueError(f"lease line {line_number} releases a lease twice")
-                released.add(lease_id)
+                group_was_alive = payload.get("group_was_alive")
+                port_was_open = payload.get("port_was_open")
+                if not isinstance(group_was_alive, bool):
+                    raise TypeError(f"lease line {line_number} has invalid release group evidence")
+                if not isinstance(port_was_open, bool):
+                    raise TypeError(f"lease line {line_number} has invalid release port evidence")
+                releases[lease_id] = ReleaseObservation(group_was_alive, port_was_open)
             else:
                 raise ValueError(f"lease line {line_number} has an invalid operation")
         except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
             errors.append(f"{type(exc).__name__}: {exc}")
-    return leases, released, errors
+    return leases, releases, errors
 
 
 def _marker_path(directory: Path, lease_id: str) -> Path:
@@ -169,11 +183,11 @@ def _write_marker(path: Path, payload: dict[str, object]) -> None:
 
 
 def _acknowledge_active(lease_file: Path, ack_dir: Path) -> None:
-    leases, released, errors = _lease_history(lease_file)
+    leases, releases, errors = _lease_history(lease_file)
     if errors:
         return
     for lease_id, lease in leases.items():
-        if lease_id in released:
+        if lease_id in releases:
             continue
         marker = _marker_path(ack_dir, lease.lease_id)
         if not marker.exists():
@@ -314,7 +328,11 @@ def _wait_for_port_close(host: str, port: int, timeout: float) -> bool:
     return not _port_open(host, port)
 
 
-def _reap(lease: ProcessLease, *, released: bool) -> dict[str, object]:
+def _reap(
+    lease: ProcessLease,
+    *,
+    release: ReleaseObservation | None,
+) -> dict[str, object]:
     group_was_alive = _process_group_alive(lease.process_group)
     port_was_open = _port_open(lease.host, lease.port)
     current_birth_identity = (
@@ -333,7 +351,9 @@ def _reap(lease: ProcessLease, *, released: bool) -> dict[str, object]:
         _signal_process_group(lease.process_group, signal.SIGKILL)
         group_closed = _wait_for_group_close(lease.process_group, _KILL_GRACE_SECONDS)
     port_closed = _wait_for_port_close(lease.host, lease.port, _PORT_GRACE_SECONDS)
-    release_was_truthful = None if not released else not group_was_alive and not port_was_open
+    release_was_truthful = (
+        None if release is None else not release.group_was_alive and not release.port_was_open
+    )
     return {
         "lease_id": lease.lease_id,
         "pid": lease.pid,
@@ -342,7 +362,9 @@ def _reap(lease: ProcessLease, *, released: bool) -> dict[str, object]:
         "port": lease.port,
         "birth_identity": lease.birth_identity,
         "ownership_matches": ownership_matches,
-        "released": released,
+        "released": release is not None,
+        "release_group_was_alive": (None if release is None else release.group_was_alive),
+        "release_port_was_open": None if release is None else release.port_was_open,
         "release_was_truthful": release_was_truthful,
         "group_was_alive": group_was_alive,
         "port_was_open": port_was_open,
@@ -352,9 +374,9 @@ def _reap(lease: ProcessLease, *, released: bool) -> dict[str, object]:
 
 
 def guard(lease_file: Path, result_file: Path) -> bool:
-    history, released, errors = _lease_history(lease_file)
+    history, releases, errors = _lease_history(lease_file)
     leases = [
-        _reap(history[lease_id], released=lease_id in released) for lease_id in sorted(history)
+        _reap(history[lease_id], release=releases.get(lease_id)) for lease_id in sorted(history)
     ]
     closed = not errors and all(
         lease["group_closed"]
@@ -368,7 +390,7 @@ def guard(lease_file: Path, result_file: Path) -> bool:
         {
             "schema": RESULT_SCHEMA,
             "status": "closed" if closed else "leaked",
-            "active_lease_count": len(history) - len(released),
+            "active_lease_count": len(history) - len(releases),
             "leases": leases,
             "errors": errors,
         },

--- a/scripts/process_lease_guardian.py
+++ b/scripts/process_lease_guardian.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guard nested process groups owned by one operational scenario.
+
+``serve`` runs outside the scenario session and treats EOF on its parent-owned
+stdin pipe as the cleanup signal. ``exec`` is a fail-closed launch wrapper: it
+registers its own new-session PID/PGID, waits for the live guardian to
+acknowledge ownership, and only then replaces itself with the target command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+import re
+import selectors
+import signal
+import socket
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, NoReturn
+
+LEASE_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_FILE"
+ACK_DIR_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_ACK_DIR"
+READY_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_READY_FILE"
+CLOSED_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_CLOSED_FILE"
+WRAPPER_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_WRAPPER"
+LEASE_SCHEMA = "archetype.operational-process-lease/v1"
+RESULT_SCHEMA = "archetype.operational-process-lease-cleanup/v1"
+_TERM_GRACE_SECONDS = 5.0
+_KILL_GRACE_SECONDS = 5.0
+_PORT_GRACE_SECONDS = 5.0
+_ACK_TIMEOUT_SECONDS = 5.0
+_LEASE_PREFIX = re.compile(r"[a-z0-9][a-z0-9_.-]{0,63}")
+
+
+@dataclass(frozen=True)
+class ProcessLease:
+    lease_id: str
+    pid: int
+    process_group: int
+    host: str
+    port: int
+    birth_identity: str
+
+
+def _strict_json_object(encoded: str, *, line_number: int) -> dict[str, Any]:
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-standard JSON constant {value}")
+
+    payload = json.loads(encoded, parse_constant=reject_constant)
+    if not isinstance(payload, dict):
+        raise TypeError(f"lease line {line_number} is not a JSON object")
+    return payload
+
+
+def _append_record(path: Path, payload: dict[str, object]) -> None:
+    encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise RuntimeError("process lease journal is not a regular file")
+        if os.write(descriptor, encoded) != len(encoded):
+            raise RuntimeError("process lease journal accepted a partial record")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _parse_lease(payload: dict[str, Any], *, line_number: int) -> ProcessLease:
+    if payload.get("schema") != LEASE_SCHEMA or payload.get("operation") != "acquire":
+        raise ValueError(f"lease line {line_number} has an invalid acquire envelope")
+    lease_id = payload.get("lease_id")
+    pid = payload.get("pid")
+    process_group = payload.get("process_group")
+    host = payload.get("host")
+    port = payload.get("port")
+    birth_identity = payload.get("birth_identity")
+    if not isinstance(lease_id, str) or not lease_id:
+        raise TypeError(f"lease line {line_number} has an invalid lease_id")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 1:
+        raise TypeError(f"lease line {line_number} has an invalid pid")
+    if not isinstance(process_group, int) or isinstance(process_group, bool):
+        raise TypeError(f"lease line {line_number} has an invalid process_group")
+    if process_group <= 1 or process_group != pid:
+        raise ValueError(f"lease line {line_number} must name an owned session leader")
+    if not isinstance(host, str) or host not in {"127.0.0.1", "::1", "localhost"}:
+        raise ValueError(f"lease line {line_number} must name a loopback listener")
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        raise TypeError(f"lease line {line_number} has an invalid port")
+    if not isinstance(birth_identity, str) or not birth_identity:
+        raise TypeError(f"lease line {line_number} has an invalid birth_identity")
+    return ProcessLease(lease_id, pid, process_group, host, port, birth_identity)
+
+
+def _lease_history(
+    path: Path,
+) -> tuple[dict[str, ProcessLease], set[str], list[str]]:
+    leases: dict[str, ProcessLease] = {}
+    released: set[str] = set()
+    errors: list[str] = []
+    if not path.exists():
+        return leases, released, errors
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        return leases, released, [f"could not read lease journal: {type(exc).__name__}: {exc}"]
+
+    for line_number, encoded in enumerate(lines, start=1):
+        if not encoded.strip():
+            continue
+        try:
+            payload = _strict_json_object(encoded, line_number=line_number)
+            if payload.get("schema") != LEASE_SCHEMA:
+                raise ValueError(f"lease line {line_number} has an invalid schema")
+            operation = payload.get("operation")
+            lease_id = payload.get("lease_id")
+            if operation == "acquire":
+                lease = _parse_lease(payload, line_number=line_number)
+                if lease.lease_id in leases:
+                    raise ValueError(f"lease line {line_number} reacquires an active lease")
+                leases[lease.lease_id] = lease
+            elif operation == "release":
+                if not isinstance(lease_id, str) or not lease_id:
+                    raise TypeError(f"lease line {line_number} has an invalid lease_id")
+                if lease_id not in leases:
+                    raise ValueError(f"lease line {line_number} releases an unknown lease")
+                if lease_id in released:
+                    raise ValueError(f"lease line {line_number} releases a lease twice")
+                released.add(lease_id)
+            else:
+                raise ValueError(f"lease line {line_number} has an invalid operation")
+        except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+            errors.append(f"{type(exc).__name__}: {exc}")
+    return leases, released, errors
+
+
+def _marker_path(directory: Path, lease_id: str) -> Path:
+    digest = hashlib.sha256(lease_id.encode()).hexdigest()
+    return directory / f"{digest}.ack"
+
+
+def _write_marker(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _acknowledge_active(lease_file: Path, ack_dir: Path) -> None:
+    leases, released, errors = _lease_history(lease_file)
+    if errors:
+        return
+    for lease_id, lease in leases.items():
+        if lease_id in released:
+            continue
+        marker = _marker_path(ack_dir, lease.lease_id)
+        if not marker.exists():
+            _write_marker(
+                marker,
+                {
+                    "schema": LEASE_SCHEMA,
+                    "lease_id": lease.lease_id,
+                    "pid": lease.pid,
+                    "process_group": lease.process_group,
+                    "birth_identity": lease.birth_identity,
+                    "status": "accepted",
+                },
+            )
+
+
+def _acknowledgement_is_exact(path: Path, lease: ProcessLease) -> bool:
+    try:
+        payload = _strict_json_object(path.read_text(encoding="utf-8"), line_number=1)
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return False
+    return payload == {
+        "schema": LEASE_SCHEMA,
+        "lease_id": lease.lease_id,
+        "pid": lease.pid,
+        "process_group": lease.process_group,
+        "birth_identity": lease.birth_identity,
+        "status": "accepted",
+    }
+
+
+def _process_birth_identity(process_id: int) -> str | None:
+    """Return a kernel process-instance token, not a wall-clock display value."""
+
+    if sys.platform == "darwin":
+        return _darwin_process_birth_identity(process_id)
+    if sys.platform.startswith("linux"):
+        try:
+            # The command name is parenthesized and may contain spaces. Field
+            # 22 (index 19 after the closing parenthesis) is the kernel start
+            # time in clock ticks since boot.
+            fields = Path(f"/proc/{process_id}/stat").read_text().rsplit(")", 1)[1].split()
+            start_ticks = fields[19]
+        except (IndexError, OSError):
+            return None
+        return f"linux-start-ticks:{start_ticks}"
+    return None
+
+
+def _darwin_process_birth_identity(process_id: int) -> str | None:
+    class ProcBsdInfo(ctypes.Structure):
+        _fields_ = [
+            ("pbi_flags", ctypes.c_uint32),
+            ("pbi_status", ctypes.c_uint32),
+            ("pbi_xstatus", ctypes.c_uint32),
+            ("pbi_pid", ctypes.c_uint32),
+            ("pbi_ppid", ctypes.c_uint32),
+            ("pbi_uid", ctypes.c_uint32),
+            ("pbi_gid", ctypes.c_uint32),
+            ("pbi_ruid", ctypes.c_uint32),
+            ("pbi_rgid", ctypes.c_uint32),
+            ("pbi_svuid", ctypes.c_uint32),
+            ("pbi_svgid", ctypes.c_uint32),
+            ("rfu_1", ctypes.c_uint32),
+            ("pbi_comm", ctypes.c_char * 16),
+            ("pbi_name", ctypes.c_char * 32),
+            ("pbi_nfiles", ctypes.c_uint32),
+            ("pbi_pgid", ctypes.c_uint32),
+            ("pbi_pjobc", ctypes.c_uint32),
+            ("e_tdev", ctypes.c_uint32),
+            ("e_tpgid", ctypes.c_uint32),
+            ("pbi_nice", ctypes.c_int32),
+            ("pbi_start_tvsec", ctypes.c_uint64),
+            ("pbi_start_tvusec", ctypes.c_uint64),
+        ]
+
+    try:
+        libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+    except OSError:
+        return None
+    libproc.proc_pidinfo.argtypes = (
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.c_int,
+    )
+    libproc.proc_pidinfo.restype = ctypes.c_int
+    info = ProcBsdInfo()
+    size = ctypes.sizeof(info)
+    if libproc.proc_pidinfo(process_id, 3, 0, ctypes.byref(info), size) != size:
+        return None
+    if info.pbi_pid != process_id:
+        return None
+    return f"darwin-start-time:{info.pbi_start_tvsec}:{info.pbi_start_tvusec}"
+
+
+def _process_group_alive(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _signal_process_group(process_group: int, requested_signal: signal.Signals) -> None:
+    try:
+        os.killpg(process_group, requested_signal)
+    except (PermissionError, ProcessLookupError):
+        pass
+
+
+def _wait_for_group_close(process_group: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _process_group_alive(process_group):
+            return True
+        time.sleep(0.05)
+    return not _process_group_alive(process_group)
+
+
+def _port_open(host: str, port: int) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=0.2):
+            return True
+    except OSError:
+        return False
+
+
+def _wait_for_port_close(host: str, port: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _port_open(host, port):
+            return True
+        time.sleep(0.05)
+    return not _port_open(host, port)
+
+
+def _reap(lease: ProcessLease, *, released: bool) -> dict[str, object]:
+    group_was_alive = _process_group_alive(lease.process_group)
+    port_was_open = _port_open(lease.host, lease.port)
+    current_birth_identity = (
+        _process_birth_identity(lease.pid) if group_was_alive else lease.birth_identity
+    )
+    # The launch wrapper remains the session leader for the target's complete
+    # lifetime. Missing or changed leader identity is therefore not evidence
+    # of ownership and must fail closed rather than signal a reused PGID.
+    ownership_matches = current_birth_identity == lease.birth_identity
+    if group_was_alive and ownership_matches:
+        _signal_process_group(lease.process_group, signal.SIGTERM)
+    group_closed = not group_was_alive or (
+        ownership_matches and _wait_for_group_close(lease.process_group, _TERM_GRACE_SECONDS)
+    )
+    if not group_closed and ownership_matches:
+        _signal_process_group(lease.process_group, signal.SIGKILL)
+        group_closed = _wait_for_group_close(lease.process_group, _KILL_GRACE_SECONDS)
+    port_closed = _wait_for_port_close(lease.host, lease.port, _PORT_GRACE_SECONDS)
+    release_was_truthful = None if not released else not group_was_alive and not port_was_open
+    return {
+        "lease_id": lease.lease_id,
+        "pid": lease.pid,
+        "process_group": lease.process_group,
+        "host": lease.host,
+        "port": lease.port,
+        "birth_identity": lease.birth_identity,
+        "ownership_matches": ownership_matches,
+        "released": released,
+        "release_was_truthful": release_was_truthful,
+        "group_was_alive": group_was_alive,
+        "port_was_open": port_was_open,
+        "group_closed": group_closed,
+        "port_closed": port_closed,
+    }
+
+
+def guard(lease_file: Path, result_file: Path) -> bool:
+    history, released, errors = _lease_history(lease_file)
+    leases = [
+        _reap(history[lease_id], released=lease_id in released) for lease_id in sorted(history)
+    ]
+    closed = not errors and all(
+        lease["group_closed"]
+        and lease["port_closed"]
+        and lease["ownership_matches"]
+        and lease["release_was_truthful"] is not False
+        for lease in leases
+    )
+    _write_marker(
+        result_file,
+        {
+            "schema": RESULT_SCHEMA,
+            "status": "closed" if closed else "leaked",
+            "active_lease_count": len(history) - len(released),
+            "leases": leases,
+            "errors": errors,
+        },
+    )
+    return closed
+
+
+def serve(
+    *,
+    lease_file: Path,
+    ack_dir: Path,
+    ready_file: Path,
+    closed_file: Path,
+    result_file: Path,
+) -> bool:
+    """Acknowledge live leases until parent EOF, then close every remainder."""
+
+    shutdown_requested = False
+
+    def request_shutdown(_signum: int, _frame: object) -> None:
+        nonlocal shutdown_requested
+        shutdown_requested = True
+
+    signal.signal(signal.SIGTERM, request_shutdown)
+    signal.signal(signal.SIGINT, request_shutdown)
+    selector = selectors.DefaultSelector()
+    try:
+        selector.register(sys.stdin.buffer, selectors.EVENT_READ)
+        ack_dir.mkdir(parents=True, exist_ok=True)
+        _write_marker(
+            ready_file,
+            {"schema": LEASE_SCHEMA, "status": "ready", "pid": os.getpid()},
+        )
+        while not shutdown_requested:
+            _acknowledge_active(lease_file, ack_dir)
+            events = selector.select(timeout=0.05)
+            if events and os.read(sys.stdin.fileno(), 4096) == b"":
+                break
+    finally:
+        # Once cleanup begins, a second CI cancellation/escalation signal must
+        # not interrupt TERM/KILL, port proof, or result publication.
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        selector.close()
+    _write_marker(closed_file, {"schema": LEASE_SCHEMA, "status": "closed"})
+    return guard(lease_file, result_file)
+
+
+def _required_env_path(name: str) -> Path:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"guarded exec requires {name}")
+    return Path(value)
+
+
+def execute(*, lease_prefix: str, host: str, port: int, command: list[str]) -> NoReturn:
+    """Acquire ownership, then retain session leadership while the target runs."""
+
+    if _LEASE_PREFIX.fullmatch(lease_prefix) is None:
+        raise ValueError("lease prefix must be a safe lowercase identifier")
+    if not command:
+        raise ValueError("guarded exec requires a command")
+    lease_file = _required_env_path(LEASE_ENV)
+    ack_dir = _required_env_path(ACK_DIR_ENV)
+    ready_file = _required_env_path(READY_ENV)
+    closed_file = _required_env_path(CLOSED_ENV)
+    process_id = os.getpid()
+    if os.getpgrp() != process_id:
+        raise RuntimeError("guarded exec must be launched as a new session leader")
+    lease_id = f"{lease_prefix}:{process_id}"
+    birth_identity = _process_birth_identity(process_id)
+    if birth_identity is None:
+        raise RuntimeError("guarded exec could not bind the process birth identity")
+    if not ready_file.is_file() or closed_file.exists():
+        raise RuntimeError("process lease guardian is not accepting registrations")
+    _append_record(
+        lease_file,
+        {
+            "schema": LEASE_SCHEMA,
+            "operation": "acquire",
+            "lease_id": lease_id,
+            "pid": process_id,
+            "process_group": process_id,
+            "host": host,
+            "port": port,
+            "birth_identity": birth_identity,
+        },
+    )
+    lease = ProcessLease(lease_id, process_id, process_id, host, port, birth_identity)
+    acknowledgement = _marker_path(ack_dir, lease_id)
+    deadline = time.monotonic() + _ACK_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if closed_file.exists():
+            raise RuntimeError("process lease guardian closed before acknowledging the launch")
+        if acknowledgement.is_file() and _acknowledgement_is_exact(acknowledgement, lease):
+            break
+        time.sleep(0.02)
+    else:
+        raise RuntimeError("process lease guardian did not acknowledge the launch")
+    if closed_file.exists():
+        raise RuntimeError("process lease guardian closed before target exec")
+    target = subprocess.Popen(command, env=os.environ.copy())
+    target.wait()
+    # The wrapper intentionally remains the kernel-visible session leader even
+    # after an unexpected target exit. Its owner will observe failed readiness
+    # or I/O, close the group through ``terminate()``, and only then release the
+    # lease. Exiting here could leave target descendants under an ownerless,
+    # eventually reusable numeric PGID.
+    while True:
+        time.sleep(3600)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="mode", required=True)
+    server = commands.add_parser("serve")
+    server.add_argument("--lease-file", type=Path, required=True)
+    server.add_argument("--ack-dir", type=Path, required=True)
+    server.add_argument("--ready-file", type=Path, required=True)
+    server.add_argument("--closed-file", type=Path, required=True)
+    server.add_argument("--result-file", type=Path, required=True)
+    executor = commands.add_parser("exec")
+    executor.add_argument("--lease-prefix", required=True)
+    executor.add_argument("--host", required=True)
+    executor.add_argument("--port", type=int, required=True)
+    executor.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.mode == "serve":
+        return (
+            0
+            if serve(
+                lease_file=args.lease_file,
+                ack_dir=args.ack_dir,
+                ready_file=args.ready_file,
+                closed_file=args.closed_file,
+                result_file=args.result_file,
+            )
+            else 1
+        )
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command.pop(0)
+    execute(
+        lease_prefix=args.lease_prefix,
+        host=args.host,
+        port=args.port,
+        command=command,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - subprocess entry point
+    raise SystemExit(main())

--- a/scripts/run_operational_scenarios.py
+++ b/scripts/run_operational_scenarios.py
@@ -45,6 +45,9 @@ if __package__:
         RESULT_SCHEMA as PROCESS_LEASE_RESULT_SCHEMA,
     )
     from scripts.process_lease_guardian import (
+        TARGET_STATUS_DIR_ENV as PROCESS_TARGET_STATUS_DIR_ENV,
+    )
+    from scripts.process_lease_guardian import (
         WRAPPER_ENV as PROCESS_LEASE_WRAPPER_ENV,
     )
     from scripts.process_lease_guardian import (
@@ -75,6 +78,9 @@ else:
     )
     from process_lease_guardian import (
         RESULT_SCHEMA as PROCESS_LEASE_RESULT_SCHEMA,
+    )
+    from process_lease_guardian import (
+        TARGET_STATUS_DIR_ENV as PROCESS_TARGET_STATUS_DIR_ENV,
     )
     from process_lease_guardian import (
         WRAPPER_ENV as PROCESS_LEASE_WRAPPER_ENV,
@@ -578,6 +584,7 @@ def _run_process(
         stderr_path = capture_root / "stderr"
         lease_file = capture_root / "process-leases.jsonl"
         lease_ack_dir = capture_root / "process-lease-acks"
+        target_status_dir = capture_root / "process-target-status"
         lease_ready_file = capture_root / "process-lease-ready.json"
         lease_closed_file = capture_root / "process-lease-closed.json"
         lease_result_file = capture_root / "process-lease-cleanup.json"
@@ -623,6 +630,7 @@ def _run_process(
                         process_env[PROCESS_LEASE_ACK_DIR_ENV] = str(lease_ack_dir)
                         process_env[PROCESS_LEASE_READY_ENV] = str(lease_ready_file)
                         process_env[PROCESS_LEASE_CLOSED_ENV] = str(lease_closed_file)
+                        process_env[PROCESS_TARGET_STATUS_DIR_ENV] = str(target_status_dir)
                         process_env[PROCESS_LEASE_WRAPPER_ENV] = str(
                             Path(__file__).with_name("process_lease_guardian.py").resolve()
                         )

--- a/scripts/run_operational_scenarios.py
+++ b/scripts/run_operational_scenarios.py
@@ -29,6 +29,27 @@ from typing import Any, NoReturn, cast
 from packaging.utils import canonicalize_name, parse_wheel_filename
 
 if __package__:
+    from scripts.process_lease_guardian import (
+        ACK_DIR_ENV as PROCESS_LEASE_ACK_DIR_ENV,
+    )
+    from scripts.process_lease_guardian import (
+        CLOSED_ENV as PROCESS_LEASE_CLOSED_ENV,
+    )
+    from scripts.process_lease_guardian import (
+        LEASE_ENV as PROCESS_LEASE_ENV,
+    )
+    from scripts.process_lease_guardian import (
+        READY_ENV as PROCESS_LEASE_READY_ENV,
+    )
+    from scripts.process_lease_guardian import (
+        RESULT_SCHEMA as PROCESS_LEASE_RESULT_SCHEMA,
+    )
+    from scripts.process_lease_guardian import (
+        WRAPPER_ENV as PROCESS_LEASE_WRAPPER_ENV,
+    )
+    from scripts.process_lease_guardian import (
+        guard as reap_process_leases,
+    )
     from scripts.run_example_receipt import CAPTURED_RECEIPT_ENV, RECEIPT_PREFIX
     from scripts.validate_operational_scenarios import (
         REGISTRY,
@@ -40,6 +61,27 @@ else:
     # ``python scripts/run_operational_scenarios.py`` places only ``scripts/``
     # on sys.path. Keep the CLI executable without adding the repository root
     # (and therefore its source tree) to installed-wheel scenario imports.
+    from process_lease_guardian import (
+        ACK_DIR_ENV as PROCESS_LEASE_ACK_DIR_ENV,
+    )
+    from process_lease_guardian import (
+        CLOSED_ENV as PROCESS_LEASE_CLOSED_ENV,
+    )
+    from process_lease_guardian import (
+        LEASE_ENV as PROCESS_LEASE_ENV,
+    )
+    from process_lease_guardian import (
+        READY_ENV as PROCESS_LEASE_READY_ENV,
+    )
+    from process_lease_guardian import (
+        RESULT_SCHEMA as PROCESS_LEASE_RESULT_SCHEMA,
+    )
+    from process_lease_guardian import (
+        WRAPPER_ENV as PROCESS_LEASE_WRAPPER_ENV,
+    )
+    from process_lease_guardian import (
+        guard as reap_process_leases,
+    )
     from run_example_receipt import CAPTURED_RECEIPT_ENV, RECEIPT_PREFIX
     from validate_operational_scenarios import (
         REGISTRY,
@@ -61,6 +103,9 @@ WORKSPACE_DISTRIBUTIONS: tuple[tuple[str, str, str], ...] = (
 )
 _PROCESS_TERM_GRACE_SECONDS = 2.0
 _PROCESS_KILL_GRACE_SECONDS = 2.0
+_PROCESS_LEASE_GUARDIAN_ENV = "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_GUARDIAN"
+_PROCESS_LEASE_GUARDIAN_TIMEOUT_SECONDS = 20.0
+_PROCESS_LEASE_READY_TIMEOUT_SECONDS = 5.0
 
 
 @dataclass(frozen=True)
@@ -327,6 +372,8 @@ def _scenario_environment(
         env["ARCHETYPE_APPLE_CONTAINER_SANDBOX_PARITY"] = "1"
     if row.get("id") == "dogfood.agent_mission.modal_live":
         env["ARCHETYPE_MODAL_AGENT_MISSION_LIVE"] = "1"
+    if row.get("id") == "example.14_biome_agent":
+        env[_PROCESS_LEASE_GUARDIAN_ENV] = "1"
     return env
 
 
@@ -389,6 +436,41 @@ def _stop_timed_out_process(process: subprocess.Popen[bytes]) -> tuple[int | Non
             returncode = process.poll()
     group_closed = _terminate_process_group(process.pid)
     return returncode, group_closed
+
+
+def _wait_for_guardian_ready(
+    guardian: subprocess.Popen[bytes],
+    ready_file: Path,
+) -> bool:
+    deadline = time.monotonic() + _PROCESS_LEASE_READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if ready_file.is_file():
+            return guardian.poll() is None
+        if guardian.poll() is not None:
+            return False
+        time.sleep(0.02)
+    return ready_file.is_file() and guardian.poll() is None
+
+
+def _wait_for_guarded_process(
+    process: subprocess.Popen[bytes],
+    *,
+    timeout_seconds: int,
+    guardian: subprocess.Popen[bytes] | None,
+) -> int:
+    """Wait while proving an enabled nested-process guardian remains live."""
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        if guardian is not None and guardian.poll() is not None:
+            raise RuntimeError("process lease guardian exited while the scenario was running")
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise subprocess.TimeoutExpired(process.args, timeout_seconds)
+        try:
+            return process.wait(timeout=min(remaining, 0.25))
+        except subprocess.TimeoutExpired:
+            pass
 
 
 def _process_group_snapshot(process_group: int) -> str:
@@ -491,37 +573,158 @@ def _run_process(
 ) -> dict[str, object]:
     started = time.perf_counter()
     with tempfile.TemporaryDirectory(prefix="archetype-operational-capture-") as capture:
-        stdout_path = Path(capture) / "stdout"
-        stderr_path = Path(capture) / "stderr"
+        capture_root = Path(capture)
+        stdout_path = capture_root / "stdout"
+        stderr_path = capture_root / "stderr"
+        lease_file = capture_root / "process-leases.jsonl"
+        lease_ack_dir = capture_root / "process-lease-acks"
+        lease_ready_file = capture_root / "process-lease-ready.json"
+        lease_closed_file = capture_root / "process-lease-closed.json"
+        lease_result_file = capture_root / "process-lease-cleanup.json"
         launch_error: str | None = None
         process: subprocess.Popen[bytes] | None = None
+        guardian: subprocess.Popen[bytes] | None = None
+        process_lease_cleanup: dict[str, object] | None = None
         timed_out = False
         process_group_leaked = False
+        process_env = env.copy()
+        lease_guardian_required = process_env.get(_PROCESS_LEASE_GUARDIAN_ENV) == "1"
         with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
-            try:
-                process = subprocess.Popen(
-                    command,
-                    cwd=cwd,
-                    env=env,
-                    stdout=stdout,
-                    stderr=stderr,
-                    start_new_session=True,
-                )
-            except OSError as exc:
-                returncode = None
-                launch_error = f"{type(exc).__name__}: {exc}"
-            else:
+            if lease_guardian_required:
                 try:
-                    returncode = process.wait(timeout=timeout_seconds)
-                except subprocess.TimeoutExpired:
-                    timed_out = True
-                    # Photograph the group BEFORE killing it: a scenario that
-                    # hangs silently for its whole budget (#678's 600s R2
-                    # stall) otherwise leaves a receipt naming nothing. The
-                    # snapshot names the processes that were still running.
-                    timeout_snapshot = _process_group_snapshot(process.pid)
-                    returncode, group_closed = _stop_timed_out_process(process)
-                    process_group_leaked = not group_closed
+                    guardian = subprocess.Popen(
+                        [
+                            sys.executable,
+                            str(Path(__file__).with_name("process_lease_guardian.py").resolve()),
+                            "serve",
+                            "--lease-file",
+                            str(lease_file),
+                            "--ack-dir",
+                            str(lease_ack_dir),
+                            "--ready-file",
+                            str(lease_ready_file),
+                            "--closed-file",
+                            str(lease_closed_file),
+                            "--result-file",
+                            str(lease_result_file),
+                        ],
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.DEVNULL,
+                        stderr=stderr,
+                        start_new_session=True,
+                    )
+                except OSError as exc:
+                    launch_error = f"process lease guardian failed to launch: {exc}"
+                else:
+                    if not _wait_for_guardian_ready(guardian, lease_ready_file):
+                        launch_error = "process lease guardian did not become ready"
+                    else:
+                        process_env[PROCESS_LEASE_ENV] = str(lease_file)
+                        process_env[PROCESS_LEASE_ACK_DIR_ENV] = str(lease_ack_dir)
+                        process_env[PROCESS_LEASE_READY_ENV] = str(lease_ready_file)
+                        process_env[PROCESS_LEASE_CLOSED_ENV] = str(lease_closed_file)
+                        process_env[PROCESS_LEASE_WRAPPER_ENV] = str(
+                            Path(__file__).with_name("process_lease_guardian.py").resolve()
+                        )
+
+            returncode: int | None = None
+            try:
+                if launch_error is None:
+                    try:
+                        process = subprocess.Popen(
+                            command,
+                            cwd=cwd,
+                            env=process_env,
+                            stdout=stdout,
+                            stderr=stderr,
+                            start_new_session=True,
+                        )
+                    except OSError as exc:
+                        launch_error = f"{type(exc).__name__}: {exc}"
+                    else:
+                        try:
+                            returncode = _wait_for_guarded_process(
+                                process,
+                                timeout_seconds=timeout_seconds,
+                                guardian=guardian,
+                            )
+                        except subprocess.TimeoutExpired:
+                            timed_out = True
+                            # Photograph the group BEFORE killing it: a scenario that
+                            # hangs silently for its whole budget (#678's 600s R2
+                            # stall) otherwise leaves a receipt naming nothing. The
+                            # snapshot names the processes that were still running.
+                            timeout_snapshot = _process_group_snapshot(process.pid)
+                            returncode, group_closed = _stop_timed_out_process(process)
+                            process_group_leaked = not group_closed
+                        except RuntimeError as exc:
+                            launch_error = str(exc)
+                            returncode, group_closed = _stop_timed_out_process(process)
+                            process_group_leaked = not group_closed
+            except BaseException:
+                if process is not None and process.poll() is None:
+                    _stop_timed_out_process(process)
+                raise
+            finally:
+                if guardian is not None:
+                    assert guardian.stdin is not None
+                    try:
+                        guardian.stdin.close()
+                    except BrokenPipeError:
+                        pass
+                    try:
+                        guardian_returncode = guardian.wait(
+                            timeout=_PROCESS_LEASE_GUARDIAN_TIMEOUT_SECONDS
+                        )
+                    except subprocess.TimeoutExpired:
+                        _stop_timed_out_process(guardian)
+                        guardian_returncode = guardian.poll()
+                        launch_error = "process lease guardian timed out during cleanup"
+                        process_group_leaked = True
+                    if not lease_result_file.is_file():
+                        try:
+                            fallback_closed = reap_process_leases(lease_file, lease_result_file)
+                        except Exception as exc:
+                            launch_error = (
+                                "process lease fallback cleanup failed: "
+                                f"{type(exc).__name__}: {exc}"
+                            )
+                            process_group_leaked = True
+                        else:
+                            guardian_returncode = 0 if fallback_closed else 1
+                    if lease_result_file.is_file():
+                        try:
+                            process_lease_cleanup = _strict_json_object(
+                                lease_result_file.read_text(encoding="utf-8"),
+                                label="process lease cleanup result",
+                            )
+                        except (OSError, TypeError, ValueError) as exc:
+                            launch_error = (
+                                f"invalid process lease cleanup result: {type(exc).__name__}: {exc}"
+                            )
+                            process_group_leaked = True
+                    else:
+                        launch_error = "process lease guardian emitted no cleanup result"
+                        process_group_leaked = True
+                    if process_lease_cleanup is not None:
+                        lease_status = process_lease_cleanup.get("status")
+                        lease_schema = process_lease_cleanup.get("schema")
+                        active_count = process_lease_cleanup.get("active_lease_count")
+                        if (
+                            guardian_returncode != 0
+                            or lease_schema != PROCESS_LEASE_RESULT_SCHEMA
+                            or lease_status != "closed"
+                            or not isinstance(active_count, int)
+                            or isinstance(active_count, bool)
+                            or active_count < 0
+                        ):
+                            launch_error = "process lease guardian could not prove cleanup"
+                            process_group_leaked = True
+                        elif active_count and not timed_out:
+                            # A normal process exit must release its own leases.
+                            # The guardian recovered the host, but the scenario
+                            # still violated its cleanup contract.
+                            process_group_leaked = True
 
         stdout_raw = stdout_path.read_bytes()
         stderr_raw = stderr_path.read_bytes()
@@ -547,8 +750,8 @@ def _run_process(
                     launch_error = "process group survived SIGTERM and SIGKILL"
 
     failed = timed_out or launch_error is not None or returncode != 0
-    secret_values = _secret_environment_values(env)
-    return {
+    secret_values = _secret_environment_values(process_env)
+    result: dict[str, object] = {
         "command": command,
         "returncode": returncode,
         "timed_out": timed_out,
@@ -571,6 +774,9 @@ def _run_process(
         "stdout_text": stdout_raw.decode("utf-8", errors="replace"),
         "process_group_leaked": process_group_leaked,
     }
+    if process_lease_cleanup is not None:
+        result["process_leases"] = process_lease_cleanup
+    return result
 
 
 def _base_environment(

--- a/tests/examples/test_biome_agent_contract.py
+++ b/tests/examples/test_biome_agent_contract.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import runpy
 import signal
@@ -558,7 +559,12 @@ def test_launch_revalidates_exact_upstream_heads_and_starts_an_owned_group(
     )
     monkeypatch.setattr(biome_bootstrap, "is_port_open", lambda *args, **kwargs: False)
     launched: list[tuple[list[str], dict[str, object]]] = []
+
     sentinel = object()
+    lease_file = tmp_path / "process-leases.jsonl"
+    wrapper = tmp_path / "process-lease-guardian.py"
+    monkeypatch.setenv(biome_bootstrap._PROCESS_LEASE_ENV, str(lease_file))
+    monkeypatch.setenv(biome_bootstrap._PROCESS_LEASE_WRAPPER_ENV, str(wrapper))
 
     def popen(command, **kwargs):
         launched.append((command, kwargs))
@@ -569,10 +575,25 @@ def test_launch_revalidates_exact_upstream_heads_and_starts_an_owned_group(
     assert launch(checkout) is sentinel
     assert launched == [
         (
-            [str(executable), "--scene", "etc/scenes/archetype_agent.flecs"],
+            [
+                sys.executable,
+                str(wrapper),
+                "exec",
+                "--lease-prefix",
+                "biome",
+                "--host",
+                BIOME_HOST,
+                "--port",
+                str(biome_bootstrap.BIOME_PORT),
+                "--",
+                str(executable),
+                "--scene",
+                "etc/scenes/archetype_agent.flecs",
+            ],
             {"cwd": biome, "start_new_session": True},
         )
     ]
+    assert not lease_file.exists(), "the exec wrapper, not its parent, must acquire the lease"
 
     revisions[biome] = "0" * 40
     with pytest.raises(RuntimeError, match="expected exact pin"):
@@ -586,7 +607,10 @@ def test_launch_revalidates_exact_upstream_heads_and_starts_an_owned_group(
     assert len(launched) == 1
 
 
-def test_terminate_closes_owned_descendants_and_listener(tmp_path: Path) -> None:
+def test_terminate_closes_owned_descendants_and_listener(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     with socket.socket() as reservation:
         reservation.bind((BIOME_HOST, 0))
         port = reservation.getsockname()[1]
@@ -627,6 +651,8 @@ time.sleep(60)
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+    lease_file = tmp_path / "process-leases.jsonl"
+    monkeypatch.setenv(biome_bootstrap._PROCESS_LEASE_ENV, str(lease_file))
     try:
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline and not marker.exists():
@@ -645,6 +671,14 @@ time.sleep(60)
 
         assert not is_process_group_alive(process.pid)
         assert not is_port_open(BIOME_HOST, port)
+        records = [json.loads(line) for line in lease_file.read_text().splitlines()]
+        assert records == [
+            {
+                "schema": biome_bootstrap._PROCESS_LEASE_SCHEMA,
+                "operation": "release",
+                "lease_id": f"biome:{process.pid}",
+            }
+        ]
     finally:
         if is_process_group_alive(process.pid):
             try:

--- a/tests/examples/test_biome_agent_contract.py
+++ b/tests/examples/test_biome_agent_contract.py
@@ -42,6 +42,7 @@ from biome_agent import (  # noqa: E402
     TerrainCell,
     monitor_mission,
     run_durable_episode,
+    wait_until_ready,
 )
 from biome_agent import bootstrap as biome_bootstrap  # noqa: E402
 from biome_agent.bootstrap import (  # noqa: E402
@@ -51,6 +52,7 @@ from biome_agent.bootstrap import (  # noqa: E402
     FLECS_REVISION,
     MISSION_SCENE,
     BiomeCheckout,
+    BiomeProcess,
     is_port_open,
     is_process_group_alive,
     launch,
@@ -560,11 +562,19 @@ def test_launch_revalidates_exact_upstream_heads_and_starts_an_owned_group(
     monkeypatch.setattr(biome_bootstrap, "is_port_open", lambda *args, **kwargs: False)
     launched: list[tuple[list[str], dict[str, object]]] = []
 
-    sentinel = object()
+    class Sentinel:
+        pid = 4321
+
+    sentinel = Sentinel()
     lease_file = tmp_path / "process-leases.jsonl"
     wrapper = tmp_path / "process-lease-guardian.py"
+    target_status_dir = tmp_path / "target-status"
     monkeypatch.setenv(biome_bootstrap._PROCESS_LEASE_ENV, str(lease_file))
     monkeypatch.setenv(biome_bootstrap._PROCESS_LEASE_WRAPPER_ENV, str(wrapper))
+    monkeypatch.setenv(
+        biome_bootstrap._PROCESS_TARGET_STATUS_DIR_ENV,
+        str(target_status_dir),
+    )
 
     def popen(command, **kwargs):
         launched.append((command, kwargs))
@@ -572,7 +582,11 @@ def test_launch_revalidates_exact_upstream_heads_and_starts_an_owned_group(
 
     monkeypatch.setattr(biome_bootstrap.subprocess, "Popen", popen)
 
-    assert launch(checkout) is sentinel
+    process = launch(checkout)
+    assert process == BiomeProcess(
+        sentinel,  # type: ignore[arg-type]
+        biome_bootstrap._target_status_path(target_status_dir, "biome:4321"),
+    )
     assert launched == [
         (
             [
@@ -605,6 +619,49 @@ def test_launch_revalidates_exact_upstream_heads_and_starts_an_owned_group(
     with pytest.raises(RuntimeError, match="unrelated source changes"):
         launch(checkout)
     assert len(launched) == 1
+
+
+def test_native_target_exit_is_visible_while_group_leader_remains(
+    tmp_path: Path,
+) -> None:
+    class Leader:
+        pid = 4321
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+        @staticmethod
+        def wait(timeout: float | None = None) -> int:
+            del timeout
+            return 0
+
+    class ReadyClient:
+        @staticmethod
+        def is_ready() -> bool:
+            return True
+
+    status_file = biome_bootstrap._target_status_path(tmp_path, "biome:4321")
+    status_file.write_text(
+        json.dumps(
+            {
+                "schema": biome_bootstrap._PROCESS_LEASE_SCHEMA,
+                "lease_id": "biome:4321",
+                "pid": 4321,
+                "process_group": 4321,
+                "status": "target_exited",
+                "target_pid": 4322,
+                "returncode": 7,
+            }
+        ),
+        encoding="utf-8",
+    )
+    process = BiomeProcess(Leader(), status_file)  # type: ignore[arg-type]
+
+    started = time.monotonic()
+    assert wait_until_ready(ReadyClient(), process, timeout=5) is False  # type: ignore[arg-type]
+    assert time.monotonic() - started < 0.5
+    assert process.poll() == 7
 
 
 def test_terminate_closes_owned_descendants_and_listener(

--- a/tests/examples/test_biome_agent_contract.py
+++ b/tests/examples/test_biome_agent_contract.py
@@ -716,6 +716,13 @@ time.sleep(60)
             time.sleep(0.05)
         assert marker.is_file()
         assert is_port_open(BIOME_HOST, port)
+        with pytest.raises(RuntimeError, match="refusing to release a live"):
+            biome_bootstrap._release_process_lease(
+                process.pid,
+                host=BIOME_HOST,
+                port=port,
+            )
+        assert not lease_file.exists()
 
         terminate(
             process,
@@ -734,6 +741,8 @@ time.sleep(60)
                 "schema": biome_bootstrap._PROCESS_LEASE_SCHEMA,
                 "operation": "release",
                 "lease_id": f"biome:{process.pid}",
+                "group_was_alive": False,
+                "port_was_open": False,
             }
         ]
     finally:

--- a/tests/scripts/test_run_operational_scenarios.py
+++ b/tests/scripts/test_run_operational_scenarios.py
@@ -37,6 +37,9 @@ from scripts.process_lease_guardian import (
     RESULT_SCHEMA as PROCESS_LEASE_RESULT_SCHEMA,
 )
 from scripts.process_lease_guardian import (
+    TARGET_STATUS_DIR_ENV as PROCESS_TARGET_STATUS_DIR_ENV,
+)
+from scripts.process_lease_guardian import (
     WRAPPER_ENV as PROCESS_LEASE_WRAPPER_ENV,
 )
 from scripts.process_lease_guardian import _process_birth_identity, guard
@@ -450,6 +453,79 @@ time.sleep(60)
                 os.killpg(nested_group, signal.SIGKILL)
             except ProcessLookupError:
                 pass
+
+
+def test_guarded_wrapper_reports_target_exit_without_abandoning_group(tmp_path: Path) -> None:
+    observed = tmp_path / "target-exit.json"
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+    outer_source = f"""
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+wrapper = subprocess.Popen(
+    [
+        sys.executable,
+        os.environ[{PROCESS_LEASE_WRAPPER_ENV!r}],
+        "exec",
+        "--lease-prefix",
+        "status",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        sys.argv[2],
+        "--",
+        sys.executable,
+        "-c",
+        "raise SystemExit(7)",
+    ],
+    start_new_session=True,
+)
+lease_id = f"status:{{wrapper.pid}}"
+digest = hashlib.sha256(lease_id.encode()).hexdigest()
+status = Path(os.environ[{PROCESS_TARGET_STATUS_DIR_ENV!r}]) / f"{{digest}}.target.json"
+deadline = time.monotonic() + 5
+while time.monotonic() < deadline and not status.is_file():
+    if wrapper.poll() is not None:
+        raise SystemExit("supervisor abandoned its process group")
+    time.sleep(0.01)
+if not status.is_file():
+    raise SystemExit("supervisor emitted no target status")
+payload = json.loads(status.read_text())
+payload["wrapper_poll"] = wrapper.poll()
+Path(sys.argv[1]).write_text(json.dumps(payload))
+time.sleep(60)
+"""
+    env = os.environ.copy()
+    env[operational_runner._PROCESS_LEASE_GUARDIAN_ENV] = "1"
+
+    result = _run_process(
+        [sys.executable, "-c", outer_source, str(observed), str(port)],
+        cwd=tmp_path,
+        env=env,
+        timeout_seconds=3,
+        log_prefix=tmp_path / "target-exit",
+        redacted=False,
+    )
+
+    payload = json.loads(observed.read_text())
+    assert payload["schema"] == PROCESS_LEASE_SCHEMA
+    assert payload["lease_id"] == f"status:{payload['pid']}"
+    assert payload["pid"] == payload["process_group"]
+    assert payload["target_pid"] != payload["pid"]
+    assert payload["returncode"] == 7
+    assert payload["status"] == "target_exited"
+    assert payload["wrapper_poll"] is None
+    assert result["timed_out"] is True
+    assert result["process_group_leaked"] is False
+    cleanup = cast(dict[str, Any], result["process_leases"])
+    assert cleanup["status"] == "closed"
 
 
 def test_guarded_normal_release_is_verified_before_cleanup_closes(tmp_path: Path) -> None:
@@ -884,6 +960,9 @@ env.update({
     "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_READY_FILE": sys.argv[4],
     "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_CLOSED_FILE": sys.argv[5],
     "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_WRAPPER": sys.argv[1],
+    "ARCHETYPE_OPERATIONAL_PROCESS_TARGET_STATUS_DIR": str(
+        Path(sys.argv[3]).with_name("abrupt-target-status")
+    ),
 })
 listener = subprocess.Popen(
     [
@@ -1017,6 +1096,7 @@ def test_guarded_exec_refuses_target_when_guardian_closes_before_ack(tmp_path: P
             PROCESS_LEASE_ACK_DIR_ENV: str(ack_dir),
             PROCESS_LEASE_READY_ENV: str(ready_file),
             PROCESS_LEASE_CLOSED_ENV: str(closed_file),
+            PROCESS_TARGET_STATUS_DIR_ENV: str(tmp_path / "target-status"),
         }
     )
     wrapper = ROOT / "scripts" / "process_lease_guardian.py"

--- a/tests/scripts/test_run_operational_scenarios.py
+++ b/tests/scripts/test_run_operational_scenarios.py
@@ -12,7 +12,6 @@ import signal
 import socket
 import subprocess
 import sys
-import threading
 import time
 from pathlib import Path
 from typing import Any, cast
@@ -438,6 +437,8 @@ time.sleep(60)
         assert lease["ownership_matches"] is True
         assert lease["released"] is False
         assert lease["release_was_truthful"] is None
+        assert lease["release_group_was_alive"] is None
+        assert lease["release_port_was_open"] is None
         assert lease["group_was_alive"] is True
         assert lease["port_was_open"] is True
         assert lease["group_closed"] is True
@@ -615,6 +616,8 @@ terminate(
     (lease,) = cast(list[dict[str, Any]], cleanup["leases"])
     assert lease["released"] is True
     assert lease["release_was_truthful"] is True
+    assert lease["release_group_was_alive"] is False
+    assert lease["release_port_was_open"] is False
     assert lease["ownership_matches"] is True
     assert lease["group_was_alive"] is False
     assert lease["port_was_open"] is False
@@ -669,6 +672,8 @@ time.sleep(60)
             "schema": PROCESS_LEASE_SCHEMA,
             "operation": "release",
             "lease_id": lease_id,
+            "group_was_alive": True,
+            "port_was_open": True,
         }
         lease_file = tmp_path / "dishonest-leases.jsonl"
         lease_file.write_text(
@@ -676,11 +681,13 @@ time.sleep(60)
             encoding="utf-8",
         )
         result_file = tmp_path / "dishonest-result.json"
-        reaper = threading.Thread(target=process.wait, daemon=True)
-        reaper.start()
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=2)
+        with socket.socket() as probe:
+            probe.settimeout(0.2)
+            assert probe.connect_ex(("127.0.0.1", port)) != 0
 
         assert guard(lease_file, result_file) is False
-        reaper.join(timeout=2)
 
         result = json.loads(result_file.read_text(encoding="utf-8"))
         assert result["status"] == "leaked"
@@ -688,8 +695,10 @@ time.sleep(60)
         (lease,) = result["leases"]
         assert lease["released"] is True
         assert lease["release_was_truthful"] is False
-        assert lease["group_was_alive"] is True
-        assert lease["port_was_open"] is True
+        assert lease["release_group_was_alive"] is True
+        assert lease["release_port_was_open"] is True
+        assert lease["group_was_alive"] is False
+        assert lease["port_was_open"] is False
         assert lease["group_closed"] is True
         assert lease["port_closed"] is True
         with pytest.raises(ProcessLookupError):

--- a/tests/scripts/test_run_operational_scenarios.py
+++ b/tests/scripts/test_run_operational_scenarios.py
@@ -9,14 +9,37 @@ import asyncio
 import json
 import os
 import signal
+import socket
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
 import scripts.run_operational_scenarios as operational_runner
+from scripts.process_lease_guardian import (
+    ACK_DIR_ENV as PROCESS_LEASE_ACK_DIR_ENV,
+)
+from scripts.process_lease_guardian import (
+    CLOSED_ENV as PROCESS_LEASE_CLOSED_ENV,
+)
+from scripts.process_lease_guardian import (
+    LEASE_ENV as PROCESS_LEASE_ENV,
+)
+from scripts.process_lease_guardian import LEASE_SCHEMA as PROCESS_LEASE_SCHEMA
+from scripts.process_lease_guardian import (
+    READY_ENV as PROCESS_LEASE_READY_ENV,
+)
+from scripts.process_lease_guardian import (
+    RESULT_SCHEMA as PROCESS_LEASE_RESULT_SCHEMA,
+)
+from scripts.process_lease_guardian import (
+    WRAPPER_ENV as PROCESS_LEASE_WRAPPER_ENV,
+)
+from scripts.process_lease_guardian import _process_birth_identity, guard
 from scripts.run_example_receipt import (
     CAPTURED_RECEIPT_ENV,
     MAX_RECEIPT_BYTES,
@@ -311,6 +334,741 @@ def test_timeout_is_failed_and_process_group_is_cleaned(tmp_path: Path) -> None:
     assert result["timed_out"] is True
     assert result["returncode"] != 0
     assert result["process_group_leaked"] is False
+
+
+def test_timeout_reaps_registered_nested_process_group_and_listener(tmp_path: Path) -> None:
+    marker = tmp_path / "nested.json"
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+    nested_source = """
+import json
+import os
+import signal
+import socket
+import sys
+import time
+from pathlib import Path
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+listener = socket.socket()
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", int(sys.argv[3])))
+listener.listen()
+Path(sys.argv[1]).write_text(json.dumps({
+    "pid": os.getpid(),
+    "pgid": os.getpgrp(),
+    "parent_pgid": int(sys.argv[2]),
+    "port": int(sys.argv[3]),
+}))
+while True:
+    time.sleep(1)
+"""
+    outer_source = f"""
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+marker = Path(sys.argv[1])
+nested = subprocess.Popen(
+    [
+        sys.executable,
+        os.environ[{PROCESS_LEASE_WRAPPER_ENV!r}],
+        "exec",
+        "--lease-prefix",
+        "nested",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        sys.argv[3],
+        "--",
+        sys.executable,
+        "-c",
+        sys.argv[2],
+        str(marker),
+        str(os.getpgrp()),
+        sys.argv[3],
+    ],
+    start_new_session=True,
+)
+while not marker.is_file():
+    if nested.poll() is not None:
+        raise SystemExit("nested listener exited before registration")
+    time.sleep(0.01)
+time.sleep(60)
+"""
+    env = os.environ.copy()
+    env[operational_runner._PROCESS_LEASE_GUARDIAN_ENV] = "1"
+    nested_group: int | None = None
+    try:
+        result = _run_process(
+            [sys.executable, "-c", outer_source, str(marker), nested_source, str(port)],
+            cwd=tmp_path,
+            env=env,
+            timeout_seconds=5,
+            log_prefix=tmp_path / "nested-timeout",
+            redacted=False,
+        )
+        state = json.loads(marker.read_text(encoding="utf-8"))
+        nested_group = state["pgid"]
+
+        assert state["pid"] != nested_group
+        assert nested_group != state["parent_pgid"]
+        assert result["timed_out"] is True
+        assert result["returncode"] != 0
+        assert result["process_group_leaked"] is False
+        cleanup = cast(dict[str, Any], result["process_leases"])
+        assert cleanup["schema"] == PROCESS_LEASE_RESULT_SCHEMA
+        assert cleanup["status"] == "closed"
+        assert cleanup["active_lease_count"] == 1
+        assert cleanup["errors"] == []
+        (lease,) = cast(list[dict[str, Any]], cleanup["leases"])
+        assert lease["lease_id"] == f"nested:{nested_group}"
+        assert lease["pid"] == nested_group
+        assert lease["process_group"] == nested_group
+        assert lease["host"] == "127.0.0.1"
+        assert lease["port"] == state["port"]
+        assert isinstance(lease["birth_identity"], str)
+        assert lease["birth_identity"]
+        assert lease["ownership_matches"] is True
+        assert lease["released"] is False
+        assert lease["release_was_truthful"] is None
+        assert lease["group_was_alive"] is True
+        assert lease["port_was_open"] is True
+        assert lease["group_closed"] is True
+        assert lease["port_closed"] is True
+        with pytest.raises(ProcessLookupError):
+            os.killpg(nested_group, 0)
+        with socket.socket() as probe:
+            probe.settimeout(0.2)
+            assert probe.connect_ex(("127.0.0.1", state["port"])) != 0
+    finally:
+        if nested_group is not None:
+            try:
+                os.killpg(nested_group, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def test_guarded_normal_release_is_verified_before_cleanup_closes(tmp_path: Path) -> None:
+    marker = tmp_path / "normal-release.json"
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+    target_source = """
+import json
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+
+listener = socket.socket()
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", int(sys.argv[2])))
+listener.listen()
+Path(sys.argv[1]).write_text(json.dumps({"pid": os.getpid(), "pgid": os.getpgrp()}))
+time.sleep(60)
+"""
+    outer_source = f"""
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, {str(ROOT / "examples")!r})
+from biome_agent.bootstrap import terminate
+
+marker = Path(sys.argv[1])
+process = subprocess.Popen(
+    [
+        sys.executable,
+        os.environ[{PROCESS_LEASE_WRAPPER_ENV!r}],
+        "exec",
+        "--lease-prefix",
+        "biome",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        sys.argv[3],
+        "--",
+        sys.executable,
+        "-c",
+        sys.argv[2],
+        str(marker),
+        sys.argv[3],
+    ],
+    start_new_session=True,
+)
+while not marker.is_file():
+    if process.poll() is not None:
+        raise SystemExit("guarded target exited before readiness")
+    time.sleep(0.01)
+terminate(
+    process,
+    host="127.0.0.1",
+    port=int(sys.argv[3]),
+    term_timeout=1,
+    kill_timeout=2,
+    port_timeout=2,
+)
+"""
+    env = os.environ.copy()
+    env[operational_runner._PROCESS_LEASE_GUARDIAN_ENV] = "1"
+
+    result = _run_process(
+        [sys.executable, "-c", outer_source, str(marker), target_source, str(port)],
+        cwd=tmp_path,
+        env=env,
+        timeout_seconds=10,
+        log_prefix=tmp_path / "normal-release",
+        redacted=False,
+    )
+
+    assert result["returncode"] == 0
+    assert result["timed_out"] is False
+    assert result["launch_error"] is None
+    assert result["process_group_leaked"] is False
+    cleanup = cast(dict[str, Any], result["process_leases"])
+    assert cleanup["status"] == "closed"
+    assert cleanup["active_lease_count"] == 0
+    assert cleanup["errors"] == []
+    (lease,) = cast(list[dict[str, Any]], cleanup["leases"])
+    assert lease["released"] is True
+    assert lease["release_was_truthful"] is True
+    assert lease["ownership_matches"] is True
+    assert lease["group_was_alive"] is False
+    assert lease["port_was_open"] is False
+    assert lease["group_closed"] is True
+    assert lease["port_closed"] is True
+
+
+def test_guardian_rejects_release_while_group_and_port_are_live(tmp_path: Path) -> None:
+    marker = tmp_path / "dishonest-release-ready"
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+    target_source = """
+import socket
+import sys
+import time
+from pathlib import Path
+
+listener = socket.socket()
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", int(sys.argv[2])))
+listener.listen()
+Path(sys.argv[1]).write_text("ready")
+time.sleep(60)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", target_source, str(marker), str(port)],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not marker.is_file():
+            assert process.poll() is None
+            time.sleep(0.01)
+        assert marker.is_file()
+        birth_identity = _process_birth_identity(process.pid)
+        assert birth_identity is not None
+        lease_id = f"dishonest:{process.pid}"
+        acquire = {
+            "schema": PROCESS_LEASE_SCHEMA,
+            "operation": "acquire",
+            "lease_id": lease_id,
+            "pid": process.pid,
+            "process_group": process.pid,
+            "host": "127.0.0.1",
+            "port": port,
+            "birth_identity": birth_identity,
+        }
+        release = {
+            "schema": PROCESS_LEASE_SCHEMA,
+            "operation": "release",
+            "lease_id": lease_id,
+        }
+        lease_file = tmp_path / "dishonest-leases.jsonl"
+        lease_file.write_text(
+            json.dumps(acquire, sort_keys=True) + "\n" + json.dumps(release, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        result_file = tmp_path / "dishonest-result.json"
+        reaper = threading.Thread(target=process.wait, daemon=True)
+        reaper.start()
+
+        assert guard(lease_file, result_file) is False
+        reaper.join(timeout=2)
+
+        result = json.loads(result_file.read_text(encoding="utf-8"))
+        assert result["status"] == "leaked"
+        assert result["active_lease_count"] == 0
+        (lease,) = result["leases"]
+        assert lease["released"] is True
+        assert lease["release_was_truthful"] is False
+        assert lease["group_was_alive"] is True
+        assert lease["port_was_open"] is True
+        assert lease["group_closed"] is True
+        assert lease["port_closed"] is True
+        with pytest.raises(ProcessLookupError):
+            os.killpg(process.pid, 0)
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=2)
+
+
+def test_guardian_refuses_stale_group_after_original_leader_exits(tmp_path: Path) -> None:
+    child_ready = tmp_path / "descendant-ready"
+    leader_ready = tmp_path / "leader.json"
+    release_leader = tmp_path / "release-leader"
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+    child_source = """
+import socket
+import sys
+import time
+from pathlib import Path
+
+listener = socket.socket()
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", int(sys.argv[2])))
+listener.listen()
+Path(sys.argv[1]).write_text("ready")
+time.sleep(60)
+"""
+    leader_source = """
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+child = subprocess.Popen([
+    sys.executable,
+    "-c",
+    sys.argv[1],
+    sys.argv[2],
+    sys.argv[5],
+])
+while not Path(sys.argv[2]).is_file():
+    if child.poll() is not None:
+        raise SystemExit("descendant exited before readiness")
+    time.sleep(0.01)
+Path(sys.argv[3]).write_text(json.dumps({
+    "pid": os.getpid(),
+    "pgid": os.getpgrp(),
+    "child_pid": child.pid,
+}))
+while not Path(sys.argv[4]).is_file():
+    time.sleep(0.01)
+"""
+    leader = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            leader_source,
+            child_source,
+            str(child_ready),
+            str(leader_ready),
+            str(release_leader),
+            str(port),
+        ],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    process_group: int | None = None
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not leader_ready.is_file():
+            assert leader.poll() is None
+            time.sleep(0.01)
+        state = json.loads(leader_ready.read_text())
+        process_group = state["pgid"]
+        assert state["pid"] == leader.pid == process_group
+        birth_identity = _process_birth_identity(leader.pid)
+        assert birth_identity is not None
+        lease_id = f"leader-exit:{leader.pid}"
+        lease_file = tmp_path / "leader-exit-leases.jsonl"
+        lease_file.write_text(
+            json.dumps(
+                {
+                    "schema": PROCESS_LEASE_SCHEMA,
+                    "operation": "acquire",
+                    "lease_id": lease_id,
+                    "pid": leader.pid,
+                    "process_group": process_group,
+                    "host": "127.0.0.1",
+                    "port": port,
+                    "birth_identity": birth_identity,
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        release_leader.write_text("exit")
+        leader.wait(timeout=2)
+        with socket.socket() as probe:
+            probe.settimeout(0.2)
+            assert probe.connect_ex(("127.0.0.1", port)) == 0
+
+        result_file = tmp_path / "leader-exit-result.json"
+        assert guard(lease_file, result_file) is False
+
+        result = json.loads(result_file.read_text())
+        assert result["status"] == "leaked"
+        (lease,) = result["leases"]
+        assert lease["ownership_matches"] is False
+        assert lease["group_was_alive"] is True
+        assert lease["group_closed"] is False
+        assert lease["port_closed"] is False
+        os.killpg(process_group, 0)
+        with socket.socket() as probe:
+            probe.settimeout(0.2)
+            assert probe.connect_ex(("127.0.0.1", port)) == 0
+    finally:
+        if process_group is not None:
+            try:
+                os.killpg(process_group, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        if leader.poll() is None:
+            leader.kill()
+            leader.wait(timeout=2)
+
+
+def test_shutdown_during_ready_publication_still_closes_guardian(tmp_path: Path) -> None:
+    lease_file = tmp_path / "ready-race-leases.jsonl"
+    ack_dir = tmp_path / "ready-race-acks"
+    ready_file = tmp_path / "ready-race-ready.json"
+    closed_file = tmp_path / "ready-race-closed.json"
+    result_file = tmp_path / "ready-race-result.json"
+    source = """
+import os
+import signal
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+import scripts.process_lease_guardian as guardian
+
+ready_file = Path(sys.argv[4])
+write_marker = guardian._write_marker
+
+def write_then_cancel(path, payload):
+    write_marker(path, payload)
+    if path == ready_file:
+        os.kill(os.getpid(), signal.SIGTERM)
+
+guardian._write_marker = write_then_cancel
+closed = guardian.serve(
+    lease_file=Path(sys.argv[2]),
+    ack_dir=Path(sys.argv[3]),
+    ready_file=ready_file,
+    closed_file=Path(sys.argv[5]),
+    result_file=Path(sys.argv[6]),
+)
+raise SystemExit(0 if closed else 1)
+"""
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            source,
+            str(ROOT),
+            str(lease_file),
+            str(ack_dir),
+            str(ready_file),
+            str(closed_file),
+            str(result_file),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        assert process.wait(timeout=5) == 0
+        assert ready_file.is_file()
+        assert closed_file.is_file()
+        result = json.loads(result_file.read_text())
+        assert result["status"] == "closed"
+        assert result["active_lease_count"] == 0
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=2)
+
+
+def test_parent_death_and_repeated_signals_still_close_guarded_listener(
+    tmp_path: Path,
+) -> None:
+    lease_file = tmp_path / "abrupt-leases.jsonl"
+    ack_dir = tmp_path / "abrupt-acks"
+    ready_file = tmp_path / "abrupt-ready.json"
+    closed_file = tmp_path / "abrupt-closed.json"
+    result_file = tmp_path / "abrupt-result.json"
+    guardian_pid_file = tmp_path / "guardian.pid"
+    listener_marker = tmp_path / "listener.json"
+    runner_ready = tmp_path / "runner-ready"
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+    listener_source = """
+import json
+import os
+import signal
+import socket
+import sys
+import time
+from pathlib import Path
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+listener = socket.socket()
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", int(sys.argv[2])))
+listener.listen()
+Path(sys.argv[1]).write_text(json.dumps({
+    "pid": os.getpid(),
+    "pgid": os.getpgrp(),
+    "port": int(sys.argv[2]),
+}))
+time.sleep(60)
+"""
+    runner_source = """
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+guardian = subprocess.Popen(
+    [
+        sys.executable,
+        sys.argv[1],
+        "serve",
+        "--lease-file",
+        sys.argv[2],
+        "--ack-dir",
+        sys.argv[3],
+        "--ready-file",
+        sys.argv[4],
+        "--closed-file",
+        sys.argv[5],
+        "--result-file",
+        sys.argv[6],
+    ],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    start_new_session=True,
+)
+while not Path(sys.argv[4]).is_file():
+    if guardian.poll() is not None:
+        raise SystemExit("guardian exited before readiness")
+    time.sleep(0.01)
+env = os.environ.copy()
+env.update({
+    "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_FILE": sys.argv[2],
+    "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_ACK_DIR": sys.argv[3],
+    "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_READY_FILE": sys.argv[4],
+    "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_CLOSED_FILE": sys.argv[5],
+    "ARCHETYPE_OPERATIONAL_PROCESS_LEASE_WRAPPER": sys.argv[1],
+})
+listener = subprocess.Popen(
+    [
+        sys.executable,
+        sys.argv[1],
+        "exec",
+        "--lease-prefix",
+        "abrupt",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        sys.argv[10],
+        "--",
+        sys.executable,
+        "-c",
+        sys.argv[11],
+        sys.argv[8],
+        sys.argv[10],
+    ],
+    env=env,
+    start_new_session=True,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+while not Path(sys.argv[8]).is_file():
+    if listener.poll() is not None:
+        raise SystemExit("listener exited before readiness")
+    time.sleep(0.01)
+Path(sys.argv[7]).write_text(str(guardian.pid))
+Path(sys.argv[9]).write_text(str(listener.pid))
+time.sleep(60)
+"""
+    guardian_script = ROOT / "scripts" / "process_lease_guardian.py"
+    runner = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            runner_source,
+            str(guardian_script),
+            str(lease_file),
+            str(ack_dir),
+            str(ready_file),
+            str(closed_file),
+            str(result_file),
+            str(guardian_pid_file),
+            str(listener_marker),
+            str(runner_ready),
+            str(port),
+            listener_source,
+        ],
+        cwd=tmp_path,
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    guardian_group: int | None = None
+    listener_group: int | None = None
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not runner_ready.is_file():
+            assert runner.poll() is None
+            time.sleep(0.02)
+        assert runner_ready.is_file()
+        guardian_group = int(guardian_pid_file.read_text())
+        listener_state = json.loads(listener_marker.read_text())
+        listener_group = listener_state["pgid"]
+        assert listener_state["pid"] != listener_group
+        with socket.socket() as probe:
+            probe.settimeout(0.2)
+            assert probe.connect_ex(("127.0.0.1", port)) == 0
+
+        os.kill(runner.pid, signal.SIGKILL)
+        runner.wait(timeout=2)
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not closed_file.is_file():
+            time.sleep(0.02)
+        assert closed_file.is_file(), "guardian did not observe parent-pipe EOF"
+        os.kill(guardian_group, signal.SIGTERM)
+        os.kill(guardian_group, signal.SIGTERM)
+
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline and not result_file.is_file():
+            time.sleep(0.05)
+        assert result_file.is_file(), "guardian emitted no result after repeated cancellation"
+        result = json.loads(result_file.read_text())
+        assert result["status"] == "closed"
+        assert result["active_lease_count"] == 1
+        (lease,) = result["leases"]
+        assert lease["ownership_matches"] is True
+        assert lease["released"] is False
+        assert lease["group_closed"] is True
+        assert lease["port_closed"] is True
+        with pytest.raises(ProcessLookupError):
+            os.killpg(listener_group, 0)
+        with socket.socket() as probe:
+            probe.settimeout(0.2)
+            assert probe.connect_ex(("127.0.0.1", port)) != 0
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                os.killpg(guardian_group, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("guardian wrote its result but did not exit")
+    finally:
+        for process_group in (listener_group, guardian_group, runner.pid):
+            if process_group is None:
+                continue
+            try:
+                os.killpg(process_group, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        if runner.poll() is None:
+            runner.wait(timeout=2)
+
+
+def test_guarded_exec_refuses_target_when_guardian_closes_before_ack(tmp_path: Path) -> None:
+    lease_file = tmp_path / "leases.jsonl"
+    ack_dir = tmp_path / "acks"
+    ready_file = tmp_path / "ready.json"
+    closed_file = tmp_path / "closed.json"
+    target_marker = tmp_path / "target-ran"
+    ready_file.write_text('{"status":"ready"}\n', encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {
+            PROCESS_LEASE_ENV: str(lease_file),
+            PROCESS_LEASE_ACK_DIR_ENV: str(ack_dir),
+            PROCESS_LEASE_READY_ENV: str(ready_file),
+            PROCESS_LEASE_CLOSED_ENV: str(closed_file),
+        }
+    )
+    wrapper = ROOT / "scripts" / "process_lease_guardian.py"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(wrapper),
+            "exec",
+            "--lease-prefix",
+            "preack",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "27750",
+            "--",
+            sys.executable,
+            "-c",
+            f"from pathlib import Path; Path({str(target_marker)!r}).write_text('ran')",
+        ],
+        cwd=tmp_path,
+        env=env,
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        record: dict[str, Any] | None = None
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and record is None:
+            assert process.poll() is None
+            if lease_file.is_file():
+                try:
+                    records = [json.loads(line) for line in lease_file.read_text().splitlines()]
+                except json.JSONDecodeError:
+                    records = []
+                if len(records) == 1 and records[0].get("birth_identity"):
+                    record = records[0]
+            time.sleep(0.01)
+        assert record is not None, "wrapper never published a complete pre-exec lease"
+        assert record["pid"] == process.pid
+        assert record["process_group"] == process.pid
+        time.sleep(0.1)
+        assert process.poll() is None
+        assert not target_marker.exists(), "target ran without a guardian acknowledgement"
+
+        closed_file.write_text('{"status":"closed"}\n', encoding="utf-8")
+        assert process.wait(timeout=2) != 0
+        assert not target_marker.exists()
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=2)
 
 
 def test_transient_group_signal_denial_still_requires_exit_proof(monkeypatch) -> None:
@@ -747,10 +1505,18 @@ def test_external_service_prerequisites_enable_dedicated_test_lanes() -> None:
             "prerequisites": ["credential:MODAL_TOKEN_ID"],
         },
     )
+    biome = _scenario_environment(
+        {},
+        {
+            "id": "example.14_biome_agent",
+            "prerequisites": ["infrastructure:ARCHETYPE_BIOME_LIVE"],
+        },
+    )
 
     assert docker["ARCHETYPE_DOCKER_SANDBOX_PARITY"] == "1"
     assert apple["ARCHETYPE_APPLE_CONTAINER_SANDBOX_PARITY"] == "1"
     assert modal["ARCHETYPE_MODAL_AGENT_MISSION_LIVE"] == "1"
+    assert biome[operational_runner._PROCESS_LEASE_GUARDIAN_ENV] == "1"
 
 
 def test_skipped_only_pytest_evidence_cannot_pass(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- add a Biome-only process-lease guardian to the operational scenario runner
- require a kernel-bound PID/PGID acknowledgement before starting native Biome
- retain the acknowledged wrapper as the session leader and independently prove process-group and loopback-port closure on normal exit, timeout, parent death, or cancellation
- reject untruthful release records and stale or changed process identities
- document the guarded live-evidence contract and the disposable upstream patch boundary

## Why

The live Biome subprocess owns a nested session. Killing only the pytest scenario group could leave that native group and port 27750 alive while the operational receipt incorrectly reported cleanup. This patch makes cleanup evidence independent of the scenario process and fail-closed.

## Validation

- `make ci` — static audits, 3,232 passed / 22 skipped, five distribution builds, and all wheel/sdist installation matrices
- focused operational/Biome suite — 73 passed
- Markdown lint — 0 issues
- two independent adversarial reviews found no remaining release-blocking lifecycle issue
