### PR TITLE
feat(api): authenticate mission clients and bind versioned execution profiles

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -298,6 +298,21 @@ environment, but it has a distinct sandbox identity, receives no Git
 publication secret, is never checkpointed, and closes after its evidence is
 durable.
 
+### Authenticated mission clients and execution profiles
+
+External agents and UIs authenticate as service principals. They do not inherit
+developer-mode `Bearer <role>` identity and they cannot choose execution
+authority. The client names a `profile_id`. The host owns the versioned
+execution profile: repositories, refs, sandbox, drivers, model, budgets,
+secrets (by name), and whether cancel, attach, steer, or takeover is allowed.
+
+`archetype.missions.execution_profiles` owns the digestible profile values.
+`archetype.missions.control` owns capability, ownership, and pin policy.
+`archetype.api.principals` verifies credentials. An accepted mission-control
+run records profile id, version, and digest so a later catalog change cannot
+reinterpret that run. Durable asynchronous `MissionRun` execution is a
+separate lifecycle.
+
 ## 4. State and transition protocol
 
 ```mermaid
@@ -1053,6 +1068,8 @@ The implementation follows this layout:
 | File | Owns |
 |---|---|
 | `archetype/missions/contracts.py` | Supported authoring, configuration, and result values. |
+| `archetype/missions/execution_profiles.py` | Versioned server-owned execution profiles and canonical digests. |
+| `archetype/missions/control.py` | Mission-control capability, ownership, and accepted-run pins. |
 | `archetype/missions/components.py` | Mission, task, validator, candidate, critic, sandbox, execution, and output Components. |
 | `archetype/missions/relations.py` | Membership, dependency, guard, placement, candidate/review, and provenance Relations. |
 | `archetype/missions/transitions.py` | Small persisted status vocabularies and transition tables. |

--- a/docs/guide/api-layer.md
+++ b/docs/guide/api-layer.md
@@ -59,18 +59,52 @@ async def run_world(
 
 ## Authentication context
 
-The served API is a single-tenant development surface, and this is the
-deliberate v0.6 posture. There is no authentication system: every caller is
-the tenant. A request with no `Authorization` header receives the admin role;
-`Bearer <role>` self-asserts one of admin/operator/player/viewer. Roles
-therefore scope cooperating agents — a client instructed to send
-`Bearer viewer` is genuinely viewer-scoped by the command gate — but they are
-not a security boundary against an adversarial caller, and binding the server
-beyond loopback exposes an unauthenticated admin API. The credentials that
-matter are the storage credentials in Daft's `IOConfig`. Real
-authentication/authorization against an external identity provider is a
-future hardening slice. The trusted runtime has no actor context. See
+The served ECS API is a single-tenant development surface, and this is the
+deliberate v0.6 posture for existing world, command, simulation, and query
+routes. Those routes have no verified authentication: a request with no
+`Authorization` header receives the admin role, and `Bearer <role>`
+self-asserts one of admin/operator/player/viewer. Roles therefore scope
+cooperating agents — a client instructed to send `Bearer viewer` is genuinely
+viewer-scoped by the command gate — but they are not a security boundary
+against an adversarial caller. Binding those developer routes beyond loopback
+exposes an unauthenticated admin API. The credentials that matter for storage
+are in Daft's `IOConfig`. The trusted runtime has no actor context. See
 [Command Gate](command-gate.md).
+
+### Mission-control authentication
+
+Mission-control and interactive routes do not inherit developer-mode identity.
+They authenticate an opaque bearer credential to a stable service principal
+through `get_mission_principal`. A role label such as `admin` is never accepted
+as a credential. Missing, malformed, unknown, expired, and revoked credentials
+fail closed. The process stores only a salted HMAC verifier; the credential
+never appears in logs, errors, events, receipts, or model-visible tool results.
+
+Principals carry explicit capabilities (`mission:submit`, `mission:read`,
+`mission:cancel`, `mission:attach`, `mission:steer`, `mission:takeover`) plus
+profile allowlists. Resource ownership is enforced in addition to capability
+names: one principal cannot read or control another principal's accepted runs
+without an explicit grant.
+
+`archetype serve --host` records `ARCHETYPE_BIND_HOST`. Loopback developer
+mode remains the documented ECS posture and cannot enable unauthenticated
+mission execution. Non-loopback hosting stays fail-closed for mission-control
+unless verified principals are configured; an empty principal directory rejects
+every mission-control request.
+
+The client supplies a `profile_id`, not execution internals. A versioned
+server-owned execution profile owns allowed repositories, base refs, branch
+namespace, sandbox backend and environment, agent/critic drivers, model,
+timeouts, tick/retry/concurrency/cost ceilings, validator and publication
+bounds, secret names, provider credential names, and whether cancel, attach,
+steer, or takeover is allowed. An accepted run pins profile id, version, and
+canonical digest. Changing later configuration cannot reinterpret that pin.
+Request bodies cannot carry sandbox, secret, driver, model, critic, budget, or
+timeout fields.
+
+Credential verification lives in `archetype.api`. Profile values and
+authorization policy live in `archetype.missions`. Wiring/runtime resources
+compose the catalogs. API handlers do not construct Mission domain state.
 
 ## Route Structure
 
@@ -207,6 +241,7 @@ archetype query <world-id> Agent,Score --where "score__value > 0.5" --count
 
 - App factory: `packages/archetype-ecs/src/archetype/api/app.py`
 - Dependency injection: `packages/archetype-ecs/src/archetype/api/deps.py`
+- Mission service principals: `packages/archetype-ecs/src/archetype/api/principals.py`
 - Request/response models: `packages/archetype-ecs/src/archetype/api/models.py`
 - Routes: `packages/archetype-ecs/src/archetype/api/routes/`
 - CLI: `packages/archetype-ecs/src/archetype/cli/main.py`

--- a/docs/guide/application-architecture.md
+++ b/docs/guide/application-architecture.md
@@ -70,6 +70,11 @@ CLI or remote client
   -> the same registered family handler
 ```
 
+Mission-control and interactive routes authenticate a verified service
+principal instead of developer-mode `ActorCtx`. Missions-owned profile and
+capability policy authorize the operation; API handlers do not construct
+domain state.
+
 The CLI is an HTTP client except for the server-startup entrypoint. It does not
 authorize calls or import application/runtime implementation code. FastAPI
 translates transport models, authenticates principals, constructs exact

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -26,6 +26,7 @@ machine authority; this page is its review surface.
 | `runtime.lifecycle.single_flight_and_drain` | `runtime` | high | [docs/guide/specification.md](../guide/specification.md) — Concurrency Contract | pytest: 3; eval: 2 | `pr`, `main`, `release` |
 | `runtime.lifecycle.retryable_teardown` | `runtime` | high | [docs/guide/runtime.md](../guide/runtime.md) — R4 — Async context manager is canonical | pytest: 6 | `pr`, `main`, `release` |
 | `gateway.authorization.rbac` | `commands` | high | [docs/guide/command-gate.md](../guide/command-gate.md) — 1. The gate model | pytest: 3; static: 1; eval: 5 | `pr`, `main`, `release` |
+| `missions.control.authenticated_profiles` | `api` | high | [docs/guide/api-layer.md](../guide/api-layer.md) — Mission-control authentication | pytest: 3 | `pr`, `main`, `release` |
 | `commands.identity.idempotent` | `commands` | high | [docs/guide/specification.md](../guide/specification.md) — Command ledger, scheduler, and dispatcher | pytest: 1; static: 1; eval: 4 | `pr`, `main`, `release` |
 | `commands.settlement.atomic` | `commands` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 7. Commands, commits, artifacts, and audit | pytest: 3; eval: 2 | `pr`, `main`, `release` |
 | `commands.failure.preserves_progress` | `commands` | high | [docs/guide/specification.md](../guide/specification.md) — Command ledger, scheduler, and dispatcher | pytest: 1; eval: 4 | `pr`, `main`, `release` |

--- a/docs/reference/rest-api-missions.md
+++ b/docs/reference/rest-api-missions.md
@@ -10,6 +10,184 @@ These routes are contributed only when this trusted world-library manifest is ex
 
 ## Missions
 
+### Submit Mission Control Run
+
+```text
+POST /v1/mission-control/runs
+```
+
+Accept a profile-bound mission run pin for a verified principal.
+
+**Request body:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `profile_id` | string | Yes | — | Profile Id |
+| `repository` | string | Yes | — | Repository |
+| `branch` | string | Yes | — | Branch |
+| `base_ref` | string | No | `"main"` | Base Ref |
+| `name` | string | No | `"agent-mission"` | Name |
+
+**Response** (`202`):
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `run_id` | string | Yes | — | Run Id |
+| `owner_principal_id` | string | Yes | — | Owner Principal Id |
+| `profile_id` | string | Yes | — | Profile Id |
+| `profile_version` | string | Yes | — | Profile Version |
+| `profile_digest` | string | Yes | — | Profile Digest |
+| `state` | string | No | `"accepted"` | State |
+
+**Error codes:** `422`
+
+---
+
+### Get Mission Control Run
+
+```text
+GET /v1/mission-control/runs/{run_id}
+```
+
+Read one accepted run pin the principal is allowed to see.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `run_id` | string |  |
+
+**Response** (`200`):
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `run_id` | string | Yes | — | Run Id |
+| `owner_principal_id` | string | Yes | — | Owner Principal Id |
+| `profile_id` | string | Yes | — | Profile Id |
+| `profile_version` | string | Yes | — | Profile Version |
+| `profile_digest` | string | Yes | — | Profile Digest |
+| `state` | string | No | `"accepted"` | State |
+
+**Error codes:** `422`
+
+---
+
+### Attach Mission Control Run
+
+```text
+POST /v1/mission-control/runs/{run_id}/attach
+```
+
+Authorize first-person attachment for one accepted run pin.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `run_id` | string |  |
+
+**Response** (`200`):
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `run_id` | string | Yes | — | Run Id |
+| `owner_principal_id` | string | Yes | — | Owner Principal Id |
+| `profile_id` | string | Yes | — | Profile Id |
+| `profile_version` | string | Yes | — | Profile Version |
+| `profile_digest` | string | Yes | — | Profile Digest |
+| `state` | string | No | `"accepted"` | State |
+
+**Error codes:** `422`
+
+---
+
+### Cancel Mission Control Run
+
+```text
+POST /v1/mission-control/runs/{run_id}/cancel
+```
+
+Authorize cancellation for one accepted run pin.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `run_id` | string |  |
+
+**Response** (`200`):
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `run_id` | string | Yes | — | Run Id |
+| `owner_principal_id` | string | Yes | — | Owner Principal Id |
+| `profile_id` | string | Yes | — | Profile Id |
+| `profile_version` | string | Yes | — | Profile Version |
+| `profile_digest` | string | Yes | — | Profile Digest |
+| `state` | string | No | `"accepted"` | State |
+
+**Error codes:** `422`
+
+---
+
+### Steer Mission Control Run
+
+```text
+POST /v1/mission-control/runs/{run_id}/steer
+```
+
+Authorize steering for one accepted run pin.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `run_id` | string |  |
+
+**Response** (`200`):
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `run_id` | string | Yes | — | Run Id |
+| `owner_principal_id` | string | Yes | — | Owner Principal Id |
+| `profile_id` | string | Yes | — | Profile Id |
+| `profile_version` | string | Yes | — | Profile Version |
+| `profile_digest` | string | Yes | — | Profile Digest |
+| `state` | string | No | `"accepted"` | State |
+
+**Error codes:** `422`
+
+---
+
+### Takeover Mission Control Run
+
+```text
+POST /v1/mission-control/runs/{run_id}/takeover
+```
+
+Authorize writable takeover for one accepted run pin.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `run_id` | string |  |
+
+**Response** (`200`):
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `run_id` | string | Yes | — | Run Id |
+| `owner_principal_id` | string | Yes | — | Owner Principal Id |
+| `profile_id` | string | Yes | — | Profile Id |
+| `profile_version` | string | Yes | — | Profile Version |
+| `profile_digest` | string | Yes | — | Profile Digest |
+| `state` | string | No | `"accepted"` | State |
+
+**Error codes:** `422`
+
+---
+
 ### List Missions
 
 ```text

--- a/packages/archetype-ecs/src/archetype/api/app.py
+++ b/packages/archetype-ecs/src/archetype/api/app.py
@@ -36,6 +36,7 @@ async def lifespan(app: FastAPI):
 
     # Composition stays lazy: importing the ASGI module and calling
     # ``create_app`` must not construct providers, catalogs, or tasks.
+    from archetype.api.principals import MissionPrincipalDirectory
     from archetype.wiring import RuntimeBootstrapConfig, build_runtime_resources
 
     configure_host_observability(service_name="archetype-api")
@@ -46,6 +47,7 @@ async def lifespan(app: FastAPI):
         )
     )
     app.state.resources = resources
+    app.state.mission_principals = MissionPrincipalDirectory.from_env()
     try:
         yield
     finally:

--- a/packages/archetype-ecs/src/archetype/api/deps.py
+++ b/packages/archetype-ecs/src/archetype/api/deps.py
@@ -19,6 +19,12 @@ from __future__ import annotations
 from fastapi import Header, HTTPException, Request
 from uuid_utils import NAMESPACE_URL, uuid5
 
+from archetype.api.principals import (
+    AuthenticationError,
+    MissionPrincipal,
+    MissionPrincipalDirectory,
+    parse_bearer_credential,
+)
 from archetype.commands.dispatch import CommandDispatcher
 from archetype.commands.models import ActorCtx
 
@@ -54,3 +60,31 @@ async def get_actor_ctx(authorization: str | None = Header(None)) -> ActorCtx:
         id=uuid5(NAMESPACE_URL, f"archetype:development-principal:{role}"),
         roles={role},
     )
+
+
+def mission_principal_directory(request: Request) -> MissionPrincipalDirectory:
+    """Return the process-owned mission principal directory, or empty."""
+
+    directory = getattr(request.app.state, "mission_principals", None)
+    if isinstance(directory, MissionPrincipalDirectory):
+        return directory
+    return MissionPrincipalDirectory.empty()
+
+
+async def get_mission_principal(
+    request: Request,
+    authorization: str | None = Header(None),
+) -> MissionPrincipal:
+    """Authenticate a mission-control caller with a verified service principal.
+
+    Missing, malformed, unknown, expired, revoked, and role-label credentials
+    fail closed. This dependency is for mission-control and interactive routes
+    only; existing developer routes keep ``get_actor_ctx``.
+    """
+
+    directory = mission_principal_directory(request)
+    try:
+        credential = parse_bearer_credential(authorization)
+        return directory.authenticate(credential)
+    except AuthenticationError:
+        raise HTTPException(status_code=401, detail="Authentication required") from None

--- a/packages/archetype-ecs/src/archetype/api/principals.py
+++ b/packages/archetype-ecs/src/archetype/api/principals.py
@@ -1,0 +1,299 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verified mission service principals for the API transport boundary.
+
+Developer-mode ``Bearer <role>`` identity remains on existing ECS routes.
+Mission-control authenticates an opaque credential to a stable principal and
+never treats a role label as proof of identity.
+"""
+
+from __future__ import annotations
+
+import hmac
+import ipaddress
+import os
+import secrets
+import tomllib
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEVELOPER_ROLE_LABELS = frozenset({"admin", "operator", "player", "viewer"})
+MISSION_CAPABILITIES = frozenset(
+    {
+        "mission:submit",
+        "mission:read",
+        "mission:cancel",
+        "mission:attach",
+        "mission:steer",
+        "mission:takeover",
+    }
+)
+_MIN_CREDENTIAL_LENGTH = 24
+_PRINCIPALS_PATH_ENV = "ARCHETYPE_MISSION_PRINCIPALS_PATH"
+_BIND_HOST_ENV = "ARCHETYPE_BIND_HOST"
+
+
+class AuthenticationError(Exception):
+    """Closed authentication failure that must not carry credential material."""
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return whether ``host`` is a loopback bind or address."""
+
+    normalized = host.strip().lower().strip("[]")
+    if not normalized or normalized == "localhost":
+        return True
+    if normalized in {"::1", "0:0:0:0:0:0:0:1"}:
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def parse_bearer_credential(authorization: str | None) -> str:
+    """Return the bearer credential or raise a closed authentication error."""
+
+    if authorization is None or not authorization.strip():
+        raise AuthenticationError("authentication required")
+    scheme, separator, token = authorization.partition(" ")
+    if separator == "" or scheme.lower() != "bearer" or not token.strip():
+        raise AuthenticationError("invalid credentials")
+    credential = token.strip()
+    if credential.lower() in DEVELOPER_ROLE_LABELS:
+        raise AuthenticationError("invalid credentials")
+    return credential
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _require_identifier(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value.strip() != value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _frozen_strings(values: object, *, label: str) -> frozenset[str]:
+    if values is None:
+        return frozenset()
+    if not isinstance(values, list | tuple | set | frozenset):
+        raise ValueError(f"{label} must be a list of strings")
+    items: list[str] = []
+    for item in values:
+        if not isinstance(item, str) or not item.strip() or item.strip() != item:
+            raise ValueError(f"{label} must contain non-empty strings")
+        items.append(item)
+    if len(set(items)) != len(items):
+        raise ValueError(f"{label} must not contain duplicates")
+    return frozenset(items)
+
+
+def _verifier(credential: str, salt: bytes) -> bytes:
+    return hmac.new(salt, credential.encode("utf-8"), "sha256").digest()
+
+
+@dataclass(frozen=True, slots=True)
+class MissionPrincipal:
+    """Stable authenticated identity for mission-control and interactive routes."""
+
+    principal_id: str
+    capabilities: frozenset[str]
+    allowed_profile_ids: frozenset[str]
+    granted_run_ids: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        principal_id = _require_identifier(self.principal_id, label="principal_id")
+        if principal_id.lower() in DEVELOPER_ROLE_LABELS:
+            raise ValueError("principal_id must not be a developer role label")
+        unknown = sorted(self.capabilities - MISSION_CAPABILITIES)
+        if unknown:
+            raise ValueError(f"unsupported mission capabilities: {', '.join(unknown)}")
+        object.__setattr__(self, "principal_id", principal_id)
+        object.__setattr__(self, "capabilities", frozenset(self.capabilities))
+        object.__setattr__(
+            self,
+            "allowed_profile_ids",
+            frozenset(self.allowed_profile_ids),
+        )
+        object.__setattr__(self, "granted_run_ids", frozenset(self.granted_run_ids))
+
+    def has_capability(self, capability: str) -> bool:
+        """Return whether this principal was granted ``capability``."""
+
+        return capability in self.capabilities
+
+
+@dataclass(frozen=True, slots=True)
+class _PrincipalRecord:
+    principal: MissionPrincipal
+    salt: bytes = field(repr=False)
+    verifier: bytes = field(repr=False)
+    expires_at: datetime | None = None
+    revoked: bool = False
+
+
+def _parse_expiry(value: object) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise ValueError("expires_at must be an RFC 3339 timestamp")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("expires_at must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _credential_from_mapping(
+    raw: Mapping[str, Any],
+    environ: Mapping[str, str],
+) -> str:
+    token_env = raw.get("token_env")
+    if token_env is not None:
+        name = _require_identifier(token_env, label="token_env")
+        credential = environ.get(name, "")
+        if not credential.strip():
+            raise RuntimeError(f"{name} is required for mission principal provisioning")
+        return credential.strip()
+    credential = raw.get("credential")
+    if isinstance(credential, str) and credential.strip():
+        return credential.strip()
+    raise ValueError("principal requires token_env or credential at provisioning time")
+
+
+def _record_from_mapping(
+    raw: Mapping[str, Any],
+    environ: Mapping[str, str],
+) -> _PrincipalRecord:
+    principal = MissionPrincipal(
+        principal_id=_require_identifier(raw.get("id"), label="principal id"),
+        capabilities=_frozen_strings(raw.get("capabilities"), label="capabilities"),
+        allowed_profile_ids=_frozen_strings(
+            raw.get("allowed_profile_ids"),
+            label="allowed_profile_ids",
+        ),
+        granted_run_ids=_frozen_strings(raw.get("granted_run_ids"), label="granted_run_ids"),
+    )
+    credential = _credential_from_mapping(raw, environ)
+    if len(credential) < _MIN_CREDENTIAL_LENGTH:
+        raise ValueError("mission principal credential is too short")
+    if credential.lower() in DEVELOPER_ROLE_LABELS:
+        raise ValueError("mission principal credential must not be a role label")
+    salt = secrets.token_bytes(16)
+    return _PrincipalRecord(
+        principal=principal,
+        salt=salt,
+        verifier=_verifier(credential, salt),
+        expires_at=_parse_expiry(raw.get("expires_at")),
+        revoked=bool(raw.get("revoked", False)),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MissionPrincipalDirectory:
+    """Process-owned verifier set for mission service principals."""
+
+    _records: tuple[_PrincipalRecord, ...] = ()
+
+    def __post_init__(self) -> None:
+        ids = [record.principal.principal_id for record in self._records]
+        if len(set(ids)) != len(ids):
+            raise ValueError("mission principal ids must be unique")
+
+    @classmethod
+    def empty(cls) -> MissionPrincipalDirectory:
+        """Return a fail-closed directory with no verifiers."""
+
+        return cls()
+
+    @classmethod
+    def from_env(
+        cls,
+        environ: Mapping[str, str] | None = None,
+    ) -> MissionPrincipalDirectory:
+        """Load principals from ``ARCHETYPE_MISSION_PRINCIPALS_PATH`` if set."""
+
+        source = os.environ if environ is None else environ
+        configured = source.get(_PRINCIPALS_PATH_ENV, "").strip()
+        if not configured:
+            return cls.empty()
+        path = Path(configured).expanduser()
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+        rows = document.get("principal", [])
+        if not isinstance(rows, list):
+            raise ValueError("mission principal document must contain [[principal]] tables")
+        records = tuple(_record_from_mapping(row, source) for row in rows)
+        return cls(records)
+
+    @classmethod
+    def from_provisioning(
+        cls,
+        rows: tuple[Mapping[str, Any], ...],
+        environ: Mapping[str, str] | None = None,
+    ) -> MissionPrincipalDirectory:
+        """Build a directory from provisioning rows, discarding raw credentials."""
+
+        source = os.environ if environ is None else environ
+        return cls(tuple(_record_from_mapping(row, source) for row in rows))
+
+    @property
+    def configured(self) -> bool:
+        """Whether at least one verifier is installed."""
+
+        return bool(self._records)
+
+    def authenticate(
+        self,
+        credential: str,
+        *,
+        now: datetime | None = None,
+    ) -> MissionPrincipal:
+        """Resolve a credential to a principal or fail closed."""
+
+        if not self._records:
+            raise AuthenticationError("invalid credentials")
+        offered = credential.encode("utf-8")
+        matched: _PrincipalRecord | None = None
+        for record in self._records:
+            expected = hmac.new(record.salt, offered, "sha256").digest()
+            if hmac.compare_digest(expected, record.verifier):
+                matched = record
+                break
+        if matched is None:
+            raise AuthenticationError("invalid credentials")
+        if matched.revoked:
+            raise AuthenticationError("invalid credentials")
+        expires_at = matched.expires_at
+        if expires_at is not None and (now or _utc_now()) >= expires_at:
+            raise AuthenticationError("invalid credentials")
+        return matched.principal
+
+    def require_non_loopback_configuration(self, bind_host: str) -> None:
+        """Refuse unauthenticated mission hosting on a non-loopback bind."""
+
+        if not is_loopback_host(bind_host) and not self.configured:
+            raise RuntimeError("non-loopback mission hosting requires verified mission principals")
+
+
+def bind_host_from_env(environ: Mapping[str, str] | None = None) -> str:
+    """Return the process bind host captured at server start."""
+
+    source = os.environ if environ is None else environ
+    return source.get(_BIND_HOST_ENV, "127.0.0.1").strip() or "127.0.0.1"
+
+
+__all__ = [
+    "DEVELOPER_ROLE_LABELS",
+    "MISSION_CAPABILITIES",
+    "AuthenticationError",
+    "MissionPrincipal",
+    "MissionPrincipalDirectory",
+    "bind_host_from_env",
+    "is_loopback_host",
+    "parse_bearer_credential",
+]

--- a/packages/archetype-ecs/src/archetype/cli/main.py
+++ b/packages/archetype-ecs/src/archetype/cli/main.py
@@ -246,8 +246,11 @@ def serve(
     reload: bool = typer.Option(False, help="Enable auto-reload"),
 ):
     """Start the FastAPI server."""
+    import os
+
     import uvicorn
 
+    os.environ["ARCHETYPE_BIND_HOST"] = host
     configure_host_observability(service_name="archetype-api")
     uvicorn.run("archetype.api.app:create_app", host=host, port=port, reload=reload, factory=True)
 

--- a/packages/archetype-ecs/src/archetype/runtime_resources.py
+++ b/packages/archetype-ecs/src/archetype/runtime_resources.py
@@ -716,6 +716,7 @@ class RuntimeResources:
         self._sealed = False
         self._audit_close: _OwnedClose | None = None
         self._storage_close: _OwnedClose | None = None
+        self._host_capabilities: dict[str, Any] = {}
 
     @property
     def dispatcher(self) -> Any:
@@ -770,6 +771,29 @@ class RuntimeResources:
             return self._world_libraries[name]
         except KeyError:
             raise KeyError(f"world library {name!r} is not installed") from None
+
+    def retain_host_capability(self, name: str, value: object) -> None:
+        """Retain one inert host capability for the process lifetime.
+
+        World-library installers may bind catalogs here. The owner stays
+        generic: it does not interpret product operations.
+        """
+
+        _validate_owner(name)
+        if self._close_state is not RuntimeCloseState.OPEN:
+            raise RuntimeError("runtime resource admission is closed")
+        if name in self._host_capabilities:
+            raise RuntimeError(f"host capability {name!r} is already retained")
+        self._host_capabilities[name] = value
+
+    def host_capability(self, name: str) -> Any:
+        """Resolve one retained host capability."""
+
+        _validate_owner(name)
+        try:
+            return self._host_capabilities[name]
+        except KeyError:
+            raise KeyError(f"host capability {name!r} is not retained") from None
 
     @property
     def close_state(self) -> RuntimeCloseState:
@@ -987,6 +1011,7 @@ class RuntimeResources:
         if self._sealed:
             return
         self._sealed = True
+        self._host_capabilities.clear()
         for reservation in self._owners.values():
             reservation._seal()
 

--- a/packages/archetype-missions/src/archetype/missions/_extension.py
+++ b/packages/archetype-missions/src/archetype/missions/_extension.py
@@ -28,6 +28,7 @@ from archetype.missions.coding_agents.harness import (
     CodingAgentHarness,
     CodingAgentHarnessConfig,
 )
+from archetype.missions.control import MissionControlCatalog
 from archetype.missions.critic_activity_coordinator import MissionCriticActivityCoordinator
 from archetype.missions.critic_activity_world import (
     MissionCriticActivityBinding,
@@ -39,6 +40,7 @@ from archetype.missions.critics import (
     CriticHarness,
     CriticHarnessConfig,
 )
+from archetype.missions.execution_profiles import ExecutionProfileCatalog
 from archetype.missions.local_activity_values import LocalMissionAuthorValueStore
 from archetype.missions.local_critic_activity_values import LocalMissionCriticValueStore
 from archetype.missions.modal_author import (
@@ -493,6 +495,10 @@ def install(context: WorldLibraryContext) -> InstalledWorldLibrary:
     )
     trajectories = TrajectoryService(context.storage)
     handlers = _operation_handlers(context, transcripts, trajectories)
+    context.resources.retain_host_capability(
+        "missions:control",
+        MissionControlCatalog(ExecutionProfileCatalog.from_env()),
+    )
 
     if set(handlers) != set(MISSION_OPERATION_MODELS):
         raise RuntimeError("Missions operation composition is incomplete")

--- a/packages/archetype-missions/src/archetype/missions/api.py
+++ b/packages/archetype-missions/src/archetype/missions/api.py
@@ -1,16 +1,18 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Optional Agent Missions read-projection router."""
+"""Optional Agent Missions read-projection and mission-control routers."""
 
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, Literal, cast
 
 from daft import DataFrame, Expression, col
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict
 
-from archetype.api.deps import get_actor_ctx, get_dispatcher
+from archetype.api.deps import get_actor_ctx, get_dispatcher, get_mission_principal
 from archetype.api.errors import raise_api_error
 from archetype.api.models import dataframe_to_rows
+from archetype.api.principals import MissionPrincipal
 from archetype.commands.dispatch import CommandDispatcher
 from archetype.commands.models import ActorCtx
 from archetype.core.component import Component
@@ -25,10 +27,64 @@ from archetype.missions.components import (
     TaskValidator,
     ValidationResult,
 )
+from archetype.missions.control import MissionControlCatalog, MissionRunPin
+from archetype.missions.execution_profiles import MissionProfileRequest
 from archetype.missions.relations import DependsOn, Guards, PartOfMission
 from archetype.world.models import ComponentTypeRef, GetWorldInfo, QueryComponents
 
 _TASK_TYPES: list[type[Component]] = [Task, TaskState, TaskDispatch, TaskPolicy]
+_MISSION_CONTROL_CAPABILITY = "missions:control"
+
+
+class _FrozenRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class MissionControlSubmitRequest(_FrozenRequest):
+    """Client-owned mission-control coordinates. Host execution stays off this body."""
+
+    profile_id: str
+    repository: str
+    branch: str
+    base_ref: str = "main"
+    name: str = "agent-mission"
+
+
+class MissionRunPinResponse(_FrozenRequest):
+    """Bounded accepted-run projection with no host secrets or credentials."""
+
+    run_id: str
+    owner_principal_id: str
+    profile_id: str
+    profile_version: str
+    profile_digest: str
+    state: Literal["accepted"] = "accepted"
+
+
+def _pin_response(pin: MissionRunPin) -> MissionRunPinResponse:
+    return MissionRunPinResponse(
+        run_id=pin.run_id,
+        owner_principal_id=pin.owner_principal_id,
+        profile_id=pin.profile_id,
+        profile_version=pin.profile_version,
+        profile_digest=pin.profile_digest,
+    )
+
+
+def get_mission_control(request: Request) -> MissionControlCatalog:
+    """Return the host-composed mission-control catalog or fail closed."""
+
+    resources = getattr(request.app.state, "resources", None)
+    lookup = getattr(resources, "host_capability", None)
+    if not callable(lookup):
+        raise HTTPException(status_code=401, detail="Authentication required")
+    try:
+        catalog = lookup(_MISSION_CONTROL_CAPABILITY)
+    except (KeyError, ValueError, RuntimeError):
+        raise HTTPException(status_code=401, detail="Authentication required") from None
+    if not isinstance(catalog, MissionControlCatalog):
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return catalog
 
 
 async def _components_frame(
@@ -237,6 +293,93 @@ async def get_task_card(
         raise_api_error(exc)
 
 
+async def submit_mission_control_run(
+    req: MissionControlSubmitRequest,
+    principal: Annotated[MissionPrincipal, Depends(get_mission_principal)],
+    catalog: Annotated[MissionControlCatalog, Depends(get_mission_control)],
+) -> MissionRunPinResponse:
+    """Accept a profile-bound mission run pin for a verified principal."""
+
+    try:
+        pin = catalog.submit(
+            principal,
+            MissionProfileRequest(
+                profile_id=req.profile_id,
+                repository=req.repository,
+                branch=req.branch,
+                base_ref=req.base_ref,
+            ),
+        )
+        return _pin_response(pin)
+    except Exception as exc:
+        raise_api_error(exc)
+
+
+async def get_mission_control_run(
+    run_id: str,
+    principal: Annotated[MissionPrincipal, Depends(get_mission_principal)],
+    catalog: Annotated[MissionControlCatalog, Depends(get_mission_control)],
+) -> MissionRunPinResponse:
+    """Read one accepted run pin the principal is allowed to see."""
+
+    try:
+        return _pin_response(catalog.pin_for(principal, run_id))
+    except Exception as exc:
+        raise_api_error(exc)
+
+
+async def cancel_mission_control_run(
+    run_id: str,
+    principal: Annotated[MissionPrincipal, Depends(get_mission_principal)],
+    catalog: Annotated[MissionControlCatalog, Depends(get_mission_control)],
+) -> MissionRunPinResponse:
+    """Authorize cancellation for one accepted run pin."""
+
+    try:
+        return _pin_response(catalog.cancel(principal, run_id))
+    except Exception as exc:
+        raise_api_error(exc)
+
+
+async def attach_mission_control_run(
+    run_id: str,
+    principal: Annotated[MissionPrincipal, Depends(get_mission_principal)],
+    catalog: Annotated[MissionControlCatalog, Depends(get_mission_control)],
+) -> MissionRunPinResponse:
+    """Authorize first-person attachment for one accepted run pin."""
+
+    try:
+        return _pin_response(catalog.attach(principal, run_id))
+    except Exception as exc:
+        raise_api_error(exc)
+
+
+async def steer_mission_control_run(
+    run_id: str,
+    principal: Annotated[MissionPrincipal, Depends(get_mission_principal)],
+    catalog: Annotated[MissionControlCatalog, Depends(get_mission_control)],
+) -> MissionRunPinResponse:
+    """Authorize steering for one accepted run pin."""
+
+    try:
+        return _pin_response(catalog.steer(principal, run_id))
+    except Exception as exc:
+        raise_api_error(exc)
+
+
+async def takeover_mission_control_run(
+    run_id: str,
+    principal: Annotated[MissionPrincipal, Depends(get_mission_principal)],
+    catalog: Annotated[MissionControlCatalog, Depends(get_mission_control)],
+) -> MissionRunPinResponse:
+    """Authorize writable takeover for one accepted run pin."""
+
+    try:
+        return _pin_response(catalog.takeover(principal, run_id))
+    except Exception as exc:
+        raise_api_error(exc)
+
+
 def create_router() -> APIRouter:
     """Create one fresh Missions router for an API host installation."""
 
@@ -258,6 +401,43 @@ def create_router() -> APIRouter:
         get_task_card,
         methods=["GET"],
         response_model=dict[str, Any],
+    )
+    router.add_api_route(
+        "/v1/mission-control/runs",
+        submit_mission_control_run,
+        methods=["POST"],
+        response_model=MissionRunPinResponse,
+        status_code=status.HTTP_202_ACCEPTED,
+    )
+    router.add_api_route(
+        "/v1/mission-control/runs/{run_id}",
+        get_mission_control_run,
+        methods=["GET"],
+        response_model=MissionRunPinResponse,
+    )
+    router.add_api_route(
+        "/v1/mission-control/runs/{run_id}/cancel",
+        cancel_mission_control_run,
+        methods=["POST"],
+        response_model=MissionRunPinResponse,
+    )
+    router.add_api_route(
+        "/v1/mission-control/runs/{run_id}/attach",
+        attach_mission_control_run,
+        methods=["POST"],
+        response_model=MissionRunPinResponse,
+    )
+    router.add_api_route(
+        "/v1/mission-control/runs/{run_id}/steer",
+        steer_mission_control_run,
+        methods=["POST"],
+        response_model=MissionRunPinResponse,
+    )
+    router.add_api_route(
+        "/v1/mission-control/runs/{run_id}/takeover",
+        takeover_mission_control_run,
+        methods=["POST"],
+        response_model=MissionRunPinResponse,
     )
     return router
 

--- a/packages/archetype-missions/src/archetype/missions/control.py
+++ b/packages/archetype-missions/src/archetype/missions/control.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mission-control policy: capabilities, ownership, and profile pins.
+
+API transport authenticates a principal. This module authorizes the resulting
+operation against missions-owned profile and run-pin state. It does not
+construct Mission ECS entities or start provider work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from uuid_utils import uuid7
+
+from archetype.missions.execution_profiles import (
+    ExecutionProfile,
+    ExecutionProfileCatalog,
+    MissionProfileRequest,
+    PinnedExecutionProfile,
+    authorize_profile_request,
+)
+
+MISSION_CONTROL_CAPABILITY = {
+    "submit": "mission:submit",
+    "read": "mission:read",
+    "cancel": "mission:cancel",
+    "attach": "mission:attach",
+    "steer": "mission:steer",
+    "takeover": "mission:takeover",
+}
+_PROFILE_FLAGS = {
+    "mission:cancel": "allow_cancel",
+    "mission:attach": "allow_attach",
+    "mission:steer": "allow_steer",
+    "mission:takeover": "allow_takeover",
+}
+
+
+@runtime_checkable
+class MissionActor(Protocol):
+    """Authenticated mission caller consumed by missions-owned policy."""
+
+    principal_id: str
+    capabilities: frozenset[str]
+    allowed_profile_ids: frozenset[str]
+    granted_run_ids: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class MissionRunPin:
+    """Accepted run identity bound to one pinned execution profile.
+
+    Durable asynchronous execution belongs to MissionRun. This pin is the
+    server-owned profile/ownership fact required before that lifecycle.
+    """
+
+    run_id: str
+    owner_principal_id: str
+    profile_id: str
+    profile_version: str
+    profile_digest: str
+    granted_principal_ids: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        for label in (
+            "run_id",
+            "owner_principal_id",
+            "profile_id",
+            "profile_version",
+            "profile_digest",
+        ):
+            value = getattr(self, label)
+            if not isinstance(value, str) or not value.strip() or value.strip() != value:
+                raise ValueError(f"{label} must be a non-empty string")
+        object.__setattr__(
+            self,
+            "granted_principal_ids",
+            frozenset(self.granted_principal_ids),
+        )
+
+
+def require_capability(actor: MissionActor, capability: str) -> None:
+    """Fail closed when the principal lacks an explicit capability."""
+
+    if capability not in actor.capabilities:
+        raise PermissionError("Permission denied")
+
+
+def require_profile_access(actor: MissionActor, profile_id: str) -> None:
+    """Fail closed when the principal may not select this profile."""
+
+    if profile_id not in actor.allowed_profile_ids:
+        raise PermissionError("Permission denied")
+
+
+def require_profile_capability(profile: ExecutionProfile, capability: str) -> None:
+    """Fail closed when the pinned profile forbids an interactive capability."""
+
+    flag = _PROFILE_FLAGS.get(capability)
+    if flag is not None and not bool(getattr(profile, flag)):
+        raise PermissionError("Permission denied")
+
+
+def require_run_access(actor: MissionActor, pin: MissionRunPin) -> None:
+    """Fail closed unless the caller owns the run or holds an explicit grant."""
+
+    if pin.owner_principal_id == actor.principal_id:
+        return
+    if pin.run_id in actor.granted_run_ids:
+        return
+    if actor.principal_id in pin.granted_principal_ids:
+        return
+    raise PermissionError("Permission denied")
+
+
+class MissionControlCatalog:
+    """Process-local accepted-run pins over a versioned profile catalog."""
+
+    def __init__(self, profiles: ExecutionProfileCatalog) -> None:
+        self._profiles = profiles
+        self._pins: dict[str, MissionRunPin] = {}
+
+    @property
+    def profiles(self) -> ExecutionProfileCatalog:
+        """Return the immutable execution-profile catalog."""
+
+        return self._profiles
+
+    def submit(self, actor: MissionActor, request: MissionProfileRequest) -> MissionRunPin:
+        """Authorize submit, bind the current profile, and record the pin."""
+
+        require_capability(actor, MISSION_CONTROL_CAPABILITY["submit"])
+        require_profile_access(actor, request.profile_id)
+        profile = self._profiles.resolve(request.profile_id)
+        pinned = authorize_profile_request(profile, request)
+        pin = MissionRunPin(
+            run_id=str(uuid7()),
+            owner_principal_id=actor.principal_id,
+            profile_id=pinned.profile_id,
+            profile_version=pinned.version,
+            profile_digest=pinned.digest,
+        )
+        self._pins[pin.run_id] = pin
+        return pin
+
+    def pin_for(self, actor: MissionActor, run_id: str) -> MissionRunPin:
+        """Return one accepted pin after ownership and read authorization."""
+
+        return self._authorize_run(actor, run_id, MISSION_CONTROL_CAPABILITY["read"])
+
+    def cancel(self, actor: MissionActor, run_id: str) -> MissionRunPin:
+        """Authorize cancellation against ownership and profile policy."""
+
+        return self._authorize_run(actor, run_id, MISSION_CONTROL_CAPABILITY["cancel"])
+
+    def attach(self, actor: MissionActor, run_id: str) -> MissionRunPin:
+        """Authorize attachment against ownership and profile policy."""
+
+        return self._authorize_run(actor, run_id, MISSION_CONTROL_CAPABILITY["attach"])
+
+    def steer(self, actor: MissionActor, run_id: str) -> MissionRunPin:
+        """Authorize steering against ownership and profile policy."""
+
+        return self._authorize_run(actor, run_id, MISSION_CONTROL_CAPABILITY["steer"])
+
+    def takeover(self, actor: MissionActor, run_id: str) -> MissionRunPin:
+        """Authorize takeover against ownership and profile policy."""
+
+        return self._authorize_run(actor, run_id, MISSION_CONTROL_CAPABILITY["takeover"])
+
+    def grant(self, actor: MissionActor, run_id: str, grantee_principal_id: str) -> MissionRunPin:
+        """Grant another principal access to a run the actor owns."""
+
+        pin = self._require_pin(run_id)
+        if pin.owner_principal_id != actor.principal_id:
+            raise PermissionError("Permission denied")
+        if not isinstance(grantee_principal_id, str) or not grantee_principal_id.strip():
+            raise ValueError("grantee_principal_id must be a non-empty string")
+        updated = MissionRunPin(
+            run_id=pin.run_id,
+            owner_principal_id=pin.owner_principal_id,
+            profile_id=pin.profile_id,
+            profile_version=pin.profile_version,
+            profile_digest=pin.profile_digest,
+            granted_principal_ids=pin.granted_principal_ids | {grantee_principal_id.strip()},
+        )
+        self._pins[run_id] = updated
+        return updated
+
+    def replace_profiles(self, profiles: ExecutionProfileCatalog) -> None:
+        """Install a new catalog without rewriting existing pins."""
+
+        self._profiles = profiles
+
+    def _require_pin(self, run_id: str) -> MissionRunPin:
+        try:
+            return self._pins[run_id]
+        except KeyError:
+            raise KeyError(f"mission run {run_id!r} is not accepted") from None
+
+    def _authorize_run(self, actor: MissionActor, run_id: str, capability: str) -> MissionRunPin:
+        require_capability(actor, capability)
+        pin = self._require_pin(run_id)
+        require_run_access(actor, pin)
+        profile = self._profiles.resolve(
+            pin.profile_id,
+            version=pin.profile_version,
+            digest=pin.profile_digest,
+        )
+        require_profile_capability(profile, capability)
+        return pin
+
+
+__all__ = [
+    "MISSION_CONTROL_CAPABILITY",
+    "MissionActor",
+    "MissionControlCatalog",
+    "MissionRunPin",
+    "PinnedExecutionProfile",
+    "require_capability",
+    "require_profile_access",
+    "require_profile_capability",
+    "require_run_access",
+]

--- a/packages/archetype-missions/src/archetype/missions/execution_profiles.py
+++ b/packages/archetype-missions/src/archetype/missions/execution_profiles.py
@@ -1,0 +1,457 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Server-owned, versioned execution profiles for Agent Missions.
+
+Clients supply a ``profile_id``. The host owns provider, sandbox, model,
+budget, secret, and interactive-capability choices. An accepted run pins
+profile id, version, and canonical digest so later configuration changes
+cannot reinterpret that run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tomllib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from archetype.missions.contracts import RepositoryPublicationPolicy
+
+_PROFILES_PATH_ENV = "ARCHETYPE_MISSION_PROFILES_PATH"
+_DIGEST_FIELDS = (
+    "profile_id",
+    "version",
+    "allowed_repositories",
+    "allowed_base_refs",
+    "branch_namespace",
+    "sandbox_backend",
+    "sandbox_environment",
+    "agent_driver",
+    "critic_driver",
+    "model",
+    "timeout_seconds",
+    "max_ticks",
+    "max_retries",
+    "max_concurrency",
+    "cost_ceiling_usd_cents",
+    "max_validators_per_task",
+    "max_validator_timeout_seconds",
+    "publication_policy",
+    "checkpoint_after_dispatch",
+    "secret_names",
+    "provider_credential_names",
+    "allow_cancel",
+    "allow_attach",
+    "allow_steer",
+    "allow_takeover",
+)
+
+
+def _require_text(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value.strip() != value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _require_tuple(value: object, *, label: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list | tuple):
+        raise ValueError(f"{label} must be a list of strings")
+    items: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip() or item.strip() != item:
+            raise ValueError(f"{label} must contain non-empty strings")
+        items.append(item)
+    if len(set(items)) != len(items):
+        raise ValueError(f"{label} must not contain duplicates")
+    return tuple(items)
+
+
+def _require_positive_int(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _require_bool(value: object, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be a boolean")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionProfile:
+    """Immutable host-owned execution authority for one profile version."""
+
+    profile_id: str
+    version: str
+    allowed_repositories: tuple[str, ...]
+    allowed_base_refs: tuple[str, ...]
+    branch_namespace: str
+    sandbox_backend: str
+    sandbox_environment: str
+    agent_driver: str
+    critic_driver: str
+    model: str
+    timeout_seconds: int
+    max_ticks: int
+    max_retries: int
+    max_concurrency: int
+    cost_ceiling_usd_cents: int
+    max_validators_per_task: int
+    max_validator_timeout_seconds: int
+    publication_policy: RepositoryPublicationPolicy
+    checkpoint_after_dispatch: bool
+    secret_names: tuple[str, ...]
+    provider_credential_names: tuple[str, ...]
+    allow_cancel: bool
+    allow_attach: bool
+    allow_steer: bool
+    allow_takeover: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "profile_id", _require_text(self.profile_id, label="profile_id"))
+        object.__setattr__(self, "version", _require_text(self.version, label="version"))
+        repositories = _require_tuple(
+            self.allowed_repositories,
+            label="allowed_repositories",
+        )
+        if not repositories:
+            raise ValueError("allowed_repositories must not be empty")
+        object.__setattr__(self, "allowed_repositories", repositories)
+        refs = _require_tuple(self.allowed_base_refs, label="allowed_base_refs")
+        if not refs:
+            raise ValueError("allowed_base_refs must not be empty")
+        object.__setattr__(self, "allowed_base_refs", refs)
+        object.__setattr__(
+            self,
+            "branch_namespace",
+            _require_text(self.branch_namespace, label="branch_namespace"),
+        )
+        object.__setattr__(
+            self,
+            "sandbox_backend",
+            _require_text(self.sandbox_backend, label="sandbox_backend"),
+        )
+        object.__setattr__(
+            self,
+            "sandbox_environment",
+            _require_text(self.sandbox_environment, label="sandbox_environment"),
+        )
+        object.__setattr__(
+            self,
+            "agent_driver",
+            _require_text(self.agent_driver, label="agent_driver"),
+        )
+        object.__setattr__(
+            self,
+            "critic_driver",
+            _require_text(self.critic_driver, label="critic_driver"),
+        )
+        object.__setattr__(self, "model", _require_text(self.model, label="model"))
+        object.__setattr__(
+            self,
+            "timeout_seconds",
+            _require_positive_int(self.timeout_seconds, label="timeout_seconds"),
+        )
+        object.__setattr__(
+            self,
+            "max_ticks",
+            _require_positive_int(self.max_ticks, label="max_ticks"),
+        )
+        object.__setattr__(
+            self,
+            "max_retries",
+            _require_positive_int(self.max_retries, label="max_retries"),
+        )
+        object.__setattr__(
+            self,
+            "max_concurrency",
+            _require_positive_int(self.max_concurrency, label="max_concurrency"),
+        )
+        object.__setattr__(
+            self,
+            "cost_ceiling_usd_cents",
+            _require_positive_int(
+                self.cost_ceiling_usd_cents,
+                label="cost_ceiling_usd_cents",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_validators_per_task",
+            _require_positive_int(
+                self.max_validators_per_task,
+                label="max_validators_per_task",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_validator_timeout_seconds",
+            _require_positive_int(
+                self.max_validator_timeout_seconds,
+                label="max_validator_timeout_seconds",
+            ),
+        )
+        try:
+            policy = RepositoryPublicationPolicy(self.publication_policy)
+        except ValueError as exc:
+            raise ValueError("unsupported publication_policy") from exc
+        object.__setattr__(self, "publication_policy", policy)
+        object.__setattr__(
+            self,
+            "checkpoint_after_dispatch",
+            _require_bool(
+                self.checkpoint_after_dispatch,
+                label="checkpoint_after_dispatch",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "secret_names",
+            _require_tuple(self.secret_names, label="secret_names"),
+        )
+        object.__setattr__(
+            self,
+            "provider_credential_names",
+            _require_tuple(
+                self.provider_credential_names,
+                label="provider_credential_names",
+            ),
+        )
+        for flag in ("allow_cancel", "allow_attach", "allow_steer", "allow_takeover"):
+            object.__setattr__(self, flag, _require_bool(getattr(self, flag), label=flag))
+
+    @property
+    def canonical_payload(self) -> dict[str, Any]:
+        """Return the digestible profile document."""
+
+        payload: dict[str, Any] = {}
+        for field_name in _DIGEST_FIELDS:
+            value = getattr(self, field_name)
+            if isinstance(value, tuple):
+                payload[field_name] = list(value)
+            elif isinstance(value, RepositoryPublicationPolicy):
+                payload[field_name] = str(value)
+            else:
+                payload[field_name] = value
+        return payload
+
+    @property
+    def digest(self) -> str:
+        """Return the canonical identity of this profile version."""
+
+        encoded = json.dumps(
+            self.canonical_payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class PinnedExecutionProfile:
+    """Accepted profile identity that cannot be reinterpreted later."""
+
+    profile_id: str
+    version: str
+    digest: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "profile_id", _require_text(self.profile_id, label="profile_id"))
+        object.__setattr__(self, "version", _require_text(self.version, label="version"))
+        object.__setattr__(self, "digest", _require_text(self.digest, label="digest"))
+
+
+@dataclass(frozen=True, slots=True)
+class MissionProfileRequest:
+    """Client-supplied coordinates that a profile may admit."""
+
+    profile_id: str
+    repository: str
+    branch: str
+    base_ref: str = "main"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "profile_id", _require_text(self.profile_id, label="profile_id"))
+        object.__setattr__(self, "repository", _require_text(self.repository, label="repository"))
+        object.__setattr__(self, "branch", _require_text(self.branch, label="branch"))
+        object.__setattr__(self, "base_ref", _require_text(self.base_ref, label="base_ref"))
+
+
+def pin_profile(profile: ExecutionProfile) -> PinnedExecutionProfile:
+    """Pin the exact id, version, and digest of one profile."""
+
+    return PinnedExecutionProfile(
+        profile_id=profile.profile_id,
+        version=profile.version,
+        digest=profile.digest,
+    )
+
+
+def authorize_profile_request(
+    profile: ExecutionProfile,
+    request: MissionProfileRequest,
+) -> PinnedExecutionProfile:
+    """Admit client coordinates that stay inside the selected profile."""
+
+    if request.profile_id != profile.profile_id:
+        raise PermissionError("Permission denied")
+    if request.repository not in profile.allowed_repositories:
+        raise PermissionError("Permission denied")
+    if request.base_ref not in profile.allowed_base_refs:
+        raise PermissionError("Permission denied")
+    if not request.branch.startswith(profile.branch_namespace):
+        raise PermissionError("Permission denied")
+    return pin_profile(profile)
+
+
+def _profile_from_mapping(raw: Mapping[str, Any]) -> ExecutionProfile:
+    return ExecutionProfile(
+        profile_id=_require_text(raw.get("profile_id"), label="profile_id"),
+        version=_require_text(raw.get("version"), label="version"),
+        allowed_repositories=_require_tuple(
+            raw.get("allowed_repositories"),
+            label="allowed_repositories",
+        ),
+        allowed_base_refs=_require_tuple(raw.get("allowed_base_refs"), label="allowed_base_refs"),
+        branch_namespace=_require_text(raw.get("branch_namespace"), label="branch_namespace"),
+        sandbox_backend=_require_text(raw.get("sandbox_backend"), label="sandbox_backend"),
+        sandbox_environment=_require_text(
+            raw.get("sandbox_environment"),
+            label="sandbox_environment",
+        ),
+        agent_driver=_require_text(raw.get("agent_driver"), label="agent_driver"),
+        critic_driver=_require_text(raw.get("critic_driver"), label="critic_driver"),
+        model=_require_text(raw.get("model"), label="model"),
+        timeout_seconds=_require_positive_int(raw.get("timeout_seconds"), label="timeout_seconds"),
+        max_ticks=_require_positive_int(raw.get("max_ticks"), label="max_ticks"),
+        max_retries=_require_positive_int(raw.get("max_retries"), label="max_retries"),
+        max_concurrency=_require_positive_int(raw.get("max_concurrency"), label="max_concurrency"),
+        cost_ceiling_usd_cents=_require_positive_int(
+            raw.get("cost_ceiling_usd_cents"),
+            label="cost_ceiling_usd_cents",
+        ),
+        max_validators_per_task=_require_positive_int(
+            raw.get("max_validators_per_task"),
+            label="max_validators_per_task",
+        ),
+        max_validator_timeout_seconds=_require_positive_int(
+            raw.get("max_validator_timeout_seconds"),
+            label="max_validator_timeout_seconds",
+        ),
+        publication_policy=raw.get("publication_policy", "commit_and_push"),
+        checkpoint_after_dispatch=_require_bool(
+            raw.get("checkpoint_after_dispatch", True),
+            label="checkpoint_after_dispatch",
+        ),
+        secret_names=_require_tuple(raw.get("secret_names"), label="secret_names"),
+        provider_credential_names=_require_tuple(
+            raw.get("provider_credential_names"),
+            label="provider_credential_names",
+        ),
+        allow_cancel=_require_bool(raw.get("allow_cancel", False), label="allow_cancel"),
+        allow_attach=_require_bool(raw.get("allow_attach", False), label="allow_attach"),
+        allow_steer=_require_bool(raw.get("allow_steer", False), label="allow_steer"),
+        allow_takeover=_require_bool(raw.get("allow_takeover", False), label="allow_takeover"),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionProfileCatalog:
+    """Immutable (id, version) catalog with a current version per profile id."""
+
+    _profiles: dict[tuple[str, str], ExecutionProfile]
+    _current: dict[str, str]
+
+    def __init__(
+        self,
+        profiles: tuple[ExecutionProfile, ...] = (),
+    ) -> None:
+        by_key: dict[tuple[str, str], ExecutionProfile] = {}
+        current: dict[str, str] = {}
+        for profile in profiles:
+            key = (profile.profile_id, profile.version)
+            existing = by_key.get(key)
+            if existing is not None and existing.digest != profile.digest:
+                raise ValueError(
+                    f"profile {profile.profile_id!r} version {profile.version!r} "
+                    "changed its canonical digest"
+                )
+            by_key[key] = profile
+            current[profile.profile_id] = profile.version
+        object.__setattr__(self, "_profiles", by_key)
+        object.__setattr__(self, "_current", current)
+
+    @classmethod
+    def empty(cls) -> ExecutionProfileCatalog:
+        """Return a fail-closed catalog with no profiles."""
+
+        return cls()
+
+    @classmethod
+    def from_env(
+        cls,
+        environ: Mapping[str, str] | None = None,
+    ) -> ExecutionProfileCatalog:
+        """Load profiles from ``ARCHETYPE_MISSION_PROFILES_PATH`` if set."""
+
+        source = os.environ if environ is None else environ
+        configured = source.get(_PROFILES_PATH_ENV, "").strip()
+        if not configured:
+            return cls.empty()
+        path = Path(configured).expanduser()
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+        rows = document.get("profile", [])
+        if not isinstance(rows, list):
+            raise ValueError("mission profile document must contain [[profile]] tables")
+        return cls(tuple(_profile_from_mapping(row) for row in rows))
+
+    def resolve(
+        self,
+        profile_id: str,
+        *,
+        version: str | None = None,
+        digest: str | None = None,
+    ) -> ExecutionProfile:
+        """Return one immutable profile version, optionally checking its digest."""
+
+        resolved_version = version or self._current.get(profile_id)
+        if resolved_version is None:
+            raise KeyError(f"execution profile {profile_id!r} is not configured")
+        try:
+            profile = self._profiles[(profile_id, resolved_version)]
+        except KeyError:
+            raise KeyError(
+                f"execution profile {profile_id!r} version {resolved_version!r} is not configured"
+            ) from None
+        if digest is not None and profile.digest != digest:
+            raise ValueError("pinned execution profile digest does not match")
+        return profile
+
+    def pin(
+        self,
+        profile_id: str,
+        *,
+        version: str | None = None,
+    ) -> PinnedExecutionProfile:
+        """Resolve and pin one profile version."""
+
+        return pin_profile(self.resolve(profile_id, version=version))
+
+
+__all__ = [
+    "ExecutionProfile",
+    "ExecutionProfileCatalog",
+    "MissionProfileRequest",
+    "PinnedExecutionProfile",
+    "authorize_profile_request",
+    "pin_profile",
+]

--- a/packages/archetype-missions/tests/test_missions_extension.py
+++ b/packages/archetype-missions/tests/test_missions_extension.py
@@ -62,9 +62,18 @@ class _World:
 
 
 def _context(tmp_path: Path) -> WorldLibraryContext:
+    retained: dict[str, object] = {}
+
+    def retain_host_capability(name: str, value: object) -> None:
+        retained[name] = value
+
+    resources = SimpleNamespace(
+        retain_host_capability=retain_host_capability,
+        host_capabilities=retained,
+    )
     return WorldLibraryContext(
         registry=OperationRegistry(),
-        resources=SimpleNamespace(),
+        resources=resources,
         worlds=SimpleNamespace(),
         lifecycle=SimpleNamespace(),
         scheduler=SimpleNamespace(),
@@ -112,6 +121,7 @@ def test_install_registers_only_the_seven_declared_operations(tmp_path: Path) ->
     assert tuple(spec.model for spec in context.registry.specs) == MISSION_OPERATION_MODELS
     assert tuple(spec.name for spec in context.registry.specs) == get_manifest().operation_names
     assert all(spec.trusted and not spec.untrusted for spec in context.registry.specs)
+    assert "missions:control" in context.resources.host_capabilities
 
 
 def test_install_rejects_unknown_library_configuration(tmp_path: Path) -> None:

--- a/quality/api_import_boundaries.toml
+++ b/quality/api_import_boundaries.toml
@@ -69,9 +69,12 @@ allowed_dependencies = [
   "archetype.api.deps",
   "archetype.api.errors",
   "archetype.api.models",
+  "archetype.api.principals",
   "archetype.commands.dispatch",
   "archetype.commands.models",
   "archetype.missions.components",
+  "archetype.missions.control",
+  "archetype.missions.execution_profiles",
   "archetype.missions.relations",
   "archetype.world.models",
 ]
@@ -86,7 +89,7 @@ forbidden_dependencies = [
   "archetype.world.registry",
   "archetype.world.simulation",
 ]
-rationale = "The optional Missions transport adapter projects family state through framework API dependencies and the actor-aware dispatcher without acquiring workflow or composition authority"
+rationale = "The optional Missions transport adapter authenticates verified principals, projects family state, and authorizes profile-bound mission-control operations without acquiring workflow or composition authority"
 
 [public_api]
 targets = ["packages/archetype-ecs/src/archetype/**/*.py"]

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -274,6 +274,22 @@ benchmarks = []
 profiles = ["pr", "main", "release"]
 
 [[contract]]
+id = "missions.control.authenticated_profiles"
+source = "docs/guide/api-layer.md"
+section = "Mission-control authentication"
+owner = "api"
+risk = "high"
+pytest = [
+  "tests/api/test_mission_principals.py",
+  "tests/api/test_mission_control_routes.py",
+  "tests/missions/test_execution_profiles.py",
+]
+static = []
+evals = []
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
 id = "commands.identity.idempotent"
 source = "docs/guide/specification.md"
 section = "Command ledger, scheduler, and dispatcher"

--- a/tests/api/test_dispatch_contracts.py
+++ b/tests/api/test_dispatch_contracts.py
@@ -795,6 +795,12 @@ _EXPECTED_DECLARED_ROUTES = {
     ("GET", "/worlds/{world_id}/missions"): 200,
     ("GET", "/worlds/{world_id}/missions/{mission_id}/tasks"): 200,
     ("GET", "/worlds/{world_id}/tasks/{task_id}"): 200,
+    ("POST", "/v1/mission-control/runs"): 202,
+    ("GET", "/v1/mission-control/runs/{run_id}"): 200,
+    ("POST", "/v1/mission-control/runs/{run_id}/cancel"): 200,
+    ("POST", "/v1/mission-control/runs/{run_id}/attach"): 200,
+    ("POST", "/v1/mission-control/runs/{run_id}/steer"): 200,
+    ("POST", "/v1/mission-control/runs/{run_id}/takeover"): 200,
     ("GET", "/"): 200,
     ("GET", "/healthz"): 200,
 }
@@ -834,7 +840,7 @@ def test_supported_paths_statuses_and_response_shapes_are_unchanged() -> None:
     mission_routes = {
         key: value
         for key, value in _EXPECTED_DECLARED_ROUTES.items()
-        if "/missions" in key[1] or "/tasks/{task_id}" in key[1]
+        if "/missions" in key[1] or "/tasks/{task_id}" in key[1] or "/mission-control" in key[1]
     }
     framework_routes = {
         key: value for key, value in _EXPECTED_DECLARED_ROUTES.items() if key not in mission_routes

--- a/tests/api/test_mission_control_routes.py
+++ b/tests/api/test_mission_control_routes.py
@@ -1,0 +1,288 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP contracts for authenticated mission-control routes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from archetype.api.app import create_app
+from quality.secret_corpus import SECRET_LEAK_CORPUS
+
+_AGENT_TOKEN = "K" * 40
+_READER_TOKEN = "mission-reader-credential-bbbb"
+_STRANGER_TOKEN = "mission-stranger-credential-cccc"
+_SUBMIT_BODY = {
+    "profile_id": "coding-default",
+    "repository": "VangelisTech/archetype",
+    "branch": "agent/issue-808",
+    "base_ref": "main",
+}
+
+
+def _write_principals(path) -> None:
+    path.write_text(
+        """
+[[principal]]
+id = "agent"
+token_env = "ARCHETYPE_MISSION_PRINCIPAL_AGENT_TOKEN"
+capabilities = [
+  "mission:submit",
+  "mission:read",
+  "mission:cancel",
+  "mission:attach",
+  "mission:steer",
+  "mission:takeover",
+]
+allowed_profile_ids = ["coding-default"]
+
+[[principal]]
+id = "reader"
+token_env = "ARCHETYPE_MISSION_PRINCIPAL_READER_TOKEN"
+capabilities = ["mission:read"]
+allowed_profile_ids = ["coding-default"]
+
+[[principal]]
+id = "stranger"
+token_env = "ARCHETYPE_MISSION_PRINCIPAL_STRANGER_TOKEN"
+capabilities = ["mission:read", "mission:cancel"]
+allowed_profile_ids = ["coding-default"]
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_profiles(path) -> None:
+    path.write_text(
+        """
+[[profile]]
+profile_id = "coding-default"
+version = "1"
+allowed_repositories = ["VangelisTech/archetype"]
+allowed_base_refs = ["main"]
+branch_namespace = "agent/"
+sandbox_backend = "modal"
+sandbox_environment = "coding-agent:v1"
+agent_driver = "codex-app-server"
+critic_driver = "codex-app-server"
+model = "gpt-5"
+timeout_seconds = 3600
+max_ticks = 100
+max_retries = 3
+max_concurrency = 1
+cost_ceiling_usd_cents = 5000
+max_validators_per_task = 8
+max_validator_timeout_seconds = 900
+publication_policy = "commit_and_push"
+checkpoint_after_dispatch = true
+secret_names = ["codex-auth"]
+provider_credential_names = ["modal"]
+allow_cancel = true
+allow_attach = true
+allow_steer = true
+allow_takeover = true
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch) -> Iterator[TestClient]:
+    principals = tmp_path / "principals.toml"
+    profiles = tmp_path / "profiles.toml"
+    _write_principals(principals)
+    _write_profiles(profiles)
+    monkeypatch.setenv("ARCHETYPE_CATALOG_DIR", str(tmp_path / "catalogs"))
+    monkeypatch.setenv("ARCHETYPE_MISSION_PRINCIPALS_PATH", str(principals))
+    monkeypatch.setenv("ARCHETYPE_MISSION_PROFILES_PATH", str(profiles))
+    monkeypatch.setenv("ARCHETYPE_MISSION_PRINCIPAL_AGENT_TOKEN", _AGENT_TOKEN)
+    monkeypatch.setenv("ARCHETYPE_MISSION_PRINCIPAL_READER_TOKEN", _READER_TOKEN)
+    monkeypatch.setenv("ARCHETYPE_MISSION_PRINCIPAL_STRANGER_TOKEN", _STRANGER_TOKEN)
+    monkeypatch.setenv("ARCHETYPE_BIND_HOST", "127.0.0.1")
+    app = create_app()
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _assert_no_credentials(payload: str) -> None:
+    assert _AGENT_TOKEN not in payload
+    assert _READER_TOKEN not in payload
+    assert _STRANGER_TOKEN not in payload
+    for case in SECRET_LEAK_CORPUS:
+        assert case.payload not in payload
+
+
+def test_developer_routes_remain_on_loopback_developer_auth(client: TestClient) -> None:
+    anonymous = client.get("/healthz")
+    assert anonymous.status_code == 200
+    role = client.get("/worlds", headers=_auth("player"))
+    assert role.status_code == 200
+
+
+def test_mission_control_fails_closed_without_a_verified_principal(
+    client: TestClient,
+) -> None:
+    missing = client.post("/v1/mission-control/runs", json=_SUBMIT_BODY)
+    unknown = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers=_auth("mission-unknown-credential-zzzz"),
+    )
+    malformed = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers={"Authorization": "Basic abcdefghijklmnopqrstuvwxyz"},
+    )
+    role = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers=_auth("admin"),
+    )
+    for response in (missing, unknown, malformed, role):
+        assert response.status_code == 401
+        _assert_no_credentials(response.text)
+
+
+def test_submit_pins_the_selected_profile(client: TestClient) -> None:
+    response = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers=_auth(_AGENT_TOKEN),
+    )
+    assert response.status_code == 202, response.text
+    body = response.json()
+    assert body["owner_principal_id"] == "agent"
+    assert body["profile_id"] == "coding-default"
+    assert body["profile_version"] == "1"
+    assert len(body["profile_digest"]) == 64
+    assert body["state"] == "accepted"
+    _assert_no_credentials(response.text)
+    assert "modal" not in body
+    assert "gpt-5" not in response.text
+    assert "codex-auth" not in response.text
+
+
+def test_request_cannot_choose_host_execution_fields(client: TestClient) -> None:
+    for extra in (
+        {"model": "gpt-5"},
+        {"sandbox_backend": "modal"},
+        {"timeout_seconds": 12},
+        {"driver": "codex"},
+        {"secret": "codex-auth"},
+    ):
+        response = client.post(
+            "/v1/mission-control/runs",
+            json={**_SUBMIT_BODY, **extra},
+            headers=_auth(_AGENT_TOKEN),
+        )
+        assert response.status_code == 422, response.text
+        _assert_no_credentials(response.text)
+
+
+def test_request_cannot_leave_profile_allowlists(client: TestClient) -> None:
+    response = client.post(
+        "/v1/mission-control/runs",
+        json={**_SUBMIT_BODY, "repository": "other/repo"},
+        headers=_auth(_AGENT_TOKEN),
+    )
+    assert response.status_code == 403
+    _assert_no_credentials(response.text)
+
+
+def test_capabilities_are_enforced_per_route(client: TestClient) -> None:
+    created = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers=_auth(_AGENT_TOKEN),
+    )
+    run_id = created.json()["run_id"]
+    owner = client.app.state.mission_principals.authenticate(_AGENT_TOKEN)
+    catalog = client.app.state.resources.host_capability("missions:control")
+    catalog.grant(owner, run_id, "reader")
+    reader = _auth(_READER_TOKEN)
+
+    readable = client.get(f"/v1/mission-control/runs/{run_id}", headers=reader)
+    assert readable.status_code == 200, readable.text
+    for path in (
+        f"/v1/mission-control/runs/{run_id}/cancel",
+        f"/v1/mission-control/runs/{run_id}/attach",
+        f"/v1/mission-control/runs/{run_id}/steer",
+        f"/v1/mission-control/runs/{run_id}/takeover",
+    ):
+        denied = client.post(path, headers=reader)
+        assert denied.status_code == 403
+        _assert_no_credentials(denied.text)
+
+    submit_denied = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers=reader,
+    )
+    assert submit_denied.status_code == 403
+
+
+def test_foreign_principal_cannot_read_without_a_grant(client: TestClient) -> None:
+    created = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers=_auth(_AGENT_TOKEN),
+    )
+    run_id = created.json()["run_id"]
+    denied = client.get(
+        f"/v1/mission-control/runs/{run_id}",
+        headers=_auth(_STRANGER_TOKEN),
+    )
+    assert denied.status_code == 403
+    _assert_no_credentials(denied.text)
+
+    catalog = client.app.state.resources.host_capability("missions:control")
+    owner = client.app.state.mission_principals.authenticate(_AGENT_TOKEN)
+    catalog.grant(owner, run_id, "stranger")
+    allowed = client.get(
+        f"/v1/mission-control/runs/{run_id}",
+        headers=_auth(_STRANGER_TOKEN),
+    )
+    assert allowed.status_code == 200, allowed.text
+    assert allowed.json()["run_id"] == run_id
+
+
+def test_same_profile_version_digest_is_stable_across_submits(client: TestClient) -> None:
+    first = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers=_auth(_AGENT_TOKEN),
+    )
+    second = client.post(
+        "/v1/mission-control/runs",
+        json=_SUBMIT_BODY,
+        headers=_auth(_AGENT_TOKEN),
+    )
+    assert first.json()["profile_digest"] == second.json()["profile_digest"]
+    assert first.json()["run_id"] != second.json()["run_id"]
+
+
+def test_non_loopback_without_principals_cannot_run_missions(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ARCHETYPE_CATALOG_DIR", str(tmp_path / "catalogs"))
+    monkeypatch.delenv("ARCHETYPE_MISSION_PRINCIPALS_PATH", raising=False)
+    monkeypatch.setenv("ARCHETYPE_BIND_HOST", "0.0.0.0")
+    app = create_app()
+    with TestClient(app) as test_client:
+        assert test_client.get("/healthz").status_code == 200
+        denied = test_client.post(
+            "/v1/mission-control/runs",
+            json=_SUBMIT_BODY,
+            headers=_auth(_AGENT_TOKEN),
+        )
+        assert denied.status_code == 401
+        _assert_no_credentials(denied.text)

--- a/tests/api/test_mission_principals.py
+++ b/tests/api/test_mission_principals.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verified mission service-principal contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from archetype.api.principals import (
+    AuthenticationError,
+    MissionPrincipal,
+    MissionPrincipalDirectory,
+    is_loopback_host,
+    parse_bearer_credential,
+)
+
+_TOKEN = "mission-agent-credential-aaaa"
+_OTHER = "mission-reader-credential-bbbb"
+
+
+def _directory(**overrides: object) -> MissionPrincipalDirectory:
+    row = {
+        "id": "agent",
+        "token_env": "ARCHETYPE_MISSION_PRINCIPAL_AGENT_TOKEN",
+        "capabilities": ["mission:submit", "mission:read"],
+        "allowed_profile_ids": ["coding-default"],
+        **overrides,
+    }
+    return MissionPrincipalDirectory.from_provisioning(
+        (row,),
+        {"ARCHETYPE_MISSION_PRINCIPAL_AGENT_TOKEN": _TOKEN},
+    )
+
+
+def test_missing_and_malformed_credentials_fail_closed() -> None:
+    with pytest.raises(AuthenticationError, match="authentication required"):
+        parse_bearer_credential(None)
+    with pytest.raises(AuthenticationError, match="authentication required"):
+        parse_bearer_credential("   ")
+    with pytest.raises(AuthenticationError, match="invalid credentials"):
+        parse_bearer_credential("Basic abc")
+    with pytest.raises(AuthenticationError, match="invalid credentials"):
+        parse_bearer_credential("Bearer")
+    with pytest.raises(AuthenticationError, match="invalid credentials"):
+        parse_bearer_credential("Bearer admin")
+    with pytest.raises(AuthenticationError, match="invalid credentials"):
+        parse_bearer_credential("Bearer operator")
+
+
+def test_role_labels_are_never_accepted_as_credentials() -> None:
+    directory = _directory()
+    for role in ("admin", "operator", "player", "viewer"):
+        with pytest.raises(AuthenticationError, match="invalid credentials"):
+            directory.authenticate(role)
+        with pytest.raises(AuthenticationError):
+            parse_bearer_credential(f"Bearer {role}")
+
+
+def test_unknown_expired_and_revoked_credentials_fail_closed() -> None:
+    directory = _directory()
+    with pytest.raises(AuthenticationError, match="invalid credentials"):
+        directory.authenticate(_OTHER)
+
+    expired = _directory(expires_at=(datetime.now(UTC) - timedelta(seconds=1)).isoformat())
+    with pytest.raises(AuthenticationError, match="invalid credentials"):
+        expired.authenticate(_TOKEN)
+
+    revoked = _directory(revoked=True)
+    with pytest.raises(AuthenticationError, match="invalid credentials"):
+        revoked.authenticate(_TOKEN)
+
+
+def test_empty_directory_fails_closed() -> None:
+    with pytest.raises(AuthenticationError, match="invalid credentials"):
+        MissionPrincipalDirectory.empty().authenticate(_TOKEN)
+
+
+def test_valid_principal_is_stable_and_does_not_echo_the_credential() -> None:
+    directory = _directory()
+    principal = directory.authenticate(_TOKEN)
+    again = directory.authenticate(_TOKEN)
+
+    assert principal == again
+    assert principal.principal_id == "agent"
+    assert principal.capabilities == frozenset({"mission:submit", "mission:read"})
+    assert _TOKEN not in repr(directory)
+    assert _TOKEN not in repr(principal)
+    assert _TOKEN not in str(directory)
+
+
+def test_principal_id_cannot_be_a_developer_role() -> None:
+    with pytest.raises(ValueError, match="developer role"):
+        MissionPrincipal(
+            principal_id="admin",
+            capabilities=frozenset({"mission:read"}),
+            allowed_profile_ids=frozenset({"coding-default"}),
+        )
+
+
+def test_loopback_detection_and_non_loopback_fail_closed() -> None:
+    assert is_loopback_host("127.0.0.1")
+    assert is_loopback_host("localhost")
+    assert is_loopback_host("::1")
+    assert not is_loopback_host("0.0.0.0")
+    assert not is_loopback_host("192.168.1.9")
+
+    empty = MissionPrincipalDirectory.empty()
+    empty.require_non_loopback_configuration("127.0.0.1")
+    with pytest.raises(RuntimeError, match="non-loopback mission hosting"):
+        empty.require_non_loopback_configuration("0.0.0.0")
+    _directory().require_non_loopback_configuration("0.0.0.0")
+
+
+def test_errors_never_include_credential_material() -> None:
+    directory = _directory()
+    with pytest.raises(AuthenticationError) as caught:
+        directory.authenticate(_TOKEN + "-forged")
+    assert _TOKEN not in str(caught.value)
+    assert _TOKEN not in repr(caught.value)

--- a/tests/missions/test_execution_profiles.py
+++ b/tests/missions/test_execution_profiles.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Server-owned execution profile and mission-control policy contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from archetype.api.principals import MissionPrincipal
+from archetype.missions.control import MissionControlCatalog, MissionRunPin
+from archetype.missions.execution_profiles import (
+    ExecutionProfile,
+    ExecutionProfileCatalog,
+    MissionProfileRequest,
+    authorize_profile_request,
+)
+
+
+def _profile(**overrides: object) -> ExecutionProfile:
+    values: dict[str, object] = {
+        "profile_id": "coding-default",
+        "version": "1",
+        "allowed_repositories": ("VangelisTech/archetype",),
+        "allowed_base_refs": ("main",),
+        "branch_namespace": "agent/",
+        "sandbox_backend": "modal",
+        "sandbox_environment": "coding-agent:v1",
+        "agent_driver": "codex-app-server",
+        "critic_driver": "codex-app-server",
+        "model": "gpt-5",
+        "timeout_seconds": 3600,
+        "max_ticks": 100,
+        "max_retries": 3,
+        "max_concurrency": 1,
+        "cost_ceiling_usd_cents": 5000,
+        "max_validators_per_task": 8,
+        "max_validator_timeout_seconds": 900,
+        "publication_policy": "commit_and_push",
+        "checkpoint_after_dispatch": True,
+        "secret_names": ("codex-auth",),
+        "provider_credential_names": ("modal",),
+        "allow_cancel": True,
+        "allow_attach": True,
+        "allow_steer": True,
+        "allow_takeover": True,
+    }
+    values.update(overrides)
+    return ExecutionProfile(**values)  # type: ignore[arg-type]
+
+
+def _actor(*, capabilities: set[str], principal_id: str = "agent") -> MissionPrincipal:
+    return MissionPrincipal(
+        principal_id=principal_id,
+        capabilities=frozenset(capabilities),
+        allowed_profile_ids=frozenset({"coding-default"}),
+    )
+
+
+def _request(**overrides: str) -> MissionProfileRequest:
+    values = {
+        "profile_id": "coding-default",
+        "repository": "VangelisTech/archetype",
+        "branch": "agent/issue-808",
+        "base_ref": "main",
+    }
+    values.update(overrides)
+    return MissionProfileRequest(**values)
+
+
+def test_same_profile_id_and_version_always_resolve_to_the_same_digest() -> None:
+    first = _profile()
+    second = _profile()
+    catalog = ExecutionProfileCatalog((first, second))
+
+    assert first.digest == second.digest
+    assert catalog.resolve("coding-default").digest == first.digest
+    assert catalog.pin("coding-default").digest == first.digest
+
+
+def test_mutating_a_version_in_place_fails_closed() -> None:
+    original = _profile()
+    changed = _profile(model="other-model")
+    with pytest.raises(ValueError, match="canonical digest"):
+        ExecutionProfileCatalog((original, changed))
+
+
+def test_existing_pins_retain_meaning_after_a_new_current_version() -> None:
+    version_one = _profile()
+    control = MissionControlCatalog(ExecutionProfileCatalog((version_one,)))
+    actor = _actor(capabilities={"mission:submit", "mission:read"})
+    pin = control.submit(actor, _request())
+    original_digest = pin.profile_digest
+    assert pin.profile_version == "1"
+
+    version_two = _profile(version="2", model="gpt-5.1", max_ticks=50)
+    control.replace_profiles(ExecutionProfileCatalog((version_one, version_two)))
+    reread = control.pin_for(actor, pin.run_id)
+
+    assert reread.profile_digest == original_digest
+    assert control.profiles.resolve("coding-default").digest == version_two.digest
+    assert control.profiles.resolve("coding-default").digest != original_digest
+    assert control.profiles.resolve("coding-default", version="1").digest == original_digest
+
+
+def test_request_cannot_leave_the_selected_profile() -> None:
+    profile = _profile()
+    authorize_profile_request(profile, _request())
+    with pytest.raises(PermissionError, match="Permission denied"):
+        authorize_profile_request(profile, _request(repository="other/repo"))
+    with pytest.raises(PermissionError, match="Permission denied"):
+        authorize_profile_request(profile, _request(base_ref="release"))
+    with pytest.raises(PermissionError, match="Permission denied"):
+        authorize_profile_request(profile, _request(branch="main"))
+
+
+def test_capabilities_are_enforced_independently() -> None:
+    catalog = MissionControlCatalog(ExecutionProfileCatalog((_profile(),)))
+    owner = _actor(
+        capabilities={
+            "mission:submit",
+            "mission:read",
+            "mission:cancel",
+            "mission:attach",
+            "mission:steer",
+            "mission:takeover",
+        }
+    )
+    pin = catalog.submit(owner, _request())
+
+    for capability, method in (
+        ("mission:read", catalog.pin_for),
+        ("mission:cancel", catalog.cancel),
+        ("mission:attach", catalog.attach),
+        ("mission:steer", catalog.steer),
+        ("mission:takeover", catalog.takeover),
+    ):
+        allowed = _actor(capabilities={capability})
+        method(allowed, pin.run_id)
+        denied = _actor(capabilities={"mission:submit"})
+        with pytest.raises(PermissionError, match="Permission denied"):
+            method(denied, pin.run_id)
+
+
+def test_profile_flags_can_forbid_interactive_capabilities() -> None:
+    profile = _profile(
+        allow_cancel=False,
+        allow_attach=False,
+        allow_steer=False,
+        allow_takeover=False,
+    )
+    catalog = MissionControlCatalog(ExecutionProfileCatalog((profile,)))
+    owner = _actor(
+        capabilities={
+            "mission:submit",
+            "mission:cancel",
+            "mission:attach",
+            "mission:steer",
+            "mission:takeover",
+        }
+    )
+    pin = catalog.submit(owner, _request())
+    for method in (catalog.cancel, catalog.attach, catalog.steer, catalog.takeover):
+        with pytest.raises(PermissionError, match="Permission denied"):
+            method(owner, pin.run_id)
+
+
+def test_foreign_principal_requires_an_explicit_grant() -> None:
+    catalog = MissionControlCatalog(ExecutionProfileCatalog((_profile(),)))
+    owner = _actor(capabilities={"mission:submit", "mission:read"})
+    stranger = _actor(
+        principal_id="stranger",
+        capabilities={"mission:read"},
+    )
+    pin = catalog.submit(owner, _request())
+    with pytest.raises(PermissionError, match="Permission denied"):
+        catalog.pin_for(stranger, pin.run_id)
+
+    catalog.grant(owner, pin.run_id, "stranger")
+    reread = catalog.pin_for(stranger, pin.run_id)
+    assert reread.run_id == pin.run_id
+    assert reread.profile_digest == pin.profile_digest
+
+
+def test_pins_and_profiles_do_not_carry_credential_values() -> None:
+    secret = "sk-proj-" + "A" * 32
+    profile = _profile(secret_names=("codex-auth",))
+    pin = MissionRunPin(
+        run_id="run-1",
+        owner_principal_id="agent",
+        profile_id=profile.profile_id,
+        profile_version=profile.version,
+        profile_digest=profile.digest,
+    )
+    assert secret not in repr(profile)
+    assert secret not in repr(pin)
+    assert "codex-auth" in profile.secret_names

--- a/tests/scripts/test_generate_api_docs.py
+++ b/tests/scripts/test_generate_api_docs.py
@@ -63,6 +63,7 @@ def test_framework_and_missions_routes_use_explicit_compositions(
     assert "# Agent Missions REST API Reference" in missions_rest_reference
     assert "| Distribution | `archetype-missions` |" in missions_rest_reference
     assert "GET /worlds/{world_id}/missions" in missions_rest_reference
+    assert "POST /v1/mission-control/runs" in missions_rest_reference
     assert "GET /healthz" not in missions_rest_reference
 
 


### PR DESCRIPTION
## Summary
- Authenticate mission-control callers as verified service principals instead of developer-mode `Bearer <role>` identity (`Closes #808`).
- Bind accepted runs to a versioned, server-owned execution profile (id, version, canonical digest) so clients cannot choose sandbox, model, secrets, or budgets.
- Enforce `mission:submit|read|cancel|attach|steer|takeover` independently, plus resource ownership/grants. Existing ECS developer routes are unchanged.

Parent epic: #813. This PR does not implement durable `MissionRun` (#807) or the `/v1/mission-runs` REST surface (#809).

## Test plan
- [x] Missing, unknown, malformed, expired, revoked, and role-label credentials fail closed on mission-control routes
- [x] Capabilities are enforced independently for submit, read, cancel, attach, steer, and takeover
- [x] A principal cannot access another principal's runs without an explicit grant
- [x] Request bodies cannot carry host execution fields; repository/ref/branch must stay inside the profile
- [x] Same profile id/version always resolves to the same digest; existing pins retain meaning after a new current version
- [x] Credential-shaped corpus never appears in status, errors, or snapshots
- [x] Loopback developer routes remain unauthenticated; non-loopback mission-control stays fail-closed without principals
- [x] `make ci` passes


Made with [Cursor](https://cursor.com)