### PR TITLE
fix: harden release publication follow-ups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,7 +490,7 @@ jobs:
 
   publish-testpypi-libraries:
     name: Publish independently attested distributions to TestPyPI
-    needs: [authorize-release, testpypi-preflight]
+    needs: [authorize-release, testpypi-preflight, publish-testpypi]
     if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -691,7 +691,7 @@ jobs:
 
   publish-libraries:
     name: Publish independently attested distributions to PyPI
-    needs: [authorize-release, pypi-preflight]
+    needs: [authorize-release, pypi-preflight, publish]
     if: github.actor == 'everettVT' && github.triggering_actor == 'everettVT'
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,10 +209,13 @@ The exact canonical `vMAJOR.MINOR.PATCH` tag, including an annotated tag's peele
 commit, must still resolve to the workflow's original `GITHUB_SHA`. This narrows the
 final mutable-ref window without exposing the publish token to checked-out code.
 
-Before the first five-project release, register pending Trusted Publishers for the
-four new project names on both PyPI and TestPyPI. This preconfigures their OIDC
-identities; it does not reserve or claim the names. Each new name remains claimable
-until the first successful OIDC publication creates the project on that registry.
+For a first publication, register pending Trusted Publishers on both PyPI and
+TestPyPI. Each registry permits at most three pending projects per account, so a
+release adding more names must use the protected-environment two-wave procedure in
+the repository harness. This preconfigures OIDC identities; it does not reserve or
+claim the names. Each new name remains claimable until the first successful OIDC
+publication creates the project. Once created, the publisher is established and an
+ordinary patch release does not register it again.
 Every row uses repository `VangelisTech/archetype` and must be registered once with
 `release-testpypi` and once with `release-pypi`:
 

--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -678,6 +678,15 @@ copy for thread admission and never writes a refresh back. Give each
 concurrently active runtime its own Volume because v0.6 does not claim
 cross-runtime compare-and-swap over the mutable login credential.
 
+Release evidence does not treat `codex login status` as proof of usable model
+access. Before the repository mission, a separate Sandbox bound to the same
+workspace, Environment, App, and auth Volume completes one bounded real Codex
+turn through the normal thread-admission barrier. The barrier removes and
+verifies absence of `auth.json` before the model turn. Preflight and mission
+failures expose only a bounded category plus output length/digest summaries;
+raw stderr, error, friction, credentials, and provider URLs do not enter the
+release log.
+
 The GitHub Secret should contain a fine-grained, expiring token scoped to the
 one destination repository, with Metadata read and Contents read/write only.
 Do not grant Actions/Workflows, administration, or organization permissions.

--- a/docs/guide/release-0.6.md
+++ b/docs/guide/release-0.6.md
@@ -100,13 +100,18 @@ The 0.6 release is one coordinated set: five wheels and five source
 distributions at version `0.6.0`. Release evidence installs the base framework,
 each individual library with the framework, and the complete stack from those
 exact artifacts, plus Smol in isolation. A partial five-project publication is
-not a completed release. Before the first release, register pending Trusted
-Publishers for the four new
-project names on both PyPI and TestPyPI. Registration preconfigures OIDC; it does
-not reserve or claim a name, and each new name remains claimable until the first
+not a completed release. PyPI and TestPyPI allow at most three pending projects
+per account, while 0.6 introduced four names. Bootstrap each registry in two
+waves within the same release attempt: register pending Trusted Publishers for
+no more than three new projects, wait until those successful OIDC publications
+create the projects and free the pending slots, then register and approve the
+remaining waiting publisher. Registration preconfigures OIDC; it does not
+reserve or claim a name, and each new name remains claimable until the first
 successful OIDC publication creates the project on that registry. See
 [Repository harness](repository-harness.md) for the exact, package-specific
-OIDC identities and the direct-workflow bootstrap required for new projects.
+OIDC identities and protected-environment bootstrap sequence. All five projects,
+including `archetype-smol`, were claimed by v0.6.1; ordinary patch releases do
+not recreate pending publishers.
 
 Release publication also requires the live, pinned Biome scenario. The
 release-only proof runs on the same approved, one-job ephemeral Apple Silicon

--- a/docs/guide/repository-harness.md
+++ b/docs/guide/repository-harness.md
@@ -206,7 +206,16 @@ publisher matrix below. Every row uses repository `VangelisTech/archetype`.
 Register pending Trusted Publishers to preconfigure the OIDC identities for
 project names that do not yet exist. This registration does not reserve or
 claim a name: each new name remains claimable until the first successful OIDC
-publication creates the project on that registry.
+publication creates the project on that registry. Each registry permits at most
+three pending projects per account. When one coordinated release introduces
+more names, register the first wave only. After the established ECS publisher
+succeeds, the parent dispatches every package-specific workflow. Approve only
+the registered first-wave deployments; leave the remaining child waiting at
+its protected environment. Successful first-wave publication creates those
+projects and frees the pending slots. Register the remaining publisher, then
+approve its already-waiting deployment. Complete both waves within the same
+parent release attempt and its 45-minute coordinator timeout; an intentional
+child failure or parent rerun is not the bootstrap mechanism.
 Pending GitHub publishers are unique by repository, workflow, and environment,
 so multiple not-yet-created projects cannot all use `release.yml` with the same
 environment. PyPI also does not support reusable workflows as Trusted
@@ -334,11 +343,15 @@ gh workflow run release.yml \
 
 Approve `release-apple-macos` once; the admitted job runs Biome evidence and
 then Apple Container evidence in that order. After the exact-evidence gate
-succeeds, approve every pending `release-testpypi` deployment. Approve every
-pending `release-pypi` deployment only after the TestPyPI
-installed-distribution matrix succeeds. The ECS publisher remains in the parent
-run; each new distribution is a separately approved direct workflow run. The
-parent waits for the exact child run IDs and fails unless all of them succeed.
+succeeds, approve the parent ECS `release-testpypi` deployment. Only after that
+job succeeds does the parent dispatch the package-specific TestPyPI workflows;
+approve their deployments using the one- or two-wave procedure above. Approve
+the parent ECS `release-pypi` deployment only after the TestPyPI
+installed-distribution matrix succeeds. Its success similarly precedes the
+package-specific PyPI dispatch and approvals. The parent waits for the exact
+child run IDs and fails unless all of them succeed. Once all projects exist,
+their Trusted Publishers are established rather than pending, so ordinary patch
+releases simply approve all dispatched package-specific deployments.
 The ephemeral runner deregisters after the shared Mac job; discard its working
 directory before preparing a rerun or future release.
 
@@ -352,7 +365,7 @@ Release-lane authentication is explicit and provider-scoped:
 | Physical AI (Modal + R2) | The same scoped Modal and R2 credentials run one T4-backed seeded episode. Modal owns provider execution and immutable result blobs; the Archetype World commits intent and observation evidence to a unique R2 prefix, then a fresh runtime cold-resumes and reconciles the same digest without replay. |
 | Biome | No cloud credential is accepted. The explicitly enabled release target builds and launches the pinned upstream Biome/Flecs sources on the logged-in Mac, and the live test proves the active GUI/Metal process, loopback REST readiness, native mission result, durable Archetype evidence, and cleanup. |
 | Apple Container | A one-job ephemeral, bare-metal Apple Silicon runner in the exact-workflow-restricted `archetype-release-macos` group supplies the local host authority. It may run under the operator's current macOS account and bears `self-hosted`, `macOS`, `ARM64`, and `archetype-apple-container-macos-26`. The job provisions Python 3.12 through `uv`, verifies macOS 26, and starts the local `container` service; it creates no macOS login or `/Users/runner` tool cache, and accepts no Apple cloud token. GitHub-hosted arm64 macOS runners are not substitutes because they do not expose the Virtualization.framework VM support required by Apple Container. |
-| Modal Agent Mission | `MODAL_TOKEN_ID` plus `MODAL_TOKEN_SECRET` authenticate the Modal control plane. Actions repository variable `CODING_AGENT_MODAL_PROFILE` becomes the SDK selector `MODAL_PROFILE`; `CODING_AGENT_MODAL_ENVIRONMENT` becomes both the Archetype selector and SDK selector `MODAL_ENVIRONMENT`, while the workspace and remaining Environment-scoped variables bind all named objects. `CODEX_AUTH_VOLUME` supplies the separately device-authenticated Codex `auth.json`. `CODING_AGENT_GITHUB_SECRET` names the Modal Secret resolved for the isolated publisher, but the paid live lane deliberately pushes to a provider-local bare remote and never attaches that secret or mutates GitHub. Deterministic broker contracts separately prove that only the exact GitHub push process can receive `GITHUB_TOKEN`. Modal Connect Tokens authenticate the two transient viewport URLs. |
+| Modal Agent Mission | `MODAL_TOKEN_ID` plus `MODAL_TOKEN_SECRET` authenticate the Modal control plane. Actions repository variable `CODING_AGENT_MODAL_PROFILE` becomes the SDK selector `MODAL_PROFILE`; `CODING_AGENT_MODAL_ENVIRONMENT` becomes both the Archetype selector and SDK selector `MODAL_ENVIRONMENT`, while the workspace and remaining Environment-scoped variables bind all named objects. `CODEX_AUTH_VOLUME` supplies the separately device-authenticated Codex `auth.json`. Before repository setup, the exact-wheel lane creates a separate preflight Sandbox and completes one bounded real Codex turn through the same thread-admission and OAuth-scrub barrier; `codex login status` alone is not release evidence. A failure exposes only an allowlisted category and length/digest summaries. `CODING_AGENT_GITHUB_SECRET` names the Modal Secret resolved for the isolated publisher, but the paid live lane deliberately pushes to a provider-local bare remote and never attaches that secret or mutates GitHub. Deterministic broker contracts separately prove that only the exact GitHub push process can receive `GITHUB_TOKEN`. Modal Connect Tokens authenticate the two transient viewport URLs. |
 
 The operator-dispatched release workflow is serialized under one release
 concurrency group because its configured Codex auth Volume is a static mutable

--- a/scripts/release_agent_diagnostics.py
+++ b/scripts/release_agent_diagnostics.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Secret-safe diagnostics for paid coding-agent release evidence."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+
+_CLASSIFICATION_MARKERS = (
+    (
+        "provider_configuration",
+        (
+            "configured namespace",
+            "environment identity does not match",
+            "namespace lookup failed",
+            "workspace identity does not match",
+        ),
+    ),
+    (
+        "authentication",
+        (
+            "auth.json",
+            "authentication",
+            "credential",
+            "not logged in",
+            "oauth",
+            "refresh token",
+            "unauthorized",
+        ),
+    ),
+    ("rate_limit", ("quota", "rate limit", "usage limit")),
+    ("timeout", ("timed out", "timeout")),
+    (
+        "transport",
+        (
+            "connection refused",
+            "connection reset",
+            "dns",
+            "network",
+            "service unavailable",
+        ),
+    ),
+)
+_KNOWN_STATUSES = frozenset({"errored", "exited", "interrupted"})
+
+
+def bounded_text_summary(value: str, *, allowlisted_markers: Iterable[str] = ()) -> str:
+    """Return an allowlisted marker or only the length and digest of arbitrary text."""
+
+    stripped = value.strip()
+    markers = frozenset(allowlisted_markers)
+    if stripped in markers:
+        return stripped
+    digest = hashlib.sha256(value.encode()).hexdigest()[:16]
+    return f"unrecognized(length={len(value)},sha256={digest})"
+
+
+def classify_agent_failure(*values: str) -> str:
+    """Map private provider output to one bounded operational category."""
+
+    normalized = "\n".join(values).lower()
+    for classification, markers in _CLASSIFICATION_MARKERS:
+        if any(marker in normalized for marker in markers):
+            return classification
+    return "execution"
+
+
+def summarize_agent_failure(
+    *,
+    status: str,
+    returncode: int,
+    stdout: str = "",
+    stderr: str = "",
+    error: str = "",
+    friction_messages: Iterable[str] = (),
+    allowlisted_stdout: Iterable[str] = (),
+) -> str:
+    """Summarize one failure without returning raw agent or provider output."""
+
+    friction = tuple(friction_messages)
+    classification = classify_agent_failure(stderr, error, *friction)
+    safe_status = status if status in _KNOWN_STATUSES else "unknown"
+    return " ".join(
+        (
+            f"classification={classification}",
+            f"status={safe_status}",
+            f"returncode={returncode}",
+            f"stdout={bounded_text_summary(stdout, allowlisted_markers=allowlisted_stdout)}",
+            f"stderr={bounded_text_summary(stderr)}",
+            f"error={bounded_text_summary(error)}",
+            f"friction_count={len(friction)}",
+        )
+    )
+
+
+__all__ = [
+    "bounded_text_summary",
+    "classify_agent_failure",
+    "summarize_agent_failure",
+]

--- a/tests/infrastructure/test_modal_agent_mission_live.py
+++ b/tests/infrastructure/test_modal_agent_mission_live.py
@@ -29,7 +29,10 @@ from archetype.missions.coding_agents import (
     CodingAgentHarness,
     CodingAgentHarnessConfig,
 )
-from archetype.missions.coding_agents.app_server import CodexAppServerDriver
+from archetype.missions.coding_agents.app_server import (
+    CodexAppServerDriver,
+    run_codex_app_server_turn,
+)
 from archetype.missions.coding_agents.contracts import (
     DispatchedValidator,
     TaskDispatchRequest,
@@ -46,10 +49,15 @@ from archetype.missions.sandboxes import (
     SandboxSpec,
     SandboxStatus,
 )
+from scripts.release_agent_diagnostics import (
+    bounded_text_summary,
+    summarize_agent_failure,
+)
 
 _LIVE = os.environ.get("ARCHETYPE_MODAL_AGENT_MISSION_LIVE") == "1"
 _PROOF = "archetype-modal-live-steer-v1\n"
 _FINAL_MESSAGE = "ARCHETYPE_MODAL_LIVE_OK"
+_PREFLIGHT_MESSAGE = "ARCHETYPE_MODAL_AUTH_OK"
 _OBSERVATION_ROOT = "/tmp/archetype-agent-missions/live"
 _REMOTE = "/workspace/origin.git"
 _BRANCH = "agent/modal-live"
@@ -223,11 +231,8 @@ exit 1
         probe.cancel()
         await asyncio.gather(probe, return_exceptions=True)
         observation = await harness_task
-        raise AssertionError(
-            "Codex turn completed before the writable TUI lane opened: "
-            f"status={observation.status.value} "
-            f"agent_returncode={observation.agent_returncode}"
-        )
+        summary = _safe_agent_failure_summary(observation)
+        raise AssertionError(f"Codex turn completed before the writable TUI lane opened: {summary}")
     result = await probe
     return _assert_success(result, "wait for Modal session_ready").strip()
 
@@ -356,18 +361,87 @@ async def _viewport_websocket_screen(
 
 
 def _safe_agent_output_summary(value: str) -> str:
-    stripped = value.strip()
     known_markers = {
         _FINAL_MESSAGE,
         "LIVE_MODAL_MISSING_STEER",
         "LIVE_MODAL_CREDENTIAL_EXPOSED",
     }
-    if stripped in known_markers:
-        return stripped
-    digest = hashlib.sha256(value.encode()).hexdigest()[:16]
-    if _FINAL_MESSAGE in value:
-        return f"{_FINAL_MESSAGE}+extra(length={len(value)},sha256={digest})"
-    return f"unrecognized(length={len(value)},sha256={digest})"
+    return bounded_text_summary(value, allowlisted_markers=known_markers)
+
+
+def _safe_agent_failure_summary(observation: AgentExecutionResult) -> str:
+    return summarize_agent_failure(
+        status=observation.status.value,
+        returncode=observation.agent_returncode,
+        stdout=observation.agent_stdout,
+        stderr=observation.agent_stderr,
+        error=observation.error,
+        friction_messages=(finding.message for finding in observation.friction),
+        allowlisted_stdout=(
+            _FINAL_MESSAGE,
+            "LIVE_MODAL_MISSING_STEER",
+            "LIVE_MODAL_CREDENTIAL_EXPOSED",
+        ),
+    )
+
+
+async def _create_modal_session(
+    backend: ModalSandboxBackend,
+    *,
+    evidence: str,
+) -> ModalSandboxSession:
+    session = await backend.create(
+        SandboxSpec(
+            provider="modal",
+            environment=backend.environment,
+            workdir="/workspace/repo",
+            timeout_seconds=12 * 60,
+            idle_timeout_seconds=5 * 60,
+            metadata=(("evidence", evidence),),
+        )
+    )
+    assert isinstance(session, ModalSandboxSession)
+    return session
+
+
+async def _preflight_codex_subscription(backend: ModalSandboxBackend) -> None:
+    """Prove the exact namespace and subscription before the repository mission."""
+
+    session = await _create_modal_session(backend, evidence="modal-codex-auth-preflight")
+    try:
+        workspace = await _remote_exec(session, "mkdir", "-p", "/workspace/repo")
+        _assert_success(workspace, "create Modal Codex preflight workspace")
+        observation = await run_codex_app_server_turn(
+            session,
+            connector=ModalCodexAppServerConnector(),
+            workspace="/workspace/repo",
+            prompt=(
+                "This is an authentication preflight. Do not call tools. Reply with exactly "
+                f"{_PREFLIGHT_MESSAGE} and nothing else."
+            ),
+            timeout_seconds=90,
+        )
+        if observation.returncode != 0 or observation.stdout.strip() != _PREFLIGHT_MESSAGE:
+            summary = summarize_agent_failure(
+                status="exited",
+                returncode=observation.returncode,
+                stdout=observation.stdout,
+                stderr=observation.stderr,
+                allowlisted_stdout=(_PREFLIGHT_MESSAGE,),
+            )
+            raise AssertionError(f"Modal Codex authentication preflight failed: {summary}")
+        credential_absent = await _remote_exec(
+            session,
+            "test",
+            "!",
+            "-e",
+            "/root/.codex/auth.json",
+        )
+        _assert_success(credential_absent, "verify preflight credential cleanup")
+    finally:
+        await session.close()
+
+    assert await session.status() is SandboxStatus.CLOSED
 
 
 async def test_modal_codex_harness_steers_validates_publishes_and_cleans_up() -> None:
@@ -387,17 +461,8 @@ async def test_modal_codex_harness_steers_validates_publishes_and_cleans_up() ->
     # The release scenario registry separately requires the token pair in CI.
 
     backend = ModalSandboxBackend(config)
-    session = await backend.create(
-        SandboxSpec(
-            provider="modal",
-            environment=backend.environment,
-            workdir="/workspace/repo",
-            timeout_seconds=12 * 60,
-            idle_timeout_seconds=5 * 60,
-            metadata=(("evidence", "modal-agent-mission-live"),),
-        )
-    )
-    assert isinstance(session, ModalSandboxSession)
+    await _preflight_codex_subscription(backend)
+    session = await _create_modal_session(backend, evidence="modal-agent-mission-live")
     harness_task: asyncio.Task[AgentExecutionResult] | None = None
     try:
         initialized = await _remote_exec(
@@ -501,9 +566,11 @@ rm -rf -- /workspace/seed
 
         observation = await asyncio.wait_for(harness_task, timeout=5 * 60)
         if observation.status is not AgentExecutionStatus.EXITED:
-            raise AssertionError("the live repository harness did not exit normally")
+            summary = _safe_agent_failure_summary(observation)
+            raise AssertionError(f"the live repository harness did not exit normally: {summary}")
         if observation.agent_returncode != 0:
-            raise AssertionError("the live Codex app-server turn returned nonzero")
+            summary = _safe_agent_failure_summary(observation)
+            raise AssertionError(f"the live Codex app-server turn returned nonzero: {summary}")
         if len(observation.validation) != 1 or not observation.validation[0].passed:
             summary = _safe_agent_output_summary(observation.agent_stdout)
             raise AssertionError(

--- a/tests/scripts/test_quality_workflow.py
+++ b/tests/scripts/test_quality_workflow.py
@@ -471,6 +471,10 @@ def test_live_modal_release_scenario_is_credentialed_and_opted_in() -> None:
         "infrastructure:CODING_AGENT_GITHUB_SECRET",
     }
     assert "ARCHETYPE_MODAL_AGENT_MISSION_LIVE=1" in MAKEFILE.read_text(encoding="utf-8")
+    live_test = (ROOT / modal["source_path"]).read_text(encoding="utf-8")
+    assert "await _preflight_codex_subscription(backend)" in live_test
+    assert "run_codex_app_server_turn(" in live_test
+    assert "summarize_agent_failure(" in live_test
 
 
 def test_live_physical_ai_release_scenario_binds_modal_compute_to_r2() -> None:
@@ -668,6 +672,9 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         in test_preflight
     )
     assert "needs: [authorize-release, testpypi-preflight]" in publish_test
+    assert (
+        "needs: [authorize-release, testpypi-preflight, publish-testpypi]" in publish_test_libraries
+    )
     assert "environment: release-testpypi" in publish_test
     assert "repository-url: https://test.pypi.org/legacy/" in publish_test
     assert "needs: [publish-testpypi, publish-testpypi-libraries]" in test_smoke
@@ -692,6 +699,7 @@ def test_release_workflow_aggregates_platform_evidence_before_publish() -> None:
         in pypi_preflight
     )
     assert "needs: [authorize-release, pypi-preflight]" in publish
+    assert "needs: [authorize-release, pypi-preflight, publish]" in publish_libraries
     assert "needs: [publish, publish-libraries]" in registry_smoke
     assert "scripts/verify_release_index.py" in registry_smoke
     assert "scripts/registry_smoke.py" in registry_smoke

--- a/tests/scripts/test_release_agent_diagnostics.py
+++ b/tests/scripts/test_release_agent_diagnostics.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for secret-safe coding-agent release diagnostics."""
+
+from __future__ import annotations
+
+from scripts.release_agent_diagnostics import (
+    bounded_text_summary,
+    classify_agent_failure,
+    summarize_agent_failure,
+)
+
+
+def test_bounded_text_summary_emits_only_exact_allowlisted_markers() -> None:
+    marker = "ARCHETYPE_MODAL_AUTH_OK"
+
+    assert bounded_text_summary(marker, allowlisted_markers=(marker,)) == marker
+    summary = bounded_text_summary(f"token=secret {marker}", allowlisted_markers=(marker,))
+
+    assert summary.startswith("unrecognized(length=")
+    assert "secret" not in summary
+    assert marker not in summary
+
+
+def test_failure_classification_is_bounded() -> None:
+    assert classify_agent_failure("OAuth refresh token expired") == "authentication"
+    assert classify_agent_failure("workspace identity does not match") == ("provider_configuration")
+    assert classify_agent_failure("request timed out") == "timeout"
+    assert classify_agent_failure("unexpected exit") == "execution"
+
+
+def test_failure_summary_does_not_disclose_provider_output() -> None:
+    secret = "ghp_do-not-print"
+    summary = summarize_agent_failure(
+        status="exited",
+        returncode=1,
+        stdout=f"stdout {secret}",
+        stderr=f"Unauthorized credential {secret}",
+        error=f"OAuth failed for {secret}",
+        friction_messages=(f"refresh token rejected: {secret}",),
+    )
+
+    assert "classification=authentication" in summary
+    assert "status=exited" in summary
+    assert "returncode=1" in summary
+    assert "friction_count=1" in summary
+    assert secret not in summary
+    assert "Unauthorized" not in summary

--- a/tests/scripts/test_world_library_docs.py
+++ b/tests/scripts/test_world_library_docs.py
@@ -110,6 +110,21 @@ def test_pending_trusted_publishers_do_not_claim_new_project_names() -> None:
         assert "remains claimable until the first successful oidc publication" in content
 
 
+def test_first_publication_runbook_stages_pending_publishers_without_reruns() -> None:
+    release_note = " ".join(
+        (ROOT / "docs/guide/release-0.6.md").read_text(encoding="utf-8").split()
+    )
+    harness = " ".join(
+        (ROOT / "docs/guide/repository-harness.md").read_text(encoding="utf-8").split()
+    )
+
+    assert "at most three pending projects" in release_note
+    assert "two waves within the same release attempt" in release_note
+    assert "including `archetype-smol`, were claimed by v0.6.1" in release_note
+    assert "leave the remaining child waiting at" in harness
+    assert "an intentional child failure or parent rerun is not the bootstrap mechanism" in harness
+
+
 def test_contributing_names_each_trusted_publisher_workflow() -> None:
     contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- serialize package-specific publisher dispatch behind the protected ECS publication for each registry
- preflight the exact Modal/Codex namespace with a bounded real model turn before repository setup
- emit only categorized, length/digest-bounded diagnostics for early Codex failures
- document the two-wave pending-publisher bootstrap and the established v0.6.1 Smol publisher

## Root cause

The v0.6.1 release exposed three independent harness gaps:

1. Protected ECS publication and package-specific dispatch were sibling jobs. While the ECS job awaited approval, GitHub reported the parent run as waiting rather than in progress, so child authorization failed closed.
2. The Modal lane trusted configuration and login status until the full mission. Its early-exit assertion omitted the retained stderr/error/friction evidence, leaving only a nonzero return code.
3. The first-publication docs instructed maintainers to register four pending projects even though each registry permits only three.

## Impact

Normal releases now publish ECS before dispatching library workflows. The Modal lane proves actual model access through the existing OAuth-scrub barrier before touching a repository, while keeping provider output secret-safe. First-time publishers can use two protected-environment waves within one parent attempt; ordinary patch releases reuse the established publishers.

Closes #815.
Closes #816.
Closes #817.

## Validation

- `make ci`
  - static validation passed
  - 3,254 tests passed, 22 skipped
  - all five wheels and sdists built
  - installed distribution matrix passed for base, missions, physical-ai, research, all, Smol, and sdist probes
- focused release workflow, diagnostics, documentation, and live-test collection contracts passed

The paid Modal live scenario was not rerun at PR cadence; the next release execution remains the real-provider oracle for the new preflight.
