### PR TITLE
fix: give the release evidence gate packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,6 +348,9 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+        with:
+          version: "0.9.28"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-evidence
@@ -359,7 +362,8 @@ jobs:
           merge-multiple: true
       - name: Verify complete exact-wheel evidence
         run: >-
-          python scripts/verify_release_evidence.py
+          uvx --with packaging==26.1 python
+          scripts/verify_release_evidence.py
           --manifest evidence/release-artifact.json
           --out release-evidence-summary.json
           evidence/operational-release-results.json

--- a/packages/archetype-ecs/pyproject.toml
+++ b/packages/archetype-ecs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-ecs"
-version = "0.6.0"
+version = "0.6.1"
 description = "DataFrame-first, append-only ECS framework for simulations and world libraries."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-ecs/src/archetype/__init__.py
+++ b/packages/archetype-ecs/src/archetype/__init__.py
@@ -44,7 +44,7 @@ os.environ.setdefault("DO_NOT_TRACK", "1")
 # subpackages while this distribution remains the sole root-facade owner.
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = [
     # Core types

--- a/packages/archetype-ecs/src/archetype/migration/handlers.py
+++ b/packages/archetype-ecs/src/archetype/migration/handlers.py
@@ -105,7 +105,7 @@ def _archetype_version() -> str:
     try:
         return version("archetype-ecs")
     except PackageNotFoundError:  # pragma: no cover - source tree without install metadata
-        return "0.6.0"
+        return "0.6.1"
 
 
 def _artifact_plan(inventory: ArtifactInventory) -> ArtifactPlanEvidence:

--- a/packages/archetype-missions/pyproject.toml
+++ b/packages/archetype-missions/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-missions"
-version = "0.6.0"
+version = "0.6.1"
 description = "Coding-agent missions, sandboxes, transcripts, and trajectories for Archetype."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-missions/src/archetype/missions/_extension.py
+++ b/packages/archetype-missions/src/archetype/missions/_extension.py
@@ -535,7 +535,7 @@ def install(context: WorldLibraryContext) -> InstalledWorldLibrary:
 MANIFEST = WorldLibraryManifest(
     name="missions",
     distribution="archetype-missions",
-        version="0.6.1",
+    version="0.6.1",
     requires_framework=">=0.6,<0.7",
     operation_models=MISSION_OPERATION_MODELS,
     install=install,

--- a/packages/archetype-missions/src/archetype/missions/_extension.py
+++ b/packages/archetype-missions/src/archetype/missions/_extension.py
@@ -535,7 +535,7 @@ def install(context: WorldLibraryContext) -> InstalledWorldLibrary:
 MANIFEST = WorldLibraryManifest(
     name="missions",
     distribution="archetype-missions",
-    version="0.6.0",
+        version="0.6.1",
     requires_framework=">=0.6,<0.7",
     operation_models=MISSION_OPERATION_MODELS,
     install=install,

--- a/packages/archetype-missions/tests/test_missions_extension.py
+++ b/packages/archetype-missions/tests/test_missions_extension.py
@@ -85,7 +85,7 @@ def test_manifest_declares_exact_missions_surface() -> None:
     assert first is second
     assert first.name == "missions"
     assert first.distribution == "archetype-missions"
-    assert first.version == "0.6.0"
+    assert first.version == "0.6.1"
     assert first.requires_framework == ">=0.6,<0.7"
     assert first.operation_models == MISSION_OPERATION_MODELS
     assert first.operation_names == (

--- a/packages/archetype-physical-ai/pyproject.toml
+++ b/packages/archetype-physical-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-physical-ai"
-version = "0.6.0"
+version = "0.6.1"
 description = "Physical state, policies, and hosted episode workflows for Archetype."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-physical-ai/src/archetype/physical_ai/_extension.py
+++ b/packages/archetype-physical-ai/src/archetype/physical_ai/_extension.py
@@ -196,7 +196,7 @@ def get_manifest() -> WorldLibraryManifest:
     return WorldLibraryManifest(
         name=_LIBRARY_NAME,
         distribution="archetype-physical-ai",
-        version="0.6.0",
+        version="0.6.1",
         requires_framework=">=0.6,<0.7",
         operation_models=(RunHostedEpisode,),
         install=_install,

--- a/packages/archetype-physical-ai/src/archetype/physical_ai/hosted_modal.py
+++ b/packages/archetype-physical-ai/src/archetype/physical_ai/hosted_modal.py
@@ -744,7 +744,7 @@ def build_seeded_modal_hosted_episode_app(
     if image is None:
         image = (
             modal.Image.debian_slim(python_version="3.12")
-            .uv_pip_install("archetype-ecs==0.6.0")
+            .uv_pip_install("archetype-ecs==0.6.1")
             .add_local_python_source("archetype", copy=True)
         )
     app = modal.App(config.app_name)

--- a/packages/archetype-physical-ai/tests/test_physical_ai_extension.py
+++ b/packages/archetype-physical-ai/tests/test_physical_ai_extension.py
@@ -48,7 +48,7 @@ def test_physical_ai_manifest_is_complete_and_side_effect_free() -> None:
     assert first == second
     assert first.name == "physical-ai"
     assert first.distribution == "archetype-physical-ai"
-    assert first.version == "0.6.0"
+    assert first.version == "0.6.1"
     assert first.requires_framework == ">=0.6,<0.7"
     assert first.operation_models == (RunHostedEpisode,)
     assert first.operation_names == ("run_hosted_episode",)

--- a/packages/archetype-research/pyproject.toml
+++ b/packages/archetype-research/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-research"
-version = "0.6.0"
+version = "0.6.1"
 description = "Minimal world-library optimization and AutoResearch workflows for Archetype."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-research/src/archetype/research/_extension.py
+++ b/packages/archetype-research/src/archetype/research/_extension.py
@@ -79,7 +79,7 @@ def get_manifest() -> WorldLibraryManifest:
     return WorldLibraryManifest(
         name=_LIBRARY_NAME,
         distribution="archetype-research",
-        version="0.6.0",
+        version="0.6.1",
         requires_framework=">=0.6,<0.7",
         operation_models=(AutoResearch,),
         install=_install,

--- a/packages/archetype-research/tests/test_research_extension.py
+++ b/packages/archetype-research/tests/test_research_extension.py
@@ -56,7 +56,7 @@ def test_research_manifest_is_complete_and_side_effect_free() -> None:
     assert first == second
     assert first.name == "research"
     assert first.distribution == "archetype-research"
-    assert first.version == "0.6.0"
+    assert first.version == "0.6.1"
     assert first.requires_framework == ">=0.6,<0.7"
     assert first.operation_models == (AutoResearch,)
     assert first.operation_names == ("autoresearch",)

--- a/packages/archetype-smol/pyproject.toml
+++ b/packages/archetype-smol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-smol"
-version = "0.6.0"
+version = "0.6.1"
 description = "A tiny synchronous, in-memory DataFrame ECS for learning Archetype's core model."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-smol/src/archetype/smol/__init__.py
+++ b/packages/archetype-smol/src/archetype/smol/__init__.py
@@ -9,4 +9,4 @@ from .world import RunResult, World
 
 __all__ = ["Component", "Processor", "RunResult", "World"]
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "archetype-workspace"
-version = "0.6.0"
+version = "0.6.1"
 description = "Development workspace for the Archetype framework, first-party world libraries, and independent Smol teaching engine."
 requires-python = ">=3.12"
 dependencies = [
-    "archetype-ecs[all,coding-agent,logfire,sim]==0.6.0",
-    "archetype-smol==0.6.0",
+    "archetype-ecs[all,coding-agent,logfire,sim]==0.6.1",
+    "archetype-smol==0.6.1",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -623,6 +623,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         assert "--min-tier 0 --max-tier 6" in make_target.group("body")
     assert "tests/infrastructure/test_r2_idempotency.py" in external
     assert "scripts/verify_release_evidence.py" in gate
+    assert "uvx --with packaging==26.1 python" in gate
     assert "operational-release-biome-results.json" in gate
     assert "operational-release-apple-results.json" in gate
     assert "operational-release-modal-results.json" in gate
@@ -790,7 +791,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         "softprops/action-gh-release@"
     )
     assert 'version: "latest"' not in workflow
-    assert workflow.count('version: "0.9.28"') == 8
+    assert workflow.count('version: "0.9.28"') == 9
     assert workflow.count("persist-credentials: false") == 12
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -198,7 +198,7 @@ wheels = [
 
 [[package]]
 name = "archetype-ecs"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/archetype-ecs" }
 dependencies = [
     { name = "av" },
@@ -290,7 +290,7 @@ provides-extras = ["missions", "physical-ai", "research", "all", "coding-agent",
 
 [[package]]
 name = "archetype-missions"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/archetype-missions" }
 dependencies = [
     { name = "archetype-ecs" },
@@ -318,7 +318,7 @@ provides-extras = ["modal"]
 
 [[package]]
 name = "archetype-physical-ai"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/archetype-physical-ai" }
 dependencies = [
     { name = "archetype-ecs" },
@@ -356,7 +356,7 @@ provides-extras = ["modal", "sim", "all"]
 
 [[package]]
 name = "archetype-research"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/archetype-research" }
 dependencies = [
     { name = "archetype-ecs" },
@@ -373,7 +373,7 @@ requires-dist = [
 
 [[package]]
 name = "archetype-smol"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/archetype-smol" }
 dependencies = [
     { name = "daft" },
@@ -390,7 +390,7 @@ requires-dist = [
 
 [[package]]
 name = "archetype-workspace"
-version = "0.6.0"
+version = "0.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "archetype-ecs", extra = ["all", "coding-agent", "logfire", "sim"] },


### PR DESCRIPTION
## Summary
- The v0.6.0 release run passed every evidence lane, then died in Exact release evidence with `ModuleNotFoundError: No module named 'packaging'`.
- The gate now uses the same pinned `uvx --with packaging==26.1` path as the neighboring index jobs.
- Package version is 0.6.1 because `v0.6.0` is immutable and a rerun of that tag cannot pick up the workflow fix.

## Test plan
- [x] Focused workflow and extension tests
- [ ] GitHub PR checks
- [ ] After merge: tag `v0.6.1`, pin the Mac runner group, dispatch `release.yml`


Made with [Cursor](https://cursor.com)