### PR TITLE
fix(mcp): rebind mission_submit to the shipped REST submit schema

### DIFF
--- a/docs/guide/agent-missions.md
+++ b/docs/guide/agent-missions.md
@@ -1266,12 +1266,19 @@ Boundaries:
   `tools/list`, `tools/call`, and `ping` work on the supported protocol
   versions; unsupported request methods return `-32601`.
 
-Contract seam: until issue #809 lands, the executable oracle is the
-offline fake server in `tests/missions/mcp/conftest.py`, which implements
-the documented REST contract; `tests/missions/mcp/test_mission_mcp_live_loopback.py`
-activates route-drift enforcement when `archetype.missions.api` ships
-`/v1/mission-runs` and keeps the live loopback proof as an explicitly
-skipped test until a served surface exists.
+Contract binding (issue #833): the submit body mirrors
+`archetype.missions.api.MissionRunSubmitRequest` field for field —
+`branch`, `base_ref`, `name`, and `tasks[]` with `command`-shaped
+validators — and optional fields the REST model defaults are omitted from
+the wire so the server owns every default. The offline fake server in
+`tests/missions/mcp/conftest.py` validates each submit body against that
+real pydantic model, and
+`tests/missions/mcp/test_mission_mcp_rest_contract.py` additionally
+validates the adapter's serialized body against the model directly, so
+schema drift between the adapter and the shipped REST surface fails CI.
+`tests/missions/mcp/test_mission_mcp_live_loopback.py` enforces route-set
+agreement unconditionally and keeps the live loopback proof as an
+environment-gated test against a served host.
 
 ## Companion contracts
 

--- a/packages/archetype-missions/src/archetype/missions/mcp/client.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/client.py
@@ -9,10 +9,14 @@ templates, opaque ids are validated before they may enter a URL or header,
 and the client never follows a redirect, so a response cannot re-aim it at
 another origin. Error text stays bounded and carries no credential bytes.
 
-Seam (issue #810): field names for the submit body mirror issue #809's
-documented contract. When the REST models land, the drift test in
-``tests/missions/mcp/test_mission_mcp_live_loopback.py`` binds this module
-to them.
+The submit body mirrors ``archetype.missions.api.MissionRunSubmitRequest``
+field for field (issue #833). Optional fields the REST model defaults
+(``base_ref``, ``name``, validator ``expected_returncode`` and
+``timeout_seconds``, task ``max_dispatches``) are omitted when the caller
+does not supply them, so the server stays the single owner of every
+default. The offline contract tests in ``tests/missions/mcp/`` validate
+the serialized body directly against that pydantic model, so any drift
+from the shipped REST schema fails CI instead of 422ing in production.
 """
 
 from __future__ import annotations
@@ -99,19 +103,23 @@ class MissionRunClient:
         *,
         profile_id: str,
         repository: str,
-        ref: str,
-        mission: str,
+        branch: str,
         tasks: list[dict[str, Any]],
         idempotency_key: str,
+        base_ref: str | None = None,
+        name: str | None = None,
     ) -> dict[str, Any]:
         key = require_opaque_id(idempotency_key, label="idempotency_key")
-        body = {
+        body: dict[str, Any] = {
             "profile_id": profile_id,
             "repository": repository,
-            "ref": ref,
-            "mission": mission,
+            "branch": branch,
             "tasks": tasks,
         }
+        if base_ref is not None:
+            body["base_ref"] = base_ref
+        if name is not None:
+            body["name"] = name
         response = self._request(
             "POST",
             _RUNS_PATH,

--- a/packages/archetype-missions/src/archetype/missions/mcp/server.py
+++ b/packages/archetype-missions/src/archetype/missions/mcp/server.py
@@ -34,43 +34,65 @@ from archetype.missions.mcp.config import McpHostConfig, McpHostConfigError
 SERVER_NAME = "archetype-missions-mcp"
 SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
 
-# Fixed input bounds (issue #810: "fixed byte/item limits"). Output bounds
-# (events page, rendered result bytes) remain host-configured knobs.
+# Fixed input bounds (issue #810: "fixed byte/item limits"). The submit
+# bounds mirror the REST request models in ``archetype.missions.api``
+# (issue #833) so a schema-conformant tool call cannot 422 at the route.
+# Output bounds (events page, rendered result bytes) remain
+# host-configured knobs.
 _MAX_OPAQUE_ID_CHARS = 256
 _MAX_COORDINATE_CHARS = 512
-_MAX_TASK_NAME_CHARS = 200
+_MAX_NAME_CHARS = 128
 _MAX_TASKS = 32
 _MAX_PROMPT_BYTES = 65536
+_MAX_VALIDATOR_COMMAND_ITEMS = 64
+_MAX_COMMAND_ARGUMENT_CHARS = 4096
+_MAX_TASK_DISPATCHES = 10
 _MAX_DIAGNOSTIC_BYTES = 512
 # Largest accepted stdin frame; a newline-less flood is rejected in bounded
 # chunks instead of buffering an unbounded line.
 _MAX_FRAME_CHARS = 16 * 1024 * 1024
 
-_TASK_KEYS = {"name", "prompt", "validators", "depends_on"}
+_TASK_KEYS = {"name", "prompt", "validators", "depends_on", "max_dispatches"}
+_VALIDATOR_KEYS = {"name", "command", "expected_returncode", "timeout_seconds"}
 
 # Single-line coordinate: no ASCII control characters.
 _LINE_PATTERN = "^[^\\u0000-\\u001f]+$"
 
+_VALIDATOR_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "minLength": 1, "maxLength": _MAX_NAME_CHARS},
+        "command": {
+            "type": "array",
+            "items": {"type": "string", "maxLength": _MAX_COMMAND_ARGUMENT_CHARS},
+            "minItems": 1,
+            "maxItems": _MAX_VALIDATOR_COMMAND_ITEMS,
+        },
+        "expected_returncode": {"type": "integer"},
+        "timeout_seconds": {"type": "integer", "minimum": 1},
+    },
+    "required": ["name", "command"],
+    "additionalProperties": False,
+}
+
 _TASK_SCHEMA = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "minLength": 1, "maxLength": _MAX_TASK_NAME_CHARS},
+        "name": {"type": "string", "minLength": 1, "maxLength": _MAX_NAME_CHARS},
         "prompt": {"type": "string", "minLength": 1, "maxLength": _MAX_PROMPT_BYTES},
-        "validators": {
+        "validators": {"type": "array", "items": _VALIDATOR_SCHEMA, "minItems": 1},
+        "depends_on": {
             "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string", "minLength": 1},
-                    "argv": {"type": "array", "items": {"type": "string"}},
-                },
-                "required": ["name", "argv"],
-                "additionalProperties": False,
-            },
+            "items": {"type": "string", "minLength": 1},
+            "maxItems": _MAX_TASKS,
         },
-        "depends_on": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "max_dispatches": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": _MAX_TASK_DISPATCHES,
+        },
     },
-    "required": ["name", "prompt"],
+    "required": ["name", "prompt", "validators"],
     "additionalProperties": False,
 }
 
@@ -140,6 +162,10 @@ def _validate_line(value: object, label: str) -> str:
     return _require_string(value, label=label, max_chars=_MAX_COORDINATE_CHARS)
 
 
+def _validate_name(value: object, label: str) -> str:
+    return _require_string(value, label=label, max_chars=_MAX_NAME_CHARS)
+
+
 def _validate_limit(value: object, label: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise MissionToolError("invalid_argument", f"{label} must be a positive integer")
@@ -147,31 +173,58 @@ def _validate_limit(value: object, label: str) -> int:
 
 
 def _validate_validators(validators: object, *, label: str) -> list[dict[str, Any]]:
-    if not isinstance(validators, list):
-        raise MissionToolError("invalid_argument", f"{label} must be an array")
+    if not isinstance(validators, list) or not validators:
+        raise MissionToolError("invalid_argument", f"{label} must be a non-empty array")
     clean: list[dict[str, Any]] = []
     for position, raw_validator in enumerate(validators):
         item_label = f"{label}[{position}]"
         validator = _string_keyed(raw_validator, label=item_label)
-        _reject_unknown(validator, {"name", "argv"})
+        _reject_unknown(validator, _VALIDATOR_KEYS)
         name = validator.get("name")
-        argv = validator.get("argv")
-        if not isinstance(name, str) or not name:
+        command = validator.get("command")
+        if not isinstance(name, str) or not name or len(name) > _MAX_NAME_CHARS:
             raise MissionToolError(
-                "invalid_argument", f"{item_label}.name must be a non-empty string"
-            )
-        if not isinstance(argv, list):
-            raise MissionToolError(
-                "invalid_argument", f"{item_label}.argv must be an array of strings"
+                "invalid_argument",
+                f"{item_label}.name must be a non-empty string of at most "
+                f"{_MAX_NAME_CHARS} characters",
             )
         _utf8_or_reject(name, f"{item_label}.name")
-        for position_argv, item in enumerate(argv):
-            if not isinstance(item, str):
+        if (
+            not isinstance(command, list)
+            or not command
+            or len(command) > _MAX_VALIDATOR_COMMAND_ITEMS
+        ):
+            raise MissionToolError(
+                "invalid_argument",
+                f"{item_label}.command must be an array of 1 to "
+                f"{_MAX_VALIDATOR_COMMAND_ITEMS} strings",
+            )
+        for position_argument, item in enumerate(command):
+            if not isinstance(item, str) or len(item) > _MAX_COMMAND_ARGUMENT_CHARS:
                 raise MissionToolError(
-                    "invalid_argument", f"{item_label}.argv must be an array of strings"
+                    "invalid_argument",
+                    f"{item_label}.command must be an array of strings of at "
+                    f"most {_MAX_COMMAND_ARGUMENT_CHARS} characters",
                 )
-            _utf8_or_reject(item, f"{item_label}.argv[{position_argv}]")
-        clean.append({"name": name, "argv": argv})
+            _utf8_or_reject(item, f"{item_label}.command[{position_argument}]")
+        clean_validator: dict[str, Any] = {"name": name, "command": command}
+        if "expected_returncode" in validator:
+            expected = validator["expected_returncode"]
+            if isinstance(expected, bool) or not isinstance(expected, int):
+                raise MissionToolError(
+                    "invalid_argument",
+                    f"{item_label}.expected_returncode must be an integer",
+                )
+            clean_validator["expected_returncode"] = expected
+        if "timeout_seconds" in validator:
+            timeout = validator["timeout_seconds"]
+            if isinstance(timeout, bool) or not isinstance(timeout, int) or timeout < 1:
+                raise MissionToolError(
+                    "invalid_argument",
+                    f"{item_label}.timeout_seconds must be a positive integer",
+                )
+            clean_validator["timeout_seconds"] = timeout
+        clean.append(clean_validator)
     return clean
 
 
@@ -187,7 +240,7 @@ def _validate_tasks(tasks: object, label: str) -> list[dict[str, Any]]:
         task = _string_keyed(raw_task, label=f"{label}[{index}]")
         _reject_unknown(task, _TASK_KEYS)
         name = task.get("name")
-        if not isinstance(name, str) or not name or len(name) > _MAX_TASK_NAME_CHARS:
+        if not isinstance(name, str) or not name or len(name) > _MAX_NAME_CHARS:
             raise MissionToolError(
                 "invalid_argument", f"{label}[{index}].name must be a short string"
             )
@@ -203,17 +256,22 @@ def _validate_tasks(tasks: object, label: str) -> list[dict[str, Any]]:
                 f"{label}[{index}].prompt must be a non-empty string of at "
                 f"most {_MAX_PROMPT_BYTES} bytes",
             )
-        clean: dict[str, Any] = {"name": name, "prompt": prompt}
-        if "validators" in task:
-            clean["validators"] = _validate_validators(
-                task["validators"], label=f"{label}[{index}].validators"
-            )
+        clean: dict[str, Any] = {
+            "name": name,
+            "prompt": prompt,
+            # The REST task model requires at least one validator; reject a
+            # missing key here so the mistake fails before the wire.
+            "validators": _validate_validators(
+                task.get("validators"), label=f"{label}[{index}].validators"
+            ),
+        }
         if "depends_on" in task:
             depends_on = task["depends_on"]
-            if not isinstance(depends_on, list):
+            if not isinstance(depends_on, list) or len(depends_on) > _MAX_TASKS:
                 raise MissionToolError(
                     "invalid_argument",
-                    f"{label}[{index}].depends_on must be an array of task names",
+                    f"{label}[{index}].depends_on must be an array of at most "
+                    f"{_MAX_TASKS} task names",
                 )
             for position_dep, item in enumerate(depends_on):
                 if not isinstance(item, str) or not item:
@@ -223,6 +281,19 @@ def _validate_tasks(tasks: object, label: str) -> list[dict[str, Any]]:
                     )
                 _utf8_or_reject(item, f"{label}[{index}].depends_on[{position_dep}]")
             clean["depends_on"] = depends_on
+        if "max_dispatches" in task:
+            dispatches = task["max_dispatches"]
+            if (
+                isinstance(dispatches, bool)
+                or not isinstance(dispatches, int)
+                or not 1 <= dispatches <= _MAX_TASK_DISPATCHES
+            ):
+                raise MissionToolError(
+                    "invalid_argument",
+                    f"{label}[{index}].max_dispatches must be an integer "
+                    f"between 1 and {_MAX_TASK_DISPATCHES}",
+                )
+            clean["max_dispatches"] = dispatches
         validated.append(clean)
     return validated
 
@@ -248,6 +319,15 @@ _ARGUMENT_KINDS: dict[str, tuple[dict[str, Any], Callable[[object, str], Any]]] 
         },
         _validate_line,
     ),
+    "name": (
+        {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": _MAX_NAME_CHARS,
+            "pattern": _LINE_PATTERN,
+        },
+        _validate_name,
+    ),
     "limit": ({"type": "integer", "minimum": 1}, _validate_limit),
     "tasks": (
         {"type": "array", "items": _TASK_SCHEMA, "minItems": 1, "maxItems": _MAX_TASKS},
@@ -272,17 +352,19 @@ _TOOL_SPECS: tuple[_ToolSpec, ...] = (
         description=(
             "Explicitly start a durable Archetype coding mission and return "
             "immediately with its run_id and status coordinates; the mission "
-            "keeps running after this process exits. Reusing the same "
-            "idempotency_key with identical inputs returns the original run. "
-            "Execution authority comes from the server-owned profile, never "
-            "from these arguments."
+            "keeps running after this process exits. Work lands on the "
+            "caller-named branch, cut from base_ref (server default: main). "
+            "Reusing the same idempotency_key with identical inputs returns "
+            "the original run. Execution authority comes from the "
+            "server-owned profile, never from these arguments."
         ),
         client_method="submit",
         arguments=(
             ("profile_id", "opaque_id", True),
             ("repository", "line", True),
-            ("ref", "line", True),
-            ("mission", "line", True),
+            ("branch", "line", True),
+            ("base_ref", "line", False),
+            ("name", "name", False),
             ("tasks", "tasks", True),
             ("idempotency_key", "opaque_id", True),
         ),

--- a/tests/missions/mcp/conftest.py
+++ b/tests/missions/mcp/conftest.py
@@ -3,13 +3,15 @@
 
 """Offline fake MissionRun control surface for Mission MCP contract tests.
 
-Contract seam (issue #810): :class:`FakeMissionControl` implements the
-MissionRun REST contract exactly as documented in issue #809 — the routes,
-``Idempotency-Key`` submit semantics, cursor events, terminal result, and
-idempotent cancel — because that surface has not landed on ``main`` yet.
-``test_mission_mcp_live_loopback.py`` holds the binding tests that activate
-once ``archetype.missions.api`` ships ``/v1/mission-runs``; rebinding these
-fixtures to the real response models is deliberately a one-file change here.
+Contract binding (issue #833): :class:`FakeMissionControl` is pinned to the
+shipped REST surface in ``archetype.missions.api``, not to a hand-mirrored
+copy of the adapter's own expectations. Every submit body is validated
+against the real ``MissionRunSubmitRequest`` pydantic model
+(``extra="forbid"``) and answered with a real
+``MissionRunAcceptedResponse`` payload, and run states use the real
+``MissionRunState`` literals — so an adapter that drifts from the shipped
+schema 422s in these offline tests exactly as it would in production.
+Read-path payloads remain bounded fake projections.
 """
 
 from __future__ import annotations
@@ -25,7 +27,13 @@ from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
+from pydantic import ValidationError
 
+from archetype.missions.api import (
+    MissionRunAcceptedResponse,
+    MissionRunProfileResponse,
+    MissionRunSubmitRequest,
+)
 from archetype.missions.mcp.config import McpHostConfig
 from archetype.missions.mcp.server import MissionMcpServer
 
@@ -45,7 +53,7 @@ class RecordedRequest:
 class FakeRun:
     run_id: str
     profile_id: str = "profile-default"
-    state: str = "queued"
+    state: str = "accepted"
     request_digest: str = ""
     events: list[dict[str, Any]] = field(default_factory=list)
     result: dict[str, Any] | None = None
@@ -204,12 +212,24 @@ class FakeMissionControl:
     def _submit(self, handler: BaseHTTPRequestHandler, body: bytes) -> None:
         key = handler.headers.get("Idempotency-Key")
         if not key:
-            self._respond(handler, 400, {"detail": "Idempotency-Key header required"})
+            self._respond(handler, 422, {"detail": "Idempotency-Key header required"})
             return
         try:
             payload = json.loads(body.decode("utf-8"))
         except ValueError:
             self._respond(handler, 422, {"detail": "Body must be JSON"})
+            return
+        try:
+            request = MissionRunSubmitRequest.model_validate(payload)
+        except ValidationError as exc:
+            # The real route rejects with 422 through the same model
+            # (extra="forbid"); mirroring it here is what keeps the offline
+            # suite honest about the shipped submit schema (issue #833).
+            self._respond(
+                handler,
+                422,
+                {"detail": f"MissionRunSubmitRequest rejected the body: {exc.error_count()}"},
+            )
             return
         digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
         existing = self.submissions.get(key)
@@ -226,8 +246,8 @@ class FakeMissionControl:
             return
         run = FakeRun(
             run_id=f"run-{uuid.uuid4().hex[:12]}",
-            profile_id=str(payload.get("profile_id", "profile-default")),
-            state="queued",
+            profile_id=request.profile_id,
+            state="accepted",
             request_digest=digest,
         )
         self.runs[run.run_id] = run
@@ -236,12 +256,17 @@ class FakeMissionControl:
 
     @staticmethod
     def _accepted(run: FakeRun) -> dict[str, Any]:
-        return {
-            "run_id": run.run_id,
-            "request_digest": run.request_digest,
-            "state": run.state,
-            "status_url": f"/v1/mission-runs/{run.run_id}",
-        }
+        return MissionRunAcceptedResponse(
+            run_id=run.run_id,
+            state=run.state,  # type: ignore[arg-type]  # pydantic enforces the literal
+            request_digest=run.request_digest,
+            profile=MissionRunProfileResponse(
+                profile_id=run.profile_id,
+                version="1",
+                digest="fake-profile-digest",
+            ),
+            status_url=f"/v1/mission-runs/{run.run_id}",
+        ).model_dump(mode="json")
 
     def _list(self, handler: BaseHTTPRequestHandler) -> None:
         runs = [
@@ -274,7 +299,7 @@ class FakeMissionControl:
         )
 
     def _cancel(self, handler: BaseHTTPRequestHandler, run: FakeRun) -> None:
-        if run.state in {"completed", "failed", "cancelled"}:
+        if run.state in {"succeeded", "failed", "cancelled", "interrupted"}:
             self._respond(handler, 200, {"run_id": run.run_id, "state": run.state})
             return
         run.state = "cancelling"
@@ -363,13 +388,14 @@ def submit_arguments(**overrides: Any) -> dict[str, Any]:
     arguments: dict[str, Any] = {
         "profile_id": "profile-default",
         "repository": "vangelis/archetype",
-        "ref": "main",
-        "mission": "demo-mission",
+        "branch": "agent/demo-mission",
+        "base_ref": "main",
+        "name": "demo-mission",
         "tasks": [
             {
                 "name": "fix-bug",
                 "prompt": "Fix the reported bug.",
-                "validators": [{"name": "pytest", "argv": ["pytest", "-q"]}],
+                "validators": [{"name": "pytest", "command": ["pytest", "-q"]}],
             }
         ],
         "idempotency_key": "key-0001",

--- a/tests/missions/mcp/test_mission_mcp_hostile_args.py
+++ b/tests/missions/mcp/test_mission_mcp_hostile_args.py
@@ -134,15 +134,18 @@ def test_submit_configuration_overrides_are_rejected(call, fake_control, overrid
         {"model": "expensive-model"},
         {"driver": "raw-shell"},
         {"budget": 10**9},
+        {"validators": [{"name": "v", "command": ["true"], "shell": "/bin/bash"}]},
+        {"validators": [{"name": "v", "command": ["true"], "env": {"PATH": "/evil"}}]},
     ],
 )
 def test_profile_widening_through_task_payload_is_rejected(call, fake_control, task_widening):
-    """Task items carry name/prompt/validators/depends_on only (issue #808)."""
+    """Tasks carry name/prompt/validators/depends_on/max_dispatches only."""
 
     tasks = [
         {
             "name": "fix-bug",
             "prompt": "Fix the reported bug.",
+            "validators": [{"name": "pytest", "command": ["pytest", "-q"]}],
             **task_widening,
         }
     ]
@@ -153,12 +156,15 @@ def test_profile_widening_through_task_payload_is_rejected(call, fake_control, t
 
 
 def test_task_count_and_prompt_bytes_are_bounded(call, fake_control):
-    many = [{"name": f"task-{index}", "prompt": "p"} for index in range(33)]
+    validators = [{"name": "true", "command": ["true"]}]
+    many = [
+        {"name": f"task-{index}", "prompt": "p", "validators": validators} for index in range(33)
+    ]
     is_error, payload = call("mission_submit", submit_arguments(tasks=many))
     assert is_error is True
     assert payload["error"]["code"] == "invalid_argument"
 
-    huge_prompt = [{"name": "task", "prompt": "x" * 70000}]
+    huge_prompt = [{"name": "task", "prompt": "x" * 70000, "validators": validators}]
     is_error, payload = call("mission_submit", submit_arguments(tasks=huge_prompt))
     assert is_error is True
     assert payload["error"]["code"] == "invalid_argument"
@@ -255,23 +261,40 @@ def test_credential_with_json_escapables_is_still_redacted(fake_control):
     assert "[redacted]" in payload["error"]["message"]
 
 
+_SAFE_VALIDATORS = [{"name": "true", "command": ["true"]}]
+
+
 @pytest.mark.parametrize(
     "arguments",
     [
         submit_arguments(repository=f"repo{SURROGATE}"),
-        submit_arguments(mission=f"m{SURROGATE}"),
-        submit_arguments(tasks=[{"name": f"t{SURROGATE}", "prompt": "p"}]),
-        submit_arguments(tasks=[{"name": "t", "prompt": f"p{SURROGATE}"}]),
+        submit_arguments(branch=f"b{SURROGATE}"),
+        submit_arguments(name=f"m{SURROGATE}"),
+        submit_arguments(
+            tasks=[{"name": f"t{SURROGATE}", "prompt": "p", "validators": _SAFE_VALIDATORS}]
+        ),
+        submit_arguments(
+            tasks=[{"name": "t", "prompt": f"p{SURROGATE}", "validators": _SAFE_VALIDATORS}]
+        ),
         submit_arguments(
             tasks=[
                 {
                     "name": "t",
                     "prompt": "p",
-                    "validators": [{"name": "v", "argv": [f"a{SURROGATE}"]}],
+                    "validators": [{"name": "v", "command": [f"a{SURROGATE}"]}],
                 }
             ]
         ),
-        submit_arguments(tasks=[{"name": "t", "prompt": "p", "depends_on": [f"d{SURROGATE}"]}]),
+        submit_arguments(
+            tasks=[
+                {
+                    "name": "t",
+                    "prompt": "p",
+                    "validators": _SAFE_VALIDATORS,
+                    "depends_on": [f"d{SURROGATE}"],
+                }
+            ]
+        ),
     ],
 )
 def test_unpaired_surrogates_are_invalid_arguments_before_the_wire(call, fake_control, arguments):

--- a/tests/missions/mcp/test_mission_mcp_live_loopback.py
+++ b/tests/missions/mcp/test_mission_mcp_live_loopback.py
@@ -1,17 +1,20 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Binding seams left for issue #809 (recorded, not faked).
+"""Route-drift enforcement and the live loopback proof (issues #809/#833).
 
-Two explicitly gated tests own the gap between the offline fake contract
-in ``conftest.py`` and the real MissionRun REST surface:
+The MissionRun REST surface shipped on ``main`` (issue #821), so the
+route-set agreement test runs unconditionally: the adapter's six fixed
+paths must exist in ``archetype.missions.api.create_router``. Body-level
+schema agreement lives in ``test_mission_mcp_rest_contract.py``, which
+validates the adapter's serialized submit payload directly against the
+real ``MissionRunSubmitRequest`` model.
 
-* ``test_installed_rest_routes_match_the_adapter_contract`` skips while
-  ``archetype.missions.api`` has no ``/v1/mission-runs`` routes and
-  activates automatically once they land, so route drift fails CI.
-* ``test_live_loopback_roundtrip`` is the live Archetype proof, skipped
-  until a served loopback host with the issue #809 surface exists
-  (repo convention: freeze dogfood runs as skipif tests).
+``test_live_loopback_roundtrip`` is the live Archetype proof (repo
+convention: freeze dogfood runs as skipif tests). It stays gated on the
+loopback environment variables because it needs a served host with a real
+execution-profile catalog and principals file; the v0.6.3 dogfood receipt
+records the composition recipe.
 """
 
 from __future__ import annotations
@@ -30,11 +33,10 @@ LOOPBACK_URL_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_URL"
 LOOPBACK_CREDENTIAL_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_CREDENTIAL"
 LOOPBACK_PROFILE_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_PROFILE"
 LOOPBACK_REPOSITORY_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_REPOSITORY"
+LOOPBACK_BRANCH_PREFIX_ENV = "ARCHETYPE_MISSIONS_MCP_LOOPBACK_BRANCH_PREFIX"
 
-# The adapter's REST surface: the five routes documented in issue #809 plus
-# the principal-scoped GET collection that mission_list targets (OPEN Q:
-# #809 does not document a list route; the PR body records the assumption,
-# and this set drift-enforces it once the real routes land).
+# The adapter's REST surface: the six fixed paths in
+# archetype/missions/mcp/client.py, all shipped by issue #821.
 ADAPTER_ROUTES = {
     ("POST", "/v1/mission-runs"),
     ("GET", "/v1/mission-runs"),
@@ -59,15 +61,11 @@ def _installed_mission_run_routes() -> set[tuple[str, str]]:
 
 def test_installed_rest_routes_match_the_adapter_contract():
     installed = _installed_mission_run_routes()
-    if not installed:
-        pytest.skip(
-            "Recorded seam (issue #810): archetype.missions.api does not ship "
-            "/v1/mission-runs yet (issue #809 in flight). The offline fake in "
-            "tests/missions/mcp/conftest.py carries the documented contract; "
-            "when the routes land this test activates and any drift from the "
-            "adapter's route set fails CI. Then bind FakeMissionControl's "
-            "payloads to the real response models."
-        )
+    assert installed, (
+        "archetype.missions.api no longer ships /v1/mission-runs routes; the "
+        "MCP adapter in archetype/missions/mcp/client.py targets that "
+        "surface (issues #809/#821/#833)."
+    )
     missing = {
         (method, path)
         for method, path in ADAPTER_ROUTES
@@ -77,8 +75,8 @@ def test_installed_rest_routes_match_the_adapter_contract():
         )
     }
     assert not missing, (
-        "Issue #809 landed with a different MissionRun route set than the "
-        f"MCP adapter targets; missing {sorted(missing)}. Update "
+        "The installed MissionRun route set drifted from the paths the MCP "
+        f"adapter targets; missing {sorted(missing)}. Update "
         "archetype/missions/mcp/client.py and rebind "
         "tests/missions/mcp/conftest.py to the real models."
     )
@@ -88,11 +86,13 @@ def test_installed_rest_routes_match_the_adapter_contract():
 @pytest.mark.skipif(
     LOOPBACK_URL_ENV not in os.environ,
     reason=(
-        "Live loopback Archetype proof pending issue #809: export "
-        f"{LOOPBACK_URL_ENV}, {LOOPBACK_CREDENTIAL_ENV}, "
-        f"{LOOPBACK_PROFILE_ENV}, and {LOOPBACK_REPOSITORY_ENV} against a "
-        "served host exposing the MissionRun REST surface to run the "
-        "submit -> get -> events -> cancel roundtrip through the MCP tools."
+        "Live loopback Archetype proof (frozen from the issue #833 fix "
+        f"evidence): export {LOOPBACK_URL_ENV}, {LOOPBACK_CREDENTIAL_ENV}, "
+        f"{LOOPBACK_PROFILE_ENV}, and {LOOPBACK_REPOSITORY_ENV} (optionally "
+        f"{LOOPBACK_BRANCH_PREFIX_ENV}, default 'agent/') against a served "
+        "host with a real execution-profile catalog to run the submit -> "
+        "duplicate-submit -> get -> events -> cancel roundtrip through the "
+        "MCP tools."
     ),
 )
 def test_live_loopback_roundtrip():
@@ -108,26 +108,32 @@ def test_live_loopback_roundtrip():
         return call_tool(server, name, arguments)
 
     try:
+        unique = uuid.uuid4().hex[:12]
+        prefix = os.environ.get(LOOPBACK_BRANCH_PREFIX_ENV, "agent/")
         submit = {
             "profile_id": os.environ[LOOPBACK_PROFILE_ENV],
             "repository": os.environ[LOOPBACK_REPOSITORY_ENV],
-            "ref": "main",
-            "mission": "mcp-loopback-proof",
+            "branch": f"{prefix}mcp-loopback-proof-{unique}",
+            "base_ref": "main",
+            "name": "mcp-loopback-proof",
             "tasks": [
                 {
                     "name": "noop-proof",
                     "prompt": "Report the repository name and stop.",
-                    "validators": [{"name": "true", "argv": ["true"]}],
+                    "validators": [{"name": "true", "command": ["true"]}],
                 }
             ],
-            "idempotency_key": f"loopback-{uuid.uuid4().hex}",
+            "idempotency_key": f"loopback-{unique}",
         }
         is_error, accepted = tool("mission_submit", submit)
         assert is_error is False, accepted
         run_id = accepted["run_id"]
+        assert accepted["state"] == "accepted"
+        assert accepted["profile"]["profile_id"] == submit["profile_id"]
 
         is_error, duplicate = tool("mission_submit", submit)
-        assert is_error is False and duplicate["run_id"] == run_id
+        assert is_error is False, duplicate
+        assert duplicate["run_id"] == run_id
 
         is_error, status = tool("mission_get", {"run_id": run_id})
         assert is_error is False and status["run_id"] == run_id
@@ -135,7 +141,9 @@ def test_live_loopback_roundtrip():
         is_error, events = tool("mission_events", {"run_id": run_id, "limit": 10})
         assert is_error is False and "events" in events
 
+        # Cancel immediately after acceptance to bound provider spend; the
+        # committed-fact race semantics are the server's to resolve.
         is_error, cancelled = tool("mission_cancel", {"run_id": run_id})
-        assert is_error is False
+        assert is_error is False, cancelled
     finally:
         server.close()

--- a/tests/missions/mcp/test_mission_mcp_protocol.py
+++ b/tests/missions/mcp/test_mission_mcp_protocol.py
@@ -189,9 +189,16 @@ def test_declared_schemas_agree_with_runtime_validation():
     samples = {
         "opaque_id": ("run-1", "a/b"),
         "line": ("main", "bad\nline"),
+        "name": ("demo-mission", "bad\nname"),
         "limit": (5, 0),
         "tasks": (
-            [{"name": "t", "prompt": "p"}],
+            [
+                {
+                    "name": "t",
+                    "prompt": "p",
+                    "validators": [{"name": "v", "command": ["true"]}],
+                }
+            ],
             [{"name": "t", "prompt": "p", "sandbox": {}}],
         ),
     }

--- a/tests/missions/mcp/test_mission_mcp_rest_contract.py
+++ b/tests/missions/mcp/test_mission_mcp_rest_contract.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Vangelis Technologies Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Offline contract tests: MCP tools over the documented issue #809 REST surface."""
+"""Offline contract tests: MCP tools over the shipped MissionRun REST surface."""
 
 from __future__ import annotations
 
@@ -10,6 +10,11 @@ import json
 
 import pytest
 
+from archetype.missions.api import (
+    MissionRunSubmitRequest,
+    MissionRunTaskRequest,
+    MissionRunValidatorRequest,
+)
 from archetype.missions.mcp.config import McpHostConfig, McpHostConfigError
 from archetype.missions.mcp.server import MissionMcpServer
 from tests.missions.mcp.conftest import call_tool, host_environ, submit_arguments
@@ -19,11 +24,134 @@ def test_submit_returns_run_id_before_completion(call, fake_control):
     is_error, payload = call("mission_submit", submit_arguments())
     assert is_error is False
     assert payload["run_id"]
-    assert payload["state"] == "queued"
+    assert payload["state"] == "accepted"
     assert payload["request_digest"]
+    assert payload["profile"]["profile_id"] == "profile-default"
     assert payload["status_url"].endswith(payload["run_id"])
     # The fake never completes work: acceptance is decoupled from completion.
     assert fake_control.runs[payload["run_id"]].result is None
+
+
+def test_submit_body_is_the_shipped_rest_submit_schema(call, fake_control):
+    """The serialized wire body must satisfy the real request model directly.
+
+    Issue #833 regression gate: the shipped adapter sealed the draft
+    issue #809 field names while the REST route landed different ones, and
+    the offline fake mirrored the adapter's own mistake, so every real
+    ``mission_submit`` 422ed. This test validates the exact bytes the
+    adapter posts against ``archetype.missions.api.MissionRunSubmitRequest``
+    (``extra="forbid"``) with no fake in the loop, so any future rename on
+    either side fails CI instead of production.
+    """
+
+    is_error, _ = call("mission_submit", submit_arguments())
+    assert is_error is False
+    recorded = fake_control.requests[-1]
+    assert (recorded.method, recorded.path) == ("POST", "/v1/mission-runs")
+    assert recorded.headers["Idempotency-Key"] == "key-0001"
+    request = MissionRunSubmitRequest.model_validate(json.loads(recorded.body))
+    assert request.profile_id == "profile-default"
+    assert request.repository == "vangelis/archetype"
+    assert request.branch == "agent/demo-mission"
+    assert request.base_ref == "main"
+    assert request.name == "demo-mission"
+    task = request.tasks[0]
+    assert task.name == "fix-bug"
+    assert task.prompt == "Fix the reported bug."
+    assert task.validators[0].name == "pytest"
+    assert task.validators[0].command == ["pytest", "-q"]
+
+
+def test_submit_omitted_optionals_defer_to_the_rest_defaults(call, fake_control):
+    """Absent optional arguments stay off the wire; the server owns defaults."""
+
+    arguments = submit_arguments()
+    del arguments["base_ref"]
+    del arguments["name"]
+    is_error, _ = call("mission_submit", arguments)
+    assert is_error is False
+    body = json.loads(fake_control.requests[-1].body)
+    assert "base_ref" not in body and "name" not in body
+    assert "max_dispatches" not in body["tasks"][0]
+    assert "expected_returncode" not in body["tasks"][0]["validators"][0]
+    request = MissionRunSubmitRequest.model_validate(body)
+    assert request.base_ref == "main"
+    assert request.name == "agent-mission"
+    assert request.tasks[0].max_dispatches == 3
+    assert request.tasks[0].validators[0].expected_returncode == 0
+    assert request.tasks[0].validators[0].timeout_seconds == 300
+
+
+def test_submit_can_express_every_client_writable_rest_field(call, fake_control):
+    """A maximal tool call covers the full field set of every request model,
+    so a new client-writable REST field makes this test fail until the
+    adapter grows it."""
+
+    arguments = submit_arguments(
+        tasks=[
+            {
+                "name": "fix-bug",
+                "prompt": "Fix the reported bug.",
+                "validators": [
+                    {
+                        "name": "pytest",
+                        "command": ["pytest", "-q"],
+                        "expected_returncode": 0,
+                        "timeout_seconds": 120,
+                    }
+                ],
+                "depends_on": [],
+                "max_dispatches": 2,
+            }
+        ]
+    )
+    is_error, _ = call("mission_submit", arguments)
+    assert is_error is False
+    body = json.loads(fake_control.requests[-1].body)
+    request = MissionRunSubmitRequest.model_validate(body)
+    assert request.tasks[0].validators[0].timeout_seconds == 120
+    assert request.tasks[0].max_dispatches == 2
+    assert set(body) == set(MissionRunSubmitRequest.model_fields)
+    assert set(body["tasks"][0]) == set(MissionRunTaskRequest.model_fields)
+    assert set(body["tasks"][0]["validators"][0]) == set(MissionRunValidatorRequest.model_fields)
+
+
+def test_draft_schema_field_names_fail_before_the_wire(call, fake_control):
+    """The pre-#821 draft names (`ref`, `mission`, `validators[].argv`) that
+    shipped the issue #833 bug are now rejected by the tool itself."""
+
+    renamed = submit_arguments()
+    del renamed["branch"]
+    renamed["ref"] = "main"
+    renamed["mission"] = renamed.pop("name")
+    is_error, payload = call("mission_submit", renamed)
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+    draft_validator = [
+        {
+            "name": "t",
+            "prompt": "p",
+            "validators": [{"name": "pytest", "argv": ["pytest", "-q"]}],
+        }
+    ]
+    is_error, payload = call("mission_submit", submit_arguments(tasks=draft_validator))
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert fake_control.requests == []
+
+
+def test_task_without_validators_fails_before_the_wire(call, fake_control):
+    """The REST task model requires a non-empty validator list."""
+
+    is_error, payload = call(
+        "mission_submit", submit_arguments(tasks=[{"name": "t", "prompt": "p"}])
+    )
+    assert is_error is True
+    assert payload["error"]["code"] == "invalid_argument"
+    assert "validators" in payload["error"]["message"]
+    assert fake_control.requests == []
 
 
 def test_duplicate_submit_after_process_death_returns_original_run(fake_control):
@@ -48,7 +176,7 @@ def test_duplicate_submit_after_process_death_returns_original_run(fake_control)
 
 def test_submit_with_changed_content_conflicts(call):
     call("mission_submit", submit_arguments())
-    is_error, payload = call("mission_submit", submit_arguments(mission="different-mission"))
+    is_error, payload = call("mission_submit", submit_arguments(name="different-mission"))
     assert is_error is True
     assert payload["error"]["code"] == "conflict"
 
@@ -126,7 +254,7 @@ def test_result_nonterminal_is_not_ready(call, fake_control):
 
 def test_result_terminal_is_immutable(call, fake_control):
     run = fake_control.seed_run(
-        state="completed", result={"status": "green", "commits": ["abc123"]}
+        state="succeeded", result={"status": "green", "commits": ["abc123"]}
     )
     _, first = call("mission_result", {"run_id": run.run_id})
     _, second = call("mission_result", {"run_id": run.run_id})
@@ -145,10 +273,10 @@ def test_cancel_is_idempotent(call, fake_control):
 
 
 def test_cancel_completion_race_reports_the_committed_fact(call, fake_control):
-    run = fake_control.seed_run(state="completed", result={"status": "green"})
+    run = fake_control.seed_run(state="succeeded", result={"status": "green"})
     is_error, payload = call("mission_cancel", {"run_id": run.run_id})
     assert is_error is False
-    assert payload["state"] == "completed"
+    assert payload["state"] == "succeeded"
 
 
 def test_cancel_cannot_target_an_unauthorized_run(call, fake_control):
@@ -160,7 +288,7 @@ def test_cancel_cannot_target_an_unauthorized_run(call, fake_control):
 
 def test_list_is_scoped_to_the_authenticated_principal(call, fake_control):
     own_one = fake_control.seed_run(state="running")
-    own_two = fake_control.seed_run(state="queued")
+    own_two = fake_control.seed_run(state="accepted")
     fake_control.seed_run(state="running", foreign=True)
     is_error, payload = call("mission_list", {})
     assert is_error is False
@@ -173,7 +301,7 @@ def test_oversized_payload_is_truncated_with_an_explicit_marker(fake_control):
     whose JSON escaping expands aggressively (control chars, quotes)."""
 
     run = fake_control.seed_run(
-        state="completed",
+        state="succeeded",
         result={"log": ('"' + "\x01\x02" + "\\") * 900},
     )
     config = McpHostConfig.from_env(


### PR DESCRIPTION
Closes #833

## Root cause

Three layers lined up to ship a submit path that could never work:

1. **Draft-schema seal.** `archetype/missions/mcp/client.py` was written against issue #809's *draft* contract — `ref`, `mission`, `tasks[].validators[].argv` — while the REST route that actually landed (#821) takes `branch`, `base_ref`, `name`, and `tasks[].validators[].command` (+ `expected_returncode`, `timeout_seconds`, `max_dispatches`) with `extra="forbid"`. Every `mission_submit` through the shipped binary 422ed; no run was ever minted (fail-closed, at least).
2. **Fake-mirror.** The offline `FakeMissionControl` mirrored the adapter's own wrong schema instead of the real models, so the contract suite proved the adapter agreed with itself. The route-drift test bound route *presence* only, not body field names.
3. **Gated live proof.** The body-level live-loopback test shipped skipif-gated on "#809 pending" and never ran between #821 landing and the release.

Proven by the v0.6.3 live dogfood (receipt finding 1, `da-nang-v1/.context/dogfood/receipt-v063.json`).

## The fix

- **`client.py`** — submit body mirrors `archetype.missions.api.MissionRunSubmitRequest` field for field. Optional fields the REST model defaults (`base_ref`, `name`, validator `expected_returncode`/`timeout_seconds`, task `max_dispatches`) are omitted from the wire when the caller does not supply them, so the server stays the single owner of every default. Adapter boundaries preserved: opaque-id validation, fixed prompt/task caps, `Idempotency-Key` header forwarding, structural redaction, truncation envelope.
- **`server.py`** — the `mission_submit` inputSchema renders from the same `_ToolSpec`/`_ARGUMENT_KINDS` table as runtime validation, now advertising the corrected shape. Tightenings: task/mission names capped 200 → 128 (REST `_MAX_NAME_CHARS`), validator `command` bounded to 1–64 items of ≤ 4096 chars (REST bounds), `depends_on` capped at 32, tasks **require** a non-empty `validators` list (the REST task model does). Explicit loosenings, all additive and REST-expressible: optional `base_ref` and `name` arguments, optional validator `expected_returncode`/`timeout_seconds`, optional task `max_dispatches` (1–10) — the dogfood found these inexpressible even after a rename.
- **`tests/missions/mcp/conftest.py`** — `FakeMissionControl` now validates every submit body against the real `MissionRunSubmitRequest` pydantic model (422 on `ValidationError`, exactly like the route) and answers with a real `MissionRunAcceptedResponse` payload using real `MissionRunState` literals. The fake can no longer mirror an adapter mistake.

## The drift-proof test (closing the gap that let this ship)

`tests/missions/mcp/test_mission_mcp_rest_contract.py` now validates the adapter's **serialized wire bytes** directly against the real models — no fake in the loop:

- `test_submit_body_is_the_shipped_rest_submit_schema` — recorded POST body must satisfy `MissionRunSubmitRequest.model_validate` (`extra="forbid"`), field values asserted.
- `test_submit_omitted_optionals_defer_to_the_rest_defaults` — absent optionals stay off the wire and resolve to the REST defaults (`base_ref="main"`, `name="agent-mission"`, `max_dispatches=3`, `expected_returncode=0`, `timeout_seconds=300`).
- `test_submit_can_express_every_client_writable_rest_field` — a maximal call's body achieves **field-set equality** with `MissionRunSubmitRequest`/`MissionRunTaskRequest`/`MissionRunValidatorRequest.model_fields`, so a new client-writable REST field fails CI until the adapter grows it.
- `test_draft_schema_field_names_fail_before_the_wire` — the pre-#821 names (`ref`, `mission`, `argv`) are locked out as a regression case.

Seam-gate cleanup: `test_installed_rest_routes_match_the_adapter_contract` no longer has a skip branch — #809/#821 are on main, so route-set agreement is enforced unconditionally. The live roundtrip stays env-gated only because it needs a served host (frozen-dogfood-as-skipif convention), with its reason text and submit shape rebound.

## Live loopback evidence (fix proof)

Stood up the v0.6.3 dogfood host composition (principals TOML + `dogfood-modal` Modal-backed profile catalog + uvicorn on `127.0.0.1:8833`) served **from this branch's source**, and drove the un-gated `test_live_loopback_roundtrip` through the fixed MCP adapter:

- `POST /v1/mission-runs` → **202 Accepted**, `run_id 01a0306f-b96e-7ec1-bd41-985b4835ac25`, state `accepted`, pinned profile digest `967a76f1…9516` (same digest as the dogfood receipt).
- Byte-identical duplicate submit → 202, **same run_id** (idempotent replay through MCP — the exact step the dogfood recorded as BLOCKED BY SHIPPED BUG).
- `mission_get`, `mission_events` → 200 through the adapter.
- `mission_cancel` immediately after acceptance → 202 `cancelling`; terminal `cancelled` ~24s later with `has_result: false` — cancel landed before any Codex dispatch, so no branch was pushed and no meaningful Modal spend. Event stream gap-free: `accepted(1) → running(2) → cancel_requested(3) → cancelling(4) → cancelled(5)`.
- Credential redacted throughout; host shut down after capture.

## Verification

- `make ci` (static + test + package-smoke): green — 3501 passed, 23 skipped; installed distribution matrix passed.
- `tests/missions/mcp/`: 165 passed, 1 env-gated skip (the live test, which passed when run live above).
- Self-reviewed the diff against `.claude/skills/footgun-detector/SKILL.md` — signature rows ↔ client kwargs match, advertised schema fragments ↔ runtime validators agree bound-for-bound, all new validation fails closed before the wire; the one leftover fake-only state literal (`"queued"`) found by the sweep is fixed.

Docs: `docs/guide/agent-missions.md` §11 seam paragraph replaced with the contract-binding description.

Ship as v0.6.4 when you call it, per the issue.

@everettVT

🤖 Generated with [Claude Code](https://claude.com/claude-code)