### PR TITLE
release: bump versions to 0.6.2

### DIFF
--- a/packages/archetype-ecs/pyproject.toml
+++ b/packages/archetype-ecs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-ecs"
-version = "0.6.1"
+version = "0.6.2"
 description = "DataFrame-first, append-only ECS framework for simulations and world libraries."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-ecs/src/archetype/__init__.py
+++ b/packages/archetype-ecs/src/archetype/__init__.py
@@ -44,7 +44,7 @@ os.environ.setdefault("DO_NOT_TRACK", "1")
 # subpackages while this distribution remains the sole root-facade owner.
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 __all__ = [
     # Core types

--- a/packages/archetype-ecs/src/archetype/migration/handlers.py
+++ b/packages/archetype-ecs/src/archetype/migration/handlers.py
@@ -105,7 +105,7 @@ def _archetype_version() -> str:
     try:
         return version("archetype-ecs")
     except PackageNotFoundError:  # pragma: no cover - source tree without install metadata
-        return "0.6.1"
+        return "0.6.2"
 
 
 def _artifact_plan(inventory: ArtifactInventory) -> ArtifactPlanEvidence:

--- a/packages/archetype-ecs/tests/test_world_library_manifests.py
+++ b/packages/archetype-ecs/tests/test_world_library_manifests.py
@@ -203,7 +203,7 @@ def test_entry_point_distribution_mismatch_is_rejected(
     ("entry_name", "distribution_version", "message"),
     [
         ("metadata-name", "0.6.0", "entry point 'metadata-name' loaded manifest 'alpha'"),
-        ("alpha", "0.6.1", "declares version '0.6.0', loaded from '0.6.1'"),
+        ("alpha", "0.6.2", "declares version '0.6.0', loaded from '0.6.2'"),
     ],
 )
 def test_entry_point_identity_must_match_manifest_metadata(

--- a/packages/archetype-missions/pyproject.toml
+++ b/packages/archetype-missions/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-missions"
-version = "0.6.1"
+version = "0.6.2"
 description = "Coding-agent missions, sandboxes, transcripts, and trajectories for Archetype."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-missions/src/archetype/missions/_extension.py
+++ b/packages/archetype-missions/src/archetype/missions/_extension.py
@@ -883,7 +883,7 @@ def install(context: WorldLibraryContext) -> InstalledWorldLibrary:
 MANIFEST = WorldLibraryManifest(
     name="missions",
     distribution="archetype-missions",
-    version="0.6.1",
+    version="0.6.2",
     requires_framework=">=0.6,<0.7",
     operation_models=MISSION_OPERATION_MODELS,
     install=install,

--- a/packages/archetype-missions/tests/test_missions_extension.py
+++ b/packages/archetype-missions/tests/test_missions_extension.py
@@ -100,7 +100,7 @@ def test_manifest_declares_exact_missions_surface() -> None:
     assert first is second
     assert first.name == "missions"
     assert first.distribution == "archetype-missions"
-    assert first.version == "0.6.1"
+    assert first.version == "0.6.2"
     assert first.requires_framework == ">=0.6,<0.7"
     assert first.operation_models == MISSION_OPERATION_MODELS
     assert first.operation_names == (

--- a/packages/archetype-physical-ai/pyproject.toml
+++ b/packages/archetype-physical-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-physical-ai"
-version = "0.6.1"
+version = "0.6.2"
 description = "Physical state, policies, and hosted episode workflows for Archetype."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-physical-ai/src/archetype/physical_ai/_extension.py
+++ b/packages/archetype-physical-ai/src/archetype/physical_ai/_extension.py
@@ -196,7 +196,7 @@ def get_manifest() -> WorldLibraryManifest:
     return WorldLibraryManifest(
         name=_LIBRARY_NAME,
         distribution="archetype-physical-ai",
-        version="0.6.1",
+        version="0.6.2",
         requires_framework=">=0.6,<0.7",
         operation_models=(RunHostedEpisode,),
         install=_install,

--- a/packages/archetype-physical-ai/src/archetype/physical_ai/hosted_modal.py
+++ b/packages/archetype-physical-ai/src/archetype/physical_ai/hosted_modal.py
@@ -744,7 +744,7 @@ def build_seeded_modal_hosted_episode_app(
     if image is None:
         image = (
             modal.Image.debian_slim(python_version="3.12")
-            .uv_pip_install("archetype-ecs==0.6.1")
+            .uv_pip_install("archetype-ecs==0.6.2")
             .add_local_python_source("archetype", copy=True)
         )
     app = modal.App(config.app_name)

--- a/packages/archetype-physical-ai/tests/test_physical_ai_extension.py
+++ b/packages/archetype-physical-ai/tests/test_physical_ai_extension.py
@@ -48,7 +48,7 @@ def test_physical_ai_manifest_is_complete_and_side_effect_free() -> None:
     assert first == second
     assert first.name == "physical-ai"
     assert first.distribution == "archetype-physical-ai"
-    assert first.version == "0.6.1"
+    assert first.version == "0.6.2"
     assert first.requires_framework == ">=0.6,<0.7"
     assert first.operation_models == (RunHostedEpisode,)
     assert first.operation_names == ("run_hosted_episode",)

--- a/packages/archetype-research/pyproject.toml
+++ b/packages/archetype-research/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-research"
-version = "0.6.1"
+version = "0.6.2"
 description = "Minimal world-library optimization and AutoResearch workflows for Archetype."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-research/src/archetype/research/_extension.py
+++ b/packages/archetype-research/src/archetype/research/_extension.py
@@ -79,7 +79,7 @@ def get_manifest() -> WorldLibraryManifest:
     return WorldLibraryManifest(
         name=_LIBRARY_NAME,
         distribution="archetype-research",
-        version="0.6.1",
+        version="0.6.2",
         requires_framework=">=0.6,<0.7",
         operation_models=(AutoResearch,),
         install=_install,

--- a/packages/archetype-research/tests/test_research_extension.py
+++ b/packages/archetype-research/tests/test_research_extension.py
@@ -56,7 +56,7 @@ def test_research_manifest_is_complete_and_side_effect_free() -> None:
     assert first == second
     assert first.name == "research"
     assert first.distribution == "archetype-research"
-    assert first.version == "0.6.1"
+    assert first.version == "0.6.2"
     assert first.requires_framework == ">=0.6,<0.7"
     assert first.operation_models == (AutoResearch,)
     assert first.operation_names == ("autoresearch",)

--- a/packages/archetype-smol/pyproject.toml
+++ b/packages/archetype-smol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-smol"
-version = "0.6.1"
+version = "0.6.2"
 description = "A tiny synchronous, in-memory DataFrame ECS for learning Archetype's core model."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/archetype-smol/src/archetype/smol/__init__.py
+++ b/packages/archetype-smol/src/archetype/smol/__init__.py
@@ -9,4 +9,4 @@ from .world import RunResult, World
 
 __all__ = ["Component", "Processor", "RunResult", "World"]
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archetype-workspace"
-version = "0.6.1"
+version = "0.6.2"
 description = "Development workspace for the Archetype framework, first-party world libraries, and independent Smol teaching engine."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/scripts/test_dispatch_release_publishers.py
+++ b/tests/scripts/test_dispatch_release_publishers.py
@@ -272,7 +272,7 @@ def test_await_accepts_only_exact_supported_workflow_path_forms(path: str) -> No
         ("path", ".github/workflows/release.yml"),
         ("event", "push"),
         ("head_sha", "b" * 40),
-        ("head_branch", "v0.6.1"),
+        ("head_branch", "v0.6.2"),
         ("url", "https://api.github.com/repos/other/repo/actions/runs/9001"),
         ("html_url", "https://github.com/other/repo/actions/runs/9001"),
         ("repository", {"full_name": "other/repo"}),

--- a/tests/scripts/test_package_smoke.py
+++ b/tests/scripts/test_package_smoke.py
@@ -101,7 +101,7 @@ def test_wheel_validation_binds_project_and_version_metadata(tmp_path: Path) -> 
     with pytest.raises(RuntimeError, match="unexpected project name"):
         package_smoke._validate_wheel_contents("archetype-research", wrong_project)
 
-    wrong_version = _research_wheel(tmp_path / "wrong-version.whl", version="0.6.1")
+    wrong_version = _research_wheel(tmp_path / "wrong-version.whl", version="0.6.2")
     with pytest.raises(RuntimeError, match="does not match the attested wheel version"):
         package_smoke._validate_wheel_contents(
             "archetype-research",

--- a/tests/scripts/test_release_evidence.py
+++ b/tests/scripts/test_release_evidence.py
@@ -251,7 +251,7 @@ def test_release_artifact_manifest_binds_every_filename_to_its_version(
 ) -> None:
     dist, manifest_path, _wheels = _artifact(tmp_path)
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    manifest["artifacts"][-1]["name"] = "archetype_smol-0.6.1.tar.gz"
+    manifest["artifacts"][-1]["name"] = "archetype_smol-0.6.2.tar.gz"
 
     with pytest.raises(ValueError, match="not bound to manifest version 0.6.0"):
         verify_artifact(manifest, dist, expected_commit="a" * 40)

--- a/tests/scripts/test_release_publisher_tag_check.py
+++ b/tests/scripts/test_release_publisher_tag_check.py
@@ -216,7 +216,7 @@ def test_publisher_tag_check_rejects_malformed_output(
 def test_publisher_tag_check_rejects_an_unexpected_ref(tmp_path: Path) -> None:
     result = _run_tag_check(
         tmp_path,
-        output=f"{EXPECTED_COMMIT}\trefs/tags/v0.6.1\n",
+        output=f"{EXPECTED_COMMIT}\trefs/tags/v0.6.2\n",
     )
 
     assert result.returncode != 0

--- a/tests/scripts/test_run_operational_scenarios.py
+++ b/tests/scripts/test_run_operational_scenarios.py
@@ -1522,7 +1522,7 @@ def test_wheel_set_resolution_rejects_missing_duplicate_and_mixed_versions(
     with pytest.raises(ValueError, match="exactly one local wheel for archetype-research"):
         _resolve_wheel_artifacts(wheel=anchor, wheel_dir=tmp_path)
 
-    mixed = tmp_path / "archetype_research-0.6.1-py3-none-any.whl"
+    mixed = tmp_path / "archetype_research-0.6.2-py3-none-any.whl"
     mixed.write_bytes(b"mixed version")
     with pytest.raises(ValueError, match="same-version first-party artifact set"):
         _resolve_wheel_artifacts(wheel=anchor, wheel_dir=tmp_path)

--- a/tests/scripts/test_verify_publisher_dispatch.py
+++ b/tests/scripts/test_verify_publisher_dispatch.py
@@ -205,7 +205,7 @@ def test_verify_publisher_dispatch_rejects_wrong_parent_run(
     elif case == "triggering_actor":
         parent["triggering_actor"] = {"login": "someone-else"}
     elif case == "tag":
-        parent["head_branch"] = "v0.6.1"
+        parent["head_branch"] = "v0.6.2"
     elif case == "sha":
         parent["head_sha"] = "c" * 40
     elif case == "attempt":

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ requires-dist = [
 
 [[package]]
 name = "archetype-workspace"
-version = "0.6.1"
+version = "0.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "archetype-ecs", extra = ["all", "coding-agent", "logfire", "sim"] },

--- a/uv.lock
+++ b/uv.lock
@@ -198,7 +198,7 @@ wheels = [
 
 [[package]]
 name = "archetype-ecs"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/archetype-ecs" }
 dependencies = [
     { name = "av" },
@@ -290,7 +290,7 @@ provides-extras = ["missions", "physical-ai", "research", "all", "coding-agent",
 
 [[package]]
 name = "archetype-missions"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/archetype-missions" }
 dependencies = [
     { name = "archetype-ecs" },
@@ -320,7 +320,7 @@ provides-extras = ["modal"]
 
 [[package]]
 name = "archetype-physical-ai"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/archetype-physical-ai" }
 dependencies = [
     { name = "archetype-ecs" },
@@ -358,7 +358,7 @@ provides-extras = ["modal", "sim", "all"]
 
 [[package]]
 name = "archetype-research"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/archetype-research" }
 dependencies = [
     { name = "archetype-ecs" },
@@ -375,7 +375,7 @@ requires-dist = [
 
 [[package]]
 name = "archetype-smol"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/archetype-smol" }
 dependencies = [
     { name = "daft" },


### PR DESCRIPTION
Version bump for tonight's mission-control release: #820 (MCP server), #823 (mission auth + execution profiles), #821 (durable MissionRun lifecycle + REST surface) are on main and ship as v0.6.2 per the stay-in-0.6.x series decision.

All five packages 0.6.1 → 0.6.2; uv.lock refreshed. No code changes.

@everettVT

🤖 Generated with [Claude Code](https://claude.com/claude-code)