### PR TITLE
feat(mcp): ship Archetype's native agent-facing Mission tool server

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -1180,6 +1180,53 @@ its execution sandbox after publishing exact evidence. Modal is paid and
 credentialed, so it remains an explicit release operation rather than ordinary
 CI.
 
+## 11. Mission MCP server
+
+Archetype ships a native agent-facing MCP server (issue #810) as the
+`archetype-missions-mcp` console entry point (equivalently
+`python -m archetype.missions.mcp`), implemented in
+`archetype.missions.mcp`. It is a thin typed stdio adapter over the
+supported MissionRun REST contract (issue #809): Archetype remains mission
+and policy authority, and the MCP process is replaceable transport.
+
+Tool surface — exactly six asynchronous tools: `mission_submit` (returns
+immediately with `run_id` and status coordinates), `mission_get`,
+`mission_events` (opaque cursor plus clamped limit), `mission_result`,
+`mission_cancel`, and `mission_list` (scoped to the authenticated
+principal). Interactive attachment tools belong to issue #811 and are
+absent, never stubbed.
+
+Boundaries:
+
+- Trusted host configuration only: `ARCHETYPE_MISSIONS_MCP_URL`,
+  `ARCHETYPE_MISSIONS_MCP_CREDENTIAL` (or `..._CREDENTIAL_FILE`),
+  `ARCHETYPE_MISSIONS_MCP_TIMEOUT_SECONDS`,
+  `ARCHETYPE_MISSIONS_MCP_MAX_EVENTS_PAGE`,
+  `ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES`,
+  `ARCHETYPE_MISSIONS_MCP_MAX_TASKS`, and
+  `ARCHETYPE_MISSIONS_MCP_MAX_PROMPT_BYTES` are read once at process
+  start. Tool arguments carry domain inputs and opaque ids only; a model
+  can never supply a URL, bearer token, REST path or method, execution
+  backend, secret, or configuration override, and the client never
+  follows redirects.
+- `mission_submit` requires an explicit call and a caller-owned
+  `idempotency_key` forwarded as the `Idempotency-Key` header, so submit
+  retries — including from a fresh process after a crash — converge on
+  the original run and cancellation stays idempotent by `run_id`.
+- JSON-RPC stdout carries protocol frames only; diagnostics go to
+  bounded stderr with credential redaction. Tool results are bounded by
+  the host byte limit and say explicitly when content is truncated.
+- MCP conformance: `initialize`, the `initialized` notification,
+  `tools/list`, `tools/call`, and `ping` work on the supported protocol
+  versions; unsupported request methods return `-32601`.
+
+Contract seam: until issue #809 lands, the executable oracle is the
+offline fake server in `tests/missions/mcp/conftest.py`, which implements
+the documented REST contract; `tests/missions/mcp/test_mission_mcp_live_loopback.py`
+activates route-drift enforcement when `archetype.missions.api` ships
+`/v1/mission-runs` and keeps the live loopback proof as an explicitly
+skipped test until a served surface exists.
+
 ## Companion contracts
 
 - [Runtime](runtime.md)

--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -1202,7 +1202,8 @@ Boundaries:
   `ARCHETYPE_MISSIONS_MCP_CREDENTIAL` (or `..._CREDENTIAL_FILE`),
   `ARCHETYPE_MISSIONS_MCP_TIMEOUT_SECONDS`,
   `ARCHETYPE_MISSIONS_MCP_MAX_EVENTS_PAGE`, and
-  `ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES` are read once at process
+  `ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES` (minimum 256, so the
+  truncation envelope always fits) are read once at process
   start; input caps (32 tasks, 64 KiB prompt bytes) are fixed module
   constants. Tool arguments carry domain inputs and opaque ids only; a model
   can never supply a URL, bearer token, REST path or method, execution

--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -1201,11 +1201,10 @@ Boundaries:
 - Trusted host configuration only: `ARCHETYPE_MISSIONS_MCP_URL`,
   `ARCHETYPE_MISSIONS_MCP_CREDENTIAL` (or `..._CREDENTIAL_FILE`),
   `ARCHETYPE_MISSIONS_MCP_TIMEOUT_SECONDS`,
-  `ARCHETYPE_MISSIONS_MCP_MAX_EVENTS_PAGE`,
-  `ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES`,
-  `ARCHETYPE_MISSIONS_MCP_MAX_TASKS`, and
-  `ARCHETYPE_MISSIONS_MCP_MAX_PROMPT_BYTES` are read once at process
-  start. Tool arguments carry domain inputs and opaque ids only; a model
+  `ARCHETYPE_MISSIONS_MCP_MAX_EVENTS_PAGE`, and
+  `ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES` are read once at process
+  start; input caps (32 tasks, 64 KiB prompt bytes) are fixed module
+  constants. Tool arguments carry domain inputs and opaque ids only; a model
   can never supply a URL, bearer token, REST path or method, execution
   backend, secret, or configuration override, and the client never
   follows redirects.

--- a/docs/reference/contract-traceability.md
+++ b/docs/reference/contract-traceability.md
@@ -64,6 +64,7 @@ machine authority; this page is its review surface.
 | `missions.sandbox.checkpoint_restore` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — Supported sandbox backends | pytest: 3 | `pr`, `main`, `release` |
 | `release.package.installable` | `release` | high | [docs/guide/api-stability.md](../guide/api-stability.md) — What counts as public | pytest: 2; static: 1 | `release` |
 | `storage.remote.control_parity` | `storage` | high | [docs/guide/application-architecture.md](../guide/application-architecture.md) — 10. Supported durability profile | pytest: 2; static: 1 | `main`, `release` |
+| `missions.mcp.trusted_host_adapter` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 11. Mission MCP server | pytest: 3 | `pr`, `main`, `release` |
 | `missions.agent_v1.public_authoring` | `missions` | medium | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 2. Public authoring surface | pytest: 2 | `pr`, `main`, `release` |
 | `missions.agent_v1.validator_gated` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — 4. State and transition protocol | pytest: 7; static: 2 | `pr`, `main`, `release` |
 | `missions.agent_v1.exact_head_critic` | `missions` | high | [docs/guide/agent-missions.md](../guide/agent-missions.md) — Independent exact-head critic | pytest: 4 | `pr`, `main`, `release` |

--- a/packages/archetype-missions/pyproject.toml
+++ b/packages/archetype-missions/pyproject.toml
@@ -21,11 +21,15 @@ dependencies = [
     "daft>=0.7.19",
     "pydantic>=2.0",
     "fastapi>=0.110",
+    "httpx>=0.27",
     "uuid-utils>=0.11.0",
 ]
 
 [project.optional-dependencies]
 modal = ["modal==1.5.2"]
+
+[project.scripts]
+archetype-missions-mcp = "archetype.missions.mcp.server:main"
 
 [project.entry-points."archetype.world_libraries"]
 missions = "archetype.missions._extension:get_manifest"

--- a/packages/archetype-missions/src/archetype/missions/mcp/__init__.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Archetype's native agent-facing Mission MCP server (issue #810).
+
+A thin typed stdio adapter over the supported MissionRun REST contract
+(issue #809). Archetype remains mission and policy authority; this process
+is replaceable transport. Base URL, credential, TLS policy, and limits come
+exclusively from trusted host configuration (:mod:`archetype.missions.mcp.config`);
+tool arguments carry domain inputs and opaque ids only.
+"""
+
+from archetype.missions.mcp.config import McpHostConfig, McpHostConfigError
+from archetype.missions.mcp.server import MissionMcpServer, main
+
+__all__ = [
+    "McpHostConfig",
+    "McpHostConfigError",
+    "MissionMcpServer",
+    "main",
+]

--- a/packages/archetype-missions/src/archetype/missions/mcp/__main__.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/__main__.py
@@ -1,0 +1,9 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module entry point: ``python -m archetype.missions.mcp``."""
+
+from archetype.missions.mcp.server import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/archetype-missions/src/archetype/missions/mcp/client.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/client.py
@@ -30,6 +30,10 @@ from archetype.missions.mcp.config import McpHostConfig
 # injection at the validation boundary.
 _OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
 
+#: Advertised in every opaque-id tool schema; the same expression
+#: :func:`require_opaque_id` enforces at runtime.
+OPAQUE_ID_PATTERN = _OPAQUE_ID.pattern
+
 _RUNS_PATH = "/v1/mission-runs"
 
 
@@ -102,7 +106,7 @@ class MissionRunClient:
     ) -> dict[str, Any]:
         key = require_opaque_id(idempotency_key, label="idempotency_key")
         body = {
-            "profile_id": require_opaque_id(profile_id, label="profile_id"),
+            "profile_id": profile_id,
             "repository": repository,
             "ref": ref,
             "mission": mission,
@@ -120,7 +124,9 @@ class MissionRunClient:
         path = f"{_RUNS_PATH}/{require_opaque_id(run_id, label='run_id')}"
         return self._payload(self._request("GET", path), ok={200})
 
-    def events(self, run_id: str, *, after: str | None, limit: int | None) -> dict[str, Any]:
+    def events(
+        self, run_id: str, *, after: str | None = None, limit: int | None = None
+    ) -> dict[str, Any]:
         path = f"{_RUNS_PATH}/{require_opaque_id(run_id, label='run_id')}/events"
         params: dict[str, str] = {"limit": str(self._clamped_limit(limit))}
         if after is not None:
@@ -135,7 +141,7 @@ class MissionRunClient:
         path = f"{_RUNS_PATH}/{require_opaque_id(run_id, label='run_id')}/cancel"
         return self._payload(self._request("POST", path), ok={200, 202})
 
-    def list_runs(self, *, limit: int | None) -> dict[str, Any]:
+    def list_runs(self, *, limit: int | None = None) -> dict[str, Any]:
         params = {"limit": str(self._clamped_limit(limit))}
         return self._payload(self._request("GET", _RUNS_PATH, params=params), ok={200})
 

--- a/packages/archetype-missions/src/archetype/missions/mcp/client.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/client.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed HTTP adapter over the supported MissionRun REST contract.
+
+The client exposes exactly the six documented mission-control operations
+(issue #809). There is no generic request surface: paths are fixed
+templates, opaque ids are validated before they may enter a URL or header,
+and the client never follows a redirect, so a response cannot re-aim it at
+another origin. Error text stays bounded and carries no credential bytes.
+
+Seam (issue #810): field names for the submit body mirror issue #809's
+documented contract. When the REST models land, the drift test in
+``tests/missions/mcp/test_mission_mcp_live_loopback.py`` binds this module
+to them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+
+from archetype.missions.mcp.config import McpHostConfig
+
+# Opaque ids may enter a URL path segment, query value, or header value.
+# The charset therefore excludes separators, whitespace, and control bytes,
+# which closes path traversal, query/fragment smuggling, and header
+# injection at the validation boundary.
+_OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+
+_RUNS_PATH = "/v1/mission-runs"
+
+
+class MissionToolError(Exception):
+    """Bounded, model-visible tool failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def require_opaque_id(value: object, *, label: str) -> str:
+    """Return ``value`` when it is a safe opaque id; fail closed otherwise."""
+
+    if not isinstance(value, str) or not _OPAQUE_ID.fullmatch(value):
+        raise MissionToolError(
+            "invalid_argument",
+            f"{label} must be an opaque id of at most 256 URL-safe characters",
+        )
+    return value
+
+
+def _bounded_detail(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return ""
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if not isinstance(detail, str):
+        return ""
+    return detail[:200]
+
+
+class MissionRunClient:
+    """Six exact operations over trusted host transport configuration."""
+
+    def __init__(
+        self,
+        config: McpHostConfig,
+        *,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._config = config
+        headers = {"Accept": "application/json"}
+        if config.credential is not None:
+            headers["Authorization"] = f"Bearer {config.credential}"
+        self._http = httpx.Client(
+            base_url=config.base_url,
+            headers=headers,
+            timeout=config.timeout_seconds,
+            follow_redirects=False,
+            transport=transport,
+        )
+
+    def close(self) -> None:
+        self._http.close()
+
+    # -- exact operations ---------------------------------------------------
+
+    def submit(
+        self,
+        *,
+        profile_id: str,
+        repository: str,
+        ref: str,
+        mission: str,
+        tasks: list[dict[str, Any]],
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        key = require_opaque_id(idempotency_key, label="idempotency_key")
+        body = {
+            "profile_id": require_opaque_id(profile_id, label="profile_id"),
+            "repository": repository,
+            "ref": ref,
+            "mission": mission,
+            "tasks": tasks,
+        }
+        response = self._request(
+            "POST",
+            _RUNS_PATH,
+            json=body,
+            headers={"Idempotency-Key": key},
+        )
+        return self._payload(response, ok={202})
+
+    def get(self, run_id: str) -> dict[str, Any]:
+        path = f"{_RUNS_PATH}/{require_opaque_id(run_id, label='run_id')}"
+        return self._payload(self._request("GET", path), ok={200})
+
+    def events(self, run_id: str, *, after: str | None, limit: int | None) -> dict[str, Any]:
+        path = f"{_RUNS_PATH}/{require_opaque_id(run_id, label='run_id')}/events"
+        params: dict[str, str] = {"limit": str(self._clamped_limit(limit))}
+        if after is not None:
+            params["after"] = require_opaque_id(after, label="after")
+        return self._payload(self._request("GET", path, params=params), ok={200})
+
+    def result(self, run_id: str) -> dict[str, Any]:
+        path = f"{_RUNS_PATH}/{require_opaque_id(run_id, label='run_id')}/result"
+        return self._payload(self._request("GET", path), ok={200})
+
+    def cancel(self, run_id: str) -> dict[str, Any]:
+        path = f"{_RUNS_PATH}/{require_opaque_id(run_id, label='run_id')}/cancel"
+        return self._payload(self._request("POST", path), ok={200, 202})
+
+    def list_runs(self, *, limit: int | None) -> dict[str, Any]:
+        params = {"limit": str(self._clamped_limit(limit))}
+        return self._payload(self._request("GET", _RUNS_PATH, params=params), ok={200})
+
+    # -- transport ----------------------------------------------------------
+
+    def _clamped_limit(self, limit: int | None) -> int:
+        maximum = self._config.max_events_page
+        if limit is None:
+            return maximum
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
+            raise MissionToolError("invalid_argument", "limit must be a positive integer")
+        return min(limit, maximum)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        try:
+            return self._http.request(method, path, params=params, json=json, headers=headers)
+        except httpx.HTTPError as exc:
+            raise MissionToolError(
+                "unavailable",
+                f"mission control transport failure ({type(exc).__name__})",
+            ) from exc
+
+    def _payload(self, response: httpx.Response, *, ok: set[int]) -> dict[str, Any]:
+        status = response.status_code
+        if status in ok:
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise MissionToolError(
+                    "protocol_error", "mission control returned a non-JSON body"
+                ) from exc
+            if not isinstance(payload, dict):
+                raise MissionToolError(
+                    "protocol_error", "mission control returned a non-object body"
+                )
+            return payload
+        if 300 <= status < 400:
+            raise MissionToolError(
+                "protocol_error",
+                f"mission control returned an unexpected redirect ({status}); "
+                "redirects are never followed",
+            )
+        code = {
+            401: "unauthenticated",
+            403: "forbidden",
+            404: "not_found",
+            409: "conflict",
+            425: "not_ready",
+            422: "invalid_argument",
+        }.get(status, "upstream_error")
+        detail = _bounded_detail(response)
+        message = f"mission control rejected the request ({status})"
+        if detail:
+            message = f"{message}: {detail}"
+        raise MissionToolError(code, message)

--- a/packages/archetype-missions/src/archetype/missions/mcp/config.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/config.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trusted host configuration for the Mission MCP server.
+
+Issue #810 boundary: every transport coordinate — base URL, credential,
+TLS trust, and limits — is fixed by the host environment that launched the
+process. Tool arguments carry domain inputs and opaque ids only; nothing a
+model supplies can reach or override a value defined here.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+ENV_BASE_URL = "ARCHETYPE_MISSIONS_MCP_URL"
+ENV_CREDENTIAL = "ARCHETYPE_MISSIONS_MCP_CREDENTIAL"
+ENV_CREDENTIAL_FILE = "ARCHETYPE_MISSIONS_MCP_CREDENTIAL_FILE"
+ENV_TIMEOUT_SECONDS = "ARCHETYPE_MISSIONS_MCP_TIMEOUT_SECONDS"
+ENV_MAX_EVENTS_PAGE = "ARCHETYPE_MISSIONS_MCP_MAX_EVENTS_PAGE"
+ENV_MAX_RESULT_BYTES = "ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES"
+ENV_MAX_TASKS = "ARCHETYPE_MISSIONS_MCP_MAX_TASKS"
+ENV_MAX_PROMPT_BYTES = "ARCHETYPE_MISSIONS_MCP_MAX_PROMPT_BYTES"
+
+_DEFAULT_BASE_URL = "http://localhost:8000"
+
+
+class McpHostConfigError(ValueError):
+    """Closed configuration failure; messages never carry credential bytes."""
+
+
+def _positive_int(environ: dict[str, str], name: str, default: int) -> int:
+    raw = environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError as exc:
+        raise McpHostConfigError(f"{name} must be a positive integer") from exc
+    if value <= 0:
+        raise McpHostConfigError(f"{name} must be a positive integer")
+    return value
+
+
+def _positive_float(environ: dict[str, str], name: str, default: float) -> float:
+    raw = environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw.strip())
+    except ValueError as exc:
+        raise McpHostConfigError(f"{name} must be a positive number") from exc
+    if value <= 0:
+        raise McpHostConfigError(f"{name} must be a positive number")
+    return value
+
+
+def _base_url(environ: dict[str, str]) -> str:
+    raw = environ.get(ENV_BASE_URL, "").strip() or _DEFAULT_BASE_URL
+    parts = urlsplit(raw)
+    if parts.scheme not in {"http", "https"}:
+        raise McpHostConfigError(f"{ENV_BASE_URL} must be an http(s) URL")
+    if not parts.hostname:
+        raise McpHostConfigError(f"{ENV_BASE_URL} must name a host")
+    if parts.username is not None or parts.password is not None:
+        raise McpHostConfigError(f"{ENV_BASE_URL} must not embed credentials")
+    if parts.query or parts.fragment:
+        raise McpHostConfigError(f"{ENV_BASE_URL} must not carry a query or fragment")
+    return raw.rstrip("/")
+
+
+def _credential(environ: dict[str, str]) -> str | None:
+    inline = environ.get(ENV_CREDENTIAL, "").strip()
+    file_path = environ.get(ENV_CREDENTIAL_FILE, "").strip()
+    if inline and file_path:
+        raise McpHostConfigError(f"set {ENV_CREDENTIAL} or {ENV_CREDENTIAL_FILE}, not both")
+    if file_path:
+        try:
+            inline = Path(file_path).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise McpHostConfigError(f"{ENV_CREDENTIAL_FILE} is not a readable file") from exc
+        if not inline:
+            raise McpHostConfigError(f"{ENV_CREDENTIAL_FILE} names an empty file")
+    if not inline:
+        return None
+    if any(ord(char) < 0x21 or ord(char) > 0x7E for char in inline):
+        raise McpHostConfigError(
+            "the configured credential must be printable ASCII without whitespace"
+        )
+    return inline
+
+
+@dataclass(frozen=True, slots=True)
+class McpHostConfig:
+    """Immutable process-lifetime transport configuration."""
+
+    base_url: str
+    credential: str | None
+    timeout_seconds: float
+    max_events_page: int
+    max_result_bytes: int
+    max_tasks: int
+    max_prompt_bytes: int
+
+    @classmethod
+    def from_env(cls, environ: dict[str, str] | None = None) -> McpHostConfig:
+        """Resolve trusted host configuration once at process start."""
+
+        source = dict(os.environ if environ is None else environ)
+        return cls(
+            base_url=_base_url(source),
+            credential=_credential(source),
+            timeout_seconds=_positive_float(source, ENV_TIMEOUT_SECONDS, 30.0),
+            max_events_page=_positive_int(source, ENV_MAX_EVENTS_PAGE, 100),
+            max_result_bytes=_positive_int(source, ENV_MAX_RESULT_BYTES, 65536),
+            max_tasks=_positive_int(source, ENV_MAX_TASKS, 32),
+            max_prompt_bytes=_positive_int(source, ENV_MAX_PROMPT_BYTES, 65536),
+        )

--- a/packages/archetype-missions/src/archetype/missions/mcp/config.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/config.py
@@ -56,6 +56,15 @@ def _positive_float(environ: dict[str, str], name: str, default: float) -> float
     return value
 
 
+def _bounded_result_bytes(environ: dict[str, str]) -> int:
+    value = _positive_int(environ, ENV_MAX_RESULT_BYTES, 65536)
+    if value < 256:
+        # The explicit truncation envelope needs structural room; below this
+        # floor a bounded rendering guarantee is unsatisfiable.
+        raise McpHostConfigError(f"{ENV_MAX_RESULT_BYTES} must be at least 256")
+    return value
+
+
 def _base_url(environ: dict[str, str]) -> str:
     raw = environ.get(ENV_BASE_URL, "").strip() or _DEFAULT_BASE_URL
     parts = urlsplit(raw)
@@ -111,5 +120,5 @@ class McpHostConfig:
             credential=_credential(source),
             timeout_seconds=_positive_float(source, ENV_TIMEOUT_SECONDS, 30.0),
             max_events_page=_positive_int(source, ENV_MAX_EVENTS_PAGE, 100),
-            max_result_bytes=_positive_int(source, ENV_MAX_RESULT_BYTES, 65536),
+            max_result_bytes=_bounded_result_bytes(source),
         )

--- a/packages/archetype-missions/src/archetype/missions/mcp/config.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/config.py
@@ -22,8 +22,6 @@ ENV_CREDENTIAL_FILE = "ARCHETYPE_MISSIONS_MCP_CREDENTIAL_FILE"
 ENV_TIMEOUT_SECONDS = "ARCHETYPE_MISSIONS_MCP_TIMEOUT_SECONDS"
 ENV_MAX_EVENTS_PAGE = "ARCHETYPE_MISSIONS_MCP_MAX_EVENTS_PAGE"
 ENV_MAX_RESULT_BYTES = "ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES"
-ENV_MAX_TASKS = "ARCHETYPE_MISSIONS_MCP_MAX_TASKS"
-ENV_MAX_PROMPT_BYTES = "ARCHETYPE_MISSIONS_MCP_MAX_PROMPT_BYTES"
 
 _DEFAULT_BASE_URL = "http://localhost:8000"
 
@@ -102,8 +100,6 @@ class McpHostConfig:
     timeout_seconds: float
     max_events_page: int
     max_result_bytes: int
-    max_tasks: int
-    max_prompt_bytes: int
 
     @classmethod
     def from_env(cls, environ: dict[str, str] | None = None) -> McpHostConfig:
@@ -116,6 +112,4 @@ class McpHostConfig:
             timeout_seconds=_positive_float(source, ENV_TIMEOUT_SECONDS, 30.0),
             max_events_page=_positive_int(source, ENV_MAX_EVENTS_PAGE, 100),
             max_result_bytes=_positive_int(source, ENV_MAX_RESULT_BYTES, 65536),
-            max_tasks=_positive_int(source, ENV_MAX_TASKS, 32),
-            max_prompt_bytes=_positive_int(source, ENV_MAX_PROMPT_BYTES, 65536),
         )

--- a/packages/archetype-missions/src/archetype/missions/mcp/server.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/server.py
@@ -1,0 +1,556 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal MCP stdio server for Archetype Agent Missions.
+
+JSON-RPC 2.0 frames are the only bytes this process writes to stdout;
+diagnostics go to bounded, credential-redacted stderr. The server exposes
+exactly the six asynchronous mission tools from issue #810 and returns
+``-32601`` for any unsupported request method. Interactive attachment
+tools (issue #811) are deliberately absent rather than stubbed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, TextIO
+
+from archetype.missions.mcp.client import (
+    MissionRunClient,
+    MissionToolError,
+    require_opaque_id,
+)
+from archetype.missions.mcp.config import McpHostConfig, McpHostConfigError
+
+SERVER_NAME = "archetype-missions-mcp"
+SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
+
+_MAX_COORDINATE_CHARS = 512
+_MAX_TASK_NAME_CHARS = 200
+_MAX_DIAGNOSTIC_BYTES = 512
+
+_TASK_KEYS = {"name", "prompt", "validators", "depends_on"}
+
+_OPAQUE_ID_SCHEMA = {"type": "string", "minLength": 1, "maxLength": 256}
+
+_TASK_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "minLength": 1, "maxLength": _MAX_TASK_NAME_CHARS},
+        "prompt": {"type": "string", "minLength": 1},
+        "validators": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "argv": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["name", "argv"],
+                "additionalProperties": False,
+            },
+        },
+        "depends_on": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["name", "prompt"],
+    "additionalProperties": False,
+}
+
+TOOLS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "mission_submit",
+        "description": (
+            "Explicitly start a durable Archetype coding mission and return "
+            "immediately with its run_id and status coordinates; the mission "
+            "keeps running after this process exits. Reusing the same "
+            "idempotency_key with identical inputs returns the original run. "
+            "Execution authority comes from the server-owned profile, never "
+            "from these arguments."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "profile_id": _OPAQUE_ID_SCHEMA,
+                "repository": {"type": "string", "minLength": 1},
+                "ref": {"type": "string", "minLength": 1},
+                "mission": {"type": "string", "minLength": 1},
+                "tasks": {"type": "array", "items": _TASK_SCHEMA, "minItems": 1},
+                "idempotency_key": _OPAQUE_ID_SCHEMA,
+            },
+            "required": [
+                "profile_id",
+                "repository",
+                "ref",
+                "mission",
+                "tasks",
+                "idempotency_key",
+            ],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "mission_get",
+        "description": "Read the bounded status projection of one mission run.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"run_id": _OPAQUE_ID_SCHEMA},
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "mission_events",
+        "description": (
+            "Read ordered mission-run events after an opaque cursor; replay "
+            "from the same cursor has no gaps or duplicates."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "run_id": _OPAQUE_ID_SCHEMA,
+                "after": _OPAQUE_ID_SCHEMA,
+                "limit": {"type": "integer", "minimum": 1},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "mission_result",
+        "description": (
+            "Read the immutable terminal result of one mission run; fails "
+            "with not_ready while the run is nonterminal."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"run_id": _OPAQUE_ID_SCHEMA},
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "mission_cancel",
+        "description": (
+            "Record durable cancellation intent for one mission run; repeat "
+            "calls are idempotent and completion races resolve to the "
+            "committed execution fact."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"run_id": _OPAQUE_ID_SCHEMA},
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "mission_list",
+        "description": "List mission runs owned by the authenticated principal.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"limit": {"type": "integer", "minimum": 1}},
+            "additionalProperties": False,
+        },
+    },
+)
+
+
+def _server_version() -> str:
+    try:
+        return version("archetype-missions")
+    except PackageNotFoundError:  # pragma: no cover - source-tree fallback
+        return "0.0.0"
+
+
+class _Diagnostics:
+    """Bounded stderr sink that redacts the configured credential."""
+
+    def __init__(self, stream: TextIO, secrets: tuple[str, ...]) -> None:
+        self._stream = stream
+        self._secrets = tuple(secret for secret in secrets if secret)
+
+    def emit(self, text: str) -> None:
+        for secret in self._secrets:
+            text = text.replace(secret, "[redacted]")
+        line = " ".join(text.split())
+        encoded = line.encode("utf-8", errors="replace")[:_MAX_DIAGNOSTIC_BYTES]
+        try:
+            self._stream.write(f"{SERVER_NAME}: {encoded.decode('utf-8', errors='replace')}\n")
+            self._stream.flush()
+        except OSError:  # pragma: no cover - diagnostics must never kill frames
+            pass
+
+
+def _require_string(value: object, *, label: str, max_chars: int) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > max_chars
+        or any(ord(char) < 0x20 for char in value)
+    ):
+        raise MissionToolError(
+            "invalid_argument",
+            f"{label} must be a non-empty single-line string of at most {max_chars} characters",
+        )
+    return value
+
+
+def _reject_unknown(arguments: dict[str, Any], allowed: set[str]) -> None:
+    unknown = sorted(set(arguments) - allowed)
+    if unknown:
+        raise MissionToolError(
+            "invalid_argument",
+            f"unknown argument(s): {', '.join(unknown[:5])}; tool arguments "
+            "carry domain inputs and opaque ids only",
+        )
+
+
+def _string_keyed(value: object, *, label: str) -> dict[str, Any]:
+    """Normalize an untrusted mapping into ``dict[str, Any]`` or fail closed."""
+
+    if not isinstance(value, dict):
+        raise MissionToolError("invalid_argument", f"{label} must be an object")
+    normalized: dict[str, Any] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise MissionToolError("invalid_argument", f"{label} keys must be strings")
+        normalized[key] = item
+    return normalized
+
+
+def _require_arguments(params: object) -> dict[str, Any]:
+    if params is None:
+        return {}
+    return _string_keyed(params, label="arguments")
+
+
+class MissionMcpServer:
+    """Stdio MCP server over one :class:`MissionRunClient`."""
+
+    def __init__(
+        self,
+        config: McpHostConfig,
+        *,
+        client: MissionRunClient | None = None,
+        stderr: TextIO | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client if client is not None else MissionRunClient(config)
+        self._diagnostics = _Diagnostics(
+            stderr if stderr is not None else sys.stderr,
+            (config.credential or "",),
+        )
+
+    # -- protocol -----------------------------------------------------------
+
+    def serve(self, stdin: TextIO | None = None, stdout: TextIO | None = None) -> int:
+        """Run the newline-delimited JSON-RPC loop until stdin closes."""
+
+        source = stdin if stdin is not None else sys.stdin
+        sink = stdout if stdout is not None else sys.stdout
+        self._diagnostics.emit(f"serving mission tools for {self._config.base_url}")
+        try:
+            for raw_line in source:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                response = self.handle_line(line)
+                if response is not None:
+                    try:
+                        sink.write(json.dumps(response, sort_keys=True) + "\n")
+                        sink.flush()
+                    except OSError:
+                        # The host closed our stdout; stop serving cleanly.
+                        break
+        finally:
+            self.close()
+        return 0
+
+    def close(self) -> None:
+        self._client.close()
+
+    def handle_line(self, line: str) -> dict[str, Any] | None:
+        try:
+            message = json.loads(line)
+        except (ValueError, RecursionError):
+            return _error_frame(None, -32700, "Parse error")
+        return self.handle_message(message)
+
+    def handle_message(self, message: object) -> dict[str, Any] | None:
+        if not isinstance(message, dict):
+            return _error_frame(None, -32600, "Invalid Request")
+        request_id = message.get("id")
+        method = message.get("method")
+        if message.get("jsonrpc") != "2.0" or not isinstance(method, str):
+            if request_id is None:
+                return None
+            return _error_frame(request_id, -32600, "Invalid Request")
+        params = message.get("params")
+        if request_id is None:
+            # Notifications (including notifications/initialized) are accepted
+            # as no-ops; JSON-RPC forbids responding to them.
+            return None
+        if method == "initialize":
+            return _result_frame(request_id, self._initialize(params))
+        if method == "ping":
+            return _result_frame(request_id, {})
+        if method == "tools/list":
+            return _result_frame(request_id, {"tools": list(TOOLS)})
+        if method == "tools/call":
+            return self._tools_call(request_id, params)
+        return _error_frame(request_id, -32601, "Method not found")
+
+    def _initialize(self, params: object) -> dict[str, Any]:
+        requested = None
+        if isinstance(params, dict):
+            requested = params.get("protocolVersion")
+        negotiated = (
+            requested
+            if requested in SUPPORTED_PROTOCOL_VERSIONS
+            else SUPPORTED_PROTOCOL_VERSIONS[0]
+        )
+        return {
+            "protocolVersion": negotiated,
+            "capabilities": {"tools": {"listChanged": False}},
+            "serverInfo": {"name": SERVER_NAME, "version": _server_version()},
+            "instructions": (
+                "Asynchronous Archetype mission control. mission_submit starts "
+                "real, budgeted work and must be an explicit decision; every "
+                "other tool is read-only or idempotent."
+            ),
+        }
+
+    def _tools_call(self, request_id: object, params: object) -> dict[str, Any]:
+        if not isinstance(params, dict):
+            return _error_frame(request_id, -32602, "Invalid params")
+        name = params.get("name")
+        if not isinstance(name, str):
+            return _error_frame(request_id, -32602, "Invalid params")
+        handlers = {
+            "mission_submit": self._call_submit,
+            "mission_get": self._call_get,
+            "mission_events": self._call_events,
+            "mission_result": self._call_result,
+            "mission_cancel": self._call_cancel,
+            "mission_list": self._call_list,
+        }
+        handler = handlers.get(name)
+        if handler is None:
+            return _error_frame(request_id, -32602, f"Unknown tool: {name}")
+        try:
+            arguments = _require_arguments(params.get("arguments"))
+            payload = handler(arguments)
+        except MissionToolError as exc:
+            self._diagnostics.emit(f"tool {name} failed: {exc.code}")
+            return _result_frame(
+                request_id,
+                self._tool_content(
+                    {"error": {"code": exc.code, "message": exc.message}},
+                    is_error=True,
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 - frames must stay protocol-pure
+            self._diagnostics.emit(f"tool {name} failed unexpectedly: {type(exc).__name__}")
+            return _result_frame(
+                request_id,
+                self._tool_content(
+                    {
+                        "error": {
+                            "code": "internal",
+                            "message": f"internal adapter failure ({type(exc).__name__})",
+                        }
+                    },
+                    is_error=True,
+                ),
+            )
+        return _result_frame(request_id, self._tool_content(payload, is_error=False))
+
+    # -- tool handlers ------------------------------------------------------
+
+    def _call_submit(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        _reject_unknown(
+            arguments,
+            {"profile_id", "repository", "ref", "mission", "tasks", "idempotency_key"},
+        )
+        for field in (
+            "profile_id",
+            "repository",
+            "ref",
+            "mission",
+            "tasks",
+            "idempotency_key",
+        ):
+            if field not in arguments:
+                raise MissionToolError("invalid_argument", f"missing required argument: {field}")
+        return self._client.submit(
+            profile_id=require_opaque_id(arguments["profile_id"], label="profile_id"),
+            repository=_require_string(
+                arguments["repository"],
+                label="repository",
+                max_chars=_MAX_COORDINATE_CHARS,
+            ),
+            ref=_require_string(arguments["ref"], label="ref", max_chars=_MAX_COORDINATE_CHARS),
+            mission=_require_string(
+                arguments["mission"], label="mission", max_chars=_MAX_COORDINATE_CHARS
+            ),
+            tasks=self._validated_tasks(arguments["tasks"]),
+            idempotency_key=require_opaque_id(
+                arguments["idempotency_key"], label="idempotency_key"
+            ),
+        )
+
+    def _validated_tasks(self, tasks: object) -> list[dict[str, Any]]:
+        if not isinstance(tasks, list) or not tasks:
+            raise MissionToolError("invalid_argument", "tasks must be a non-empty array")
+        if len(tasks) > self._config.max_tasks:
+            raise MissionToolError(
+                "invalid_argument",
+                f"tasks must contain at most {self._config.max_tasks} items",
+            )
+        validated: list[dict[str, Any]] = []
+        for index, raw_task in enumerate(tasks):
+            task = _string_keyed(raw_task, label=f"tasks[{index}]")
+            _reject_unknown(task, _TASK_KEYS)
+            name = task.get("name")
+            if not isinstance(name, str) or not name or len(name) > _MAX_TASK_NAME_CHARS:
+                raise MissionToolError(
+                    "invalid_argument", f"tasks[{index}].name must be a short string"
+                )
+            prompt = task.get("prompt")
+            if (
+                not isinstance(prompt, str)
+                or not prompt
+                or len(prompt.encode("utf-8")) > self._config.max_prompt_bytes
+            ):
+                raise MissionToolError(
+                    "invalid_argument",
+                    f"tasks[{index}].prompt must be a non-empty string of at "
+                    f"most {self._config.max_prompt_bytes} bytes",
+                )
+            clean: dict[str, Any] = {"name": name, "prompt": prompt}
+            if "validators" in task:
+                clean["validators"] = self._validated_validators(task["validators"], index=index)
+            if "depends_on" in task:
+                depends_on = task["depends_on"]
+                if not isinstance(depends_on, list) or any(
+                    not isinstance(item, str) or not item for item in depends_on
+                ):
+                    raise MissionToolError(
+                        "invalid_argument",
+                        f"tasks[{index}].depends_on must be an array of task names",
+                    )
+                clean["depends_on"] = depends_on
+            validated.append(clean)
+        return validated
+
+    @staticmethod
+    def _validated_validators(validators: object, *, index: int) -> list[dict[str, Any]]:
+        if not isinstance(validators, list):
+            raise MissionToolError(
+                "invalid_argument", f"tasks[{index}].validators must be an array"
+            )
+        clean: list[dict[str, Any]] = []
+        for position, raw_validator in enumerate(validators):
+            label = f"tasks[{index}].validators[{position}]"
+            validator = _string_keyed(raw_validator, label=label)
+            _reject_unknown(validator, {"name", "argv"})
+            name = validator.get("name")
+            argv = validator.get("argv")
+            if not isinstance(name, str) or not name:
+                raise MissionToolError(
+                    "invalid_argument", f"{label}.name must be a non-empty string"
+                )
+            if not isinstance(argv, list) or any(not isinstance(item, str) for item in argv):
+                raise MissionToolError(
+                    "invalid_argument", f"{label}.argv must be an array of strings"
+                )
+            clean.append({"name": name, "argv": argv})
+        return clean
+
+    def _call_get(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        _reject_unknown(arguments, {"run_id"})
+        return self._client.get(self._run_id(arguments))
+
+    def _call_events(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        _reject_unknown(arguments, {"run_id", "after", "limit"})
+        after = arguments.get("after")
+        if after is not None:
+            after = require_opaque_id(after, label="after")
+        return self._client.events(
+            self._run_id(arguments),
+            after=after,
+            limit=self._limit_argument(arguments),
+        )
+
+    def _call_result(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        _reject_unknown(arguments, {"run_id"})
+        return self._client.result(self._run_id(arguments))
+
+    def _call_cancel(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        _reject_unknown(arguments, {"run_id"})
+        return self._client.cancel(self._run_id(arguments))
+
+    def _call_list(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        _reject_unknown(arguments, {"limit"})
+        return self._client.list_runs(limit=self._limit_argument(arguments))
+
+    @staticmethod
+    def _limit_argument(arguments: dict[str, Any]) -> int | None:
+        if "limit" not in arguments:
+            return None
+        value = arguments["limit"]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise MissionToolError("invalid_argument", "limit must be a positive integer")
+        return value
+
+    @staticmethod
+    def _run_id(arguments: dict[str, Any]) -> str:
+        if "run_id" not in arguments:
+            raise MissionToolError("invalid_argument", "missing required argument: run_id")
+        return require_opaque_id(arguments["run_id"], label="run_id")
+
+    # -- rendering ----------------------------------------------------------
+
+    def _tool_content(self, payload: dict[str, Any], *, is_error: bool) -> dict[str, Any]:
+        rendered = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+        if self._config.credential:
+            # Defense in depth: even an upstream body that echoed the bearer
+            # credential must never enter a model-visible tool result.
+            rendered = rendered.replace(self._config.credential, "[redacted]")
+        encoded = rendered.encode("utf-8")
+        limit = self._config.max_result_bytes
+        if len(encoded) > limit:
+            prefix = encoded[:limit].decode("utf-8", errors="ignore")
+            rendered = json.dumps(
+                {
+                    "truncated": True,
+                    "limit_bytes": limit,
+                    "content_prefix": prefix,
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+            )
+        return {
+            "content": [{"type": "text", "text": rendered}],
+            "isError": is_error,
+        }
+
+
+def _result_frame(request_id: object, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _error_frame(request_id: object, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def main() -> int:
+    """Console entry point: ``archetype-missions-mcp``."""
+
+    try:
+        config = McpHostConfig.from_env()
+    except McpHostConfigError as exc:
+        sys.stderr.write(f"{SERVER_NAME}: {exc}\n")
+        return 2
+    return MissionMcpServer(config).serve()

--- a/packages/archetype-missions/src/archetype/missions/mcp/server.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/server.py
@@ -42,6 +42,9 @@ _MAX_TASK_NAME_CHARS = 200
 _MAX_TASKS = 32
 _MAX_PROMPT_BYTES = 65536
 _MAX_DIAGNOSTIC_BYTES = 512
+# Largest accepted stdin frame; a newline-less flood is rejected in bounded
+# chunks instead of buffering an unbounded line.
+_MAX_FRAME_CHARS = 16 * 1024 * 1024
 
 _TASK_KEYS = {"name", "prompt", "validators", "depends_on"}
 
@@ -72,6 +75,19 @@ _TASK_SCHEMA = {
 }
 
 
+def _utf8_or_reject(value: str, label: str) -> bytes:
+    """Encode ``value`` or fail closed: an unpaired surrogate is a permanently
+    invalid argument, not a transient internal transport failure."""
+
+    try:
+        return value.encode("utf-8")
+    except UnicodeEncodeError:
+        raise MissionToolError(
+            "invalid_argument",
+            f"{label} must not contain unpaired surrogate code points",
+        ) from None
+
+
 def _require_string(value: object, *, label: str, max_chars: int) -> str:
     if (
         not isinstance(value, str)
@@ -83,6 +99,7 @@ def _require_string(value: object, *, label: str, max_chars: int) -> str:
             "invalid_argument",
             f"{label} must be a non-empty single-line string of at most {max_chars} characters",
         )
+    _utf8_or_reject(value, label)
     return value
 
 
@@ -143,10 +160,17 @@ def _validate_validators(validators: object, *, label: str) -> list[dict[str, An
             raise MissionToolError(
                 "invalid_argument", f"{item_label}.name must be a non-empty string"
             )
-        if not isinstance(argv, list) or any(not isinstance(item, str) for item in argv):
+        if not isinstance(argv, list):
             raise MissionToolError(
                 "invalid_argument", f"{item_label}.argv must be an array of strings"
             )
+        _utf8_or_reject(name, f"{item_label}.name")
+        for position_argv, item in enumerate(argv):
+            if not isinstance(item, str):
+                raise MissionToolError(
+                    "invalid_argument", f"{item_label}.argv must be an array of strings"
+                )
+            _utf8_or_reject(item, f"{item_label}.argv[{position_argv}]")
         clean.append({"name": name, "argv": argv})
     return clean
 
@@ -167,11 +191,12 @@ def _validate_tasks(tasks: object, label: str) -> list[dict[str, Any]]:
             raise MissionToolError(
                 "invalid_argument", f"{label}[{index}].name must be a short string"
             )
+        _utf8_or_reject(name, f"{label}[{index}].name")
         prompt = task.get("prompt")
         if (
             not isinstance(prompt, str)
             or not prompt
-            or len(prompt.encode("utf-8")) > _MAX_PROMPT_BYTES
+            or len(_utf8_or_reject(prompt, f"{label}[{index}].prompt")) > _MAX_PROMPT_BYTES
         ):
             raise MissionToolError(
                 "invalid_argument",
@@ -185,13 +210,18 @@ def _validate_tasks(tasks: object, label: str) -> list[dict[str, Any]]:
             )
         if "depends_on" in task:
             depends_on = task["depends_on"]
-            if not isinstance(depends_on, list) or any(
-                not isinstance(item, str) or not item for item in depends_on
-            ):
+            if not isinstance(depends_on, list):
                 raise MissionToolError(
                     "invalid_argument",
                     f"{label}[{index}].depends_on must be an array of task names",
                 )
+            for position_dep, item in enumerate(depends_on):
+                if not isinstance(item, str) or not item:
+                    raise MissionToolError(
+                        "invalid_argument",
+                        f"{label}[{index}].depends_on must be an array of task names",
+                    )
+                _utf8_or_reject(item, f"{label}[{index}].depends_on[{position_dep}]")
             clean["depends_on"] = depends_on
         validated.append(clean)
     return validated
@@ -390,7 +420,22 @@ class MissionMcpServer:
         sink = stdout if stdout is not None else sys.stdout
         self._diagnostics.emit(f"serving mission tools for {self._config.base_url}")
         try:
-            for raw_line in source:
+            while True:
+                raw_line = source.readline(_MAX_FRAME_CHARS + 1)
+                if raw_line == "":
+                    break
+                if len(raw_line) > _MAX_FRAME_CHARS:
+                    # Discard the rest of the oversized frame in bounded
+                    # chunks; never buffer an unbounded line.
+                    while raw_line and not raw_line.endswith("\n"):
+                        raw_line = source.readline(_MAX_FRAME_CHARS + 1)
+                    response = _error_frame(None, -32700, "Frame too large")
+                    try:
+                        sink.write(json.dumps(response, sort_keys=True) + "\n")
+                        sink.flush()
+                    except OSError:
+                        break
+                    continue
                 line = raw_line.strip()
                 if not line:
                     continue
@@ -501,28 +546,51 @@ class MissionMcpServer:
     # -- rendering ----------------------------------------------------------
 
     def _tool_content(self, payload: dict[str, Any], *, is_error: bool) -> dict[str, Any]:
-        rendered = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+        # Defense in depth: redact structurally, before serialization, so a
+        # credential containing JSON-escaped characters (quote, backslash)
+        # can never survive as a non-contiguous escaped substring.
         if self._config.credential:
-            # Defense in depth: even an upstream body that echoed the bearer
-            # credential must never enter a model-visible tool result.
-            rendered = rendered.replace(self._config.credential, "[redacted]")
-        encoded = rendered.encode("utf-8")
+            payload = _redact_value(payload, self._config.credential)
+        rendered = json.dumps(payload, sort_keys=True, ensure_ascii=False)
         limit = self._config.max_result_bytes
-        if len(encoded) > limit:
-            prefix = encoded[:limit].decode("utf-8", errors="ignore")
-            rendered = json.dumps(
-                {
-                    "truncated": True,
-                    "limit_bytes": limit,
-                    "content_prefix": prefix,
-                },
-                sort_keys=True,
-                ensure_ascii=False,
-            )
+        if len(rendered.encode("utf-8")) > limit:
+            rendered = _truncation_envelope(rendered, limit)
         return {
             "content": [{"type": "text", "text": rendered}],
             "isError": is_error,
         }
+
+
+def _redact_value(value: Any, secret: str) -> Any:
+    """Replace ``secret`` inside every string of a JSON-shaped value."""
+
+    if isinstance(value, str):
+        return value.replace(secret, "[redacted]")
+    if isinstance(value, list):
+        return [_redact_value(item, secret) for item in value]
+    if isinstance(value, dict):
+        return {
+            _redact_value(key, secret): _redact_value(item, secret) for key, item in value.items()
+        }
+    return value
+
+
+def _truncation_envelope(rendered: str, limit: int) -> str:
+    """Render an explicit truncation marker whose FULL serialized form fits
+    ``limit`` bytes: shrink the raw prefix until the envelope, with all JSON
+    escaping applied, measures within the bound."""
+
+    prefix = rendered.encode("utf-8")[:limit].decode("utf-8", errors="ignore")
+    while True:
+        envelope = json.dumps(
+            {"truncated": True, "limit_bytes": limit, "content_prefix": prefix},
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        overshoot = len(envelope.encode("utf-8")) - limit
+        if overshoot <= 0 or not prefix:
+            return envelope
+        prefix = prefix[: -max(1, overshoot)]
 
 
 def _result_frame(request_id: object, result: dict[str, Any]) -> dict[str, Any]:

--- a/packages/archetype-missions/src/archetype/missions/mcp/server.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/server.py
@@ -8,16 +8,23 @@ diagnostics go to bounded, credential-redacted stderr. The server exposes
 exactly the six asynchronous mission tools from issue #810 and returns
 ``-32601`` for any unsupported request method. Interactive attachment
 tools (issue #811) are deliberately absent rather than stubbed.
+
+Each tool is one :class:`_ToolSpec` row: the advertised ``inputSchema``
+and the runtime argument validation render from the same
+``_ARGUMENT_KINDS`` table, so the two encodings cannot drift.
 """
 
 from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, TextIO
 
 from archetype.missions.mcp.client import (
+    OPAQUE_ID_PATTERN,
     MissionRunClient,
     MissionToolError,
     require_opaque_id,
@@ -27,19 +34,25 @@ from archetype.missions.mcp.config import McpHostConfig, McpHostConfigError
 SERVER_NAME = "archetype-missions-mcp"
 SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
 
+# Fixed input bounds (issue #810: "fixed byte/item limits"). Output bounds
+# (events page, rendered result bytes) remain host-configured knobs.
+_MAX_OPAQUE_ID_CHARS = 256
 _MAX_COORDINATE_CHARS = 512
 _MAX_TASK_NAME_CHARS = 200
+_MAX_TASKS = 32
+_MAX_PROMPT_BYTES = 65536
 _MAX_DIAGNOSTIC_BYTES = 512
 
 _TASK_KEYS = {"name", "prompt", "validators", "depends_on"}
 
-_OPAQUE_ID_SCHEMA = {"type": "string", "minLength": 1, "maxLength": 256}
+# Single-line coordinate: no ASCII control characters.
+_LINE_PATTERN = "^[^\\u0000-\\u001f]+$"
 
 _TASK_SCHEMA = {
     "type": "object",
     "properties": {
         "name": {"type": "string", "minLength": 1, "maxLength": _MAX_TASK_NAME_CHARS},
-        "prompt": {"type": "string", "minLength": 1},
+        "prompt": {"type": "string", "minLength": 1, "maxLength": _MAX_PROMPT_BYTES},
         "validators": {
             "type": "array",
             "items": {
@@ -52,134 +65,11 @@ _TASK_SCHEMA = {
                 "additionalProperties": False,
             },
         },
-        "depends_on": {"type": "array", "items": {"type": "string"}},
+        "depends_on": {"type": "array", "items": {"type": "string", "minLength": 1}},
     },
     "required": ["name", "prompt"],
     "additionalProperties": False,
 }
-
-TOOLS: tuple[dict[str, Any], ...] = (
-    {
-        "name": "mission_submit",
-        "description": (
-            "Explicitly start a durable Archetype coding mission and return "
-            "immediately with its run_id and status coordinates; the mission "
-            "keeps running after this process exits. Reusing the same "
-            "idempotency_key with identical inputs returns the original run. "
-            "Execution authority comes from the server-owned profile, never "
-            "from these arguments."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "profile_id": _OPAQUE_ID_SCHEMA,
-                "repository": {"type": "string", "minLength": 1},
-                "ref": {"type": "string", "minLength": 1},
-                "mission": {"type": "string", "minLength": 1},
-                "tasks": {"type": "array", "items": _TASK_SCHEMA, "minItems": 1},
-                "idempotency_key": _OPAQUE_ID_SCHEMA,
-            },
-            "required": [
-                "profile_id",
-                "repository",
-                "ref",
-                "mission",
-                "tasks",
-                "idempotency_key",
-            ],
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "mission_get",
-        "description": "Read the bounded status projection of one mission run.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {"run_id": _OPAQUE_ID_SCHEMA},
-            "required": ["run_id"],
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "mission_events",
-        "description": (
-            "Read ordered mission-run events after an opaque cursor; replay "
-            "from the same cursor has no gaps or duplicates."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "run_id": _OPAQUE_ID_SCHEMA,
-                "after": _OPAQUE_ID_SCHEMA,
-                "limit": {"type": "integer", "minimum": 1},
-            },
-            "required": ["run_id"],
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "mission_result",
-        "description": (
-            "Read the immutable terminal result of one mission run; fails "
-            "with not_ready while the run is nonterminal."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {"run_id": _OPAQUE_ID_SCHEMA},
-            "required": ["run_id"],
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "mission_cancel",
-        "description": (
-            "Record durable cancellation intent for one mission run; repeat "
-            "calls are idempotent and completion races resolve to the "
-            "committed execution fact."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {"run_id": _OPAQUE_ID_SCHEMA},
-            "required": ["run_id"],
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "mission_list",
-        "description": "List mission runs owned by the authenticated principal.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {"limit": {"type": "integer", "minimum": 1}},
-            "additionalProperties": False,
-        },
-    },
-)
-
-
-def _server_version() -> str:
-    try:
-        return version("archetype-missions")
-    except PackageNotFoundError:  # pragma: no cover - source-tree fallback
-        return "0.0.0"
-
-
-class _Diagnostics:
-    """Bounded stderr sink that redacts the configured credential."""
-
-    def __init__(self, stream: TextIO, secrets: tuple[str, ...]) -> None:
-        self._stream = stream
-        self._secrets = tuple(secret for secret in secrets if secret)
-
-    def emit(self, text: str) -> None:
-        for secret in self._secrets:
-            text = text.replace(secret, "[redacted]")
-        line = " ".join(text.split())
-        encoded = line.encode("utf-8", errors="replace")[:_MAX_DIAGNOSTIC_BYTES]
-        try:
-            self._stream.write(f"{SERVER_NAME}: {encoded.decode('utf-8', errors='replace')}\n")
-            self._stream.flush()
-        except OSError:  # pragma: no cover - diagnostics must never kill frames
-            pass
 
 
 def _require_string(value: object, *, label: str, max_chars: int) -> str:
@@ -223,6 +113,255 @@ def _require_arguments(params: object) -> dict[str, Any]:
     if params is None:
         return {}
     return _string_keyed(params, label="arguments")
+
+
+def _validate_opaque_id(value: object, label: str) -> str:
+    return require_opaque_id(value, label=label)
+
+
+def _validate_line(value: object, label: str) -> str:
+    return _require_string(value, label=label, max_chars=_MAX_COORDINATE_CHARS)
+
+
+def _validate_limit(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise MissionToolError("invalid_argument", f"{label} must be a positive integer")
+    return value
+
+
+def _validate_validators(validators: object, *, label: str) -> list[dict[str, Any]]:
+    if not isinstance(validators, list):
+        raise MissionToolError("invalid_argument", f"{label} must be an array")
+    clean: list[dict[str, Any]] = []
+    for position, raw_validator in enumerate(validators):
+        item_label = f"{label}[{position}]"
+        validator = _string_keyed(raw_validator, label=item_label)
+        _reject_unknown(validator, {"name", "argv"})
+        name = validator.get("name")
+        argv = validator.get("argv")
+        if not isinstance(name, str) or not name:
+            raise MissionToolError(
+                "invalid_argument", f"{item_label}.name must be a non-empty string"
+            )
+        if not isinstance(argv, list) or any(not isinstance(item, str) for item in argv):
+            raise MissionToolError(
+                "invalid_argument", f"{item_label}.argv must be an array of strings"
+            )
+        clean.append({"name": name, "argv": argv})
+    return clean
+
+
+def _validate_tasks(tasks: object, label: str) -> list[dict[str, Any]]:
+    if not isinstance(tasks, list) or not tasks:
+        raise MissionToolError("invalid_argument", f"{label} must be a non-empty array")
+    if len(tasks) > _MAX_TASKS:
+        raise MissionToolError(
+            "invalid_argument", f"{label} must contain at most {_MAX_TASKS} items"
+        )
+    validated: list[dict[str, Any]] = []
+    for index, raw_task in enumerate(tasks):
+        task = _string_keyed(raw_task, label=f"{label}[{index}]")
+        _reject_unknown(task, _TASK_KEYS)
+        name = task.get("name")
+        if not isinstance(name, str) or not name or len(name) > _MAX_TASK_NAME_CHARS:
+            raise MissionToolError(
+                "invalid_argument", f"{label}[{index}].name must be a short string"
+            )
+        prompt = task.get("prompt")
+        if (
+            not isinstance(prompt, str)
+            or not prompt
+            or len(prompt.encode("utf-8")) > _MAX_PROMPT_BYTES
+        ):
+            raise MissionToolError(
+                "invalid_argument",
+                f"{label}[{index}].prompt must be a non-empty string of at "
+                f"most {_MAX_PROMPT_BYTES} bytes",
+            )
+        clean: dict[str, Any] = {"name": name, "prompt": prompt}
+        if "validators" in task:
+            clean["validators"] = _validate_validators(
+                task["validators"], label=f"{label}[{index}].validators"
+            )
+        if "depends_on" in task:
+            depends_on = task["depends_on"]
+            if not isinstance(depends_on, list) or any(
+                not isinstance(item, str) or not item for item in depends_on
+            ):
+                raise MissionToolError(
+                    "invalid_argument",
+                    f"{label}[{index}].depends_on must be an array of task names",
+                )
+            clean["depends_on"] = depends_on
+        validated.append(clean)
+    return validated
+
+
+# One row per argument kind: (advertised JSON Schema fragment, runtime
+# validator). Both sides of every tool argument come from this table.
+_ARGUMENT_KINDS: dict[str, tuple[dict[str, Any], Callable[[object, str], Any]]] = {
+    "opaque_id": (
+        {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": _MAX_OPAQUE_ID_CHARS,
+            "pattern": OPAQUE_ID_PATTERN,
+        },
+        _validate_opaque_id,
+    ),
+    "line": (
+        {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": _MAX_COORDINATE_CHARS,
+            "pattern": _LINE_PATTERN,
+        },
+        _validate_line,
+    ),
+    "limit": ({"type": "integer", "minimum": 1}, _validate_limit),
+    "tasks": (
+        {"type": "array", "items": _TASK_SCHEMA, "minItems": 1, "maxItems": _MAX_TASKS},
+        _validate_tasks,
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolSpec:
+    """One mission tool: name, description, client method, argument rows."""
+
+    name: str
+    description: str
+    client_method: str
+    arguments: tuple[tuple[str, str, bool], ...]  # (argument, kind, required)
+
+
+_TOOL_SPECS: tuple[_ToolSpec, ...] = (
+    _ToolSpec(
+        name="mission_submit",
+        description=(
+            "Explicitly start a durable Archetype coding mission and return "
+            "immediately with its run_id and status coordinates; the mission "
+            "keeps running after this process exits. Reusing the same "
+            "idempotency_key with identical inputs returns the original run. "
+            "Execution authority comes from the server-owned profile, never "
+            "from these arguments."
+        ),
+        client_method="submit",
+        arguments=(
+            ("profile_id", "opaque_id", True),
+            ("repository", "line", True),
+            ("ref", "line", True),
+            ("mission", "line", True),
+            ("tasks", "tasks", True),
+            ("idempotency_key", "opaque_id", True),
+        ),
+    ),
+    _ToolSpec(
+        name="mission_get",
+        description="Read the bounded status projection of one mission run.",
+        client_method="get",
+        arguments=(("run_id", "opaque_id", True),),
+    ),
+    _ToolSpec(
+        name="mission_events",
+        description=(
+            "Read ordered mission-run events after an opaque cursor; replay "
+            "from the same cursor has no gaps or duplicates."
+        ),
+        client_method="events",
+        arguments=(
+            ("run_id", "opaque_id", True),
+            ("after", "opaque_id", False),
+            ("limit", "limit", False),
+        ),
+    ),
+    _ToolSpec(
+        name="mission_result",
+        description=(
+            "Read the immutable terminal result of one mission run; fails "
+            "with not_ready while the run is nonterminal."
+        ),
+        client_method="result",
+        arguments=(("run_id", "opaque_id", True),),
+    ),
+    _ToolSpec(
+        name="mission_cancel",
+        description=(
+            "Record durable cancellation intent for one mission run; repeat "
+            "calls are idempotent and completion races resolve to the "
+            "committed execution fact."
+        ),
+        client_method="cancel",
+        arguments=(("run_id", "opaque_id", True),),
+    ),
+    _ToolSpec(
+        name="mission_list",
+        description="List mission runs owned by the authenticated principal.",
+        client_method="list_runs",
+        arguments=(("limit", "limit", False),),
+    ),
+)
+
+_SPECS_BY_NAME = {spec.name: spec for spec in _TOOL_SPECS}
+
+
+def _input_schema(spec: _ToolSpec) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            argument: dict(_ARGUMENT_KINDS[kind][0]) for argument, kind, _ in spec.arguments
+        },
+        "additionalProperties": False,
+    }
+    required = [argument for argument, _, is_required in spec.arguments if is_required]
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _validate_arguments(spec: _ToolSpec, arguments: dict[str, Any]) -> dict[str, Any]:
+    _reject_unknown(arguments, {argument for argument, _, _ in spec.arguments})
+    validated: dict[str, Any] = {}
+    for argument, kind, is_required in spec.arguments:
+        if argument not in arguments:
+            if is_required:
+                raise MissionToolError("invalid_argument", f"missing required argument: {argument}")
+            continue
+        validated[argument] = _ARGUMENT_KINDS[kind][1](arguments[argument], argument)
+    return validated
+
+
+TOOLS: tuple[dict[str, Any], ...] = tuple(
+    {"name": spec.name, "description": spec.description, "inputSchema": _input_schema(spec)}
+    for spec in _TOOL_SPECS
+)
+
+
+def _server_version() -> str:
+    try:
+        return version("archetype-missions")
+    except PackageNotFoundError:  # pragma: no cover - source-tree fallback
+        return "0.0.0"
+
+
+class _Diagnostics:
+    """Bounded stderr sink that redacts the configured credential."""
+
+    def __init__(self, stream: TextIO, secrets: tuple[str, ...]) -> None:
+        self._stream = stream
+        self._secrets = tuple(secret for secret in secrets if secret)
+
+    def emit(self, text: str) -> None:
+        for secret in self._secrets:
+            text = text.replace(secret, "[redacted]")
+        line = " ".join(text.split())
+        encoded = line.encode("utf-8", errors="replace")[:_MAX_DIAGNOSTIC_BYTES]
+        try:
+            self._stream.write(f"{SERVER_NAME}: {encoded.decode('utf-8', errors='replace')}\n")
+            self._stream.flush()
+        except OSError:  # pragma: no cover - diagnostics must never kill frames
+            pass
 
 
 class MissionMcpServer:
@@ -327,20 +466,13 @@ class MissionMcpServer:
         name = params.get("name")
         if not isinstance(name, str):
             return _error_frame(request_id, -32602, "Invalid params")
-        handlers = {
-            "mission_submit": self._call_submit,
-            "mission_get": self._call_get,
-            "mission_events": self._call_events,
-            "mission_result": self._call_result,
-            "mission_cancel": self._call_cancel,
-            "mission_list": self._call_list,
-        }
-        handler = handlers.get(name)
-        if handler is None:
+        spec = _SPECS_BY_NAME.get(name)
+        if spec is None:
             return _error_frame(request_id, -32602, f"Unknown tool: {name}")
         try:
             arguments = _require_arguments(params.get("arguments"))
-            payload = handler(arguments)
+            validated = _validate_arguments(spec, arguments)
+            payload = getattr(self._client, spec.client_method)(**validated)
         except MissionToolError as exc:
             self._diagnostics.emit(f"tool {name} failed: {exc.code}")
             return _result_frame(
@@ -365,150 +497,6 @@ class MissionMcpServer:
                 ),
             )
         return _result_frame(request_id, self._tool_content(payload, is_error=False))
-
-    # -- tool handlers ------------------------------------------------------
-
-    def _call_submit(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        _reject_unknown(
-            arguments,
-            {"profile_id", "repository", "ref", "mission", "tasks", "idempotency_key"},
-        )
-        for field in (
-            "profile_id",
-            "repository",
-            "ref",
-            "mission",
-            "tasks",
-            "idempotency_key",
-        ):
-            if field not in arguments:
-                raise MissionToolError("invalid_argument", f"missing required argument: {field}")
-        return self._client.submit(
-            profile_id=require_opaque_id(arguments["profile_id"], label="profile_id"),
-            repository=_require_string(
-                arguments["repository"],
-                label="repository",
-                max_chars=_MAX_COORDINATE_CHARS,
-            ),
-            ref=_require_string(arguments["ref"], label="ref", max_chars=_MAX_COORDINATE_CHARS),
-            mission=_require_string(
-                arguments["mission"], label="mission", max_chars=_MAX_COORDINATE_CHARS
-            ),
-            tasks=self._validated_tasks(arguments["tasks"]),
-            idempotency_key=require_opaque_id(
-                arguments["idempotency_key"], label="idempotency_key"
-            ),
-        )
-
-    def _validated_tasks(self, tasks: object) -> list[dict[str, Any]]:
-        if not isinstance(tasks, list) or not tasks:
-            raise MissionToolError("invalid_argument", "tasks must be a non-empty array")
-        if len(tasks) > self._config.max_tasks:
-            raise MissionToolError(
-                "invalid_argument",
-                f"tasks must contain at most {self._config.max_tasks} items",
-            )
-        validated: list[dict[str, Any]] = []
-        for index, raw_task in enumerate(tasks):
-            task = _string_keyed(raw_task, label=f"tasks[{index}]")
-            _reject_unknown(task, _TASK_KEYS)
-            name = task.get("name")
-            if not isinstance(name, str) or not name or len(name) > _MAX_TASK_NAME_CHARS:
-                raise MissionToolError(
-                    "invalid_argument", f"tasks[{index}].name must be a short string"
-                )
-            prompt = task.get("prompt")
-            if (
-                not isinstance(prompt, str)
-                or not prompt
-                or len(prompt.encode("utf-8")) > self._config.max_prompt_bytes
-            ):
-                raise MissionToolError(
-                    "invalid_argument",
-                    f"tasks[{index}].prompt must be a non-empty string of at "
-                    f"most {self._config.max_prompt_bytes} bytes",
-                )
-            clean: dict[str, Any] = {"name": name, "prompt": prompt}
-            if "validators" in task:
-                clean["validators"] = self._validated_validators(task["validators"], index=index)
-            if "depends_on" in task:
-                depends_on = task["depends_on"]
-                if not isinstance(depends_on, list) or any(
-                    not isinstance(item, str) or not item for item in depends_on
-                ):
-                    raise MissionToolError(
-                        "invalid_argument",
-                        f"tasks[{index}].depends_on must be an array of task names",
-                    )
-                clean["depends_on"] = depends_on
-            validated.append(clean)
-        return validated
-
-    @staticmethod
-    def _validated_validators(validators: object, *, index: int) -> list[dict[str, Any]]:
-        if not isinstance(validators, list):
-            raise MissionToolError(
-                "invalid_argument", f"tasks[{index}].validators must be an array"
-            )
-        clean: list[dict[str, Any]] = []
-        for position, raw_validator in enumerate(validators):
-            label = f"tasks[{index}].validators[{position}]"
-            validator = _string_keyed(raw_validator, label=label)
-            _reject_unknown(validator, {"name", "argv"})
-            name = validator.get("name")
-            argv = validator.get("argv")
-            if not isinstance(name, str) or not name:
-                raise MissionToolError(
-                    "invalid_argument", f"{label}.name must be a non-empty string"
-                )
-            if not isinstance(argv, list) or any(not isinstance(item, str) for item in argv):
-                raise MissionToolError(
-                    "invalid_argument", f"{label}.argv must be an array of strings"
-                )
-            clean.append({"name": name, "argv": argv})
-        return clean
-
-    def _call_get(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        _reject_unknown(arguments, {"run_id"})
-        return self._client.get(self._run_id(arguments))
-
-    def _call_events(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        _reject_unknown(arguments, {"run_id", "after", "limit"})
-        after = arguments.get("after")
-        if after is not None:
-            after = require_opaque_id(after, label="after")
-        return self._client.events(
-            self._run_id(arguments),
-            after=after,
-            limit=self._limit_argument(arguments),
-        )
-
-    def _call_result(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        _reject_unknown(arguments, {"run_id"})
-        return self._client.result(self._run_id(arguments))
-
-    def _call_cancel(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        _reject_unknown(arguments, {"run_id"})
-        return self._client.cancel(self._run_id(arguments))
-
-    def _call_list(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        _reject_unknown(arguments, {"limit"})
-        return self._client.list_runs(limit=self._limit_argument(arguments))
-
-    @staticmethod
-    def _limit_argument(arguments: dict[str, Any]) -> int | None:
-        if "limit" not in arguments:
-            return None
-        value = arguments["limit"]
-        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-            raise MissionToolError("invalid_argument", "limit must be a positive integer")
-        return value
-
-    @staticmethod
-    def _run_id(arguments: dict[str, Any]) -> str:
-        if "run_id" not in arguments:
-            raise MissionToolError("invalid_argument", "missing required argument: run_id")
-        return require_opaque_id(arguments["run_id"], label="run_id")
 
     # -- rendering ----------------------------------------------------------
 

--- a/quality/contracts.toml
+++ b/quality/contracts.toml
@@ -855,6 +855,22 @@ benchmarks = []
 profiles = ["main", "release"]
 
 [[contract]]
+id = "missions.mcp.trusted_host_adapter"
+source = "docs/guide/agent-missions.md"
+section = "11. Mission MCP server"
+owner = "missions"
+risk = "high"
+pytest = [
+  "tests/missions/mcp/test_mission_mcp_protocol.py",
+  "tests/missions/mcp/test_mission_mcp_rest_contract.py",
+  "tests/missions/mcp/test_mission_mcp_hostile_args.py",
+]
+static = []
+evals = []
+benchmarks = []
+profiles = ["pr", "main", "release"]
+
+[[contract]]
 id = "missions.agent_v1.public_authoring"
 source = "docs/guide/agent-missions.md"
 section = "2. Public authoring surface"

--- a/scripts/check_gate_coverage.py
+++ b/scripts/check_gate_coverage.py
@@ -267,6 +267,11 @@ INTERNAL_ONLY_EXCEPTIONS = {
     "archetype.missions.critics.harness._UnverifiableReview": (
         "caught and normalized inside CriticHarness.review before the mission handler returns"
     ),
+    "archetype.missions.mcp.client.MissionToolError": (
+        "caught inside MissionMcpServer._tools_call and rendered as a bounded "
+        "isError MCP tool result; the MCP stdio adapter is an HTTP client of "
+        "the REST surface and never enters a registered API handler (issue #810)"
+    ),
     "archetype.missions.sandboxes._subprocess._CleanupTimeout": (
         "caught inside run_host and normalized into a bounded timeout ProcessResult"
     ),

--- a/scripts/package_smoke.py
+++ b/scripts/package_smoke.py
@@ -305,7 +305,7 @@ import asyncio
 import importlib.util
 import json
 import sys
-from importlib.metadata import version
+from importlib.metadata import entry_points, version
 from pathlib import Path
 
 import archetype
@@ -341,6 +341,14 @@ mission_paths = sorted(
     if "/missions" in path or "/tasks/" in path
 )
 assert len(mission_paths) == (3 if "missions" in expected else 0), mission_paths
+console_scripts = {{point.name: point for point in entry_points(group="console_scripts")}}
+if "missions" in expected:
+    mcp_point = console_scripts["archetype-missions-mcp"]
+    assert mcp_point.value == "archetype.missions.mcp.server:main", mcp_point.value
+    assert callable(mcp_point.load())
+    assert (Path(sys.executable).parent / "archetype-missions-mcp").exists()
+else:
+    assert "archetype-missions-mcp" not in console_scripts, sorted(console_scripts)
 print(json.dumps({{"matrix": {matrix!r}, "libraries": expected, "operations": operation_count, "module": str(package_root)}}))
 """
     process = subprocess.run(

--- a/tests/missions/mcp/conftest.py
+++ b/tests/missions/mcp/conftest.py
@@ -332,23 +332,29 @@ def mcp_server(host_config, stderr_sink):
     server.close()
 
 
+def call_tool(
+    server: MissionMcpServer, name: str, arguments: dict[str, Any] | None = None
+) -> tuple[bool, dict[str, Any]]:
+    """Invoke one tool on ``server`` through the full MCP frame path."""
+
+    frame = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        }
+    )
+    assert frame is not None and "result" in frame, frame
+    result = frame["result"]
+    payload = json.loads(result["content"][0]["text"])
+    return result["isError"], payload
+
+
 @pytest.fixture
 def call(mcp_server):
-    """Invoke one tool through the full MCP frame path."""
-
     def _call(name: str, arguments: dict[str, Any] | None = None):
-        frame = mcp_server.handle_message(
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "tools/call",
-                "params": {"name": name, "arguments": arguments or {}},
-            }
-        )
-        assert frame is not None and "result" in frame, frame
-        result = frame["result"]
-        payload = json.loads(result["content"][0]["text"])
-        return result["isError"], payload
+        return call_tool(mcp_server, name, arguments)
 
     return _call
 
@@ -370,8 +376,3 @@ def submit_arguments(**overrides: Any) -> dict[str, Any]:
     }
     arguments.update(overrides)
     return arguments
-
-
-@pytest.fixture
-def submit_args():
-    return submit_arguments

--- a/tests/missions/mcp/conftest.py
+++ b/tests/missions/mcp/conftest.py
@@ -1,0 +1,377 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Offline fake MissionRun control surface for Mission MCP contract tests.
+
+Contract seam (issue #810): :class:`FakeMissionControl` implements the
+MissionRun REST contract exactly as documented in issue #809 — the routes,
+``Idempotency-Key`` submit semantics, cursor events, terminal result, and
+idempotent cancel — because that surface has not landed on ``main`` yet.
+``test_mission_mcp_live_loopback.py`` holds the binding tests that activate
+once ``archetype.missions.api`` ships ``/v1/mission-runs``; rebinding these
+fixtures to the real response models is deliberately a one-file change here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import threading
+import uuid
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from archetype.missions.mcp.config import McpHostConfig
+from archetype.missions.mcp.server import MissionMcpServer
+
+CREDENTIAL = "mcp-test-credential-0123456789abcdef"
+
+
+@dataclass
+class RecordedRequest:
+    method: str
+    path: str
+    query: dict[str, list[str]]
+    headers: dict[str, str]
+    body: bytes
+
+
+@dataclass
+class FakeRun:
+    run_id: str
+    profile_id: str = "profile-default"
+    state: str = "queued"
+    request_digest: str = ""
+    events: list[dict[str, Any]] = field(default_factory=list)
+    result: dict[str, Any] | None = None
+
+    def projection(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "profile_id": self.profile_id,
+            "state": self.state,
+            "request_digest": self.request_digest,
+        }
+
+
+class FakeMissionControl:
+    """Threading HTTP fake bound to loopback, recording every request."""
+
+    def __init__(self) -> None:
+        self.credential = CREDENTIAL
+        self.requests: list[RecordedRequest] = []
+        self.runs: dict[str, FakeRun] = {}
+        self.submissions: dict[str, tuple[str, str]] = {}
+        self.foreign_run_ids: set[str] = set()
+        self.redirect_next = False
+        self.fail_next_status: int | None = None
+        self.fail_next_detail = ""
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self) -> None:
+        control = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args: object) -> None:
+                pass
+
+            def do_GET(self) -> None:
+                control._handle(self, "GET")
+
+            def do_POST(self) -> None:
+                control._handle(self, "POST")
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    @property
+    def base_url(self) -> str:
+        assert self._server is not None
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    # -- seeding helpers ----------------------------------------------------
+
+    def seed_run(
+        self,
+        *,
+        state: str = "running",
+        events: int = 0,
+        result: dict[str, Any] | None = None,
+        foreign: bool = False,
+    ) -> FakeRun:
+        run = FakeRun(run_id=f"run-{uuid.uuid4().hex[:12]}", state=state)
+        run.events = [
+            {
+                "event_id": f"{run.run_id}-event-{index}",
+                "cursor": str(index),
+                "schema_version": 1,
+                "ts": f"2026-08-18T00:00:{index:02d}Z",
+                "phase": "task",
+                "type": "progress",
+                "payload": {"message": f"step {index}"},
+            }
+            for index in range(1, events + 1)
+        ]
+        run.result = result
+        self.runs[run.run_id] = run
+        if foreign:
+            self.foreign_run_ids.add(run.run_id)
+        return run
+
+    # -- request handling ---------------------------------------------------
+
+    def _handle(self, handler: BaseHTTPRequestHandler, method: str) -> None:
+        parts = urlsplit(handler.path)
+        length = int(handler.headers.get("Content-Length") or 0)
+        body = handler.rfile.read(length) if length else b""
+        self.requests.append(
+            RecordedRequest(
+                method=method,
+                path=parts.path,
+                query=parse_qs(parts.query),
+                headers={key: value for key, value in handler.headers.items()},
+                body=body,
+            )
+        )
+        if self.redirect_next:
+            self.redirect_next = False
+            self._respond(
+                handler,
+                302,
+                {"detail": "moved"},
+                extra_headers={"Location": f"{self.base_url}/v1/mission-runs/evil-target"},
+            )
+            return
+        if self.fail_next_status is not None:
+            status = self.fail_next_status
+            self.fail_next_status = None
+            self._respond(handler, status, {"detail": self.fail_next_detail})
+            return
+        if handler.headers.get("Authorization") != f"Bearer {self.credential}":
+            self._respond(handler, 401, {"detail": "Authentication required"})
+            return
+        segments = [segment for segment in parts.path.split("/") if segment]
+        if segments[:2] != ["v1", "mission-runs"]:
+            self._respond(handler, 404, {"detail": "Not found"})
+            return
+        rest = segments[2:]
+        if method == "POST" and not rest:
+            self._submit(handler, body)
+            return
+        if method == "GET" and not rest:
+            self._list(handler)
+            return
+        if not rest:
+            self._respond(handler, 404, {"detail": "Not found"})
+            return
+        run = self.runs.get(rest[0])
+        if run is None or rest[0] in self.foreign_run_ids:
+            self._respond(handler, 404, {"detail": "Unknown mission run"})
+            return
+        if method == "GET" and len(rest) == 1:
+            self._respond(handler, 200, run.projection())
+            return
+        if method == "GET" and rest[1:] == ["events"]:
+            self._events(handler, run, parse_qs(parts.query))
+            return
+        if method == "GET" and rest[1:] == ["result"]:
+            self._result(handler, run)
+            return
+        if method == "POST" and rest[1:] == ["cancel"]:
+            self._cancel(handler, run)
+            return
+        self._respond(handler, 404, {"detail": "Not found"})
+
+    def _submit(self, handler: BaseHTTPRequestHandler, body: bytes) -> None:
+        key = handler.headers.get("Idempotency-Key")
+        if not key:
+            self._respond(handler, 400, {"detail": "Idempotency-Key header required"})
+            return
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except ValueError:
+            self._respond(handler, 422, {"detail": "Body must be JSON"})
+            return
+        digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+        existing = self.submissions.get(key)
+        if existing is not None:
+            recorded_digest, run_id = existing
+            if recorded_digest != digest:
+                self._respond(
+                    handler,
+                    409,
+                    {"detail": "Idempotency-Key reuse with a different request"},
+                )
+                return
+            self._respond(handler, 202, self._accepted(self.runs[run_id]))
+            return
+        run = FakeRun(
+            run_id=f"run-{uuid.uuid4().hex[:12]}",
+            profile_id=str(payload.get("profile_id", "profile-default")),
+            state="queued",
+            request_digest=digest,
+        )
+        self.runs[run.run_id] = run
+        self.submissions[key] = (digest, run.run_id)
+        self._respond(handler, 202, self._accepted(run))
+
+    @staticmethod
+    def _accepted(run: FakeRun) -> dict[str, Any]:
+        return {
+            "run_id": run.run_id,
+            "request_digest": run.request_digest,
+            "state": run.state,
+            "status_url": f"/v1/mission-runs/{run.run_id}",
+        }
+
+    def _list(self, handler: BaseHTTPRequestHandler) -> None:
+        runs = [
+            run.projection()
+            for run_id, run in sorted(self.runs.items())
+            if run_id not in self.foreign_run_ids
+        ]
+        self._respond(handler, 200, {"runs": runs})
+
+    def _events(
+        self,
+        handler: BaseHTTPRequestHandler,
+        run: FakeRun,
+        query: dict[str, list[str]],
+    ) -> None:
+        after = int(query.get("after", ["0"])[0])
+        limit = int(query.get("limit", ["100"])[0])
+        selected = [event for event in run.events if int(event["cursor"]) > after][:limit]
+        next_cursor = selected[-1]["cursor"] if selected else str(after)
+        self._respond(handler, 200, {"events": selected, "next_cursor": next_cursor})
+
+    def _result(self, handler: BaseHTTPRequestHandler, run: FakeRun) -> None:
+        if run.result is None:
+            self._respond(handler, 425, {"detail": "Mission run is not terminal"})
+            return
+        self._respond(
+            handler,
+            200,
+            {"run_id": run.run_id, "state": run.state, "result": run.result},
+        )
+
+    def _cancel(self, handler: BaseHTTPRequestHandler, run: FakeRun) -> None:
+        if run.state in {"completed", "failed", "cancelled"}:
+            self._respond(handler, 200, {"run_id": run.run_id, "state": run.state})
+            return
+        run.state = "cancelling"
+        self._respond(handler, 202, {"run_id": run.run_id, "state": "cancelling"})
+
+    def _respond(
+        self,
+        handler: BaseHTTPRequestHandler,
+        status: int,
+        payload: dict[str, Any],
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> None:
+        encoded = json.dumps(payload).encode("utf-8")
+        handler.send_response(status)
+        handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(encoded)))
+        for name, value in (extra_headers or {}).items():
+            handler.send_header(name, value)
+        handler.end_headers()
+        handler.wfile.write(encoded)
+
+
+@pytest.fixture
+def fake_control():
+    control = FakeMissionControl()
+    control.start()
+    yield control
+    control.stop()
+
+
+def host_environ(control: FakeMissionControl, **overrides: str) -> dict[str, str]:
+    environ = {
+        "ARCHETYPE_MISSIONS_MCP_URL": control.base_url,
+        "ARCHETYPE_MISSIONS_MCP_CREDENTIAL": control.credential,
+    }
+    environ.update(overrides)
+    return environ
+
+
+@pytest.fixture
+def host_config(fake_control):
+    return McpHostConfig.from_env(host_environ(fake_control))
+
+
+@pytest.fixture
+def stderr_sink():
+    return io.StringIO()
+
+
+@pytest.fixture
+def mcp_server(host_config, stderr_sink):
+    server = MissionMcpServer(host_config, stderr=stderr_sink)
+    yield server
+    server.close()
+
+
+@pytest.fixture
+def call(mcp_server):
+    """Invoke one tool through the full MCP frame path."""
+
+    def _call(name: str, arguments: dict[str, Any] | None = None):
+        frame = mcp_server.handle_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments or {}},
+            }
+        )
+        assert frame is not None and "result" in frame, frame
+        result = frame["result"]
+        payload = json.loads(result["content"][0]["text"])
+        return result["isError"], payload
+
+    return _call
+
+
+def submit_arguments(**overrides: Any) -> dict[str, Any]:
+    arguments: dict[str, Any] = {
+        "profile_id": "profile-default",
+        "repository": "vangelis/archetype",
+        "ref": "main",
+        "mission": "demo-mission",
+        "tasks": [
+            {
+                "name": "fix-bug",
+                "prompt": "Fix the reported bug.",
+                "validators": [{"name": "pytest", "argv": ["pytest", "-q"]}],
+            }
+        ],
+        "idempotency_key": "key-0001",
+    }
+    arguments.update(overrides)
+    return arguments
+
+
+@pytest.fixture
+def submit_args():
+    return submit_arguments

--- a/tests/missions/mcp/test_mission_mcp_hostile_args.py
+++ b/tests/missions/mcp/test_mission_mcp_hostile_args.py
@@ -18,7 +18,7 @@ import pytest
 
 from archetype.missions.mcp.config import McpHostConfig
 from archetype.missions.mcp.server import MissionMcpServer
-from tests.missions.mcp.conftest import CREDENTIAL
+from tests.missions.mcp.conftest import CREDENTIAL, call_tool, submit_arguments
 
 HOSTILE_OPAQUE_IDS = [
     "../admin",
@@ -75,8 +75,8 @@ def test_hostile_cursor_never_reaches_the_wire(call, fake_control, hostile):
     "hostile",
     ["../key", "key with space", "key\r\nX-Evil: 1", "", "k" * 300],
 )
-def test_hostile_idempotency_key_cannot_inject_headers(call, fake_control, hostile, submit_args):
-    is_error, payload = call("mission_submit", submit_args(idempotency_key=hostile))
+def test_hostile_idempotency_key_cannot_inject_headers(call, fake_control, hostile):
+    is_error, payload = call("mission_submit", submit_arguments(idempotency_key=hostile))
     assert is_error is True
     assert payload["error"]["code"] == "invalid_argument"
     assert fake_control.requests == []
@@ -114,8 +114,8 @@ def test_configuration_overrides_are_unknown_arguments(call, fake_control, tool,
 
 
 @pytest.mark.parametrize("override", CONFIG_OVERRIDE_ARGUMENTS)
-def test_submit_configuration_overrides_are_rejected(call, fake_control, override, submit_args):
-    is_error, payload = call("mission_submit", {**submit_args(), **override})
+def test_submit_configuration_overrides_are_rejected(call, fake_control, override):
+    is_error, payload = call("mission_submit", {**submit_arguments(), **override})
     assert is_error is True
     assert payload["error"]["code"] == "invalid_argument"
     assert fake_control.requests == []
@@ -131,9 +131,7 @@ def test_submit_configuration_overrides_are_rejected(call, fake_control, overrid
         {"budget": 10**9},
     ],
 )
-def test_profile_widening_through_task_payload_is_rejected(
-    call, fake_control, task_widening, submit_args
-):
+def test_profile_widening_through_task_payload_is_rejected(call, fake_control, task_widening):
     """Task items carry name/prompt/validators/depends_on only (issue #808)."""
 
     tasks = [
@@ -143,20 +141,20 @@ def test_profile_widening_through_task_payload_is_rejected(
             **task_widening,
         }
     ]
-    is_error, payload = call("mission_submit", submit_args(tasks=tasks))
+    is_error, payload = call("mission_submit", submit_arguments(tasks=tasks))
     assert is_error is True
     assert payload["error"]["code"] == "invalid_argument"
     assert fake_control.requests == []
 
 
-def test_task_count_and_prompt_bytes_are_bounded(call, fake_control, submit_args):
+def test_task_count_and_prompt_bytes_are_bounded(call, fake_control):
     many = [{"name": f"task-{index}", "prompt": "p"} for index in range(33)]
-    is_error, payload = call("mission_submit", submit_args(tasks=many))
+    is_error, payload = call("mission_submit", submit_arguments(tasks=many))
     assert is_error is True
     assert payload["error"]["code"] == "invalid_argument"
 
     huge_prompt = [{"name": "task", "prompt": "x" * 70000}]
-    is_error, payload = call("mission_submit", submit_args(tasks=huge_prompt))
+    is_error, payload = call("mission_submit", submit_arguments(tasks=huge_prompt))
     assert is_error is True
     assert payload["error"]["code"] == "invalid_argument"
     assert fake_control.requests == []
@@ -196,24 +194,12 @@ def test_transport_failure_is_bounded_and_credential_free():
     )
     server = MissionMcpServer(config, stderr=io.StringIO())
     try:
-        frame = server.handle_message(
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "tools/call",
-                "params": {
-                    "name": "mission_get",
-                    "arguments": {"run_id": "run-1"},
-                },
-            }
-        )
+        is_error, payload = call_tool(server, "mission_get", {"run_id": "run-1"})
     finally:
         server.close()
-    result = frame["result"]
-    assert result["isError"] is True
-    text = result["content"][0]["text"]
-    assert CREDENTIAL not in text
-    assert json.loads(text)["error"]["code"] == "unavailable"
+    assert is_error is True
+    assert CREDENTIAL not in json.dumps(payload)
+    assert payload["error"]["code"] == "unavailable"
 
 
 def test_stderr_diagnostics_redact_the_credential_and_stay_bounded(mcp_server, stderr_sink):

--- a/tests/missions/mcp/test_mission_mcp_hostile_args.py
+++ b/tests/missions/mcp/test_mission_mcp_hostile_args.py
@@ -1,0 +1,240 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Malicious-argument corpus: hostile tool arguments cannot escape the adapter.
+
+Issue #810 acceptance: arguments cannot redirect the HTTP client, widen the
+profile, traverse paths, inject headers, or expose credentials. Every
+rejected argument must fail before a single request reaches the fake
+server.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from archetype.missions.mcp.config import McpHostConfig
+from archetype.missions.mcp.server import MissionMcpServer
+from tests.missions.mcp.conftest import CREDENTIAL
+
+HOSTILE_OPAQUE_IDS = [
+    "../admin",
+    "..%2F..%2Fsecrets",
+    "runs/../../v1/principals",
+    "a/b",
+    "a?admin=true",
+    "a#fragment",
+    "a b",
+    "a\r\nX-Injected: 1",
+    "a\nAuthorization: Bearer stolen",
+    "http://evil.example/v1/mission-runs",
+    "",
+    ".hidden",
+    "-leading-dash",
+    "a" * 300,
+    "run\x00id",
+    "run🚀id",
+]
+
+CONFIG_OVERRIDE_ARGUMENTS = [
+    {"base_url": "http://evil.example"},
+    {"url": "http://evil.example"},
+    {"token": "attacker-token"},
+    {"authorization": "Bearer stolen"},
+    {"headers": {"Authorization": "Bearer stolen"}},
+    {"path": "/v1/principals"},
+    {"method": "DELETE"},
+    {"backend": "modal"},
+    {"profile": "admin"},
+    {"credential_file": "/etc/passwd"},
+]
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_OPAQUE_IDS)
+def test_hostile_run_id_never_reaches_the_wire(call, fake_control, hostile):
+    is_error, payload = call("mission_get", {"run_id": hostile})
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_OPAQUE_IDS)
+def test_hostile_cursor_never_reaches_the_wire(call, fake_control, hostile):
+    run = fake_control.seed_run(state="running", events=1)
+    fake_control.requests.clear()
+    is_error, payload = call("mission_events", {"run_id": run.run_id, "after": hostile})
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["../key", "key with space", "key\r\nX-Evil: 1", "", "k" * 300],
+)
+def test_hostile_idempotency_key_cannot_inject_headers(call, fake_control, hostile, submit_args):
+    is_error, payload = call("mission_submit", submit_args(idempotency_key=hostile))
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+
+@pytest.mark.parametrize("limit", [0, -5, "10", 2.5, True, False, None])
+def test_invalid_limit_is_rejected_before_the_wire(call, fake_control, limit):
+    run = fake_control.seed_run(state="running")
+    fake_control.requests.clear()
+    is_error, payload = call("mission_events", {"run_id": run.run_id, "limit": limit})
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+
+@pytest.mark.parametrize("override", CONFIG_OVERRIDE_ARGUMENTS)
+@pytest.mark.parametrize(
+    "tool,base",
+    [
+        ("mission_get", {"run_id": "run-1"}),
+        ("mission_events", {"run_id": "run-1"}),
+        ("mission_result", {"run_id": "run-1"}),
+        ("mission_cancel", {"run_id": "run-1"}),
+        ("mission_list", {}),
+    ],
+)
+def test_configuration_overrides_are_unknown_arguments(call, fake_control, tool, base, override):
+    """A model can never supply a URL, credential, path, method, or backend."""
+
+    is_error, payload = call(tool, {**base, **override})
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert "unknown argument" in payload["error"]["message"]
+    assert fake_control.requests == []
+
+
+@pytest.mark.parametrize("override", CONFIG_OVERRIDE_ARGUMENTS)
+def test_submit_configuration_overrides_are_rejected(call, fake_control, override, submit_args):
+    is_error, payload = call("mission_submit", {**submit_args(), **override})
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+
+@pytest.mark.parametrize(
+    "task_widening",
+    [
+        {"sandbox": {"image": "attacker/image"}},
+        {"env": {"AWS_SECRET_ACCESS_KEY": "x"}},
+        {"model": "expensive-model"},
+        {"driver": "raw-shell"},
+        {"budget": 10**9},
+    ],
+)
+def test_profile_widening_through_task_payload_is_rejected(
+    call, fake_control, task_widening, submit_args
+):
+    """Task items carry name/prompt/validators/depends_on only (issue #808)."""
+
+    tasks = [
+        {
+            "name": "fix-bug",
+            "prompt": "Fix the reported bug.",
+            **task_widening,
+        }
+    ]
+    is_error, payload = call("mission_submit", submit_args(tasks=tasks))
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+
+def test_task_count_and_prompt_bytes_are_bounded(call, fake_control, submit_args):
+    many = [{"name": f"task-{index}", "prompt": "p"} for index in range(33)]
+    is_error, payload = call("mission_submit", submit_args(tasks=many))
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+
+    huge_prompt = [{"name": "task", "prompt": "x" * 70000}]
+    is_error, payload = call("mission_submit", submit_args(tasks=huge_prompt))
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+
+def test_a_redirect_response_is_an_error_and_is_never_followed(call, fake_control):
+    run = fake_control.seed_run(state="running")
+    fake_control.requests.clear()
+    fake_control.redirect_next = True
+    is_error, payload = call("mission_get", {"run_id": run.run_id})
+    assert is_error is True
+    assert payload["error"]["code"] == "protocol_error"
+    assert "redirect" in payload["error"]["message"]
+    assert len(fake_control.requests) == 1
+    assert "evil-target" not in fake_control.requests[0].path
+
+
+def test_upstream_failure_text_is_bounded_and_credential_free(call, fake_control):
+    run = fake_control.seed_run(state="running")
+    fake_control.requests.clear()
+    fake_control.fail_next_status = 500
+    fake_control.fail_next_detail = "boom " * 2000
+    is_error, payload = call("mission_get", {"run_id": run.run_id})
+    assert is_error is True
+    assert payload["error"]["code"] == "upstream_error"
+    assert len(payload["error"]["message"]) < 300
+    assert CREDENTIAL not in json.dumps(payload)
+
+
+def test_transport_failure_is_bounded_and_credential_free():
+    config = McpHostConfig.from_env(
+        {
+            "ARCHETYPE_MISSIONS_MCP_URL": "http://127.0.0.1:9",
+            "ARCHETYPE_MISSIONS_MCP_CREDENTIAL": CREDENTIAL,
+            "ARCHETYPE_MISSIONS_MCP_TIMEOUT_SECONDS": "0.2",
+        }
+    )
+    server = MissionMcpServer(config, stderr=io.StringIO())
+    try:
+        frame = server.handle_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "mission_get",
+                    "arguments": {"run_id": "run-1"},
+                },
+            }
+        )
+    finally:
+        server.close()
+    result = frame["result"]
+    assert result["isError"] is True
+    text = result["content"][0]["text"]
+    assert CREDENTIAL not in text
+    assert json.loads(text)["error"]["code"] == "unavailable"
+
+
+def test_stderr_diagnostics_redact_the_credential_and_stay_bounded(mcp_server, stderr_sink):
+    mcp_server._diagnostics.emit(f"Authorization: Bearer {CREDENTIAL} " + "overflow " * 500)
+    written = stderr_sink.getvalue()
+    assert CREDENTIAL not in written
+    assert "[redacted]" in written
+    longest = max(len(line) for line in written.splitlines())
+    assert longest <= 600
+
+
+def test_upstream_body_echoing_the_credential_is_redacted(call, fake_control):
+    run = fake_control.seed_run(state="running")
+    fake_control.fail_next_status = 500
+    fake_control.fail_next_detail = f"leaked Bearer {CREDENTIAL} in detail"
+    is_error, payload = call("mission_get", {"run_id": run.run_id})
+    assert is_error is True
+    assert CREDENTIAL not in json.dumps(payload)
+    assert "[redacted]" in payload["error"]["message"]
+
+
+def test_deeply_nested_hostile_frame_is_a_parse_error(mcp_server):
+    frame = mcp_server.handle_line("[" * 20000)
+    assert frame["error"]["code"] == -32700

--- a/tests/missions/mcp/test_mission_mcp_hostile_args.py
+++ b/tests/missions/mcp/test_mission_mcp_hostile_args.py
@@ -18,7 +18,12 @@ import pytest
 
 from archetype.missions.mcp.config import McpHostConfig
 from archetype.missions.mcp.server import MissionMcpServer
-from tests.missions.mcp.conftest import CREDENTIAL, call_tool, submit_arguments
+from tests.missions.mcp.conftest import (
+    CREDENTIAL,
+    call_tool,
+    host_environ,
+    submit_arguments,
+)
 
 HOSTILE_OPAQUE_IDS = [
     "../admin",
@@ -224,3 +229,57 @@ def test_upstream_body_echoing_the_credential_is_redacted(call, fake_control):
 def test_deeply_nested_hostile_frame_is_a_parse_error(mcp_server):
     frame = mcp_server.handle_line("[" * 20000)
     assert frame["error"]["code"] == -32700
+
+
+TRICKY_CREDENTIAL = 'mcp-cred-"quoted\\slash-0123456789abcdef'
+SURROGATE = "\udc80"
+
+
+def test_credential_with_json_escapables_is_still_redacted(fake_control):
+    """Redaction is structural: a credential containing a quote and a
+    backslash is no longer a contiguous substring after JSON escaping, yet
+    it must never survive into a model-visible tool result."""
+
+    fake_control.credential = TRICKY_CREDENTIAL
+    run = fake_control.seed_run(state="running")
+    fake_control.fail_next_status = 500
+    fake_control.fail_next_detail = f"leak {TRICKY_CREDENTIAL} end"
+    config = McpHostConfig.from_env(host_environ(fake_control))
+    server = MissionMcpServer(config, stderr=io.StringIO())
+    try:
+        is_error, payload = call_tool(server, "mission_get", {"run_id": run.run_id})
+    finally:
+        server.close()
+    assert is_error is True
+    assert TRICKY_CREDENTIAL not in json.dumps(payload)
+    assert "[redacted]" in payload["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        submit_arguments(repository=f"repo{SURROGATE}"),
+        submit_arguments(mission=f"m{SURROGATE}"),
+        submit_arguments(tasks=[{"name": f"t{SURROGATE}", "prompt": "p"}]),
+        submit_arguments(tasks=[{"name": "t", "prompt": f"p{SURROGATE}"}]),
+        submit_arguments(
+            tasks=[
+                {
+                    "name": "t",
+                    "prompt": "p",
+                    "validators": [{"name": "v", "argv": [f"a{SURROGATE}"]}],
+                }
+            ]
+        ),
+        submit_arguments(tasks=[{"name": "t", "prompt": "p", "depends_on": [f"d{SURROGATE}"]}]),
+    ],
+)
+def test_unpaired_surrogates_are_invalid_arguments_before_the_wire(call, fake_control, arguments):
+    """A permanently invalid input must surface as invalid_argument, never as
+    a transient-looking internal transport failure."""
+
+    is_error, payload = call("mission_submit", arguments)
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert "surrogate" in payload["error"]["message"]
+    assert fake_control.requests == []

--- a/tests/missions/mcp/test_mission_mcp_live_loopback.py
+++ b/tests/missions/mcp/test_mission_mcp_live_loopback.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Binding seams left for issue #809 (recorded, not faked).
+
+Two explicitly gated tests own the gap between the offline fake contract
+in ``conftest.py`` and the real MissionRun REST surface:
+
+* ``test_installed_rest_routes_match_the_adapter_contract`` skips while
+  ``archetype.missions.api`` has no ``/v1/mission-runs`` routes and
+  activates automatically once they land, so route drift fails CI.
+* ``test_live_loopback_roundtrip`` is the live Archetype proof, skipped
+  until a served loopback host with the issue #809 surface exists
+  (repo convention: freeze dogfood runs as skipif tests).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import uuid
+
+import pytest
+
+from archetype.missions.mcp.config import McpHostConfig
+from archetype.missions.mcp.server import MissionMcpServer
+
+LOOPBACK_URL_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_URL"
+LOOPBACK_CREDENTIAL_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_CREDENTIAL"
+LOOPBACK_PROFILE_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_PROFILE"
+LOOPBACK_REPOSITORY_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_REPOSITORY"
+
+# The adapter's REST surface, exactly as documented in issue #809 plus the
+# principal-scoped list route required by issue #810 (OPEN Q: #809 does not
+# document a list route; the PR body records the GET-collection assumption).
+ADAPTER_ROUTES = {
+    ("POST", "/v1/mission-runs"),
+    ("GET", "/v1/mission-runs/{run_id}"),
+    ("GET", "/v1/mission-runs/{run_id}/events"),
+    ("GET", "/v1/mission-runs/{run_id}/result"),
+    ("POST", "/v1/mission-runs/{run_id}/cancel"),
+}
+
+
+def _installed_mission_run_routes() -> set[tuple[str, str]]:
+    from archetype.missions.api import create_router
+
+    routes: set[tuple[str, str]] = set()
+    for route in create_router().routes:
+        path = getattr(route, "path", "")
+        for method in getattr(route, "methods", ()) or ():
+            if "/mission-runs" in path:
+                routes.add((method, path))
+    return routes
+
+
+def test_installed_rest_routes_match_the_adapter_contract():
+    installed = _installed_mission_run_routes()
+    if not installed:
+        pytest.skip(
+            "Recorded seam (issue #810): archetype.missions.api does not ship "
+            "/v1/mission-runs yet (issue #809 in flight). The offline fake in "
+            "tests/missions/mcp/conftest.py carries the documented contract; "
+            "when the routes land this test activates and any drift from the "
+            "adapter's route set fails CI. Then bind FakeMissionControl's "
+            "payloads to the real response models."
+        )
+    missing = {
+        (method, path)
+        for method, path in ADAPTER_ROUTES
+        if not any(
+            method == installed_method and path == installed_path
+            for installed_method, installed_path in installed
+        )
+    }
+    assert not missing, (
+        "Issue #809 landed with a different MissionRun route set than the "
+        f"MCP adapter targets; missing {sorted(missing)}. Update "
+        "archetype/missions/mcp/client.py and rebind "
+        "tests/missions/mcp/conftest.py to the real models."
+    )
+
+
+@pytest.mark.external
+@pytest.mark.skipif(
+    LOOPBACK_URL_ENV not in os.environ,
+    reason=(
+        "Live loopback Archetype proof pending issue #809: export "
+        f"{LOOPBACK_URL_ENV}, {LOOPBACK_CREDENTIAL_ENV}, "
+        f"{LOOPBACK_PROFILE_ENV}, and {LOOPBACK_REPOSITORY_ENV} against a "
+        "served host exposing the MissionRun REST surface to run the "
+        "submit -> get -> events -> cancel roundtrip through the MCP tools."
+    ),
+)
+def test_live_loopback_roundtrip():
+    config = McpHostConfig.from_env(
+        {
+            "ARCHETYPE_MISSIONS_MCP_URL": os.environ[LOOPBACK_URL_ENV],
+            "ARCHETYPE_MISSIONS_MCP_CREDENTIAL": os.environ.get(LOOPBACK_CREDENTIAL_ENV, ""),
+        }
+    )
+    server = MissionMcpServer(config, stderr=io.StringIO())
+
+    def tool(name: str, arguments: dict) -> tuple[bool, dict]:
+        frame = server.handle_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        result = frame["result"]
+        return result["isError"], json.loads(result["content"][0]["text"])
+
+    try:
+        submit = {
+            "profile_id": os.environ[LOOPBACK_PROFILE_ENV],
+            "repository": os.environ[LOOPBACK_REPOSITORY_ENV],
+            "ref": "main",
+            "mission": "mcp-loopback-proof",
+            "tasks": [
+                {
+                    "name": "noop-proof",
+                    "prompt": "Report the repository name and stop.",
+                    "validators": [{"name": "true", "argv": ["true"]}],
+                }
+            ],
+            "idempotency_key": f"loopback-{uuid.uuid4().hex}",
+        }
+        is_error, accepted = tool("mission_submit", submit)
+        assert is_error is False, accepted
+        run_id = accepted["run_id"]
+
+        is_error, duplicate = tool("mission_submit", submit)
+        assert is_error is False and duplicate["run_id"] == run_id
+
+        is_error, status = tool("mission_get", {"run_id": run_id})
+        assert is_error is False and status["run_id"] == run_id
+
+        is_error, events = tool("mission_events", {"run_id": run_id, "limit": 10})
+        assert is_error is False and "events" in events
+
+        is_error, cancelled = tool("mission_cancel", {"run_id": run_id})
+        assert is_error is False
+    finally:
+        server.close()

--- a/tests/missions/mcp/test_mission_mcp_live_loopback.py
+++ b/tests/missions/mcp/test_mission_mcp_live_loopback.py
@@ -17,7 +17,6 @@ in ``conftest.py`` and the real MissionRun REST surface:
 from __future__ import annotations
 
 import io
-import json
 import os
 import uuid
 
@@ -25,17 +24,20 @@ import pytest
 
 from archetype.missions.mcp.config import McpHostConfig
 from archetype.missions.mcp.server import MissionMcpServer
+from tests.missions.mcp.conftest import call_tool
 
 LOOPBACK_URL_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_URL"
 LOOPBACK_CREDENTIAL_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_CREDENTIAL"
 LOOPBACK_PROFILE_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_PROFILE"
 LOOPBACK_REPOSITORY_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_REPOSITORY"
 
-# The adapter's REST surface, exactly as documented in issue #809 plus the
-# principal-scoped list route required by issue #810 (OPEN Q: #809 does not
-# document a list route; the PR body records the GET-collection assumption).
+# The adapter's REST surface: the five routes documented in issue #809 plus
+# the principal-scoped GET collection that mission_list targets (OPEN Q:
+# #809 does not document a list route; the PR body records the assumption,
+# and this set drift-enforces it once the real routes land).
 ADAPTER_ROUTES = {
     ("POST", "/v1/mission-runs"),
+    ("GET", "/v1/mission-runs"),
     ("GET", "/v1/mission-runs/{run_id}"),
     ("GET", "/v1/mission-runs/{run_id}/events"),
     ("GET", "/v1/mission-runs/{run_id}/result"),
@@ -103,16 +105,7 @@ def test_live_loopback_roundtrip():
     server = MissionMcpServer(config, stderr=io.StringIO())
 
     def tool(name: str, arguments: dict) -> tuple[bool, dict]:
-        frame = server.handle_message(
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "tools/call",
-                "params": {"name": name, "arguments": arguments},
-            }
-        )
-        result = frame["result"]
-        return result["isError"], json.loads(result["content"][0]["text"])
+        return call_tool(server, name, arguments)
 
     try:
         submit = {

--- a/tests/missions/mcp/test_mission_mcp_protocol.py
+++ b/tests/missions/mcp/test_mission_mcp_protocol.py
@@ -208,3 +208,19 @@ def test_declared_schemas_agree_with_runtime_validation():
             if "pattern" in fragment:
                 assert re.fullmatch(fragment["pattern"], good)
                 assert not re.fullmatch(fragment["pattern"], bad)
+
+
+def test_oversized_frame_is_rejected_boundedly(host_config, monkeypatch):
+    """A newline-less flood is discarded in bounded chunks and answered with
+    a parse error; the loop keeps serving later frames."""
+
+    from archetype.missions.mcp import server as server_module
+
+    monkeypatch.setattr(server_module, "_MAX_FRAME_CHARS", 128)
+    stdin = io.StringIO("x" * 300 + "\n" + json.dumps(_request("ping", 9)) + "\n")
+    stdout = io.StringIO()
+    server = MissionMcpServer(host_config, stderr=io.StringIO())
+    assert server.serve(stdin, stdout) == 0
+    frames = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert frames[0]["error"] == {"code": -32700, "message": "Frame too large"}
+    assert frames[1] == {"jsonrpc": "2.0", "id": 9, "result": {}}

--- a/tests/missions/mcp/test_mission_mcp_protocol.py
+++ b/tests/missions/mcp/test_mission_mcp_protocol.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -177,3 +178,33 @@ def test_stdio_subprocess_end_to_end(fake_control):
     assert payload["run_id"] == run.run_id
     assert fake_control.credential not in process.stdout
     assert fake_control.credential not in process.stderr
+
+
+def test_declared_schemas_agree_with_runtime_validation():
+    """Advertised inputSchema fragments and runtime validators render from one table."""
+
+    from archetype.missions.mcp import server as server_module
+    from archetype.missions.mcp.client import MissionToolError
+
+    samples = {
+        "opaque_id": ("run-1", "a/b"),
+        "line": ("main", "bad\nline"),
+        "limit": (5, 0),
+        "tasks": (
+            [{"name": "t", "prompt": "p"}],
+            [{"name": "t", "prompt": "p", "sandbox": {}}],
+        ),
+    }
+    for spec in server_module._TOOL_SPECS:
+        schema = next(t for t in TOOLS if t["name"] == spec.name)["inputSchema"]
+        for argument, kind, required in spec.arguments:
+            fragment, validator = server_module._ARGUMENT_KINDS[kind]
+            assert schema["properties"][argument] == fragment
+            assert (argument in schema.get("required", [])) is required
+            good, bad = samples[kind]
+            validator(good, argument)  # schema-conforming values pass
+            with pytest.raises(MissionToolError):
+                validator(bad, argument)  # schema-violating values fail closed
+            if "pattern" in fragment:
+                assert re.fullmatch(fragment["pattern"], good)
+                assert not re.fullmatch(fragment["pattern"], bad)

--- a/tests/missions/mcp/test_mission_mcp_protocol.py
+++ b/tests/missions/mcp/test_mission_mcp_protocol.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP protocol conformance for the Mission MCP server (issue #810)."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from archetype.missions.mcp.server import (
+    SUPPORTED_PROTOCOL_VERSIONS,
+    TOOLS,
+    MissionMcpServer,
+)
+from tests.missions.mcp.conftest import host_environ
+
+EXPECTED_TOOL_NAMES = [
+    "mission_submit",
+    "mission_get",
+    "mission_events",
+    "mission_result",
+    "mission_cancel",
+    "mission_list",
+]
+
+
+def _request(method: str, request_id: int = 1, params: dict | None = None) -> dict:
+    frame: dict = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        frame["params"] = params
+    return frame
+
+
+def test_initialize_echoes_a_supported_protocol_version(mcp_server):
+    frame = mcp_server.handle_message(
+        _request("initialize", params={"protocolVersion": "2025-03-26"})
+    )
+    result = frame["result"]
+    assert result["protocolVersion"] == "2025-03-26"
+    assert result["serverInfo"]["name"] == "archetype-missions-mcp"
+    assert "tools" in result["capabilities"]
+
+
+def test_initialize_answers_latest_supported_for_unknown_version(mcp_server):
+    frame = mcp_server.handle_message(
+        _request("initialize", params={"protocolVersion": "1999-01-01"})
+    )
+    assert frame["result"]["protocolVersion"] == SUPPORTED_PROTOCOL_VERSIONS[0]
+
+
+def test_initialized_notification_produces_no_frame(mcp_server):
+    assert (
+        mcp_server.handle_message({"jsonrpc": "2.0", "method": "notifications/initialized"}) is None
+    )
+
+
+def test_unknown_notification_is_ignored_without_frame(mcp_server):
+    assert (
+        mcp_server.handle_message({"jsonrpc": "2.0", "method": "notifications/unknown-extension"})
+        is None
+    )
+
+
+def test_ping_returns_empty_result(mcp_server):
+    frame = mcp_server.handle_message(_request("ping"))
+    assert frame == {"jsonrpc": "2.0", "id": 1, "result": {}}
+
+
+def test_unsupported_method_returns_method_not_found(mcp_server):
+    for method in ("resources/list", "prompts/list", "completion/complete"):
+        frame = mcp_server.handle_message(_request(method))
+        assert frame["error"]["code"] == -32601, method
+
+
+def test_parse_error_returns_32700(mcp_server):
+    frame = mcp_server.handle_line("{not json")
+    assert frame["error"]["code"] == -32700
+    assert frame["id"] is None
+
+
+def test_invalid_request_returns_32600(mcp_server):
+    frame = mcp_server.handle_message({"id": 5, "method": "ping"})
+    assert frame["error"]["code"] == -32600
+
+
+def test_unknown_tool_returns_invalid_params(mcp_server):
+    frame = mcp_server.handle_message(
+        _request("tools/call", params={"name": "mission_attach", "arguments": {}})
+    )
+    assert frame["error"]["code"] == -32602
+
+
+def test_tools_list_is_exactly_the_six_mission_tools(mcp_server):
+    frame = mcp_server.handle_message(_request("tools/list"))
+    names = [tool["name"] for tool in frame["result"]["tools"]]
+    assert names == EXPECTED_TOOL_NAMES
+
+
+def test_no_interactive_attachment_tools_are_stubbed():
+    """Issue #811 tools must be absent entirely, not stubbed as successful."""
+
+    names = {tool["name"] for tool in TOOLS}
+    for forbidden in ("attach", "steer", "takeover", "terminal", "viewport"):
+        assert not any(forbidden in name for name in names), names
+
+
+def test_every_tool_schema_rejects_unknown_properties():
+    def closed(schema: dict) -> None:
+        assert schema.get("additionalProperties") is False, schema
+        for nested in schema.get("properties", {}).values():
+            if nested.get("type") == "object":
+                closed(nested)
+            if nested.get("type") == "array" and isinstance(nested.get("items"), dict):
+                if nested["items"].get("type") == "object":
+                    closed(nested["items"])
+
+    for tool in TOOLS:
+        closed(tool["inputSchema"])
+
+
+def test_serve_writes_protocol_frames_only_to_stdout(fake_control, host_config):
+    lines = [
+        json.dumps(_request("initialize", 1, {"protocolVersion": "2025-06-18"})),
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        json.dumps(_request("tools/list", 2)),
+        "this line is not json",
+        json.dumps(_request("ping", 3)),
+    ]
+    stdin = io.StringIO("\n".join(lines) + "\n")
+    stdout = io.StringIO()
+    server = MissionMcpServer(host_config, stderr=io.StringIO())
+    assert server.serve(stdin, stdout) == 0
+    frames = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert [frame.get("id") for frame in frames] == [1, 2, None, 3]
+    assert frames[2]["error"]["code"] == -32700
+    assert all(frame["jsonrpc"] == "2.0" for frame in frames)
+
+
+@pytest.mark.process
+def test_stdio_subprocess_end_to_end(fake_control):
+    """A real ``python -m archetype.missions.mcp`` process speaks MCP over stdio."""
+
+    run = fake_control.seed_run(state="running", events=2)
+    requests = [
+        _request("initialize", 1, {"protocolVersion": "2025-06-18"}),
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        _request("tools/list", 2),
+        _request(
+            "tools/call",
+            3,
+            {"name": "mission_get", "arguments": {"run_id": run.run_id}},
+        ),
+        _request("ping", 4),
+    ]
+    env = dict(os.environ)
+    env.update(host_environ(fake_control))
+    process = subprocess.run(
+        [sys.executable, "-m", "archetype.missions.mcp"],
+        input="".join(json.dumps(frame) + "\n" for frame in requests),
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+    )
+    assert process.returncode == 0, process.stderr
+    frames = [json.loads(line) for line in process.stdout.splitlines()]
+    assert [frame["id"] for frame in frames] == [1, 2, 3, 4]
+    tool_result = frames[2]["result"]
+    assert tool_result["isError"] is False
+    payload = json.loads(tool_result["content"][0]["text"])
+    assert payload["run_id"] == run.run_id
+    assert fake_control.credential not in process.stdout
+    assert fake_control.credential not in process.stderr

--- a/tests/missions/mcp/test_mission_mcp_rest_contract.py
+++ b/tests/missions/mcp/test_mission_mcp_rest_contract.py
@@ -6,8 +6,11 @@
 from __future__ import annotations
 
 import io
+import json
 
-from archetype.missions.mcp.config import McpHostConfig
+import pytest
+
+from archetype.missions.mcp.config import McpHostConfig, McpHostConfigError
 from archetype.missions.mcp.server import MissionMcpServer
 from tests.missions.mcp.conftest import call_tool, host_environ, submit_arguments
 
@@ -166,16 +169,43 @@ def test_list_is_scoped_to_the_authenticated_principal(call, fake_control):
 
 
 def test_oversized_payload_is_truncated_with_an_explicit_marker(fake_control):
-    run = fake_control.seed_run(state="completed", result={"log": "x" * 5000})
+    """The FULL rendered tool text obeys max_result_bytes even for content
+    whose JSON escaping expands aggressively (control chars, quotes)."""
+
+    run = fake_control.seed_run(
+        state="completed",
+        result={"log": ('"' + "\x01\x02" + "\\") * 900},
+    )
     config = McpHostConfig.from_env(
         host_environ(fake_control, ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES="256")
     )
     server = MissionMcpServer(config, stderr=io.StringIO())
     try:
-        is_error, payload = call_tool(server, "mission_result", {"run_id": run.run_id})
+        frame = server.handle_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "mission_result",
+                    "arguments": {"run_id": run.run_id},
+                },
+            }
+        )
     finally:
         server.close()
-    assert is_error is False
+    result = frame["result"]
+    assert result["isError"] is False
+    rendered = result["content"][0]["text"]
+    assert len(rendered.encode("utf-8")) <= 256
+    payload = json.loads(rendered)
     assert payload["truncated"] is True
     assert payload["limit_bytes"] == 256
-    assert len(payload["content_prefix"].encode("utf-8")) <= 256
+    assert payload["content_prefix"]
+
+
+def test_result_bytes_floor_fails_closed(fake_control):
+    with pytest.raises(McpHostConfigError):
+        McpHostConfig.from_env(
+            host_environ(fake_control, ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES="40")
+        )

--- a/tests/missions/mcp/test_mission_mcp_rest_contract.py
+++ b/tests/missions/mcp/test_mission_mcp_rest_contract.py
@@ -6,28 +6,14 @@
 from __future__ import annotations
 
 import io
-import json
 
 from archetype.missions.mcp.config import McpHostConfig
 from archetype.missions.mcp.server import MissionMcpServer
-from tests.missions.mcp.conftest import host_environ, submit_arguments
+from tests.missions.mcp.conftest import call_tool, host_environ, submit_arguments
 
 
-def _tool(server: MissionMcpServer, name: str, arguments: dict | None = None):
-    frame = server.handle_message(
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {"name": name, "arguments": arguments or {}},
-        }
-    )
-    result = frame["result"]
-    return result["isError"], json.loads(result["content"][0]["text"])
-
-
-def test_submit_returns_run_id_before_completion(call, fake_control, submit_args):
-    is_error, payload = call("mission_submit", submit_args())
+def test_submit_returns_run_id_before_completion(call, fake_control):
+    is_error, payload = call("mission_submit", submit_arguments())
     assert is_error is False
     assert payload["run_id"]
     assert payload["state"] == "queued"
@@ -37,19 +23,19 @@ def test_submit_returns_run_id_before_completion(call, fake_control, submit_args
     assert fake_control.runs[payload["run_id"]].result is None
 
 
-def test_duplicate_submit_after_process_death_returns_original_run(fake_control, submit_args):
+def test_duplicate_submit_after_process_death_returns_original_run(fake_control):
     """A fresh MCP process reusing the idempotency key recovers the same run."""
 
     config = McpHostConfig.from_env(host_environ(fake_control))
     first = MissionMcpServer(config, stderr=io.StringIO())
     try:
-        _, original = _tool(first, "mission_submit", submit_args())
+        _, original = call_tool(first, "mission_submit", submit_arguments())
     finally:
         first.close()
 
     second = MissionMcpServer(config, stderr=io.StringIO())
     try:
-        is_error, recovered = _tool(second, "mission_submit", submit_args())
+        is_error, recovered = call_tool(second, "mission_submit", submit_arguments())
     finally:
         second.close()
     assert is_error is False
@@ -57,18 +43,18 @@ def test_duplicate_submit_after_process_death_returns_original_run(fake_control,
     assert recovered["request_digest"] == original["request_digest"]
 
 
-def test_submit_with_changed_content_conflicts(call, submit_args):
-    call("mission_submit", submit_args())
-    is_error, payload = call("mission_submit", submit_args(mission="different-mission"))
+def test_submit_with_changed_content_conflicts(call):
+    call("mission_submit", submit_arguments())
+    is_error, payload = call("mission_submit", submit_arguments(mission="different-mission"))
     assert is_error is True
     assert payload["error"]["code"] == "conflict"
 
 
-def test_missing_credential_fails_closed(fake_control, submit_args):
+def test_missing_credential_fails_closed(fake_control):
     config = McpHostConfig.from_env({"ARCHETYPE_MISSIONS_MCP_URL": fake_control.base_url})
     server = MissionMcpServer(config, stderr=io.StringIO())
     try:
-        is_error, payload = _tool(server, "mission_submit", submit_arguments())
+        is_error, payload = call_tool(server, "mission_submit", submit_arguments())
     finally:
         server.close()
     assert is_error is True
@@ -186,7 +172,7 @@ def test_oversized_payload_is_truncated_with_an_explicit_marker(fake_control):
     )
     server = MissionMcpServer(config, stderr=io.StringIO())
     try:
-        is_error, payload = _tool(server, "mission_result", {"run_id": run.run_id})
+        is_error, payload = call_tool(server, "mission_result", {"run_id": run.run_id})
     finally:
         server.close()
     assert is_error is False

--- a/tests/missions/mcp/test_mission_mcp_rest_contract.py
+++ b/tests/missions/mcp/test_mission_mcp_rest_contract.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Vangelis Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Offline contract tests: MCP tools over the documented issue #809 REST surface."""
+
+from __future__ import annotations
+
+import io
+import json
+
+from archetype.missions.mcp.config import McpHostConfig
+from archetype.missions.mcp.server import MissionMcpServer
+from tests.missions.mcp.conftest import host_environ, submit_arguments
+
+
+def _tool(server: MissionMcpServer, name: str, arguments: dict | None = None):
+    frame = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        }
+    )
+    result = frame["result"]
+    return result["isError"], json.loads(result["content"][0]["text"])
+
+
+def test_submit_returns_run_id_before_completion(call, fake_control, submit_args):
+    is_error, payload = call("mission_submit", submit_args())
+    assert is_error is False
+    assert payload["run_id"]
+    assert payload["state"] == "queued"
+    assert payload["request_digest"]
+    assert payload["status_url"].endswith(payload["run_id"])
+    # The fake never completes work: acceptance is decoupled from completion.
+    assert fake_control.runs[payload["run_id"]].result is None
+
+
+def test_duplicate_submit_after_process_death_returns_original_run(fake_control, submit_args):
+    """A fresh MCP process reusing the idempotency key recovers the same run."""
+
+    config = McpHostConfig.from_env(host_environ(fake_control))
+    first = MissionMcpServer(config, stderr=io.StringIO())
+    try:
+        _, original = _tool(first, "mission_submit", submit_args())
+    finally:
+        first.close()
+
+    second = MissionMcpServer(config, stderr=io.StringIO())
+    try:
+        is_error, recovered = _tool(second, "mission_submit", submit_args())
+    finally:
+        second.close()
+    assert is_error is False
+    assert recovered["run_id"] == original["run_id"]
+    assert recovered["request_digest"] == original["request_digest"]
+
+
+def test_submit_with_changed_content_conflicts(call, submit_args):
+    call("mission_submit", submit_args())
+    is_error, payload = call("mission_submit", submit_args(mission="different-mission"))
+    assert is_error is True
+    assert payload["error"]["code"] == "conflict"
+
+
+def test_missing_credential_fails_closed(fake_control, submit_args):
+    config = McpHostConfig.from_env({"ARCHETYPE_MISSIONS_MCP_URL": fake_control.base_url})
+    server = MissionMcpServer(config, stderr=io.StringIO())
+    try:
+        is_error, payload = _tool(server, "mission_submit", submit_arguments())
+    finally:
+        server.close()
+    assert is_error is True
+    assert payload["error"]["code"] == "unauthenticated"
+
+
+def test_get_returns_bounded_projection(call, fake_control):
+    run = fake_control.seed_run(state="running")
+    is_error, payload = call("mission_get", {"run_id": run.run_id})
+    assert is_error is False
+    assert payload == {
+        "run_id": run.run_id,
+        "profile_id": run.profile_id,
+        "state": "running",
+        "request_digest": "",
+    }
+
+
+def test_get_unknown_run_is_not_found(call):
+    is_error, payload = call("mission_get", {"run_id": "run-does-not-exist"})
+    assert is_error is True
+    assert payload["error"]["code"] == "not_found"
+
+
+def test_events_cursor_replay_has_no_gaps_or_duplicates(call, fake_control):
+    run = fake_control.seed_run(state="running", events=7)
+    _, first = call("mission_events", {"run_id": run.run_id, "limit": 3})
+    assert [event["cursor"] for event in first["events"]] == ["1", "2", "3"]
+
+    _, replay = call("mission_events", {"run_id": run.run_id, "limit": 3})
+    assert replay == first
+
+    cursor = first["next_cursor"]
+    _, second = call("mission_events", {"run_id": run.run_id, "after": cursor, "limit": 3})
+    assert [event["cursor"] for event in second["events"]] == ["4", "5", "6"]
+    _, tail = call(
+        "mission_events",
+        {"run_id": run.run_id, "after": second["next_cursor"], "limit": 3},
+    )
+    assert [event["cursor"] for event in tail["events"]] == ["7"]
+    seen = [event["event_id"] for page in (first, second, tail) for event in page["events"]]
+    assert len(seen) == len(set(seen)) == 7
+
+
+def test_events_past_the_end_returns_stable_cursor(call, fake_control):
+    run = fake_control.seed_run(state="running", events=2)
+    _, page = call("mission_events", {"run_id": run.run_id, "after": "2"})
+    assert page["events"] == []
+    assert page["next_cursor"] == "2"
+
+
+def test_events_limit_is_clamped_to_the_host_page_bound(call, fake_control):
+    run = fake_control.seed_run(state="running", events=3)
+    is_error, _ = call("mission_events", {"run_id": run.run_id, "limit": 999999})
+    assert is_error is False
+    sent = fake_control.requests[-1].query["limit"]
+    assert sent == ["100"]  # the McpHostConfig default page bound
+
+
+def test_result_nonterminal_is_not_ready(call, fake_control):
+    run = fake_control.seed_run(state="running")
+    is_error, payload = call("mission_result", {"run_id": run.run_id})
+    assert is_error is True
+    assert payload["error"]["code"] == "not_ready"
+
+
+def test_result_terminal_is_immutable(call, fake_control):
+    run = fake_control.seed_run(
+        state="completed", result={"status": "green", "commits": ["abc123"]}
+    )
+    _, first = call("mission_result", {"run_id": run.run_id})
+    _, second = call("mission_result", {"run_id": run.run_id})
+    assert first == second
+    assert first["result"] == {"status": "green", "commits": ["abc123"]}
+
+
+def test_cancel_is_idempotent(call, fake_control):
+    run = fake_control.seed_run(state="running")
+    is_error, first = call("mission_cancel", {"run_id": run.run_id})
+    assert is_error is False
+    assert first["state"] == "cancelling"
+    is_error, second = call("mission_cancel", {"run_id": run.run_id})
+    assert is_error is False
+    assert second["state"] == "cancelling"
+
+
+def test_cancel_completion_race_reports_the_committed_fact(call, fake_control):
+    run = fake_control.seed_run(state="completed", result={"status": "green"})
+    is_error, payload = call("mission_cancel", {"run_id": run.run_id})
+    assert is_error is False
+    assert payload["state"] == "completed"
+
+
+def test_cancel_cannot_target_an_unauthorized_run(call, fake_control):
+    foreign = fake_control.seed_run(state="running", foreign=True)
+    is_error, payload = call("mission_cancel", {"run_id": foreign.run_id})
+    assert is_error is True
+    assert payload["error"]["code"] == "not_found"
+
+
+def test_list_is_scoped_to_the_authenticated_principal(call, fake_control):
+    own_one = fake_control.seed_run(state="running")
+    own_two = fake_control.seed_run(state="queued")
+    fake_control.seed_run(state="running", foreign=True)
+    is_error, payload = call("mission_list", {})
+    assert is_error is False
+    listed = {run["run_id"] for run in payload["runs"]}
+    assert listed == {own_one.run_id, own_two.run_id}
+
+
+def test_oversized_payload_is_truncated_with_an_explicit_marker(fake_control):
+    run = fake_control.seed_run(state="completed", result={"log": "x" * 5000})
+    config = McpHostConfig.from_env(
+        host_environ(fake_control, ARCHETYPE_MISSIONS_MCP_MAX_RESULT_BYTES="256")
+    )
+    server = MissionMcpServer(config, stderr=io.StringIO())
+    try:
+        is_error, payload = _tool(server, "mission_result", {"run_id": run.run_id})
+    finally:
+        server.close()
+    assert is_error is False
+    assert payload["truncated"] is True
+    assert payload["limit_bytes"] == 256
+    assert len(payload["content_prefix"].encode("utf-8")) <= 256

--- a/tests/scripts/test_check_gate_coverage.py
+++ b/tests/scripts/test_check_gate_coverage.py
@@ -31,6 +31,7 @@ def test_error_taxonomy_governs_registered_family_exceptions() -> None:
         "archetype.missions.coding_agents.app_server.CodexAppServerError",
         "archetype.missions.coding_agents.app_server.CodexTurnCompletionBarrierError",
         "archetype.missions.critics.harness._UnverifiableReview",
+        "archetype.missions.mcp.client.MissionToolError",
         "archetype.missions.sandboxes._subprocess._CleanupTimeout",
         "archetype.missions.sandboxes._subprocess._JoinTimeout",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -296,6 +296,7 @@ dependencies = [
     { name = "archetype-ecs" },
     { name = "daft" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "uuid-utils" },
 ]
@@ -310,6 +311,7 @@ requires-dist = [
     { name = "archetype-ecs", editable = "packages/archetype-ecs" },
     { name = "daft", specifier = ">=0.7.19" },
     { name = "fastapi", specifier = ">=0.110" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.5.2" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "uuid-utils", specifier = ">=0.11.0" },


### PR DESCRIPTION
Closes #810

Ships Archetype's native agent-facing Mission MCP server as a thin typed stdio adapter over the supported MissionRun REST contract (#809). Archetype remains mission and policy authority; the MCP process is replaceable transport.

## What ships

- `archetype.missions.mcp` in the archetype-missions distribution: `config.py` (trusted host configuration read once from `ARCHETYPE_MISSIONS_MCP_*`), `client.py` (six exact REST operations, no generic request surface, redirects never followed), `server.py` (newline-delimited JSON-RPC 2.0 stdio loop, six tool schemas, bounded rendering, redacting stderr diagnostics), `__main__.py`.
- Entry points: console script `archetype-missions-mcp` plus `python -m archetype.missions.mcp` — the "equivalent package entry point" the issue allows, so tool schemas ship in the same distribution as the missions REST router and track the API release. No new third-party dependency beyond declaring `httpx` (already in the workspace universe); the JSON-RPC loop is hand-rolled stdlib, no MCP SDK or client framework.
- Tools: `mission_submit` (async — returns `run_id` and status coordinates immediately; caller-owned `idempotency_key` forwarded as the `Idempotency-Key` header so a fresh process converges on the original run), `mission_get`, `mission_events` (opaque cursor + host-clamped limit), `mission_result`, `mission_cancel`, `mission_list`. Interactive attachment tools (#811) are absent entirely, not stubbed.
- `scripts/package_smoke.py` now proves the MCP console entry point resolves, loads, and has an installed binary in every wheel matrix containing missions — and is absent otherwise (runs inside `make ci`).
- Contract registered: `missions.mcp.trusted_host_adapter` in `quality/contracts.toml`, sourced to the new `docs/guide/agent-missions.md` section "11. Mission MCP server".

Diff split: ~908 lines src, ~1141 lines tests, ~85 lines packaging/docs/quality. (Post-audit head `6f41ef86`: one table-driven tool spec renders both the advertised schemas and the runtime validation, the tools/call frame helper is hoisted, input caps are fixed constants, and the GET collection route is drift-enforced; net -16 lines.)

## Acceptance evidence

- MCP conformance: initialize (version negotiation), initialized notification, tools/list, tools/call, ping; unsupported request methods return `-32601`; parse errors `-32700`; a real `python -m archetype.missions.mcp` subprocess roundtrip proves stdout carries protocol frames only (`tests/missions/mcp/test_mission_mcp_protocol.py`).
- Offline fake-server contract tests (`tests/missions/mcp/conftest.py::FakeMissionControl` implements the documented #809 contract on a loopback socket): submit returns before completion; duplicate submit from a fresh process returns the original run; changed digest conflicts; event cursor replay has no gaps, reordering, or duplicates; result is not-ready-gated while nonterminal and immutable once terminal; cancel is idempotent, completion races resolve to the committed execution fact, and cancel cannot target an unauthorized run; list is principal-scoped (`test_mission_mcp_rest_contract.py`).
- Malicious-argument corpus (`test_mission_mcp_hostile_args.py`): path traversal / query / fragment / header-injection ids, configuration-override argument names (`base_url`, `token`, `headers`, `path`, `method`, `backend`, ...), profile widening through task payloads (`sandbox`, `env`, `model`, `driver`, `budget`), oversized task counts and prompt bytes — every one rejected before a single request reaches the wire; redirects surface as bounded errors and are never followed; upstream and transport failures stay bounded; the credential is redacted from tool results and stderr (including an upstream body that echoes it); deeply nested hostile frames are parse errors, not crashes.
- Bounded results: host `max_result_bytes` cap with an explicit `{"truncated": true, "limit_bytes": N, "content_prefix": ...}` marker envelope.
- `MissionToolError` is declared in the gate-coverage audit's `INTERNAL_ONLY_EXCEPTIONS` with rationale: it is caught inside `MissionMcpServer._tools_call` and never crosses a registered API boundary.

## Seams recorded for #809 (not faked)

- `test_mission_mcp_live_loopback.py::test_installed_rest_routes_match_the_adapter_contract` skips today with the gap documented; it activates automatically once `archetype.missions.api` ships `/v1/mission-runs`, so route drift fails CI, and its failure message instructs rebinding `FakeMissionControl` payloads to the real response models — deliberately a one-file change in `tests/missions/mcp/conftest.py`.
- `test_live_loopback_roundtrip` is the live loopback Archetype proof, `skipif`-gated on `ARCHETYPE_MISSIONS_MCP_LOOPBACK_URL` (repo convention: freeze dogfood runs as skipif tests), pending a served #809 surface.
- Submit body field names (`profile_id`, `repository`, `ref`, `mission`, `tasks`) are the adapter's canonical reading of #809's documented body, sealed inside `client.py` so rebinding to the landed models is one file.

## Contracts and invariants

- New: `missions.mcp.trusted_host_adapter` — trusted host configuration only; tool arguments carry domain inputs and opaque ids; protocol-pure stdout; bounded, truncation-marked, credential-free output; idempotency identity preserved across submit retries and cancellation.
- Honored existing registry contracts: `commands.identity.idempotent` (same key and content converge on the original admission; changed content conflicts — mirrored through `Idempotency-Key` submit semantics), `gateway.authorization.rbac` (the adapter never fabricates authority; principal/profile policy from #808/#809 stays decisive; a missing credential fails closed at the REST boundary, and client-side autoapproval is never treated as human authorization), `release.package.installable` (wheel smoke extended for the MCP entry point), `architecture.dependencies.enforced` (`archetype.missions.mcp` imports stdlib + httpx only — no `api`/`cli`/`wiring` or cross-family edges).
- Umbrella specification sections honored: "Adapter contracts" (the adapter preserves the underlying REST semantics rather than inventing new ones) and "Service error taxonomy" (failures surface as bounded client-safe codes; internal text stays server-side).

## OPEN Q

1. `mission_list`: #810 requires a principal-scoped list tool, but #809's documented route set has no list route. The adapter and fake use `GET /v1/mission-runs` (the natural collection URL, principal-scoped by authentication). If #809 lands a different shape, the binding test fails CI and `MissionRunClient.list_runs` is a one-method change.
2. Task DAG field shapes: #809 documents "an explicit bounded task DAG/validator request" without field names. The adapter enforces structural bounds only (name / prompt / validators / depends_on, with fixed input caps: 32 tasks, 64 KiB prompt bytes) and leaves domain validation (validator count, acyclicity) to the mission authority per #808's profile contract. Exact names bind when #809's models land.
3. Cancel status codes: #809 requires durable intent and idempotency but no status code; the adapter accepts 200 and 202 as the bounded cancel projection.

## Validation

- `make ci` (static gates + full test suite + package/wheel smoke): pass.
- New suite: 146 passed, 2 skipped — the two recorded #809 seams above.
- Footgun self-review against `.claude/skills/footgun-detector/SKILL.md` performed; fixed during review: a dead `_initialized` flag, `RecursionError` on hostile nesting escaping the serve loop, and upstream credential echo reaching tool results.

@everettVT — draft until #809 lands; the live-loopback proof stays skip-gated until then. Automerge not armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
