### PR TITLE
fix: compile Smol selective validation on standalone installs

### DIFF
--- a/packages/archetype-smol/src/archetype/smol/world.py
+++ b/packages/archetype-smol/src/archetype/smol/world.py
@@ -175,6 +175,32 @@ def _preserve_or_validate_untouched_field(
     return validator(value)
 
 
+_MISSING = object()
+
+
+def _compile_detached(schema: Any, component_type: type[Component]) -> SchemaValidator:
+    """Compile `schema` rather than reusing the component's own validator.
+
+    When pydantic-core builds a `model` node it reuses an existing
+    `cls.__pydantic_validator__`, which silently discards the selective
+    wrappers applied above and replays every field validator. Detaching the
+    attribute for the duration of the build is what makes pydantic-core read
+    the schema we just patched. The window is one cached build on the
+    single-threaded step path, and the attribute is restored before any
+    component is validated.
+    """
+
+    owned = component_type.__dict__.get("__pydantic_validator__", _MISSING)
+    component_type.__pydantic_validator__ = None  # type: ignore[assignment]
+    try:
+        return SchemaValidator(schema)
+    finally:
+        if owned is _MISSING:
+            del component_type.__pydantic_validator__
+        else:
+            component_type.__pydantic_validator__ = owned
+
+
 @cache
 def _changed_fields_validator(
     component_type: type[Component],
@@ -193,7 +219,7 @@ def _changed_fields_validator(
                 _preserve_or_validate_untouched_field,
                 field_schema["schema"],
             )
-    return SchemaValidator(schema)
+    return _compile_detached(schema, component_type)
 
 
 def _validate_changed_fields[ComponentT: Component](

--- a/packages/archetype-smol/tests/test_smol.py
+++ b/packages/archetype-smol/tests/test_smol.py
@@ -21,6 +21,7 @@ from pydantic import (
     model_serializer,
     model_validator,
 )
+from pydantic_core import SchemaValidator
 
 import archetype.smol as smol
 from archetype.smol import Component, Processor, World
@@ -320,6 +321,68 @@ def test_partial_updates_do_not_replay_untouched_field_validators() -> None:
             "statefulposition__position": 1,
             "statefulposition__generation": 1,
         },
+    ]
+
+
+def test_selective_validation_survives_a_plain_core_class_validator() -> None:
+    """Pin the standalone install shape, where no Pydantic plugin is present.
+
+    A dev environment that installs a Pydantic plugin gets a
+    `PluggableSchemaValidator` on the component class, which pydantic-core
+    cannot reuse, so selective validation works by accident. A published Smol
+    install has a plain `SchemaValidator` instead; pydantic-core reuses it when
+    compiling the `model` node and discards the untouched-field wrappers,
+    replaying every validator. Force the published shape so this suite fails
+    here rather than only for installed users.
+    """
+
+    validated: list[tuple[str, int]] = []
+
+    class DetachedPosition(Component):
+        position: int
+        generation: int
+
+        @field_validator("position")
+        @classmethod
+        def validate_position(cls, value: int) -> int:
+            validated.append(("position", value))
+            return value
+
+        @field_validator("generation")
+        @classmethod
+        def increment_generation(cls, value: int) -> int:
+            validated.append(("generation", value))
+            return value + 1
+
+    class MoveDetached(Processor):
+        components = (DetachedPosition,)
+
+        def process(self, df, *, tick):
+            del tick
+            return df.with_column(
+                "detachedposition__position",
+                col("detachedposition__position") + 1,
+            )
+
+    DetachedPosition.__pydantic_validator__ = SchemaValidator(
+        DetachedPosition.__pydantic_core_schema__
+    )
+    assert type(DetachedPosition.__pydantic_validator__) is SchemaValidator
+
+    world = World(processors=[MoveDetached()])
+    world.spawn(DetachedPosition(position=0, generation=0))
+
+    world.step()
+
+    assert validated == [("position", 0), ("generation", 0), ("position", 1)]
+    assert world.query(DetachedPosition).to_pylist() == [
+        {
+            "entity_id": 1,
+            "tick": 1,
+            "is_active": True,
+            "detachedposition__position": 1,
+            "detachedposition__generation": 1,
+        }
     ]
 
 


### PR DESCRIPTION
Follow-up to #797, which merged with 14 unresolved Codex threads. Twelve were genuinely fixed. Two (#4 and #12 — the only thread GitHub still showed as non-outdated) describe one real bug that is live in every published install.

## The bug

`_changed_fields_validator()` patches a copy of the component core schema so untouched fields reuse their already-validated values. pydantic-core reuses an existing `cls.__pydantic_validator__` when it compiles a `model` node, so the patched schema was discarded and every field validator replayed.

A processor that changes one field silently mutates the others:

```
spawn(StatefulPosition(position=0, generation=0))   # generation validator: v + 1
step()                                              # processor touches position only
  before: [(position,0), (generation,0), (position,1), (generation,1)]   generation drifts every tick
  after:  [(position,0), (generation,0), (position,1)]
```

## Why CI was green

The dev workspace installs `logfire`, which registers a `pydantic` entry point. Component classes therefore carry a `PluggableSchemaValidator`, which pydantic-core cannot reuse — so it compiled the patched schema and the wrappers worked by accident.

`archetype-smol` publishes with only `daft`, `pydantic`, `pydantic-core`. No plugin, so every real install took the broken path. The two regression tests committed with #797 fail against a clean install of the package they cover:

```
$ uv run --isolated --package archetype-smol pytest packages/archetype-smol/tests
2 failed, 31 passed
  test_partial_updates_do_not_replay_untouched_field_validators
  test_before_model_validator_observes_changed_candidate_once
```

Confirmed with no Archetype code in the loop — same pydantic 2.13.4 / pydantic-core 2.46.4, identical core schema, reuse happens at build time:

| `__pydantic_validator__` | patched schema honored? |
|---|---|
| `PluggableSchemaValidator` (workspace) | yes |
| `SchemaValidator` (standalone) | **no** |
| workspace + `PYDANTIC_DISABLE_PLUGINS=1` | **no** |

## The fix

Detach `__pydantic_validator__` for the duration of the cached build so pydantic-core reads the patched schema. One build per `(component type, changed fields)` on the single-threaded step path; restored in a `finally` before any component is validated.

## Regression guard

The existing tests could only fail on a standalone install, which nothing in CI exercised. `test_selective_validation_survives_a_plain_core_class_validator` forces a plain core `SchemaValidator` onto the component class, reproducing the published shape inside the normal suite. It fails on the pre-fix code **in the workspace**, where the plugin otherwise masks the bug.

## Verification

| | before | after |
|---|---|---|
| standalone smol install | 2 failed, 31 passed | **34 passed** |
| workspace | 33 passed | **34 passed** |
| workspace, plugins disabled | 2 failed, 31 passed | **34 passed** |

`make check` clean. `make test`: 3251 passed, 22 skipped.

## Disposition of the other #797 threads

Safe to resolve — verified against `main`, all passing on a standalone install:

- **#3** bound raised to `pydantic>=2.11` / `pydantic-core>=2.33`
- **#1, #2, #5, #7, #11** fixed by real changes: `by_name=True`; unchanged-component reuse in `_decode_frame()`; one atomic `validate_python()`; recursive `_find_model_fields_node()` descent; `any_schema()` removed
- **#6, #8, #9, #10, #13, #14** moot by design — `_is_supported_field_value()` rejects tuples, dicts and nested models at `spawn()`, so the Daft struct-padding round trips they describe are unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)